### PR TITLE
Add options to select quantities dumped to plot files

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -289,7 +289,7 @@ Particle initialization
 * ``<species>.plot_vars`` (list of `strings` separated by spaces, optional) 
     List of particle quantities to write to `plotfiles`. By defaults, all 
     quantities are written to file. Choices are 
-    * `w` for the particle weight,
+    * ``w`` for the particle weight,
     * ``ux`` ``uy`` ``uz`` for the particle momentum, 
     * ``Ex`` ``Ey`` ``Ez`` for the electric field on particles,
     * ``Bx`` ``By`` ``Bz`` for the magnetic field on particles.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -283,6 +283,20 @@ Particle initialization
     axes (4 particles in 2D, 6 particles in 3D). When `1`, particles are split
     along the diagonals (4 particles in 2D, 8 particles in 3D).
 
+* ``<species>.plot_species`` (`0` or `1` optional; default `1`)
+    Whether to plot particle quantities for this species.
+
+* ``<species>.plot_vars`` (list of `strings` separated by spaces, optional) 
+    List of particle quantities to write to `plotfiles`. By defaults, all 
+    quantities are written to file. Choices are 
+    * `w` for the particle weight,
+    * ``ux`` ``uy`` ``uz`` for the particle momentum, 
+    * ``Ex`` ``Ey`` ``Ez`` for the electric field on particles,
+    * ``Bx`` ``By`` ``Bz`` for the magnetic field on particles.
+    The particle positions are always included. Use 
+    ``<species>.plot_vars = none`` to plot no particle data, except 
+    particle position.
+
 * ``warpx.serialize_ics`` (`0 or 1`)
     Whether or not to use OpenMP threading for particle initialization.
 
@@ -652,13 +666,17 @@ Diagnostics and output
     (This is done by averaging the field.) ``plot_coarsening_ratio`` should
     be an integer divisor of ``blocking_factor``.
 
-* ``warpx.particle_plot_vars`` (`strings`, separated by spaces ; default: all)
-    Control which particle variables get written to the plot file. Choices are:
-    `w`, `ux`, `uy`, `uz`, `Ex`, `Ey`, `Ez`, `Bx`, `By`, and `Bz`.
-    The particle positions and ids are always included.
-
 * ``amr.plot_file`` (`string`)
     Root for output file names. Supports sub-directories. Default `diags/plotfiles/plt`
+
+* ``warpx.plot_J_field`` (`0` or `1` optional; default `1`)
+    Whether to plot the current density.
+
+* ``warpx.plot_E_field`` (`0` or `1` optional; default `1`)
+    Whether to plot the electric field.
+
+* ``warpx.plot_B_field`` (`0` or `1` optional; default `1`)
+    Whether to plot the magnetic field.
 
 Checkpoints and restart
 -----------------------

--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -13,7 +13,6 @@ amr.max_level = 0
 
 amr.plot_int = 20   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_rho = 1
-warpx.particle_plot_vars = w ux Bz Ey
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian
@@ -61,6 +60,7 @@ electrons.ymin = -20.e-6
 electrons.ymax = 20.e-6
 electrons.zmin = -20.e-6
 electrons.zmax = 20.e-6
+electrons.plot_vars = w ux Bz Ey
 
 electrons.profile = constant
 electrons.density = 2.e24   # number of electrons per m^3
@@ -79,6 +79,7 @@ positrons.ymin = -20.e-6
 positrons.ymax = 20.e-6
 positrons.zmin = -20.e-6
 positrons.zmax = 20.e-6
