### PR TITLE
Reorganize field IO

### DIFF
--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -9,4 +9,14 @@ void
 PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
 		  const std::array<std::unique_ptr<MultiFab>,3>& data);
 
+void
+AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
+                         const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
+                         const int dcomp, const int ngrow );
+
+void
+AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
+                         const MultiFab & scalar_field,
+                         const int dcomp, const int ngrow );
+
 #endif

--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -1,0 +1,12 @@
+#ifndef WARPX_FielIO_H_
+#define WARPX_FielIO_H_
+
+#include <WarpX.H>
+
+using namespace amrex;
+
+void
+PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
+		  const std::array<std::unique_ptr<MultiFab>,3>& data);
+
+#endif

--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -10,12 +10,12 @@ PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
 		  const std::array<std::unique_ptr<MultiFab>,3>& data);
 
 void
-AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
+AverageAndPackVectorField( MultiFab& mf_avg,
                          const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
                          const int dcomp, const int ngrow );
 
 void
-AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
+AverageAndPackScalarField( MultiFab& mf_avg,
                          const MultiFab & scalar_field,
                          const int dcomp, const int ngrow );
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -21,24 +21,21 @@ AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> > mf_avg,
     // Check the type of staggering of the 3-component `vector_field`
     // and average accordingly:
     // - Fully cell-centered field (no average needed; simply copy)
-    if ( std::all_of( 0, AMREX_SPACEDIM,
-        [](int i){ return vector_field[lev][i]->is_cell_centered(); } ) ){
+    if ( vector_field[lev][0]->is_cell_centered() ){
 
         MultiFab::Copy(*mf_avg[lev], *vector_field[lev][0], 0, dcomp  , 1, ngrow);
         MultiFab::Copy(*mf_avg[lev], *vector_field[lev][1], 0, dcomp+1, 1, ngrow);
         MultiFab::Copy(*mf_avg[lev], *vector_field[lev][2], 0, dcomp+2, 1, ngrow);
 
     // - Fully nodal
-    } else if ( std::all_of( 0, AMREX_SPACEDIM,
-        [](int i){ return vector_field[lev][i]->is_nodal(); } ) ){
+} else if ( vector_field[lev][0]->is_nodal() ){
 
         amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *vector_field[lev][0], 0, 1);
         amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *vector_field[lev][1], 0, 1);
         amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *vector_field[lev][2], 0, 1);
 
-    // - Staggered, in the same way as E on a Yee grid
-    } else if ( std::all_of( 0, AMREX_SPACEDIM,
-        [](int i){ return vector_field[lev][i]->is_cell_centered(i); } ) ){
+    // - Edge centered, in the same way as E on a Yee grid
+} else if ( vector_field[lev][0]->is_cell_centered(0) ){
 
         PackPlotDataPtrs(srcmf, vector);
         amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
@@ -47,9 +44,8 @@ AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> > mf_avg,
         MultiFab::average_node_to_cellcenter(*mf_avg[lev], *vector_field[lev][1], 0, dcomp+1, 1, ngrow);
 #endif
 
-    // - Staggered, in the same way as B on a Yee grid
-    } else if ( std::all_of( 0, AMREX_SPACEDIM,
-        [](int i){ return vector_field[lev][i]->is_nodal(i); } ) ){
+    // - Face centered, in the same way as B on a Yee grid
+} else if ( vector_field[lev][0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector);
         amrex::average_face_to_cellcenter(*mf_avg[lev], dcomp, srcmf);

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -101,14 +101,14 @@ AverageAndPackScalarField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
     // Check the type of staggering of the 3-component `vector_field`
     // and average accordingly:
     // - Fully cell-centered field (no average needed; simply copy)
-    if ( vector_field[0]->is_cell_centered() ){
+    if ( scalar_field.is_cell_centered() ){
 
-        MultiFab::Copy(*mf_avg[lev], *scalar_field, 0, dcomp, 1, ngrow);
+        MultiFab::Copy(*mf_avg[lev], scalar_field, 0, dcomp, 1, ngrow);
 
     // - Fully nodal
-    } else if ( vector_field[0]->is_nodal() ){
+    } else if ( scalar_field.is_nodal() ){
 
-        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, *scalar_field, 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, scalar_field, 0, 1);
 
     } else {
         amrex::Abort("Unknown staggering.");
@@ -164,7 +164,7 @@ WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
 
       // MultiFab containing number of particles in each cell
       mypc->Increment(temp_dat, lev);
-      AverageAndPackScalarField( mf_avg, temp_data, dcomp, lev, ngrow, varnames, "part_per_cell" );
+      AverageAndPackScalarField( mf_avg, temp_dat, dcomp, lev, ngrow, varnames, "part_per_cell" );
       dcomp += 1;
     }
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -1,5 +1,6 @@
 
 #include <WarpX.H>
+#include <FieldIO.H>
 
 using namespace amrex;
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -6,7 +6,7 @@ using namespace amrex;
 
 void
 PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
-                         const std::array<std::unique_ptr<MultiFab>,3>& data)
+                  const std::array<std::unique_ptr<MultiFab>,3>& data)
 {
     BL_ASSERT(pmf.size() == AMREX_SPACEDIM);
 #if (AMREX_SPACEDIM == 3)
@@ -20,16 +20,16 @@ PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
 }
 
 /** \brief Takes an array of 3 MultiFab `vector_field`
-  * (representing the x, y, z components of a vector),
-  * averages it to the cell center, and stores the
-  * resulting MultiFab in mf_avg (in the components dcomp to dcomp+2)
-  */
+ * (representing the x, y, z components of a vector),
+ * averages it to the cell center, and stores the
+ * resulting MultiFab in mf_avg (in the components dcomp to dcomp+2)
+ */
 void
 AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
-    const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
-    const int dcomp, const int lev, const int ngrow,
-    Vector<std::string>& varnames,
-    const std::string field_name, const std::string field_subscript )
+                           const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
+                           const int dcomp, const int lev, const int ngrow,
+                           Vector<std::string>& varnames,
+                           const std::string field_name, const std::string field_subscript )
 {
     // Append the names of the current vector field to the list of names
     if (lev == 0){
@@ -51,15 +51,18 @@ AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
         MultiFab::Copy(*mf_avg[lev], *vector_field[1], 0, dcomp+1, 1, ngrow);
         MultiFab::Copy(*mf_avg[lev], *vector_field[2], 0, dcomp+2, 1, ngrow);
 
-    // - Fully nodal
-} else if ( vector_field[0]->is_nodal() ){
+        // - Fully nodal
+    } else if ( vector_field[0]->is_nodal() ){
 
-        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *vector_field[0], 0, 1);
-        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *vector_field[1], 0, 1);
-        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *vector_field[2], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , 
+                                          *vector_field[0], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, 
+                                          *vector_field[1], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, 
+                                          *vector_field[2], 0, 1);
 
-    // - Face centered, in the same way as B on a Yee grid
-} else if ( vector_field[0]->is_nodal(0) ){
+        // - Face centered, in the same way as B on a Yee grid
+    } else if ( vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
         amrex::average_face_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
@@ -68,31 +71,32 @@ AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
         MultiFab::Copy(*mf_avg[lev], *vector_field[1], 0, dcomp+1, 1, ngrow);
 #endif
 
-    // - Edge centered, in the same way as E on a Yee grid
-} else if ( !vector_field[0]->is_nodal(0) ){
+        // - Edge centered, in the same way as E on a Yee grid
+    } else if ( !vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
         amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
 #if (AMREX_SPACEDIM == 2)
         MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
-        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *vector_field[1], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, 
+                                          *vector_field[1], 0, 1);
 #endif
 
     } else {
-       amrex::Abort("Unknown staggering.");
+        amrex::Abort("Unknown staggering.");
     }
 }
 
 /** \brief Take a MultiFab `scalar_field`
-  * averages it to the cell center, and stores the
-  * resulting MultiFab in mf_avg (in the components dcomp)
-  */
+ * averages it to the cell center, and stores the
+ * resulting MultiFab in mf_avg (in the components dcomp)
+ */
 void
 AverageAndPackScalarField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
