### PR TITLE
DeviceVector -> ManagedDeviceVector

### DIFF
--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -336,7 +336,7 @@ LaserParticleContainer::Evolve (int lev,
       if (local_jy[thread_num]  == nullptr) local_jy[thread_num].reset(  new amrex::FArrayBox());
       if (local_jz[thread_num]  == nullptr) local_jz[thread_num].reset(  new amrex::FArrayBox());
 
-        Cuda::DeviceVector<Real> plane_Xp, plane_Yp, amplitude_E;
+        Cuda::ManagedDeviceVector<Real> plane_Xp, plane_Yp, amplitude_E;
 
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
 	{

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -64,10 +64,10 @@ public:
                          amrex::Real dt) override;
 
     virtual void PushPX(WarpXParIter& pti,
-	                amrex::Cuda::DeviceVector<amrex::Real>& xp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& yp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& zp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& giv,
+	                amrex::Cuda::ManagedDeviceVector<amrex::Real>& xp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& yp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& zp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& giv,
                         amrex::Real dt);
 
     virtual void PushP (int lev, amrex::Real dt,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -927,7 +927,7 @@ PhysicalParticleContainer::FieldGather (int lev,
 #pragma omp parallel
 #endif
     {
-        Cuda::DeviceVector<Real> xp, yp, zp;
+        Cuda::ManagedDeviceVector<Real> xp, yp, zp;
 
 	for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
 	{
@@ -1444,7 +1444,7 @@ PhysicalParticleContainer::SplitParticles(int lev)
 {
     auto& mypc = WarpX::GetInstance().GetPartContainer();
     auto& pctmp_split = mypc.GetPCtmp();
-    Cuda::DeviceVector<Real> xp, yp, zp;
+    Cuda::ManagedDeviceVector<Real> xp, yp, zp;
     RealVector psplit_x, psplit_y, psplit_z, psplit_w;
     RealVector psplit_ux, psplit_uy, psplit_uz;
     long np_split_to_add = 0;
@@ -1593,10 +1593,10 @@ PhysicalParticleContainer::SplitParticles(int lev)
 
 void
 PhysicalParticleContainer::PushPX(WarpXParIter& pti,
-	                          Cuda::DeviceVector<Real>& xp,
-                                  Cuda::DeviceVector<Real>& yp,
-                                  Cuda::DeviceVector<Real>& zp,
-                                  Cuda::DeviceVector<Real>& giv,
+	                          Cuda::ManagedDeviceVector<Real>& xp,
+                                  Cuda::ManagedDeviceVector<Real>& yp,
+                                  Cuda::ManagedDeviceVector<Real>& zp,
+                                  Cuda::ManagedDeviceVector<Real>& giv,
                                   Real dt)
 {
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -43,10 +43,10 @@ public:
                          amrex::Real dt) override;
 
     virtual void PushPX(WarpXParIter& pti,
-	                amrex::Cuda::DeviceVector<amrex::Real>& xp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& yp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& zp,
-                        amrex::Cuda::DeviceVector<amrex::Real>& giv,
+	                amrex::Cuda::ManagedDeviceVector<amrex::Real>& xp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& yp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& zp,
+                        amrex::Cuda::ManagedDeviceVector<amrex::Real>& giv,
                         amrex::Real dt) override;
 
     virtual void PushP (int lev, amrex::Real dt,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -73,7 +73,7 @@ RigidInjectedParticleContainer::RemapParticles()
                 // Note that the particles are already in the boosted frame.
                 // This value is saved to advance the particles not injected yet
 
-                Cuda::DeviceVector<Real> xp, yp, zp;
+                Cuda::ManagedDeviceVector<Real> xp, yp, zp;
 
                 for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
                 {
@@ -134,7 +134,7 @@ RigidInjectedParticleContainer::BoostandRemapParticles()
 #pragma omp parallel
 #endif
     {
-        Cuda::DeviceVector<Real> xp, yp, zp;
+        Cuda::ManagedDeviceVector<Real> xp, yp, zp;
 
         for (WarpXParIter pti(*this, 0); pti.isValid(); ++pti)
         {
@@ -205,10 +205,10 @@ RigidInjectedParticleContainer::BoostandRemapParticles()
 
 void
 RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
-	                               Cuda::DeviceVector<Real>& xp,
-                                       Cuda::DeviceVector<Real>& yp,
-                                       Cuda::DeviceVector<Real>& zp,
-                                       Cuda::DeviceVector<Real>& giv,
+	                               Cuda::ManagedDeviceVector<Real>& xp,
+                                       Cuda::ManagedDeviceVector<Real>& yp,
+                                       Cuda::ManagedDeviceVector<Real>& zp,
+                                       Cuda::ManagedDeviceVector<Real>& giv,
                                        Real dt)
 {
 
@@ -241,7 +241,7 @@ RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
 #endif
 
     // Save the position and momenta, making copies
-    Cuda::DeviceVector<Real> xp_save, yp_save, zp_save;
+    Cuda::ManagedDeviceVector<Real> xp_save, yp_save, zp_save;
     RealVector uxp_save, uyp_save, uzp_save;
 
     if (!done_injecting_lev) {
@@ -362,7 +362,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
 #pragma omp parallel
 #endif
     {
-        Cuda::DeviceVector<Real> xp, yp, zp, giv;
+        Cuda::ManagedDeviceVector<Real> xp, yp, zp, giv;
 
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -36,12 +36,12 @@ public:
     WarpXParIter (ContainerType& pc, int level);
 
 #if (AMREX_SPACEDIM == 2)
-    void GetPosition (amrex::Cuda::DeviceVector<amrex::Real>& x,
-                      amrex::Cuda::DeviceVector<amrex::Real>& y,
-                      amrex::Cuda::DeviceVector<amrex::Real>& z) const;
-    void SetPosition (const amrex::Cuda::DeviceVector<amrex::Real>& x,
-                      const amrex::Cuda::DeviceVector<amrex::Real>& y,
-                      const amrex::Cuda::DeviceVector<amrex::Real>& z);
+    void GetPosition (amrex::Cuda::ManagedDeviceVector<amrex::Real>& x,
+                      amrex::Cuda::ManagedDeviceVector<amrex::Real>& y,
+                      amrex::Cuda::ManagedDeviceVector<amrex::Real>& z) const;
+    void SetPosition (const amrex::Cuda::ManagedDeviceVector<amrex::Real>& x,
+                      const amrex::Cuda::ManagedDeviceVector<amrex::Real>& y,
+                      const amrex::Cuda::ManagedDeviceVector<amrex::Real>& z);
 #endif
 
     const std::array<RealVector, PIdx::nattribs>& GetAttribs () const { 
@@ -220,7 +220,7 @@ protected:
   amrex::Vector<std::unique_ptr<amrex::FArrayBox> > local_jy;
   amrex::Vector<std::unique_ptr<amrex::FArrayBox> > local_jz;
 
-  amrex::Vector<amrex::Cuda::DeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
+  amrex::Vector<amrex::Cuda::ManagedDeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
 
 private:
     virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -18,14 +18,14 @@ WarpXParIter::WarpXParIter (ContainerType& pc, int level)
 
 #if (AMREX_SPACEDIM == 2)
 void
-WarpXParIter::GetPosition (Cuda::DeviceVector<Real>& x, Cuda::DeviceVector<Real>& y, Cuda::DeviceVector<Real>& z) const
+WarpXParIter::GetPosition (Cuda::ManagedDeviceVector<Real>& x, Cuda::ManagedDeviceVector<Real>& y, Cuda::ManagedDeviceVector<Real>& z) const
 {
     amrex::ParIter<0,0,PIdx::nattribs>::GetPosition(x, z);
     y.resize(x.size(), std::numeric_limits<Real>::quiet_NaN());
 }
 
 void
-WarpXParIter::SetPosition (const Cuda::DeviceVector<Real>& x, const Cuda::DeviceVector<Real>& y, const Cuda::DeviceVector<Real>& z)
+WarpXParIter::SetPosition (const Cuda::ManagedDeviceVector<Real>& x, const Cuda::ManagedDeviceVector<Real>& y, const Cuda::ManagedDeviceVector<Real>& z)
 {
     amrex::ParIter<0,0,PIdx::nattribs>::SetPosition(x, z);
 }
@@ -732,7 +732,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 #pragma omp parallel
 #endif
     {
-        Cuda::DeviceVector<Real> xp, yp, zp;
+        Cuda::ManagedDeviceVector<Real> xp, yp, zp;
         FArrayBox local_rho;
 
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -955,7 +955,7 @@ WarpXParticleContainer::PushX (int lev, Real dt)
 #pragma omp parallel
 #endif
     {
-        Cuda::DeviceVector<Real> xp, yp, zp, giv;
+        Cuda::ManagedDeviceVector<Real> xp, yp, zp, giv;
 
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {


### PR DESCRIPTION
This helps, but don't fully restore the memory usage to where it used to be:

END REGION WarpX::Evolve()
Total GPU global memory (MB) spread across MPI: [16128 ... 16128]
Free  GPU global memory (MB) spread across MPI: [1 ... 7579]
[The         Arena] space (MB) used spread across MPI: [9864 ... 27145]
[The  Device Arena] space (MB) used spread across MPI: [8 ... 8]
[The Managed Arena] space (MB) used spread across MPI: [8 ... 8]
[The  Pinned Arena] space (MB) used spread across MPI: [8 ... 16]
AMReX (18.11-1643-g1460aef9fb25) finalized