### PR TITLE
Perfect mirrors

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -373,6 +373,25 @@ Laser initialization
     Temporal chirp at focus.
     See definition in Akturk et al., Opt Express, vol 12, no 19 (2014).
 
+* ``warpx.num_mirrors`` (`int`) optional (default `0`)
+    Users can input perfect mirror condition inside the simulation domain.
+    The number of mirrors is given by ``warpx.num_mirrors``. The mirrors are 
+    orthogonal to the `z` direction. The following parameters are required 
+    when ``warpx.num_mirrors`` is >0.
+
+* ``warpx.mirror_z`` (list of `float`) required if ``warpx.num_mirrors>0``
+    ``z`` location of the front of the mirrors.
+
+* ``warpx.mirror_z_width`` (list of `float`) required if ``warpx.num_mirrors>0``
+    ``z`` width of the mirrors.
+
+* ``warpx.mirror_z_npoints`` (list of `int`) required if ``warpx.num_mirrors>0``
+    In the boosted frame, depending on `gamma_boost`, ``warpx.mirror_z_width`` 
+    can be smaller than the cell size, so that the mirror would not work. This 
+    parameter is the minimum number of points for the mirror. If 
+    ``mirror_z_width < dz/cell_size``, the upper bound of the mirror is increased 
+    so that it contains at least ``mirror_z_npoints``.
+
 Numerics and algorithms
 -----------------------
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -537,7 +537,7 @@ WarpX::applyMirrors(Real time){
             NullifyMF(By, lev, z_min, z_max);
             NullifyMF(Bz, lev, z_min, z_max);
             if (lev>0){
-            // Get fine patch field MultiFabs
+            // Get coarse patch field MultiFabs
             MultiFab& Ex = *Efield_cp[lev][0].get();
             MultiFab& Ey = *Efield_cp[lev][1].get();
             MultiFab& Ez = *Efield_cp[lev][2].get();

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -522,7 +522,7 @@ WarpX::applyMirrors(Real time){
             Real dz = WarpX::CellSize(lev)[2];
             Real z_max = std::max(z_max_tmp, 
                                  z_min+mirror_z_npoints[i_mirror]*dz);
-            // Get field MultiFabs
+            // Get fine patch field MultiFabs
             MultiFab& Ex = *Efield_fp[lev][0].get();
             MultiFab& Ey = *Efield_fp[lev][1].get();
             MultiFab& Ez = *Efield_fp[lev][2].get();
@@ -536,6 +536,22 @@ WarpX::applyMirrors(Real time){
             NullifyMF(Bx, lev, z_min, z_max);
             NullifyMF(By, lev, z_min, z_max);
             NullifyMF(Bz, lev, z_min, z_max);
+            if (lev>0){
+            // Get fine patch field MultiFabs
+            MultiFab& Ex = *Efield_cp[lev][0].get();
+            MultiFab& Ey = *Efield_cp[lev][1].get();
+            MultiFab& Ez = *Efield_cp[lev][2].get();
+            MultiFab& Bx = *Bfield_cp[lev][0].get();
+            MultiFab& By = *Bfield_cp[lev][1].get();
+            MultiFab& Bz = *Bfield_cp[lev][2].get();
+            // Set each field to zero between z_min and z_max
+            NullifyMF(Ex, lev, z_min, z_max);
+            NullifyMF(Ey, lev, z_min, z_max);
+            NullifyMF(Ez, lev, z_min, z_max);
+            NullifyMF(Bx, lev, z_min, z_max);
+            NullifyMF(By, lev, z_min, z_max);
+            NullifyMF(Bz, lev, z_min, z_max);
+            }
         }
     }
 }

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -38,7 +38,7 @@ WarpX::EvolveEM (int numsteps)
     {
         Real walltime_beg_step = amrex::second();
 
-	// Start loop on time steps
+        // Start loop on time steps
         amrex::Print() << "\nSTEP " << step+1 << " starts ...\n";
 #ifdef WARPX_USE_PY
         if (warpx_py_beforestep) warpx_py_beforestep();
@@ -53,16 +53,16 @@ WarpX::EvolveEM (int numsteps)
             if (step > 0 && (step+1) % load_balance_int == 0)
             {
                 LoadBalance();
-		// Reset the costs to 0
-		for (int lev = 0; lev <= finest_level; ++lev) {
-		  costs[lev]->setVal(0.0);
-		}
+                // Reset the costs to 0
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    costs[lev]->setVal(0.0);
+                }
             }
 
             for (int lev = 0; lev <= finest_level; ++lev) {
-	      // Perform running average of the costs
-	      // (Giving more importance to most recent costs)
-	      (*costs[lev].get()).mult( (1. - 2./load_balance_int) );
+                // Perform running average of the costs
+                // (Giving more importance to most recent costs)
+                (*costs[lev].get()).mult( (1. - 2./load_balance_int) );
             }
         }
 
