### PR TITLE
Fix guard cell summation

### DIFF
--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -19,21 +19,13 @@ void
 WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
                    const int icomp=0, const int ncomp=1){
 #ifdef WARPX_USE_PSATD
-    // Update both valid cells and guard cells
-    const int n_grow = mf.nGrow();
-    // Create temporary MultiFab, for safe summation
-    // (The MFInfo and Factory are similar to those used inside `SumBounday`)
-    amrex::MultiFab tmp(mf.boxArray(), mf.DistributionMap(), ncomp, n_grow,
-            amrex::MFInfo().SetDeviceFab(false), mf.Factory());
-    amrex::MultiFab::Copy(tmp, mf, icomp, 0, ncomp, n_grow); // Local copy
-    mf.setVal(0.0, icomp, ncomp, 0);
-    // Perform summation on overlapping grid points
-    mf.ParallelCopy(tmp, 0, icomp, ncomp, n_grow, n_grow,
-                    period, amrex::FabArrayBase::ADD);
+   // Update both valid cells and guard cells
+   const amrex::IntVect n_updated_guards = mf.nGrowVect();
 #else
-    // Update only the valid cells
-    mf.SumBoundary(icomp, ncomp, period);
+   // Update only the valid cells
+   const amrex::IntVect n_updated_guards = amrex::IntVect::TheZeroVector();
 #endif
+    mf.SumBoundary(icomp, ncomp, n_updated_guards, period);
 }
 
 /* \brief Sum the values of `src` where the different boxes overlap
@@ -52,19 +44,18 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
  *       The component from which we copy in `src` is always 0.
  */
 void
-WarpXSumGuardCells(amrex::MultiFab& dst, const amrex::MultiFab& src,
+WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
                    const amrex::Periodicity& period,
                    const int icomp=0, const int ncomp=1){
 #ifdef WARPX_USE_PSATD
     // Update both valid cells and guard cells
-    const int n_updated_guards = dst.nGrow();
+    const amrex::IntVect n_updated_guards = dst.nGrowVect();
 #else
     // Update only the valid cells
-    const int n_updated_guards = 0;
+    const amrex::IntVect n_updated_guards = amrex::IntVect::TheZeroVector();
 #endif
-    dst.setVal(0.0, icomp, ncomp, 0);
-    dst.ParallelCopy( src, 0, icomp, ncomp, n_updated_guards,
-                      dst.nGrow(), period, amrex::FabArrayBase::ADD );
+    src.SumBoundary(icomp, ncomp, n_updated_guards, period);
+    amrex::Copy( dst, src, 0, icomp, ncomp, n_updated_guards );
 }
 
 #endif // WARPX_SUM_GUARD_CELLS_H_


### PR DESCRIPTION
PR #111 had a small bug, which affects the first guard cell in each nodal direction.

Here is an illustration, in the case of periodic plasma wave, where the `Jz` field typically looks like this after the first iteration:
![Jz](https://user-images.githubusercontent.com/6685781/57109518-86ba1580-6cea-11e9-98e1-ef9f8588e9b0.png)

After PR #111, line outs of Jz along x (at different z positions), looks like this:
![Buggy](https://user-images.githubusercontent.com/6685781/57109549-9fc2c680-6cea-11e9-9172-915b23446763.png)
The red lines show the positions of the outermost *nodes* of the valid box ; for the dashed lines, the data in the guard cells was obtained in postprocessing by explicitly copying the data from the valid box - using the periodicity of the box ; the colored line show the actual data from the simulation. Note that the first guard cell is slightly off.)

With the current PR, we obtain the right result:
![Fixed](https://user-images.githubusercontent.com/6685781/57109715-0cd65c00-6ceb-11e9-8b28-af793704874a.png)

@WeiqunZhang Using `SumBoundary` fixed the issue here, but I am not sure why. Do you understand this, given the code change.