### PR TITLE
Print WarpX and PICSAR git hashes

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -58,6 +58,11 @@ endif
 
 include $(PICSAR_HOME)/src/Make.package
 
+WARPX_GIT_VERSION := $(shell cd $(WARPX_HOME); git describe --abbrev=12 --dirty --always --tags)
+PICSAR_GIT_VERSION := $(shell cd $(PICSAR_HOME); git describe --abbrev=12 --dirty --always --tags)
+DEFINES += -DWARPX_GIT_VERSION=\"$(WARPX_GIT_VERSION)\"
+DEFINES += -DPICSAR_GIT_VERSION=\"$(PICSAR_GIT_VERSION)\"
+
 DEFINES += -DPICSAR_NO_ASSUMED_ALIGNMENT
 DEFINES += -DWARPX
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -59,6 +59,9 @@ public:
     WarpX ();
     ~WarpX ();
 
+    static std::string Version ();
+    static std::string PicsarVersion ();
+
     int Verbose () const { return verbose; }
 
     void InitData ();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1041,3 +1041,24 @@ WarpX::RestoreCurrent (int lev)
         }
     }
 }
+
+std::string
+WarpX::Version ()
+{
+#ifdef WARPX_GIT_VERSION
+    return std::string(WARPX_GIT_VERSION);
+#else
+    return std::string("Unknown");
+#endif
+}
+
+std::string
+WarpX::PicsarVersion ()
+{
+#ifdef WARPX_GIT_VERSION
+    return std::string(PICSAR_GIT_VERSION);
+#else
+    return std::string("Unknown");
+#endif
+}
+

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -41,6 +41,8 @@ int main(int argc, char* argv[])
 	ParallelDescriptor::ReduceRealMax(end_total ,ParallelDescriptor::IOProcessorNumber());
 	if (warpx.Verbose()) {
             amrex::Print() << "Total Time                     : " << end_total << '\n';
+            amrex::Print() << "WarpX Version: " << WarpX::Version() << '\n';
+            amrex::Print() << "PICSAR Version: " << WarpX::PicsarVersion() << '\n';
 	}
     }
 


### PR DESCRIPTION
WarpX now has two new functions returning the git repo information stored at compile time.

    static std::string WarpX::Version();
    static std::string WarpX::PicsarVersion();

At the end of a run, if `WarpX::Verbose()` is `true`, messages like below will be printed before AMReX profiling information.

    WarpX Version: 18.11-258-g595134e48b10-dirty
    PICSAR Version: 5e926d8bb280

The version string for WarpX shows: (1) it is 258 commits after tag `18.11`; (2) the git hash is `595134e48b10` (note that the first letter g should be ignored); (3) "dirty" means the repo has local changes.