-    const MultiFab & scalar_field,
-    const int dcomp, const int lev, const int ngrow,
-    Vector<std::string>& varnames,
-    const std::string field_name )
+                           const MultiFab & scalar_field,
+                           const int dcomp, const int lev, const int ngrow,
+                           Vector<std::string>& varnames,
+                           const std::string field_name )
 {
     // Append the name to the list of names
     if (lev == 0){
@@ -106,7 +110,7 @@ AverageAndPackScalarField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
 
         MultiFab::Copy(*mf_avg[lev], scalar_field, 0, dcomp, 1, ngrow);
 
-    // - Fully nodal
+        // - Fully nodal
     } else if ( scalar_field.is_nodal() ){
 
         amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, scalar_field, 0, 1);
@@ -117,8 +121,8 @@ AverageAndPackScalarField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
 }
 
 /** \brief Write the different fields of the simulation,
-* averaged to the cell center of each cell (default WarpX output)
-*/
+ * averaged to the cell center of each cell (default WarpX output)
+ */
 void
 WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
 {
@@ -127,207 +131,232 @@ WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
     // mf_avg will contain the averaged, cell-centered fields
     Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
 
-  // Count how many different fields should be written (ncomp)
-  const int ncomp = 3*3
-  + static_cast<int>(plot_part_per_cell)
-  + static_cast<int>(plot_part_per_grid)
-  + static_cast<int>(plot_part_per_proc)
-  + static_cast<int>(plot_proc_number)
-  + static_cast<int>(plot_divb)
-  + static_cast<int>(plot_dive)
-  + static_cast<int>(plot_rho)
-  + static_cast<int>(plot_F)
-  + static_cast<int>(plot_finepatch)*6
-  + static_cast<int>(plot_crsepatch)*6
-  + static_cast<int>(costs[0] != nullptr);
+    // Count how many different fields should be written (ncomp)
+    const int ncomp = 3*3
+        + static_cast<int>(plot_part_per_cell)
+        + static_cast<int>(plot_part_per_grid)
+        + static_cast<int>(plot_part_per_proc)
+        + static_cast<int>(plot_proc_number)
+        + static_cast<int>(plot_divb)
+        + static_cast<int>(plot_dive)
+        + static_cast<int>(plot_rho)
+        + static_cast<int>(plot_F)
+        + static_cast<int>(plot_finepatch)*6
+        + static_cast<int>(plot_crsepatch)*6
+        + static_cast<int>(costs[0] != nullptr);
 
-  const int ngrow = 0;
+    const int ngrow = 0;
 
-  // Loop over levels of refinement
-  for (int lev = 0; lev <= finest_level; ++lev)
-  {
-    // Allocate pointers to the `ncomp` fields that will be added
-    mf_avg[lev].reset(new MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
-
-    // Go through the different fields, pack them into mf_avg[lev], and increment dcomp
-    int dcomp = 0;
-    AverageAndPackVectorField( mf_avg, current_fp[lev], dcomp, lev, ngrow, varnames, "j", "" );
-    dcomp += 3;
-    AverageAndPackVectorField( mf_avg, Efield_aux[lev], dcomp, lev, ngrow, varnames, "E", "" );
-    dcomp += 3;
-    AverageAndPackVectorField( mf_avg, Bfield_aux[lev], dcomp, lev, ngrow, varnames, "B", "" );
-    dcomp += 3;
-
-    if (plot_part_per_cell)
-    {
-      MultiFab temp_dat(grids[lev],mf_avg[lev]->DistributionMap(),1,0);
-      temp_dat.setVal(0);
-
-      // MultiFab containing number of particles in each cell
-      mypc->Increment(temp_dat, lev);
-      AverageAndPackScalarField( mf_avg, temp_dat, dcomp, lev, ngrow, varnames, "part_per_cell" );
-      dcomp += 1;
-    }
-
-    if (plot_part_per_grid || plot_part_per_proc)
-    {
-      const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
-
-      if (plot_part_per_grid)
-      {
-        // MultiFab containing number of particles per grid (stored as constant for all cells in each grid)
-        #ifdef _OPENMP
-        #pragma omp parallel
-        #endif
-        for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
-          (*mf_avg[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), dcomp);
-        }
-        if (lev == 0)
+    // Loop over levels of refinement
+    for (int lev = 0; lev <= finest_level; ++lev)
         {
-          varnames.push_back("part_per_grid");
+            // Allocate pointers to the `ncomp` fields that will be added
+            mf_avg[lev].reset(new MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
+
+            // Go through the different fields, pack them into mf_avg[lev], 
+            // and increment dcomp
+            int dcomp = 0;
+            AverageAndPackVectorField( mf_avg, current_fp[lev], dcomp, 
+                                       lev, ngrow, varnames, "j", "" );
+            dcomp += 3;
+            AverageAndPackVectorField( mf_avg, Efield_aux[lev], dcomp, 
+                                       lev, ngrow, varnames, "E", "" );
+            dcomp += 3;
+            AverageAndPackVectorField( mf_avg, Bfield_aux[lev], dcomp, 
+                                       lev, ngrow, varnames, "B", "" );
+            dcomp += 3;
+
+            if (plot_part_per_cell)
+                {
+                    MultiFab temp_dat(grids[lev],mf_avg[lev]->DistributionMap(),1,0);
+                    temp_dat.setVal(0);
+
+                    // MultiFab containing number of particles in each cell
+                    mypc->Increment(temp_dat, lev);
+                    AverageAndPackScalarField( mf_avg, temp_dat, dcomp, lev, 
+                                               ngrow, varnames, "part_per_cell" );
+                    dcomp += 1;
+                }
+
+            if (plot_part_per_grid || plot_part_per_proc)
+                {
+                    const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
+
+                    if (plot_part_per_grid)
+                        {
+                            // MultiFab containing number of particles per grid 
+                            // (stored as constant for all cells in each grid)
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+                            for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+                                (*mf_avg[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), 
+                                                           dcomp);
+                            }
+                            if (lev == 0)
+                                {
+                                    varnames.push_back("part_per_grid");
+                                }
+                            dcomp += 1;
+                        }
+
+                    if (plot_part_per_proc)
+                        {
+                            // MultiFab containing number of particles per process 
+                            // (stored as constant for all cells in each grid)
+                            long n_per_proc = 0;
+#ifdef _OPENMP
+#pragma omp parallel reduction(+:n_per_proc)
+#endif
+                            for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+                                n_per_proc += npart_in_grid[mfi.index()];
+                            }
+                            mf_avg[lev]->setVal(static_cast<Real>(n_per_proc), dcomp,1);
+                            if (lev == 0)
+                                {
+                                    varnames.push_back("part_per_proc");
+                                }
+                            dcomp += 1;
+                        }
+                }
+
+            if (plot_proc_number)
+                {
+                    // MultiFab containing the Processor ID
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+                    for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+                        (*mf_avg[lev])[mfi].setVal(static_cast<Real>(ParallelDescriptor::MyProc()), 
+                                                   dcomp);
+                    }
+                    if (lev == 0)
+                        {
+                            varnames.push_back("proc_number");
+                        }
+                    dcomp += 1;
+                }
+
+            if (plot_divb)
+                {
+                    if (do_nodal) amrex::Abort("TODO: do_nodal && plot_divb");
+                    ComputeDivB(*mf_avg[lev], dcomp,
+                                {Bfield_aux[lev][0].get(),
+                                        Bfield_aux[lev][1].get(),
+                                        Bfield_aux[lev][2].get()},
+                                WarpX::CellSize(lev)
+                                );
+                    if (lev == 0)
+                        {
+                            varnames.push_back("divB");
+                        }
+                    dcomp += 1;
+                }
+
+            if (plot_dive)
+                {
+                    if (do_nodal) amrex::Abort("TODO: do_nodal && plot_dive");
+                    const BoxArray& ba = amrex::convert(boxArray(lev),IntVect::TheUnitVector());
+                    MultiFab dive(ba,DistributionMap(lev),1,0);
+                    ComputeDivE( dive, 0,
+                                 {Efield_aux[lev][0].get(), 
+                                         Efield_aux[lev][1].get(), 
+                                         Efield_aux[lev][2].get()},
+                                 WarpX::CellSize(lev)
+                                 );
+                    AverageAndPackScalarField( mf_avg, dive, dcomp, 
+                                               lev, ngrow, varnames, "divE" );
+                    dcomp += 1;
+                }
+
+            if (plot_rho)
+                {
+                    AverageAndPackScalarField( mf_avg, *rho_fp[lev], dcomp, 
+                                               lev, ngrow, varnames, "rho" );
+                    dcomp += 1;
+                }
+
+            if (plot_F)
+                {
+                    AverageAndPackScalarField( mf_avg, *F_fp[lev], dcomp, 
+                                               lev, ngrow, varnames, "F" );
+                    dcomp += 1;
+                }
+
+            if (plot_finepatch)
+                {
+                    AverageAndPackVectorField( mf_avg, Efield_fp[lev], dcomp, 
+                                               lev, ngrow, varnames, 
+                                               "E", "_fp" );
+                    dcomp += 3;
+                    AverageAndPackVectorField( mf_avg, Bfield_fp[lev], dcomp, lev, 
+                                               ngrow, varnames, "B", "_fp" );
+                    dcomp += 3;
+                }
+
+            if (plot_crsepatch)
+                {
+
+                    if (lev == 0)
+                        {
+                            mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
+                            varnames.push_back("Ex_cp");
+                            varnames.push_back("Ey_cp");
+                            varnames.push_back("Ez_cp");
+                        }
+                    else
+                        {
+                            if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
+                            std::array<std::unique_ptr<MultiFab>, 3> E = getInterpolatedE(lev);
+                            AverageAndPackVectorField( mf_avg, E, dcomp, lev, 
+                                                       ngrow, varnames, "E", "_cp" );
+                        }
+                    dcomp += 3;
+
+                    // now the magnetic field
+                    if (lev == 0)
+                        {
+                            mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
+                            varnames.push_back("Bx_cp");
+                            varnames.push_back("By_cp");
+                            varnames.push_back("Bz_cp");
+                        }
+                    else
+                        {
+                            if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
+                            std::array<std::unique_ptr<MultiFab>, 3> B = getInterpolatedB(lev);
+                            AverageAndPackVectorField( mf_avg, B, dcomp, lev, 
+                                                       ngrow, varnames, "B", "_cp" );
+                        }
+                    dcomp += 3;
+                }
+
+            if (costs[0] != nullptr)
+                {
+                    AverageAndPackScalarField( mf_avg, *costs[lev], 
+                                               dcomp, 
+                                               lev, ngrow, varnames, 
+                                               "costs" );
+                    dcomp += 1;
+                }
+
+            BL_ASSERT(dcomp == ncomp);
         }
-        dcomp += 1;
-      }
 
-      if (plot_part_per_proc)
-      {
-        // MultiFab containing number of particles per process (stored as constant for all cells in each grid)
-        long n_per_proc = 0;
-        #ifdef _OPENMP
-        #pragma omp parallel reduction(+:n_per_proc)
-        #endif
-        for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
-          n_per_proc += npart_in_grid[mfi.index()];
-        }
-        mf_avg[lev]->setVal(static_cast<Real>(n_per_proc), dcomp,1);
-        if (lev == 0)
-        {
-          varnames.push_back("part_per_proc");
-        }
-        dcomp += 1;
-      }
-    }
-
-    if (plot_proc_number)
-    {
-      // MultiFab containing the Processor ID
-      #ifdef _OPENMP
-      #pragma omp parallel
-      #endif
-      for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
-        (*mf_avg[lev])[mfi].setVal(static_cast<Real>(ParallelDescriptor::MyProc()), dcomp);
-      }
-      if (lev == 0)
-      {
-        varnames.push_back("proc_number");
-      }
-      dcomp += 1;
-    }
-
-    if (plot_divb)
-    {
-      if (do_nodal) amrex::Abort("TODO: do_nodal && plot_divb");
-      ComputeDivB(*mf_avg[lev], dcomp,
-          {Bfield_aux[lev][0].get(),Bfield_aux[lev][1].get(),Bfield_aux[lev][2].get()},
-          WarpX::CellSize(lev)
-      );
-      if (lev == 0)
-      {
-        varnames.push_back("divB");
-      }
-      dcomp += 1;
-    }
-
-    if (plot_dive)
-    {
-      if (do_nodal) amrex::Abort("TODO: do_nodal && plot_dive");
-      const BoxArray& ba = amrex::convert(boxArray(lev),IntVect::TheUnitVector());
-      MultiFab dive(ba,DistributionMap(lev),1,0);
-      ComputeDivE( dive, 0,
-        {Efield_aux[lev][0].get(), Efield_aux[lev][1].get(), Efield_aux[lev][2].get()},
-        WarpX::CellSize(lev)
-      );
-      AverageAndPackScalarField( mf_avg, dive, dcomp, lev, ngrow, varnames, "divE" );
-      dcomp += 1;
-    }
-
-    if (plot_rho)
-    {
-      AverageAndPackScalarField( mf_avg, *rho_fp[lev], dcomp, lev, ngrow, varnames, "rho" );
-      dcomp += 1;
-    }
-
-    if (plot_F)
-    {
-      AverageAndPackScalarField( mf_avg, *F_fp[lev], dcomp, lev, ngrow, varnames, "F" );
-      dcomp += 1;
-    }
-
-    if (plot_finepatch)
-    {
-      AverageAndPackVectorField( mf_avg, Efield_fp[lev], dcomp, lev, ngrow, varnames, "E", "_fp" );
-      dcomp += 3;
-      AverageAndPackVectorField( mf_avg, Bfield_fp[lev], dcomp, lev, ngrow, varnames, "B", "_fp" );
-      dcomp += 3;
-    }
-
-    if (plot_crsepatch)
-    {
-
-      if (lev == 0)
-      {
-        mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
-        varnames.push_back("Ex_cp");
-        varnames.push_back("Ey_cp");
-        varnames.push_back("Ez_cp");
-      }
-      else
-      {
-        if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
-        std::array<std::unique_ptr<MultiFab>, 3> E = getInterpolatedE(lev);
-        AverageAndPackVectorField( mf_avg, E, dcomp, lev, ngrow, varnames, "E", "_cp" );
-      }
-      dcomp += 3;
-
-      // now the magnetic field
-      if (lev == 0)
-      {
-        mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
-        varnames.push_back("Bx_cp");
-        varnames.push_back("By_cp");
-        varnames.push_back("Bz_cp");
-      }
-      else
-      {
-        if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
-        std::array<std::unique_ptr<MultiFab>, 3> B = getInterpolatedB(lev);
-        AverageAndPackVectorField( mf_avg, B, dcomp, lev, ngrow, varnames, "B", "_cp" );
-      }
-      dcomp += 3;
-    }
-
-    if (costs[0] != nullptr)
-    {
-      AverageAndPackScalarField( mf_avg, *costs[lev], dcomp, lev, ngrow, varnames, "costs" );
-      dcomp += 1;
-    }
-
-    BL_ASSERT(dcomp == ncomp);
-  }
-
-  // Write the fields contained in `mf_avg`, and corresponding to the
-  // names `varnames`, into a plotfile.
-  // Prepare extra directory (filled later), for the raw fields
-  Vector<std::string> rfs;
-  if (plot_raw_fields) rfs.emplace_back("raw_fields");
-  amrex::WriteMultiLevelPlotfile(
-    plotfilename, finest_level+1,
-    amrex::GetVecOfConstPtrs(mf_avg),
-    varnames, Geom(), t_new[0], istep, refRatio(),
-    "HyperCLaw-V1.1",
-    "Level_",
-    "Cell",
-    rfs
-  );
+    // Write the fields contained in `mf_avg`, and corresponding to the
+    // names `varnames`, into a plotfile.
+    // Prepare extra directory (filled later), for the raw fields
+    Vector<std::string> rfs;
+    if (plot_raw_fields) rfs.emplace_back("raw_fields");
+    amrex::WriteMultiLevelPlotfile(
+                                   plotfilename, finest_level+1,
+                                   amrex::GetVecOfConstPtrs(mf_avg),
+                                   varnames, Geom(), t_new[0], istep, 
+                                   refRatio(),
+                                   "HyperCLaw-V1.1",
+                                   "Level_",
+                                   "Cell",
+                                   rfs
+                                   );
 
 };

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -25,7 +25,7 @@ PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
   */
 void
 AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
