### PR TITLE
Particle splitting

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -208,6 +208,15 @@ Particle initialization
     Inject a backward-propagating beam to reduce the effect of charge-separation
     fields when running in the boosted frame. See examples.
 
+* ``<species_name>.do_splitting`` (`bool`) optional (default `0`)
+    Split particles of the species when crossing the boundary from a lower 
+    resolution domain to a higher resolution domain.
+
+* ``<species_name>.split_type`` (`int`) optional (default `0`)
+    Splitting technique. When `0`, particles are split along the simulation
+    axes (4 particles in 2D, 6 particles in 3D). When `1`, particles are split
+    along the diagonals (4 particles in 2D, 8 particles in 3D).
+
 * ``warpx.serialize_ics`` (`0 or 1`)
     Whether or not to use OpenMP threading for particle initialization.
 
@@ -392,6 +401,7 @@ Numerics and algorithms
 
      - ``0``: Vectorized version
      - ``1``: Non-optimized version
+
     .. warning::
 
         The vectorized version does not run on GPU. Use 

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -175,7 +175,6 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
-    bool do_splitting = false;
 
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -198,6 +198,7 @@ private:
 
     // physical particles (+ laser)
     amrex::Vector<std::unique_ptr<WarpXParticleContainer> > allcontainers;
+    // Temporary particle container, used e.g. for particle splitting.
     std::unique_ptr<PhysicalParticleContainer> pc_tmp;
 
     void ReadParameters ();

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -175,6 +175,8 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
+    bool do_splitting = false;
+
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;
 

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -180,9 +180,6 @@ public:
 
     std::vector<std::string> GetSpeciesNames() const { return species_names; }
 
-	// std::unique_ptr<amrex::ParticleContainer<0,0,PIdx::nattribs>> pc_tmp;
-    // std::unique_ptr<WarpXParticleContainer> pc_tmp;
-
 	PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
     
 protected:

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -179,6 +179,11 @@ public:
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;
 
     std::vector<std::string> GetSpeciesNames() const { return species_names; }
+
+	// std::unique_ptr<amrex::ParticleContainer<0,0,PIdx::nattribs>> pc_tmp;
+    // std::unique_ptr<WarpXParticleContainer> pc_tmp;
+
+	PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
     
 protected:
 
@@ -195,6 +200,7 @@ private:
 
     // physical particles (+ laser)
     amrex::Vector<std::unique_ptr<WarpXParticleContainer> > allcontainers;
+	std::unique_ptr<PhysicalParticleContainer> pc_tmp;
 
     void ReadParameters ();
 

--- a/Source/ParticleContainer.H
+++ b/Source/ParticleContainer.H
@@ -180,7 +180,7 @@ public:
 
     std::vector<std::string> GetSpeciesNames() const { return species_names; }
 
-	PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
+    PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
     
 protected:
 
@@ -197,7 +197,7 @@ private:
 
     // physical particles (+ laser)
     amrex::Vector<std::unique_ptr<WarpXParticleContainer> > allcontainers;
-	std::unique_ptr<PhysicalParticleContainer> pc_tmp;
+    std::unique_ptr<PhysicalParticleContainer> pc_tmp;
 
     void ReadParameters ();
 

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -24,7 +24,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[i].reset(new RigidInjectedParticleContainer(amr_core, i, species_names[i]));
         }
         allcontainers[i]->deposit_on_main_grid = deposit_on_main_grid[i];
-        if (allcontainers[i]->do_splitting){ do_splitting=true; }
     }
     if (WarpX::use_laser) {
 	allcontainers[n-1].reset(new LaserParticleContainer(amr_core,n-1));

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -28,13 +28,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     if (WarpX::use_laser) {
 	allcontainers[n-1].reset(new LaserParticleContainer(amr_core,n-1));
     }
-	//	pc_tmp = WarpXParticleContainer(amr_core, 0);
-	// pc_tmp = std::unique_ptr<WarpXParticleContainer> (new WarpXParticleContainer(this));
-	pc_tmp.reset(new PhysicalParticleContainer(amr_core));
-	// pc_tmp = std::unique_ptr<WarpXParticleContainer> (new WarpXParticleContainer(amr_core, 0));
-	// pc_tmp = std::unique_ptr<PhysicalParticleContainer> (new PhysicalParticleContainer(amr_core));
-	// pc_tmp = std::unique_ptr<amrex::ParticleContainer<0,0,PIdx::nattribs>> (new amrex::ParticleContainer<0,0,PIdx::nattribs>);
-	
+	pc_tmp.reset(new PhysicalParticleContainer(amr_core));	
 }
 
 void

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -277,7 +277,7 @@ MultiParticleContainer::Redistribute ()
     for (auto& pc : allcontainers) {
 	pc->Redistribute();
     }
-	pc_tmp->Redistribute();
+    pc_tmp->Redistribute();
 }
 
 void
@@ -286,7 +286,7 @@ MultiParticleContainer::RedistributeLocal (const int num_ghost)
     for (auto& pc : allcontainers) {
 	pc->Redistribute(0, 0, 0, num_ghost);
     }
-	pc_tmp->Redistribute(0, 0, 0, num_ghost);
+    pc_tmp->Redistribute(0, 0, 0, num_ghost);
 }
 
 Vector<long>
@@ -310,7 +310,7 @@ MultiParticleContainer::Increment (MultiFab& mf, int lev)
     for (auto& pc : allcontainers) {
 	pc->Increment(mf,lev);
     }
-	pc_tmp->Increment(mf,lev);
+    pc_tmp->Increment(mf,lev);
 }
 
 void
@@ -319,7 +319,7 @@ MultiParticleContainer::SetParticleBoxArray (int lev, BoxArray& new_ba)
     for (auto& pc : allcontainers) {
 	pc->SetParticleBoxArray(lev,new_ba);
     }
-	pc_tmp->SetParticleBoxArray(lev,new_ba);
+    pc_tmp->SetParticleBoxArray(lev,new_ba);
 }
 
 void
