### PR TITLE
Add a notebook for developers to interactively use AMReX

### DIFF
--- a/Tools/AMReX_developer_notebook.ipynb
+++ b/Tools/AMReX_developer_notebook.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "\n",
+    "This notebook allows to use the `AMReX` library interactively in the Jupyter notebook.\n",
+    "\n",
+    "This is meant to help WarpX developers, by providing a way to quickly test/prototype AMReX-based code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup\n",
+    "\n",
+    "- Compile `AMReX` as a library as a dynamic library: from the `amrex` root source folder:\n",
+    "```\n",
+    "mkdir builddir\n",
+    "cd builddir\n",
+    "cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_MPI=OFF\n",
+    "make install\n",
+    "```\n",
+    "(For MacOS, see [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#cmake-and-macos))\n",
+    "\n",
+    "This will create the library files in `tmp_install_dir/include` and `tmp_install_dir/lib`.\n",
+    "\n",
+    "- Create a new `conda` environment and do:\n",
+    "```\n",
+    "conda install -c conda-forge xeus-cling jupyter\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#pragma cling add_include_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/include\")\n",
+    "#pragma cling add_library_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/lib\")\n",
+    "#pragma cling load(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/lib/libamrex.a\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "C++14",
+   "language": "C++14",
+   "name": "xeus-cling-cpp14"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-c++src",
+   "file_extension": ".cpp",
+   "mimetype": "text/x-c++src",
+   "name": "c++",
+   "version": "-std=c++14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Tools/AMReX_developer_notebook.ipynb
+++ b/Tools/AMReX_developer_notebook.ipynb
@@ -29,9 +29,18 @@
     "This will create the library files in `tmp_install_dir/include` and `tmp_install_dir/lib`.\n",
     "\n",
     "- Create a new `conda` environment and do:\n",
+    "For Linux:\n",
     "```\n",
     "conda install -c conda-forge xeus-cling jupyter\n",
-    "```"
+    "```\n",
+    "For MacOS:\n",
+    "```\n",
+    "conda install -c QuantStack -c conda-forge xeus-cling jupyter\n",
+    "```\n",
+    "\n",
+    "- Copy this notebook outside of the source folder of WarpX (so that it is not tracked by `git`), and open it with `jupyter notebook`.\n",
+    "\n",
+    "- Change the paths of the cells below to the path of your amrex installation, and execute them"
    ]
   },
   {
@@ -40,10 +49,88 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#pragma cling add_include_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/include\")\n",
-    "#pragma cling add_library_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/lib\")\n",
-    "#pragma cling load(\"/home/rlehe/Documents/codes/warpx_directory/amrex/tmp_install_dir/lib/libamrex.a\")"
+    "#pragma cling add_include_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/install_nompi_dynamic/include\")\n",
+    "#pragma cling add_library_path(\"/home/rlehe/Documents/codes/warpx_directory/amrex/install_nompi_dynamic/lib\")\n",
+    "#pragma cling load(\"libamrex.so\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define AMREX_SPACEDIM 3\n",
+    "#include <AMReX.H>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MPI_Comm dummy_mpi_comm;\n",
+    "amrex::Initialize(dummy_mpi_comm);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <AMReX_Box.H>\n",
+    "#include <AMReX_IntVect.H>\n",
+    "#include <AMReX_Print.H>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using namespace amrex;\n",
+    "\n",
+    "IntVect lo(AMREX_D_DECL(64,64,64));\n",
+    "IntVect hi(AMREX_D_DECL(127,127,127));\n",
+    "IndexType typ({AMREX_D_DECL(1,1,1)});\n",
+    "Box cc(lo,hi);        // By default, Box is cell based.\n",
+    "Box nd(lo,hi+1,typ);  // Construct a nodal Box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Print() << \"A cell-centered Box \" << cc << \"\\n\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Print() << \"An all nodal Box    \" << nd << \"\\n\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/Tools/AMReX_developer_notebook.ipynb
+++ b/Tools/AMReX_developer_notebook.ipynb
@@ -91,31 +91,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#include <AMReX_Box.H>\n",
-    "#include <AMReX_IntVect.H>\n",
-    "#include <AMReX_Print.H>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "using namespace amrex;\n",
+    "# Example: typical MultiFab creation / looping\n",
     "\n",
-    "IntVect lo(AMREX_D_DECL(64,64,64));\n",
-    "IntVect hi(AMREX_D_DECL(127,127,127));\n",
-    "IndexType typ({AMREX_D_DECL(1,1,1)});"
+    "- Create a box that represents the full domain, and a split it into a BoxArray"
    ]
   },
   {
@@ -124,7 +102,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "?IntVect"
+    "#include <AMReX_Print.H>\n",
+    "#include <AMReX_IntVect.H>\n",
+    "#include <AMReX_Box.H>\n",
+    "#include <AMReX_BoxArray.H>\n",
+    "using namespace amrex;"
    ]
   },
   {
@@ -133,7 +115,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Print() << \"The high vector\" << hi;"
+    "Box domain(IntVect{0,0,0}, IntVect{127,127,127});\n",
+    "BoxArray ba(domain);  // Make a new BoxArray of size 128^3\n",
+    "Print() << ba;"
    ]
   },
   {
@@ -142,8 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Box cc(lo,hi);        // By default, Box is cell based.\n",
-    "Box nd(lo,hi+1,typ);  // Construct a nodal Box"
+    "ba.maxSize(64);       // Chop into boxes of size 64^3\n",
+    "Print() << ba;"
    ]
   },
   {
@@ -152,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Print() << \"A cell-centered Box \" << cc << \"\\n\";"
+    "?ba     // ba is a BoxArray ; get the doc for this"
    ]
   },
   {
@@ -161,7 +145,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Print() << \"An all nodal Box    \" << nd << \"\\n\";"
+    "?ba[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Create a distribution mapping over the created BoxArray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <AMReX_DistributionMapping.H>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DistributionMapping dm{ba}; // Create distribution mapping from BoxArray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Here, the mapping is trivial since we are using a single MPI proc\n",
+    "Print() << \"Number of boxes: \" << dm.size() << std::endl;\n",
+    "for (int i=0; i<dm.size(); i++){\n",
+    "    Print() << \"Box number \" << i << \" is owned by MPI proc \" << dm[i] <<std::endl;\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Create a corresponding MultiFab"
    ]
   },
   {
@@ -179,7 +208,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "?MultiFab"
+    "int ncomp = 1;\n",
+    "int ngrow = 0;\n",
+    "MultiFab mf(ba, dm, ncomp, ngrow);"
    ]
   },
   {
@@ -187,7 +218,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "// Right now, the MultiFab allocated with non-sensical data, as it has not been initialize\n",
+    "Print() << mf[0];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mf.setVal(0);\n",
+    "Print() << mf[0];"
+   ]
   }
  ],
  "metadata": {

--- a/Tools/AMReX_developer_notebook.ipynb
+++ b/Tools/AMReX_developer_notebook.ipynb
@@ -28,17 +28,30 @@
     "\n",
     "This will create the library files in `tmp_install_dir/include` and `tmp_install_dir/lib`.\n",
     "\n",
-    "- Create a new `conda` environment and do:\n",
+    "- Create a new `conda` environment and install `xeus-cling`\n",
     "For Linux:\n",
     "```\n",
+    "conda create -n xeus\n",
+    "source activate xeus\n",
     "conda install -c conda-forge xeus-cling jupyter\n",
     "```\n",
     "For MacOS:\n",
     "```\n",
+    "conda create -n xeus\n",
+    "source activate xeus\n",
     "conda install -c QuantStack -c conda-forge xeus-cling jupyter\n",
     "```\n",
     "\n",
-    "- Copy this notebook outside of the source folder of WarpX (so that it is not tracked by `git`), and open it with `jupyter notebook`.\n",
+    "- **Optional:** in order to link the documentation:\n",
+    "In the source folder of amrex, open the file `Docs/Doxygen/doxygen.conf` and change the line `GENERATE_TAGFILE       = ` to `GENERATE_TAGFILE       = amrex.tag.xml`, then run `doxygen doxygen.conf`. This creates a file `amrex.tag`. Copy this file to `$HOME/miniconda3/envs/xeus/share/xcpp/tagfiles/`. Then create a file `amrex.json` in `$HOME/miniconda3/envs/xeus/etc/tags.d/`, and enter the following text:\n",
+    "```\n",
+    "{\n",
+    "    \"url\": \"https://amrex-codes.github.io/amrex/doxygen/\",\n",
+    "    \"tagfile\": \"amrex.tag\"\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "- Copy this notebook outside of the source folder of WarpX (so that it is not tracked by `git`), and open it with `source activate xeus ; jupyter notebook`.\n",
     "\n",
     "- Change the paths of the cells below to the path of your amrex installation, and execute them"
    ]