@@ -81,8 +81,8 @@ WarpX::EvolveEM (int numsteps)
             }
             is_synchronized = false;
         } else {
-           // Beyond one step, we have E^{n} and B^{n}.
-           // Particles have p^{n-1/2} and x^{n}.
+            // Beyond one step, we have E^{n} and B^{n}.
+            // Particles have p^{n-1/2} and x^{n}.
             FillBoundaryE();
             FillBoundaryB();
             UpdateAuxilaryData();
@@ -109,8 +109,10 @@ WarpX::EvolveEM (int numsteps)
             UpdateAuxilaryData();
             for (int lev = 0; lev <= finest_level; ++lev) {
                 mypc->PushP(lev, 0.5*dt[lev],
-                    *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
-                    *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
+                            *Efield_aux[lev][0],*Efield_aux[lev][1],
+                            *Efield_aux[lev][2],
+                            *Bfield_aux[lev][0],*Bfield_aux[lev][1],
+                            *Bfield_aux[lev][2]);
             }
             is_synchronized = true;
         }
@@ -122,18 +124,18 @@ WarpX::EvolveEM (int numsteps)
             ++istep[lev];
         }
 
-	cur_time += dt[0];
+        cur_time += dt[0];
 
         bool to_make_plot = (plot_int > 0) && ((step+1) % plot_int == 0);
 
         bool do_insitu = ((step+1) >= insitu_start) &&
-             (insitu_int > 0) && ((step+1) % insitu_int == 0);
+            (insitu_int > 0) && ((step+1) % insitu_int == 0);
 
         bool move_j = is_synchronized || to_make_plot || do_insitu;
         // If is_synchronized we need to shift j too so that next step we can evolve E by dt/2.
         // We might need to move j because we are going to make a plotfile.
 
-	int num_moved = MoveWindow(move_j);
+        int num_moved = MoveWindow(move_j);
         
         if (max_level == 0) {
             int num_redistribute_ghost = num_moved + 1;
@@ -143,11 +145,11 @@ WarpX::EvolveEM (int numsteps)
             mypc->Redistribute();
         }
 
-	bool to_sort = (sort_int > 0) && ((step+1) % sort_int == 0);
-	if (to_sort) {
-	    amrex::Print() << "re-sorting particles \n";
-	    mypc->SortParticlesByCell();
-	}
+        bool to_sort = (sort_int > 0) && ((step+1) % sort_int == 0);
+        if (to_sort) {
+            amrex::Print() << "re-sorting particles \n";
+            mypc->SortParticlesByCell();
+        }
 
         amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
                       << " DT = " << dt[0] << "\n";
@@ -157,10 +159,10 @@ WarpX::EvolveEM (int numsteps)
                       << " s; This step = " << walltime_end_step-walltime_beg_step
                       << " s; Avg. per step = " << walltime/(step+1) << " s\n";
 
-	// sync up time
-	for (int i = 0; i <= max_level; ++i) {
-	    t_new[i] = cur_time;
-	}
+        // sync up time
+        for (int i = 0; i <= max_level; ++i) {
+            t_new[i] = cur_time;
+        }
 
         if (do_boosted_frame_diagnostic) {
             std::unique_ptr<MultiFab> cell_centered_data = nullptr;
@@ -170,7 +172,7 @@ WarpX::EvolveEM (int numsteps)
             myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
         }
 
-	if (to_make_plot || do_insitu)
+        if (to_make_plot || do_insitu)
         {
             FillBoundaryE();
             FillBoundaryB();
@@ -182,34 +184,34 @@ WarpX::EvolveEM (int numsteps)
                                   *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
             }
 
-	    last_plot_file_step = step+1;
-	    last_insitu_step = step+1;
+            last_plot_file_step = step+1;
+            last_insitu_step = step+1;
 