@@ -328,7 +328,7 @@ MultiParticleContainer::SetParticleDistributionMap (int lev, DistributionMapping
     for (auto& pc : allcontainers) {
 	pc->SetParticleDistributionMap(lev,new_dm);
     }
-	pc_tmp->SetParticleDistributionMap(lev,new_dm);
+    pc_tmp->SetParticleDistributionMap(lev,new_dm);
 }
 
 void
@@ -337,7 +337,7 @@ MultiParticleContainer::PostRestart ()
     for (auto& pc : allcontainers) {
 	pc->PostRestart();
     }
-	pc_tmp->PostRestart();
+    pc_tmp->PostRestart();
 }
 
 void

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -28,6 +28,13 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     if (WarpX::use_laser) {
 	allcontainers[n-1].reset(new LaserParticleContainer(amr_core,n-1));
     }
+	//	pc_tmp = WarpXParticleContainer(amr_core, 0);
+	// pc_tmp = std::unique_ptr<WarpXParticleContainer> (new WarpXParticleContainer(this));
+	pc_tmp.reset(new PhysicalParticleContainer(amr_core));
+	// pc_tmp = std::unique_ptr<WarpXParticleContainer> (new WarpXParticleContainer(amr_core, 0));
+	// pc_tmp = std::unique_ptr<PhysicalParticleContainer> (new PhysicalParticleContainer(amr_core));
+	// pc_tmp = std::unique_ptr<amrex::ParticleContainer<0,0,PIdx::nattribs>> (new amrex::ParticleContainer<0,0,PIdx::nattribs>);
+	
 }
 
 void
@@ -81,6 +88,7 @@ MultiParticleContainer::AllocData ()
     for (auto& pc : allcontainers) {
 	pc->AllocData();
     }
+    pc_tmp->AllocData();
 }
 
 void
@@ -89,6 +97,7 @@ MultiParticleContainer::InitData ()
     for (auto& pc : allcontainers) {
 	pc->InitData();
     }
+    pc_tmp->InitData();
 }
 
 
@@ -274,6 +283,7 @@ MultiParticleContainer::Redistribute ()
     for (auto& pc : allcontainers) {
 	pc->Redistribute();
     }
+	pc_tmp->Redistribute();
 }
 
 void
@@ -282,6 +292,7 @@ MultiParticleContainer::RedistributeLocal (const int num_ghost)
     for (auto& pc : allcontainers) {
 	pc->Redistribute(0, 0, 0, num_ghost);
     }
+	pc_tmp->Redistribute(0, 0, 0, num_ghost);
 }
 
 Vector<long>
@@ -305,6 +316,7 @@ MultiParticleContainer::Increment (MultiFab& mf, int lev)
     for (auto& pc : allcontainers) {
 	pc->Increment(mf,lev);
     }
+	pc_tmp->Increment(mf,lev);
 }
 
 void
@@ -313,6 +325,7 @@ MultiParticleContainer::SetParticleBoxArray (int lev, BoxArray& new_ba)
     for (auto& pc : allcontainers) {
 	pc->SetParticleBoxArray(lev,new_ba);
     }
+	pc_tmp->SetParticleBoxArray(lev,new_ba);
 }
 
 void
@@ -321,6 +334,7 @@ MultiParticleContainer::SetParticleDistributionMap (int lev, DistributionMapping
     for (auto& pc : allcontainers) {
 	pc->SetParticleDistributionMap(lev,new_dm);
     }
+	pc_tmp->SetParticleDistributionMap(lev,new_dm);
 }
 
 void
@@ -329,6 +343,7 @@ MultiParticleContainer::PostRestart ()
     for (auto& pc : allcontainers) {
 	pc->PostRestart();
     }
+	pc_tmp->PostRestart();
 }
 
 void

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -24,6 +24,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[i].reset(new RigidInjectedParticleContainer(amr_core, i, species_names[i]));
         }
         allcontainers[i]->deposit_on_main_grid = deposit_on_main_grid[i];
+        if (allcontainers[i]->do_splitting){ do_splitting=true; }
     }
     if (WarpX::use_laser) {
 	allcontainers[n-1].reset(new LaserParticleContainer(amr_core,n-1));

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -308,7 +308,6 @@ MultiParticleContainer::Increment (MultiFab& mf, int lev)
     for (auto& pc : allcontainers) {
 	pc->Increment(mf,lev);
     }
-    pc_tmp->Increment(mf,lev);
 }
 
 void
@@ -317,7 +316,6 @@ MultiParticleContainer::SetParticleBoxArray (int lev, BoxArray& new_ba)
     for (auto& pc : allcontainers) {
 	pc->SetParticleBoxArray(lev,new_ba);
     }
-    pc_tmp->SetParticleBoxArray(lev,new_ba);
 }
 
 void
@@ -326,7 +324,6 @@ MultiParticleContainer::SetParticleDistributionMap (int lev, DistributionMapping
     for (auto& pc : allcontainers) {
 	pc->SetParticleDistributionMap(lev,new_dm);
     }
-    pc_tmp->SetParticleDistributionMap(lev,new_dm);
 }
 
 void

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -278,7 +278,6 @@ MultiParticleContainer::Redistribute ()
     for (auto& pc : allcontainers) {
 	pc->Redistribute();
     }
-    pc_tmp->Redistribute();
 }
 
 void
@@ -287,7 +286,6 @@ MultiParticleContainer::RedistributeLocal (const int num_ghost)
     for (auto& pc : allcontainers) {
 	pc->Redistribute(0, 0, 0, num_ghost);
     }
-    pc_tmp->Redistribute(0, 0, 0, num_ghost);
 }
 
 Vector<long>

--- a/Source/ParticleContainer.cpp
+++ b/Source/ParticleContainer.cpp
@@ -28,7 +28,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     if (WarpX::use_laser) {
 	allcontainers[n-1].reset(new LaserParticleContainer(amr_core,n-1));
     }
-	pc_tmp.reset(new PhysicalParticleContainer(amr_core));	
+    pc_tmp.reset(new PhysicalParticleContainer(amr_core));	
 }
 
 void

