### PR TITLE
Fix momentum in plotfiles

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -36,11 +36,13 @@ MultiParticleContainer::WritePlotFile (const std::string& dir,
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
         auto& pc = allcontainers[i];
         if (pc->plot_species) {
+            pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
             // real_names contains a list of all particle attributes.
             // pc->plot_flags is 1 or 0, whether quantity is dumped or not.
             pc->WritePlotFile(dir, species_names[i],
                               pc->plot_flags, int_flags,
                               real_names, int_names);
+            pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
         }
     }
 }
@@ -69,3 +71,42 @@ MultiParticleContainer::WriteHeader (std::ostream& os) const
     }
 }
 
+// Particle momentum is defined as gamma*velocity, which is neither 
+// SI mass*gamma*velocity nor normalized gamma*velocity/c.
+// This converts momentum to SI units (or vice-versa) to write SI data
+// to file.
+void
+PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
+{
+    BL_PROFILE("PPC::ConvertUnits()");
+    Real factor = 1;
+    if (convert_direction == ConvertDirection::WarpX_to_SI){
+        factor = mass;
+    } else if (convert_direction == ConvertDirection::SI_to_WarpX){
+        factor = 1./mass;
+    }
+
+    for (int lev=0; lev<=finestLevel(); lev++){
+
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
+        {
+            // - momenta are stored as a struct of array, in `attribs`
+            auto& attribs = pti.GetAttribs();
+            Real* AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
+            Real* AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
+            Real* AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
+            // Loop over the particles and update the position
+            const long np = pti.numParticles();
+            ParallelFor( np,
+                [=] AMREX_GPU_DEVICE (long i) {
+                    ux[i] *= factor;
+                    uy[i] *= factor;
+                    uz[i] *= factor;
+                }
+            );
+        }
+    }
+}

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -101,6 +101,8 @@ public:
                                   const amrex::Real t_lab, const amrex::Real dt,
                                   DiagnosticParticles& diagnostic_particles) final;
 
+    virtual void ConvertUnits (ConvertDirection convert_dir) override;
+
 protected:
 
     std::string species_name;

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -6,6 +6,8 @@
 #include <AMReX_Particles.H>
 #include <AMReX_AmrCore.H>
 
+enum struct ConvertDirection{WarpX_to_SI, SI_to_WarpX};
+
 struct PIdx
 {
     enum { // Particle Attributes stored in amrex::ParticleContainer's struct of array
@@ -226,6 +228,8 @@ public:
     void ReadHeader (std::istream& is);
 
     void WriteHeader (std::ostream& os) const;
+
+    virtual void ConvertUnits (ConvertDirection convert_dir){};
 
     static void ReadParameters ();
 


### PR DESCRIPTION
Addresses issue https://github.com/ECP-WarpX/WarpX/issues/135.

Particle momentum is converted to SI units before writing to file, then back to WarpX units.

This PR is ready for review, but I have not been able to test it on GPU.