### PR TITLE
Port laser initialization to GPU

### DIFF
--- a/Examples/Tests/gpu_test/inputs
+++ b/Examples/Tests/gpu_test/inputs
@@ -56,7 +56,7 @@ electrons.uz_th  = 0.01 # uth the std of the (unitless) momentum
 electrons.uz_m   = 10.  # Mean momentum along z (unitless)
 
 # Laser
-warpx.use_laser    = 0
+warpx.use_laser    = 1
 laser.profile      = Gaussian
 laser.position     = 0. 0. 0.e-6 # This point is on the laser plane
 laser.direction    = 0. 0. 1.     # The plane normal direction

--- a/Examples/Tests/gpu_test/inputs
+++ b/Examples/Tests/gpu_test/inputs
@@ -1,5 +1,5 @@
 # Maximum number of time steps
-max_step = 20
+max_step = 10
 
 # number of grid points
 amr.n_cell =  64 64 64
@@ -54,3 +54,16 @@ electrons.ux_th  = 0.01 # uth the std of the (unitless) momentum
 electrons.uy_th  = 0.01 # uth the std of the (unitless) momentum
 electrons.uz_th  = 0.01 # uth the std of the (unitless) momentum
 electrons.uz_m   = 10.  # Mean momentum along z (unitless)
+
+# Laser
+warpx.use_laser    = 0
+laser.profile      = Gaussian
+laser.position     = 0. 0. 0.e-6 # This point is on the laser plane
+laser.direction    = 0. 0. 1.     # The plane normal direction
+laser.polarization = 1. 0. 0.    # The main polarization vector
+laser.e_max        = 16.e12        # Maximum amplitude of the laser field (in V/m)
+laser.profile_waist = 3.e-6      # The waist of the laser (in meters)
+laser.profile_duration = 15.e-15  # The duration of the laser (in seconds)
+laser.profile_t_peak = 30.e-15    # The time at which the laser reaches its peak (in seconds)
+laser.profile_focal_distance = 100.e-6  # Focal distance from the antenna (in meters)
+laser.wavelength = 0.8e-6         # The wavelength of the laser (in meters)

--- a/Source/LaserParticleContainer.cpp
+++ b/Source/LaserParticleContainer.cpp
@@ -429,38 +429,12 @@ LaserParticleContainer::Evolve (int lev,
 	    }
 
 	    // Calculate the corresponding momentum and position for the particles
-            for (int i = 0; i < np; ++i)
-            {
-                // Calculate the velocity according to the amplitude of E
-                Real sign_charge = std::copysign( 1.0, wp[i] );
-                Real v_over_c = sign_charge * mobility * amplitude_E[i];
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE( v_over_c < 1,
-                    "The laser particles have to move unphysically in order to emit the laser.");
-                // The velocity is along the laser polarization p_X
-                Real vx = PhysConst::c * v_over_c * p_X[0];
-                Real vy = PhysConst::c * v_over_c * p_X[1];
-                Real vz = PhysConst::c * v_over_c * p_X[2];
-                // When running in the boosted-frame, their is additional
-                // velocity along nvec
-                if (WarpX::gamma_boost > 1.) {
-                    vx -= PhysConst::c * WarpX::beta_boost * nvec[0];
-                    vy -= PhysConst::c * WarpX::beta_boost * nvec[1];
-                    vz -= PhysConst::c * WarpX::beta_boost * nvec[2];
-                }
-                // Get the corresponding momenta
-                giv[i] = std::sqrt(1 - std::pow(v_over_c,2))/WarpX::gamma_boost;
-                Real gamma = 1./giv[i];
-                uxp[i] = gamma * vx;
-                uyp[i] = gamma * vy;
-                uzp[i] = gamma * vz;
-                // Push the the particle positions
-                xp[i] += vx * dt;
-#if (AMREX_SPACEDIM == 3)
-                yp[i] += vy * dt;
-#endif
-                zp[i] += vz * dt;
-            }
-
+            update_laser_particle(
+               &np, xp.dataPtr(), yp.dataPtr(), zp.dataPtr(),
+               uxp.dataPtr(), uyp.dataPtr(), uzp.dataPtr(), giv.dataPtr(),
+               wp.dataPtr(), amplitude_E.dataPtr(), &p_X[0], &p_X[1], &p_X[2],
+               &nvec[0], &nvec[1], &nvec[2], &mobility, &dt,
+               &PhysConst::c, &WarpX::beta_boost, &WarpX::gamma_boost );
 	    BL_PROFILE_VAR_STOP(blp_pxr_pp);
 
 	    //