-        if (to_make_plot)
-    	    WritePlotFile();
+            if (to_make_plot)
+                WritePlotFile();
 
-        if (do_insitu)
-            UpdateInSitu();
-	}
+            if (do_insitu)
+                UpdateInSitu();
+        }
 
+        if (check_int > 0 && (step+1) % check_int == 0) {
+            last_check_file_step = step+1;
+            WriteCheckPointFile();
+        }
 
-	if (check_int > 0 && (step+1) % check_int == 0) {
-	    last_check_file_step = step+1;
-	    WriteCheckPointFile();
-	}
-
-	if (cur_time >= stop_time - 1.e-3*dt[0]) {
-	    max_time_reached = true;
-	    break;
-	}
+        if (cur_time >= stop_time - 1.e-3*dt[0]) {
+            max_time_reached = true;
+            break;
+        }
 
 #ifdef WARPX_USE_PY
         if (warpx_py_afterstep) warpx_py_afterstep();
 #endif
-	// End loop on time steps
+        // End loop on time steps
     }
 
-    bool write_plot_file = plot_int > 0 && istep[0] > last_plot_file_step && (max_time_reached || istep[0] >= max_step);
+    bool write_plot_file = plot_int > 0 && istep[0] > last_plot_file_step 
+        && (max_time_reached || istep[0] >= max_step);
 
     bool do_insitu = (insitu_start >= istep[0]) && (insitu_int > 0) &&
         (istep[0] > last_insitu_step) && (max_time_reached || istep[0] >= max_step);
@@ -222,8 +224,10 @@ WarpX::EvolveEM (int numsteps)
 
         for (int lev = 0; lev <= finest_level; ++lev) {
             mypc->FieldGather(lev,
-                              *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
-                              *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
+                              *Efield_aux[lev][0],*Efield_aux[lev][1],
+                              *Efield_aux[lev][2],
+                              *Bfield_aux[lev][0],*Bfield_aux[lev][1],
+                              *Bfield_aux[lev][2]);
         }
 
         if (write_plot_file)
@@ -233,8 +237,9 @@ WarpX::EvolveEM (int numsteps)
             UpdateInSitu();
     }
 
