### PR TITLE
Fixes for the Python RZ version

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -30,18 +30,24 @@ def _get_package_root():
 # --- Default to 3D if geometry is not setup yet.
 try:
     _prob_lo = geometry.prob_lo
+    _coord_sys = geometry.coord_sys
 except AttributeError:
-    geometry_dim = 3
+    geometry_dim = '3d'
 else:
-    geometry_dim = len(_prob_lo)
-    del _prob_lo
+    if _coord_sys == 0:
+        geometry_dim = '%dd'%len(_prob_lo)
+    elif _coord_sys == 1:
+        geometry_dim = 'rz'
+    else:
+        raise Exception('Undefined coordinate system %d'%_coord_sys)
+    del _prob_lo, _coord_sys
 
 _libc = ctypes.CDLL(_find_library('c'))
 
 try:
-    libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), "libwarpx%dd.so"%geometry_dim))
+    libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), "libwarpx%s.so"%geometry_dim))
 except OSError:
-    raise Exception('libwarpx%dd.so was not installed. It can be installed by running "make" in the Python directory of WarpX'%geometry_dim)
+    raise Exception('libwarpx%s.so was not installed. It can be installed by running "make" in the Python directory of WarpX'%geometry_dim)
 
 dim = libwarpx.warpx_SpaceDim()
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -10,12 +10,12 @@ import argparse
 from setuptools import setup
 
 argparser = argparse.ArgumentParser(add_help=False)
-argparser.add_argument('--with-libwarpx', type=int, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the makefile.')
+argparser.add_argument('--with-libwarpx', type=str, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the makefile.')
 args, unknown = argparser.parse_known_args()
 sys.argv = [sys.argv[0]] + unknown
 
 if args.with_libwarpx:
-    package_data = {'pywarpx' : ['libwarpx%dd.so'%args.with_libwarpx]}
+    package_data = {'pywarpx' : ['libwarpx%s.so'%args.with_libwarpx]}
 else:
     package_data = {}
 

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -41,7 +41,7 @@ endif
   CFLAGS   += -fPIC
   FFLAGS   += -fPIC
   F90FLAGS += -fPIC
-  USERSuffix = .Lib
+  USERSuffix := .Lib
   DEFINES += -DWARPX_USE_PY
 endif
 
@@ -107,7 +107,7 @@ ifeq ($(USE_PSATD),TRUE)
     INCLUDE_LOCATIONS += $(FFTW_HOME)/include
     LIBRARY_LOCATIONS += $(FFTW_HOME)/lib
   endif
-  USERSuffix += .PSATD
+  USERSuffix := $(USERSuffix).PSATD
   DEFINES += -DWARPX_USE_PSATD
   ifeq ($(USE_CUDA),TRUE)
     DEFINES += -DFFTW -DCUDA_FFT=1 # PICSAR uses it
@@ -119,7 +119,7 @@ ifeq ($(USE_PSATD),TRUE)
 endif
 
 ifeq ($(USE_RZ),TRUE)
-  USERSuffix += .RZ
+  USERSuffix := $(USERSuffix).RZ
   DEFINES += -DWARPX_RZ
 endif
 
@@ -154,17 +154,23 @@ else
   SHARED_OPTION = -shared
 endif
 
-installwarpx: libwarpx$(DIM)d.so
-	mv libwarpx$(DIM)d.so Python/pywarpx
-	cd Python; python setup.py install --with-libwarpx $(DIM) $(PYINSTALLOPTIONS)
+ifeq ($(USE_RZ),TRUE)
+  PYDIM = rz
+else
+  PYDIM = $(DIM)d
+endif
 
-libwarpx$(DIM)d.a: $(objForExecs)
+installwarpx: libwarpx$(PYDIM).so
+	mv libwarpx$(PYDIM).so Python/pywarpx
+	cd Python; python setup.py install --with-libwarpx $(PYDIM) $(PYINSTALLOPTIONS)
+
+libwarpx$(PYDIM).a: $(objForExecs)
 	@echo Making static library $@ ...
 	$(SILENT) $(AR) -crv $@ $^
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 	@echo SUCCESS
 
-libwarpx$(DIM)d.so: $(objForExecs)
+libwarpx$(PYDIM).so: $(objForExecs)
 	@echo Making dynamic library $@ ...
 	$(SILENT) $(CXX) $(SHARED_OPTION) -fPIC -o $@ $^ $(LDFLAGS) $(libraries)
 	$(SILENT) $(RM) AMReX_buildInfo.cpp

--- a/Source/Python/Make.package
+++ b/Source/Python/Make.package
@@ -1,7 +1,7 @@
-ifeq ($(USE_PYTHON_MAIN),TRUE)
-  CEXE_sources += WarpXWrappers.cpp
-  CEXE_headers += WarpXWrappers.h
-endif
+#ifeq ($(USE_PYTHON_MAIN),TRUE)
+#  CEXE_sources += WarpXWrappers.cpp
+#  CEXE_headers += WarpXWrappers.h
+#endif
 CEXE_sources += WarpXWrappers.cpp
 CEXE_sources += WarpX_py.cpp
 CEXE_headers += WarpXWrappers.h


### PR DESCRIPTION
These are changed needed so that the Python version of the RZ version can be built and installed. The 3d, 2d, and now rz compiled versions can be installed into Python as separate libraries.