-    std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
+    const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
     const int dcomp, const int lev, const int ngrow,
     Vector<std::string>& varnames,
     const std::string field_name, const std::string field_subscript )
@@ -74,7 +74,7 @@ AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
         amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
 #if (AMREX_SPACEDIM == 2)
         MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
-        MultiFab::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *vector_field[1], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *vector_field[1], 0, 1);
 #endif
 
     } else {

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -108,13 +108,9 @@ AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
  * averaged to the cell center of each cell (default WarpX output)
  */
 void
-WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
+WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
+    amrex::Vector<std::unique_ptr<MultiFab>>& mf_avg, const int ngrow) const
 {
-
-    Vector<std::string> varnames; // Name of the written fields
-    // mf_avg will contain the averaged, cell-centered fields
-    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
-
     // Count how many different fields should be written (ncomp)
     const int ncomp = 3*3
         + static_cast<int>(plot_part_per_cell)
@@ -128,8 +124,6 @@ WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
         + static_cast<int>(plot_finepatch)*6
         + static_cast<int>(plot_crsepatch)*6
         + static_cast<int>(costs[0] != nullptr);
-
-    const int ngrow = 0;
 
     // Loop over levels of refinement
     for (int lev = 0; lev <= finest_level; ++lev)
@@ -300,23 +294,6 @@ WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
             dcomp += 1;
         }
 
-        BL_ASSERT(dcomp == ncomp);
-        } // end loop over levels of refinement
-
-    // Write the fields contained in `mf_avg`, and corresponding to the
-    // names `varnames`, into a plotfile.
-    // Prepare extra directory (filled later), for the raw fields
-    Vector<std::string> rfs;
-    if (plot_raw_fields) rfs.emplace_back("raw_fields");
-    amrex::WriteMultiLevelPlotfile(
-                                   plotfilename, finest_level+1,
-                                   amrex::GetVecOfConstPtrs(mf_avg),
-                                   varnames, Geom(), t_new[0], istep,
-                                   refRatio(),
-                                   "HyperCLaw-V1.1",
-                                   "Level_",
-                                   "Cell",
-                                   rfs
-                                   );
-
+    BL_ASSERT(dcomp == ncomp);
+    } // end loop over levels of refinement
 };

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -24,8 +24,8 @@ PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
   * resulting MultiFab in mf_avg (in the components dcomp to dcomp+2)
   */
 void
-AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> > mf_avg,
-    Vector<std::array< std::unique_ptr<MultiFab>, 3 >> vector_field,
+AverageAndPackVectorField( Vector<std::unique_ptr<MultiFab> >& mf_avg,
+    const Vector<std::array< std::unique_ptr<MultiFab>, 3 >>& vector_field,
     const int dcomp, const int lev, const int ngrow,
     Vector<std::string>& varnames,
     const std::string field_name, const std::string field_subscript )

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -46,17 +46,17 @@ AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
     } else if ( vector_field[0]->is_nodal() ){
 
         amrex::average_node_to_cellcenter(*mf_avg, dcomp  ,
-                                          *vector_field[0], 0, 1);
+                                          *vector_field[0], 0, 1, ngrow);
         amrex::average_node_to_cellcenter(*mf_avg, dcomp+1,
-                                          *vector_field[1], 0, 1);
+                                          *vector_field[1], 0, 1, ngrow);
         amrex::average_node_to_cellcenter(*mf_avg, dcomp+2,
-                                          *vector_field[2], 0, 1);
+                                          *vector_field[2], 0, 1, ngrow);
 
         // - Face centered, in the same way as B on a Yee grid
     } else if ( vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
-        amrex::average_face_to_cellcenter(*mf_avg, dcomp, srcmf);
+        amrex::average_face_to_cellcenter(*mf_avg, dcomp, srcmf, ngrow);
 #if (AMREX_SPACEDIM == 2)
         MultiFab::Copy(*mf_avg, *mf_avg, dcomp+1, dcomp+2, 1, ngrow);
         MultiFab::Copy(*mf_avg, *vector_field[1], 0, dcomp+1, 1, ngrow);
@@ -66,11 +66,11 @@ AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
     } else if ( !vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
-        amrex::average_edge_to_cellcenter(*mf_avg, dcomp, srcmf);
+        amrex::average_edge_to_cellcenter(*mf_avg, dcomp, srcmf, ngrow);
 #if (AMREX_SPACEDIM == 2)
         MultiFab::Copy(*mf_avg, *mf_avg, dcomp+1, dcomp+2, 1, ngrow);
         amrex::average_node_to_cellcenter(*mf_avg, dcomp+1,
-                                          *vector_field[1], 0, 1);
+                                          *vector_field[1], 0, 1, ngrow);
 #endif
 
     } else {
@@ -97,7 +97,7 @@ AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
         // - Fully nodal
     } else if ( scalar_field.is_nodal() ){
 
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp, scalar_field, 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg, dcomp, scalar_field, 0, 1, ngrow);
 
     } else {
         amrex::Abort("Unknown staggering.");

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -25,7 +25,7 @@ PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
  * resulting MultiFab in mf_avg (in the components dcomp to dcomp+2)
  */
 void
-AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
+AverageAndPackVectorField( MultiFab& mf_avg,
                            const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
                            const int dcomp, const int ngrow )
 {
@@ -38,38 +38,38 @@ AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
     // - Fully cell-centered field (no average needed; simply copy)
     if ( vector_field[0]->is_cell_centered() ){
 
-        MultiFab::Copy( *mf_avg, *vector_field[0], 0, dcomp  , 1, ngrow);
-        MultiFab::Copy( *mf_avg, *vector_field[1], 0, dcomp+1, 1, ngrow);
-        MultiFab::Copy( *mf_avg, *vector_field[2], 0, dcomp+2, 1, ngrow);
+        MultiFab::Copy( mf_avg, *vector_field[0], 0, dcomp  , 1, ngrow);
+        MultiFab::Copy( mf_avg, *vector_field[1], 0, dcomp+1, 1, ngrow);
+        MultiFab::Copy( mf_avg, *vector_field[2], 0, dcomp+2, 1, ngrow);
 
         // - Fully nodal
     } else if ( vector_field[0]->is_nodal() ){
 
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp  ,
+        amrex::average_node_to_cellcenter( mf_avg, dcomp  ,
                                           *vector_field[0], 0, 1, ngrow);
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp+1,
+        amrex::average_node_to_cellcenter( mf_avg, dcomp+1,
                                           *vector_field[1], 0, 1, ngrow);
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp+2,
+        amrex::average_node_to_cellcenter( mf_avg, dcomp+2,
                                           *vector_field[2], 0, 1, ngrow);
 
         // - Face centered, in the same way as B on a Yee grid
     } else if ( vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
-        amrex::average_face_to_cellcenter(*mf_avg, dcomp, srcmf, ngrow);
+        amrex::average_face_to_cellcenter( mf_avg, dcomp, srcmf, ngrow);
 #if (AMREX_SPACEDIM == 2)
-        MultiFab::Copy(*mf_avg, *mf_avg, dcomp+1, dcomp+2, 1, ngrow);
-        MultiFab::Copy(*mf_avg, *vector_field[1], 0, dcomp+1, 1, ngrow);
+        MultiFab::Copy( mf_avg, mf_avg, dcomp+1, dcomp+2, 1, ngrow);
+        MultiFab::Copy( mf_avg, *vector_field[1], 0, dcomp+1, 1, ngrow);
 #endif
 
         // - Edge centered, in the same way as E on a Yee grid
     } else if ( !vector_field[0]->is_nodal(0) ){
 
         PackPlotDataPtrs(srcmf, vector_field);
-        amrex::average_edge_to_cellcenter(*mf_avg, dcomp, srcmf, ngrow);
+        amrex::average_edge_to_cellcenter( mf_avg, dcomp, srcmf, ngrow);
 #if (AMREX_SPACEDIM == 2)
-        MultiFab::Copy(*mf_avg, *mf_avg, dcomp+1, dcomp+2, 1, ngrow);
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp+1,
+        MultiFab::Copy( mf_avg, mf_avg, dcomp+1, dcomp+2, 1, ngrow);
+        amrex::average_node_to_cellcenter( mf_avg, dcomp+1,
                                           *vector_field[1], 0, 1, ngrow);
 #endif
 
@@ -83,7 +83,7 @@ AverageAndPackVectorField( const std::unique_ptr<MultiFab>& mf_avg,
  * resulting MultiFab in mf_avg (in the components dcomp)
  */
 void
-AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
+AverageAndPackScalarField( MultiFab& mf_avg,
                            const MultiFab & scalar_field,
                            const int dcomp, const int ngrow )
 {
@@ -92,12 +92,12 @@ AverageAndPackScalarField( std::unique_ptr<MultiFab>& mf_avg,
     // - Fully cell-centered field (no average needed; simply copy)
     if ( scalar_field.is_cell_centered() ){
 
-        MultiFab::Copy(*mf_avg, scalar_field, 0, dcomp, 1, ngrow);
+        MultiFab::Copy( mf_avg, scalar_field, 0, dcomp, 1, ngrow);
 
         // - Fully nodal
     } else if ( scalar_field.is_nodal() ){
 
-        amrex::average_node_to_cellcenter(*mf_avg, dcomp, scalar_field, 0, 1, ngrow);
+        amrex::average_node_to_cellcenter( mf_avg, dcomp, scalar_field, 0, 1, ngrow);
 
     } else {
         amrex::Abort("Unknown staggering.");
@@ -134,13 +134,13 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         // Go through the different fields, pack them into mf_avg[lev],
         // add the corresponding names to `varnames` and increment dcomp
         int dcomp = 0;
-        AverageAndPackVectorField(mf_avg[lev], current_fp[lev], dcomp, ngrow);
+        AverageAndPackVectorField(*mf_avg[lev], current_fp[lev], dcomp, ngrow);
         if(lev==0) for(auto name:{"jx","jy","jz"}) varnames.push_back(name);
         dcomp += 3;
-        AverageAndPackVectorField(mf_avg[lev], Efield_aux[lev], dcomp, ngrow);
+        AverageAndPackVectorField(*mf_avg[lev], Efield_aux[lev], dcomp, ngrow);
         if(lev==0) for(auto name:{"Ex","Ey","Ez"}) varnames.push_back(name);
         dcomp += 3;
-        AverageAndPackVectorField(mf_avg[lev], Bfield_aux[lev], dcomp, ngrow);
+        AverageAndPackVectorField(*mf_avg[lev], Bfield_aux[lev], dcomp, ngrow);
         if(lev==0) for(auto name:{"Bx","By","Bz"}) varnames.push_back(name);
         dcomp += 3;
 
@@ -151,7 +151,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
 
             // MultiFab containing number of particles in each cell
             mypc->Increment(temp_dat, lev);
-            AverageAndPackScalarField( mf_avg[lev], temp_dat, dcomp, ngrow );
+            AverageAndPackScalarField( *mf_avg[lev], temp_dat, dcomp, ngrow );
             if(lev==0) varnames.push_back("part_per_cell");
             dcomp += 1;
         }
@@ -227,31 +227,31 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
                                  Efield_aux[lev][2].get()},
                          WarpX::CellSize(lev)
                          );
-            AverageAndPackScalarField( mf_avg[lev], dive, dcomp, ngrow );
+            AverageAndPackScalarField( *mf_avg[lev], dive, dcomp, ngrow );
             if(lev == 0) varnames.push_back("divE");
             dcomp += 1;
         }
 
         if (plot_rho)
         {
-            AverageAndPackScalarField( mf_avg[lev], *rho_fp[lev], dcomp, ngrow );
+            AverageAndPackScalarField( *mf_avg[lev], *rho_fp[lev], dcomp, ngrow );
             if(lev == 0) varnames.push_back("rho");
             dcomp += 1;
         }
 
         if (plot_F)
         {
-            AverageAndPackScalarField( mf_avg[lev], *F_fp[lev], dcomp, ngrow);
-            if(lev == 0) varnames.push_back("rho");
+            AverageAndPackScalarField( *mf_avg[lev], *F_fp[lev], dcomp, ngrow);
+            if(lev == 0) varnames.push_back("F");
             dcomp += 1;
         }
 
         if (plot_finepatch)
         {
-            AverageAndPackVectorField( mf_avg[lev], Efield_fp[lev], dcomp, ngrow );
+            AverageAndPackVectorField( *mf_avg[lev], Efield_fp[lev], dcomp, ngrow );
             if(lev==0) for(auto name:{"Ex_fp","Ey_fp","Ez_fp"}) varnames.push_back(name);
             dcomp += 3;
-            AverageAndPackVectorField( mf_avg[lev], Bfield_fp[lev], dcomp, ngrow );
+            AverageAndPackVectorField( *mf_avg[lev], Bfield_fp[lev], dcomp, ngrow );
             if(lev==0) for(auto name:{"Bx_fp","By_fp","Bz_fp"}) varnames.push_back(name);
             dcomp += 3;
         }
@@ -266,7 +266,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             {
                 if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
                 std::array<std::unique_ptr<MultiFab>, 3> E = getInterpolatedE(lev);
-                AverageAndPackVectorField( mf_avg[lev], E, dcomp, ngrow );
+                AverageAndPackVectorField( *mf_avg[lev], E, dcomp, ngrow );
 
             }
             if(lev==0) for(auto name:{"Ex_cp","Ey_cp","Ez_cp"}) varnames.push_back(name);
@@ -281,7 +281,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             {
                 if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
                 std::array<std::unique_ptr<MultiFab>, 3> B = getInterpolatedB(lev);
-                AverageAndPackVectorField( mf_avg[lev], B, dcomp, ngrow );
+                AverageAndPackVectorField( *mf_avg[lev], B, dcomp, ngrow );
             }
             if(lev==0) for(auto name:{"Bx_cp","By_cp","Bz_cp"}) varnames.push_back(name);
             dcomp += 3;
@@ -289,7 +289,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
 
         if (costs[0] != nullptr)
         {
-            AverageAndPackScalarField( mf_avg[lev], *costs[lev], dcomp, ngrow );
+            AverageAndPackScalarField( *mf_avg[lev], *costs[lev], dcomp, ngrow );
             if(lev==0) varnames.push_back("costs");
             dcomp += 1;
         }

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -1,0 +1,358 @@
+
+#include <WarpX.H>
+
+using namespace amrex;
+
+/** \brief Write the different fields of the simulation,
+* averaged to the cell center of each cell (default WarpX output)
+*/
+void
+WarpX::WriteAveragedFields ( const std::string& plotfilename ) const
+{
+
+    Vector<std::string> varnames; // Name of the written fields
+    // mf_avg will contain the averaged, cell-centered fields
+    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
+
+  // Count how many different fields should be written (ncomp)
+  const int ncomp = 3*3
+  + static_cast<int>(plot_part_per_cell)
+  + static_cast<int>(plot_part_per_grid)
+  + static_cast<int>(plot_part_per_proc)
+  + static_cast<int>(plot_proc_number)
+  + static_cast<int>(plot_divb)
+  + static_cast<int>(plot_dive)
+  + static_cast<int>(plot_rho)
+  + static_cast<int>(plot_F)
+  + static_cast<int>(plot_finepatch)*6
+  + static_cast<int>(plot_crsepatch)*6
+  + static_cast<int>(costs[0] != nullptr);
+
+  // Loop over levels of refinement
+  for (int lev = 0; lev <= finest_level; ++lev)
+  {
+    const int ngrow = 0;
+    mf_avg[lev].reset(new MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
+
+    Vector<const MultiFab*> srcmf(AMREX_SPACEDIM);
+    int dcomp = 0;
+
+    // j
+    if (do_nodal)
+    {
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *current_fp[lev][0], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *current_fp[lev][1], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *current_fp[lev][2], 0, 1);
+    }
+    else
+    {
+      PackPlotDataPtrs(srcmf, current_fp[lev]);
+      amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+      #if (AMREX_SPACEDIM == 2)
+      MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *current_fp[lev][1], 0, 1);
+      #endif
+    }
+    if (lev == 0)
+    {
+      varnames.push_back("jx");
+      varnames.push_back("jy");
+      varnames.push_back("jz");
+    }
+    dcomp += 3;
+
+    // E
+    if (do_nodal)
+    {
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *Efield_aux[lev][0], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Efield_aux[lev][1], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *Efield_aux[lev][2], 0, 1);
+    }
+    else
+    {
+      PackPlotDataPtrs(srcmf, Efield_aux[lev]);
+      amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+      #if (AMREX_SPACEDIM == 2)
+      MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Efield_aux[lev][1], 0, 1);
+      #endif
+    }
+    if (lev == 0)
+    {
+      varnames.push_back("Ex");
+      varnames.push_back("Ey");
+      varnames.push_back("Ez");
+    }
+    dcomp += 3;
+
+    // B
+    if (do_nodal)
+    {
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *Bfield_aux[lev][0], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Bfield_aux[lev][1], 0, 1);
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *Bfield_aux[lev][2], 0, 1);
+    }
+    else
+    {
+      PackPlotDataPtrs(srcmf, Bfield_aux[lev]);
+      amrex::average_face_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+      #if (AMREX_SPACEDIM == 2)
+      MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+      MultiFab::Copy(*mf_avg[lev], *Bfield_aux[lev][1], 0, dcomp+1, 1, ngrow);
+      #endif
+    }
+    if (lev == 0)
+    {
+      varnames.push_back("Bx");
+      varnames.push_back("By");
+      varnames.push_back("Bz");
+    }
+    dcomp += 3;
+
+    if (plot_part_per_cell)
+    {
+      MultiFab temp_dat(grids[lev],mf_avg[lev]->DistributionMap(),1,0);
+      temp_dat.setVal(0);
+
+      // MultiFab containing number of particles in each cell
+      mypc->Increment(temp_dat, lev);
+      MultiFab::Copy(*mf_avg[lev], temp_dat, 0, dcomp, 1, 0);
+      if (lev == 0)
+      {
+        varnames.push_back("part_per_cell");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_part_per_grid || plot_part_per_proc)
+    {
+      const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
+
+      if (plot_part_per_grid)
+      {
+        // MultiFab containing number of particles per grid (stored as constant for all cells in each grid)
+        #ifdef _OPENMP
+        #pragma omp parallel
+        #endif
+        for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+          (*mf_avg[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), dcomp);
+        }
+        if (lev == 0)
+        {
+          varnames.push_back("part_per_grid");
+        }
+        dcomp += 1;
+      }
+
+      if (plot_part_per_proc)
+      {
+        // MultiFab containing number of particles per process (stored as constant for all cells in each grid)
+        long n_per_proc = 0;
+        #ifdef _OPENMP
+        #pragma omp parallel reduction(+:n_per_proc)
+        #endif
+        for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+          n_per_proc += npart_in_grid[mfi.index()];
+        }
+        mf_avg[lev]->setVal(static_cast<Real>(n_per_proc), dcomp,1);
+        if (lev == 0)
+        {
+          varnames.push_back("part_per_proc");
+        }
+        dcomp += 1;
+      }
+    }
+
+    if (plot_proc_number)
+    {
+      // MultiFab containing the Processor ID
+      #ifdef _OPENMP
+      #pragma omp parallel
+      #endif
+      for (MFIter mfi(*mf_avg[lev]); mfi.isValid(); ++mfi) {
+        (*mf_avg[lev])[mfi].setVal(static_cast<Real>(ParallelDescriptor::MyProc()), dcomp);
+      }
+      if (lev == 0)
+      {
+        varnames.push_back("proc_number");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_divb)
+    {
+      if (do_nodal) amrex::Abort("TODO: do_nodal && plot_divb");
+      ComputeDivB(*mf_avg[lev], dcomp, {Bfield_aux[lev][0].get(),Bfield_aux[lev][1].get(),Bfield_aux[lev][2].get()}, WarpX::CellSize(lev));
+      if (lev == 0)
+      {
+        varnames.push_back("divB");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_dive)
+    {
+      if (do_nodal) amrex::Abort("TODO: do_nodal && plot_dive");
+      const BoxArray& ba = amrex::convert(boxArray(lev),IntVect::TheUnitVector());
+      MultiFab dive(ba,DistributionMap(lev),1,0);
+      ComputeDivE( dive, 0,
+        {Efield_aux[lev][0].get(), Efield_aux[lev][1].get(), Efield_aux[lev][2].get()},
+        WarpX::CellSize(lev)
+      );
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, dive, 0, 1);
+      if (lev == 0)
+      {
+        varnames.push_back("divE");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_rho)
+    {
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, *rho_fp[lev], 0, 1);
+      if (lev == 0)
+      {
+        varnames.push_back("rho");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_F)
+    {
+      amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp, *F_fp[lev], 0, 1);
+      if (lev == 0)
+      {
+        varnames.push_back("F");
+      }
+      dcomp += 1;
+    }
+
+    if (plot_finepatch)
+    {
+      if (do_nodal)
+      {
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *Efield_fp[lev][0], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Efield_fp[lev][1], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *Efield_fp[lev][2], 0, 1);
+      }
+      else
+      {
+        PackPlotDataPtrs(srcmf, Efield_fp[lev]);
+        amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+        #if (AMREX_SPACEDIM == 2)
+        MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Efield_fp[lev][1], 0, 1);
+        #endif
+      }
+      if (lev == 0)
+      {
+        varnames.push_back("Ex_fp");
+        varnames.push_back("Ey_fp");
+        varnames.push_back("Ez_fp");
+      }
+      dcomp += 3;
+
+      if (do_nodal)
+      {
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp  , *Bfield_fp[lev][0], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *Bfield_fp[lev][1], 0, 1);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+2, *Bfield_fp[lev][2], 0, 1);
+      }
+      else
+      {
+        PackPlotDataPtrs(srcmf, Bfield_fp[lev]);
+        amrex::average_face_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+        #if (AMREX_SPACEDIM == 2)
+        MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+        MultiFab::Copy(*mf_avg[lev], *Bfield_fp[lev][1], 0, dcomp+1, 1, ngrow);
+        #endif
+      }
+      if (lev == 0)
+      {
+        varnames.push_back("Bx_fp");
+        varnames.push_back("By_fp");
+        varnames.push_back("Bz_fp");
+      }
+      dcomp += 3;
+    }
+
+    if (plot_crsepatch)
+    {
+      // First the electric field
+      if (lev == 0)
+      {
+        mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
+      }
+      else
+      {
+        if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
+        std::array<std::unique_ptr<MultiFab>, 3> E = getInterpolatedE(lev);
+        PackPlotDataPtrs(srcmf, E);
+        amrex::average_edge_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+        #if (AMREX_SPACEDIM == 2)
+        MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+        amrex::average_node_to_cellcenter(*mf_avg[lev], dcomp+1, *E[1], 0, 1);
+        #endif
+      }
+      if (lev == 0)
+      {
+        varnames.push_back("Ex_cp");
+        varnames.push_back("Ey_cp");
+        varnames.push_back("Ez_cp");
+      }
+      dcomp += 3;
+
+      // now the magnetic field
+      if (lev == 0)
+      {
+        mf_avg[lev]->setVal(0.0, dcomp, 3, ngrow);
+      }
+      else
+      {
+        if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
+        std::array<std::unique_ptr<MultiFab>, 3> B = getInterpolatedB(lev);
+        PackPlotDataPtrs(srcmf, B);
+        amrex::average_face_to_cellcenter(*mf_avg[lev], dcomp, srcmf);
+        #if (AMREX_SPACEDIM == 2)
+        MultiFab::Copy(*mf_avg[lev], *mf_avg[lev], dcomp+1, dcomp+2, 1, ngrow);
+        MultiFab::Copy(*mf_avg[lev], *B[1], 0, dcomp+1, 1, ngrow);
+        #endif
+      }
+      if (lev == 0)
+      {
+        varnames.push_back("Bx_cp");
+        varnames.push_back("By_cp");
+        varnames.push_back("Bz_cp");
+      }
+      dcomp += 3;
+    }
+
+    if (costs[0] != nullptr)
+    {
+      MultiFab::Copy(*mf_avg[lev], *costs[lev], 0, dcomp, 1, 0);
+      if (lev == 0)
+      {
+        varnames.push_back("costs");
+      }
+      dcomp += 1;
+    }
+
+    BL_ASSERT(dcomp == ncomp);
+  }
+
+  // Write the fields contained in `mf_avg`, and corresponding to the
+  // names `varnames`, into a plotfile.
+  // Prepare extra directory (filled later), for the raw fields
+  Vector<std::string> rfs;
+  if (plot_raw_fields) rfs.emplace_back("raw_fields");
+  amrex::WriteMultiLevelPlotfile(
+    plotfilename, finest_level+1,
+    amrex::GetVecOfConstPtrs(mf_avg),
+    varnames, Geom(), t_new[0], istep, refRatio(),
+    "HyperCLaw-V1.1",
+    "Level_",
+    "Cell",
+    rfs
+  );
+
+}

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -1,7 +1,7 @@
 CEXE_sources += WarpXIO.cpp
 CEXE_sources += BoostedFrameDiagnostic.cpp
 CEXE_sources += ParticleIO.cpp