--- a/Source/LaserParticleContainer.cpp
+++ b/Source/LaserParticleContainer.cpp
@@ -313,7 +313,7 @@ LaserParticleContainer::Evolve (int lev,
 #endif
     {
 	Cuda::DeviceVector<Real> xp, yp, zp, giv;
-        RealVector plane_Xp, plane_Yp, amplitude_E;
+        Cuda::DeviceVector<Real> plane_Xp, plane_Yp, amplitude_E;
         FArrayBox local_rho, local_jx, local_jy, local_jz;
 
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -348,6 +348,8 @@ LaserParticleContainer::Evolve (int lev,
             pti.GetPosition(xp, yp, zp);
 	    BL_PROFILE_VAR_STOP(blp_copy);
 
+#pragma acc parallel deviceptr(plane_Xp,plane_Yp,xp,yp,zp)
+#pragma acc loop
 	    for (int i = 0; i < np; ++i)
             {
                 // Find the coordinates of the particles in the emission plane
@@ -364,6 +366,7 @@ LaserParticleContainer::Evolve (int lev,
                 plane_Yp[i] = 0;
 #endif
             }
+
 
             const std::array<Real,3>& xyzmin_tile = WarpX::LowerCorner(pti.tilebox(), lev);
             const std::array<Real,3>& xyzmin_grid = WarpX::LowerCorner(box, lev);
@@ -438,6 +441,8 @@ LaserParticleContainer::Evolve (int lev,
 	    }
 
 	    // Calculate the corresponding momentum and position for the particles
+#pragma acc parallel deviceptr(amplitude_E,wp,uxp,uyp,uzp,xp,yp,zp,giv)
+#pragma acc loop
             for (int i = 0; i < np; ++i)
             {
                 // Calculate the velocity according to the amplitude of E

--- a/Source/WarpX_f.H
+++ b/Source/WarpX_f.H
@@ -184,8 +184,17 @@ extern "C"
        amrex::Real* xp, amrex::Real* yp, amrex::Real* zp,
        amrex::Real* plane_Xp, amrex::Real* plane_Yp,
        amrex::Real* u_Xx, amrex::Real* u_Xy, amrex::Real* u_Xz,
-       amrex::Real* u_Yx, amrex::Real* u_Yy, amrex::Real* u_Yz,                                           
-       amrex::Real* positionx, amrex::Real* positiony, amrex::Real* positionz );  
+       amrex::Real* u_Yx, amrex::Real* u_Yy, amrex::Real* u_Yz,
+       amrex::Real* positionx, amrex::Real* positiony, amrex::Real* positionz );
+  
+  void update_laser_particle( const long* np,
+       amrex::Real* xp, amrex::Real* yp, amrex::Real* zp,
+       amrex::Real* uxp, amrex::Real* uyp, amrex::Real* uzp,
+       amrex::Real* giv, amrex::Real* wp, amrex::Real* amplitude_E,
+       amrex::Real* p_Xx, amrex::Real* p_Xy, amrex::Real* p_Xz,
+       amrex::Real* nvecx, amrex::Real* nvecy, amrex::Real* nvecz,
+       amrex::Real* mobility, amrex::Real* dt,  const amrex::Real* c,
+       const amrex::Real* beta_boost, const amrex::Real* gamma_boost );
   
     // Maxwell solver
 

--- a/Source/WarpX_f.H
+++ b/Source/WarpX_f.H
@@ -180,6 +180,13 @@ extern "C"
 
         void parse_function_laser( const long* np, amrex::Real* Xp, amrex::Real* Yp, amrex::Real* t, amrex::Real* amplitude, const int parser_instance_number );
 
+  void calculate_laser_plane_coordinates( const long* np,
+       amrex::Real* xp, amrex::Real* yp, amrex::Real* zp,
+       amrex::Real* plane_Xp, amrex::Real* plane_Yp,
+       amrex::Real* u_Xx, amrex::Real* u_Xy, amrex::Real* u_Xz,
+       amrex::Real* u_Yx, amrex::Real* u_Yy, amrex::Real* u_Yz,                                           
+       amrex::Real* positionx, amrex::Real* positiony, amrex::Real* positionz );  
+  
     // Maxwell solver
 
         void warpx_push_evec(

--- a/Source/WarpX_laser.F90
+++ b/Source/WarpX_laser.F90
@@ -58,6 +58,8 @@ contains
 #endif
 
     ! Loop through the macroparticle to calculate the proper amplitude
+    !$acc parallel deviceptr(amplitude, Xp, Yp)
+    !$acc loop gang vector
     do i = 1, np
       ! Exp argument for the temporal gaussian envelope + STCs
       stc_exponent = 1./stretch_factor * inv_tau2 * &
@@ -69,7 +71,9 @@ contains
       exp_argument = - ( Xp(i)*Xp(i) + Yp(i)*Yp(i) ) * inv_complex_waist_2
       ! stcfactor + transverse envelope
       amplitude(i) = DREAL( stcfactor * exp( exp_argument ) )
-    enddo
+   enddo
+   !$acc end loop
+   !$acc end parallel
 
   end subroutine warpx_gaussian_laser
 
@@ -109,13 +113,17 @@ contains
     end if
 
     ! Loop through the macroparticle to calculate the proper amplitude
+    !$acc parallel deviceptr(amplitude, Xp, Yp)
+    !$acc loop gang vector
     do i = 1, np
       space_envelope = exp(- ( Xp(i)*Xp(i) + Yp(i)*Yp(i) ) * inv_wz_2)
       arg_osc = omega0*t - omega0/clight*(Xp(i)*Xp(i) + Yp(i)*Yp(i)) * inv_Rz / 2
       oscillations = cos(arg_osc)
       amplitude(i) = e_max * time_envelope * space_envelope * oscillations
     enddo
-
+    !$acc end loop
+    !$acc end parallel
+    
   end subroutine warpx_harris_laser
 
   ! Parse function from the input script for the laser temporal profile

--- a/Source/WarpX_laser.F90
+++ b/Source/WarpX_laser.F90
@@ -294,7 +294,9 @@ contains
     
     real(amrex_real)     :: vx, vy, vz, v_over_c, sign_charge, gamma
     integer  :: ip
-    
+
+    !$acc parallel deviceptr(amplitude_E, wp, xp, yp, zp, uxp, uyp, uzp, giv)
+    !$acc loop
     do ip = 1, np
        ! Calculate the velocity according to the amplitude of E       
        sign_charge = SIGN( 1.0, wp(ip) )
@@ -322,7 +324,8 @@ contains
 #endif
        zp(ip) = zp(ip) + vz * dt
     enddo
-
+    !$acc end loop
+    !$acc end parallel
 
 #ifdef USE_ACC_LASER_SUBROUTINE
   end subroutine update_laser_particle_acc


### PR DESCRIPTION
This PR implements the laser initialization on GPU, by adding the corresponding OpenACC directives. 

**Important:** So far the "parsed" laser profile (where the user enters an expression as a string) was not ported to GPU.

Some of the particles operations (e.g. compute laser plan coordinates, update particles positions and momenta) used to be performed in the C++ code. Because OpenACC directives in C++ were not interpreted by the compiler (missing flags?), I moved them to the Fortran code.

Note that the Fortran code requires a lot of boilerplate. As discussed off-line, I added fortran wrapper subroutines to circumvent the fact that OpenACC directives break the `bind(C,` naming. Maybe we'll find a more streamlined process in the future...

The current implementation is reasonably efficient on GPU, but I still see a lot of gaps in the Compute section of profiler timeline. I think that this is because the `LaserParticleContainer.cpp` does not contain the latest change for current deposition on the GPU which have been added to `PhysicalParticleContainer.cpp`.