+positrons.plot_vars = w ux Bz Ey
 
 positrons.profile = constant
 positrons.density = 2.e24   # number of positrons per m^3

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -299,7 +299,10 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
     amrex::Vector<MultiFab>& mf_avg, const int ngrow) const
 {
     // Count how many different fields should be written (ncomp)
-    const int ncomp = 3*3
+    const int ncomp = 0
+        + static_cast<int>(plot_E_field)*3
+        + static_cast<int>(plot_B_field)*3
+        + static_cast<int>(plot_J_field)*3
         + static_cast<int>(plot_part_per_cell)
         + static_cast<int>(plot_part_per_grid)
         + static_cast<int>(plot_part_per_proc)
@@ -321,15 +324,21 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         // Go through the different fields, pack them into mf_avg[lev],
         // add the corresponding names to `varnames` and increment dcomp
         int dcomp = 0;
-        AverageAndPackVectorField(mf_avg[lev], current_fp[lev], dcomp, ngrow);
-        if(lev==0) for(auto name:{"jx","jy","jz"}) varnames.push_back(name);
-        dcomp += 3;
-        AverageAndPackVectorField(mf_avg[lev], Efield_aux[lev], dcomp, ngrow);
-        if(lev==0) for(auto name:{"Ex","Ey","Ez"}) varnames.push_back(name);
-        dcomp += 3;
-        AverageAndPackVectorField(mf_avg[lev], Bfield_aux[lev], dcomp, ngrow);
-        if(lev==0) for(auto name:{"Bx","By","Bz"}) varnames.push_back(name);
-        dcomp += 3;
+        if (plot_J_field) {
+            AverageAndPackVectorField(mf_avg[lev], current_fp[lev], dcomp, ngrow);
+            if(lev==0) for(auto name:{"jx","jy","jz"}) varnames.push_back(name);
+            dcomp += 3;
+        }
+        if (plot_E_field) {
+            AverageAndPackVectorField(mf_avg[lev], Efield_aux[lev], dcomp, ngrow);
+            if(lev==0) for(auto name:{"Ex","Ey","Ez"}) varnames.push_back(name);
+            dcomp += 3;
+        }
+        if (plot_B_field) {
+            AverageAndPackVectorField(mf_avg[lev], Bfield_aux[lev], dcomp, ngrow);
+            if(lev==0) for(auto name:{"Bx","By","Bz"}) varnames.push_back(name);
+            dcomp += 3;
+        }
 
         if (plot_part_per_cell)
         {

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -36,6 +36,8 @@ MultiParticleContainer::WritePlotFile (const std::string& dir,
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
         auto& pc = allcontainers[i];
         if (pc->plot_species) {
+            // real_names contains a list of all particle attributes.
+            // pc->plot_flags is 1 or 0, whether quantity is dumped or not.
             pc->WritePlotFile(dir, species_names[i],
                               pc->plot_flags, int_flags,
                               real_names, int_names);

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -28,7 +28,6 @@ MultiParticleContainer::Checkpoint (const std::string& dir) const
 
 void
 MultiParticleContainer::WritePlotFile (const std::string& dir,
-                                       const Vector<int>& real_flags,
                                        const Vector<std::string>& real_names) const
 {
     Vector<std::string> int_names;    
@@ -36,8 +35,8 @@ MultiParticleContainer::WritePlotFile (const std::string& dir,
     
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
 	allcontainers[i]->WritePlotFile(dir, species_names[i],
-                                        real_flags, int_flags,
-                                        real_names, int_names);
+                                    allcontainers[i]->plot_flags, int_flags,
+                                    real_names, int_names);
     }
 }
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -32,11 +32,15 @@ MultiParticleContainer::WritePlotFile (const std::string& dir,
 {
     Vector<std::string> int_names;    
     Vector<int> int_flags;
+    Vector<int> real_flags;
     
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-	allcontainers[i]->WritePlotFile(dir, species_names[i],
-                                    allcontainers[i]->plot_flags, int_flags,
-                                    real_names, int_names);
+        real_flags = allcontainers[i]->plot_flags;
+        for(int j=0;j<PIdx::nattribs;j++){std::cout<<real_flags[j]<<" ";} std::cout<<std::endl;
+        
+        allcontainers[i]->WritePlotFile(dir, species_names[i],
+                                        real_flags, int_flags,
+                                        real_names, int_names);
     }
 }
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -32,15 +32,14 @@ MultiParticleContainer::WritePlotFile (const std::string& dir,
 {
     Vector<std::string> int_names;    
     Vector<int> int_flags;
-    Vector<int> real_flags;
     
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-        real_flags = allcontainers[i]->plot_flags;
-        for(int j=0;j<PIdx::nattribs;j++){std::cout<<real_flags[j]<<" ";} std::cout<<std::endl;
-        
-        allcontainers[i]->WritePlotFile(dir, species_names[i],
-                                        real_flags, int_flags,
-                                        real_names, int_names);
+        auto& pc = allcontainers[i];
+        if (pc->plot_species) {
+            pc->WritePlotFile(dir, species_names[i],
+                              pc->plot_flags, int_flags,
+                              real_names, int_names);
+        }
     }
 }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -642,7 +642,7 @@ WarpX::WritePlotFile () const
         particle_varnames.push_back("uzold");
     }
 
-    mypc->WritePlotFile(plotfilename, particle_plot_flags, particle_varnames);
+    mypc->WritePlotFile(plotfilename, particle_varnames);
 
     WriteJobInfo(plotfilename);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -130,7 +130,6 @@ public:
     void Checkpoint (const std::string& dir) const;
 
     void WritePlotFile( const std::string& dir,
-                        const amrex::Vector<int>& real_flags, 
                         const amrex::Vector<std::string>& real_names) const;
     
     void Restart (const std::string& dir);

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -112,6 +112,9 @@ protected:
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
 
+    amrex::Vector<int> plot_flags;
+    amrex::Vector<std::string> plot_vars;
+
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,
 			    const amrex::RealBox& tile_real_box,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -112,8 +112,10 @@ protected:
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
 
+    /*
     amrex::Vector<int> plot_flags;
     amrex::Vector<std::string> plot_vars;
+    */
 
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -112,11 +112,6 @@ protected:
     bool boost_adjust_transverse_positions = false;
     bool do_backward_propagation = false;
 
-    /*
-    amrex::Vector<int> plot_flags;
-    amrex::Vector<std::string> plot_vars;
-    */
-
     long NumParticlesToAdd (const amrex::Box& overlap_box,
 			    const amrex::RealBox& overlap_realbox,
 			    const amrex::RealBox& tile_real_box,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -100,9 +100,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
             plot_flags.resize(PIdx::nattribs + 6, 0);
         } else {
-            // Set plot_flags to 1 for data in plot_vars
             plot_flags.resize(PIdx::nattribs, 0);
-            Print()<<"here2"<<std::endl;
         }
         // If not none, set plot_flags values to 1 for elements in plot_vars.
         if (plot_vars[0] != "none"){
@@ -110,7 +108,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
                 // Return error if var not in PIdx. 
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE( 
                     ParticleStringNames::to_index.count(var), 
-                    "<species>.plot_vars argument not in ParticleStringNames");
+                    "plot_vars argument not in ParticleStringNames");
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }
         }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -82,6 +82,26 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp.query("do_splitting", do_splitting);
     pp.query("split_type", split_type);
     pp.query("do_continuous_injection", do_continuous_injection);