-    if (check_int > 0 && istep[0] > last_check_file_step && (max_time_reached || istep[0] >= max_step)) {
-	WriteCheckPointFile();
+    if (check_int > 0 && istep[0] > last_check_file_step && 
+        (max_time_reached || istep[0] >= max_step)) {
+        WriteCheckPointFile();
     }
 
     if (do_boosted_frame_diagnostic) {
@@ -466,23 +471,23 @@ WarpX::ComputeDt ()
     Real deltat = 0.;
 
     if (maxwell_fdtd_solver_id == 0) {
-      // CFL time step Yee solver
+        // CFL time step Yee solver
 #ifdef WARPX_RZ
-      // Derived semi-analytically by R. Lehe
-      deltat  = cfl * 1./( std::sqrt((1+0.2105)/(dx[0]*dx[0]) + 1./(dx[1]*dx[1])) * PhysConst::c );
+        // Derived semi-analytically by R. Lehe
+        deltat  = cfl * 1./( std::sqrt((1+0.2105)/(dx[0]*dx[0]) + 1./(dx[1]*dx[1])) * PhysConst::c );
 #else
-      deltat  = cfl * 1./( std::sqrt(AMREX_D_TERM(  1./(dx[0]*dx[0]),
-                                                  + 1./(dx[1]*dx[1]),
-                                                  + 1./(dx[2]*dx[2]))) * PhysConst::c );
+        deltat  = cfl * 1./( std::sqrt(AMREX_D_TERM(  1./(dx[0]*dx[0]),
+                                                      + 1./(dx[1]*dx[1]),
+                                                      + 1./(dx[2]*dx[2]))) * PhysConst::c );
 #endif
     } else {
-      // CFL time step CKC solver
+        // CFL time step CKC solver
 #if (BL_SPACEDIM == 3)
-      const Real delta = std::min(dx[0],std::min(dx[1],dx[2]));
+        const Real delta = std::min(dx[0],std::min(dx[1],dx[2]));
 #elif (BL_SPACEDIM == 2)
-      const Real delta = std::min(dx[0],dx[1]);
+        const Real delta = std::min(dx[0],dx[1]);
 #endif
-      deltat = cfl*delta/PhysConst::c;
+        deltat = cfl*delta/PhysConst::c;
     }
     dt.resize(0);
     dt.resize(max_level+1,deltat);
@@ -521,7 +526,7 @@ WarpX::applyMirrors(Real time){
             // mirror_z_npoints[i_mirror] cells
             Real dz = WarpX::CellSize(lev)[2];
             Real z_max = std::max(z_max_tmp, 
-                                 z_min+mirror_z_npoints[i_mirror]*dz);
+                                  z_min+mirror_z_npoints[i_mirror]*dz);
             // Get fine patch field MultiFabs
             MultiFab& Ex = *Efield_fp[lev][0].get();
             MultiFab& Ey = *Efield_fp[lev][1].get();
@@ -537,20 +542,20 @@ WarpX::applyMirrors(Real time){
             NullifyMF(By, lev, z_min, z_max);
             NullifyMF(Bz, lev, z_min, z_max);
             if (lev>0){
-            // Get coarse patch field MultiFabs
-            MultiFab& Ex = *Efield_cp[lev][0].get();
-            MultiFab& Ey = *Efield_cp[lev][1].get();
-            MultiFab& Ez = *Efield_cp[lev][2].get();
-            MultiFab& Bx = *Bfield_cp[lev][0].get();
-            MultiFab& By = *Bfield_cp[lev][1].get();
-            MultiFab& Bz = *Bfield_cp[lev][2].get();
-            // Set each field to zero between z_min and z_max
-            NullifyMF(Ex, lev, z_min, z_max);
-            NullifyMF(Ey, lev, z_min, z_max);
-            NullifyMF(Ez, lev, z_min, z_max);
-            NullifyMF(Bx, lev, z_min, z_max);
-            NullifyMF(By, lev, z_min, z_max);
-            NullifyMF(Bz, lev, z_min, z_max);
+                // Get coarse patch field MultiFabs
+                MultiFab& Ex = *Efield_cp[lev][0].get();
+                MultiFab& Ey = *Efield_cp[lev][1].get();
+                MultiFab& Ez = *Efield_cp[lev][2].get();
+                MultiFab& Bx = *Bfield_cp[lev][0].get();
+                MultiFab& By = *Bfield_cp[lev][1].get();
+                MultiFab& Bz = *Bfield_cp[lev][2].get();
+                // Set each field to zero between z_min and z_max
+                NullifyMF(Ex, lev, z_min, z_max);
+                NullifyMF(Ey, lev, z_min, z_max);
+                NullifyMF(Ez, lev, z_min, z_max);
+                NullifyMF(Bx, lev, z_min, z_max);
+                NullifyMF(By, lev, z_min, z_max);
+                NullifyMF(Bz, lev, z_min, z_max);
             }
         }
     }

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -1,7 +1,11 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
+#include <AMReX_MultiFab.H>
 
 void ReadBoostedFrameParameters(amrex::Real& gamma_boost, amrex::Real& beta_boost,
                                 amrex::Vector<int>& boost_direction);
 
 void ConvertLabParamsToBoost();
+
+void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, 
+               amrex::Real zmax);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -3,6 +3,7 @@
 #include <WarpXUtil.H>
 #include <WarpXConst.H>
 #include <AMReX_ParmParse.H>
+#include <WarpX.H>
 
 using namespace amrex;
 