-CEXE_sources += FieldIO.cpp
+CEXE_headers += FieldIO.cpp
 CEXE_headers += BoostedFrameDiagnostic.H
 CEXE_headers += ElectrostaticIO.cpp
 F90EXE_sources += BoostedFrame_module.F90

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -1,7 +1,8 @@
 CEXE_sources += WarpXIO.cpp
 CEXE_sources += BoostedFrameDiagnostic.cpp
 CEXE_sources += ParticleIO.cpp
-CEXE_headers += FieldIO.cpp
+CEXE_sources += FieldIO.cpp
+CEXE_headers += FieldIO.H
 CEXE_headers += BoostedFrameDiagnostic.H
 CEXE_headers += ElectrostaticIO.cpp
 F90EXE_sources += BoostedFrame_module.F90

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -1,6 +1,7 @@
 CEXE_sources += WarpXIO.cpp
 CEXE_sources += BoostedFrameDiagnostic.cpp
 CEXE_sources += ParticleIO.cpp
+CEXE_sources += FieldIO.cpp
 CEXE_headers += BoostedFrameDiagnostic.H
 CEXE_headers += ElectrostaticIO.cpp
 F90EXE_sources += BoostedFrame_module.F90

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -544,42 +544,39 @@ WarpX::UpdateInSitu () const
             dcomp += 1;
         }
 