--- a/Source/PhysicalParticleContainer.H
+++ b/Source/PhysicalParticleContainer.H
@@ -80,7 +80,7 @@ public:
 
     virtual void PostRestart () final {}
 
-    void SplitParticles(WarpXParIter& pti, int lev);
+    void SplitParticles(int lev);
 
     // Inject particles in Box 'part_box'
     virtual void AddParticles (int lev);
@@ -113,7 +113,7 @@ protected:
     // particle and the time of the boosted frame.
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
-    bool do_splitting = false;
+    //     bool do_splitting = false;
 
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,

--- a/Source/PhysicalParticleContainer.H
+++ b/Source/PhysicalParticleContainer.H
@@ -15,6 +15,9 @@ public:
     PhysicalParticleContainer (amrex::AmrCore* amr_core,
                                int ispecies,
                                const std::string& name);
+
+    PhysicalParticleContainer (amrex::AmrCore* amr_core);
+
     virtual ~PhysicalParticleContainer () {}
 
     virtual void InitData () override;
@@ -77,6 +80,8 @@ public:
 
     virtual void PostRestart () final {}
 
+	void SplitParticles(WarpXParIter& pti, int lev);
+
     // Inject particles in Box 'part_box'
     virtual void AddParticles (int lev);
     void AddPlasma(int lev, amrex::RealBox part_realbox = amrex::RealBox());
@@ -108,6 +113,7 @@ protected:
     // particle and the time of the boosted frame.
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
+	bool do_splitting = false;
 
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,

--- a/Source/PhysicalParticleContainer.H
+++ b/Source/PhysicalParticleContainer.H
@@ -80,7 +80,7 @@ public:
 
     virtual void PostRestart () final {}
 
-	void SplitParticles(WarpXParIter& pti, int lev);
+    void SplitParticles(WarpXParIter& pti, int lev);
 
     // Inject particles in Box 'part_box'
     virtual void AddParticles (int lev);
@@ -113,7 +113,7 @@ protected:
     // particle and the time of the boosted frame.
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
-	bool do_splitting = false;
+    bool do_splitting = false;
 
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,

--- a/Source/PhysicalParticleContainer.H
+++ b/Source/PhysicalParticleContainer.H
@@ -113,7 +113,6 @@ protected:
     // particle and the time of the boosted frame.
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
-    //     bool do_splitting = false;
 
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -1568,7 +1568,6 @@ PhysicalParticleContainer::SplitParticles(int lev)
             }
         }
     }
-    if (np_split_to_add>0){
 	// Add local arrays psplit_x etc. to the temporary
 	// particle container pctmp_split. Split particles
 	// are tagged with p.id()=NoSplitParticleID so that 
@@ -1587,10 +1586,9 @@ PhysicalParticleContainer::SplitParticles(int lev)
                                   psplit_w.dataPtr(),
                                   1, NoSplitParticleID);
 	// Copy particles from tmp to current particle container
-        addParticles(pctmp_split,1);
+    addParticles(pctmp_split,1);
 	// Clear tmp container
