### PR TITLE
Corrected picmi implementation fix momentums

### DIFF
--- a/Examples/Modules/gaussian_beam/gaussian_beam_PICMI.py
+++ b/Examples/Modules/gaussian_beam/gaussian_beam_PICMI.py
@@ -17,7 +17,7 @@ number_sim_particles = 32768
 total_charge = 8.010883097437485e-07
 
 beam_rms_size = 0.25
-electron_beam_divergence = -0.04
+electron_beam_divergence = -0.04*picmi.c
 
 em_order = 3
 

--- a/Examples/Tests/Langmuir/langmuir2d_PICMI.py
+++ b/Examples/Tests/Langmuir/langmuir2d_PICMI.py
@@ -9,7 +9,9 @@ ymin = -20.e-6
 xmax = +20.e-6
 ymax = +20.e-6
 
-uniform_plasma = picmi.UniformDistribution(density=1.e25, upper_bound=[0., None, None], directed_velocity=[0.1, 0., 0.])
+uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+                                           upper_bound = [0., None, None],
+                                           directed_velocity = [0.1*picmi.c, 0., 0.])
 
 electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI.py
@@ -14,7 +14,9 @@ xmax = +20.e-6
 ymax = +20.e-6
 zmax = +20.e-6
 
-uniform_plasma = picmi.UniformDistribution(density=1.e25, upper_bound=[0., None, None], directed_velocity=[0.1, 0., 0.])
+uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+                                           upper_bound = [0., None, None],
+                                           directed_velocity = [0.1*picmi.c, 0., 0.])
 
 electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI_rt.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI_rt.py
@@ -14,7 +14,9 @@ xmax = +20.e-6
 ymax = +20.e-6
 zmax = +20.e-6
 
-uniform_plasma = picmi.UniformDistribution(density=1.e25, upper_bound=[0., None, None], directed_velocity=[0.1, 0., 0.])
+uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+                                           upper_bound = [0., None, None],
+                                           directed_velocity = [0.1*picmi.c, 0., 0.])
 
 electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI_rz.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI_rz.py
@@ -9,7 +9,9 @@ zmin = -20.e-6
 rmax = +20.e-6
 zmax = +20.e-6
 
-uniform_plasma = picmi.UniformDistribution(density=1.e25, upper_bound=[None, None, 0.], directed_velocity=[0., 0., 0.1])
+uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+                                           upper_bound = [None, None, 0.],
+                                           directed_velocity = [0., 0., 0.1*picmi.c])
 
 electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -94,24 +94,25 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
         #species.zmin
         #species.zmax
 
+        # --- Note that WarpX takes gamma*beta as input
         if np.any(np.not_equal(self.velocity_divergence, 0.)):
             species.momentum_distribution_type = "radial_expansion"
-            species.u_over_r = self.velocity_divergence[0]
-            #species.u_over_y = self.velocity_divergence[1]
-            #species.u_over_z = self.velocity_divergence[2]
+            species.u_over_r = self.velocity_divergence[0]/c
+            #species.u_over_y = self.velocity_divergence[1]/c
+            #species.u_over_z = self.velocity_divergence[2]/c
         elif np.any(np.not_equal(self.rms_velocity, 0.)):
             species.momentum_distribution_type = "gaussian"
-            species.ux_m = self.centroid_velocity[0]
-            species.uy_m = self.centroid_velocity[1]
-            species.uz_m = self.centroid_velocity[2]
-            species.ux_th = self.rms_velocity[0]
-            species.uy_th = self.rms_velocity[1]
-            species.uz_th = self.rms_velocity[2]
+            species.ux_m = self.centroid_velocity[0]/c
+            species.uy_m = self.centroid_velocity[1]/c
+            species.uz_m = self.centroid_velocity[2]/c
+            species.ux_th = self.rms_velocity[0]/c
+            species.uy_th = self.rms_velocity[1]/c
+            species.uz_th = self.rms_velocity[2]/c
         else:
             species.momentum_distribution_type = "constant"
-            species.ux = self.centroid_velocity[0]
-            species.uy = self.centroid_velocity[1]
-            species.uz = self.centroid_velocity[2]
+            species.ux = self.centroid_velocity[0]/c
+            species.uy = self.centroid_velocity[1]/c
+            species.uz = self.centroid_velocity[2]/c
 
 
 class UniformDistribution(picmistandard.PICMI_UniformDistribution):
@@ -139,19 +140,20 @@ class UniformDistribution(picmistandard.PICMI_UniformDistribution):
         species.profile = "constant"
         species.density = self.density
 
+        # --- Note that WarpX takes gamma*beta as input
         if np.any(np.not_equal(self.rms_velocity, 0.)):
             species.momentum_distribution_type = "gaussian"
-            species.ux_m = self.directed_velocity[0]
-            species.uy_m = self.directed_velocity[1]
-            species.uz_m = self.directed_velocity[2]
-            species.ux_th = self.rms_velocity[0]
-            species.uy_th = self.rms_velocity[1]
-            species.uz_th = self.rms_velocity[2]
+            species.ux_m = self.directed_velocity[0]/c
+            species.uy_m = self.directed_velocity[1]/c
+            species.uz_m = self.directed_velocity[2]/c
+            species.ux_th = self.rms_velocity[0]/c
+            species.uy_th = self.rms_velocity[1]/c
+            species.uz_th = self.rms_velocity[2]/c
         else:
             species.momentum_distribution_type = "constant"
-            species.ux = self.directed_velocity[0]
-            species.uy = self.directed_velocity[1]
-            species.uz = self.directed_velocity[2]
+            species.ux = self.directed_velocity[0]/c
+            species.uy = self.directed_velocity[1]/c
+            species.uz = self.directed_velocity[2]/c
 
         if self.fill_in:
             species.do_continuous_injection = 1
@@ -185,19 +187,20 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution):
         for k,v in self.user_defined_kw.items():
             setattr(pywarpx.my_constants, k, v)
 
+        # --- Note that WarpX takes gamma*beta as input
         if np.any(np.not_equal(self.rms_velocity, 0.)):
             species.momentum_distribution_type = "gaussian"
-            species.ux_m = self.directed_velocity[0]
-            species.uy_m = self.directed_velocity[1]
-            species.uz_m = self.directed_velocity[2]
-            species.ux_th = self.rms_velocity[0]
-            species.uy_th = self.rms_velocity[1]
-            species.uz_th = self.rms_velocity[2]
+            species.ux_m = self.directed_velocity[0]/c
+            species.uy_m = self.directed_velocity[1]/c
+            species.uz_m = self.directed_velocity[2]/c
+            species.ux_th = self.rms_velocity[0]/c
+            species.uy_th = self.rms_velocity[1]/c
+            species.uz_th = self.rms_velocity[2]/c
         else:
             species.momentum_distribution_type = "constant"
-            species.ux = self.directed_velocity[0]
-            species.uy = self.directed_velocity[1]
-            species.uz = self.directed_velocity[2]
+            species.ux = self.directed_velocity[0]/c
+            species.uy = self.directed_velocity[1]/c
+            species.uz = self.directed_velocity[2]/c
 
         if self.fill_in:
             species.do_continuous_injection = 1


### PR DESCRIPTION
Cho was seeing problems with inputting a Gaussian beam getting the wrong momentum. This fixes the issue. The picmi standard specifies that velocities are input with units m/s, but the picmi implementation was not dividing by c needed since the input files use gamma*beta instead. This also makes the corresponding fix to several picmi input files.

Note that this will likely break some peoples input files, but the change is needed to be consistent with the standard.