### PR TITLE
HDF5 IO for the Boosted Frame Diagnostics

### DIFF
--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -6,6 +6,7 @@
 #include <AMReX_VisMF.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Geometry.H>
 
 #include "MultiParticleContainer.H"
 #include "WarpXConst.H"
@@ -36,9 +37,13 @@ class BoostedFrameDiagnostic {
         amrex::Real current_z_lab;
         amrex::Real current_z_boost;
         int file_num;
+        int initial_i;
+        const BoostedFrameDiagnostic& my_bfd;
 
-        LabSnapShot(amrex::Real t_lab_in, amrex::Real zmin_lab_in, 
-                    amrex::Real zmax_lab_in, int file_num_in);
+        LabSnapShot(amrex::Real t_lab_in, amrex::Real t_boost,
+                    amrex::Real zmin_lab_in, 
+                    amrex::Real zmax_lab_in, int file_num_in,
+                    const BoostedFrameDiagnostic& bfd);
         
         ///
         /// This snapshot is at time t_lab, and the simulation is at time t_boost.
@@ -64,7 +69,9 @@ class BoostedFrameDiagnostic {
     amrex::Real dt_snapshots_lab_;
     amrex::Real dt_boost_;
     int N_snapshots_;
-    int Nz_lab_;    
+    unsigned Nx_lab_;
+    unsigned Ny_lab_;
+    unsigned Nz_lab_;   
     int boost_direction_;
 
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > data_buffer_;
@@ -79,11 +86,12 @@ class BoostedFrameDiagnostic {
                            const std::string& name, const int i_lab);
     
 public:
-
+    
     BoostedFrameDiagnostic(amrex::Real zmin_lab, amrex::Real zmax_lab, 
                            amrex::Real v_window_lab, amrex::Real dt_snapshots_lab,
                            int N_snapshots, amrex::Real gamma_boost,
-                           amrex::Real t_boost, amrex::Real dt_boost, int boost_direction);
+                           amrex::Real t_boost, amrex::Real dt_boost, int boost_direction,
+                           const amrex::Geometry& geom);
     
     void Flush(const amrex::Geometry& geom);
     

--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -84,6 +84,8 @@ class BoostedFrameDiagnostic {
     
     void writeParticleData(const WarpXParticleContainer::DiagnosticParticleData& pdata,
                            const std::string& name, const int i_lab);
+
+    void writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata);
     
 public:
     

--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -85,9 +85,10 @@ class BoostedFrameDiagnostic {
     void writeParticleData(const WarpXParticleContainer::DiagnosticParticleData& pdata,
                            const std::string& name, const int i_lab);
 
+#ifdef WARPX_USE_HDF5
     void writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata,
                                const std::string& name, const std::string& species_name);
-    
+#endif
 public:
     
     BoostedFrameDiagnostic(amrex::Real zmin_lab, amrex::Real zmax_lab, 

--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -75,7 +75,7 @@ class BoostedFrameDiagnostic {
     int boost_direction_;
 
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > data_buffer_;
-    amrex::Vector<amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> > particles_buffer_; 
+    amrex::Vector<amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> > particles_buffer_;
     int num_buffer_ = 256;
     int max_box_size_ = 256;
     amrex::Vector<int> buff_counter_;
@@ -85,7 +85,8 @@ class BoostedFrameDiagnostic {
     void writeParticleData(const WarpXParticleContainer::DiagnosticParticleData& pdata,
                            const std::string& name, const int i_lab);
 
-    void writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata);
+    void writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata,
+                               const std::string& name, const std::string& species_name);
     
 public:
     

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -161,7 +161,7 @@ namespace
 
         // Create collective io prop list.
         hid_t collective_plist = H5Pcreate(H5P_DATASET_XFER);
-        H5Pset_dxpl_mpio(collective_plist, H5FD_MPIO_COLLECTIVE);
+        H5Pset_dxpl_mpio(collective_plist, H5FD_MPIO_INDEPENDENT);
 
         // Iterate over Fabs, select matching hyperslab and write.
         hid_t status;
@@ -226,6 +226,8 @@ namespace
             write_count++;
         }
 
+        ParallelDescriptor::Barrier();
+        
         // Close HDF5 resources.
         H5Pclose(collective_plist);
         H5Sclose(file_dataspace);

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -166,7 +166,7 @@ namespace
     }
 
     /*
-      Creates an extendible dataset, suitable for storing particle data.
+      Resize an extendible dataset, suitable for storing particle data.
       Should be run only by the master rank.
     */
     long output_resize_particle_field(const std::string& file_path, const std::string& field_path,
@@ -205,7 +205,7 @@ namespace
     }
 
     /*
-      Creates an extendible dataset, suitable for storing particle data.
+      Writes to a dataset that has been extended to the proper size. Suitable for writing particle data.
       Should be run on all ranks collectively.
     */
     void output_write_particle_field(const std::string& file_path, const std::string& field_path,
@@ -717,6 +717,8 @@ writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdat
         }
     }
 
+    // Note, this has the effect of an MPI Barrier between the above resize operation
+    // and the below write.
     ParallelDescriptor::ReduceLongMax(old_np);
     
     // Write data here

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -384,9 +384,13 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
             
             if (WarpX::do_boosted_frame_particles) {
                 for (int j = 0; j < mypc.nSpecies(); ++j) {
+#ifdef WARPX_USE_HDF5
+                    writeParticleDataHDF5(particles_buffer_[i][j]);
+#else
                     std::stringstream part_ss;
                     part_ss << snapshots_[i].file_name + "/" + species_names[j] + "/";
                     writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
+#endif
                 }
                 particles_buffer_[i].clear();
             }
@@ -509,9 +513,13 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             
             if (WarpX::do_boosted_frame_particles) {
                 for (int j = 0; j < mypc.nSpecies(); ++j) {
+#ifdef WARPX_USE_HDF5
+                    writeParticleDataHDF5(particles_buffer_[i][j]);
+#else
                     std::stringstream part_ss;
                     part_ss << snapshots_[i].file_name + "/" + species_names[j] + "/";
                     writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
+#endif
                 }            
                 particles_buffer_[i].clear();
             }