-        pctmp_split.clearParticles();
-    }
+    pctmp_split.clearParticles();
 }
 
 void

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -1441,100 +1441,100 @@ PhysicalParticleContainer::Evolve (int lev,
 void
 PhysicalParticleContainer::SplitParticles(WarpXParIter& pti, int lev)
 {
-	auto& mypc = WarpX::GetInstance().GetPartContainer();
-	auto& pctmp_split = mypc.GetPCtmp();
-	Cuda::DeviceVector<Real> xp, yp, zp;
-	pti.GetPosition(xp, yp, zp);
-	auto& attribs = pti.GetAttribs();
-	auto& wp  = attribs[PIdx::w ];
-	auto& uxp = attribs[PIdx::ux];
-	auto& uyp = attribs[PIdx::uy];
-	auto& uzp = attribs[PIdx::uz];
-	const long np = pti.numParticles();
-	Print()<<"lev "<<lev<<std::endl;
-	const std::array<Real,3>& dx = WarpX::CellSize(lev);
-	Print()<< "dx "<<dx[0]<<' '<<dx[1]<<' '<<dx[2]<<' '<<std::endl;
-	auto& particles = pti.GetArrayOfStructs();
-
-	RealVector psplit_x, psplit_y, psplit_z, psplit_w;
-	RealVector psplit_ux, psplit_uy, psplit_uz;
-	for(int i=0; i<np; i++){
-		auto& p = particles[i];
-		if (p.id() == SplitParticleID){
-			Print()<<"splitting particles\n";
+    auto& mypc = WarpX::GetInstance().GetPartContainer();
+    auto& pctmp_split = mypc.GetPCtmp();
+    Cuda::DeviceVector<Real> xp, yp, zp;
+    pti.GetPosition(xp, yp, zp);
+    auto& attribs = pti.GetAttribs();
+    auto& wp  = attribs[PIdx::w ];
+    auto& uxp = attribs[PIdx::ux];
+    auto& uyp = attribs[PIdx::uy];
+    auto& uzp = attribs[PIdx::uz];
+    const long np = pti.numParticles();
+    //Print()<<"lev "<<lev<<std::endl;
+    const std::array<Real,3>& dx = WarpX::CellSize(lev);
+    //Print()<< "dx "<<dx[0]<<' '<<dx[1]<<' '<<dx[2]<<' '<<std::endl;
+    auto& particles = pti.GetArrayOfStructs();
+    RealVector psplit_x, psplit_y, psplit_z, psplit_w;
+    RealVector psplit_ux, psplit_uy, psplit_uz;
+    for(int i=0; i<np; i++){
+        auto& p = particles[i];
+        if (p.id() == SplitParticleID){
+            Print()<<"splitting particles\n";
 #if (AMREX_SPACEDIM==2)
-			long np_split = 4;
+            long np_split = 4;
 #elif(AMREX_SPACEDIM==3)
-			long np_split = 6;
+            long np_split = 6;
 #endif
-			for (int ishift = -1; ishift < 2; ishift +=2 ){
+            for (int ishift = -1; ishift < 2; ishift +=2 ){
 #if (AMREX_SPACEDIM==2)
-				// Add one particle with offset in x
-				psplit_x.push_back( xp[i] + ishift*dx[0]/2 );
-				psplit_y.push_back( 0. );
-				psplit_z.push_back( zp[i] );
-				psplit_ux.push_back( uxp[i] );
-				psplit_uy.push_back( 0. );
-				psplit_uz.push_back( uzp[i] );
-				psplit_w.push_back( wp[i]/np_split );
-				// Add one particle with offset in z
-				psplit_x.push_back( xp[i] );
-				psplit_y.push_back( 0. );
-				psplit_z.push_back( zp[i] + ishift*dx[2]/2 );
-				psplit_ux.push_back( uxp[i] );
-				psplit_uy.push_back( 0. );
-				psplit_uz.push_back( uzp[i] );
-				psplit_w.push_back( wp[i]/np_split );
+                // Add one particle with offset in x
+                psplit_x.push_back( xp[i] + ishift*dx[0]/2 );
+                psplit_y.push_back( 0. );
+                psplit_z.push_back( zp[i] );
+                psplit_ux.push_back( uxp[i] );
+                psplit_uy.push_back( 0. );
+                psplit_uz.push_back( uzp[i] );
+                psplit_w.push_back( wp[i]/np_split );
+                // Add one particle with offset in z
+                psplit_x.push_back( xp[i] );
+                psplit_y.push_back( 0. );
+                psplit_z.push_back( zp[i] + ishift*dx[2]/2 );
+                psplit_ux.push_back( uxp[i] );
+                psplit_uy.push_back( 0. );
+                psplit_uz.push_back( uzp[i] );
+                psplit_w.push_back( wp[i]/np_split );
 #elif (AMREX_SPACEDIM==3)
-				// Add one particle with offset in x
-				psplit_x.push_back( xp[i] + ishift*dx[0]/2 );
-				psplit_y.push_back( yp[i] );
-				psplit_z.push_back( zp[i] );
-				psplit_ux.push_back( uxp[i] );
-				psplit_uy.push_back( uyp[i] );
-				psplit_uz.push_back( uzp[i] );
-				psplit_w.push_back( wp[i]/np_split );
-				// Add one particle with offset in y
-				psplit_x.push_back( xp[i] );
-				psplit_y.push_back( yp[i] + ishift*dx[1]/2);
-				psplit_z.push_back( zp[i] );
-				psplit_ux.push_back( uxp[i] );
-				psplit_uy.push_back( uyp[i] );
-				psplit_uz.push_back( uzp[i] );
-				psplit_w.push_back( wp[i]/np_split );
-				// Add one particle with offset in x
-				psplit_x.push_back( xp[i] );
-				psplit_y.push_back( yp[i] );
-				psplit_z.push_back( zp[i] + ishift*dx[2]/2 );
-				psplit_ux.push_back( uxp[i] );
-				psplit_uy.push_back( uyp[i] );
-				psplit_uz.push_back( uzp[i] );
-				psplit_w.push_back( wp[i]/np_split );
+                // Add one particle with offset in x
+                psplit_x.push_back( xp[i] + ishift*dx[0]/2 );
+                psplit_y.push_back( yp[i] );
+                psplit_z.push_back( zp[i] );
+                psplit_ux.push_back( uxp[i] );
+                psplit_uy.push_back( uyp[i] );
+                psplit_uz.push_back( uzp[i] );
+                psplit_w.push_back( wp[i]/np_split );
+                // Add one particle with offset in y
+                psplit_x.push_back( xp[i] );
+                psplit_y.push_back( yp[i] + ishift*dx[1]/2);
+                psplit_z.push_back( zp[i] );
+                psplit_ux.push_back( uxp[i] );
+                psplit_uy.push_back( uyp[i] );
+                psplit_uz.push_back( uzp[i] );
+                psplit_w.push_back( wp[i]/np_split );
+                // Add one particle with offset in x
+                psplit_x.push_back( xp[i] );
+                psplit_y.push_back( yp[i] );
+                psplit_z.push_back( zp[i] + ishift*dx[2]/2 );
+                psplit_ux.push_back( uxp[i] );
+                psplit_uy.push_back( uyp[i] );
+                psplit_uz.push_back( uzp[i] );
+                psplit_w.push_back( wp[i]/np_split );
 #endif
-			}
-			Print()<<"AddNParticles start\n";
-			pctmp_split.AddNParticles(lev, 
-									   np_split,
-									   psplit_x.dataPtr(),
-									   psplit_y.dataPtr(),
-									   psplit_z.dataPtr(),
-									   psplit_ux.dataPtr(),
-									   psplit_uy.dataPtr(),
-									   psplit_uz.dataPtr(),
-									   1,
-									   psplit_w.dataPtr(),
-									   1);
-			Print()<<"AddNParticles end\n";
-			p.m_idata.id = -p.m_idata.id; // invalidate the particle
-		}
-	}
-	// --- @atmyers -------------
-	// Add particles in pctmp_split to pti, assuming all particles
-	// already are in the appropriate tiles (no need to re-Redistribute).
-	// Delete particles in pctmp_split.
-	// pti.LocalCopyParticles(pctmp_split);
-	// --------------------------
+            }
+            Print()<<"AddNParticles start\n";
+            pctmp_split.AddNParticles(lev, 
+                                       np_split,
+                                       psplit_x.dataPtr(),
+                                       psplit_y.dataPtr(),
+                                       psplit_z.dataPtr(),
+                                       psplit_ux.dataPtr(),
+                                       psplit_uy.dataPtr(),
+                                       psplit_uz.dataPtr(),
+                                       1,
+                                       psplit_w.dataPtr(),
+                                       1);
+            Print()<<"AddNParticles end\n";
+            p.m_idata.id = -p.m_idata.id; // invalidate the particle
+        }
+    }
+    // --- @atmyers -------------
+    // Add particles in pctmp_split to pti, assuming all particles
+    // already are in the appropriate tiles (no need to re-Redistribute).
+    // Delete particles in pctmp_split.
+    // pti.LocalCopyParticles(pctmp_split);
+    // --------------------------
 }
+
 void
 PhysicalParticleContainer::PushPX(WarpXParIter& pti,
 	                          Cuda::DeviceVector<Real>& xp,

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -1443,8 +1443,6 @@ PhysicalParticleContainer::SplitParticles(WarpXParIter& pti, int lev)
 {
 	auto& mypc = WarpX::GetInstance().GetPartContainer();
 	auto& pctmp_split = mypc.GetPCtmp();
-	// std::unique_ptr<PhysicalParticleContainer> pc_tmp = mypc.pc_tmp;
-	//	WarpXParticleContainer ppc_tmp(amr_core, ispecies);
 	Cuda::DeviceVector<Real> xp, yp, zp;
 	pti.GetPosition(xp, yp, zp);
 	auto& attribs = pti.GetAttribs();
@@ -1459,7 +1457,6 @@ PhysicalParticleContainer::SplitParticles(WarpXParIter& pti, int lev)
 
 	RealVector psplit_x, psplit_y, psplit_z, psplit_w;
 	RealVector psplit_ux, psplit_uy, psplit_uz;
-	//	for (auto& p : particles){
 	for(int i=0; i<np; i++){
 		auto& p = particles[i];
 		if (p.id() == SplitParticleID){
@@ -1491,19 +1488,6 @@ PhysicalParticleContainer::SplitParticles(WarpXParIter& pti, int lev)
 #endif
 		}
 	}
-	/*
-	for (auto& p : particles){
-		if (p.id() == SplitParticleID){
-			Print()<<"toto\n";
-			
-		}
-	}
-
-	auto& uxp = attribs[PIdx::ux];
-	
-	for(int i, i<np, ++i){
-		if 
-		}*/
 }
 void
 PhysicalParticleContainer::PushPX(WarpXParIter& pti,

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -79,13 +79,13 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     pp.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
     pp.query("do_backward_propagation", do_backward_propagation);
-	pp.query("do_splitting", do_splitting);
+    pp.query("do_splitting", do_splitting);
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
     : WarpXParticleContainer(amr_core, 0)
 {
-	plasma_injector.reset(new PlasmaInjector());
+    plasma_injector.reset(new PlasmaInjector());
 }
 
 void PhysicalParticleContainer::InitData()
@@ -1403,7 +1403,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 //
                 BL_PROFILE_VAR_START(blp_pxr_pp);
                 PushPX(pti, m_xp[thread_num], m_yp[thread_num], m_zp[thread_num], 
-					   m_giv[thread_num], dt);
+                       m_giv[thread_num], dt);
                 BL_PROFILE_VAR_STOP(blp_pxr_pp);
 
 				// Split particles

--- a/Source/PhysicalParticleContainer.cpp
+++ b/Source/PhysicalParticleContainer.cpp
@@ -84,7 +84,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
     : WarpXParticleContainer(amr_core, 0)
-{}
+{
+	plasma_injector.reset(new PlasmaInjector());
+}
 
 void PhysicalParticleContainer::InitData()
 {

--- a/Source/PlasmaInjector.H
+++ b/Source/PlasmaInjector.H
@@ -239,6 +239,8 @@ public:
 
     using vec3 = std::array<amrex::Real, 3>;
 
+	PlasmaInjector();
+
     PlasmaInjector(int ispecies, const std::string& name);
 
     amrex::Real getDensity(amrex::Real x, amrex::Real y, amrex::Real z);

--- a/Source/PlasmaInjector.H
+++ b/Source/PlasmaInjector.H
@@ -239,7 +239,7 @@ public:
 
     using vec3 = std::array<amrex::Real, 3>;
 
-	PlasmaInjector();
+    PlasmaInjector();
 
     PlasmaInjector(int ispecies, const std::string& name);
 

--- a/Source/PlasmaInjector.cpp
+++ b/Source/PlasmaInjector.cpp
@@ -202,7 +202,7 @@ void RegularPosition::getPositionUnitBox(vec3& r, int i_part, int ref_fac)
 }
 
 PlasmaInjector::PlasmaInjector(){
-	part_pos = NULL;
+    part_pos = NULL;
 }
 
 PlasmaInjector::PlasmaInjector(int ispecies, const std::string& name)

--- a/Source/PlasmaInjector.cpp
+++ b/Source/PlasmaInjector.cpp
@@ -201,6 +201,10 @@ void RegularPosition::getPositionUnitBox(vec3& r, int i_part, int ref_fac)
   r[2] = (0.5+iz_part)/nz;
 }
 
+PlasmaInjector::PlasmaInjector(){
+	part_pos = NULL;
+}
+
 PlasmaInjector::PlasmaInjector(int ispecies, const std::string& name)
     : species_id(ispecies), species_name(name)
 {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -613,6 +613,13 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         ngJz = std::max(ngJz,2);
     }
 
+    // Add one J guard cell when doing splitting
+    if (mypc->do_splitting==true){
+        ngJx += 1;
+        ngJy += 1;
+        ngJz += 1;
+    }
+
 #if (AMREX_SPACEDIM == 3)
     IntVect ngE(ngx,ngy,ngz);
     IntVect ngJ(ngJx,ngJy,ngJz);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -601,11 +601,6 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
     int ngJy = ngy_tmp;
     int ngJz = ngz_tmp;
 
-	// add J guard cells if doing splitting
-	ngJx += 1;
-	ngJy += 1;
-	ngJz += 1;
-
     // When calling the moving window (with one level of refinement),  we shift
     // the fine grid by 2 cells ; therefore, we need at least 2 guard cells
     // on level 1. This may not be necessary for level 0.

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -601,6 +601,11 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
     int ngJy = ngy_tmp;
     int ngJz = ngz_tmp;
 
+	// add J guard cells if doing splitting
+	ngJx += 1;
+	ngJy += 1;
+	ngJz += 1;
+
     // When calling the moving window (with one level of refinement),  we shift
     // the fine grid by 2 cells ; therefore, we need at least 2 guard cells
     // on level 1. This may not be necessary for level 0.

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -613,13 +613,6 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         ngJz = std::max(ngJz,2);
     }
 
