### PR TITLE
Rigid injected restart

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -19,6 +19,20 @@ WarpXParticleContainer::WriteHeader (std::ostream& os) const
 }
 
 void
+RigidInjectedParticleContainer::ReadHeader (std::istream& is)
+{
+    is >> charge >> mass;
+    WarpX::GotoNextLine(is);
+}
+
+void
+RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
+{
+    // no need to write species_id
+    os << charge << " " << mass << "\n";
+}
+
+void
 MultiParticleContainer::Checkpoint (const std::string& dir) const
 {
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -5,6 +5,53 @@
 using namespace amrex;
 
 void
+RigidInjectedParticleContainer::ReadHeader (std::istream& is)
+{
+    is >> charge >> mass;
+    WarpX::GotoNextLine(is);
+
+    int nlevs;
+    is >> nlevs;
+    WarpX::GotoNextLine(is);
+
+    AMREX_ASSERT(zinject_plane_levels.size() == 0);
+    AMREX_ASSERT(done_injecting.size() == 0);
+
+    for (int i = 0; i < nlevs; ++i)
+    {
+        int zinject_plane_tmp;
+        is >> zinject_plane_tmp;
+        zinject_plane_levels.push_back(zinject_plane_tmp);
+        WarpX::GotoNextLine(is);        
+    } 
+
+    for (int i = 0; i < nlevs; ++i)
+    {
+        int done_injecting_tmp;
+        is >> done_injecting_tmp;
+        done_injecting.push_back(done_injecting_tmp);
+        WarpX::GotoNextLine(is);
+    }     
+}
+
+void
+RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
+{
+    // no need to write species_id
+    os << charge << " " << mass << "\n";
+    int nlevs = zinject_plane_levels.size();
+    os << nlevs << "\n";
+    for (int i = 0; i < nlevs; ++i)
+    {
+        os << zinject_plane_levels[i] << "\n";
+    }
+    for (int i = 0; i < nlevs; ++i)
+    {
+        os << done_injecting[i] << "\n";
+    }
+}
+
+void
 WarpXParticleContainer::ReadHeader (std::istream& is)
 {
     is >> charge >> mass;
@@ -13,20 +60,6 @@ WarpXParticleContainer::ReadHeader (std::istream& is)
 
 void
 WarpXParticleContainer::WriteHeader (std::ostream& os) const
-{
-    // no need to write species_id
-    os << charge << " " << mass << "\n";
-}
-
-void
-RigidInjectedParticleContainer::ReadHeader (std::istream& is)
-{
-    is >> charge >> mass;
-    WarpX::GotoNextLine(is);
-}
-
-void
-RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
 {
     // no need to write species_id
     os << charge << " " << mass << "\n";

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -57,6 +57,10 @@ public:
                         const amrex::MultiFab& By,
                         const amrex::MultiFab& Bz) override;
 
+    virtual void ReadHeader (std::istream& is) override;
+
+    virtual void WriteHeader (std::ostream& os) const override;
+    
 private:
 
     // User input quantities

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -77,7 +77,6 @@ RigidInjectedParticleContainer::RemapParticles()
 
                 for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
                 {
-
                     auto& attribs = pti.GetAttribs();
                     auto& uxp = attribs[PIdx::ux];
                     auto& uyp = attribs[PIdx::uy];

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -225,9 +225,9 @@ public:
                          amrex::Real x, amrex::Real y, amrex::Real z,
                          std::array<amrex::Real,PIdx::nattribs>& attribs);
 
-    void ReadHeader (std::istream& is);
+    virtual void ReadHeader (std::istream& is);
 
-    void WriteHeader (std::ostream& os) const;
+    virtual void WriteHeader (std::ostream& os) const;
 
     virtual void ConvertUnits (ConvertDirection convert_dir){};
 


### PR DESCRIPTION
Checkpoint / Restart currently doesn't work for RigidInjected species, because the `zinject_plane` and `done_injecting` variables weren't saved out or read in. This PR implements this capability. 