### PR TITLE
Add option to plot F and rho

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -432,6 +432,8 @@ private:
     bool plot_proc_number   = false;
     bool plot_dive          = false;
     bool plot_divb          = true;
+    bool plot_rho           = false;
+    bool plot_F             = false;
     bool plot_finepatch     = false;
     bool plot_crsepatch     = false;
     bool plot_raw_fields    = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -334,6 +334,10 @@ WarpX::ReadParameters ()
         pp.query("plot_divb"         , plot_divb);
         pp.query("plot_rho"          , plot_rho);
         pp.query("plot_F"            , plot_F);
+	if (plot_rho || plot_F){
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_dive_cleaning,
+                "plot_rho and plot_F only work if warpx.do_dive_cleaning = 1");
+	}
 
         if (maxLevel() > 0) {
             pp.query("plot_finepatch", plot_finepatch);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -332,6 +332,8 @@ WarpX::ReadParameters ()
         pp.query("plot_proc_number"  , plot_proc_number);
         pp.query("plot_dive"         , plot_dive);
         pp.query("plot_divb"         , plot_divb);
+        pp.query("plot_rho"          , plot_rho);
+        pp.query("plot_F"            , plot_F);
 
         if (maxLevel() > 0) {
             pp.query("plot_finepatch", plot_finepatch);

--- a/Source/WarpXIO.cpp
+++ b/Source/WarpXIO.cpp
@@ -468,6 +468,8 @@ WarpX::WritePlotFile () const
             + static_cast<int>(plot_proc_number)
             + static_cast<int>(plot_divb)
             + static_cast<int>(plot_dive)
+            + static_cast<int>(plot_rho)
+            + static_cast<int>(plot_F)
             + static_cast<int>(plot_finepatch)*6
             + static_cast<int>(plot_crsepatch)*6
             + static_cast<int>(costs[0] != nullptr);
@@ -618,6 +620,26 @@ WarpX::WritePlotFile () const
                 dcomp += 1;
             }
 
+            if (plot_rho)
+            {
+                amrex::average_node_to_cellcenter(*mf[lev], dcomp, *rho_fp[lev], 0, 1);
+                if (lev == 0)
+                {
+                    varnames.push_back("rho");
+                }
+                dcomp += 1;
+            }
+
+            if (plot_F)
+            {
+                amrex::average_node_to_cellcenter(*mf[lev], dcomp, *F_fp[lev], 0, 1);
+                if (lev == 0)
+                {
+                    varnames.push_back("F");
+                }
+                dcomp += 1;
+            }
+            
             if (plot_finepatch)
             {
                 PackPlotDataPtrs(srcmf, Efield_fp[lev]);


### PR DESCRIPTION
This PR add the option to plot F and rho when `do_dive_cleaning = 1`. Original code was written by @atmyers. 

Test input file is attached, and the fields can be plotted with
```
ds = yt.load( './plotfiles/plt00010/' )
sl = yt.SlicePlot(ds, 2, 'F', aspect=.1)
```
and
```
ds = yt.load( './plotfiles/plt00010/' )
sl = yt.SlicePlot(ds, 2, 'rho', aspect=.1)
```
[inputs.txt](https://github.com/ECP-WarpX/WarpX/files/2443856/inputs.txt)