@@ -102,9 +115,35 @@
     "\n",
     "IntVect lo(AMREX_D_DECL(64,64,64));\n",
     "IntVect hi(AMREX_D_DECL(127,127,127));\n",
-    "IndexType typ({AMREX_D_DECL(1,1,1)});\n",
+    "IndexType typ({AMREX_D_DECL(1,1,1)});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "?IntVect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Print() << \"The high vector\" << hi;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "Box cc(lo,hi);        // By default, Box is cell based.\n",
-    "Box nd(lo,hi+1,typ);  // Construct a nodal Box."
+    "Box nd(lo,hi+1,typ);  // Construct a nodal Box"
    ]
   },
   {
@@ -123,6 +162,24 @@
    "outputs": [],
    "source": [
     "Print() << \"An all nodal Box    \" << nd << \"\\n\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <AMReX_MultiFab.H>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "?MultiFab"
    ]
   },
   {

--- a/Tools/AMReX_developer_notebook.ipynb
+++ b/Tools/AMReX_developer_notebook.ipynb
@@ -43,7 +43,7 @@
     "```\n",
     "\n",
     "- **Optional:** in order to link the documentation:\n",
-    "In the source folder of amrex, open the file `Docs/Doxygen/doxygen.conf` and change the line `GENERATE_TAGFILE       = ` to `GENERATE_TAGFILE       = amrex.tag.xml`, then run `doxygen doxygen.conf`. This creates a file `amrex.tag`. Copy this file to `$HOME/miniconda3/envs/xeus/share/xcpp/tagfiles/`. Then create a file `amrex.json` in `$HOME/miniconda3/envs/xeus/etc/tags.d/`, and enter the following text:\n",
+    "In the source folder of amrex, open the file `Docs/Doxygen/doxygen.conf` and change the line `GENERATE_TAGFILE       = ` to `GENERATE_TAGFILE       = amrex.tag.xml`, then run `doxygen doxygen.conf`. This creates a file `amrex.tag`. Copy this file to `$HOME/miniconda3/envs/xeus/share/xeus-cling/tagfiles/`. Then create a file `amrex.json` in `$HOME/miniconda3/envs/xeus/etc/xeus-cling/tags.d/`, and enter the following text:\n",
     "```\n",
     "{\n",
     "    \"url\": \"https://amrex-codes.github.io/amrex/doxygen/\",\n",


### PR DESCRIPTION
This adds a notebook in `Tools` for developers to interactively use AMReX.

Caveat: I have not been able to use it on MacOS, because I failed to compile AMReX as a library in that case (using CMake) ; but that might be a limitation of my own setup...