-    // Add one J guard cell when doing splitting
-    if (mypc->do_splitting==true){
-        ngJx += 1;
-        ngJy += 1;
-        ngJz += 1;
-    }
-
 #if (AMREX_SPACEDIM == 3)
     IntVect ngE(ngx,ngy,ngz);
     IntVect ngJ(ngJx,ngJy,ngJz);

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -218,8 +218,8 @@ protected:
   amrex::Vector<amrex::Cuda::DeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
 
 private:
-	virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,
-									const int lev) override;
+    virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,
+                                    const int lev) override;
 };
 
 #endif

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -199,6 +199,8 @@ public:
 
     static int NextID () { return ParticleType::NextID(); }
 
+    bool do_splitting = false;
+
 protected:
 
     int species_id;

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -200,7 +200,9 @@ public:
     static int NextID () { return ParticleType::NextID(); }
 
     bool do_splitting = false;
-    int split_type = 1;
+
+    // split along axes (0) or diagonals (1)
+    int split_type = 0;
 
 protected:
 

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -200,7 +200,7 @@ public:
     static int NextID () { return ParticleType::NextID(); }
 
     bool do_splitting = false;
-    int split_type = 0;
+    int split_type = 1;
 
 protected:
 

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -181,7 +181,7 @@ public:
     void AddNParticles (int lev,
                         int n, const amrex::Real* x, const amrex::Real* y, const amrex::Real* z,
 			const amrex::Real* vx, const amrex::Real* vy, const amrex::Real* vz,
-			int nattr, const amrex::Real* attr, int uniqueparticles);
+			int nattr, const amrex::Real* attr, int uniqueparticles, int id=-1);
 
     void AddOneParticle (int lev, int grid, int tile,
                          amrex::Real x, amrex::Real y, amrex::Real z,

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -216,7 +216,10 @@ protected:
   amrex::Vector<std::unique_ptr<amrex::FArrayBox> > local_jz;
 
   amrex::Vector<amrex::Cuda::DeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
-  
+
+private:
+	virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,
+									const int lev) override;
 };
 
 #endif