-        if (plot_part_per_grid || plot_part_per_proc)
+        if (plot_part_per_grid)
         {
             const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
-
-            if (plot_part_per_grid)
-            {
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-                for (MFIter mfi(mf[lev]); mfi.isValid(); ++mfi)
-                    (mf[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), dcomp);
-
-                if (lev == 0)
-                    varnames.push_back("part_per_grid");
-
-                dcomp += 1;
-           }
-
-           if (plot_part_per_proc)
-           {
-               long n_per_proc = 0;
+            for (MFIter mfi(mf[lev]); mfi.isValid(); ++mfi)
+                (mf[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), dcomp);
+            
+            if (lev == 0)
+                varnames.push_back("part_per_grid");
+            
+            dcomp += 1;
+        }
+        
+        if (plot_part_per_proc)
+        {
+            const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
+            long n_per_proc = 0;
 #ifdef _OPENMP
 #pragma omp parallel reduction(+:n_per_proc)
 #endif
-                for (MFIter mfi(mf[lev]); mfi.isValid(); ++mfi)
-                    n_per_proc += npart_in_grid[mfi.index()];
-
-                mf[lev].setVal(static_cast<Real>(n_per_proc), dcomp, ngrow);
-
-                if (lev == 0)
-                    varnames.push_back("part_per_proc");
-
-                dcomp += 1;
-            }
+            for (MFIter mfi(mf[lev]); mfi.isValid(); ++mfi)
+                n_per_proc += npart_in_grid[mfi.index()];
+            
+            mf[lev].setVal(static_cast<Real>(n_per_proc), dcomp, ngrow);
+            
+            if (lev == 0)
+                varnames.push_back("part_per_proc");
+            
+            dcomp += 1;
         }
