### PR TITLE
Choose species in back-transformed diagnostics.

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -306,6 +306,11 @@ Particle initialization
     ``<species>.plot_vars = none`` to plot no particle data, except 
     particle position.
 
+* ``<species>.do_boosted_frame_diags`` (`0` or `1` optional, default `1`)
+    Only used when ``warpx.do_boosted_frame_diagnostic=1``. When running in a 
+    boosted frame, whether or not to plot back-transformed diagnostics for 
+    this species.
+
 * ``warpx.serialize_ics`` (`0 or 1`)
     Whether or not to use OpenMP threading for particle initialization.
 

--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -75,6 +75,10 @@ class BoostedFrameDiagnostic {
     int boost_direction_;
 
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > data_buffer_;
+    // particles_buffer_ is current blind to refinement level.
+    // particles_buffer_[i][j] is a WarpXParticleContainer::DiagnosticParticleData where
+    // - i is the back-transformed snapshot number 
+    // - j is the species number
     amrex::Vector<amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> > particles_buffer_;
     int num_buffer_ = 256;
     int max_box_size_ = 256;

--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -74,14 +74,19 @@ class BoostedFrameDiagnostic {
     unsigned Nz_lab_;   
     int boost_direction_;
 
+    // For back-transformed diagnostics of grid fields, data_buffer_[i]
+    // stores a buffer of the fields in the lab frame (in a MultiFab, i.e.
+    // with all box data etc.). When the buffer if full, dump to file.
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > data_buffer_;
-    // particles_buffer_ is current blind to refinement level.
+    // particles_buffer_ is currently blind to refinement level.
     // particles_buffer_[i][j] is a WarpXParticleContainer::DiagnosticParticleData where
     // - i is the back-transformed snapshot number 
     // - j is the species number
     amrex::Vector<amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> > particles_buffer_;
     int num_buffer_ = 256;
     int max_box_size_ = 256;
+    // buff_counter_[i] is the number of z slices in data_buffer_[i] 
+    // for snapshot number i.
     amrex::Vector<int> buff_counter_;
 
     amrex::Vector<LabSnapShot> snapshots_;

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -497,8 +497,6 @@ BoostedFrameDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
 void BoostedFrameDiagnostic::Flush(const Geometry& geom)
 {
     BL_PROFILE("BoostedFrameDiagnostic::Flush");
-
-    std::cout<<"in Flush\n";
     
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::NoFabHeader_v1);
@@ -542,11 +540,10 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
             
             if (WarpX::do_boosted_frame_particles) {
                 // for (int j = 0; j < mypc.nSpecies(); ++j) {
-                for (int j = 0; j < mypc.nspecies_lab_frame_diags; ++j) {
-                    int js = mypc.map_species_lab_diags[j];
+                for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j) {
+                    int js = mypc.mapSpeciesLabDiags(j);
                     std::string species_name = species_names[js];
 #ifdef WARPX_USE_HDF5
-                    std::cout<<"particles_buffer_ j "<<j<<'\n';
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
                                           species_name);
@@ -607,7 +604,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                 DistributionMapping buff_dm(buff_ba);
                 data_buffer_[i].reset( new MultiFab(buff_ba, buff_dm, ncomp, 0) );
             }
-            if (WarpX::do_boosted_frame_particles) particles_buffer_[i].resize(mypc.nspecies_lab_frame_diags);
+            if (WarpX::do_boosted_frame_particles) particles_buffer_[i].resize(mypc.nSpeciesLabFrameDiags());
         }
 
         if (WarpX::do_boosted_frame_fields) {
@@ -675,9 +672,9 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             
             if (WarpX::do_boosted_frame_particles) {
 
-                for (int j = 0; j < mypc.nspecies_lab_frame_diags; ++j) {
+                for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j) {
         
-                    const std::string species_name = species_names[mypc.map_species_lab_diags[j]];
+                    const std::string species_name = species_names[mypc.mapSpeciesLabDiags(j)];
 #ifdef WARPX_USE_HDF5
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
@@ -735,6 +732,7 @@ writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdat
     ParallelDescriptor::ReduceLongMax(old_np);
     
     // Write data here
+    Print()<<"particle_field_names.size()"<<particle_field_names.size()<<std::endl;
     for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
     {
         std::string field_path = species_name + "/" + particle_field_names[k];
@@ -872,9 +870,9 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
         // for (int j = 0; j < mypc.nSpecies(); ++j)
-        for (int j = 0; j < mypc.nspecies_lab_frame_diags; ++j)
+        for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j)
         {
-            int js = mypc.map_species_lab_diags[j];
+            int js = mypc.mapSpeciesLabDiags(j);
             std::string species_name = species_names[js];
             output_create_species_group(file_name, species_name);
             for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
@@ -901,8 +899,8 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();        
         
         const std::string particles_prefix = "particle";
-        for(int i = 0; i < mypc.nspecies_lab_frame_diags; ++i) {
-            int is = mypc.map_species_lab_diags[i];
+        for(int i = 0; i < mypc.nSpeciesLabFrameDiags(); ++i) {
+            int is = mypc.mapSpeciesLabDiags(i);
             std::string species_name = species_names[is];
             const std::string fullpath = file_name + "/" + species_name;
             if (!UtilCreateDirectory(fullpath, 0755))

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -582,27 +582,19 @@ writeLabFrameData(const MultiFab* cell_centered_data,
 
     const std::vector<std::string> species_names = mypc.GetSpeciesNames();
 
-    Print()<<"in BoostedFrameDiagnostic::writeLabFrameData 1\n";
-    
     for (int i = 0; i < N_snapshots_; ++i) {
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 2\n";
-        std::cout<<"i "<<i<<std::endl;
     
         const Real old_z_boost = snapshots_[i].current_z_boost;
-        std::cout<<"toto 1\n";
         snapshots_[i].updateCurrentZPositions(t_boost,
                                               inv_gamma_boost_,
                                               inv_beta_boost_);
-        std::cout<<"toto 2\n";
         
         if ( (snapshots_[i].current_z_boost < zlo_boost) or
              (snapshots_[i].current_z_boost > zhi_boost) or
              (snapshots_[i].current_z_lab < snapshots_[i].zmin_lab) or
              (snapshots_[i].current_z_lab > snapshots_[i].zmax_lab) ) continue;
 
-        std::cout<<"toto 3\n";
         int i_lab = (snapshots_[i].current_z_lab - snapshots_[i].zmin_lab) / dz_lab_;
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 3\n";
 
         if (buff_counter_[i] == 0) {
             if (WarpX::do_boosted_frame_fields) {
@@ -617,7 +609,6 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             }
             if (WarpX::do_boosted_frame_particles) particles_buffer_[i].resize(mypc.nspecies_lab_frame_diags);
         }
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 4\n";
 
         if (WarpX::do_boosted_frame_fields) {
             const int ncomp = cell_centered_data->nComp();
@@ -657,14 +648,11 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                                 &ncomp, &i_boost, &i_lab);
             }
         }
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 5\n";        
         if (WarpX::do_boosted_frame_particles) {
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 6\n";
 
-        //mypc.GetLabFrameData(snapshots_[i].file_name, i_lab, boost_direction_,
-        //                         old_z_boost, snapshots_[i].current_z_boost,
-        //                         t_boost, snapshots_[i].t_lab, dt, particles_buffer_[i]);
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 7\n";
+            mypc.GetLabFrameData(snapshots_[i].file_name, i_lab, boost_direction_,
+                                 old_z_boost, snapshots_[i].current_z_boost,
+                                 t_boost, snapshots_[i].t_lab, dt, particles_buffer_[i]);
 
         }
 
@@ -686,28 +674,21 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             }
             
             if (WarpX::do_boosted_frame_particles) {
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 8\n";
 
                 for (int j = 0; j < mypc.nspecies_lab_frame_diags; ++j) {
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 9\n";
         
                     const std::string species_name = species_names[mypc.map_species_lab_diags[j]];
 #ifdef WARPX_USE_HDF5
-                    std::cout<<"particles_buffer_ j "<<j<<'\n';
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
                                           species_name);
 #else
                     std::stringstream part_ss;
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 10\n";
 
                     part_ss << snapshots_[i].file_name + "/" + species_name + "/";
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 11\n";
-                    std::cout<<"particles_buffer_ j "<<j<<'\n';
 
-//                    writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
+                    writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
 #endif
-        std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 12\n";
                 }            
                 particles_buffer_[i].clear();
             }
@@ -894,7 +875,6 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
         for (int j = 0; j < mypc.nspecies_lab_frame_diags; ++j)
         {
             int js = mypc.map_species_lab_diags[j];
-            std::cout<<"js "<<js<<'\n';
             std::string species_name = species_names[js];
             output_create_species_group(file_name, species_name);
             for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
@@ -919,10 +899,8 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
 
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();        
-//         int nspecies = mypc.nSpecies();
         
         const std::string particles_prefix = "particle";
-//         for(int i = 0; i < nspecies; ++i) {
         for(int i = 0; i < mypc.nspecies_lab_frame_diags; ++i) {
             int is = mypc.map_species_lab_diags[i];
             std::string species_name = species_names[is];

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -498,7 +498,7 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
 {
     BL_PROFILE("BoostedFrameDiagnostic::Flush");
 
-    std::cout<<"in Flush"\n;
+    std::cout<<"in Flush\n";
     
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::NoFabHeader_v1);
@@ -546,6 +546,7 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
                     int js = mypc.map_species_lab_diags[j];
                     std::string species_name = species_names[js];
 #ifdef WARPX_USE_HDF5
+                    std::cout<<"particles_buffer_ j "<<j<<'\n';
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
                                           species_name);
@@ -585,17 +586,21 @@ writeLabFrameData(const MultiFab* cell_centered_data,
     
     for (int i = 0; i < N_snapshots_; ++i) {
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 2\n";
+        std::cout<<"i "<<i<<std::endl;
     
         const Real old_z_boost = snapshots_[i].current_z_boost;
+        std::cout<<"toto 1\n";
         snapshots_[i].updateCurrentZPositions(t_boost,
                                               inv_gamma_boost_,
                                               inv_beta_boost_);
+        std::cout<<"toto 2\n";
         
         if ( (snapshots_[i].current_z_boost < zlo_boost) or
              (snapshots_[i].current_z_boost > zhi_boost) or
              (snapshots_[i].current_z_lab < snapshots_[i].zmin_lab) or
              (snapshots_[i].current_z_lab > snapshots_[i].zmax_lab) ) continue;
 
+        std::cout<<"toto 3\n";
         int i_lab = (snapshots_[i].current_z_lab - snapshots_[i].zmin_lab) / dz_lab_;
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 3\n";
 
@@ -656,9 +661,9 @@ writeLabFrameData(const MultiFab* cell_centered_data,
         if (WarpX::do_boosted_frame_particles) {
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 6\n";
 
-            mypc.GetLabFrameData(snapshots_[i].file_name, i_lab, boost_direction_,
-                                 old_z_boost, snapshots_[i].current_z_boost,
-                                 t_boost, snapshots_[i].t_lab, dt, particles_buffer_[i]);
+        //mypc.GetLabFrameData(snapshots_[i].file_name, i_lab, boost_direction_,
+        //                         old_z_boost, snapshots_[i].current_z_boost,
+        //                         t_boost, snapshots_[i].t_lab, dt, particles_buffer_[i]);
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 7\n";
 
         }
@@ -688,6 +693,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
         
                     const std::string species_name = species_names[mypc.map_species_lab_diags[j]];
 #ifdef WARPX_USE_HDF5
+                    std::cout<<"particles_buffer_ j "<<j<<'\n';
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
                                           species_name);
@@ -697,8 +703,9 @@ writeLabFrameData(const MultiFab* cell_centered_data,
 
                     part_ss << snapshots_[i].file_name + "/" + species_name + "/";
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 11\n";
+                    std::cout<<"particles_buffer_ j "<<j<<'\n';
 
-                    writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
+//                    writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
 #endif
         std::cout<<"in BoostedFrameDiagnostic::writeLabFrameData 12\n";
                 }            

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -539,8 +539,8 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
             }
             
             if (WarpX::do_boosted_frame_particles) {
-                for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j) {
-                    int js = mypc.mapSpeciesLabDiags(j);
+                for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j) {
+                    int js = mypc.mapSpeciesBoostedFrameDiags(j);
                     std::string species_name = species_names[js];
 #ifdef WARPX_USE_HDF5
                     writeParticleDataHDF5(particles_buffer_[i][j],
@@ -603,7 +603,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                 DistributionMapping buff_dm(buff_ba);
                 data_buffer_[i].reset( new MultiFab(buff_ba, buff_dm, ncomp, 0) );
             }
-            if (WarpX::do_boosted_frame_particles) particles_buffer_[i].resize(mypc.nSpeciesLabFrameDiags());
+            if (WarpX::do_boosted_frame_particles) particles_buffer_[i].resize(mypc.nSpeciesBoostedFrameDiags());
         }
 
         if (WarpX::do_boosted_frame_fields) {
@@ -671,9 +671,9 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             
             if (WarpX::do_boosted_frame_particles) {
 
-                for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j) {
+                for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j) {
         
-                    const std::string species_name = species_names[mypc.mapSpeciesLabDiags(j)];
+                    const std::string species_name = species_names[mypc.mapSpeciesBoostedFrameDiags(j)];
 #ifdef WARPX_USE_HDF5
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
@@ -867,9 +867,9 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
     if (WarpX::do_boosted_frame_particles){
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
-        for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j)
+        for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j)
         {
-            int js = mypc.mapSpeciesLabDiags(j);
+            int js = mypc.mapSpeciesBoostedFrameDiags(j);
             std::string species_name = species_names[js];
             output_create_species_group(file_name, species_name);
             for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
@@ -896,8 +896,8 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();        
         
         const std::string particles_prefix = "particle";
-        for(int i = 0; i < mypc.nSpeciesLabFrameDiags(); ++i) {
-            int is = mypc.mapSpeciesLabDiags(i);
+        for(int i = 0; i < mypc.nSpeciesBoostedFrameDiags(); ++i) {
+            int is = mypc.mapSpeciesBoostedFrameDiags(i);
             std::string species_name = species_names[is];
             const std::string fullpath = file_name + "/" + species_name;
             if (!UtilCreateDirectory(fullpath, 0755))

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -509,7 +509,6 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
 
         int i_lab = (snapshots_[i].current_z_lab - snapshots_[i].zmin_lab) / dz_lab_;
         
-        // if 
         if (buff_counter_[i] != 0) {
             if (WarpX::do_boosted_frame_fields) {
                 const BoxArray& ba = data_buffer_[i]->boxArray();
@@ -543,9 +542,9 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
             if (WarpX::do_boosted_frame_particles) {
                 // Loop over species to be dumped to BFD
                 for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j) {
-                    // Get species id in mypc.allcontainers.
-                    int js = mypc.mapSpeciesBoostedFrameDiags(j);
-                    std::string species_name = species_names[js];
+                    // Get species name
+                    std::string species_name = 
+                        species_names[mypc.mapSpeciesBoostedFrameDiags(j)];
 #ifdef WARPX_USE_HDF5
                     // Dump species data
                     writeParticleDataHDF5(particles_buffer_[i][j],
@@ -600,7 +599,8 @@ writeLabFrameData(const MultiFab* cell_centered_data,
              (snapshots_[i].current_z_lab > snapshots_[i].zmax_lab) ) continue;
 
         // Get z index of data_buffer_ (i.e. in the lab frame) where 
-        // simulation domain (t', [zmin',zmax']) interacts with snapshot.
+        // simulation domain (t', [zmin',zmax']), back-transformed to lab 
+        // frame, intersects with snapshot.
         int i_lab = (snapshots_[i].current_z_lab - snapshots_[i].zmin_lab) / dz_lab_;
 
         // If buffer of snapshot i is empty...
@@ -691,11 +691,12 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             }
             
             if (WarpX::do_boosted_frame_particles) {
-
-                for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j) {
-        
+                // Loop over species to be dumped to BFD
+                for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j) {        
+                    // Get species name
                     const std::string species_name = species_names[mypc.mapSpeciesBoostedFrameDiags(j)];
 #ifdef WARPX_USE_HDF5
+                    // Write data to disk (HDF5)
                     writeParticleDataHDF5(particles_buffer_[i][j],
                                           snapshots_[i].file_name,
                                           species_name);
@@ -704,6 +705,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
 
                     part_ss << snapshots_[i].file_name + "/" + species_name + "/";
 
+                    // Write data to disk (custom)
                     writeParticleData(particles_buffer_[i][j], part_ss.str(), i_lab);
 #endif
                 }            
@@ -888,10 +890,12 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
     if (WarpX::do_boosted_frame_particles){
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
+        // Loop over species to be dumped to BFD
         for (int j = 0; j < mypc.nSpeciesBoostedFrameDiags(); ++j)
         {
-            int js = mypc.mapSpeciesBoostedFrameDiags(j);
-            std::string species_name = species_names[js];
+            // Loop over species to be dumped to BFD
+            std::string species_name = 
+                species_names[mypc.mapSpeciesBoostedFrameDiags(j)];
             output_create_species_group(file_name, species_name);
             for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
             {
@@ -917,9 +921,11 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();        
         
         const std::string particles_prefix = "particle";
+        // Loop over species to be dumped to BFD
         for(int i = 0; i < mypc.nSpeciesBoostedFrameDiags(); ++i) {
-            int is = mypc.mapSpeciesBoostedFrameDiags(i);
-            std::string species_name = species_names[is];
+            // Get species name
+            std::string species_name = 
+                species_names[mypc.mapSpeciesBoostedFrameDiags(i)];
             const std::string fullpath = file_name + "/" + species_name;
             if (!UtilCreateDirectory(fullpath, 0755))
                 CreateDirectoryFailed(fullpath);

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -539,7 +539,6 @@ void BoostedFrameDiagnostic::Flush(const Geometry& geom)
             }
             
             if (WarpX::do_boosted_frame_particles) {
-                // for (int j = 0; j < mypc.nSpecies(); ++j) {
                 for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j) {
                     int js = mypc.mapSpeciesLabDiags(j);
                     std::string species_name = species_names[js];
@@ -645,8 +644,8 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                                 &ncomp, &i_boost, &i_lab);
             }
         }
-        if (WarpX::do_boosted_frame_particles) {
 
+        if (WarpX::do_boosted_frame_particles) {
             mypc.GetLabFrameData(snapshots_[i].file_name, i_lab, boost_direction_,
                                  old_z_boost, snapshots_[i].current_z_boost,
                                  t_boost, snapshots_[i].t_lab, dt, particles_buffer_[i]);
@@ -732,7 +731,6 @@ writeParticleDataHDF5(const WarpXParticleContainer::DiagnosticParticleData& pdat
     ParallelDescriptor::ReduceLongMax(old_np);
     
     // Write data here
-    Print()<<"particle_field_names.size()"<<particle_field_names.size()<<std::endl;
     for (int k = 0; k < static_cast<int>(particle_field_names.size()); ++k)
     {
         std::string field_path = species_name + "/" + particle_field_names[k];
@@ -869,7 +867,6 @@ LabSnapShot(Real t_lab_in, Real t_boost, Real zmin_lab_in,
     if (WarpX::do_boosted_frame_particles){
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
-        // for (int j = 0; j < mypc.nSpecies(); ++j)
         for (int j = 0; j < mypc.nSpeciesLabFrameDiags(); ++j)
         {
             int js = mypc.mapSpeciesLabDiags(j);

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -173,9 +173,7 @@ WarpX::EvolveEM (int numsteps)
             if (WarpX::do_boosted_frame_fields) {
                 cell_centered_data = GetCellCenteredData();
             }
-            std::cout<<"before myBFD->writeLabFrameData"<<std::endl;
             myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
-            std::cout<<"after myBFD->writeLabFrameData"<<std::endl;
         }
 
         if (to_make_plot || do_insitu)

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -173,7 +173,9 @@ WarpX::EvolveEM (int numsteps)
             if (WarpX::do_boosted_frame_fields) {
                 cell_centered_data = GetCellCenteredData();
             }
+            std::cout<<"before myBFD->writeLabFrameData"<<std::endl;
             myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
+            std::cout<<"after myBFD->writeLabFrameData"<<std::endl;
         }
 
         if (to_make_plot || do_insitu)
@@ -247,7 +249,9 @@ WarpX::EvolveEM (int numsteps)
     }
 
     if (do_boosted_frame_diagnostic) {
+        std::cout<<"before myBFD->Flush"<<std::endl;
         myBFD->Flush(geom[0]);
+        std::cout<<"after myBFD->Flush"<<std::endl;
     }
 
 #ifdef BL_USE_SENSEI_INSITU

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -247,9 +247,7 @@ WarpX::EvolveEM (int numsteps)
     }
 
     if (do_boosted_frame_diagnostic) {
-        std::cout<<"before myBFD->Flush"<<std::endl;
         myBFD->Flush(geom[0]);
-        std::cout<<"after myBFD->Flush"<<std::endl;
     }
 
 #ifdef BL_USE_SENSEI_INSITU

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -25,8 +25,9 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 {
     charge = 1.0;
     mass = std::numeric_limits<Real>::max();
-
-	ParmParse pp(laser_name);
+    do_boosted_frame_diags = 0;
+        
+    ParmParse pp(laser_name);
 
 	// Parse the type of laser profile and set the corresponding flag `profile`
 	std::string laser_type_s;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -218,7 +218,10 @@ private:
 
     void ReadParameters ();
 
+    // Number of species dumped in BoostedFrameDiagnostics
     int nspecies_boosted_frame_diags = 0;
+    // map_species_boosted_frame_diags[i] is the species ID in 
+    // MultiParticleContainer for 0<i<nspecies_boosted_frame_diags
     std::vector<int> map_species_boosted_frame_diags;
     int do_boosted_frame_diags = 0;
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -157,6 +157,10 @@ public:
 
     int nSpecies() const {return nspecies;}
 
+    int nSpeciesLabFrameDiags() const {return nspecies_lab_frame_diags;}
+    int mapSpeciesLabDiags(int i) const {return map_species_lab_diags[i];}
+    int doBoostedFrameDiags() const {return do_boosted_frame_diags;}
+
     int nSpeciesDepositOnMainGrid () const {
         int r = 0;
         for (int i : deposit_on_main_grid) {
@@ -186,9 +190,6 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
-    int nspecies_lab_frame_diags = 0;
-    std::vector<int> map_species_lab_diags;
-    int do_boosted_frame_diags = 0;
 
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;
@@ -218,6 +219,10 @@ private:
     std::unique_ptr<PhysicalParticleContainer> pc_tmp;
 
     void ReadParameters ();
+
+    int nspecies_lab_frame_diags = 0;
+    std::vector<int> map_species_lab_diags;
+    int do_boosted_frame_diags = 0;
 
     // runtime parameters
     int nlasers = 0;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -153,8 +153,6 @@ public:
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
-    void setSpeciesLabFrameDiags() const;
-
     int nSpecies() const {return nspecies;}
 
     int nSpeciesLabFrameDiags() const {return nspecies_lab_frame_diags;}

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -153,6 +153,8 @@ public:
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
+    void setSpeciesLabFrameDiags() const;
+
     int nSpecies() const {return nspecies;}
 
     int nSpeciesDepositOnMainGrid () const {
@@ -184,6 +186,9 @@ public:
     // Number of coefficients for the stencil of the NCI corrector.
     // The stencil is applied in the z direction only.
     static constexpr int nstencilz_fdtd_nci_corr=5;
+    int nspecies_lab_frame_diags = 0;
+    std::vector<int> map_species_lab_diags;
+    int do_boosted_frame_diags = 0;
 
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_ex;
     amrex::Vector<amrex::Array<amrex::Real, nstencilz_fdtd_nci_corr> > fdtd_nci_stencilz_by;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -155,8 +155,8 @@ public:
 
     int nSpecies() const {return nspecies;}
 
-    int nSpeciesLabFrameDiags() const {return nspecies_lab_frame_diags;}
-    int mapSpeciesLabDiags(int i) const {return map_species_lab_diags[i];}
+    int nSpeciesBoostedFrameDiags() const {return nspecies_boosted_frame_diags;}
+    int mapSpeciesBoostedFrameDiags(int i) const {return map_species_boosted_frame_diags[i];}
     int doBoostedFrameDiags() const {return do_boosted_frame_diags;}
 
     int nSpeciesDepositOnMainGrid () const {
@@ -218,8 +218,8 @@ private:
 
     void ReadParameters ();
 
-    int nspecies_lab_frame_diags = 0;
-    std::vector<int> map_species_lab_diags;
+    int nspecies_boosted_frame_diags = 0;
+    std::vector<int> map_species_boosted_frame_diags;
     int do_boosted_frame_diags = 0;
 
     // runtime parameters

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -396,6 +396,7 @@ MultiParticleContainer
         int isp = map_species_lab_diags[i];
 std::cout<<"GetLabFrameData 2\n";
         WarpXParticleContainer* pc = allcontainers[isp].get();
+        std::cout<<"getparticleslice "<< isp<<std::endl;
         WarpXParticleContainer::DiagnosticParticles diagnostic_particles;
         pc->GetParticleSlice(direction, z_old, z_new, t_boost, t_lab, dt, diagnostic_particles);
 std::cout<<"GetLabFrameData 3\n";

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -47,6 +47,8 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 
     if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
+        //maxoldattribs
+        /*
         for (int i = 0; i < nspecies + nlasers; ++i)
         {
             allcontainers[i]->AddRealComp("xold");
@@ -56,7 +58,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[i]->AddRealComp("uyold");
             allcontainers[i]->AddRealComp("uzold");
             }
-        /*
+        */
         for (int i = 0; i < nspecies_lab_frame_diags; ++i)
         {
             int is = map_species_lab_diags[i];
@@ -67,13 +69,14 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[is]->AddRealComp("uyold");
             allcontainers[is]->AddRealComp("uzold");
         }
-        */
+        /*
         pc_tmp->AddRealComp("xold");
         pc_tmp->AddRealComp("yold");
         pc_tmp->AddRealComp("zold");
         pc_tmp->AddRealComp("uxold");
         pc_tmp->AddRealComp("uyold");
         pc_tmp->AddRealComp("uzold");
+        */
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -55,7 +55,19 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[i]->AddRealComp("uxold");
             allcontainers[i]->AddRealComp("uyold");
             allcontainers[i]->AddRealComp("uzold");
+            }
+        /*
+        for (int i = 0; i < nspecies_lab_frame_diags; ++i)
+        {
+            int is = map_species_lab_diags[i];
+            allcontainers[is]->AddRealComp("xold");
+            allcontainers[is]->AddRealComp("yold");
+            allcontainers[is]->AddRealComp("zold");
+            allcontainers[is]->AddRealComp("uxold");
+            allcontainers[is]->AddRealComp("uyold");
+            allcontainers[is]->AddRealComp("uzold");
         }
+        */
         pc_tmp->AddRealComp("xold");
         pc_tmp->AddRealComp("yold");
         pc_tmp->AddRealComp("zold");
@@ -389,17 +401,13 @@ MultiParticleContainer
 {
 
     BL_PROFILE("MultiParticleContainer::GetLabFrameData");
-    std::cout<<"GetLabFrameData 1\n";
     
     // Loop over particle species
     for (int i = 0; i < nspecies_lab_frame_diags; ++i){
         int isp = map_species_lab_diags[i];
-std::cout<<"GetLabFrameData 2\n";
         WarpXParticleContainer* pc = allcontainers[isp].get();
-        std::cout<<"getparticleslice "<< isp<<std::endl;
         WarpXParticleContainer::DiagnosticParticles diagnostic_particles;
         pc->GetParticleSlice(direction, z_old, z_new, t_boost, t_lab, dt, diagnostic_particles);
-std::cout<<"GetLabFrameData 3\n";
         // Here, diagnostic_particles[lev][index] is a WarpXParticleContainer::DiagnosticParticleData
         // where "lev" is the AMR level and "index" is a [grid index][tile index] pair.
         
@@ -409,16 +417,13 @@ std::cout<<"GetLabFrameData 3\n";
             // and Fills parts[species number i] with particle data from all grids and 
             // tiles in diagnostic_particles. parts contains particles from all 
             // AMR levels indistinctly.
-std::cout<<"GetLabFrameData 4\n";
             for (auto it = diagnostic_particles[lev].begin(); it != diagnostic_particles[lev].end(); ++it){
                 // it->first is the [grid index][tile index] key
                 // it->second is the corresponding 
                 // WarpXParticleContainer::DiagnosticParticleData value
-std::cout<<"GetLabFrameData 5\n";
                 parts[i].GetRealData(DiagIdx::w).insert(  parts[i].GetRealData(DiagIdx::w  ).end(),
                                                           it->second.GetRealData(DiagIdx::w  ).begin(),
                                                           it->second.GetRealData(DiagIdx::w  ).end());
-std::cout<<"GetLabFrameData 6\n";
                 
                 parts[i].GetRealData(DiagIdx::x).insert(  parts[i].GetRealData(DiagIdx::x  ).end(),
                                                           it->second.GetRealData(DiagIdx::x  ).begin(),

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -40,8 +40,8 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
         auto& pc = allcontainers[i];
         if (pc->do_boosted_frame_diags){
             map_species_lab_diags[nspecies_lab_frame_diags] = i;
-            nspecies_lab_frame_diags += 1;
             do_boosted_frame_diags = 1;
+            nspecies_lab_frame_diags += 1;
         }
     }
 
@@ -389,12 +389,16 @@ MultiParticleContainer
 {
 
     BL_PROFILE("MultiParticleContainer::GetLabFrameData");
+    std::cout<<"GetLabFrameData 1\n";
     
     // Loop over particle species
-    for (int i = 0; i < nspecies; ++i){
-        WarpXParticleContainer* pc = allcontainers[i].get();
+    for (int i = 0; i < nspecies_lab_frame_diags; ++i){
+        int isp = map_species_lab_diags[i];
+std::cout<<"GetLabFrameData 2\n";
+        WarpXParticleContainer* pc = allcontainers[isp].get();
         WarpXParticleContainer::DiagnosticParticles diagnostic_particles;
         pc->GetParticleSlice(direction, z_old, z_new, t_boost, t_lab, dt, diagnostic_particles);
+std::cout<<"GetLabFrameData 3\n";
         // Here, diagnostic_particles[lev][index] is a WarpXParticleContainer::DiagnosticParticleData
         // where "lev" is the AMR level and "index" is a [grid index][tile index] pair.
         
@@ -404,13 +408,16 @@ MultiParticleContainer
             // and Fills parts[species number i] with particle data from all grids and 
             // tiles in diagnostic_particles. parts contains particles from all 
             // AMR levels indistinctly.
+std::cout<<"GetLabFrameData 4\n";
             for (auto it = diagnostic_particles[lev].begin(); it != diagnostic_particles[lev].end(); ++it){
                 // it->first is the [grid index][tile index] key
                 // it->second is the corresponding 
                 // WarpXParticleContainer::DiagnosticParticleData value
+std::cout<<"GetLabFrameData 5\n";
                 parts[i].GetRealData(DiagIdx::w).insert(  parts[i].GetRealData(DiagIdx::w  ).end(),
                                                           it->second.GetRealData(DiagIdx::w  ).begin(),
                                                           it->second.GetRealData(DiagIdx::w  ).end());
+std::cout<<"GetLabFrameData 6\n";
                 
                 parts[i].GetRealData(DiagIdx::x).insert(  parts[i].GetRealData(DiagIdx::x  ).end(),
                                                           it->second.GetRealData(DiagIdx::x  ).begin(),

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -31,25 +31,25 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 
     pc_tmp.reset(new PhysicalParticleContainer(amr_core));
 
-    // Compute the number of species for which mab frame data is dumped 
+    // Compute the number of species for which lab-frame data is dumped
     // nspecies_lab_frame_diags, and map their ID to MultiParticleContainer
     // particle IDs in map_species_lab_diags.
-    map_species_lab_diags.resize(nspecies);
-    nspecies_lab_frame_diags = 0;
+    map_species_boosted_frame_diags.resize(nspecies);
+    nspecies_boosted_frame_diags = 0;
     for (int i=0; i<nspecies; i++){
         auto& pc = allcontainers[i];
         if (pc->do_boosted_frame_diags){
-            map_species_lab_diags[nspecies_lab_frame_diags] = i;
+            map_species_boosted_frame_diags[nspecies_boosted_frame_diags] = i;
             do_boosted_frame_diags = 1;
-            nspecies_lab_frame_diags += 1;
+            nspecies_boosted_frame_diags += 1;
         }
     }
 
     if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
-        for (int i = 0; i < nspecies_lab_frame_diags; ++i)
+        for (int i = 0; i < nspecies_boosted_frame_diags; ++i)
         {
-            int is = map_species_lab_diags[i];
+            int is = map_species_boosted_frame_diags[i];
             allcontainers[is]->AddRealComp("xold");
             allcontainers[is]->AddRealComp("yold");
             allcontainers[is]->AddRealComp("zold");
@@ -392,8 +392,8 @@ MultiParticleContainer
     BL_PROFILE("MultiParticleContainer::GetLabFrameData");
     
     // Loop over particle species
-    for (int i = 0; i < nspecies_lab_frame_diags; ++i){
-        int isp = map_species_lab_diags[i];
+    for (int i = 0; i < nspecies_boosted_frame_diags; ++i){
+        int isp = map_species_boosted_frame_diags[i];
         WarpXParticleContainer* pc = allcontainers[isp].get();
         WarpXParticleContainer::DiagnosticParticles diagnostic_particles;
         pc->GetParticleSlice(direction, z_old, z_new, t_boost, t_lab, dt, diagnostic_particles);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -47,18 +47,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 
     if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
-        //maxoldattribs
-        /*
-        for (int i = 0; i < nspecies + nlasers; ++i)
-        {
-            allcontainers[i]->AddRealComp("xold");
-            allcontainers[i]->AddRealComp("yold");
-            allcontainers[i]->AddRealComp("zold");
-            allcontainers[i]->AddRealComp("uxold");
-            allcontainers[i]->AddRealComp("uyold");
-            allcontainers[i]->AddRealComp("uzold");
-            }
-        */
         for (int i = 0; i < nspecies_lab_frame_diags; ++i)
         {
             int is = map_species_lab_diags[i];
@@ -69,14 +57,12 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[is]->AddRealComp("uyold");
             allcontainers[is]->AddRealComp("uzold");
         }
-        /*
         pc_tmp->AddRealComp("xold");
         pc_tmp->AddRealComp("yold");
         pc_tmp->AddRealComp("zold");
         pc_tmp->AddRealComp("uxold");
         pc_tmp->AddRealComp("uyold");
         pc_tmp->AddRealComp("uzold");
-        */
     }
 }
 
@@ -500,10 +486,3 @@ MultiParticleContainer::doContinuousInjection() const
     }
     return warpx_do_continuous_injection;
 }
-
-// Set number of species for which lab frame data is dumped
-// and maps their ID to MultiParticleContainer IDs.
-//void
-//MultiParticleContainer::setSpeciesLabFrameDiags() const
-//{
-//}

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -219,7 +219,8 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
             attribs[PIdx::uz] = u[2];
             attribs[PIdx::w ] = weight;
 
-            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+            // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+            if (WarpX::do_boosted_frame_diagnostic)
             {
                 auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
                 particle_tile.push_back_real(particle_comps["xold"], x);
@@ -503,7 +504,8 @@ PhysicalParticleContainer::AddPlasmaCPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uy] = u[1];
                     attribs[PIdx::uz] = u[2];
                     
-                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+                    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+                    if (WarpX::do_boosted_frame_diagnostic)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);
@@ -745,7 +747,8 @@ PhysicalParticleContainer::AddPlasmaGPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uz] = u[2];
 
                     // note - this will be slow on the GPU, need to revisit
-                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+                    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+                    if (WarpX::do_boosted_frame_diagnostic)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -835,9 +835,7 @@ FieldGatherES (const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 
             const auto& particles = pti.GetArrayOfStructs();
             int nstride = particles.dataShape().first;
             const long np  = pti.numParticles();
-            std::cout<<"start 1 GetAttribs\n";
             auto& attribs = pti.GetAttribs();
-            std::cout<<"end 2 GetAttribs\n";
             auto& Exp = attribs[PIdx::Ex];
             auto& Eyp = attribs[PIdx::Ey];
 #if AMREX_SPACEDIM == 3

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1863,6 +1863,8 @@ void PhysicalParticleContainer::GetParticleSlice(const int direction, const Real
     // Note the the slice should always move in the negative boost direction.
     AMREX_ALWAYS_ASSERT(z_new < z_old);
 
+    AMREX_ALWAYS_ASSERT(do_boosted_frame_diags == 1);
+
     const int nlevs = std::max(0, finestLevel()+1);
 
     // we figure out a box for coarse-grained rejection. If the RealBox corresponding to a

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -82,6 +82,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp.query("do_splitting", do_splitting);
     pp.query("split_type", split_type);
     pp.query("do_continuous_injection", do_continuous_injection);
+    // Whether to plot back-transformed (lab-frame) diagnostics 
+    // for this species.
+    pp.query("do_boosted_frame_diags", do_boosted_frame_diags);
 
     pp.query("plot_species", plot_species);
     int do_user_plot_vars;
@@ -90,14 +93,14 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         // By default, all particle variables are dumped to plotfiles,
         // including {x,y,z,ux,uy,uz}old variables when running in a 
         // boosted frame
-        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags){
             plot_flags.resize(PIdx::nattribs + 6, 1);
         } else {
             plot_flags.resize(PIdx::nattribs, 1);
         }
     } else {
         // Set plot_flag to 0 for all attribs
-        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles){
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags){
             plot_flags.resize(PIdx::nattribs + 6, 0);
         } else {
             plot_flags.resize(PIdx::nattribs, 0);
@@ -216,7 +219,7 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
             attribs[PIdx::uz] = u[2];
             attribs[PIdx::w ] = weight;
 
-            if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
             {
                 auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
                 particle_tile.push_back_real(particle_comps["xold"], x);
@@ -500,7 +503,7 @@ PhysicalParticleContainer::AddPlasmaCPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uy] = u[1];
                     attribs[PIdx::uz] = u[2];
                     
-                    if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);
@@ -742,7 +745,7 @@ PhysicalParticleContainer::AddPlasmaGPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uz] = u[2];
 
                     // note - this will be slow on the GPU, need to revisit
-                    if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);
@@ -1715,7 +1718,7 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
     auto& Bzp = attribs[PIdx::Bz];
     const long np  = pti.numParticles();
 
-    if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
         auto& xpold    = pti.GetAttribs(particle_comps["xold"]);
         auto& ypold    = pti.GetAttribs(particle_comps["yold"]);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -219,8 +219,7 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
             attribs[PIdx::uz] = u[2];
             attribs[PIdx::w ] = weight;
 
-            // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-            if (WarpX::do_boosted_frame_diagnostic)
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
             {
                 auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
                 particle_tile.push_back_real(particle_comps["xold"], x);
@@ -504,8 +503,7 @@ PhysicalParticleContainer::AddPlasmaCPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uy] = u[1];
                     attribs[PIdx::uz] = u[2];
                     
-                    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-                    if (WarpX::do_boosted_frame_diagnostic)
+                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);
@@ -747,8 +745,7 @@ PhysicalParticleContainer::AddPlasmaGPU (int lev, RealBox part_realbox)
                     attribs[PIdx::uz] = u[2];
 
                     // note - this will be slow on the GPU, need to revisit
-                    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-                    if (WarpX::do_boosted_frame_diagnostic)
+                    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
                     {
                         auto& particle_tile = DefineAndReturnParticleTile(lev, grid_id, tile_id);
                         particle_tile.push_back_real(particle_comps["xold"], x);
@@ -838,8 +835,9 @@ FieldGatherES (const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 
             const auto& particles = pti.GetArrayOfStructs();
             int nstride = particles.dataShape().first;
             const long np  = pti.numParticles();
-
+            std::cout<<"start 1 GetAttribs\n";
             auto& attribs = pti.GetAttribs();
+            std::cout<<"end 2 GetAttribs\n";
             auto& Exp = attribs[PIdx::Ex];
             auto& Eyp = attribs[PIdx::Ey];
 #if AMREX_SPACEDIM == 3

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -225,7 +225,7 @@ RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
     auto& Bzp = attribs[PIdx::Bz];
     const long np  = pti.numParticles();
 
-    if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
         auto& xpold    = pti.GetAttribs(particle_comps["xold"]);
         auto& ypold    = pti.GetAttribs(particle_comps["yold"]);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -85,7 +85,13 @@ class WarpXParticleContainer
 public:
     friend MultiParticleContainer;
 
+    // amrex::StructOfArrays with DiagIdx::nattribs amrex::Real components 
+    // for the particle data and 0 int components.
     using DiagnosticParticleData = amrex::StructOfArrays<DiagIdx::nattribs, 0>;
+    // DiagnosticParticles is a vector, with one element per MR level.
+    // DiagnosticParticles[lev] is typically a key-value pair where the key is 
+    // a pair [grid_index, tile_index], and the value is the corresponding 
+    // DiagnosticParticleData (see above) on this tile.
     using DiagnosticParticles = amrex::Vector<std::map<std::pair<int, int>, DiagnosticParticleData> >;
     
     WarpXParticleContainer (amrex::AmrCore* amr_core, int ispecies);
@@ -264,6 +270,8 @@ protected:
     // This is currently required because continuous injection does not 
     // support all features allowed by direct injection.
     int do_continuous_injection = 0;
+
+    int do_boosted_frame_diags = 0;
 
     amrex::Vector<amrex::FArrayBox> local_rho;
     amrex::Vector<amrex::FArrayBox> local_jx;

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -85,7 +85,7 @@ public:
     friend MultiParticleContainer;
 
     // amrex::StructOfArrays with DiagIdx::nattribs amrex::Real components 
-    // for the particle data and 0 int components.
+    // and 0 int components for the particle data.
     using DiagnosticParticleData = amrex::StructOfArrays<DiagIdx::nattribs, 0>;
     // DiagnosticParticles is a vector, with one element per MR level.
     // DiagnosticParticles[lev] is typically a key-value pair where the key is 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -271,7 +271,7 @@ protected:
     // support all features allowed by direct injection.
     int do_continuous_injection = 0;
 
-    int do_boosted_frame_diags = 0;
+    int do_boosted_frame_diags = 1;
 
     amrex::Vector<amrex::FArrayBox> local_rho;
     amrex::Vector<amrex::FArrayBox> local_jx;

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -59,7 +59,6 @@ public:
                       const amrex::Cuda::ManagedDeviceVector<amrex::Real>& y,
                       const amrex::Cuda::ManagedDeviceVector<amrex::Real>& z);
 #endif
-
     const std::array<RealVector, PIdx::nattribs>& GetAttribs () const { 
         return GetStructOfArrays().GetRealData(); 
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -6,8 +6,6 @@
 #include <AMReX_AmrParGDB.H>
 #include <WarpX_f.H>
 #include <WarpX.H>
-#include <AMReX_Particles.H>
-#include <AMReX_AmrCore.H>
 
 using namespace amrex;
 
@@ -24,9 +22,7 @@ WarpXParIter::GetPosition (Cuda::ManagedDeviceVector<Real>& x, Cuda::ManagedDevi
 {
     amrex::ParIter<0,0,PIdx::nattribs>::GetPosition(x, z);
 #ifdef WARPX_RZ
-    std::cout<<"start 2 GetAttribs()\n";
     const auto& attribs = GetAttribs();
-    std::cout<<"stop 2 GetAttribs()\n";
     const auto& theta = attribs[PIdx::theta];
     y.resize(x.size());
     for (unsigned int i=0 ; i < x.size() ; i++) {
@@ -43,9 +39,7 @@ void
 WarpXParIter::SetPosition (const Cuda::ManagedDeviceVector<Real>& x, const Cuda::ManagedDeviceVector<Real>& y, const Cuda::ManagedDeviceVector<Real>& z)
 {
 #ifdef WARPX_RZ
-    std::cout<<"start 3 GetAttribs()\n";
     auto& attribs = GetAttribs();
-    std::cout<<"stop 3 GetAttribs()\n";
     auto& theta = attribs[PIdx::theta];
     Cuda::DeviceVector<Real> r(x.size());
     for (unsigned int i=0 ; i < x.size() ; i++) {
@@ -1001,9 +995,7 @@ WarpXParticleContainer::PushXES (Real dt)
             int nstride = particles.dataShape().first;
             const long np  = pti.numParticles();
 
-    std::cout<<"start 4 GetAttribs()\n";
             auto& attribs = pti.GetAttribs();
-    std::cout<<"stop 4 GetAttribs()\n";
             auto& uxp = attribs[PIdx::ux];
             auto& uyp = attribs[PIdx::uy];
             auto& uzp = attribs[PIdx::uz];
@@ -1052,9 +1044,7 @@ WarpXParticleContainer::PushX (int lev, Real dt)
             // - positions are stored as an array of struct, in `ParticleType`
             ParticleType * AMREX_RESTRICT pstructs = &(pti.GetArrayOfStructs()[0]);
             // - momenta are stored as a struct of array, in `attribs`
-    std::cout<<"start 5 GetAttribs()\n";
             auto& attribs = pti.GetAttribs();
-    std::cout<<"stop 5 GetAttribs()\n";
             Real* AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
             Real* AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
             Real* AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -78,7 +78,7 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
     particle_comps["theta"] = PIdx::theta;
 #endif
 
-    if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
         particle_comps["xold"]  = PIdx::nattribs;
         particle_comps["yold"]  = PIdx::nattribs+1;
@@ -231,7 +231,7 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = z[i];
 #endif
 
-        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["xold"], x[i]);
@@ -249,7 +249,7 @@ WarpXParticleContainer::AddNParticles (int lev,
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
-        if (WarpX::do_boosted_frame_diagnostic && WarpX::do_boosted_frame_particles)
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -6,6 +6,8 @@
 #include <AMReX_AmrParGDB.H>
 #include <WarpX_f.H>
 #include <WarpX.H>
+#include <AMReX_Particles.H>
+#include <AMReX_AmrCore.H>
 
 using namespace amrex;
 
@@ -22,7 +24,9 @@ WarpXParIter::GetPosition (Cuda::ManagedDeviceVector<Real>& x, Cuda::ManagedDevi
 {
     amrex::ParIter<0,0,PIdx::nattribs>::GetPosition(x, z);
 #ifdef WARPX_RZ
+    std::cout<<"start 2 GetAttribs()\n";
     const auto& attribs = GetAttribs();
+    std::cout<<"stop 2 GetAttribs()\n";
     const auto& theta = attribs[PIdx::theta];
     y.resize(x.size());
     for (unsigned int i=0 ; i < x.size() ; i++) {
@@ -39,7 +43,9 @@ void
 WarpXParIter::SetPosition (const Cuda::ManagedDeviceVector<Real>& x, const Cuda::ManagedDeviceVector<Real>& y, const Cuda::ManagedDeviceVector<Real>& z)
 {
 #ifdef WARPX_RZ
+    std::cout<<"start 3 GetAttribs()\n";
     auto& attribs = GetAttribs();
+    std::cout<<"stop 3 GetAttribs()\n";
     auto& theta = attribs[PIdx::theta];
     Cuda::DeviceVector<Real> r(x.size());
     for (unsigned int i=0 ; i < x.size() ; i++) {
@@ -78,8 +84,7 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
     particle_comps["theta"] = PIdx::theta;
 #endif
 
-    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-    if (WarpX::do_boosted_frame_diagnostic)
+    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
         particle_comps["xold"]  = PIdx::nattribs;
         particle_comps["yold"]  = PIdx::nattribs+1;
@@ -232,8 +237,7 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = z[i];
 #endif
 
-        // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        if (WarpX::do_boosted_frame_diagnostic)
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["xold"], x[i]);
@@ -251,8 +255,7 @@ WarpXParticleContainer::AddNParticles (int lev,
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
-        // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        if (WarpX::do_boosted_frame_diagnostic)
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);
@@ -998,7 +1001,9 @@ WarpXParticleContainer::PushXES (Real dt)
             int nstride = particles.dataShape().first;
             const long np  = pti.numParticles();
 
+    std::cout<<"start 4 GetAttribs()\n";
             auto& attribs = pti.GetAttribs();
+    std::cout<<"stop 4 GetAttribs()\n";
             auto& uxp = attribs[PIdx::ux];
             auto& uyp = attribs[PIdx::uy];
             auto& uzp = attribs[PIdx::uz];
@@ -1047,7 +1052,9 @@ WarpXParticleContainer::PushX (int lev, Real dt)
             // - positions are stored as an array of struct, in `ParticleType`
             ParticleType * AMREX_RESTRICT pstructs = &(pti.GetArrayOfStructs()[0]);
             // - momenta are stored as a struct of array, in `attribs`
+    std::cout<<"start 5 GetAttribs()\n";
             auto& attribs = pti.GetAttribs();
+    std::cout<<"stop 5 GetAttribs()\n";
             Real* AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
             Real* AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
             Real* AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -78,7 +78,8 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
     particle_comps["theta"] = PIdx::theta;
 #endif
 
-    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+    // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+    if (WarpX::do_boosted_frame_diagnostic)
     {
         particle_comps["xold"]  = PIdx::nattribs;
         particle_comps["yold"]  = PIdx::nattribs+1;
@@ -231,7 +232,8 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = z[i];
 #endif
 
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+        // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+        if (WarpX::do_boosted_frame_diagnostic)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["xold"], x[i]);
@@ -249,7 +251,8 @@ WarpXParticleContainer::AddNParticles (int lev,
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+        // if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+        if (WarpX::do_boosted_frame_diagnostic)
         {
             auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
             particle_tile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -56,12 +56,9 @@ int WarpX::num_mirrors = 0;
 
 int  WarpX::sort_int = -1;
 
+bool WarpX::do_boosted_frame_diagnostic = false;
 int  WarpX::num_snapshots_lab = std::numeric_limits<int>::lowest();
 Real WarpX::dt_snapshots_lab  = std::numeric_limits<Real>::lowest();
-// bool WarpX::do_boosted_frame_diagnostic = false;
-// bool WarpX::do_boosted_frame_fields = true;
-// bool WarpX::do_boosted_frame_particles = true;
-bool WarpX::do_boosted_frame_diagnostic = false;
 bool WarpX::do_boosted_frame_fields = true;
 bool WarpX::do_boosted_frame_particles = true;
 
@@ -329,8 +326,6 @@ WarpX::ReadParameters ()
         pp.get("gamma_boost", gamma_boost);
 
         pp.query("do_boosted_frame_fields", do_boosted_frame_fields);
-        // pp.query("do_boosted_frame_particles", do_boosted_frame_particles);
-
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window,
                "The moving window should be on if using the boosted frame diagnostic.");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -160,7 +160,7 @@ WarpX::WarpX ()
             current_injection_position = geom[0].ProbLo(moving_window_dir);
         }
     }
-    do_boosted_frame_particles = mypc->do_boosted_frame_diags;
+    do_boosted_frame_particles = mypc->doBoostedFrameDiags();
 
     Efield_aux.resize(nlevs_max);
     Bfield_aux.resize(nlevs_max);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -329,7 +329,7 @@ WarpX::ReadParameters ()
         pp.get("gamma_boost", gamma_boost);
 
         pp.query("do_boosted_frame_fields", do_boosted_frame_fields);
-        pp.query("do_boosted_frame_particles", do_boosted_frame_particles);
+        // pp.query("do_boosted_frame_particles", do_boosted_frame_particles);
 
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -56,9 +56,12 @@ int WarpX::num_mirrors = 0;
 
 int  WarpX::sort_int = -1;
 
-bool WarpX::do_boosted_frame_diagnostic = false;
 int  WarpX::num_snapshots_lab = std::numeric_limits<int>::lowest();
 Real WarpX::dt_snapshots_lab  = std::numeric_limits<Real>::lowest();
+// bool WarpX::do_boosted_frame_diagnostic = false;
+// bool WarpX::do_boosted_frame_fields = true;
+// bool WarpX::do_boosted_frame_particles = true;
+bool WarpX::do_boosted_frame_diagnostic = false;
 bool WarpX::do_boosted_frame_fields = true;
 bool WarpX::do_boosted_frame_particles = true;
 
@@ -117,7 +120,7 @@ WarpX::ResetInstance ()
 {
     delete m_instance;
     m_instance = nullptr;
-}
+}	
 
 WarpX::WarpX ()
 {
@@ -157,6 +160,7 @@ WarpX::WarpX ()
             current_injection_position = geom[0].ProbLo(moving_window_dir);
         }
     }
+    do_boosted_frame_particles = mypc->do_boosted_frame_diags;
 
     Efield_aux.resize(nlevs_max);
     Bfield_aux.resize(nlevs_max);


### PR DESCRIPTION
This PR adds option to dump only selected particles to back-transformed diagnostics.
Option `warpx.do_boosted_frame_particles` is no longer read, an the user should specify `<species>.do_boosted_frame_diags` instead. Default is 1, is that all species are dumped by default.

@atmyers I also added some comments in the code. Could you have a quick look and let me know if anything is wrong?