### PR TITLE
Selective particle output

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -496,6 +496,10 @@ Diagnostics and output
     (This is done by averaging the field.) ``plot_coarsening_ratio`` should
     be an integer divisor of ``blocking_factor``.
 
+* ``warpx.particle_plot_vars`` (`strings`, separated by spaces ; default: all)
+    Control which particle variables get written to the plot file. Choices are:
+    `particle_weight`, `particle_momentum_[xyz]`, `particle_efield_[xyz]`,
+    and `particle_bfield_[xyz]`. The particle positions and ids are always included.
 
 * ``amr.plot_file`` (`string`)
     Root for output file names. Supports sub-directories. Default `diags/plotfiles/plt`

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -498,8 +498,8 @@ Diagnostics and output
 
 * ``warpx.particle_plot_vars`` (`strings`, separated by spaces ; default: all)
     Control which particle variables get written to the plot file. Choices are:
-    `particle_weight`, `particle_momentum_[xyz]`, `particle_efield_[xyz]`,
-    and `particle_bfield_[xyz]`. The particle positions and ids are always included.
+    `w`, `ux`, `uy`, `uz`, `Ex`, `Ey`, `Ez`, `Bx`, `By`, and `Bz`.
+    The particle positions and ids are always included.
 
 * ``amr.plot_file`` (`string`)
     Root for output file names. Supports sub-directories. Default `diags/plotfiles/plt`

--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -13,6 +13,7 @@ amr.max_level = 0
 
 amr.plot_int = 20   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_rho = 1
+warpx.particle_plot_vars = w ux uz
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -13,7 +13,7 @@ amr.max_level = 0
 
 amr.plot_int = 20   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_rho = 1
-warpx.particle_plot_vars = w ux uz
+warpx.particle_plot_vars = w ux Bz Ey
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Langmuir/langmuir_multi_analysis.py
+++ b/Examples/Tests/Langmuir/langmuir_multi_analysis.py
@@ -61,6 +61,23 @@ def get_theoretical_field( field, t ):
 
 # Read the file
 ds = yt.load(fn)
+
+# Check that the particle selective output worked:
+for species in ['electrons', 'positrons']:
+    for field in ['particle_weight',
+                  'particle_momentum_x',
+                  'particle_Bz',
+                  'particle_Ey']:
+        assert (species, field) in ds.field_list
+    for field in ['particle_momentum_y',
+                  'particle_momentum_z',
+                  'particle_Bx',
+                  'particle_By',
+                  'particle_Ex',
+                  'particle_Ez']:
+        assert (species, field) not in ds.field_list
+
+
 t0 = ds.current_time.to_ndarray().mean()
 data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                                     dims=ds.domain_dimensions)

--- a/Source/Diagnostics/ElectrostaticIO.cpp
+++ b/Source/Diagnostics/ElectrostaticIO.cpp
@@ -113,7 +113,9 @@ WritePlotFileES (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
     particle_varnames.push_back("By");
     particle_varnames.push_back("Bz");
 
-    mypc->Checkpoint(plotfilename, true, particle_varnames);
+    Vector<std::string> int_names;
+        
+    mypc->Checkpoint(plotfilename, particle_varnames, int_names);
 
     WriteJobInfo(plotfilename);
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -19,12 +19,20 @@ WarpXParticleContainer::WriteHeader (std::ostream& os) const
 }
 
 void
-MultiParticleContainer::Checkpoint (const std::string& dir, 
-				    bool is_checkpoint,
-                                    const Vector<std::string>& varnames) const
+MultiParticleContainer::Checkpoint (const std::string& dir) const
 {
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-	allcontainers[i]->Checkpoint(dir, species_names[i], is_checkpoint, varnames);
+	allcontainers[i]->Checkpoint(dir, species_names[i]);
+    }
+}
+
+void
+MultiParticleContainer::WritePlotFile (const std::string& dir, 
+                                       const Vector<std::string>& real_names,
+                                       const Vector<std::string>& int_names) const
+{
+    for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
+	allcontainers[i]->WritePlotFile(dir, species_names[i], real_names, int_names);
     }
 }
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -27,12 +27,17 @@ MultiParticleContainer::Checkpoint (const std::string& dir) const
 }
 
 void
