### PR TITLE
Update installation instructions

### DIFF
--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -1,11 +1,11 @@
 Building/installing WarpX
 =========================
 
-WarpX can currently be built (and run) in two variants:
-   - as a compiled executable (run with the command line)
-   - as a Python package (run through a Python script)
+WarpX can be built with various options. This page describes the most basic
+build, and points to instructions for more advanced builds.
 
-Currently, for both of these options, the user needs to build the code from source.
+Even if you are interested in more advanced builds, we recommend reading this
+page first.
 
 Downloading the source code
 ---------------------------
@@ -29,8 +29,16 @@ Then switch to the branch ``development`` of AMReX
     git checkout development
     cd ..
 
-Compiling WarpX as an executable
---------------------------------
+and to the branch ``dev`` of WarpX
+
+::
+
+    cd WarpX/
+    git checkout dev
+    cd ..
+
+Basic compilation
+-----------------
 
 ``cd`` into the directory ``WarpX`` and type
 
@@ -68,43 +76,15 @@ In order to clean a previously compiled version:
 
     make realclean
 
-
-Installing WarpX as a Python package
-------------------------------------
-
-Type
-
-::
-
-    make -j 4 USE_PYTHON_MAIN=TRUE
-
-or edit the GNUmakefile and set `USE_PYTHON_MAIN=TRUE`, and type
-
-::
-
-    make -j 4
-
-This will compile the code, and install the Python bindings as a package (named
-``pywarpx``) in your standard Python installation (i.e. in your
-``site-packages`` directory). The note on compiler options from the previous
-section also holds when compiling the Python package.
-
-In case you do not have write permissions to the default Python installation (e.g. typical on computer clusters), use the following command instead:
-
-::
-
-   make -j 4 PYINSTALLOPTIONS=--user
-
-In this case, you can also set the variable `PYTHONUSERBASE` to set the folder where `pywarpx` will be installed.
-
 Advanced building instructions
 ------------------------------
-
 
 .. toctree::
    :maxdepth: 1
 
    spectral
+   gpu_local
+   python
+   spack
    cori
    summit
-   spack

--- a/Docs/source/building/gpu_local.rst
+++ b/Docs/source/building/gpu_local.rst
@@ -1,0 +1,42 @@
+Building WarpX with GPU support (Linux only)
+--------------------------------------------
+
+.. warning::
+
+  In order to build WarpX on a specific GPU cluster (e.g. Summit),
+  look for the corresponding specific instructions, instead
+  of those on this page.
+
+In order to build WarpX with GPU support, it necessary to install:
+
+- The PGI compiler. The free PGI Community Edition can be installed from
+  `this page <https://www.pgroup.com/products/community.htm>`__.
+
+- `Spack <https://spack.readthedocs.io/en/latest/index.html>`__:
+
+  ::
+
+    git clone https://github.com/spack/spack.git
+    export SPACK_ROOT=/path/to/spack
+    . $SPACK_ROOT/share/spack/setup-env.sh
+
+Next, you will to install of version of MPI which is compatible with the PGI
+compiler (using Spack). First of all, make sure that Spack is aware of the PGI
+compiler:
+
+  ::
+
+    spack compiler find
+    spack compilers
+
+Then run:
+
+  ::
+
+    spack install mvapich2 fabrics=sock %pgi ^libpciaccess%gcc
+
+Finally, WarpX can be compiled with
+
+  ::
+
+    make -j 4 USE_GPU=TRUE COMP=pgi

--- a/Docs/source/building/gpu_local.rst
+++ b/Docs/source/building/gpu_local.rst
@@ -39,4 +39,5 @@ Finally, WarpX can be compiled with
 
   ::
 
+    spack load mvapich2%pgi
     make -j 4 USE_GPU=TRUE COMP=pgi

--- a/Docs/source/building/python.rst
+++ b/Docs/source/building/python.rst
@@ -1,0 +1,27 @@
+Installing WarpX as a Python package
+------------------------------------
+
+Type
+
+::
+
+    make -j 4 USE_PYTHON_MAIN=TRUE
+
+or edit the GNUmakefile and set `USE_PYTHON_MAIN=TRUE`, and type
+
+::
+
+    make -j 4
+
+This will compile the code, and install the Python bindings as a package (named
+``pywarpx``) in your standard Python installation (i.e. in your
+``site-packages`` directory). The note on compiler options from the previous
+section also holds when compiling the Python package.
+
+In case you do not have write permissions to the default Python installation (e.g. typical on computer clusters), use the following command instead:
+
+::
+
+   make -j 4 PYINSTALLOPTIONS=--user
+
+In this case, you can also set the variable `PYTHONUSERBASE` to set the folder where `pywarpx` will be installed.


### PR DESCRIPTION
This makes a few modifications/updates to the installation instructions, in order to reflect the current state of the code.

- I added a section on how to compile WarpX for a local GPU machine. I tested those instructions on my local machine, but @atmyers @WeiqunZhang Do you have anything to add/suggest on these instructions?

- AMReX/WarpX are currently evolving so fast that usually the `master` branch of WarpX is incompatible with the `development` branch of AMReX. Therefore, I suggest to use the `dev` branch of WarpX below. We do have stable releases that could be used instead, but maybe these would be more useful at a later stage of the code.

- I think that having the Python build instructions on the main page was making it quite long and maybe a bit confusing. I moved the Python instructions to the "advanced build" sections.

