### PR TITLE
Make the Travis test faster by using only 1 MPI and 1 OpenMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     - cp travis-tests.ini ../../rt-WarpX
     # Final setup
     - export FFTW_HOME=/usr/
-    - export OMP_NUM_THREADS=2
+    - export OMP_NUM_THREADS=1
     - cd /home/travis/regression_testing
 
 script:

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -20,6 +20,10 @@ text = re.sub( '\[(?P<name>.*)\]\nbuildDir = ',
 # Use only 2 cores for compiling
 text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )
 
+# Use only 1 MPI and 1 thread proc for tests
+text = re.sub( 'numprocs = \d+', 'numprocs = 1', text)
+text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
+
 # Remove Python test (does not compile)
 text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
 


### PR DESCRIPTION
It seems that Travis CI only grants us 1 core (or maybe 2) and therefore running with multiple MPI and multiple OpenMP will be considerably slower (due to the different processors/threads taking turns on the hardware).

This PR makes the test faster by forcing the using of only 1 MPI and 1 OpenMP:
- for 2D tests:
    - This PR: 12 min
    - dev branch: ~30 min
- for 3D tests:
    - This PR: 15 min
    - dev branch: 17 min
For individual timings of the tests, you can compare the outputs for:
- This PR: https://travis-ci.org/RemiLehe/WarpX/jobs/437256859
- dev branch: https://travis-ci.org/ECP-WarpX/WarpX/jobs/437253561

Due to the structure of WarpX (decomposes the problem into boxes and tiles, even with only 1 MPI and 1 OpenMP), it is quite unlikely that we would miss bugs by restricting ourselves to only 1 MPI/OpenMP.