-MultiParticleContainer::WritePlotFile (const std::string& dir, 
-                                       const Vector<std::string>& real_names,
-                                       const Vector<std::string>& int_names) const
+MultiParticleContainer::WritePlotFile (const std::string& dir,
+                                       const Vector<int>& real_flags,
+                                       const Vector<std::string>& real_names) const
 {
+    Vector<std::string> int_names;    
+    Vector<int> int_flags;
+    
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-	allcontainers[i]->WritePlotFile(dir, species_names[i], real_names, int_names);
+	allcontainers[i]->WritePlotFile(dir, species_names[i],
+                                        real_flags, int_flags,
+                                        real_names, int_names);
     }
 }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -176,7 +176,7 @@ WarpX::WriteCheckPointFile() const
         }
     }
 
-    mypc->Checkpoint(checkpointname, true);
+    mypc->Checkpoint(checkpointname);
 
     VisMF::SetHeaderVersion(current_version);
 }
@@ -678,7 +678,9 @@ WarpX::WritePlotFile () const
     particle_varnames.push_back("uzold");
 #endif
 
-    mypc->Checkpoint(plotfilename, true, particle_varnames);
+    Vector<std::string> int_varnames;
+    
+    mypc->WritePlotFile(plotfilename, particle_varnames, int_varnames);
 
     WriteJobInfo(plotfilename);
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -678,9 +678,7 @@ WarpX::WritePlotFile () const
     particle_varnames.push_back("uzold");
 #endif
 
-    Vector<std::string> int_varnames;
-    
-    mypc->WritePlotFile(plotfilename, particle_varnames, int_varnames);
+    mypc->WritePlotFile(plotfilename, particle_plot_flags, particle_varnames);
 
     WriteJobInfo(plotfilename);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -130,8 +130,8 @@ public:
     void Checkpoint (const std::string& dir) const;
 
     void WritePlotFile( const std::string& dir,
-                        const amrex::Vector<std::string>& real_names,
-                        const amrex::Vector<std::string>& int_names) const;
+                        const amrex::Vector<int>& real_flags, 
+                        const amrex::Vector<std::string>& real_names) const;
     
     void Restart (const std::string& dir);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -127,10 +127,12 @@ public:
     ///    
     std::unique_ptr<amrex::MultiFab> GetChargeDensity(int lev, bool local = false);
 
-    void Checkpoint (const std::string& dir,
-		     bool is_checkpoint,
-                     const amrex::Vector<std::string>& varnames = amrex::Vector<std::string>()) const;
+    void Checkpoint (const std::string& dir) const;
 
+    void WritePlotFile( const std::string& dir,
+                        const amrex::Vector<std::string>& real_names,
+                        const amrex::Vector<std::string>& int_names) const;
+    
     void Restart (const std::string& dir);
 
     void PostRestart ();

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -27,6 +27,30 @@ struct DiagIdx
     };
 };
 
+namespace ParticleStringNames
+{
+    const std::map<std::string, int> to_index = {
+        {"w",     PIdx::w    },
+        {"ux",    PIdx::ux   },
+        {"uy",    PIdx::uy   },
+        {"uz",    PIdx::uz   },
+        {"Ex",    PIdx::Ex   },
+        {"Ey",    PIdx::Ey   },
+        {"Ez",    PIdx::Ez   },
+        {"Bx",    PIdx::Bx   },
+        {"By",    PIdx::By   },
+        {"Bz",    PIdx::Bz   },
+#ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS    
+        {"xold",  PIdx::xold },
+        {"yold",  PIdx::yold },
+        {"zold",  PIdx::zold },
+        {"uxold", PIdx::uxold},
+        {"uyold", PIdx::uyold},
+        {"uzold", PIdx::uzold},
+#endif
+    };
+}
+
 class WarpXParIter
     : public amrex::ParIter<0,0,PIdx::nattribs>
 {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -536,6 +536,9 @@ private:
 
     bool is_synchronized = true;
 
+    amrex::Vector<std::string> particle_plot_vars;
+    amrex::Vector<int> particle_plot_flags;
+    
 #ifdef WARPX_USE_PSATD
     // Store fields in real space on the dual grid (i.e. the grid for the FFT push of the fields)
     // This includes data for the FFT guard cells (between FFT groups)
@@ -577,6 +580,7 @@ public:
         void operator= (FFTData const&) = delete;
         void operator= (FFTData&&) = delete;
     };
