### PR TITLE
Apply filter gpu

### DIFF
--- a/Source/Filter/BilinearFilter.H
+++ b/Source/Filter/BilinearFilter.H
@@ -1,5 +1,5 @@
 #include <AMReX_MultiFab.H>
-#include <AMReX_Vector.H>
+#include <AMReX_CudaContainers.H>
 
 #ifndef WARPX_FILTER_H_
 #define WARPX_FILTER_H_
@@ -15,11 +15,11 @@ public:
     amrex::IntVect npass_each_dir;
     amrex::IntVect stencil_length_each_dir;
 
-private:
-
     void Filter(const amrex::Box& tbx, amrex::FArrayBox const& tmpfab, amrex::FArrayBox &dstfab, int scomp, int dcomp, int ncomp);
 
-    amrex::Vector<amrex::Real> stencil_x, stencil_y, stencil_z;
+private:
+
+    amrex::Gpu::ManagedVector<amrex::Real> stencil_x, stencil_y, stencil_z;
 
     amrex::Dim3 slen;
 };

--- a/Source/Filter/BilinearFilter.cpp
+++ b/Source/Filter/BilinearFilter.cpp
@@ -9,38 +9,39 @@
 using namespace amrex;
 
 namespace {
-void compute_stencil(Vector<Real> &stencil, int npass){
-    Vector<Real> old_s(1+npass,0.);
-    Vector<Real> new_s(1+npass,0.);
+    void compute_stencil(Gpu::ManagedVector<Real> &stencil, int npass)
+    {
+        Gpu::ManagedVector<Real> old_s(1+npass,0.);
+        Gpu::ManagedVector<Real> new_s(1+npass,0.);
 
-    old_s[0] = 1.;
-    int jmax = 1;
-    amrex::Real loc;
-    // Convolve the filter with itself npass times
-    for(int ipass=1; ipass<npass+1; ipass++){
-        // element 0 has to be treated in its own way
-        new_s[0] = 0.5 * old_s[0];
-        if (1<jmax) new_s[0] += 0.5 * old_s[1];
-        loc = 0.;
-        // For each element j, apply the filter to 
-        // old_s to get new_s[j]. loc stores the tmp 
-        // filtered value.
-        for(int j=1; j<jmax+1; j++){
-            loc = 0.5 * old_s[j];
-            loc += 0.25 * old_s[j-1];
-            if (j<jmax) loc += 0.25 * old_s[j+1];
-            new_s[j] = loc;
+        old_s[0] = 1.;
+        int jmax = 1;
+        amrex::Real loc;
+        // Convolve the filter with itself npass times
+        for(int ipass=1; ipass<npass+1; ipass++){
+            // element 0 has to be treated in its own way
+            new_s[0] = 0.5 * old_s[0];
+            if (1<jmax) new_s[0] += 0.5 * old_s[1];
+            loc = 0.;
+            // For each element j, apply the filter to 
+            // old_s to get new_s[j]. loc stores the tmp 
+            // filtered value.
+            for(int j=1; j<jmax+1; j++){
+                loc = 0.5 * old_s[j];
+                loc += 0.25 * old_s[j-1];
+                if (j<jmax) loc += 0.25 * old_s[j+1];
+                new_s[j] = loc;
+            }
+            // copy new_s into old_s
+            old_s = new_s;
+            // extend the stencil length for next iteration
+            jmax += 1;
         }
-        // copy new_s into old_s
-        old_s = new_s;
-        // extend the stencil length for next iteration
-        jmax += 1;
+        // we use old_s here to make sure the stencil
+        // is corrent even when npass = 0
+        stencil = old_s;
+        stencil[0] *= 0.5; // because we will use it twice
     }
-    // we use old_s here to make sure the stencil
-    // is corrent even when npass = 0
-    stencil = old_s;
-    stencil[0] *= 0.5; // because we will use it twice
-}
 }
 
 void BilinearFilter::ComputeStencils(){
@@ -75,23 +76,35 @@ BilinearFilter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, int scomp,
     BL_PROFILE("BilinearFilter::ApplyStencil()");
     ncomp = std::min(ncomp, srcmf.nComp());
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
         FArrayBox tmpfab;
-        for (MFIter mfi(dstmf,true); mfi.isValid(); ++mfi){
+        for (MFIter mfi(dstmf,TilingIfNotGPU()); mfi.isValid(); ++mfi){
             const auto& srcfab = srcmf[mfi];
             auto& dstfab = dstmf[mfi];
             const Box& tbx = mfi.growntilebox();
             const Box& gbx = amrex::grow(tbx,stencil_length_each_dir-1);
             // tmpfab has enough ghost cells for the stencil
             tmpfab.resize(gbx,ncomp);
-            tmpfab.setVal(0.0, gbx, 0, ncomp);
+            FArrayBox* tmpfab_ptr = &tmpfab;
+            const FArrayBox* srcfab_ptr = &srcfab;
             // Copy values in srcfab into tmpfab
             const Box& ibx = gbx & srcfab.box();
-            tmpfab.copy(srcfab, ibx, scomp, ibx, 0, ncomp);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA(gbx, tgbx,
+            {
+                tmpfab_ptr->setVal(0.0, tgbx, 0, ncomp);
+            });
+
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA(ibx, tibx,
+            {
+                tmpfab_ptr->copy(*srcfab_ptr, tibx, scomp, tibx, 0, ncomp);
+            });
+
             // Apply filter
             Filter(tbx, tmpfab, dstfab, 0, dcomp, ncomp);
+
+            Gpu::Device::streamSynchronize();  // needed because of the resize above
         }
     }
 }
@@ -104,53 +117,50 @@ void BilinearFilter::Filter (const Box& tbx, FArrayBox const& tmpfab, FArrayBox 
     const auto tmp = tmpfab.array();
     const auto dst = dstfab.array();
     // tmp and dst are of type Array4 (Fortran ordering)
-    amrex::Real const* AMREX_RESTRICT sx = stencil_x.data();
-    amrex::Real const* AMREX_RESTRICT sy = stencil_y.data();
-    amrex::Real const* AMREX_RESTRICT sz = stencil_z.data();
+    amrex::Real const* AMREX_RESTRICT sx = stencil_x.dataPtr();
+    amrex::Real const* AMREX_RESTRICT sy = stencil_y.dataPtr();
+    amrex::Real const* AMREX_RESTRICT sz = stencil_z.dataPtr();
+    Dim3 slen_local = slen;
     for (int n = 0; n < ncomp; ++n) {
         // Set dst value to 0.
-        for         (int k = lo.z; k <= hi.z; ++k) {
-            for     (int j = lo.y; j <= hi.y; ++j) {
-                for (int i = lo.x; i <= hi.x; ++i) {
-                    dst(i,j,k,dcomp+n) = 0.0;
-                }
-            }
-        }
-        // 3 nested loop on 3D stencil
-        for         (int iz=0; iz < slen.z; ++iz){
-            for     (int iy=0; iy < slen.y; ++iy){
-                for (int ix=0; ix < slen.x; ++ix){
+        amrex::ParallelFor(tbx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            dst(i,j,k,dcomp+n) = 0.0;
+        });
+        
+        amrex::ParallelFor(tbx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+
+            for         (int iz=0; iz < slen_local.z; ++iz){
+                for     (int iy=0; iy < slen_local.y; ++iy){
+                    for (int ix=0; ix < slen_local.x; ++ix){
 #if (AMREX_SPACEDIM == 3)        
-                    Real sss = sx[ix]*sy[iy]*sz[iz];
+                        Real sss = sx[ix]*sy[iy]*sz[iz];
 #else
-                    Real sss = sx[ix]*sz[iy];
+                        Real sss = sx[ix]*sz[iy];
 #endif
-                    // 3 nested loop on 3D array
-                    for         (int k = lo.z; k <= hi.z; ++k) {
-                        for     (int j = lo.y; j <= hi.y; ++j) {
-                            AMREX_PRAGMA_SIMD
-                            for (int i = lo.x; i <= hi.x; ++i) {
+                        
 #if (AMREX_SPACEDIM == 3)
-                                dst(i,j,k,dcomp+n) += sss*(tmp(i-ix,j-iy,k-iz,scomp+n)
-                                                          +tmp(i+ix,j-iy,k-iz,scomp+n)
-                                                          +tmp(i-ix,j+iy,k-iz,scomp+n)
-                                                          +tmp(i+ix,j+iy,k-iz,scomp+n)
-                                                          +tmp(i-ix,j-iy,k+iz,scomp+n)
-                                                          +tmp(i+ix,j-iy,k+iz,scomp+n)
-                                                          +tmp(i-ix,j+iy,k+iz,scomp+n)
-                                                          +tmp(i+ix,j+iy,k+iz,scomp+n));
+                        dst(i,j,k,dcomp+n) += sss*(tmp(i-ix,j-iy,k-iz,scomp+n)
+                                                  +tmp(i+ix,j-iy,k-iz,scomp+n)
+                                                  +tmp(i-ix,j+iy,k-iz,scomp+n)
+                                                  +tmp(i+ix,j+iy,k-iz,scomp+n)
+                                                  +tmp(i-ix,j-iy,k+iz,scomp+n)
+                                                  +tmp(i+ix,j-iy,k+iz,scomp+n)
+                                                  +tmp(i-ix,j+iy,k+iz,scomp+n)
+                                                  +tmp(i+ix,j+iy,k+iz,scomp+n));
 #else
-                                dst(i,j,k,dcomp+n) += sss*(tmp(i-ix,j-iy,k,scomp+n)
-                                                          +tmp(i+ix,j-iy,k,scomp+n)
-                                                          +tmp(i-ix,j+iy,k,scomp+n)
-                                                          +tmp(i+ix,j+iy,k,scomp+n));
+                        dst(i,j,k,dcomp+n) += sss*(tmp(i-ix,j-iy,k,scomp+n)
+                                                  +tmp(i+ix,j-iy,k,scomp+n)
+                                                  +tmp(i-ix,j+iy,k,scomp+n)
+                                                  +tmp(i+ix,j+iy,k,scomp+n));
 #endif
-                            }
-                        }
                     }
                 }
             }
-        }
+        });
     }
 }
 

--- a/Source/Filter/BilinearFilter.cpp
+++ b/Source/Filter/BilinearFilter.cpp
@@ -127,11 +127,6 @@ void BilinearFilter::Filter (const Box& tbx, FArrayBox const& tmpfab, FArrayBox 
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             dst(i,j,k,dcomp+n) = 0.0;
-        });
-        
-        amrex::ParallelFor(tbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
 
             for         (int iz=0; iz < slen_local.z; ++iz){
                 for     (int iy=0; iy < slen_local.y; ++iy){
@@ -140,8 +135,7 @@ void BilinearFilter::Filter (const Box& tbx, FArrayBox const& tmpfab, FArrayBox 
                         Real sss = sx[ix]*sy[iy]*sz[iz];
 #else
                         Real sss = sx[ix]*sz[iy];
-#endif
-                        
+#endif                        
 #if (AMREX_SPACEDIM == 3)
                         dst(i,j,k,dcomp+n) += sss*(tmp(i-ix,j-iy,k-iz,scomp+n)
                                                   +tmp(i+ix,j-iy,k-iz,scomp+n)


### PR DESCRIPTION
This ports the Bi-linear Filter to the GPU. 

I did some initial scoping runs for the laser acceleration case on Summit. It turns out the filter was by far the slowest step, because that hadn't been offloaded to the gpu yet. This PR implements this feature. The time spent applying the filter in my run went from 230 seconds to just over 2 seconds. I verified that the answer remained the same to within machine precision.

I left the old CPU implementation inside an ifdef, since I didn't want to change the order of the loops. 