### PR TITLE
laser STC direction

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -339,16 +339,20 @@ Laser initialization
     ``laser.profile_focal_distance`` in the laboratory frame, and use ``warpx.gamma_boost``
     to automatically perform the conversion to the boosted frame.
 
+* ``laser.stc_direction`` (`3 floats`) optional (default `1. 0. 0.`)
+    Direction of laser spatio-temporal couplings.
+  	See definition in Akturk et al., Opt Express, vol 12, no 19 (2014).
+
 * ``laser.zeta`` (`float`; in meters.seconds) optional (default `0.`)
-    Spatial chirp at focus in the ``x`` direction. See definition in
+    Spatial chirp at focus in direction ``laser.stc_direction``. See definition in
     Akturk et al., Opt Express, vol 12, no 19 (2014).
 
 * ``laser.beta`` (`float`; in seconds) optional (default `0.`)
-    Angular dispersion (or angular chirp) at focus in the ``x`` direction.
+    Angular dispersion (or angular chirp) at focus in direction ``laser.stc_direction``.
     See definition in Akturk et al., Opt Express, vol 12, no 19 (2014).
 
 * ``laser.phi2`` (`float`; in seconds**2) optional (default `0.`)
-    Temporal chirp at focus in the ``x`` direction.
+    Temporal chirp at focus.
     See definition in Akturk et al., Opt Express, vol 12, no 19 (2014).
 
 Numerics and algorithms

--- a/Source/LaserParticleContainer.H
+++ b/Source/LaserParticleContainer.H
@@ -52,6 +52,8 @@ private:
     amrex::Vector<amrex::Real> position;
     amrex::Vector<amrex::Real> nvec;
     amrex::Vector<amrex::Real> p_X;
+    amrex::Vector<amrex::Real> stc_direction;
+
     long                      pusher_algo = -1;
     amrex::Real               e_max       = std::numeric_limits<amrex::Real>::quiet_NaN();
     amrex::Real               wavelength  = std::numeric_limits<amrex::Real>::quiet_NaN();
@@ -72,6 +74,7 @@ private:
     amrex::Real zeta = 0.;
     amrex::Real beta = 0.;
     amrex::Real phi2 = 0.;
+    amrex::Real theta_stc = 0.;
 
     // parse_field_function profile
     int parser_instance_number = 0;

--- a/Source/WarpX_f.H
+++ b/Source/WarpX_f.H
@@ -172,7 +172,7 @@ extern "C"
 	void warpx_gaussian_laser( const long* np,
 				amrex::Real* Xp, amrex::Real* Yp, amrex::Real* t, amrex::Real* wavelength, amrex::Real* e_max, amrex::Real* waist,
 				amrex::Real* duration, amrex::Real* t_peak, amrex::Real* f, amrex::Real* amplitude,
-				amrex::Real* zeta, amrex::Real* beta, amrex::Real* phi2 );
+				amrex::Real* zeta, amrex::Real* beta, amrex::Real* phi2, amrex::Real* theta_stc );
 
         void warpx_harris_laser( const long* np,
                                  amrex::Real* Xp, amrex::Real* Yp, amrex::Real* t, amrex::Real* wavelength,

--- a/Source/WarpX_laser.F90
+++ b/Source/WarpX_laser.F90
@@ -12,12 +12,12 @@ contains
 
   subroutine warpx_gaussian_laser( np, Xp, Yp, t, &
       wavelength, e_max, waist, duration, t_peak, f, amplitude, &
-      zeta, beta, phi2 ) bind(C, name="warpx_gaussian_laser")
+      zeta, beta, phi2, theta_stc ) bind(C, name="warpx_gaussian_laser")
 
     integer(c_long), intent(in) :: np
     real(amrex_real), intent(in)    :: Xp(np),Yp(np)
     real(amrex_real), intent(in)    :: e_max, t, t_peak, wavelength, duration, f, waist
-    real(amrex_real), intent(in)    :: zeta, beta, phi2
+    real(amrex_real), intent(in)    :: zeta, beta, phi2, theta_stc
     real(amrex_real), intent(inout) :: amplitude(np)
 
     integer(c_long)  :: i
@@ -61,7 +61,8 @@ contains
     do i = 1, np
       ! Exp argument for the temporal gaussian envelope + STCs
       stc_exponent = 1./stretch_factor * inv_tau2 * \
-          (t - t_peak - beta*k0*Xp(i) - 2*j*Xp(i)*( zeta - beta*f ) * \
+          (t - t_peak - beta*k0*(Xp(i)*cos(theta_stc) + Yp(i)*sin(theta_stc)) -\
+          2*j*(Xp(i)*cos(theta_stc) + Yp(i)*sin(theta_stc))*( zeta - beta*f ) *\
           inv_complex_waist_2)**2 
       ! stcfactor = everything but complex transverse envelope 
       stcfactor = prefactor * exp( - stc_exponent )


### PR DESCRIPTION
With previous implementation, spatial chirp and angular chirp were always in the polarization direction.
After this PR, a user can set the direction of spatio-temporal couplings independently, with `laser.stc_direction = 0. 1. 0.` in the input file for instance.