### PR TITLE
Nci corrector in gather buffer bugfix

### DIFF
--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -169,8 +169,8 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
-    std::array<amrex::Real, nstencilz_fdtd_nci_corr> fdtd_nci_stencilz_ex;
-    std::array<amrex::Real, nstencilz_fdtd_nci_corr> fdtd_nci_stencilz_by;
+    amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
+    amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;
 
 protected:
 

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -776,7 +776,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ex),
                                         BL_TO_FORTRAN_ANYD(filtered_Ex),
                                         BL_TO_FORTRAN_ANYD(Ex[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 exfab = &filtered_Ex;
 
@@ -784,7 +784,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ez),
                                         BL_TO_FORTRAN_ANYD(filtered_Ez),
                                         BL_TO_FORTRAN_ANYD(Ez[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 ezfab = &filtered_Ez;
 
@@ -792,7 +792,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_By),
                                         BL_TO_FORTRAN_ANYD(filtered_By),
                                         BL_TO_FORTRAN_ANYD(By[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 byfab = &filtered_By;
 
@@ -801,7 +801,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ey),
                                         BL_TO_FORTRAN_ANYD(filtered_Ey),
                                         BL_TO_FORTRAN_ANYD(Ey[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 eyfab = &filtered_Ey;
 
@@ -809,7 +809,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bx),
                                         BL_TO_FORTRAN_ANYD(filtered_Bx),
                                         BL_TO_FORTRAN_ANYD(Bx[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 bxfab = &filtered_Bx;
 
@@ -817,7 +817,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bz),
                                         BL_TO_FORTRAN_ANYD(filtered_Bz),
                                         BL_TO_FORTRAN_ANYD(Bz[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 bzfab = &filtered_Bz;
 #endif

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -1014,13 +1014,75 @@ PhysicalParticleContainer::Evolve (int lev,
                     const std::array<Real,3>& cxyzmin_grid = WarpX::LowerCorner(cbox, lev-1);
                     const int* cixyzmin_grid = cbox.loVect();
 
-                    const FArrayBox& cexfab = (*cEx)[pti];
-                    const FArrayBox& ceyfab = (*cEy)[pti];
-                    const FArrayBox& cezfab = (*cEz)[pti];
-                    const FArrayBox& cbxfab = (*cBx)[pti];
-                    const FArrayBox& cbyfab = (*cBy)[pti];
-                    const FArrayBox& cbzfab = (*cBz)[pti];
+                    const FArrayBox* cexfab = &(*cEx)[pti];
+                    const FArrayBox* ceyfab = &(*cEy)[pti];
+                    const FArrayBox* cezfab = &(*cEz)[pti];
+                    const FArrayBox* cbxfab = &(*cBx)[pti];
+                    const FArrayBox* cbyfab = &(*cBy)[pti];
+                    const FArrayBox* cbzfab = &(*cBz)[pti];
 
+                    if (warpx_use_fdtd_nci_corr())
+                    {
+#if (AMREX_SPACEDIM == 2)
+                        const Box& tbox = amrex::grow(cbox,{static_cast<int>(WarpX::nox),
+                                    static_cast<int>(WarpX::noz)});
+#else
+                        const Box& tbox = amrex::grow(cbox,{static_cast<int>(WarpX::nox),
+                                    static_cast<int>(WarpX::noy),
+                                    static_cast<int>(WarpX::noz)});
+#endif
+
+                        // both 2d and 3d
+                        filtered_Ex.resize(amrex::convert(tbox,WarpX::Ex_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ex),
+                                                BL_TO_FORTRAN_ANYD(filtered_Ex),
+                                                BL_TO_FORTRAN_ANYD((*cEx)[pti]),
+                                                mypc.fdtd_nci_stencilz_ex[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        cexfab = &filtered_Ex;
+
+                        filtered_Ez.resize(amrex::convert(tbox,WarpX::Ez_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ez),
+                                                BL_TO_FORTRAN_ANYD(filtered_Ez),
+                                                BL_TO_FORTRAN_ANYD((*cEz)[pti]),
+                                                mypc.fdtd_nci_stencilz_by[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        cezfab = &filtered_Ez;
+                        filtered_By.resize(amrex::convert(tbox,WarpX::By_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_By),
+                                                BL_TO_FORTRAN_ANYD(filtered_By),
+                                                BL_TO_FORTRAN_ANYD((*cBy)[pti]),
+                                                mypc.fdtd_nci_stencilz_by[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        cbyfab = &filtered_By;
+
+#if (AMREX_SPACEDIM == 3)
+                        filtered_Ey.resize(amrex::convert(tbox,WarpX::Ey_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ey),
+                                                BL_TO_FORTRAN_ANYD(filtered_Ey),
+                                                BL_TO_FORTRAN_ANYD((*cEy)[pti]),
+                                                mypc.fdtd_nci_stencilz_ex[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        ceyfab = &filtered_Ey;
+                        
+                        filtered_Bx.resize(amrex::convert(tbox,WarpX::Bx_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bx),
+                                                BL_TO_FORTRAN_ANYD(filtered_Bx),
+                                                BL_TO_FORTRAN_ANYD((*cBx)[pti]),
+                                                mypc.fdtd_nci_stencilz_by[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        cbxfab = &filtered_Bx;
+                        
+                        filtered_Bz.resize(amrex::convert(tbox,WarpX::Bz_nodal_flag));
+                        WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bz),
+                                                BL_TO_FORTRAN_ANYD(filtered_Bz),
+                                                BL_TO_FORTRAN_ANYD((*cBz)[pti]),
+                                                mypc.fdtd_nci_stencilz_ex[lev-1].data(),
+                                                &nstencilz_fdtd_nci_corr);
+                        cbzfab = &filtered_Bz;
+#endif
+                    }
+                    
                     long ncrse = np - nfine_gather;
                     warpx_geteb_energy_conserving(
                         &ncrse, xp.data()+nfine_gather, yp.data()+nfine_gather, zp.data()+nfine_gather,
@@ -1030,12 +1092,12 @@ PhysicalParticleContainer::Evolve (int lev,
                         &cxyzmin_grid[0], &cxyzmin_grid[1], &cxyzmin_grid[2],
                         &cdx[0], &cdx[1], &cdx[2],
                         &WarpX::nox, &WarpX::noy, &WarpX::noz,
-                        BL_TO_FORTRAN_ANYD(cexfab),
-                        BL_TO_FORTRAN_ANYD(ceyfab),
-                        BL_TO_FORTRAN_ANYD(cezfab),
-                        BL_TO_FORTRAN_ANYD(cbxfab),
-                        BL_TO_FORTRAN_ANYD(cbyfab),
-                        BL_TO_FORTRAN_ANYD(cbzfab),
+                        BL_TO_FORTRAN_ANYD(*cexfab),
+                        BL_TO_FORTRAN_ANYD(*ceyfab),
+                        BL_TO_FORTRAN_ANYD(*cezfab),
+                        BL_TO_FORTRAN_ANYD(*cbxfab),
+                        BL_TO_FORTRAN_ANYD(*cbyfab),
+                        BL_TO_FORTRAN_ANYD(*cbzfab),
                         &ll4symtry, &l_lower_order_in_v,
                         &lvect_fieldgathe, &WarpX::field_gathering_algo);
                 }

--- a/Source/WarpXInitData.cpp
+++ b/Source/WarpXInitData.cpp
@@ -134,20 +134,25 @@ WarpX::InitNCICorrector ()
 {
     if (warpx_use_fdtd_nci_corr())
     {
-        const Geometry& gm = Geom(finest_level);
-        const Real* dx = gm.CellSize();
-        const int l_lower_order_in_v = warpx_l_lower_order_in_v();
-        amrex::Real dz, cdtodz;
-        if (AMREX_SPACEDIM == 3){ 
-            dz = dx[2]; 
-        }else{ 
-            dz = dx[1]; 
+        mypc->fdtd_nci_stencilz_ex.resize(max_level+1);
+        mypc->fdtd_nci_stencilz_by.resize(max_level+1);
+        for (int lev = 0; lev <= max_level; ++lev)
+        {
+            const Geometry& gm = Geom(lev);
+            const Real* dx = gm.CellSize();
+            const int l_lower_order_in_v = warpx_l_lower_order_in_v();
+            amrex::Real dz, cdtodz;
+            if (AMREX_SPACEDIM == 3){
+                dz = dx[2];
+            }else{
+                dz = dx[1];
+            }
+            cdtodz = PhysConst::c * dt[lev] / dz;
+            WRPX_PXR_NCI_CORR_INIT( (mypc->fdtd_nci_stencilz_ex)[lev].data(),
+                                    (mypc->fdtd_nci_stencilz_by)[lev].data(),
+                                    mypc->nstencilz_fdtd_nci_corr, cdtodz,
+                                    l_lower_order_in_v);
         }
-        cdtodz = PhysConst::c * dt[finest_level] / dz;
-        WRPX_PXR_NCI_CORR_INIT( mypc->fdtd_nci_stencilz_ex.data(), 
-                                mypc->fdtd_nci_stencilz_by.data(), 
-                                mypc->nstencilz_fdtd_nci_corr, cdtodz, 
-                                l_lower_order_in_v);
     }
 }
 


### PR DESCRIPTION
This applies the nci corrector to the coarse level fields when using the field gather buffer. 

Before this fix:

![without_fix_slice_z_ez](https://user-images.githubusercontent.com/4329158/46323038-240c6a00-c5a1-11e8-966e-7e3276c08fd9.png)

After this fix:

![with_fix_slice_z_ez](https://user-images.githubusercontent.com/4329158/46323045-2c64a500-c5a1-11e8-9e69-dfb76c2d552a.png)

Script to reproduce:

```
stop_time = 5.e-12
amr.n_cell = 32 640

amr.max_grid_size = 1280
amr.blocking_factor = 8

warpx.n_current_deposition_buffer = 32
warpx.n_field_gather_buffer = 32

# Maximum level in hierarchy (for now must be 0, i.e., one level in total)
amr.max_level = 1
amr.plot_file = plotfiles/plt
amr.plot_int = 100

# Geometry
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 0 0      # Is periodic?
# In the lab frame: z between -1300um and -1000um
geometry.prob_lo     = -64.e-6  -128.e-6
geometry.prob_hi     =  64.e-6     0.
warpx.fine_tag_lo    = -30.e-6  -128.e-6
warpx.fine_tag_hi    =  30.e-6     0.e-6

# Verbosity
warpx.verbose = 1
warpx.plot_raw_fields = 0
warpx.do_dive_cleaning = 0
warpx.use_filter = 1
warpx.do_pml = 1
warpx.do_subcycling = 0
warpx.refine_plasma = 0
algo.maxwell_fdtd_solver = yee
amrex.v = 1
warpx.plot_raw_fields = 1 
warpx.plot_raw_fields_guards = 1 
warpx.plot_finepatch = 1 
warpx.plot_crsepatch = 1
#warpx.plot_rho = 1
#warpx.plot_F = 1

# Boost
warpx.gamma_boost = 10.0
warpx.boost_direction = z
warpx.do_boosted_frame_diagnostic = 0
warpx.num_snapshots_lab = 20
warpx.dt_snapshots_lab = 2.5e-11

# Algorithms
algo.current_deposition = 0
algo.charge_deposition = 0
algo.field_gathering = 0
algo.particle_pusher = 0

# CFL
warpx.cfl = 1.0
particles.nspecies = 6
#particles.species_names = plasma_e plasma_p
particles.species_names = driver plasma_e beam plasma_p driverback beamback
#particles.deposit_on_main_grid = driver plasma_e plasma_p driverback beamback
particles.use_fdtd_nci_corr = 1
particles.rigid_injected_species = driver beam

# interpolation
interpolation.nox = 1
interpolation.noy = 1
interpolation.noz = 1

constants.use_my_constants = 1
constants.constant_names  = lramp  pi                 dens
constants.constant_values = 2.e-3 3.141592653589793   1e+23

driver.charge = -q_e
driver.mass = m_e
driver.injection_style = "gaussian_beam"
driver.x_rms = 4.e-6
driver.y_rms = 4.e-6
driver.z_rms = 8.e-6
driver.x_m = 0.
driver.y_m = 0.
driver.z_m = -20.e-6
driver.npart = 5000
driver.q_tot = -4e-11
driver.profile = "constant"
driver.density = 8.e23                   # number of particles per m^3
driver.momentum_distribution_type = "gaussian"
driver.ux_m = 0.0
driver.uy_m = 0.0
driver.uz_m = 200000.
driver.ux_th = 2.
driver.uy_th = 2.
driver.uz_th = 0.
driver.zinject_plane = 0.
driver.rigid_advance = true
driver.projected = true
driver.focused = false

# This species is the back-propagating counterpart of the driver species
# used to reduce the effect of spurious fields at injection.
# it mostly has the same parameters, with the following differences:
# - opposite charge
# - opposite q_tot
# - flag do_backward_propagation is set to true (default is false)
driverback.charge = q_e
driverback.mass = m_e
driverback.injection_style = "gaussian_beam"
driverback.x_rms = 4.e-6
driverback.y_rms = 4.e-6
driverback.z_rms = 8.e-6
driverback.x_m = 0.
driverback.y_m = 0.
driverback.z_m = -20.e-6
driverback.npart = 5000
driverback.q_tot = 4.e-11
driverback.profile = "constant"
driverback.density = 8.e23                   # number of particles per m^3
driverback.momentum_distribution_type = "gaussian"
driverback.ux_m = 0.0
driverback.uy_m = 0.0
driverback.uz_m = 200000.
driverback.ux_th = 2.
driverback.uy_th = 2.
driverback.uz_th = 0.
driverback.zinject_plane = 0.
driverback.rigid_advance = true
driverback.projected = true
driverback.focused = false
driverback.do_backward_propagation = true

beam.charge = -q_e
beam.mass = m_e
beam.injection_style = "gaussian_beam"
beam.x_rms = 2.e-6
beam.y_rms = 2.e-6
beam.z_rms = 4.e-6
beam.x_m = 0.
beam.y_m = 0.
beam.z_m = -98.e-6
beam.npart = 5000
beam.q_tot = -6e-12
beam.profile = "constant"
beam.density = 8.e23                   # number of particles per m^3
beam.momentum_distribution_type = "gaussian"
beam.ux_m = 0.0
beam.uy_m = 0.0
beam.uz_m = 2000.
beam.ux_th = 2.
beam.uy_th = 2.
beam.uz_th = 0.
beam.zinject_plane = 0.e-6
beam.rigid_advance = true
beam.projected = true
beam.focused = false

# This species is the back-propagating counterpart of the beam species
# used to reduce the effect of spurious fields at injection.
# it mostly has the same parameters, with the following differences:
# - opposite charge
# - opposite q_tot
# - flag do_backward_propagation is set to true (default is false)
beamback.charge = q_e
beamback.mass = m_e
beamback.injection_style = "gaussian_beam"
beamback.x_rms = 2.e-6
beamback.y_rms = 2.e-6
beamback.z_rms = 4.e-6
beamback.x_m = 0.
beamback.y_m = 0.
beamback.z_m = -98.e-6
beamback.npart = 5000
beamback.q_tot = 6e-12
beamback.profile = "constant"
beamback.density = 8.e23                   # number of particles per m^3
beamback.momentum_distribution_type = "gaussian"
beamback.ux_m = 0.0
beamback.uy_m = 0.0
beamback.uz_m = 2000.
beamback.ux_th = 2.
beamback.uy_th = 2.
beamback.uz_th = 0.
beamback.zinject_plane = 0.
beamback.rigid_advance = true
beamback.projected = true
beamback.focused = false
beamback.do_backward_propagation = true

plasma_e.charge = -q_e
plasma_e.mass = m_e
plasma_e.injection_style = "NUniformPerCell"
plasma_e.zmin = 0.e-6
plasma_e.zmax = 10.
plasma_e.xmin = -50.e-6
plasma_e.xmax =  50.e-6
plasma_e.profile = parse_density_function
plasma_e.density_function(x,y,z) = "(z<lramp)*0.5*(1-cos(pi*z/lramp))*dens+(z>lramp)*dens"
# plasma_e.profile = "constant"
# plasma_e.density = 1.e23
plasma_e.num_particles_per_cell_each_dim = 2 2
plasma_e.momentum_distribution_type = "constant"
plasma_e.ux = 0.0
plasma_e.uy = 0.0
plasma_e.uz = 0.0

plasma_p.charge = q_e
plasma_p.mass = m_p
plasma_p.injection_style = "NUniformPerCell"
plasma_p.zmin = 0.e-6
plasma_p.zmax = 10.
plasma_p.profile = parse_density_function
plasma_p.density_function(x,y,z) = "(z<lramp)*0.5*(1-cos(pi*z/lramp))*dens+(z>lramp)*dens"
# plasma_p.profile = "constant"
# plasma_p.density = 1.e23
plasma_p.xmin = -50.e-6
plasma_p.xmax =  50.e-6
plasma_p.num_particles_per_cell_each_dim = 2 2
plasma_p.momentum_distribution_type = "constant"
plasma_p.ux = 0.0
plasma_p.uy = 0.0
plasma_p.uz = 0.0

# Moving window
warpx.do_moving_window = 1
warpx.moving_window_dir = z
warpx.moving_window_v = 1. # in units of the speed of light

# Particle Injection
warpx.do_plasma_injection = 1
warpx.num_injected_species = 2
warpx.injected_plasma_species = 1 3 
```