+
 private:
 
     amrex::Vector<std::unique_ptr<amrex::LayoutData<FFTData> > > dataptr_fp_fft;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -428,47 +428,50 @@ WarpX::ReadParameters ()
             fine_tag_lo = RealVect{lo};
             fine_tag_hi = RealVect{hi};
         }
-        
-        std::map<std::string, int> particle_var_map;
-        particle_var_map["particle_weight"]         = 0;
-        particle_var_map["particle_momentum_x"]     = 1;
-        particle_var_map["particle_momentum_y"]     = 2;
-        particle_var_map["particle_momentum_z"]     = 3;
-        particle_var_map["particle_efield_x"]       = 4;
-        particle_var_map["particle_efield_y"]       = 5;
-        particle_var_map["particle_efield_z"]       = 6;
-        particle_var_map["particle_bfield_x"]       = 7;
-        particle_var_map["particle_bfield_y"]       = 8;
-        particle_var_map["particle_bfield_z"]       = 9;
+
+        // select which particle comps to write
+        {
+            std::map<std::string, int> particle_var_map;
+            particle_var_map["particle_weight"]         = 0;
+            particle_var_map["particle_momentum_x"]     = 1;
+            particle_var_map["particle_momentum_y"]     = 2;
+            particle_var_map["particle_momentum_z"]     = 3;
+            particle_var_map["particle_efield_x"]       = 4;
+            particle_var_map["particle_efield_y"]       = 5;
+            particle_var_map["particle_efield_z"]       = 6;
+            particle_var_map["particle_bfield_x"]       = 7;
+            particle_var_map["particle_bfield_y"]       = 8;
+            particle_var_map["particle_bfield_z"]       = 9;
 #ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS
-        particle_var_map["particle_x_old"]          = 10;
-        particle_var_map["particle_y_old"]          = 11;
-        particle_var_map["particle_z_old"]          = 12;
-        particle_var_map["particle_momentum_x_old"] = 13;
-        particle_var_map["particle_momentum_y_old"] = 14;
-        particle_var_map["particle_momentum_z_old"] = 15;
+            particle_var_map["particle_x_old"]          = 10;
+            particle_var_map["particle_y_old"]          = 11;
+            particle_var_map["particle_z_old"]          = 12;
+            particle_var_map["particle_momentum_x_old"] = 13;
+            particle_var_map["particle_momentum_y_old"] = 14;
+            particle_var_map["particle_momentum_z_old"] = 15;
 #endif
-
-        pp.queryarr("particle_plot_vars", particle_plot_vars);
-
-        if (particle_plot_vars.size() == 0)
-        {
-            particle_plot_flags.resize(particle_var_map.size(), 1);
-        }
-        else
-        {
-            particle_plot_flags.resize(particle_var_map.size(), 0);
-        
-            for (auto& var : particle_plot_vars)
+            
+            pp.queryarr("particle_plot_vars", particle_plot_vars);
+            
+            if (particle_plot_vars.size() == 0)
             {
-                particle_plot_flags[particle_var_map[var]] = 1;
+                particle_plot_flags.resize(particle_var_map.size(), 1);
+            }
+            else
+            {
+                particle_plot_flags.resize(particle_var_map.size(), 0);
+                
+                for (auto& var : particle_plot_vars)
+                {
+                    particle_plot_flags[particle_var_map[var]] = 1;
+                }
             }
         }
         
         pp.query("load_balance_int", load_balance_int);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
-
+        
         pp.query("do_dynamic_scheduling", do_dynamic_scheduling);
 
         pp.query("do_nodal", do_nodal);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -356,9 +356,9 @@ WarpX::ReadParameters ()
 
 	pp.query("serialize_ics", serialize_ics);
 	pp.query("refine_plasma", refine_plasma);
-    pp.query("do_dive_cleaning", do_dive_cleaning);
-    pp.query("n_field_gather_buffer", n_field_gather_buffer);
-    pp.query("n_current_deposition_buffer", n_current_deposition_buffer);
+        pp.query("do_dive_cleaning", do_dive_cleaning);
+        pp.query("n_field_gather_buffer", n_field_gather_buffer);
+        pp.query("n_current_deposition_buffer", n_current_deposition_buffer);
 	pp.query("sort_int", sort_int);
 
         pp.query("do_pml", do_pml);
@@ -428,7 +428,43 @@ WarpX::ReadParameters ()
             fine_tag_lo = RealVect{lo};
             fine_tag_hi = RealVect{hi};
         }