-
+        
         if (plot_proc_number)
         {
             Real procid = static_cast<Real>(ParallelDescriptor::MyProc());

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -4,6 +4,7 @@
 #include <AMReX_FillPatchUtil_F.H>
 
 #include <WarpX.H>
+#include <FieldIO.cpp>
 
 #include "AMReX_buildInfo.H"
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -366,7 +366,7 @@ WarpX::InitFromCheckpoint ()
         }
 
         if (costs[lev]) {
-            const auto& cost_mf_name = 
+            const auto& cost_mf_name =
                 amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "costs");
             if (VisMF::Exist(cost_mf_name)) {
                 VisMF::Read(*costs[lev], cost_mf_name);
@@ -408,14 +408,14 @@ WarpX::GetCellCenteredData() {
     const int nc = 10;
 
     Vector<std::unique_ptr<MultiFab> > cc(finest_level+1);
-    
+
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         cc[lev].reset( new MultiFab(grids[lev], dmap[lev], nc, ng) );
-        
+
         Vector<const MultiFab*> srcmf(AMREX_SPACEDIM);
         int dcomp = 0;
-        
+
         // first the electric field
         PackPlotDataPtrs(srcmf, Efield_aux[lev]);
         amrex::average_edge_to_cellcenter(*cc[lev], dcomp, srcmf);
@@ -424,7 +424,7 @@ WarpX::GetCellCenteredData() {
         amrex::average_node_to_cellcenter(*cc[lev], dcomp+1, *Efield_aux[lev][1], 0, 1);
 #endif
         dcomp += 3;
-        
+
         // then the magnetic field
         PackPlotDataPtrs(srcmf, Bfield_aux[lev]);
         amrex::average_face_to_cellcenter(*cc[lev], dcomp, srcmf);
@@ -433,7 +433,7 @@ WarpX::GetCellCenteredData() {
         MultiFab::Copy(*cc[lev], *Bfield_aux[lev][1], 0, dcomp+1, 1, ng);
 #endif
         dcomp += 3;
-        
+
         // then the current density
         PackPlotDataPtrs(srcmf, current_fp[lev]);
         amrex::average_edge_to_cellcenter(*cc[lev], dcomp, srcmf);
@@ -442,18 +442,18 @@ WarpX::GetCellCenteredData() {
         amrex::average_node_to_cellcenter(*cc[lev], dcomp+1, *current_fp[lev][1], 0, 1);
 #endif
         dcomp += 3;
-        
+
         const std::unique_ptr<MultiFab>& charge_density = mypc->GetChargeDensity(lev);
         amrex::average_node_to_cellcenter(*cc[lev], dcomp, *charge_density, 0, 1);
-        
+
         cc[lev]->FillBoundary(geom[lev].periodicity());
     }
-    
+
     for (int lev = finest_level; lev > 0; --lev)
     {
         amrex::average_down(*cc[lev], *cc[lev-1], 0, nc, refRatio(lev-1));
     }
-    
+
     return std::move(cc[0]);
 }
 
@@ -754,357 +754,10 @@ WarpX::WritePlotFile () const
 
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(plotfile_headerversion);
-
     const std::string& plotfilename = amrex::Concatenate(plot_file,istep[0]);
-
     amrex::Print() << "  Writing plotfile " << plotfilename << "\n";
 
-    {
-	Vector<std::string> varnames;
-	Vector<std::unique_ptr<MultiFab> > mf(finest_level+1);
-
-        const int ncomp = 3*3
-            + static_cast<int>(plot_part_per_cell)
-            + static_cast<int>(plot_part_per_grid)
-            + static_cast<int>(plot_part_per_proc)
-            + static_cast<int>(plot_proc_number)
-            + static_cast<int>(plot_divb)
-            + static_cast<int>(plot_dive)
-            + static_cast<int>(plot_rho)
-            + static_cast<int>(plot_F)
-            + static_cast<int>(plot_finepatch)*6
-            + static_cast<int>(plot_crsepatch)*6
-            + static_cast<int>(costs[0] != nullptr);
-
-	for (int lev = 0; lev <= finest_level; ++lev)
-	{
-	    const int ngrow = 0;
-	    mf[lev].reset(new MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
-
-	    Vector<const MultiFab*> srcmf(AMREX_SPACEDIM);
-	    int dcomp = 0;
-            
-            // j
-            if (do_nodal)
-            {
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp  , *current_fp[lev][0], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *current_fp[lev][1], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+2, *current_fp[lev][2], 0, 1);
-            }
-            else
-            {
-                PackPlotDataPtrs(srcmf, current_fp[lev]);
-                amrex::average_edge_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *current_fp[lev][1], 0, 1);
-#endif
-            }
-            if (lev == 0)
-            {
-                varnames.push_back("jx");
-                varnames.push_back("jy");
-                varnames.push_back("jz");
-            }
-	    dcomp += 3;
-
-            // E
-            if (do_nodal)
-            {
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp  , *Efield_aux[lev][0], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Efield_aux[lev][1], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+2, *Efield_aux[lev][2], 0, 1);
-            }
-            else
-            {
-                PackPlotDataPtrs(srcmf, Efield_aux[lev]);
-                amrex::average_edge_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Efield_aux[lev][1], 0, 1);
-#endif
-            }
-            if (lev == 0)
-            {
-                varnames.push_back("Ex");
-                varnames.push_back("Ey");
-                varnames.push_back("Ez");
-            }
-	    dcomp += 3;
-
-            // B
-            if (do_nodal)
-            {
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp  , *Bfield_aux[lev][0], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Bfield_aux[lev][1], 0, 1);
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp+2, *Bfield_aux[lev][2], 0, 1);
-            }
-            else
-            {
-                PackPlotDataPtrs(srcmf, Bfield_aux[lev]);
-                amrex::average_face_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                MultiFab::Copy(*mf[lev], *Bfield_aux[lev][1], 0, dcomp+1, 1, ngrow);
-#endif
-            }
-            if (lev == 0)
-            {
-                varnames.push_back("Bx");
-                varnames.push_back("By");
-                varnames.push_back("Bz");
-            }
-	    dcomp += 3;
-
-            if (plot_part_per_cell)
-            {
-                MultiFab temp_dat(grids[lev],mf[lev]->DistributionMap(),1,0);
-                temp_dat.setVal(0);
-
-                // MultiFab containing number of particles in each cell
-                mypc->Increment(temp_dat, lev);
-                MultiFab::Copy(*mf[lev], temp_dat, 0, dcomp, 1, 0);
-                if (lev == 0)
-                {
-                    varnames.push_back("part_per_cell");
-                }
-                dcomp += 1;
-            }
-
-            if (plot_part_per_grid || plot_part_per_proc)
-            {
-                const Vector<long>& npart_in_grid = mypc->NumberOfParticlesInGrid(lev);
-
-                if (plot_part_per_grid)
-                {
-                    // MultiFab containing number of particles per grid (stored as constant for all cells in each grid)
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-                    for (MFIter mfi(*mf[lev]); mfi.isValid(); ++mfi) {
-                        (*mf[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]), dcomp);
-                    }
-                    if (lev == 0)
-                    {
-                        varnames.push_back("part_per_grid");
-                    }
-                    dcomp += 1;
-                }
-
-                if (plot_part_per_proc)
-                {
-                    // MultiFab containing number of particles per process (stored as constant for all cells in each grid)
-                    long n_per_proc = 0;
-#ifdef _OPENMP
-#pragma omp parallel reduction(+:n_per_proc)
-#endif
-                    for (MFIter mfi(*mf[lev]); mfi.isValid(); ++mfi) {
-                        n_per_proc += npart_in_grid[mfi.index()];
-                    }
-                    mf[lev]->setVal(static_cast<Real>(n_per_proc), dcomp,1);
-                    if (lev == 0)
-                    {
-                        varnames.push_back("part_per_proc");
-                    }
-                    dcomp += 1;
-                }
-            }
-
-            if (plot_proc_number)
-            {
-                // MultiFab containing the Processor ID
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-                for (MFIter mfi(*mf[lev]); mfi.isValid(); ++mfi) {
-                    (*mf[lev])[mfi].setVal(static_cast<Real>(ParallelDescriptor::MyProc()), dcomp);
-                }
-                if (lev == 0)
-                {
-                    varnames.push_back("proc_number");
-                }
-                dcomp += 1;
-            }
-
-            if (plot_divb)
-            {
-                if (do_nodal) amrex::Abort("TODO: do_nodal && plot_divb");
-                ComputeDivB(*mf[lev], dcomp,
-                            {Bfield_aux[lev][0].get(),Bfield_aux[lev][1].get(),Bfield_aux[lev][2].get()},
-                            WarpX::CellSize(lev));
-                if (lev == 0)
-                {
-                    varnames.push_back("divB");
-                }
-                dcomp += 1;
-            }
-
-            if (plot_dive)
-            {
-                if (do_nodal) amrex::Abort("TODO: do_nodal && plot_dive");
-                const BoxArray& ba = amrex::convert(boxArray(lev),IntVect::TheUnitVector());
-                MultiFab dive(ba,DistributionMap(lev),1,0);
-                ComputeDivE(dive, 0,
-                            {Efield_aux[lev][0].get(), Efield_aux[lev][1].get(), Efield_aux[lev][2].get()},
-                            WarpX::CellSize(lev));
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp, dive, 0, 1);
-                if (lev == 0)
-                {
-                    varnames.push_back("divE");
-                }
-                dcomp += 1;
-            }
-
-            if (plot_rho)
-            {
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp, *rho_fp[lev], 0, 1);
-                if (lev == 0)
-                {
-                    varnames.push_back("rho");
-                }
-                dcomp += 1;
-            }
-
-            if (plot_F)
-            {
-                amrex::average_node_to_cellcenter(*mf[lev], dcomp, *F_fp[lev], 0, 1);
-                if (lev == 0)
-                {
-                    varnames.push_back("F");
-                }
-                dcomp += 1;
-            }
-            
-            if (plot_finepatch)
-            {
-                if (do_nodal)
-                {
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp  , *Efield_fp[lev][0], 0, 1);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Efield_fp[lev][1], 0, 1);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+2, *Efield_fp[lev][2], 0, 1);
-                }
-                else
-                {
-                    PackPlotDataPtrs(srcmf, Efield_fp[lev]);
-                    amrex::average_edge_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                    MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Efield_fp[lev][1], 0, 1);
-#endif
-                }
-                if (lev == 0)
-                {
-                    varnames.push_back("Ex_fp");
-                    varnames.push_back("Ey_fp");
-                    varnames.push_back("Ez_fp");
-                }
-                dcomp += 3;
-
-                if (do_nodal)
-                {
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp  , *Bfield_fp[lev][0], 0, 1);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *Bfield_fp[lev][1], 0, 1);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+2, *Bfield_fp[lev][2], 0, 1);
-                }
-                else
-                {
-                    PackPlotDataPtrs(srcmf, Bfield_fp[lev]);
-                    amrex::average_face_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                    MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                    MultiFab::Copy(*mf[lev], *Bfield_fp[lev][1], 0, dcomp+1, 1, ngrow);
-#endif
-                }
-                if (lev == 0)
-                {
-                    varnames.push_back("Bx_fp");
-                    varnames.push_back("By_fp");
-                    varnames.push_back("Bz_fp");
-                }
-                dcomp += 3;
-            }
-
-            if (plot_crsepatch)
-            {
-                // First the electric field
-                if (lev == 0)
-                {
-                    mf[lev]->setVal(0.0, dcomp, 3, ngrow);
-                }
-                else
-                {
-                    if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
-                    std::array<std::unique_ptr<MultiFab>, 3> E = getInterpolatedE(lev);
-                    PackPlotDataPtrs(srcmf, E);
-                    amrex::average_edge_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                    MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                    amrex::average_node_to_cellcenter(*mf[lev], dcomp+1, *E[1], 0, 1);
-#endif
-                }
-                if (lev == 0)
-                {
-                    varnames.push_back("Ex_cp");
-                    varnames.push_back("Ey_cp");
-                    varnames.push_back("Ez_cp");
-                }
-                dcomp += 3;
-
-                // now the magnetic field                
-                if (lev == 0)
-                {
-                    mf[lev]->setVal(0.0, dcomp, 3, ngrow);
-                }
-                else
-                {
-                    if (do_nodal) amrex::Abort("TODO: do_nodal && plot_crsepatch");
-                    std::array<std::unique_ptr<MultiFab>, 3> B = getInterpolatedB(lev);
-                    PackPlotDataPtrs(srcmf, B);
-                    amrex::average_face_to_cellcenter(*mf[lev], dcomp, srcmf);
-#if (AMREX_SPACEDIM == 2)
-                    MultiFab::Copy(*mf[lev], *mf[lev], dcomp+1, dcomp+2, 1, ngrow);
-                    MultiFab::Copy(*mf[lev], *B[1], 0, dcomp+1, 1, ngrow);
-#endif
-                }
-                if (lev == 0)
-                {
-                    varnames.push_back("Bx_cp");
-                    varnames.push_back("By_cp");
-                    varnames.push_back("Bz_cp");
-                }
-                dcomp += 3;
-            }
-            
-            if (costs[0] != nullptr)
-            {
-                MultiFab::Copy(*mf[lev], *costs[lev], 0, dcomp, 1, 0);
-                if (lev == 0)
-                {
-                    varnames.push_back("costs");
-                }
-                dcomp += 1;
-            }
-
-            BL_ASSERT(dcomp == ncomp);
-	}
-
-#if 0
-        for (int lev = finest_level; lev > 0; --lev)
-        {
-            amrex::average_down(*mf[lev], *mf[lev-1], 0, ncomp, refRatio(lev-1));
-        }
-#endif
-
-        Vector<std::string> rfs;
-        if (plot_raw_fields) rfs.emplace_back("raw_fields"); // pre-build raw_fields/
-	amrex::WriteMultiLevelPlotfile(plotfilename, finest_level+1,
-                                       amrex::GetVecOfConstPtrs(mf),
-                                       varnames, Geom(), t_new[0], istep, refRatio(),
-                                       "HyperCLaw-V1.1",
-                                       "Level_",
-                                       "Cell",
-                                       rfs);
-    }
+    WarpX::WriteAveragedFields( plotfilename );
 
     if (plot_raw_fields)
     {
@@ -1207,7 +860,7 @@ WarpX::WritePlotFile () const
                     VisMF::Write(Ez, amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "Ez_cp"));
                     VisMF::Write(Bx, amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "Bx_cp"));
                     VisMF::Write(By, amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "By_cp"));
-                    VisMF::Write(Bz, amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "Bz_cp"));              
+                    VisMF::Write(Bz, amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "Bz_cp"));
                 } else {
 
                     if (plot_raw_fields_guards) {
@@ -1230,7 +883,7 @@ WarpX::WritePlotFile () const
                     }
                 }
             }
-            
+
             if (F_fp[lev]) {
                 VisMF::Write(*F_fp[lev], amrex::MultiFabFileFullPrefix(lev, raw_plotfilename, level_prefix, "F_fp"));
             }
@@ -1260,9 +913,9 @@ WarpX::WritePlotFile () const
 
     particle_varnames.push_back("uxold");
     particle_varnames.push_back("uyold");
-    particle_varnames.push_back("uzold");    
+    particle_varnames.push_back("uzold");
 #endif
-    
+
     mypc->Checkpoint(plotfilename, true, particle_varnames);
 
     WriteJobInfo(plotfilename);
