### PR TITLE
Fix/Refactor the function PushX

### DIFF
--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -10,5 +10,7 @@ CEXE_headers += WarpXParticleContainer.H
 CEXE_headers += RigidInjectedParticleContainer.H
 CEXE_headers += PhysicalParticleContainer.H
 
+include $(WARPX_HOME)/Source/Particles/Pusher/Make.package
+
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -7,8 +7,10 @@
 
 #ifndef WARPX_RZ
 
-void
-GetPosition(
+/* \brief Extract the particle's coordinates from the ParticleType struct `p`,
+ *        and stores them in the variables `x`, `y`, `z`. */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void GetPosition(
     amrex::Real& x, amrex::Real& y, amrex::Real& z,
     const WarpXParticleContainer::ParticleType& p)
 {
@@ -18,14 +20,35 @@ GetPosition(
     z = p.pos(2);
 #else
     x = p.pos(0);
+    y = std::numeric_limits<Real>::quiet_NaN();
     z = p.pos(1);
+#endif
+}
+
+/* \brief Set the particle's coordinates in the ParticleType struct `p`,
+ *        from their values in the variables `x`, `y`, `z`. */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void SetPosition(
+    WarpXParticleContainer::ParticleType& p,
+    const amrex::Real x, const amrex::Real y, const amrex::Real z)
+{
+#if (AMREX_SPACEDIM==3)
+    p.pos(0) = x;
+    p.pos(1) = y;
+    p.pos(2) = z;
+#else
+    p.pos(0) = x;
+    p.pos(1) = z;
 #endif
 }
 
 # else // if WARPX_RZ is True
 
-void
-GetCartesianPositionFromCylindrical(
+/* \brief Extract the particle's coordinates from `theta` and the attributes
+ *         of the ParticleType struct `p` (which contains the radius),
+ *         and store them in the variables `x`, `y`, `z` */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void GetCartesianPositionFromCylindrical(
     amrex::Real& x, amrex::Real& y, amrex::Real& z,
     const WarpXParticleContainer::ParticleType& p, const amrex::Real theta)
 {
@@ -33,6 +56,19 @@ GetCartesianPositionFromCylindrical(
     x = r*std::cos(theta);
     y = r*std::sin(theta);
     z = p.pos(1);
+}
+
+/* \brief Set the particle's cylindrical coordinates by setting `theta`
+ *        and the attributes of the ParticleType struct `p` (which stores the radius),
+ *        from the values of `x`, `y`, `z` */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void SetCylindricalPositionFromCartesian(
+    WarpXParticleContainer::ParticleType& p, amrex::Real& theta,
+    const amrex::Real x, const amrex::Real y, const amrex::Real z )
+{
+    theta = std::atan2(y, x);
+    p.pos(0) = std::sqrt(x*x + y*y);
+    p.pos(1) = z;
 }
 
 #endif // WARPX_RZ

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -1,0 +1,40 @@
+#ifndef WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
+#define WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
+
+#include <limits>
+#include <WarpXParticleContainer.H>
+#include <AMReX_REAL.H>
+
+#ifndef WARPX_RZ
+
+void
+GetPosition(
+    amrex::Real& x, amrex::Real& y, amrex::Real& z,
+    const WarpXParticleContainer::ParticleType& p)
+{
+#if (AMREX_SPACEDIM==3)
+    x = p.pos(0);
+    y = p.pos(1);
+    z = p.pos(2);
+#else
+    x = p.pos(0);
+    z = p.pos(1);
+#endif
+}
+
+# else // if WARPX_RZ is True
+
+void
+GetCartesianPositionFromCylindrical(
+    amrex::Real& x, amrex::Real& y, amrex::Real& z,
+    const WarpXParticleContainer::ParticleType& p, const amrex::Real theta)
+{
+    const amrex::Real r = p.pos(0);
+    x = r*std::cos(theta);
+    y = r*std::sin(theta);
+    z = p.pos(1);
+}
+
+#endif // WARPX_RZ
+
+#endif // WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -20,7 +20,7 @@ void GetPosition(
     z = p.pos(2);
 #else
     x = p.pos(0);
-    y = std::numeric_limits<Real>::quiet_NaN();
+    y = std::numeric_limits<amrex::Real>::quiet_NaN();
     z = p.pos(1);
 #endif
 }

--- a/Source/Particles/Pusher/Make.package
+++ b/Source/Particles/Pusher/Make.package
@@ -1,0 +1,3 @@
+CEXE_headers += GetAndSetPosition.H
+INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Pusher
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Pusher

--- a/Source/Particles/Pusher/Make.package
+++ b/Source/Particles/Pusher/Make.package
@@ -1,3 +1,4 @@
 CEXE_headers += GetAndSetPosition.H
+CEXE_headers += UpdatePosition.H
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Pusher
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Pusher

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -1,0 +1,28 @@
+#ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
+#define WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
+
+#include <AMReX_REAL.H>
+
+/* \brief Push the particle's positions over one timestep,
+ *    given the value of its momenta `ux`, `uy`, `uz` */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void UpdatePosition(
+    amrex::Real& x, amrex::Real& y, amrex::Real& z,
+    const amrex::Real ux, const amrex::Real uy, const amrex::Real uz,
+    const amrex::Real dt )
+{
+
+    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+
+    // Compute inverse Lorentz factor
+    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    // Update positions over one time step
+    x += ux * inv_gamma * dt;
+#if (AMREX_SPACEDIM == 3) || (defined WARPX_RZ) // RZ pushes particles in 3D
+    y += uy * inv_gamma * dt;
+#endif
+    z += uz * inv_gamma * dt;
+
+}
+
+#endif // WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -1,6 +1,8 @@
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 
+#include <AMReX_FArrayBox.H>
+#include <WarpXConst.H>
 #include <AMReX_REAL.H>
 
 /* \brief Push the particle's positions over one timestep,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1066,9 +1066,9 @@ WarpXParticleContainer::PushX (int lev, Real dt)
                     SetPosition( p, x, y, z ); // Update the object p
 #else
                     // For WARPX_RZ, the particles are still pushed in 3D Cartesian
-                    GetCartesianPositionFromCylindrical( x, y, z, p, theta );
+                    GetCartesianPositionFromCylindrical( x, y, z, p, theta[i] );
                     UpdatePosition( x, y, z, ux[i], uy[i], uz[i], dt);
-                    SetCylindricalPositionFromCartesian( p, theta, x, y, z );
+                    SetCylindricalPositionFromCartesian( p, theta[i], x, y, z );
 #endif
                 }
             );

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1062,14 +1062,12 @@ WarpXParticleContainer::PushX (int lev, Real dt)
                     Real x, y, z; // Temporary variables
 #ifndef WARPX_RZ
                     GetPosition( x, y, z, p ); // Initialize x, y, z
-#else
-                    GetCartesianPositionFromCylindrical( x, y, z, p, theta );
-#endif
-                    // Even for RZ, the particles are pushed in 3D Cartesian
                     UpdatePosition( x, y, z, ux[i], uy[i], uz[i], dt);
-#ifndef WARPX_RZ
                     SetPosition( p, x, y, z ); // Update the object p
 #else
+                    // For WARPX_RZ, the particles are still pushed in 3D Cartesian
+                    GetCartesianPositionFromCylindrical( x, y, z, p, theta );
+                    UpdatePosition( x, y, z, ux[i], uy[i], uz[i], dt);
                     SetCylindricalPositionFromCartesian( p, theta, x, y, z );
 #endif
                 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -7,6 +7,8 @@
 #include <WarpX_f.H>
 #include <WarpX.H>
 
+#include <GetAndSetPosition.H>
+
 using namespace amrex;
 
 int WarpXParticleContainer::do_not_push = 0;


### PR DESCRIPTION
This pull request fixes the function `PushX` which, as mentioned in #134 is currently not valid for 2D and RZ.

In practice, `PushX` is currently never called inside WarpX, but we could use it in the future.

More importantly: I think that this function is small enough that if can serve as an example for how to port other functions to C++/GPU (e.g. update of momenta). Therefore, I would very much welcome any feedback on the choices I made for style/structure.

Here are some of the choices I made:

- I created small device inline functions for elementary, single-particle operations (e.g. push the particle, update the ParticleType object, etc.).

- These functions are stored in `.H` files, in a separate subfolder `Pusher` of the `Particles` directory. These `.H` file are typically small, and I would favor creating many different files (e.g. for pushing the momenta, the position, etc.) rather than one big file that contains all of those kernels. This is because, in my opinion, it makes easier for other developers to intuitively find the file that contains the function that they are looking for.

- The `WarpXParticleContainer.cpp` file calls the `amrex::ParallelFor` loop, but then simply calls the low-level kernels from the `.H`. The details of the operations performed is therefore hidden at this level.

As a side-question for @atmyers @WeiqunZhang : I end up having a lot of `#ifdef`/`#endif` (sometimes imbricated), which I don't find particular elegant. Any advice on how to avoid this (e.g. using templating maybe...)?