--- a/Source/WarpXParticleContainer.H
+++ b/Source/WarpXParticleContainer.H
@@ -200,6 +200,7 @@ public:
     static int NextID () { return ParticleType::NextID(); }
 
     bool do_splitting = false;
+    int split_type = 0;
 
 protected:
 

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -878,3 +878,52 @@ WarpXParticleContainer::PushX (int lev, Real dt)
         }
     }
 }
+
+void 
+WarpXParticleContainer::particlePostLocate(ParticleType& p, 
+										   const ParticleLocData& pld,
+										   const int lev)
+{
+	//  Print()<<"in WarpXParticleContainer::particlePostLocate"<<'\n';
+	//Print()<<p.id()<<'\n';
+	if (pld.m_lev == lev+1){
+		Print()<<"particle goes to higher level"<<'\n';
+		//p.id() = -777;
+		p.m_idata.id = SplitParticleID;
+		//p.id() = -777;
+		/*
+		  std::array<Real,PIdx::nattribs> attribs;
+		  attribs = p.attribs();
+		  attribs.fill(0.0);
+		  attribs[PIdx::w ] = dens * scale_fac / (AMREX_D_TERM(fac, *fac, *fac));
+		  attribs[PIdx::ux] = u[0];
+		  attribs[PIdx::uy] = u[1];
+		  attribs[PIdx::uz] = u[2];
+#ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS
+attribs[PIdx::xold] = x;
+attribs[PIdx::yold] = y;
+attribs[PIdx::zold] = z;
+attribs[PIdx::uxold] = u[0];
+attribs[PIdx::uyold] = u[1];
+attribs[PIdx::uzold] = u[2];
+#endif
+AddOneParticle(lev, grid_id, tile_id, x, y, z, attribs);
+		*/
+
+		/*
+            const int grid_id = mfi.index();
+            const int tile_id = mfi.LocalTileIndex();
+			locateParticle(p, pld, lev_min, lev_max, nGrow, local ? grid : -1);
+		*/  
+		/*
+		  AddOneParticle(pld.m_lev, 0, 0, x, 0, z, attribs);
+		  WarpXParticleContainer::AddOneParticle (int lev, int grid, int tile,
+		  Real x, Real y, Real z,
+		  const std::array<Real,PIdx::nattribs>& attribs)
+		*/
+	}
+	if (pld.m_lev == lev-1){
+		Print()<<"particle goes to lower level"<<'\n';
+		Print()<<"Do not do anything"<<'\n';
+	}
+}

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -79,7 +79,7 @@ WarpXParticleContainer::ReadParameters ()
 #else
         do_tiling = true;
 #endif