+    {
+        pp.queryarr("plot_vars", plot_vars);
+        if (plot_vars.size() == 0){
+            if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+                plot_flags.resize(PIdx::nattribs + 6, 1);
+            } else {
+                plot_flags.resize(PIdx::nattribs, 1);
+            }
+        } else {
+            if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+                plot_flags.resize(PIdx::nattribs + 6, 0);
+            } else {
+                plot_flags.resize(PIdx::nattribs, 0);
+            }
+
+            for (const auto& var : plot_vars){
+                plot_flags[ParticleStringNames::to_index.at(var)] = 1;
+            }
+        }
+    }
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -82,22 +82,35 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp.query("do_splitting", do_splitting);
     pp.query("split_type", split_type);
     pp.query("do_continuous_injection", do_continuous_injection);
-    {
-        pp.queryarr("plot_vars", plot_vars);
-        if (plot_vars.size() == 0){
-            if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
-                plot_flags.resize(PIdx::nattribs + 6, 1);
-            } else {
-                plot_flags.resize(PIdx::nattribs, 1);
-            }
-        } else {
-            if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
-                plot_flags.resize(PIdx::nattribs + 6, 0);
-            } else {
-                plot_flags.resize(PIdx::nattribs, 0);
-            }
 
+    pp.query("plot_species", plot_species);
+    int do_user_plot_vars;
+    do_user_plot_vars = pp.queryarr("plot_vars", plot_vars);
+    if (not do_user_plot_vars){
+        // By default, all particle variables are dumped to plotfiles,
+        // including {x,y,z,ux,uy,uz}old variables when running in a 
+        // boosted frame
+        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+            plot_flags.resize(PIdx::nattribs + 6, 1);
+        } else {
+            plot_flags.resize(PIdx::nattribs, 1);
+        }
+    } else {
+        // Set plot_flag to 0 for all attribs
+        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+            plot_flags.resize(PIdx::nattribs + 6, 0);
+        } else {
+            // Set plot_flags to 1 for data in plot_vars
+            plot_flags.resize(PIdx::nattribs, 0);
+            Print()<<"here2"<<std::endl;
+        }
+        // If not none, set plot_flags values to 1 for elements in plot_vars.
+        if (plot_vars[0] != "none"){
             for (const auto& var : plot_vars){
+                // Return error if var not in PIdx. 
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE( 
+                    ParticleStringNames::to_index.count(var), 
+                    "<species>.plot_vars argument not in ParticleStringNames");
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }
         }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -272,7 +272,13 @@ protected:
 
     amrex::Vector<amrex::Cuda::ManagedDeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
 
