### PR TITLE
[WIP] Fix NCI corrector for multiple levels

### DIFF
--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -169,8 +169,8 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
-    std::array<amrex::Real, nstencilz_fdtd_nci_corr> fdtd_nci_stencilz_ex;
-    std::array<amrex::Real, nstencilz_fdtd_nci_corr> fdtd_nci_stencilz_by;
+    amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
+    amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;
 
 protected:
 

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -776,7 +776,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ex),
                                         BL_TO_FORTRAN_ANYD(filtered_Ex),
                                         BL_TO_FORTRAN_ANYD(Ex[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 exfab = &filtered_Ex;
 
@@ -784,7 +784,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ez),
                                         BL_TO_FORTRAN_ANYD(filtered_Ez),
                                         BL_TO_FORTRAN_ANYD(Ez[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 ezfab = &filtered_Ez;
 
@@ -792,7 +792,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_By),
                                         BL_TO_FORTRAN_ANYD(filtered_By),
                                         BL_TO_FORTRAN_ANYD(By[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 byfab = &filtered_By;
 
@@ -801,7 +801,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Ey),
                                         BL_TO_FORTRAN_ANYD(filtered_Ey),
                                         BL_TO_FORTRAN_ANYD(Ey[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 eyfab = &filtered_Ey;
 
@@ -809,7 +809,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bx),
                                         BL_TO_FORTRAN_ANYD(filtered_Bx),
                                         BL_TO_FORTRAN_ANYD(Bx[pti]),
-                                        mypc.fdtd_nci_stencilz_by.data(),
+                                        mypc.fdtd_nci_stencilz_by[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 bxfab = &filtered_Bx;
 
@@ -817,7 +817,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 WRPX_PXR_GODFREY_FILTER(BL_TO_FORTRAN_BOX(filtered_Bz),
                                         BL_TO_FORTRAN_ANYD(filtered_Bz),
                                         BL_TO_FORTRAN_ANYD(Bz[pti]),
-                                        mypc.fdtd_nci_stencilz_ex.data(),
+                                        mypc.fdtd_nci_stencilz_ex[lev].data(),
                                         &nstencilz_fdtd_nci_corr);
                 bzfab = &filtered_Bz;
 #endif

--- a/Source/WarpXInitData.cpp
+++ b/Source/WarpXInitData.cpp
@@ -134,20 +134,25 @@ WarpX::InitNCICorrector ()
 {
     if (warpx_use_fdtd_nci_corr())
     {
-        const Geometry& gm = Geom(finest_level);
-        const Real* dx = gm.CellSize();
-        const int l_lower_order_in_v = warpx_l_lower_order_in_v();
-        amrex::Real dz, cdtodz;
-        if (AMREX_SPACEDIM == 3){ 
-            dz = dx[2]; 
-        }else{ 
-            dz = dx[1]; 
+        mypc->fdtd_nci_stencilz_ex.resize(max_level+1);
+        mypc->fdtd_nci_stencilz_by.resize(max_level+1);
+        for (int lev = 0; lev <= max_level; ++lev)
+        {
+            const Geometry& gm = Geom(lev);
+            const Real* dx = gm.CellSize();
+            const int l_lower_order_in_v = warpx_l_lower_order_in_v();
+            amrex::Real dz, cdtodz;
+            if (AMREX_SPACEDIM == 3){ 
+                dz = dx[2]; 
+            }else{ 
+                dz = dx[1]; 
+            }
+            cdtodz = PhysConst::c * dt[lev] / dz;
+            WRPX_PXR_NCI_CORR_INIT( (mypc->fdtd_nci_stencilz_ex)[lev].data(), 
+                                    (mypc->fdtd_nci_stencilz_by)[lev].data(), 
+                                    mypc->nstencilz_fdtd_nci_corr, cdtodz, 
+                                    l_lower_order_in_v);
         }
-        cdtodz = PhysConst::c * dt[finest_level] / dz;
-        WRPX_PXR_NCI_CORR_INIT( mypc->fdtd_nci_stencilz_ex.data(), 
-                                mypc->fdtd_nci_stencilz_by.data(), 
-                                mypc->nstencilz_fdtd_nci_corr, cdtodz, 
-                                l_lower_order_in_v);
     }
 }
 


### PR DESCRIPTION
The Godfrey filter should have different coefficients for the different levels of mesh refinement (since the coefficients depend on dt/dz).

Since this is not the case in the current master branch, this PR fixes it.