@@ -524,8 +532,14 @@ writeLabFrameData(const MultiFab* cell_centered_data,
 
 void
 BoostedFrameDiagnostic::
-writeParticleData(const WarpXParticleContainer::DiagnosticParticleData& pdata, const std::string& name,
-                  const int i_lab)
+writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata)
+{
+}
+
+void
+BoostedFrameDiagnostic::
+writeParticleData(const WarpXParticleContainer::DiagnosticParticleData& pdata,
+                  const std::string& name, const int i_lab)
 {
     BL_PROFILE("BoostedFrameDiagnostic::writeParticleData");
     

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -186,7 +186,7 @@ namespace
 
     /*
       Creates an extendible dataset, suitable for storing particle data.
-      Should be run only by the master rank.
+      Should be run on all ranks collectively.
     */
     void output_write_particle_field(const std::string& file_path, const std::string& field_path,
                                      const Real* data_ptr, const long count, const long index)
@@ -267,7 +267,7 @@ namespace
     
     /*
       Creates an extendible dataset, suitable for storing particle data.
-      Should be run only by the master rank.
+      Should be run on all ranks collectively.
     */
     void output_create_particle_field(const std::string& file_path, const std::string& field_path)
     {        

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -10,6 +10,10 @@ using namespace amrex;
 
 #include <hdf5.h>
 
+/*
+  Helper functions for doing the HDF5 IO.
+
+ */
 namespace
 {
     const std::vector<std::string> particle_field_names = {"w", "x", "y", "z", "ux", "uy", "uz"};
@@ -29,6 +33,10 @@ namespace
         H5Fclose(file);
     }
 
+    /*
+      Writes a single string attribute to the given group. 
+      Should only be called by the root process.
+    */
     void write_string_attribute(hid_t& group, const std::string& key, const std::string& val)
     {
         hid_t str_type     = H5Tcopy(H5T_C_S1);
@@ -45,6 +53,10 @@ namespace
         H5Tclose(str_type);
     }
 
+    /*
+      Writes a single double attribute to the given group. 
+      Should only be called by the root process.
+    */
     void write_double_attribute(hid_t& group, const std::string& key, const double val)
     {
         hid_t scalar_space = H5Screate(H5S_SCALAR);
@@ -128,6 +140,10 @@ namespace
         H5Fclose(file);
     }
 
+    /*
+      Creates a group associated with a single particle species.
+      Should be run by all processes collectively.
+    */    
     void output_create_species_group(const std::string& file_path, const std::string& species_name)
     {
         MPI_Comm comm = MPI_COMM_WORLD;

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -166,8 +166,8 @@ namespace
         }
 
         // Close resources.
-        H5Dclose(dataset);
         H5Sclose(filespace);
+        H5Dclose(dataset);
         H5Fclose(file);
     }
 
@@ -178,7 +178,7 @@ namespace
     void output_write_particle_field(const std::string& file_path, const std::string& field_path,
                                      const Real* data_ptr, const long count, const long index)
     {        
-        BL_PROFILE("output_resize_particle_field");
+        BL_PROFILE("output_write_particle_field");
 
         MPI_Comm comm = MPI_COMM_WORLD;
         MPI_Info info = MPI_INFO_NULL;
@@ -197,7 +197,7 @@ namespace
         hsize_t dims[1];
         herr_t status;
         
-        hid_t dataset = H5Dopen2 (file, field_path.c_str(), H5P_DEFAULT);
+        hid_t dataset = H5Dopen (file, field_path.c_str(), H5P_DEFAULT);
 
         // Make sure the dataset is there.
         if (dataset < 0)

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -674,6 +674,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
     VisMF::SetHeaderVersion(current_version);    
 }
 
+#ifdef WARPX_USE_HDF5
 void
 BoostedFrameDiagnostic::
 writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdata,
@@ -718,6 +719,7 @@ writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdat
                                     particle_offsets[ParallelDescriptor::MyProc()] + old_np);
     }    
 }
+#endif
 
 void
 BoostedFrameDiagnostic::

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -58,8 +58,7 @@ namespace
       Should be run only by the root process.
     */
     void output_write_metadata(const std::string& file_path,
-                               const int istep, const Real time, const Real dt,
-                               const int nx, const int ny, const int nz)
+                               const int istep, const Real time, const Real dt)
     {
         BL_PROFILE("output_write_metadata");
         hid_t file = H5Fopen(file_path.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
@@ -95,9 +94,8 @@ namespace
       Should be run only by the master rank.
     */
     void output_create_field(const std::string& file_path, const std::string& field_path,
-                             const int nx, const int ny, const int nz)
-    {
-
+                             const unsigned nx, const unsigned ny, const unsigned nz)
+    {        
         BL_PROFILE("output_create_field");
 
         // Open the output.
@@ -174,9 +172,9 @@ namespace
 
             const Real *fab_data = mf[mfi].dataPtr();
 
-            int nx = hi_vec[0] - lo_vec[0] + 1;
-            int ny = hi_vec[1] - lo_vec[1] + 1;
-            int nz = hi_vec[2] - lo_vec[2] + 1;
+            unsigned nx = hi_vec[0] - lo_vec[0] + 1;
+            unsigned ny = hi_vec[1] - lo_vec[1] + 1;
+            unsigned nz = hi_vec[2] - lo_vec[2] + 1;
 
             // Set slab offset and shape.
             slab_offsets[0] = lo_vec[0];
@@ -228,25 +226,25 @@ namespace
     {
         AMREX_ALWAYS_ASSERT(nlevels == 1);
         const Box& domain = geom[0].Domain();
-        const int nx = domain.length(0);
-        const int ny = domain.length(1);
-        const int nz = domain.length(2);
-        if (ParallelDescriptor::IOProcessor()) {
+        const unsigned nx = domain.length(0);
+        const unsigned ny = domain.length(1);
+        const unsigned nz = domain.length(2);
+        if (ParallelDescriptor::IOProcessor())
+        {
             output_create(plotfilename);
-            output_write_metadata(plotfilename, level_steps[0], time, dt, nx, ny, nz);
+            output_write_metadata(plotfilename, level_steps[0], time, dt);
         }
         ParallelDescriptor::Barrier();
 
         const int nc = mf[0]->nComp();
         for (int i = 0; i < nc; ++i) {
             std::string field_path = "data/" + std::to_string(level_steps[0]) + "/fields/" + varnames[i];
-
             if (ParallelDescriptor::IOProcessor())
-                {
-                    output_create_field(plotfilename, field_path, nx, ny, nz);
-                }
+            {
+                output_create_field(plotfilename, field_path, nx, ny, nz);
+            }
             ParallelDescriptor::Barrier();
-
+            
             output_write_field(plotfilename, field_path, *mf[0], i);
         }
     }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -92,7 +92,7 @@ WarpX::InitDiagnostics () {
                                                moving_window_v, dt_snapshots_lab,
                                                num_snapshots_lab, gamma_boost,
                                                t_new[0], dt_boost, 
-                                               moving_window_dir));
+                                               moving_window_dir, geom[0]));
     }
 }
 

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -94,6 +94,17 @@ ifeq ($(DO_ELECTROSTATIC),TRUE)
      DEFINES += -DWARPX_DO_ELECTROSTATIC
 endif
 
+ifeq ($(USE_HDF5),TRUE)
+    HDF5_HOME ?= NOT_SET
+    ifneq ($(HDF5_HOME),NOT_SET)
+        VPATH_LOCATIONS += $(HDF5_HOME)/include
+        INCLUDE_LOCATIONS += $(HDF5_HOME)/include
+        LIBRARY_LOCATIONS += $(HDF5_HOME)/lib
+    endif
+    DEFINES += -DWARPX_USE_HDF5
+    LIBRARIES += -lhdf5 -lz
+endif     
+
 # job_info support
 CEXE_sources += AMReX_buildInfo.cpp
 CEXE_headers += $(AMREX_HOME)/Tools/C_scripts/AMReX_buildInfo.H