+    // Whether to dump particle quantities. 
+    // If true, particle position is always dumped.
+    int plot_species = 1;
+    // For all particle attribs (execept position), whether or not 
+    // to dump to file.
     amrex::Vector<int> plot_flags;
+    // list of names of attributes to dump.
     amrex::Vector<std::string> plot_vars;
 
 private:

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -272,6 +272,9 @@ protected:
 
     amrex::Vector<amrex::Cuda::ManagedDeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
 
+    amrex::Vector<int> plot_flags;
+    amrex::Vector<std::string> plot_vars;
+
 private:
     virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,
                                     const int lev) override;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -515,6 +515,9 @@ private:
     bool dump_plotfiles = true;
     bool dump_openpmd = false;
 #endif
+    bool plot_E_field       = true;
+    bool plot_B_field       = true;
+    bool plot_J_field       = true;
     bool plot_part_per_cell = true;
     bool plot_part_per_grid = false;
     bool plot_part_per_proc = false;
@@ -542,9 +545,6 @@ private:
     amrex::RealVect fine_tag_hi;
 
     bool is_synchronized = true;
-
-    amrex::Vector<std::string> particle_plot_vars;
-    amrex::Vector<int> particle_plot_flags;
 
 #ifdef WARPX_USE_PSATD
     // Store fields in real space on the dual grid (i.e. the grid for the FFT push of the fields)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -431,41 +431,6 @@ WarpX::ReadParameters ()
             fine_tag_hi = RealVect{hi};
         }
 
-        // select which particle comps to write
-        /*
-        {
-            pp.queryarr("particle_plot_vars", particle_plot_vars);
-
-            if (particle_plot_vars.size() == 0)
-            {
-                if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
-                {
-                    particle_plot_flags.resize(PIdx::nattribs + 6, 1);
-                }
-                else
-                {
-                    particle_plot_flags.resize(PIdx::nattribs, 1);
-                }                
-            }
-            else
-            {
-                if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
-                {
-                    particle_plot_flags.resize(PIdx::nattribs + 6, 0);
-                }
-                else
-                {
-                    particle_plot_flags.resize(PIdx::nattribs, 0);
-                }                
-
-                for (const auto& var : particle_plot_vars)
-                {
-                    particle_plot_flags[ParticleStringNames::to_index.at(var)] = 1;
-                }
-            }
-        }
-        */
-
         pp.query("load_balance_int", load_balance_int);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -371,6 +371,9 @@ WarpX::ReadParameters ()
         if (ParallelDescriptor::NProcs() == 1) {
             plot_proc_number = false;
         }
+        pp.query("plot_E_field"      , plot_E_field);
+        pp.query("plot_B_field"      , plot_B_field);
+        pp.query("plot_J_field"      , plot_J_field);
         pp.query("plot_part_per_cell", plot_part_per_cell);
         pp.query("plot_part_per_grid", plot_part_per_grid);
         pp.query("plot_part_per_proc", plot_part_per_proc);
@@ -429,6 +432,7 @@ WarpX::ReadParameters ()
         }
 
         // select which particle comps to write
+        /*
         {
             pp.queryarr("particle_plot_vars", particle_plot_vars);
 
@@ -460,6 +464,7 @@ WarpX::ReadParameters ()
                 }
             }
         }
+        */
 
         pp.query("load_balance_int", load_balance_int);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);


### PR DESCRIPTION
This small PR does two things:
- Add options `plot_E_field`, `plot_B_field` and `plot_J_field`, just like `plot_rho` etc.;
- Add option `<species>.plot_species` (whether or not to plot this species data to file), and replace `warpx.plot_particle_vars` with `<species>.plot_vars`, so that users can select data to dump on a per-species basis.

From a small 2D simulations, the default output give 37 MB, 
```
warpx.plot_E_field       = 0
warpx.plot_B_field       = 0
warpx.plot_J_field       = 0
warpx.plot_part_per_cell = 0
```
give 17 MB, and further adding
```
electrons.plot_species = 0
electrons.plot_vars = none
beam.plot_species = 0
beam.plot_vars = none
```
gives 48 KB in plotfiles.