-	pp.query("do_tiling",  do_tiling);
+        pp.query("do_tiling",  do_tiling);
         pp.query("do_not_push", do_not_push);
 
 	initialized = true;

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -129,7 +129,7 @@ void
 WarpXParticleContainer::AddNParticles (int lev,
                                        int n, const Real* x, const Real* y, const Real* z,
 				       const Real* vx, const Real* vy, const Real* vz,
-				       int nattr, const Real* attr, int uniqueparticles)
+				       int nattr, const Real* attr, int uniqueparticles, int id)
 {	
     BL_ASSERT(nattr == 1);
     const Real* weight = attr;
@@ -160,7 +160,12 @@ WarpXParticleContainer::AddNParticles (int lev,
     for (int i = ibegin; i < iend; ++i)
     {
         ParticleType p;
-        p.id()  = ParticleType::NextID();
+	if (id==-1)
+	{
+	    p.id() = ParticleType::NextID();
+	} else {
+	    p.id() = NoSplitParticleID;
+	}
         p.cpu() = ParallelDescriptor::MyProc();
 #if (AMREX_SPACEDIM == 3)
         p.pos(0) = x[i];
@@ -886,14 +891,11 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 {
     // Tag particle if goes to higher level.
     // It will be split later in the loop
-    if (pld.m_lev == lev+1){
-        Print()<<"particle goes to higher level"<<'\n';
-        p.m_idata.id = SplitParticleID;
+    if (pld.m_lev == lev+1 and p.m_idata.id != NoSplitParticleID){
+        p.m_idata.id = DoSplitParticleID;
     }
     // For the moment, do not do anything if particles goes
     // to lower level.
     if (pld.m_lev == lev-1){
-        Print()<<"particle goes to lower level"<<'\n';
-        Print()<<"Do not do anything"<<'\n';
     }
 }

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -130,8 +130,7 @@ WarpXParticleContainer::AddNParticles (int lev,
                                        int n, const Real* x, const Real* y, const Real* z,
 				       const Real* vx, const Real* vy, const Real* vz,
 				       int nattr, const Real* attr, int uniqueparticles)
-{
-	
+{	
     BL_ASSERT(nattr == 1);
     const Real* weight = attr;
 
@@ -155,9 +154,9 @@ WarpXParticleContainer::AddNParticles (int lev,
 
     //  Add to grid 0 and tile 0
     // Redistribute() will move them to proper places.
-	std::pair<int,int> key {0,0};
-	auto& particle_tile = GetParticles(lev)[key];
-	
+    std::pair<int,int> key {0,0};
+    auto& particle_tile = GetParticles(lev)[key];
+
     for (int i = ibegin; i < iend; ++i)
     {
         ParticleType p;
@@ -882,19 +881,19 @@ WarpXParticleContainer::PushX (int lev, Real dt)
 
 void 
 WarpXParticleContainer::particlePostLocate(ParticleType& p, 
-										   const ParticleLocData& pld,
-										   const int lev)
+                                           const ParticleLocData& pld,
+                                           const int lev)
 {
-	// Tag particle if goes to higher level.
-	// It will be split later in the loop
-	if (pld.m_lev == lev+1){
-		Print()<<"particle goes to higher level"<<'\n';
-		p.m_idata.id = SplitParticleID;
-	}
-	// For the moment, do not do anything if particles goes
-	// to lower level.
-	if (pld.m_lev == lev-1){
-		Print()<<"particle goes to lower level"<<'\n';
-		Print()<<"Do not do anything"<<'\n';
-	}
+    // Tag particle if goes to higher level.
+    // It will be split later in the loop
+    if (pld.m_lev == lev+1){
+        Print()<<"particle goes to higher level"<<'\n';
+        p.m_idata.id = SplitParticleID;
+    }
+    // For the moment, do not do anything if particles goes
+    // to lower level.
+    if (pld.m_lev == lev-1){
+        Print()<<"particle goes to lower level"<<'\n';
+        Print()<<"Do not do anything"<<'\n';
+    }
 }

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -885,10 +885,14 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 										   const ParticleLocData& pld,
 										   const int lev)
 {
+	// Tag particle if goes to higher level.
+	// It will be split later in the loop
 	if (pld.m_lev == lev+1){
 		Print()<<"particle goes to higher level"<<'\n';
 		p.m_idata.id = SplitParticleID;
 	}
+	// For the moment, do not do anything if particles goes
+	// to lower level.
 	if (pld.m_lev == lev-1){
 		Print()<<"particle goes to lower level"<<'\n';
 		Print()<<"Do not do anything"<<'\n';

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -168,8 +168,11 @@ WarpXParticleContainer::AddNParticles (int lev,
     {
 		Print()<<"here -5\n";
         ParticleType p;
+		Print()<<"here -51\n";
         p.id()  = ParticleType::NextID();
+		Print()<<"here -52\n";
         p.cpu() = ParallelDescriptor::MyProc();
+		Print()<<"here -53\n";
 #if (AMREX_SPACEDIM == 3)
         p.pos(0) = x[i];
         p.pos(1) = y[i];

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -132,17 +132,14 @@ WarpXParticleContainer::AddNParticles (int lev,
 				       int nattr, const Real* attr, int uniqueparticles)
 {
 	
-	Print()<<"here -1\n";
     BL_ASSERT(nattr == 1);
     const Real* weight = attr;
 
     int ibegin, iend;
     if (uniqueparticles) {
-	Print()<<"here -2\n";
 	ibegin = 0;
 	iend = n;
     } else {
-	Print()<<"here -3\n";
 	int myproc = ParallelDescriptor::MyProc();
 	int nprocs = ParallelDescriptor::NProcs();
 	int navg = n/nprocs;
@@ -158,27 +155,19 @@ WarpXParticleContainer::AddNParticles (int lev,
 
     //  Add to grid 0 and tile 0
     // Redistribute() will move them to proper places.
-	Print()<<"here -4\n";
-    std::pair<int,int> key {0,0};
-	Print()<<"here -10\n";
-    auto& particle_tile = GetParticles(lev)[key];
-	Print()<<"here -11\n";
-
+	std::pair<int,int> key {0,0};
+	auto& particle_tile = GetParticles(lev)[key];
+	
     for (int i = ibegin; i < iend; ++i)
     {
-		Print()<<"here -5\n";
         ParticleType p;
-		Print()<<"here -51\n";
         p.id()  = ParticleType::NextID();
-		Print()<<"here -52\n";
         p.cpu() = ParallelDescriptor::MyProc();
-		Print()<<"here -53\n";
 #if (AMREX_SPACEDIM == 3)
         p.pos(0) = x[i];
         p.pos(1) = y[i];
         p.pos(2) = z[i];
 #elif (AMREX_SPACEDIM == 2)
-		Print()<<"here -6\n";
         p.pos(0) = x[i];
         p.pos(1) = z[i];
 #endif
@@ -189,24 +178,18 @@ WarpXParticleContainer::AddNParticles (int lev,
 
     if (np > 0)
     {
-		Print()<<"here 1\n";
         particle_tile.push_back_real(PIdx::w , weight + ibegin, weight + iend);
-		Print()<<"here 2\n";
         particle_tile.push_back_real(PIdx::ux,     vx + ibegin,     vx + iend);
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
-		Print()<<"here 3\n";
         for (int comp = PIdx::uz+1; comp < PIdx::nattribs; ++comp)
         {
-		Print()<<"here 4\n";
             particle_tile.push_back_real(comp, np, 0.0);
         }
     }
 
-	Print()<<"here 5\n";
     Redistribute();
-	Print()<<"here 6\n";
 }
 
 
@@ -902,43 +885,9 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 										   const ParticleLocData& pld,
 										   const int lev)
 {
-	//  Print()<<"in WarpXParticleContainer::particlePostLocate"<<'\n';
-	//Print()<<p.id()<<'\n';
 	if (pld.m_lev == lev+1){
 		Print()<<"particle goes to higher level"<<'\n';
-		//p.id() = -777;
 		p.m_idata.id = SplitParticleID;
-		//p.id() = -777;
-		/*
-		  std::array<Real,PIdx::nattribs> attribs;
-		  attribs = p.attribs();
-		  attribs.fill(0.0);
-		  attribs[PIdx::w ] = dens * scale_fac / (AMREX_D_TERM(fac, *fac, *fac));
-		  attribs[PIdx::ux] = u[0];
-		  attribs[PIdx::uy] = u[1];
-		  attribs[PIdx::uz] = u[2];
-#ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS
-attribs[PIdx::xold] = x;
-attribs[PIdx::yold] = y;
-attribs[PIdx::zold] = z;
-attribs[PIdx::uxold] = u[0];
-attribs[PIdx::uyold] = u[1];
-attribs[PIdx::uzold] = u[2];
-#endif
-AddOneParticle(lev, grid_id, tile_id, x, y, z, attribs);
-		*/
-
-		/*
-            const int grid_id = mfi.index();
-            const int tile_id = mfi.LocalTileIndex();
-			locateParticle(p, pld, lev_min, lev_max, nGrow, local ? grid : -1);
-		*/  
-		/*
-		  AddOneParticle(pld.m_lev, 0, 0, x, 0, z, attribs);
-		  WarpXParticleContainer::AddOneParticle (int lev, int grid, int tile,
-		  Real x, Real y, Real z,
-		  const std::array<Real,PIdx::nattribs>& attribs)
-		*/
 	}
 	if (pld.m_lev == lev-1){
 		Print()<<"particle goes to lower level"<<'\n';

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -131,14 +131,18 @@ WarpXParticleContainer::AddNParticles (int lev,
 				       const Real* vx, const Real* vy, const Real* vz,
 				       int nattr, const Real* attr, int uniqueparticles)
 {
+	
+	Print()<<"here -1\n";
     BL_ASSERT(nattr == 1);
     const Real* weight = attr;
 
     int ibegin, iend;
     if (uniqueparticles) {
+	Print()<<"here -2\n";
 	ibegin = 0;
 	iend = n;
     } else {
+	Print()<<"here -3\n";
 	int myproc = ParallelDescriptor::MyProc();
 	int nprocs = ParallelDescriptor::NProcs();
 	int navg = n/nprocs;
@@ -154,11 +158,15 @@ WarpXParticleContainer::AddNParticles (int lev,
 
     //  Add to grid 0 and tile 0
     // Redistribute() will move them to proper places.
+	Print()<<"here -4\n";
     std::pair<int,int> key {0,0};
+	Print()<<"here -10\n";
     auto& particle_tile = GetParticles(lev)[key];
+	Print()<<"here -11\n";
 
     for (int i = ibegin; i < iend; ++i)
     {
+		Print()<<"here -5\n";
         ParticleType p;
         p.id()  = ParticleType::NextID();
         p.cpu() = ParallelDescriptor::MyProc();
@@ -167,6 +175,7 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = y[i];
         p.pos(2) = z[i];
 #elif (AMREX_SPACEDIM == 2)
+		Print()<<"here -6\n";
         p.pos(0) = x[i];
         p.pos(1) = z[i];
 #endif
@@ -177,18 +186,24 @@ WarpXParticleContainer::AddNParticles (int lev,
 
     if (np > 0)
     {
+		Print()<<"here 1\n";
         particle_tile.push_back_real(PIdx::w , weight + ibegin, weight + iend);
+		Print()<<"here 2\n";
         particle_tile.push_back_real(PIdx::ux,     vx + ibegin,     vx + iend);
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
+		Print()<<"here 3\n";
         for (int comp = PIdx::uz+1; comp < PIdx::nattribs; ++comp)
         {
+		Print()<<"here 4\n";
             particle_tile.push_back_real(comp, np, 0.0);
         }
     }
 
+	Print()<<"here 5\n";
     Redistribute();
+	Print()<<"here 6\n";
 }
 
 

--- a/Source/WarpXParticleContainer.cpp
+++ b/Source/WarpXParticleContainer.cpp
@@ -164,7 +164,7 @@ WarpXParticleContainer::AddNParticles (int lev,
 	{
 	    p.id() = ParticleType::NextID();
 	} else {
-	    p.id() = NoSplitParticleID;
+	    p.id() = id;
 	}
         p.cpu() = ParallelDescriptor::MyProc();
 #if (AMREX_SPACEDIM == 3)
@@ -884,6 +884,7 @@ WarpXParticleContainer::PushX (int lev, Real dt)
     }
 }
 
+// This function is called in Redistribute, just after locate
 void 
 WarpXParticleContainer::particlePostLocate(ParticleType& p, 
                                            const ParticleLocData& pld,


### PR DESCRIPTION
This PR implements particle splitting in WarpX. Each particle gets tagged (in Redistribute) when going from level `lev` to level `lev+1` (if it has not been split yet). At each iteration, a loop over particles splits tagged particles. It involves the creation of a new particle container `pc_tmp` in `MultiParticleContainer`, which required to modify initialization several functions. The split loop looks like:

- Loop over particles:
     if a particle is tagged `SplitParticleID`, create `np_split` particles (4 in 2d, 6 or 8 in 3d), and add them to `pc_tmp`. Then invalidate the particle (give it a <0 id).
- Redistribute `pc_tmp`
- Copy particles in `pc_tmp` to the initial particle container tile by tile.

For the moment, particles in `pc_tmp` are not initialized with a mass, etc. so that we cannot call the current deposition on them. That could easily be done later, in a second step.