### PR TITLE
Added code for in situ analysis with Ascent

### DIFF
--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -8,7 +8,7 @@ CPUs and GPUs to render images of simulation meshes.
 Compiling with GNU Make
 -----------------------
 After building and installing Ascent according to the instructions at
-`Building Ascent <https://ascent.readthedocs.io/en/latest/BuildingAscent.html/>`_,
+`Building Ascent <https://ascent.readthedocs.io/en/latest/BuildingAscent.html>`_,
 you can enable it in WarpX by changing the line
 
 .. code-block:: bash
@@ -54,7 +54,7 @@ Ascent uses the file :code:`ascent_actions.json` to configure analysis and
 visualization pipelines. For example, the following :code:`ascent_actions.json`
 file extracts an isosurface of the field Ex for 15 levels and saves the
 resulting images to :code:`levels_<nnnn>.png`. `Ascent Actions 
-<https://ascent.readthedocs.io/en/latest/Actions/index.html/>`_ provides an
+<https://ascent.readthedocs.io/en/latest/Actions/index.html>`_ provides an
 overview over all available analysis and visualization actions.
 
 .. code-block:: json

--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -1,0 +1,109 @@
+In situ Visualization with Ascent
+=================================
+Ascent is a system designed to meet the in-situ visualization and analysis
+needs of simulation code teams running multi-physics calculations on many-core
+HPC architectures. It provides rendering runtimes that can leverage many-core
+CPUs and GPUs to render images of simulation meshes.
+
+Compiling with GNU Make
+-----------------------
+After building and installing Ascent according to the instructions at
+`Building Ascent <https://ascent.readthedocs.io/en/latest/BuildingAscent.html/>`_,
+you can enable it in WarpX by changing the line
+
+.. code-block:: bash
+
+   USE_ASCENT_INSITU = FALSE
+
+in GNUmakefile to 
+
+.. code-block:: bash
+
+   USE_ASCENT_INSITU = TRUE
+
+Furthermore, you must ensure that either the :code:`ASCENT_HOME` shell
+environment variable contains the directory where Ascent is installed
+or you must specify this location when invoking make, i.e.,
+
+.. code-block:: bash
+
+   make -j 8 ASCENT_HOME = /path/to/ascent/install
+
+ParmParse Configuration
+-----------------------
+Once an AMReX code has been compiled with Ascent enabled, it will need
+to be enabled and configured at runtime. This is done using ParmParse input file.
+The supported parameters are described in the following table.
+
++-------------------------+------------------------------------------------------+---------+
+| parameter               | description                                          | default |
++=========================+======================================================+=========+
+| :code:`insitu.int`      | turns in situ processing on or off and controls how  |    0    |
+|                         | often data is processed.                             |         |
++-------------------------+------------------------------------------------------+---------+
+| :code:`insitu.start`    | controls when in situ processing starts.             |    0    |
++-------------------------+------------------------------------------------------+---------+
+
+A typical use case is setting :code:`insitu.int` to a value of one or greater and
+:code:`insitu.start` to the first time step where in situ analyswhere in situ analysis should be
+performed.
+
+Visualization/Analysis Pipeline Configuration
+---------------------------------------------
+Ascent uses the file :code:`ascent_actions.json` to configure analysis and
+visualization pipelines. For example, the following :code:`ascent_actions.json`
+file extracts an isosurface of the field Ex for 15 levels and saves the
+resulting images to :code:`levels_<nnnn>.png`. `Ascent Actions 
+<https://ascent.readthedocs.io/en/latest/Actions/index.html/>`_ provides an
+overview over all available analysis and visualization actions.
+
+.. code-block:: json
+
+  [
+    {
+      "action": "add_pipelines",
+      "pipelines": 
+      {
+        "p1": 
+        {
+          "f1": 
+          {
+            "type" : "contour",
+            "params" :
+            {
+              "field" : "Ex",
+              "levels": 15
+            }
+          }
+        }
+      }
+    },
+    {
+      "action": "add_scenes",
+      "scenes":
+      {
+        "s1": 
+        {
+          "image_prefix": "levels_%04d",
+          "plots": 
+          {
+          "p1": 
+            {
+              "type": "pseudocolor",
+              "pipeline": "p1",
+              "field": "Ex"
+            }
+          }
+        }
+      }
+    },
+  
+    {
+      "action": "execute"
+    },
+  
+    {
+      "action": "reset"
+    }
+  ]
+

--- a/Docs/source/visualization/visualization.rst
+++ b/Docs/source/visualization/visualization.rst
@@ -8,4 +8,5 @@ Visualizing the simulation results
    visit
    picviewer
    sensei
+   ascent
    advanced

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,13 +27,7 @@ EBASE     = main
 USE_PYTHON_MAIN = FALSE
 
 USE_SENSEI_INSITU = FALSE
-
-USE_CONDUIT ?= FALSE
-USE_ASCENT ?= FALSE
-
-# The following must be absolute paths
-CONDUIT_DIR ?= /project/projectdirs/alpine/ghweber/ascent/uberenv_libs/spack/opt/spack/cray-cnl9-haswell/gcc-5.3.0/conduit-master-w6ilqv5kfgt2wgbftzpssjj3lttgkqkv
-ASCENT_DIR ?= /project/projectdirs/alpine/ghweber/ascent/uberenv_libs/ascent-install
+USE_ASCENT_INSITU = FALSE
 
 WarpxBinDir = Bin
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,6 +28,13 @@ USE_PYTHON_MAIN = FALSE
 
 USE_SENSEI_INSITU = FALSE
 
+USE_CONDUIT ?= FALSE
+USE_ASCENT ?= FALSE
+
+# The following must be absolute paths
+CONDUIT_DIR ?= /project/projectdirs/alpine/ghweber/ascent/uberenv_libs/spack/opt/spack/cray-cnl9-haswell/gcc-5.3.0/conduit-master-w6ilqv5kfgt2wgbftzpssjj3lttgkqkv
+ASCENT_DIR ?= /project/projectdirs/alpine/ghweber/ascent/uberenv_libs/ascent-install
+
 WarpxBinDir = Bin
 
 USE_PSATD = FALSE

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -12,6 +12,15 @@ ifeq ($(USE_GPU),TRUE)
   NVCC_HOST_COMP = gcc
 endif
 
+ifeq ($(USE_ASCENT_INSITU),TRUE)
+  ASCENT_HOME ?= NOT_SET
+  ifneq ($(ASCENT_HOME),NOT_SET)
+    include $(ASCENT_HOME)/share/ascent/ascent_config.mk
+  endif
+  USE_CONDUIT = TRUE
+  USE_ASCENT = TRUE
+endif
+
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 ifndef USE_PYTHON_MAIN


### PR DESCRIPTION
This commit adds integration of Ascent by the ECP ALPINE project to WarpX. It uses the same "hook" as the SENSEI in situ analysis code and the same parameters in the inputs deck (in_situ.start, in_situ.int) but runs analysis through Ascent.