### PR TITLE
Allow to plot the fine mesh, even with only one level

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -395,8 +395,8 @@ WarpX::ReadParameters ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_dive_cleaning,
                 "plot_F only works if warpx.do_dive_cleaning = 1");
         }
+        pp.query("plot_finepatch", plot_finepatch);
         if (maxLevel() > 0) {
-            pp.query("plot_finepatch", plot_finepatch);
             pp.query("plot_crsepatch", plot_crsepatch);
         }
 


### PR DESCRIPTION
The current code does not allow the user to dump the raw data on the fine patch, when there is only one refinement level.

However, there is no reason to have that restriction: the fine patch is well defined, even with only one refinement level.