### PR TITLE
Turn tiling off by default on GPU

### DIFF
--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -74,7 +74,11 @@ WarpXParticleContainer::ReadParameters ()
     {
 	ParmParse pp("particles");
 
-        do_tiling = true;  // because the default in amrex is false
+#ifdef AMREX_USE_GPU
+        do_tiling = false; // By default, tiling is off on GPU
+#else
+        do_tiling = true;
+#endif
 	pp.query("do_tiling",  do_tiling);
         pp.query("do_not_push", do_not_push);
 


### PR DESCRIPTION
When running on GPU, the simulation will crash if tiling is on (this is expected, since tiling was not implemented for GPU yet, on the default branch).

This PR deactivates tiling by default on GPU.