### PR TITLE
fix typo in reg tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -60,7 +60,7 @@ branch = master
 [pml_x_yee]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.maxwell_fdtd_solver=yee
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=yee
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -75,7 +75,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml.py
 [pml_x_ckc]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.maxwell_fdtd_solver=ckc
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=ckc
 dim = 2
 addToCompileString =
 restartTest = 0


### PR DESCRIPTION
The command-line parameter `maxwell_fdtd_solver` had a mistake in regression tests (used `warpx.maxwell_fdtd_solver` instead of `algo.maxwell_fdtd_solver`). This PR fixes it, but it should break the `pml_x_ckc` test. We will probably have to reset this test. @WeiqunZhang would you have time look at it, once we have the results of automated tests on this branch?