### PR TITLE
Fix runtime bug in raw output

### DIFF
--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -10,7 +10,7 @@ using namespace amrex;
 
 void
 PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
-		  const std::array<std::unique_ptr<MultiFab>,3>& data);
+          const std::array<std::unique_ptr<MultiFab>,3>& data);
 
 void
 AverageAndPackVectorField( MultiFab& mf_avg,
@@ -38,13 +38,13 @@ WriteZeroRawField( const MultiFab& F, const DistributionMapping& dm,
 
 void
 WriteCoarseScalar( const std::string field_name,
-	const std::unique_ptr<MultiFab>& F_cp,
-	const std::unique_ptr<MultiFab>& F_fp,
-	const DistributionMapping& dm,
-	const std::string& filename,
-	const std::string& level_prefix,
-	const int lev, const bool plot_guards,
-	const int r_ratio, const Real* dx, const int icomp=0 );
+    const std::unique_ptr<MultiFab>& F_cp,
+    const std::unique_ptr<MultiFab>& F_fp,
+    const DistributionMapping& dm,
+    const std::string& filename,
+    const std::string& level_prefix,
+    const int lev, const bool plot_guards,
+    const Real* dx, const int icomp=0 );
 
 void
 WriteCoarseVector( const std::string field_name,
@@ -58,11 +58,11 @@ WriteCoarseVector( const std::string field_name,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
-    const int r_ratio, const Real* dx );
+    const Real* dx );
 
 std::unique_ptr<MultiFab>
 getInterpolatedScalar(
-	const MultiFab& F_cp, const MultiFab& F_fp,
+    const MultiFab& F_cp, const MultiFab& F_fp,
     const DistributionMapping& dm, const int r_ratio,
     const Real* dx, const int ngrow );
 
@@ -80,9 +80,9 @@ getInterpolatedVector(
 
 void
 coarsenCellCenteredFields(
-	Vector<MultiFab>& coarse_mf, Vector<Geometry>& coarse_geom,
-	const Vector<MultiFab>& source_mf, const Vector<Geometry>& source_geom,
-	int coarse_ratio, int finest_level );
+    Vector<MultiFab>& coarse_mf, Vector<Geometry>& coarse_geom,
+    const Vector<MultiFab>& source_mf, const Vector<Geometry>& source_geom,
+    int coarse_ratio, int finest_level );
 
 #ifdef WARPX_USE_OPENPMD
 void

--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -44,7 +44,7 @@ WriteCoarseScalar( const std::string field_name,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
-    const Real* dx, const int icomp=0 );
+    const int icomp=0 );
 
 void
 WriteCoarseVector( const std::string field_name,
@@ -57,8 +57,7 @@ WriteCoarseVector( const std::string field_name,
     const DistributionMapping& dm,
     const std::string& filename,
     const std::string& level_prefix,
-    const int lev, const bool plot_guards,
-    const Real* dx );
+    const int lev, const bool plot_guards );
 
 std::unique_ptr<MultiFab>
 getInterpolatedScalar(

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -575,7 +575,7 @@ WriteCoarseScalar( const std::string field_name,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
-    const int r_ratio, const Real* dx, const int icomp )
+    const Real* dx, const int icomp )
 {
     int ng = 0;
     if (plot_guards) ng = F_fp->nGrow();
@@ -587,6 +587,7 @@ WriteCoarseScalar( const std::string field_name,
     } else {
         // Create an alias to the component `icomp` of F_cp
         MultiFab F_comp(*F_cp, amrex::make_alias, 1, icomp);
+        const int r_ratio = WarpX::GetInstance().refRatio(lev-1)[0];
         auto F = getInterpolatedScalar( F_comp, *F_fp, dm, r_ratio, dx, ng );
         WriteRawField( *F, dm, filename, level_prefix, field_name+"_cp", lev, plot_guards );
     }
@@ -609,7 +610,7 @@ WriteCoarseVector( const std::string field_name,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
-    const int r_ratio, const Real* dx )
+    const Real* dx )
 {
     int ng = 0;
     if (plot_guards) ng = Fx_fp->nGrow();
@@ -621,6 +622,7 @@ WriteCoarseVector( const std::string field_name,
         WriteZeroRawField( *Fy_fp, dm, filename, level_prefix, field_name+"y_cp", lev, ng );
         WriteZeroRawField( *Fz_fp, dm, filename, level_prefix, field_name+"z_cp", lev, ng );
     } else {
+        const int r_ratio = WarpX::GetInstance().refRatio(lev-1)[0];
         auto F = getInterpolatedVector( Fx_cp, Fy_cp, Fz_cp, Fx_fp, Fy_fp, Fz_fp,
                                     dm, r_ratio, dx, ng );
         WriteRawField( *F[0], dm, filename, level_prefix, field_name+"x_cp", lev, plot_guards );

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -575,7 +575,7 @@ WriteCoarseScalar( const std::string field_name,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
-    const Real* dx, const int icomp )
+    const int icomp )
 {
     int ng = 0;
     if (plot_guards) ng = F_fp->nGrow();
@@ -587,8 +587,11 @@ WriteCoarseScalar( const std::string field_name,
     } else {
         // Create an alias to the component `icomp` of F_cp
         MultiFab F_comp(*F_cp, amrex::make_alias, 1, icomp);
+        // Interpolate coarse data onto fine grid
         const int r_ratio = WarpX::GetInstance().refRatio(lev-1)[0];
+        const Real* dx = WarpX::GetInstance().Geom(lev-1).CellSize();
         auto F = getInterpolatedScalar( F_comp, *F_fp, dm, r_ratio, dx, ng );
+        // Write interpolated raw data
         WriteRawField( *F, dm, filename, level_prefix, field_name+"_cp", lev, plot_guards );
     }
 }
@@ -609,8 +612,7 @@ WriteCoarseVector( const std::string field_name,
     const DistributionMapping& dm,
     const std::string& filename,
     const std::string& level_prefix,
-    const int lev, const bool plot_guards,
-    const Real* dx )
+    const int lev, const bool plot_guards )
 {
     int ng = 0;
     if (plot_guards) ng = Fx_fp->nGrow();
@@ -622,9 +624,12 @@ WriteCoarseVector( const std::string field_name,
         WriteZeroRawField( *Fy_fp, dm, filename, level_prefix, field_name+"y_cp", lev, ng );
         WriteZeroRawField( *Fz_fp, dm, filename, level_prefix, field_name+"z_cp", lev, ng );
     } else {
+        // Interpolate coarse data onto fine grid
         const int r_ratio = WarpX::GetInstance().refRatio(lev-1)[0];
+        const Real* dx = WarpX::GetInstance().Geom(lev-1).CellSize();
         auto F = getInterpolatedVector( Fx_cp, Fy_cp, Fz_cp, Fx_fp, Fy_fp, Fz_fp,
                                     dm, r_ratio, dx, ng );
+        // Write interpolated raw data
         WriteRawField( *F[0], dm, filename, level_prefix, field_name+"x_cp", lev, plot_guards );
         WriteRawField( *F[1], dm, filename, level_prefix, field_name+"y_cp", lev, plot_guards );
         WriteRawField( *F[2], dm, filename, level_prefix, field_name+"z_cp", lev, plot_guards );

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -558,30 +558,29 @@ WarpX::WritePlotFile () const
             // Coarse path
             if (plot_crsepatch) {
                 const Real* dx = Geom(lev-1).CellSize();
-                const int r_ratio = refRatio(lev-1)[0];
                 WriteCoarseVector( "E",
                     Efield_cp[lev][0], Efield_cp[lev][1], Efield_cp[lev][2],
                     Efield_fp[lev][0], Efield_fp[lev][1], Efield_fp[lev][2],
                     dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    r_ratio, dx );
+                    dx );
                 WriteCoarseVector( "B",
                     Bfield_cp[lev][0], Bfield_cp[lev][1], Bfield_cp[lev][2],
                     Bfield_fp[lev][0], Bfield_fp[lev][1], Bfield_fp[lev][2],
                     dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    r_ratio, dx );
+                    dx );
                 WriteCoarseVector( "j",
                     current_cp[lev][0], current_cp[lev][1], current_cp[lev][2],
                     current_fp[lev][0], current_fp[lev][1], current_fp[lev][2],
                     dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    r_ratio, dx );
+                    dx );
                 if (F_cp[lev]) WriteCoarseScalar(
                         "F", F_cp[lev], F_fp[lev],
                         dm, raw_pltname, level_prefix, lev,
-                        plot_raw_fields_guards, r_ratio, dx );
+                        plot_raw_fields_guards, dx );
                 if (plot_rho) WriteCoarseScalar(
                         "rho", rho_cp[lev], rho_fp[lev],
                         dm, raw_pltname, level_prefix, lev,
-                        plot_raw_fields_guards, r_ratio, dx, 1 );
+                        plot_raw_fields_guards, dx, 1 );
                         // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
             }
         }

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -557,30 +557,26 @@ WarpX::WritePlotFile () const
 
             // Coarse path
             if (plot_crsepatch) {
-                const Real* dx = Geom(lev-1).CellSize();
                 WriteCoarseVector( "E",
                     Efield_cp[lev][0], Efield_cp[lev][1], Efield_cp[lev][2],
                     Efield_fp[lev][0], Efield_fp[lev][1], Efield_fp[lev][2],
-                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    dx );
+                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards);
                 WriteCoarseVector( "B",
                     Bfield_cp[lev][0], Bfield_cp[lev][1], Bfield_cp[lev][2],
                     Bfield_fp[lev][0], Bfield_fp[lev][1], Bfield_fp[lev][2],
-                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    dx );
+                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards);
                 WriteCoarseVector( "j",
                     current_cp[lev][0], current_cp[lev][1], current_cp[lev][2],
                     current_fp[lev][0], current_fp[lev][1], current_fp[lev][2],
-                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards,
-                    dx );
+                    dm, raw_pltname, level_prefix, lev, plot_raw_fields_guards);
                 if (F_cp[lev]) WriteCoarseScalar(
                         "F", F_cp[lev], F_fp[lev],
                         dm, raw_pltname, level_prefix, lev,
-                        plot_raw_fields_guards, dx );
+                        plot_raw_fields_guards);
                 if (plot_rho) WriteCoarseScalar(
                         "rho", rho_cp[lev], rho_fp[lev],
                         dm, raw_pltname, level_prefix, lev,
-                        plot_raw_fields_guards, dx, 1 );
+                        plot_raw_fields_guards, 1);
                         // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
             }
         }


### PR DESCRIPTION
@WeiqunZhang recently pointed out that #81 introduces a bug, in that it tries to get the cell size and refinement ratio for level `lev-1`, even when `lev` is 0.

This PR modifies this by getting the cell size and refinement ratio in lower level functions, only in the case `lev > 0`.