--- a/Tools/boosted_frame_hdf5.ipynb
+++ b/Tools/boosted_frame_hdf5.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pylab inline\n",
+    "import h5py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f = h5py.File(\"/home/atmyers/AMReX-Codes/WarpX/Examples/Physics_applications/plasma_acceleration/lab_frame_data/snapshot00001\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[u'Bx',\n",
+       " u'By',\n",
+       " u'Bz',\n",
+       " u'Ex',\n",
+       " u'Ey',\n",
+       " u'Ez',\n",
+       " u'beam',\n",
+       " u'driver',\n",
+       " u'jx',\n",
+       " u'jy',\n",
+       " u'jz',\n",
+       " u'plasma_e',\n",
+       " u'plasma_p',\n",
+       " u'rho']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.QuadMesh at 0x7f1bdf7d8310>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnW2sJUd55/9P9Tl37szYxp4AsxaghZUQEYo2gEZoIxDK\nxiELJIqt/YCIlN3ZlVfzZTci2pXCsJFW4pt3P0TZD6tIFpAdKSRZRMLaQtlExiGKIkUQXkxiMKwJ\nsYVZj8fY2J6Xe+853fXsh6rqrq7uPt33nnPPPaf9/0l3uru6urvqvNR0/85TVaKqIIQQsv2Yky4A\nIYSQ1cAGnRBCRgIbdEIIGQls0AkhZCSwQSeEkJHABp0QQkYCG3RCCBkJbNAJIWQksEEnhJCRMFnn\nxbLbz+rktXet85KEELL1zJ764Y9U9XV9+dbaoE9eexfu/sSvrfCMxzBsgaz+lISQBSiq791xjkSy\nxd/tp//1x58eko/KhRBCRgIbdEIIGQls0AkhJ89JDPo6woFm2aATQshIYINOCCEjgQ06IYSMhC1v\n0I8hDmmEXo0QEjHi7/iWN+iEEEICgxp0EblTRD4nIt8RkSdE5GdE5JyIPCIiT/olu4ASQsgJMvQO\n/b8D+FNV/UkAPw3gCQCXATyqqm8F8KjfHgcjfiQj5FVL+r3e4p6jXfQ26CLyGgDvA/ApAFDVmaq+\nBOBeAFd8tisA7juuQhJCCOlnyB36WwA8D+B3ReQbIvJJETkL4LyqPuvzXAVw/rgKSQghpJ8hDfoE\nwLsA/I6qvhPATSR6RVUVHaJCRC6JyFdF5KvF9ZvLlrftCsdwTkLI2uBXeGUMadCfAfCMqn7Zb38O\nroF/TkTuBgC/vNZ2sKo+qKoXVPVCdvvZVZSZEEJIC70NuqpeBfADEXmbT7oHwLcBPAzgok+7COCh\nYykhIYSQQQwdD/3XAHxGRHYAfB/Av4X7z+CzInI/gKcBfPh4ikgIIWQIgxp0VX0MwIWWXfestjiE\nEEKOCnuKEkLISGCDTgghI+EEGvTj6IbJQboIGQUMYVwK3qETQshIYINOCCEjgQ06IYSMhKFx6KvB\nKLIdC7WAqkCtRK6a8owQQpaBd+iEEDIS2KATQshIWKtyyYzizJkD5IWB9cqlKAzUVvpF9agaRrDS\nWEMaIELWi4LfuyXhHTohhIwENuiEEDIS1qpcjChu2z1AYQ1UgUINCivIiwzWiku3AluYeiQMwGgY\nQgjpgXfohBAyEtigE0LISGCDTgghI2GtDl1EMc0KTLMCVp0LVxVYldKrz63z6XlhKqduBWr7vDqH\nRySE9DDyZoJ36IQQMhLYoBNCyEhY7+BcEUYUBlpGIdrMrZzSvKZhCr+MNYwtjNcwoYepJj1Ml4SR\nkYSsF1rTlcA7dEIIGQls0AkhZCSwQSeEkJFwYg49xXiBlhkLwI+6mLl9FpFT9149LwzyIkPhfXrr\nqI3A0bwcR30j5OSgTz8yvEMnhJCRMOgOXUSeAnAdQAEgV9ULInIOwP8C8GYATwH4sKr++HiKSQgh\npI/DKJd/rqo/irYvA3hUVR8Qkct++2OHubiFlKoloCoQUYhU6RkUmQBTU5R5LCoFM7emVcFAxfUu\ntXJ4BbMoH3UMIatHkvUu9bmMjhn5d3cZ5XIvgCt+/QqA+5YvDiGEkKMytEFXAF8Uka+JyCWfdl5V\nn/XrVwGcX3npCCGEDGaocnmvqv5QRF4P4BER+U68U1VVYkcS4f8DuAQAp15/Rzkol/HZbfQMFPRL\n0CMdp0RmLDIAmVggA3Y7FIyqYJ5nvndpmDijbe7SQ9J33KLHxVVfa9sZ+SPwSdP1HVqWUmEeJ12X\n4Gemk0F36Kr6Q7+8BuDzAN4N4DkRuRsA/PJax7EPquoFVb0wec3p1ZSaEEJIg94GXUTOisjtYR3A\nLwB4HMDDAC76bBcBPHRchSSEENLPEOVyHsDnRSTk/31V/VMR+RsAnxWR+wE8DeDDx1dMQgghffQ2\n6Kr6fQA/3ZL+AoB7jnph2+LgLKR06+4i3rcnItkmx4moC23M6k499C7NC4O5dSGN8zyrepYWUoU0\nKrBYzh3CRWqyPFE2RTh2vBjH8RptSpVXyHG58KOyKeUJYc7x8tUMe4oSQshIYINOCCEjYc1ziqKm\nVFq1S4eKAaJjtdnDNH4ELBWM712qWaVg8iJDYQWzIkNeZMgLP2FGYeq9ShsKJl7fhMfNIz5anljR\npXV1OdakcU74Kf5E9MaWmAvxk+SIf9P7XquxqxneoRNCyEhgg04IISOBDTohhIyEtTp0A8Xpybzm\nydvWU79lW4ReOmRAfEzq0cJQAQBwKsth1XnyXN0IjWGogDBMgHaGNQInJxd7rruKUSTXRVqGo7yk\nctQDuwqxmqwANtc/r7hcmxC6qPBOfFHlomKGMsdlH5NP5x06IYSMBDbohBAyEtYctqjY8ZNUdFFT\nMGjqmHSZrvdhRMvwxykK2CwHANej1CsYqy6sMfQsLTrDGhdVtmf/4KfVYY+Svecd8BrpMT9BS1cR\nGgpmQEEOO5plI+9hH7OXVDRHeKo/ktJY13WWuN4qKRVKx/ujKr0Rx2PSL7xDJ4SQkcAGnRBCRsJa\nlUsgKI90We7veHwKCqZLv1g/KFecVh6bbKfXnhiLUwAw9efxA3vNbYZZnmFuM8xz17O0yE1zsgyg\nepwb8tQW8ix82m05UZq/sV0/plOjLLrucTx2ii5WOrXH4vr1e1XNqqMtWq+35MBth/ls4BAaZMD5\nVnmu6pzD8zYPXvL9avt8SvtnPVUxjWiY5JjwWm2reuEdOiGEjAQ26IQQMhLYoBNCyEg4EYduVRre\nHKjceeW3bW07zVeer+HWTX3bj7S4KPSxRkjO/LE7gtxPQH1QTJAXBrMiw2w+cRNT5wZQqYc1DmGo\nP4/zLXDmOjAf0KExh6jNvrp1+tH+0Ra7Tq1t5+xw7gt9e5+77ftdo7PqhxiJsyfcstd3H/XYhcct\nvqTL1P/hOGr4Y9/1VV2e8vPdch03imLYiL4TtUwtjrzjPd9Wl847dEIIGQls0AkhZCSsVbmkIUNd\n6gVo6pYuHZMl+9sISqZQgVXTomJMf8hj5pZndQYLp2AOiglm+cT1KrXiwxozFLkLaWyENdZfjA56\nVEubYqnlc/ul7djk+N4QyIXl7EIWbnamJx366hVId3bombbQyBY10/2I31HZRSqmswdqz7nS5D6t\ndOS87eldCmWRNulTI4OUy1F6sqaHtlwmvO8aqbVSw0R6RRXd6uXkxxpbGt6hE0LISGCDTgghI4EN\nOiGEjIQTCVsMxP48deTxeryvzZ2nvj1DfA7bOF99pEaDInbpLb49du3heJc2cyMzWjdC40E+wUEx\nwUE+wTx3QwZ0DhPQSovfTtx5w5urVDo09eytjr2ep9O1HzdxVRs+PYrti/fFkY8Dj2k7d6dn73Ts\nC5z1UYZ7CJupc+7b35on3d88pu086XGd/vswHr87+7BrDST+DlUvv5vkRqLEyqtHTt3/HhP2haEB\naqMyRsXbtvBF3qETQshIGNygi0gmIt8QkS/47XMi8oiIPOmXdx1fMQkhhPRxGOXyUQBPALjDb18G\n8KiqPiAil/32xxadQGrqJFpvUSppulvaRpiiEdtQLbW0Mn+qZSoV00aBoFuM1y+CuWalepmraSqZ\nHTdJxqzIsF9MsJdPcTB3CmY2n6DwIzXGIY3hlSlp0Sc1zRKrklifaHJsqlTix8guNdOVD+37D01H\n6GFTG4Qd2sibnqtKlyp/FOcm6XUbMXDJuYOSqXVsbZanu8dn/AImRZb2fd3p9XJ1nUu6ztV3rfZi\ndiiafm0T0xWOvOh8i2jMM9wSvqt+rmBIeHu8htEQwqhQ1Uq9oKls/EZrz9Ft0C6D7tBF5I0AfhHA\nJ6PkewFc8etXANy32qIRQgg5DEOVy28D+A2gdlt7XlWf9etXAZxfZcEIIYQcjl7lIiK/BOCaqn5N\nRH62LY+qqnQ8Q4nIJQCXAOD0+dswMbYWvRLrlK50wKmTWLO4pXZqFoN6dEuWKhex5fmy8nzVMXGk\nTFH2IDUofCRMoaZUMOkyVzchxsxmmNkJbuVT7M2n2M+n2JtPcDCbJvoFlTYBSmWSqpZOzdK2H0HL\n1HVM/Rzt+mWxpqkvlwlY0Fh/pArFuxIN+0K0gbTkL49x2qWuUOJzaqRzqv3lR1fi3syJvkmJr5vk\njc9X266lRWWK8nTqk5Zz1apZUzDtOgaoq5AhaqVNqyzSKX0qZVGP7i5s8iYE9RG0S6pcbPTdCdux\nfrEWXq3V1cuQiJdN1y5DHPp7APyyiHwIwC6AO0Tk9wA8JyJ3q+qzInI3gGttB6vqgwAeBIC7fvL1\ny8UrEUII6aRXuajqx1X1jar6ZgAfAfDnqvqrAB4GcNFnuwjgoWMrJSGEkF6WiUN/AMD7ReRJAD/v\ntwkhhJwQh+opqqp/AeAv/PoLAO45zPECYOJdd1d4Yhqa2NYLtJEWOfMuXx7Ol/ry+Hyxj3fb7RNs\nBILDm+vEL7Pqz7rlgZ2Uf/vFFLfyHdyY7+Dm7BT25hPkRYb5PEM+z2BzA9jIC6ZufIE3T325RPlE\nUZ5XFBCLRr5yaTuOb8uPqCx9eOccO3I1UZrU15tp0khTUzleNer3SeW3g3uPHLuGtFrYYSVMBS0h\nkuGFi+pRVj52263r0bF+n3QdE06fePVwHpOkt3n3NA9Q99Yhb59LTz/zQ/J0cVhvnjpzIA1TrBx6\nfR3uNy6/Hpx6UX6nxI/wCrhe26iFMYZSLgph3HSPzp6ihBAyEtigE0LISFjr4Fwiip0sL8MSu0IS\nu/RK3Osz7vHZF4rYVCnaqlXCeqxo6tv1gcHS3qaF//+xUMFcJ7AQ7Nsp5jrBvk5wYKe4Vexgr9jB\njWIHr8xPY1ZkeHm2ixsHp7B3MMVsNkExy9yTXhHpltCzNKgTG2kWG6kSK26fhUvXZL3wxxZVugn7\nkz93Pi2vB6Ae9li+sdVqHEZY6hPjVYepVEmpW3xa2FdTMabSKvHSvxnOnJioED5ksZbPP0yrf3R2\nC6k0SPWc3UQSZdKiW+IQxTbVkmqRkKdLsXSplViVSPk90IZCEdHG8ekgd430WM+0paG5v2u7L72P\n1sllkvR4juDwp77HdmFNuV1Yl5YXflA9a1yaNdXnQV0YozNwUvYSboQwbol24R06IYSMBDbohBAy\nEtigE0LISFivQ4dix+StzvwwvrwrDDF25fX15kiLreeAbfjx2LWnIzdmiYcP54uxEBQwmOsEM80w\n1wlu2R3s2ymu210c2Clezk/jxdlZvHhwBj8+OI1X9naxt7+D+f4EOjeQufGOW0pPjuDBC4EpEjee\nAyZ36yZsF3C+PFcYvy2FWxer3ptrFOaYOGb3BvpKSsOPO+8tiR8P+7RM16zKo8adX4y/TOzfwz5b\nrZflkQXLRcRhk3GdovDGMqyx5di2cMWwr9Hd/hD+PM4XHHl6bEivPHji08P+Fl/eGN20Fhbc9Ol9\nE7N37Y/zANVvTeW+Q4QvxqGLYbIZoJpcBgByP7FMmLQ9t260U6tuu1CDwhoUxrnzwiiMFVirNZdu\nBFDrQhjdB9YbdI18eRXZutHwDp0QQkYCG3RCCBkJaw5bBKZiW0MT2zTLopDEoFXSUMSuMMRFaiU+\nLi5DqlTic5RKJ8pXS18Q2mhVMNMM+zrFHBlu2lN4uTiDF/PbcG1+B57bvx1X927H8zdvw42bp5Df\n3AH2jNMrMwBWYOZOq5gZkM0AMw9LjZYKkytkrjCFOrWSK6SwEL9dDktnUf33LgIte1z6XnZZCD10\n+yp1IkCiUcowxUz9OSM/IWVcWNnLtDHHZ5S1NzpMkmVjXVs0S6JMOs5bhiz29A6thy6ioVvS0May\nyKVecdttuqUWjohm3jRc0eVp1yjNXtktyiUJKQ7HpJPM9I18Gp+zbfTTQNaS7npzVushHLgMYfST\nzuQ2QwG3tJByhNPcZsjVKZiZzTArslK/zIsMuW2qF2vgQ4K1CmEMb3dLmOKmhi7yDp0QQkYCG3RC\nCBkJa1UuQHtP0KBbhkS0xKoljWQJmqWhZzoUS6pXMtSPS7VKrFNKRRM9job9VT7Ut5PXwsJNnjFX\nwb5muGl38JI9g+dP34Fnzp7DP5z9CTx1/Rz+3+Q12Le7kD2DyQ1BdgBMbgHTW4rJnvvL9i0m+wXM\nzEJmBWReQIoCKBRibRS1kjgOkfBsDzXGFdIYt55JqV8kE6dSMpdX1GsXdfWQNOREgHpogNMs1aBj\n0V+UpSTZHqRf4kvWNIk/ZaxQ4jxphMuqdUt0TJtuibVJX6/QvsiW2naqVdDULG1KpU2/pAPmLerN\nnQ6Ul2rTtgHy4u04LaY20QzC3L5ZOdlMrhkOignmanBgJ8hthv1iilmWlfrlwEycdikM5gKICAoB\nxAqsuLl+az1Hw9seR7tscKQL79AJIWQksEEnhJCRwAadEEJGwpodehyu1AxXrPZV/rwrVDEdMTH1\n52mIYurOF3nz2JnXepf67QyhZ6uvRyh36cwFBkDmZajxOTKE7WREOSgKWMz1Fm7pTVyf/BhvmL6I\n89OXccdkH6qCp/emkGKKnVeAneuKM88X2PnxDJNXDiB7M+DgAJjnQFEAhYVqFC4pphL6pTM31dII\nYDJIZtx2pkBmAWugEwMRL5gz3yV0UlfcYbdbcbJbwtttUXpHVZRzSxzWQ7b18CzntZaOPHHa0hFm\nVYEbkz0Efx4nNXqP1tebkzHX07r8ebq/zZ+3OfLadqtXb4YppqOhdv3+VeWpvofhXPH3sRli3PwN\nzO2v98ROKXyvUdcDOytd+lwz7JtpbWKZU1mOm/kOcpthYm1UvwxSALkYiChyZID7yMMAiz36BsM7\ndEIIGQls0AkhZCScQNhi+7N2+rgW0/XoBSynW9JrtOmWPtWSSV2xGIjfFr9tSsWSiSn1S4qFxVwL\nnNECu5LDyCsoYPBycQbPnL4Lz0zvhFgXrrjziuLU8weYXHsZ+tLLsDf3YGczN8JQQAzECCTLoFkG\nyTLnAbLMhR2KATLjtq00PwmSOT9iAZjQm1ScBrBRCKIFkKFUOhJ6f4bzxKGJqE+AIdo0L0d5oh0c\n0rhhpJqmK62+v/n9iXuHdhFrlvi4Nt0S06dbunp39+lSd71muHEoV/z9NEmbYCVMJGOwIzlmOsFU\nc+zrFEYsDuy0/K5nUBSZIPfnsyqwmZSTZKgCVjIY8ZOjqJSTpAAdc4tucOgi79AJIWQksEEnhJCR\nwAadEEJGwmgb9NS7tdHm61eNhYWNhJvtuabtkHPlxMcCaIbaSIiDCd3+7fICsMtZb5TL7vHKhIyN\n0TbohBDyaqO3QReRXRH5ioh8U0S+JSKf8OnnROQREXnSL+86/uISQgjpYkjY4gGAn1PVGyIyBfBX\nIvJ/APxLAI+q6gMichnAZQAf6ztZPHh92z6IaU4KoWZh6GI4znXt8pNQlgP92WhfczuDdXMUqnHH\nojpP4ecrLESRqVMnbl3LEhpEo8WplmGMbjvuLSqAVvtq9YPCQjFXxU0FrtsJrhZ34KnZ6/CD/XN4\nYe8MirmBGMX8jCvr5PW72JkaTG47DXPrACb0FM1zwKrrKWq1ClEEXGhhNcGlC1kUceGLJvNLH87o\n5wgtEXEvTS0NrbcEcWhiOuqhhMEe05EV4/2r0jYuDm1FJ1s9qk1r1pZW3y+NEEULgdH2kMYyj39R\n4++e9Z9JwMCI9d+j+tyfRTnCoAGi3pzWb5eIib5b7ntUwIcc+56d4btp4UdWVAMLA+O/g2EiiwwW\nc82i73xWq0voKTrXzE8YE/UUtVMc2EnZW3RmJ9gvpsj95Bczm2FeZG6uUT/vqLOQAo3mEnV2Mnoj\n4pd2cz9S/Xfo6rjhN6f+TwHcC+CKT78C4L5jKSEhhJBBDHLoIpKJyGMArgF4RFW/DOC8qj7rs1wF\ncP6YykgIIWQAg3qKqmoB4B0icieAz4vITyX7VTqe90TkEoBLAHDbPzpbphdBc4THNvGPXqU+8foj\nPHYlj21OibihtdzjW6xSLKxm7tFRnHkoIMj8w13huzdmWu85OtesGqxLo96jWg0WlGk10FEG6zVK\nlKZVb7qQ5rabysgN0u+WN3WKW2GCi/x2PDM7h6f3zuGp6+dw9eU7UOxPMDHA/A6g2AWK3QyT157G\ndG8Xkz2LbN//HRSQ3E9wMXcTXGDgBBeQMIGFqa2ruIG5NEyEkVVLrWmccD5nO9S/xWE9HlArXT8K\nqZ4ZrGtS5TPsagjP2m3aI1Ul7iWu8sXHhEf5+BxdaSLqlYpflsrD9U52+kJL7dIqJkv9WCWV6rOs\nVri3s/47IzClHg1pmSuH7yVaaIZMtdQ1RgQZtFQ5RrS8TlAoZS9QdRrF1L5T3RNcFNEb1jfBhVMu\nppzgYr+YuHl8rZ8AI0xwYTNYKyisgbW+56gVWOv0C3xP0k1WLCmHinJR1ZcAfAnABwA8JyJ3A4Bf\nXus45kFVvaCqF3bv2l22vIQQQjoYEuXyOn9nDhE5DeD9AL4D4GEAF322iwAeOq5CEkII6WeIcrkb\nwBURyeD+A/isqn5BRP4awGdF5H4ATwP48DGWkxBCSA+9Dbqq/i2Ad7akvwDgnsNe0Krx0XS2Fg5V\nOjjR0ocXWrm+AiE8y8B6B2fEhRIaCKwPN3ROLhoZLvLfLqzQee9y4mitTxzt8oYwxGoEuODLKwcY\nT/5cH5C/5s/9+UNIllXxE0NPsK8TzHSCW/YUXirO4MXiLF6Y347n9m/H1b3b8cKts3jlxi7yW1PI\ngYFmQH5WgdOC/AxgcsDMBGaeIZtnMDMgmynMHMjmCjNTmFxh5m4pViHl0tVBrPeW/icLAKUMDs4c\n/m0KvlxLf+7TovVy6Xu01tJDCGNbSGPqtPscdxmGmuRN0kuvXuriKJSxdKPlnvJfd3g0rJ74f1T9\nwk19oGEKhHKXC31zkyEA0RQJ5bUFcUicd86IH5cVhUqIFAXgBrgMHh3+OxHestI8CxoePXx/Yl+e\nhg5bSDUJRpnflulGBTaaRDoLjhzqv4sm+qzXR28EUBuRMU4HhvXWjr87rrwGhQpym6GAWwZnnteW\nbmLoWeE8e2GN8+fWoLACGy2DPw/himolvBVuofXtTYU9RQkhZCSwQSeEkJGw1gkuVIG5VvNrhhCo\n8MiWhW2YcvD8OASqDCuUKvSpNqGFD4EyqRLxGsatK+I5C2uD8EePf5nEcyMmOkbbNIstH8dM9Bhd\nwPVGszDYt1PMNMOBTnHTnsKNYhf7dopX8l28ND+DFw/O4McHp3F9/xRu7Z1CfpDBzjJI7l4DzRTF\nLiCqsDsCsYAUAing/ixgcr+dC0we0twfLGAKLbelUEjh0sS6N0isNxLxAF6p1vBKxUWeShme6HQM\nqkHEon3VX5UnDmds/bwcRsO0hSJGyqOcp0ArrdJ3vkNrF1THpNrF/auJ8qnHE1o/UUpciFjHBO0S\n57X+PEHBuOI6VVJEoZKxeinDCbU+/2i5VMCIqc1F6pYu3DeejzRQz+NI5wpOj+nCRm9METSLmki5\nuBDDkJaHpTW19aBZCq9W3HZdtSjgVUulW5DolbZ5RDd1blHeoRNCyEhgg04IISOBDTohhIyE9Tp0\nCGZ2AgNFDpThUZWXroc8dYVAmRYfXnp1oOHVa+FUqVtPQqmyxI2nk06HMnThRmg0ZXfkuWbY1ynm\nmuFWcQoHdoIbxSnczE/hRn4KsyLDy7Nd3Jzt4Nb+DmazCezcQAsDLQRSeFdnAPWvU+gSrvAjI5Te\nGxDr3bqFD0v0y8LlEescu/PpUh4bHHx6rKi7Zpj8uVb1xFunXflTz47gzWueHbV9aNnfGt7YtWwp\nV2d67W1MQhfT91ijbJFHD/u01s2/6dElde7+/av/UFAPSyzPJVW6ip8QWhENL+A/G/56Icw33gYq\nfy2l764vO9NaXHnX9tB9bdgWL11688ifh+34T8PIqCEEUaXmzTVKK925ut+mGl39gfJ7VrLh4YoB\n3qETQshIYINOCCEjYc1hi4JZMamFOKXhUUGxuFEQ66FQQcNUxy7WMOX2EVRM6OEZztGG6/VpytHf\n5ppVg+1bF544twYH1o0At19McSvfwY35Dm7Nd3BrNkVeZJjPM+TzDDb33sG6UCqo2xTAdQH0j4hQ\nH4YXJnAoB5kUaKJIqnWpqxMb7UO1HdKqbWk5lz8mWl/4SBppkdqoiwvWa2n+tiNNi0Me1Wjr+SBa\nU0EqiCod/bURhy56zVHVyWkXTUMSvSIpdUrZ61bLw0QqRaM+UXyX1lAUG9RKdDmg+ixKY1nfH++L\nlUk8ImRb3rZ9XXm68nVx2JDFWnqkP4IKKVWL31Z1k1/YKAQxaJZwXDgG5X6gbWTFRbplU0MWAd6h\nE0LIaGCDTgghI2GtysUCyDUMouUG/QEi1aJVD7W8lm6akTChd2mZ11YDBMWDAWkzGgboiGIpJ9No\nKbt/7g/RK0G35Jphbivtkg4UFAbY35tPsZ9PsTefYDafIM8zFLlxvdSsVDrFI2Ez9DZUKSNOXBn9\nI3+pQ+paQFGpFvWaBmUaykwSny+qu0R52rZrZT1CBEAaEVOLjPHbtTwh6iPVM6i2Q2FqT8S1fNoe\nHRMpmM6n6eT1dfnDm6TuMbzl3IqgKoJ6kfLQskxlHtT21RRHVK5Ss6CZ1jguvhaaiqSZt021NJIW\nqpZFc5sCw9RLoE3BxMrFbVfplVap0qp8VVRLtR2dY4Bu2XR4h04IISOBDTohhIwENuiEEDIS1urQ\nASC3pproFlJ6b6thFDdbpoeJagEXxmXE+sme3WhyVuFHZwQMpJxstpzEFm4i2nLiWlT+rq1XGlAf\nTD8MpB9GdguO3EJ8uvH5xI/w5rz5rMgwsxn28ikO5hMc5M6bF4WBLQxsIWVYokOqRalb1blLlYZL\nd5stPh0owwvDcVLKxNqi8uuhCEk+xPlSjuIVk5c79dzt69rMm+TTlvwLe5GmefrO0UXtNZDqvQs+\nPS5jCG2MXszqmiF8sX6My59cs8OTp/kaDrtnf+vLO8Ctt5bRMzScsc+3A+1hgvUwxipfyFt+NaIQ\nxZC34c5rvpAsAAANl0lEQVT9AUPc+SaHLAK8QyeEkNHABp0QQkbC2gfnAqrHpaBV4kGOolkU/aD9\nQa9IbV91THtamJ/BiE2OrShDEeMB8zt0SsibDrIfD6p/kE9wUDjFMs8zzHxooi1M1fMzCQ+sb0SP\n7lLtC+rFjQnlNUSkW1KtUk6iGaxMfK1aaJY2lUraK67xqq2IPuXRkq9zPT2u69xt52851yLV0Xn9\nxg5teS3rj/TVYF6Jcuu8bvVdqTROan9qHx6fp3meNlVSz9dUQIvPWT+y6Nw7TLO00TrRRLpfm/lj\nJdOmWhrnbinepquWAO/QCSFkJLBBJ4SQkcAGnRBCRsLawxZjwsS1XWlhPfbozruX0+OWjs9qVk6g\nm4dzRQKwSDx4OtFsyB+HQ6WhjeWA+hDMCjei4iyfYFZkKKxgnmfIi7RL/2H8m/efUt+sNgCJ3Ka6\nuMTKBwKlP6+9rI39PjHVvF1qcxmR3lX1hqdOtxeH3rWHMg5z3V2hdp1jGCx6+w6jVhO9HX8uwqQV\n9ewtJ9e6g6699+G3lkYZW9xza12b4ZVdp2krW/mbQOvRi8tzKBY47vj1qH6vSkIc2/L0nHdb4B06\nIYSMhN4GXUTeJCJfEpFvi8i3ROSjPv2ciDwiIk/65V3HX1xCCCFdDFEuOYD/pKpfF5HbAXxNRB4B\n8G8APKqqD4jIZQCXAXxsVQWzaqKQQ0RqJTxGtYUhdocXVvvroZO95YjCEwtrcFA4xTLP3V9hDQo/\nMYX6iSkGPaalIWolSQhjSJJ0P2rhjEClYMr12mlrsaHL9QDtqt/QcLSOwwdrlAXnWPg031e+vrdt\n0Eem5xrNqEKXHHoAx2XssCJdny/puLa2XTM5R02ntGobbX6mWkpwlJDEPgPTf91UnTR7kbqNjvzJ\nvm2m9w5dVZ9V1a/79esAngDwBgD3Arjis10BcN9xFZIQQkg/h3LoIvJmAO8E8GUA51X1Wb/rKoDz\nKy0ZIYSQQzE4ykVEbgPwRwB+XVVfEYkfa1Sl41lLRC4BuAQAp8/fBqAauKctmiVsuxO3a5WuZeN4\nLFYrbQMIhfy5NSjUaZZZnmFWuAiWvDD9vT+H/jDeqV3CyRb31qtfNFIwyTGxiqmldZ6yrwJHeD5d\nQnf0BkUsq1KWzX+Y16NXLyyONGlcqk+VhHP1maAOFVRl6FY09fMM0Y2H+CwOKMvC86SRQwNVy7ZF\ntwQG3aGLyBSuMf+Mqv6xT35ORO72++8GcK3tWFV9UFUvqOqFnTtPr6LMhBBCWhgS5SIAPgXgCVX9\nrWjXwwAu+vWLAB5affEIIYQMZYhyeQ+AfwXg70TkMZ/2nwE8AOCzInI/gKcBfPh4ikgIIWQIvQ26\nqv4Vuu3aPUe5aFfoYM19L/DhQx15TOzLY3cf/lQFuRrX09MK5taHJRamnJiiFpa40EGj38MO8oYt\nJ5LFu9tOXHPrbecJR5a/ARxPDNfgDoJLhj8unbeVJV+TQ16/16WXGfuvM8QHD/Hs9XMuvubig4/B\nTw914b2/JWynOw+wpyghhIwENuiEEDIS1jo4l1XBfjGpbafr2qJdhmBq4Xv156pYtwTFEkISC2sw\nt8YPrOWUCxQoCgP1c3/WFcvCWMOKlVmLBbGQjd5/7dlcXq3ydGU5qafNo1z3pBXKIlb4Oqoesvfl\noqwLynVU1XBYVbNqBpV75JolhnfohBAyEtigE0LISGCDTgghI2Htk0QfeIc+NNwwJu2qbxI51uUa\nC+snf46cefDluQ9JdH9RV34FVipDl6Z7QoKuzY1lZeVck7zdlte1j8O+XEP09En55/B7Ubwccpj/\nTWJM3jyGd+iEEDIS2KATQshIWK9yUac/Al2KpG0UxKF6JTxK5WqgGjRLveentdIRlrhwuLmFdTsZ\nhpRpU7TMGl+/kT1NHzp0cWUXXv8lD4XXowI9lEoZq24BeIdOCCGjgQ06IYSMhLUqF6CuSpZRKzHq\nJ7dIo1isXxbWRbA0JqVonHqFz5ireqpbukgb/tw83qfflbKMJjgOXbNJ2kJbepm/WuEdOiGEjAQ2\n6IQQMhLYoBNCyEhYq0MXWd6bp2GJ8yJDoVL2/IzDEqFSn5QCWI1SXqeqoxYkS7K1brlr9NBlvsNb\n+lIMhXfohBAyEtigE0LISFh72GJKqluA9kkuCmvcxBTWIC8H13IhiRp6flqphyUCR388G/mjGSEb\nR6xYNFmu8hpA/fs9ZA7gLYF36IQQMhLYoBNCyEhgg04IISPhxB16OhG0VamNkliod+femVuVckIK\ntc6Vq11hSCIwGp9GyFay4aNVbDK8QyeEkJHQ26CLyKdF5JqIPB6lnRORR0TkSb+863iLSQghpI8h\nd+j/E8AHkrTLAB5V1bcCeNRvD8KqlH9hdMRZPsH+fIqbsx3cODiFV/Z28fKtXbyyt4vrN3dx4+Yp\n3Lp1Cgd7U8xuTTHfn6CYGdjcTVKB1pETl4CPfISsl5P8zo1IsfY26Kr6lwBeTJLvBXDFr18BcN+K\ny0UIIeSQHNWhn1fVZ/36VQDnV1QeQgghR2TpKBdVVVkwmpaIXAJwCQB2Xn8H8iJzusUrF2ulnIzC\nWoG1ArVmwaBaXc9HAroSQshCRt5MHPUO/TkRuRsA/PJaV0ZVfVBVL6jqhelrzhzxcoQQQvo4aoP+\nMICLfv0igIdWUxxCCCFHZUjY4h8A+GsAbxORZ0TkfgAPAHi/iDwJ4Of9NiGEkBOk16Gr6q907Lrn\nsBcrrOD6/ik3AYUfJdH6ERLbJ28eUTwRIYQcM+wpSgghI4ENOiGEjIS1Ds5lrWDv1o5TKyEkcWV6\nZcWxSCMa9J6QrYDft6XhHTohhIwENuiEEDIS2KATQshIWO8EFyqwc4PVy7IR9+UlhJCB8A6dEEJG\nAht0QggZCSfQoG9JbNKWFJOQUUF7uhS8QyeEkJHABp0QQkbCCBp0PqMRQggwigadEEIIwAadEEJG\nAxt0QggZCWzQ22DIIiHr46R+Bhvhz29s0AkhZCSwQSeEkJGw5Q36MTwzUbcQQraULW/QCSGEBNig\nE0LISGCDTgghI4ENOiHk1cGr4PcxNuiEEDISlmrQReQDIvJdEfmeiFxeVaEIIYQcniM36CKSAfgf\nAD4I4O0AfkVE3r6qgvXDkEVCyBGQZDkilrlDfzeA76nq91V1BuAPAdy7mmIRQgg5LMs06G8A8INo\n+xmfRggh5ASYHPcFROQSgEt+8+Dpi5cfP+5rrpHXAvjRSRdihbA+m82Y6jOmugDHX59/PCTTMg36\nDwG8Kdp+o0+roaoPAngQAETkq6p6YYlrbhSsz2bD+mwuY6oLsDn1WUa5/A2At4rIW0RkB8BHADy8\nmmIRQgg5LEe+Q1fVXET+A4A/A5AB+LSqfmtlJSOEEHIolnLoqvonAP7kEIc8uMz1NhDWZ7NhfTaX\nMdUF2JD6iOoIp+0ghJBXIez6TwghI2EtDfo2DhEgIp8WkWsi8niUdk5EHhGRJ/3yrmjfx339visi\n/+JkSt2NiLxJRL4kIt8WkW+JyEd9+lbWSUR2ReQrIvJNX59P+PStrA/gel+LyDdE5At+e2vrAgAi\n8pSI/J2IPCYiX/VpW1snEblTRD4nIt8RkSdE5Gc2rj6qeqx/cD+Y/j2AfwJgB8A3Abz9uK+7gnK/\nD8C7ADwepf03AJf9+mUA/9Wvv93X6xSAt/j6Ziddh6Q+dwN4l1+/HcD/9eXeyjrBddy+za9PAXwZ\nwD/b1vr4Mv5HAL8P4Avb/nnz5XwKwGuTtK2tE4ArAP6dX98BcOem1Wcdd+hbOUSAqv4lgBeT5Hvh\n3lT45X1R+h+q6oGq/gOA78HVe2NQ1WdV9et+/TqAJ+B69m5lndRxw29O/Z9iS+sjIm8E8IsAPhkl\nb2VdetjKOonIa+Bu8j4FAKo6U9WXsGH1WUeDPqYhAs6r6rN+/SqA8359q+ooIm8G8E64u9qtrZNX\nFI8BuAbgEVXd5vr8NoDfAGCjtG2tS0ABfFFEvuZ7jAPbW6e3AHgewO96LfZJETmLDasPfxQ9Iuqe\nq7YuREhEbgPwRwB+XVVfifdtW51UtVDVd8D1Un63iPxUsn8r6iMivwTgmqp+rSvPttQl4b3+/fkg\ngH8vIu+Ld25ZnSZwCvZ3VPWdAG7CKZaSTajPOhr0QUMEbAnPicjdAOCX13z6VtRRRKZwjflnVPWP\nffJW1wkA/KPvlwB8ANtZn/cA+GUReQpOSf6ciPwetrMuJar6Q7+8BuDzcMphW+v0DIBn/FMgAHwO\nroHfqPqso0Ef0xABDwO46NcvAngoSv+IiJwSkbcAeCuAr5xA+ToREYHzf0+o6m9Fu7ayTiLyOhG5\n06+fBvB+AN/BFtZHVT+uqm9U1TfDfT/+XFV/FVtYl4CInBWR28M6gF8A8Di2tE6qehXAD0TkbT7p\nHgDfxqbVZ02/Dn8ILqri7wH85jquuYIy/wGAZwHM4f53vh/ATwB4FMCTAL4I4FyU/zd9/b4L4IMn\nXf6W+rwX7nHwbwE85v8+tK11AvBPAXzD1+dxAP/Fp29lfaIy/iyqKJetrQtcVNs3/d+3wvd+y+v0\nDgBf9Z+5/w3grk2rD3uKEkLISOCPooQQMhLYoBNCyEhgg04IISOBDTohhIwENuiEEDIS2KATQshI\nYINOCCEjgQ06IYSMhP8PDPnsHuL8AxkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f1be6b46890>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.pcolormesh(f['Ez'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 6.83593750e-05,  6.44531250e-05,  6.05468750e-05,  5.66406250e-05,\n",
+       "        5.27343750e-05,  4.88281250e-05,  4.49218750e-05,  4.10156250e-05,\n",
+       "        3.71093750e-05,  3.32031250e-05,  2.92968750e-05,  2.53906250e-05,\n",
+       "        2.14843750e-05,  1.75781250e-05,  1.36718750e-05,  9.76562500e-06,\n",
+       "        5.85937500e-06,  1.95312500e-06, -1.95312500e-06, -5.85937500e-06,\n",
+       "       -9.76562500e-06, -1.36718750e-05, -1.75781250e-05, -2.14843750e-05,\n",
+       "       -2.53906250e-05, -2.92968750e-05, -3.32031250e-05, -3.71093750e-05,\n",
+       "       -4.10156250e-05, -4.49218750e-05, -4.88281250e-05, -5.27343750e-05,\n",
+       "       -5.66406250e-05, -6.05468750e-05, -6.44531250e-05, -6.83593750e-05,\n",
+       "        6.83876027e-05,  6.44813139e-05,  6.05765108e-05,  5.66733414e-05,\n",
+       "        5.27719786e-05,  4.88726974e-05,  4.49758894e-05,  4.10820839e-05,\n",
+       "        3.71919770e-05,  3.33064690e-05,  2.94267122e-05,  2.55541686e-05,\n",
+       "        2.16906798e-05,  1.78385065e-05,  1.39994445e-05,  1.01629180e-05,\n",
+       "        6.25389642e-06,  2.13426051e-06, -2.13537487e-06, -6.25672996e-06,\n",
+       "       -1.01642969e-05, -1.39987241e-05, -1.78374765e-05, -2.16898278e-05,\n",
+       "       -2.55534886e-05, -2.94261697e-05, -3.33060363e-05, -3.71916320e-05,\n",
+       "       -4.10818090e-05, -4.49756705e-05, -4.88725230e-05, -5.27718395e-05,\n",
+       "       -5.66732296e-05, -6.05764196e-05, -6.44812373e-05, -6.83875349e-05,\n",
+       "       -6.94328986e-05,  6.94370565e-05, -6.54804990e-05,  6.54846416e-05,\n",
+       "       -6.16436297e-05, -5.78848856e-05,  5.78901869e-05,  6.16481913e-05,\n",
+       "        5.42016308e-05, -5.41953082e-05,  5.05925132e-05, -5.05848475e-05,\n",
+       "        4.70774640e-05, -4.70680808e-05,  4.36746441e-05, -4.36631128e-05,\n",
+       "       -4.03914652e-05,  4.04056198e-05, -3.72771388e-05, -2.27206907e-05,\n",
+       "        2.27565833e-05,  3.72944264e-05, -3.43446168e-05, -1.96046475e-05,\n",
+       "        3.43655171e-05,  2.47940760e-05,  1.95969324e-05, -2.47585931e-05,\n",
+       "        3.16399368e-05, -3.16150492e-05,  2.91329762e-05,  2.68551077e-05,\n",
+       "       -2.68217237e-05, -2.91038009e-05, -1.07843879e-05,  1.05308179e-05,\n",
+       "        2.96653201e-05,  3.12839786e-05, -2.95750830e-05, -3.12447920e-05,\n",
+       "        2.98133659e-05,  2.93830002e-05, -2.93115653e-05, -2.97589493e-05,\n",
+       "       -2.74057545e-05,  2.73784529e-05, -1.52491705e-05, -7.01325890e-05,\n",
+       "        1.48208154e-05,  7.01417548e-05,  6.46954805e-05, -6.46934720e-05,\n",
+       "       -6.08183925e-05,  6.08202138e-05,  5.71486907e-05, -5.71455313e-05,\n",
+       "        5.33805358e-05, -5.33765815e-05,  4.96068508e-05, -4.96021507e-05,\n",
+       "        4.58433705e-05, -4.58378061e-05, -4.20780772e-05,  4.20846972e-05,\n",
+       "       -3.83192376e-05,  3.83267274e-05, -3.45189971e-05,  3.45246001e-05,\n",
+       "        3.02811971e-05, -3.02860657e-05, -2.55059266e-05,  2.54917241e-05,\n",
+       "        2.08842578e-05, -2.08741456e-05, -1.82611992e-05,  1.83114039e-05,\n",
+       "       -1.86607858e-05, -2.15563476e-05,  2.17295129e-05,  1.87602997e-05,\n",
+       "        1.81046006e-05, -1.82336607e-05, -2.63248837e-06,  2.13295028e-06,\n",
+       "        6.90404154e-05, -6.90337876e-05, -5.33277092e-06,  5.37905295e-06,\n",
+       "       -6.62852213e-06,  6.75322114e-06, -6.29603687e-05, -9.14861847e-06,\n",
+       "        6.29561096e-05,  9.10958529e-06,  5.94327700e-05, -5.94359575e-05,\n",
+       "        5.41091993e-06, -5.86246514e-06,  8.01605544e-06, -8.25184434e-06,\n",
+       "        1.20612782e-06, -5.56780989e-05,  5.56764499e-05, -1.13647407e-06,\n",
+       "       -5.15539960e-05,  5.15522972e-05,  1.36286373e-05, -1.33311883e-05,\n",
+       "       -1.07985780e-06,  1.28446733e-06,  4.73653447e-05, -4.73671295e-05,\n",
+       "        1.31694055e-05, -1.38439857e-05,  1.79913802e-05, -1.80938646e-05,\n",
+       "        7.67216018e-06, -7.66591238e-06,  4.31119712e-05, -4.31142018e-05,\n",
+       "        5.19116877e-06, -5.26783859e-06,  3.87692231e-05, -3.87716695e-05,\n",
+       "       -3.43907719e-05, -2.50114317e-05,  2.49860945e-05,  3.43895562e-05,\n",
+       "       -3.00286808e-05,  3.00260697e-05,  5.65256480e-06,  2.39189621e-05,\n",
+       "       -7.01103598e-05,  7.01176702e-05, -6.56694175e-05,  6.56745667e-05,\n",
+       "       -6.18081621e-05,  6.18134766e-05,  5.81516122e-05, -5.81451298e-05,\n",
+       "        5.45628593e-05, -5.45549278e-05, -5.10607201e-05,  5.10704921e-05,\n",
+       "        4.76995594e-05, -4.76874269e-05, -4.44607445e-05,  4.44757956e-05,\n",
+       "        4.14264304e-05, -4.14079029e-05, -3.85517138e-05,  3.85739892e-05,\n",
+       "       -3.58777162e-05,  3.59033324e-05,  3.34342649e-05, -3.34045786e-05,\n",
+       "       -6.26378993e-06, -2.48158423e-05,  5.80313093e-06, -1.87047769e-05,\n",
+       "        1.86318709e-05, -5.73577625e-06,  3.67553286e-05, -3.77985357e-05,\n",
+       "        3.41772109e-05,  5.08392922e-05, -3.43192673e-05, -5.19919206e-05,\n",
+       "       -1.87295260e-05,  1.91867538e-05, -6.76168870e-05,  6.76075499e-05,\n",
+       "       -6.22893808e-05,  6.22728331e-05,  6.57150301e-05,  5.94638207e-05,\n",
+       "       -5.94759189e-05,  2.34749156e-05, -2.36513726e-05, -6.69613180e-05,\n",
+       "        5.55959128e-05, -5.56051385e-05,  5.13624294e-05, -5.13702079e-05,\n",
+       "       -4.73392969e-05,  4.73342692e-05, -4.33540639e-05,  4.33511061e-05,\n",
+       "        6.11405021e-06, -6.23564966e-06, -3.93497071e-05,  3.93483355e-05,\n",
+       "       -3.54041574e-05,  3.54086610e-05, -2.84968045e-05,  2.85234903e-05,\n",
+       "        3.18223636e-05, -3.18050094e-05,  8.12908796e-05,  5.21495080e-05,\n",
+       "       -5.23177145e-05, -8.26201799e-05,  8.36702777e-06,  1.82127884e-05,\n",
+       "       -9.71071152e-06, -1.77502807e-05])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f['plasma_e/x'][:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "278"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f['plasma_e/x'].size"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This provides the option to use an HDF5 format for outputting the boosted frame diagnostics, for field and particle data. It requires a parallel-capable HDF5 installation. To use it, compile WarpX with USE_HDF5=TRUE. If hdf5 is not in your default path, you'll also need to specify a HDF5_HOME environment variable along with the usual options for using the boosted frame IO, i.e.

> make -j4 USE_HDF5=TRUE HDF5_HOME=/home/atmyers/AMReX-Codes/hdf5 DIM=2 STORE_OLD_PARTICLE_ATTRIBS=TRUE

I've tested this on my local machine and Cori using a few processes. It seems to work. If someone could help me test it more rigorously that would be great. 