### PR TITLE
Validate inputs

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -15,7 +15,7 @@ correct branch:
     git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
     git clone --branch development https://github.com/AMReX-Codes/amrex.git
 
-Then, use the following set of commands to compile:
+Then, ``cd`` into the directory ``WarpX`` and use the following set of commands to compile:
 
 ::
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -531,6 +531,11 @@ Numerics and algorithms
      - ``0``: Vectorized version
      - ``1``: Non-optimized version
 
+    .. warning::
+
+        The vectorized version does not run on GPU. Use
+		``algo.charge_deposition=1`` when running on GPU.
+       
 * ``algo.field_gathering`` (`integer`)
     The algorithm for field gathering:
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -195,6 +195,8 @@ public:
     void SyncRho (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhof,
                   amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhoc);
 
+    void ValidateParameters ();
+    
     int getistep (int lev) const {return istep[lev];}
     void setistep (int lev, int ii) {istep[lev] = ii;}
     amrex::Real gett_new (int lev) const {return t_new[lev];}
@@ -215,8 +217,8 @@ public:
 
     void WritePlotFileES(const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E);
-
+                         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E);  
+    
     static std::array<amrex::Real,3> CellSize (int lev);
     static amrex::RealBox getRealBox(const amrex::Box& bx, int lev);
     static std::array<amrex::Real,3> LowerCorner (const amrex::Box& bx, int lev);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -537,13 +537,13 @@ WarpX::ValidateParameters ()
 #ifdef AMREX_USE_CUDA
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::current_deposition_algo != 1) and
                                       (WarpX::current_deposition_algo != 2),
-            "When running with GPUs, use warpx.current_deposition_algo = 0 or 3" );
+            "When running with GPUs, use algo.current_deposition = 0 or 3" );
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::charge_deposition_algo != 0),
-            "When running with GPUs, use warpx.charge_deposition_algo = 1" );    
+            "When running with GPUs, use algo.charge_deposition = 1" );    
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::field_gathering_algo != 0),
-            "When running with GPUs, use warpx.field_gathering_algo = 1" );    
+            "When running with GPUs, use algo.field_gathering = 1" );    
 
 #endif
 }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -527,6 +527,25 @@ WarpX::ReadParameters ()
         pp.query("config", insitu_config);
         pp.query("pin_mesh", insitu_pin_mesh);
     }
+
+    ValidateParameters();
+}
+
+void
+WarpX::ValidateParameters ()
+{
+#ifdef AMREX_USE_CUDA
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::current_deposition_algo != 1) and
+                                      (WarpX::current_deposition_algo != 2),
+            "When running with GPUs, use warpx.current_deposition_algo = 0 or 3" );
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::charge_deposition_algo != 0),
+            "When running with GPUs, use warpx.charge_deposition_algo = 1" );    
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpX::field_gathering_algo != 0),
+            "When running with GPUs, use warpx.field_gathering_algo = 1" );    
+
+#endif
 }
 
 // This is a virtual function.


### PR DESCRIPTION
When running with GPUs, it is easy to accidentally choose an invalid runtime parameter in your inputs file, which can cause the code to give the wrong results or crash. This adds a function that checks for this for several commonly-used inputs parameters. 