@@ -1395,13 +1048,13 @@ std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedE(int lev) const
 {
 
     const int ngrow = 0;
-    
+
     std::array<std::unique_ptr<MultiFab>, 3> interpolated_E;
     for (int i = 0; i < 3; ++i) {
         interpolated_E[i].reset( new MultiFab(Efield_aux[lev][i]->boxArray(), dmap[lev], 1, ngrow) );
         interpolated_E[i]->setVal(0.0);
     }
-    
+
     const int r_ratio = refRatio(lev-1)[0];
     const int use_limiter = 0;
 #ifdef _OPEMP
@@ -1414,15 +1067,15 @@ std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedE(int lev) const
             Box ccbx = mfi.fabbox();
             ccbx.enclosedCells();
             ccbx.coarsen(r_ratio).refine(r_ratio); // so that ccbx is coarsenable
-            
+
             const FArrayBox& cxfab = (*Efield_cp[lev][0])[mfi];
             const FArrayBox& cyfab = (*Efield_cp[lev][1])[mfi];
             const FArrayBox& czfab = (*Efield_cp[lev][2])[mfi];
-            
+
             efab[0].resize(amrex::convert(ccbx,Ex_nodal_flag));
             efab[1].resize(amrex::convert(ccbx,Ey_nodal_flag));
             efab[2].resize(amrex::convert(ccbx,Ez_nodal_flag));
-            
+
 #if (AMREX_SPACEDIM == 3)
             amrex_interp_efield(ccbx.loVect(), ccbx.hiVect(),
                                 BL_TO_FORTRAN_ANYD(efab[0]),
@@ -1458,13 +1111,13 @@ std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedE(int lev) const
 std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedB(int lev) const
 {
     const int ngrow = 0;
-    
+
     std::array<std::unique_ptr<MultiFab>, 3> interpolated_B;
     for (int i = 0; i < 3; ++i) {
         interpolated_B[i].reset( new MultiFab(Bfield_aux[lev][i]->boxArray(), dmap[lev], 1, ngrow) );
         interpolated_B[i]->setVal(0.0);
     }
-    
+
     const Real* dx = Geom(lev-1).CellSize();
     const int r_ratio = refRatio(lev-1)[0];
     const int use_limiter = 0;
@@ -1478,15 +1131,15 @@ std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedB(int lev) const
             Box ccbx = mfi.fabbox();
             ccbx.enclosedCells();
             ccbx.coarsen(r_ratio).refine(r_ratio); // so that ccbx is coarsenable
-            
+
             const FArrayBox& cxfab = (*Bfield_cp[lev][0])[mfi];
             const FArrayBox& cyfab = (*Bfield_cp[lev][1])[mfi];
             const FArrayBox& czfab = (*Bfield_cp[lev][2])[mfi];
-            
+
             bfab[0].resize(amrex::convert(ccbx,Bx_nodal_flag));
             bfab[1].resize(amrex::convert(ccbx,By_nodal_flag));
             bfab[2].resize(amrex::convert(ccbx,Bz_nodal_flag));
-            
+
 #if (AMREX_SPACEDIM == 3)
             amrex_interp_div_free_bfield(ccbx.loVect(), ccbx.hiVect(),
                                          BL_TO_FORTRAN_ANYD(bfab[0]),

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -448,7 +448,7 @@ WarpX::UpdateInSitu () const
     const int ngrow = 1;
     Vector<std::string> varnames; // Name of the written fields
     // mf_avg will contain the averaged, cell-centered fields
-    Vector<std::unique_ptr<MultiFab> > mf_avg;
+    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
     WarpX::AverageAndPackFields( varnames, mf_avg, ngrow );
 
     if (insitu_bridge->update(istep[0], t_new[0],
@@ -476,7 +476,7 @@ WarpX::WritePlotFile () const
     const int ngrow = 1;
     Vector<std::string> varnames; // Name of the written fields
     // mf_avg will contain the averaged, cell-centered fields
-    Vector<std::unique_ptr<MultiFab> > mf_avg;
+    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
     WarpX::AverageAndPackFields( varnames, mf_avg, ngrow );
 
     // Write the fields contained in `mf_avg`, and corresponding to the

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -414,6 +414,7 @@ WarpX::GetCellCenteredData() {
     {
         cc[lev].reset( new MultiFab(grids[lev], dmap[lev], nc, ng) );
 
+        int dcomp = 0;
         // first the electric field
         AverageAndPackVectorField( cc[lev], Efield_aux[lev], dcomp, ng );
         dcomp += 3;

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -473,7 +473,7 @@ WarpX::WritePlotFile () const
     amrex::Print() << "  Writing plotfile " << plotfilename << "\n";
 
     // Average the fields from the simulation to the cell centers
-    const int ngrow = 1;
+    const int ngrow = 0;
     Vector<std::string> varnames; // Name of the written fields
     // mf_avg will contain the averaged, cell-centered fields
     Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -4,7 +4,7 @@
 #include <AMReX_FillPatchUtil_F.H>
 
 #include <WarpX.H>
-#include <FieldIO.cpp>
+#include <FieldIO.H>
 
 #include "AMReX_buildInfo.H"
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -416,16 +416,16 @@ WarpX::GetCellCenteredData() {
 
         int dcomp = 0;
         // first the electric field
-        AverageAndPackVectorField( cc[lev], Efield_aux[lev], dcomp, ng );
+        AverageAndPackVectorField( *cc[lev], Efield_aux[lev], dcomp, ng );
         dcomp += 3;
         // then the magnetic field
-        AverageAndPackVectorField( cc[lev], Efield_aux[lev], dcomp, ng );
+        AverageAndPackVectorField( *cc[lev], Efield_aux[lev], dcomp, ng );
         dcomp += 3;
         // then the current density
-        AverageAndPackVectorField( cc[lev], current_fp[lev], dcomp, ng );
+        AverageAndPackVectorField( *cc[lev], current_fp[lev], dcomp, ng );
         dcomp += 3;
         const std::unique_ptr<MultiFab>& charge_density = mypc->GetChargeDensity(lev);
-        AverageAndPackScalarField( cc[lev], *charge_density, dcomp, ng );
+        AverageAndPackScalarField( *cc[lev], *charge_density, dcomp, ng );
 
         cc[lev]->FillBoundary(geom[lev].periodicity());
     }

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -1170,18 +1170,3 @@ std::array<std::unique_ptr<MultiFab>, 3> WarpX::getInterpolatedB(int lev) const
     }
     return interpolated_B;
 }
-
-void
-WarpX::PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
-                         const std::array<std::unique_ptr<MultiFab>,3>& data)
-{
-    BL_ASSERT(pmf.size() == AMREX_SPACEDIM);
-#if (AMREX_SPACEDIM == 3)
-    pmf[0] = data[0].get();
-    pmf[1] = data[1].get();
-    pmf[2] = data[2].get();
-#elif (AMREX_SPACEDIM == 2)
-    pmf[0] = data[0].get();
-    pmf[1] = data[2].get();
-#endif
-}

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -448,7 +448,7 @@ WarpX::UpdateInSitu () const
     const int ngrow = 1;
     Vector<std::string> varnames; // Name of the written fields
     // mf_avg will contain the averaged, cell-centered fields
-    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
+    Vector<MultiFab> mf_avg;
     WarpX::AverageAndPackFields( varnames, mf_avg, ngrow );
 
     if (insitu_bridge->update(istep[0], t_new[0],
@@ -476,7 +476,7 @@ WarpX::WritePlotFile () const
     const int ngrow = 0;
     Vector<std::string> varnames; // Name of the written fields
     // mf_avg will contain the averaged, cell-centered fields
-    Vector<std::unique_ptr<MultiFab> > mf_avg(finest_level+1);
+    Vector<MultiFab> mf_avg;
     WarpX::AverageAndPackFields( varnames, mf_avg, ngrow );
 
     // Write the fields contained in `mf_avg`, and corresponding to the

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -351,9 +351,6 @@ private:
 
     std::array<std::unique_ptr<amrex::MultiFab>, 3> getInterpolatedB(int lev) const;
 
-    static void PackPlotDataPtrs (amrex::Vector<const amrex::MultiFab*>& pmf,
-				  const std::array<std::unique_ptr<amrex::MultiFab>,3>& data);
-
     static void ComputeDivB (amrex::MultiFab& divB, int dcomp,
                              const std::array<const amrex::MultiFab*, 3>& B,
                              const std::array<amrex::Real,3>& dx);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -190,7 +190,7 @@ public:
     void WritePlotFile () const;
     void UpdateInSitu () const;
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,
-        amrex::Vector<std::unique_ptr<amrex::MultiFab> >& mf_avg, const int ngrow) const;
+        amrex::Vector<amrex::MultiFab>& mf_avg, const int ngrow) const;
 
     void WritePlotFileES(const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -88,7 +88,7 @@ public:
 
     static bool use_fdtd_nci_corr;
     static int  l_lower_order_in_v;
-    
+
     static bool use_laser;
     static bool use_filter;
     static bool serialize_ics;
@@ -188,8 +188,9 @@ public:
 
     void WriteCheckPointFile () const;
     void WritePlotFile () const;
-    void WriteAveragedFields ( const std::string& plotfilename ) const;
     void UpdateInSitu () const;
+    void AverageAndPackFields( amrex::Vector<std::string>& varnames,
+        amrex::Vector<std::unique_ptr<amrex::MultiFab> >& mf_avg, const int ngrow) const;
 
     void WritePlotFileES(const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
@@ -444,7 +445,7 @@ private:
 
     amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>, 3 > > current_fp_owner_masks;
     amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>, 3 > > current_cp_owner_masks;
-    
+
     amrex::Vector<std::unique_ptr<amrex::iMultiFab> > rho_fp_owner_masks;
     amrex::Vector<std::unique_ptr<amrex::iMultiFab> > rho_cp_owner_masks;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -188,6 +188,7 @@ public:
 
     void WriteCheckPointFile () const;
     void WritePlotFile () const;
+    void WriteAveragedFields ( const std::string& plotfilename ) const;
     void UpdateInSitu () const;
 
     void WritePlotFileES(const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,


### PR DESCRIPTION
This reorganizes the field IO by removing a large amount of duplication.

Basically, a lot of the code that was averaging from the nodes/edges/face to the cell centered was copied and pasted. This PR creates a dedicated function for this. Also, the corresponding function is now in a new file `FieldsIO.cpp`.