@@ -93,5 +94,46 @@ void ConvertLabParamsToBoost()
     if (max_level > 0){
       pp_wpx.addarr("fine_tag_lo", fine_tag_lo);
       pp_wpx.addarr("fine_tag_hi", fine_tag_hi);
+    }
+}
+
+/* \brief Function that sets the value of MultiFab MF to zero for z between 
+ * zmin and zmax.
+ */
+void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax){
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for(amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
+        const amrex::Box& bx = mfi.tilebox();
+        // Get box lower and upper physical z bound, and dz
+        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev)[2];
+        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev)[2];
+        amrex::Real dz  = WarpX::CellSize(lev)[2];
+        // Get box lower index in the z direction
+#if (AMREX_SPACEDIM==3)
+        const int lo_ind = bx.loVect()[2];
+#else
+        const int lo_ind = bx.loVect()[1];
+#endif
+        // Check if box intersect with [zmin, zmax]
+        if ( (zmin>zmin_box && zmin<=zmax_box) || 
+             (zmax>zmin_box && zmax<=zmax_box) ){
+            Array4<Real> arr = mf[mfi].array();
+            // Set field to 0 between zmin and zmax
+            ParallelFor(bx,
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept{
+#if (AMREX_SPACEDIM==3)
+                    if (zmin<zmin_box+(k-lo_ind)*dz || zmax>zmin_box+(k-lo_ind)*dz){
+                        arr(i,j,k) = 0.;
+                    }
+#else
+                    if (zmin<zmin_box+(j-lo_ind)*dz && zmax>zmin_box+(j-lo_ind)*dz){
+                        arr(i,j,k) = 0.;
+                    } 
+#endif
+                }
+            );
+        }
     }
 }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -125,14 +125,13 @@ void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax)
             ParallelFor(bx,
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept{
 #if (AMREX_SPACEDIM==3)
-                    if (zmin<zmin_box+(k-lo_ind)*dz || zmax>zmin_box+(k-lo_ind)*dz){
-                        arr(i,j,k) = 0.;
-                    }
+                    const Real z_gridpoint = zmin_box+(k-lo_ind)*dz;
 #else
-                    if (zmin<zmin_box+(j-lo_ind)*dz && zmax>zmin_box+(j-lo_ind)*dz){
+                    const Real z_gridpoint = zmin_box+(j-lo_ind)*dz;
+#endif 
+                    if ( (z_gridpoint >= zmin) && (z_gridpoint < zmax) ) {
                         arr(i,j,k) = 0.;
-                    } 
-#endif
+                    };
                 }
             );
         }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -101,6 +101,7 @@ void ConvertLabParamsToBoost()
  * zmin and zmax.
  */
 void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax){
+    BL_PROFILE("WarpX::NullifyMF()");
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -144,6 +144,13 @@ public:
     static amrex::IntVect filter_npass_each_dir;
     BilinearFilter bilinear_filter;
 
+    static int num_mirrors;
+    amrex::Vector<amrex::Real> mirror_z;
+    amrex::Vector<amrex::Real> mirror_z_width;
+    amrex::Vector<int> mirror_z_npoints;
+    
+    void applyMirrors(amrex::Real time);
+
     void ComputeDt ();
     int  MoveWindow (bool move_j);
     void UpdatePlasmaInjectionPosition (amrex::Real dt);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -50,6 +50,8 @@ bool WarpX::use_filter        = false;
 bool WarpX::serialize_ics     = false;
 bool WarpX::refine_plasma     = false;
 
+int WarpX::num_mirrors = 0;
+
 int  WarpX::sort_int = -1;
 
 bool WarpX::do_boosted_frame_diagnostic = false;
@@ -354,6 +356,16 @@ WarpX::ReadParameters ()
 #if (AMREX_SPACEDIM == 3)
     filter_npass_each_dir[2] = parse_filter_npass_each_dir[2];
 #endif
+
+    pp.query("num_mirrors", num_mirrors);
+    if (num_mirrors>0){
+        mirror_z.resize(num_mirrors);
+        pp.getarr("mirror_z", mirror_z, 0, num_mirrors);
+        mirror_z_width.resize(num_mirrors);
+        pp.getarr("mirror_z_width", mirror_z_width, 0, num_mirrors);
+        mirror_z_npoints.resize(num_mirrors);
+        pp.getarr("mirror_z_npoints", mirror_z_npoints, 0, num_mirrors);
+    }
 
 	pp.query("serialize_ics", serialize_ics);
 	pp.query("refine_plasma", refine_plasma);


### PR DESCRIPTION
Adds capability to have perfect reflecting conditions inside the simulation domain (not at a boundary). This is used for multi-stage laser-plasma accelerators: the laser at the end of a stage is reflected (discarded) and a new one can be injected. The image below shows the back-transformed laser field  from a 2D simulation in the presence of a mirror. The green crosses show the theoretical mirror boundaries.

New member function `applyMirrors` of class `WarpX is added, which calls `NullifyMF` (from `WarpXUtils.cpp`).

<img width="500" alt="Screen Shot 2019-05-01 at 6 06 56 PM" src="https://user-images.githubusercontent.com/26292713/57052439-f2917500-6c3b-11e9-9c78-ffccb617d755.png">

This PR addresses issue https://github.com/ECP-WarpX/WarpX/issues/110