### PR TITLE
fix for GPU - vector can't be used directly in device code.

### DIFF
--- a/Source/Diagnostics/BoostedFrameDiagnostic.H
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.H
@@ -8,6 +8,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_CudaContainers.H>
 
 #include "MultiParticleContainer.H"
 #include "WarpXConst.H"
@@ -138,7 +139,7 @@ private:
     // maps field index in data_buffer_[i] -> cell_centered_data for 
     // snapshots i. By default, all fields in cell_centered_data are dumped.
     // Needs to be amrex::Vector because used in a ParallelFor kernel.
-    amrex::Vector<int> map_actual_fields_to_dump = {0,1,2,3,4,5,6,7,8,9};
+	amrex::Gpu::ManagedDeviceVector<int> map_actual_fields_to_dump;
     // Name of fields to dump. By default, all fields in cell_centered_data.
     // Needed for file headers only.
     std::vector<std::string> mesh_field_names = {"Ex", "Ey", "Ez", 

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -466,8 +466,8 @@ namespace
             ParallelFor(bx, ncomp_to_dump,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
                 {
-#if (AMREX_SPACEDIM == 3)
 					const int icomp = field_map_ptr[n];
+#if (AMREX_SPACEDIM == 3)
                     buf_arr(i,j,k_lab,n) += tmp_arr(i,j,k,icomp);
 #else
                     buf_arr(i,k_lab,k,n) += tmp_arr(i,j,k,icomp);

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -448,7 +448,7 @@ namespace
 {
     void
     CopySlice(MultiFab& tmp, MultiFab& buf, int k_lab, 
-              const std::vector<int>& map_actual_fields_to_dump)
+              const Gpu::ManagedDeviceVector<int>& map_actual_fields_to_dump)
     {
         const int ncomp_to_dump = map_actual_fields_to_dump.size();
         // Copy data from MultiFab tmp to MultiFab data_buffer[i].
@@ -461,12 +461,13 @@ namespace
             // For 3D runs, tmp is a 2D (x,y) multifab, that contains only 
             // slice to write to file.
             const Box& bx  = mfi.tilebox();
-            
+
+			const auto field_map_ptr = map_actual_fields_to_dump.dataPtr();            
             ParallelFor(bx, ncomp_to_dump,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
                 {
-                    const int icomp = map_actual_fields_to_dump[n];
 #if (AMREX_SPACEDIM == 3)
+					const int icomp = field_map_ptr[n];
                     buf_arr(i,j,k_lab,n) += tmp_arr(i,j,k,icomp);
 #else
                     buf_arr(i,k_lab,k,n) += tmp_arr(i,j,k,icomp);
@@ -568,6 +569,7 @@ BoostedFrameDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
                                  user_fields_to_dump);
     // If user specifies fields to dump, overwrite ncomp_to_dump, 
     // map_actual_fields_to_dump and mesh_field_names.
+	for (int i = 0; i < 10; ++i) map_actual_fields_to_dump.push_back(i);
     if (do_user_fields){
         ncomp_to_dump = user_fields_to_dump.size();
         map_actual_fields_to_dump.resize(ncomp_to_dump);

--- a/Source/Diagnostics/BoostedFrameDiagnostic.cpp
+++ b/Source/Diagnostics/BoostedFrameDiagnostic.cpp
@@ -462,11 +462,11 @@ namespace
             // slice to write to file.
             const Box& bx  = mfi.tilebox();
 
-			const auto field_map_ptr = map_actual_fields_to_dump.dataPtr();            
+            const auto field_map_ptr = map_actual_fields_to_dump.dataPtr();            
             ParallelFor(bx, ncomp_to_dump,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
                 {
-					const int icomp = field_map_ptr[n];
+                    const int icomp = field_map_ptr[n];
 #if (AMREX_SPACEDIM == 3)
                     buf_arr(i,j,k_lab,n) += tmp_arr(i,j,k,icomp);
 #else


### PR DESCRIPTION
This is a change to a recently merged pull request. The vector can't be used directly in device code. This puts the field component map into managed memory and captures a data pointer to it in the device lambda. 