### PR TITLE
Adapt WarpX so it can use latest PICSAR modifications for nodal gather

### DIFF
--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -983,7 +983,7 @@ PhysicalParticleContainer::FieldGather (int lev,
                BL_TO_FORTRAN_ANYD(bxfab),
 	       BL_TO_FORTRAN_ANYD(byfab),
 	       BL_TO_FORTRAN_ANYD(bzfab),
-	       &ll4symtry, &WarpX::l_lower_order_in_v,
+	       &ll4symtry, &WarpX::l_lower_order_in_v, &WarpX::do_nodal,
 	       &lvect_fieldgathe, &WarpX::field_gathering_algo);
 
             if (cost) {
@@ -1288,7 +1288,7 @@ PhysicalParticleContainer::Evolve (int lev,
                     BL_TO_FORTRAN_ANYD(*bxfab),
                     BL_TO_FORTRAN_ANYD(*byfab),
                     BL_TO_FORTRAN_ANYD(*bzfab),
-                    &ll4symtry, &WarpX::l_lower_order_in_v,
+                    &ll4symtry, &WarpX::l_lower_order_in_v, &WarpX::do_nodal,
                     &lvect_fieldgathe, &WarpX::field_gathering_algo);
 
                 if (np_gather < np)
@@ -1385,7 +1385,7 @@ PhysicalParticleContainer::Evolve (int lev,
                         BL_TO_FORTRAN_ANYD(*cbxfab),
                         BL_TO_FORTRAN_ANYD(*cbyfab),
                         BL_TO_FORTRAN_ANYD(*cbzfab),
-                        &ll4symtry, &WarpX::l_lower_order_in_v,
+                        &ll4symtry, &WarpX::l_lower_order_in_v, &WarpX::do_nodal,
                         &lvect_fieldgathe, &WarpX::field_gathering_algo);
                 }
 
@@ -1560,7 +1560,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 BL_TO_FORTRAN_ANYD(bxfab),
                 BL_TO_FORTRAN_ANYD(byfab),
                 BL_TO_FORTRAN_ANYD(bzfab),
-                &ll4symtry, &WarpX::l_lower_order_in_v,
+                &ll4symtry, &WarpX::l_lower_order_in_v, &WarpX::do_nodal,
                 &lvect_fieldgathe, &WarpX::field_gathering_algo);
 
             warpx_particle_pusher_momenta(&np,

--- a/Source/RigidInjectedParticleContainer.cpp
+++ b/Source/RigidInjectedParticleContainer.cpp
@@ -427,7 +427,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                 BL_TO_FORTRAN_ANYD(bxfab),
                 BL_TO_FORTRAN_ANYD(byfab),
                 BL_TO_FORTRAN_ANYD(bzfab),
-                &ll4symtry, &l_lower_order_in_v,
+                &ll4symtry, &l_lower_order_in_v, &WarpX::do_nodal,
                 &lvect_fieldgathe, &WarpX::field_gathering_algo);
 
             // Save the position and momenta, making copies

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -94,7 +94,7 @@ IntVect WarpX::jz_nodal_flag(1,0);  // z is the second dimension to 2D AMReX
 int WarpX::n_field_gather_buffer = 0;
 int WarpX::n_current_deposition_buffer = -1;
 
-int WarpX::do_nodal = 0;
+int WarpX::do_nodal = false;
 
 WarpX* WarpX::m_instance = nullptr;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -424,6 +424,8 @@ WarpX::ReadParameters ()
             jx_nodal_flag = IntVect::TheNodeVector();
             jy_nodal_flag = IntVect::TheNodeVector();
             jz_nodal_flag = IntVect::TheNodeVector();
+            // Use same shape factors in all directions, for gathering
+            l_lower_order_in_v = false;
         }
     }
 

--- a/Source/WarpX_f.H
+++ b/Source/WarpX_f.H
@@ -137,7 +137,7 @@ extern "C"
 			const amrex::Real* byg, const int* byg_lo, const int* byg_hi,
 			const amrex::Real* bzg, const int* bzg_lo, const int* bzg_hi,
 			const int* ll4symtry, const int* l_lower_order_in_v,
-			const long* lvect,
+                        const int* l_nodal, const long* lvect,
 			const long* field_gathe_algo);
 
 	// Particle pusher (velocity and position)

--- a/Source/WarpX_picsar.F90
+++ b/Source/WarpX_picsar.F90
@@ -75,7 +75,7 @@ contains
        ex,ey,ez,bx,by,bz,ixyzmin,xmin,ymin,zmin,dx,dy,dz,nox,noy,noz, &
        exg,exg_lo,exg_hi,eyg,eyg_lo,eyg_hi,ezg,ezg_lo,ezg_hi, &
        bxg,bxg_lo,bxg_hi,byg,byg_lo,byg_hi,bzg,bzg_lo,bzg_hi, &
-       ll4symtry,l_lower_order_in_v, &
+       ll4symtry,l_lower_order_in_v, l_nodal,&
        lvect,field_gathe_algo) &
        bind(C, name="warpx_geteb_energy_conserving")
 
@@ -87,12 +87,12 @@ contains
     real(amrex_real), intent(in) :: xmin,ymin,zmin,dx,dy,dz
     integer(c_long), intent(in) :: field_gathe_algo
     integer(c_long), intent(in) :: np,nox,noy,noz
-    integer(c_int), intent(in)  :: ll4symtry,l_lower_order_in_v
+    integer(c_int), intent(in)  :: ll4symtry,l_lower_order_in_v, l_nodal
     integer(c_long),intent(in)   :: lvect
     real(amrex_real), intent(in), dimension(np) :: xp,yp,zp
     real(amrex_real), intent(out), dimension(np) :: ex,ey,ez,bx,by,bz
     real(amrex_real),intent(in):: exg(*), eyg(*), ezg(*), bxg(*), byg(*), bzg(*)
-    logical(pxr_logical) :: pxr_ll4symtry, pxr_l_lower_order_in_v
+    logical(pxr_logical) :: pxr_ll4symtry, pxr_l_lower_order_in_v, pxr_l_nodal
 
     ! Compute the number of valid cells and guard cells
     integer(c_long) :: exg_nvalid(AMREX_SPACEDIM), eyg_nvalid(AMREX_SPACEDIM), ezg_nvalid(AMREX_SPACEDIM),    &
@@ -102,7 +102,8 @@ contains
 
     pxr_ll4symtry = ll4symtry .eq. 1
     pxr_l_lower_order_in_v = l_lower_order_in_v .eq. 1
-
+    pxr_l_nodal = l_nodal .eq. 1
+    
     exg_nguards = ixyzmin - exg_lo
     eyg_nguards = ixyzmin - eyg_lo
     ezg_nguards = ixyzmin - ezg_lo
@@ -124,7 +125,7 @@ contains
          bxg,bxg_nguards,bxg_nvalid,&
          byg,byg_nguards,byg_nvalid,&
          bzg,bzg_nguards,bzg_nvalid,&
-	 pxr_ll4symtry, pxr_l_lower_order_in_v, &
+	 pxr_ll4symtry, pxr_l_lower_order_in_v, pxr_l_nodal, &
 	 lvect, field_gathe_algo )
 
   end subroutine warpx_geteb_energy_conserving


### PR DESCRIPTION
This PR adapts WarpX so as to be consistent with the API change introduced in PICSAR here:
https://bitbucket.org/berkeleylab/picsar/pull-requests/189

The function for field gathering takes a new boolean arguments (`l_nodal`) that tells whether the grids, which particles gather from, are nodal or staggered.