### PR TITLE
Convert box size to boosted frame, when using Python `step` function

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -174,6 +174,7 @@ def initialize(argv=None):
     if argv is None:
         argv = sys.argv
     amrex_init(argv)
+    libwarpx.warpx_ConvertLabParamsToBoost()
     libwarpx.warpx_init()
 
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -5,6 +5,7 @@
 #include <WarpXWrappers.h>
 #include <WarpXParticleContainer.H>
 #include <WarpX.H>
+#include <WarpXUtil.H>
 #include <WarpX_py.H>
 
 namespace 
@@ -168,6 +169,11 @@ extern "C"
 	auto & myspc = mypc.GetParticleContainer(speciesnumber);
         const int lev = 0;
 	myspc.AddNParticles(lev, lenx, x, y, z, vx, vy, vz, nattr, attr, uniqueparticles);
+    }
+
+    void warpx_ConvertLabParamsToBoost()
+    {
+      ConvertLabParamsToBoost();
     }
 
     double warpx_getProbLo(int dir)

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -52,7 +52,9 @@ extern "C" {
                              double* x, double* y, double* z,
                              double* vx, double* vy, double* vz,
                              int nattr, double* attr, int uniqueparticles);
-    
+
+    void warpx_ConvertLabParamsToBoost();
+  
     double warpx_getProbLo(int dir);
     
     double warpx_getProbHi(int dir);


### PR DESCRIPTION
Cho Ng recently reported that the size of the box was incorrect when running a boosted frame simulation using the Python main. (this bug does not occur when running the C++ executable instead)

Upon more investigation, and with help from @atmyers, we realized that this is because the conversion of the box size to the boosted-frame is done directly [in the C++ main](https://github.com/ECP-WarpX/WarpX/blob/master/Source/main.cpp#L26).

Therefore, this PR wraps the C++ function doing the boosted-frame conversion and adds it to `_libwarpx.initialize`. 

Note that `_libwarpx.initialize` is only called when using the `step` function (i.e. running WarpX directly with Python), but not when using the `write_input_files` (i.e. using Python to simply generate an input script for the C++ executable). Therefore, the boosted-frame conversion is done in Python only in the first case. (which is what we want, since, in the second case, that conversion is done in the C++ executable)