### PR TITLE
In documentation, use "git clone --branch" option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,14 @@ First, let us setup your local git repo. Make your own fork of the main
 on the [WarpX Github page](https://github.com/ECP-WarpX/WarpX), press the 
 fork button. Then, you can execute:
 ```
-# These 5 first lines are the same as for a standard WarpX install
+# These 4 first lines are the same as for a standard WarpX install
 mkdir warpx_directory
 cd warpx_directory
-git clone https://bitbucket.org/berkeleylab/picsar.git
-git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout development && cd .. # switch to AMReX development branch
+git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+git clone --branch development https://github.com/AMReX-Codes/amrex.git
 
 # Clone your fork on your local computer. You can get this address on your fork's Github page.
-git clone https://github.com/<myGithubUsername>/ECP-WarpX/WarpX.git
+git clone --branch dev https://github.com/<myGithubUsername>/ECP-WarpX/WarpX.git
 cd warpx
 # Keep track of the main WarpX repo, to remain up-to-date.
 git remote add upstream https://github.com/ECP-WarpX/WarpX.git

--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -17,25 +17,9 @@ single directory (e.g. ``warpx_directory``):
 
     mkdir warpx_directory
     cd warpx_directory
-    git clone https://github.com/ECP-WarpX/WarpX.git
-    git clone https://bitbucket.org/berkeleylab/picsar.git
-    git clone https://github.com/AMReX-Codes/amrex.git
-
-Then switch to the branch ``development`` of AMReX
-
-::
-
-    cd amrex/
-    git checkout development
-    cd ..
-
-and to the branch ``dev`` of WarpX
-
-::
-
-    cd WarpX/
-    git checkout dev
-    cd ..
+    git clone --branch dev https://github.com/ECP-WarpX/WarpX.git
+    git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+    git clone --branch developement https://github.com/AMReX-Codes/amrex.git
 
 Basic compilation
 -----------------

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -11,21 +11,9 @@ correct branch:
     mkdir warpx_directory
     cd warpx_directory
 
-    git clone https://github.com/ECP-WarpX/WarpX.git
-    cd WarpX
-    git checkout dev
-    cd ..
-
-    git clone https://bitbucket.org/berkeleylab/picsar.git
-    cd picsar
-    git checkout master
-    cd ..
-
-    git clone https://github.com/AMReX-Codes/amrex.git
-    cd amrex
-    git checkout development
-    cd ..
-
+    git clone --branch dev https://github.com/ECP-WarpX/WarpX.git
+    git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+    git clone --branch development https://github.com/AMReX-Codes/amrex.git
 
 Then, use the following set of commands to compile:
 

--- a/Docs/source/visualization/sensei.rst
+++ b/Docs/source/visualization/sensei.rst
@@ -250,13 +250,10 @@ First, log into cori and clone the git repo's.
    cd $SCRATCH
    mkdir warpx
    cd warpx/
-   git clone https://github.com/ECP-WarpX/WarpX.git WarpX-libsim
-   git clone https://github.com/AMReX-Codes/amrex
-   git clone https://bitbucket.org/berkeleylab/picsar.git
-   cd amrex/
-   git checkout development
-   cd ../WarpX-libsim
-   git checkout dev
+   git clone --branch dev https://github.com/ECP-WarpX/WarpX.git WarpX-libsim
+   git clone --branch development https://github.com/AMReX-Codes/amrex
+   git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+   cd WarpX-libsim
    vim GNUmakefile
 
 Next, edit the makefile to turn the SENSEI features on.
@@ -304,13 +301,10 @@ First, log into cori and clone the git repo's.
    cd $SCRATCH
    mkdir warpx
    cd warpx/
-   git clone https://github.com/ECP-WarpX/WarpX.git WarpX-catalyst
-   git clone https://github.com/AMReX-Codes/amrex
-   git clone https://bitbucket.org/berkeleylab/picsar.git
-   cd amrex/
-   git checkout development
-   cd ../WarpX-catalyst
-   git checkout dev
+   git clone --branch dev https://github.com/ECP-WarpX/WarpX.git WarpX-catalyst
+   git clone --branch development https://github.com/AMReX-Codes/amrex
+   git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+   cd WarpX-catalyst
    vim GNUmakefile
 
 Next, edit the makefile to turn the SENSEI features on.

--- a/run_test.sh
+++ b/run_test.sh
@@ -22,9 +22,8 @@ mkdir warpx
 cp -r ../* warpx
 
 # Clone PICSAR and AMReX
-git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex ; git checkout development ; cd ..
-git clone https://bitbucket.org/berkeleylab/picsar.git
+git clone --branch development https://github.com/AMReX-Codes/amrex.git
+git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
 
 # Clone the AMReX regression test utility
 git clone https://github.com/RemiLehe/regression_testing.git


### PR DESCRIPTION
@RemiLehe I went ahead and made these changes. This cleans up the documentation by using the branch option to specify the branch directly while cloning.