### PR TITLE
Rearrange species parser for consistency

### DIFF
--- a/Source/PlasmaInjector.H
+++ b/Source/PlasmaInjector.H
@@ -294,6 +294,10 @@ protected:
     std::unique_ptr<PlasmaDensityProfile> rho_prof;
     std::unique_ptr<PlasmaMomentumDistribution> mom_dist;
     std::unique_ptr<PlasmaParticlePosition> part_pos;
+    
+    void parseDensity(amrex::ParmParse pp);
+    void parseMomentum(amrex::ParmParse pp);
+    
 };
 
 #endif

--- a/Source/PlasmaInjector.cpp
+++ b/Source/PlasmaInjector.cpp
@@ -286,24 +286,26 @@ PlasmaInjector::PlasmaInjector(int ispecies, const std::string& name)
     pp.query("zmax", zmax);
 
     // parse density information
-    std::string rho_prof_s;
-    pp.get("profile", rho_prof_s);
-    std::transform(rho_prof_s.begin(),
-                   rho_prof_s.end(),
-                   rho_prof_s.begin(),
-                   ::tolower);
-    if (rho_prof_s == "constant") {
-        pp.get("density", density);
-        rho_prof.reset(new ConstantDensityProfile(density));
-    } else if (rho_prof_s == "custom") {
-        rho_prof.reset(new CustomDensityProfile(species_name));
-    } else if (rho_prof_s == "parse_density_function") {
-        // Serialize particle initialization
-        WarpX::serialize_ics = true;
-        pp.get("density_function(x,y,z)", str_density_function);
-        rho_prof.reset(new ParseDensityProfile(str_density_function));
-    } else {
-        StringParseAbortMessage("Density profile type", rho_prof_s);
+    if (part_pos_s != "gaussian_beam" ){
+        std::string rho_prof_s;
+        pp.get("profile", rho_prof_s);
+        std::transform(rho_prof_s.begin(),
+                       rho_prof_s.end(),
+                       rho_prof_s.begin(),
+                       ::tolower);
+        if (rho_prof_s == "constant") {
+            pp.get("density", density);
+            rho_prof.reset(new ConstantDensityProfile(density));
+        } else if (rho_prof_s == "custom") {
+            rho_prof.reset(new CustomDensityProfile(species_name));
+        } else if (rho_prof_s == "parse_density_function") {
+            // Serialize particle initialization
+            WarpX::serialize_ics = true;
+            pp.get("density_function(x,y,z)", str_density_function);
+            rho_prof.reset(new ParseDensityProfile(str_density_function));
+        } else {
+            StringParseAbortMessage("Density profile type", rho_prof_s);
+        }
     }
 
     // parse momentum information


### PR DESCRIPTION
When parsing arguments `species.injection_style = "gaussian_beam"`, the parser requested arguments `species.profile` and `species.density`, though these arguments are not used in the code. That confused some users.

The reason it occurred is that, depending on the value of `species.injection_style`, arguments `species.profile` and `species.momentum_distribution_type` may or may not be required. In this PR, we explicitly separate each `species.injection_style`.