+        
+        std::map<std::string, int> particle_var_map;
+        particle_var_map["particle_weight"]         = 0;
+        particle_var_map["particle_momentum_x"]     = 1;
+        particle_var_map["particle_momentum_y"]     = 2;
+        particle_var_map["particle_momentum_z"]     = 3;
+        particle_var_map["particle_efield_x"]       = 4;
+        particle_var_map["particle_efield_y"]       = 5;
+        particle_var_map["particle_efield_z"]       = 6;
+        particle_var_map["particle_bfield_x"]       = 7;
+        particle_var_map["particle_bfield_y"]       = 8;
+        particle_var_map["particle_bfield_z"]       = 9;
+#ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS
+        particle_var_map["particle_x_old"]          = 10;
+        particle_var_map["particle_y_old"]          = 11;
+        particle_var_map["particle_z_old"]          = 12;
+        particle_var_map["particle_momentum_x_old"] = 13;
+        particle_var_map["particle_momentum_y_old"] = 14;
+        particle_var_map["particle_momentum_z_old"] = 15;
+#endif
 
+        pp.queryarr("particle_plot_vars", particle_plot_vars);
+
+        if (particle_plot_vars.size() == 0)
+        {
+            particle_plot_flags.resize(particle_var_map.size(), 1);
+        }
+        else
+        {
+            particle_plot_flags.resize(particle_var_map.size(), 0);
+        
+            for (auto& var : particle_plot_vars)
+            {
+                particle_plot_flags[particle_var_map[var]] = 1;
+            }
+        }
+        
         pp.query("load_balance_int", load_balance_int);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -431,39 +431,19 @@ WarpX::ReadParameters ()
 
         // select which particle comps to write
         {
-            std::map<std::string, int> particle_var_map;
-            particle_var_map["particle_weight"]         = 0;
-            particle_var_map["particle_momentum_x"]     = 1;
-            particle_var_map["particle_momentum_y"]     = 2;
-            particle_var_map["particle_momentum_z"]     = 3;
-            particle_var_map["particle_efield_x"]       = 4;
-            particle_var_map["particle_efield_y"]       = 5;
-            particle_var_map["particle_efield_z"]       = 6;
-            particle_var_map["particle_bfield_x"]       = 7;
-            particle_var_map["particle_bfield_y"]       = 8;
-            particle_var_map["particle_bfield_z"]       = 9;
-#ifdef WARPX_STORE_OLD_PARTICLE_ATTRIBS
-            particle_var_map["particle_x_old"]          = 10;
-            particle_var_map["particle_y_old"]          = 11;
-            particle_var_map["particle_z_old"]          = 12;
-            particle_var_map["particle_momentum_x_old"] = 13;
-            particle_var_map["particle_momentum_y_old"] = 14;
-            particle_var_map["particle_momentum_z_old"] = 15;
-#endif
-            
             pp.queryarr("particle_plot_vars", particle_plot_vars);
             
             if (particle_plot_vars.size() == 0)
             {
-                particle_plot_flags.resize(particle_var_map.size(), 1);
+                particle_plot_flags.resize(PIdx::nattribs, 1);
             }
             else
             {
-                particle_plot_flags.resize(particle_var_map.size(), 0);
+                particle_plot_flags.resize(PIdx::nattribs, 0);
                 
-                for (auto& var : particle_plot_vars)
+                for (const auto& var : particle_plot_vars)
                 {
-                    particle_plot_flags[particle_var_map[var]] = 1;
+                    particle_plot_flags[ParticleStringNames::to_index.at(var)] = 1;
                 }
             }
         }


### PR DESCRIPTION
Edit: removed WIP tag - this is ready for review.

This PR implements selectively writing particle data in WarpX. Currently, all components are written out in every plot file. This allows the user to set the components to be output at run time. 

To toggle this, put something in your inputs file like:

warpx.particle_plot_vars = ux By