### PR TITLE
Implement real-to-complex FFT

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -47,7 +47,8 @@ class SpectralFieldData
         SpectralField fields;
         // tmpRealField and tmpSpectralField store fields
         // right before/after the Fourier transform
-        SpectralField tmpRealField, tmpSpectralField;
+        SpectralField tmpSpectralField; // contains Complexs
+        amrex::MultiFab tmpRealField; // contains Reals
         FFTplans forward_plan, backward_plan;
         // Correcting "shift" factors when performing FFT from/to
         // a cell-centered grid in real space, instead of a nodal grid

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -33,7 +33,8 @@ class SpectralKSpace
                         const amrex::DistributionMapping& dm,
                         const amrex::RealVect realspace_dx );
         KVectorComponent getKComponent(
-            const amrex::DistributionMapping& dm, const int i_dim ) const;
+            const amrex::DistributionMapping& dm,
+            const int i_dim, const bool only_positive_k ) const;
         KVectorComponent getModifiedKComponent(
             const amrex::DistributionMapping& dm, const int i_dim,
             const int n_order, const bool nodal ) const;

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -34,6 +34,7 @@ class SpectralKSpace
                         const amrex::RealVect realspace_dx );
         KVectorComponent getKComponent(
             const amrex::DistributionMapping& dm,
+            const amrex::BoxArray& realspace_ba,
             const int i_dim, const bool only_positive_k ) const;
         KVectorComponent getModifiedKComponent(
             const amrex::DistributionMapping& dm, const int i_dim,


### PR DESCRIPTION
This replaces the complex-to-complex FFT by real-to-complex FFT.

The main change is that the spectral space now only contains the positive value of k along the first dimension, thereby reducing the corresponding box by 50%

Performance benefits
- Reduces the memory required to store the fields in spectral space by about 50%.
- The time spent in FFTs is reduced by about 50% (measured on CPU, without threading)