### PR TITLE
Added change in ConvertLabPAramsToBoost() to write slice data in the …

### DIFF
--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -783,7 +783,7 @@ WarpX::InitializeSliceMultiFabs ()
     current_slice.resize(nlevels);
     Efield_slice.resize(nlevels);
     Bfield_slice.resize(nlevels);
-
+ 
 }
 
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -135,7 +135,8 @@ WarpX::EvolveEM (int numsteps)
         bool to_make_plot = (plot_int > 0) && ((step+1) % plot_int == 0);
 
         // slice generation //
-        bool to_make_slice_plot = (slice_plot_int > 0) && ( (step+1)% slice_plot_int == 0);        
+        bool to_make_slice_plot = (slice_plot_int > 0) && ( (step+1)% slice_plot_int == 0); 
+
         bool do_insitu = ((step+1) >= insitu_start) &&
             (insitu_int > 0) && ((step+1) % insitu_int == 0);
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -51,15 +51,24 @@ void ConvertLabParamsToBoost()
     Vector<Real> prob_hi(AMREX_SPACEDIM);
     Vector<Real> fine_tag_lo(AMREX_SPACEDIM);
     Vector<Real> fine_tag_hi(AMREX_SPACEDIM);
+    Vector<Real> slice_lo(AMREX_SPACEDIM);
+    Vector<Real> slice_hi(AMREX_SPACEDIM);
 
     ParmParse pp_geom("geometry");
     ParmParse pp_wpx("warpx");
     ParmParse pp_amr("amr");
+    ParmParse pp_slice("slice");
 
     pp_geom.getarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
     BL_ASSERT(prob_lo.size() == AMREX_SPACEDIM);
     pp_geom.getarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
     BL_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
+
+    pp_slice.queryarr("dom_lo",slice_lo,0,AMREX_SPACEDIM);
+    BL_ASSERT(slice_lo.size() == AMREX_SPACEDIM);
+    pp_slice.queryarr("dom_hi",slice_hi,0,AMREX_SPACEDIM);
+    BL_ASSERT(slice_hi.size() == AMREX_SPACEDIM);
+    
 
     pp_amr.query("max_level", max_level);
     if (max_level > 0){
@@ -86,15 +95,22 @@ void ConvertLabParamsToBoost()
               fine_tag_lo[idim] *= convert_factor;
               fine_tag_hi[idim] *= convert_factor;
             }
+            slice_lo[idim] *= convert_factor;
+            slice_hi[idim] *= convert_factor;
             break;
         }
     }
+
     pp_geom.addarr("prob_lo", prob_lo);
     pp_geom.addarr("prob_hi", prob_hi);
     if (max_level > 0){
       pp_wpx.addarr("fine_tag_lo", fine_tag_lo);
       pp_wpx.addarr("fine_tag_hi", fine_tag_hi);
     }
+
+    pp_slice.addarr("dom_lo",slice_lo);
+    pp_slice.addarr("dom_hi",slice_hi);
+
 }
 
 /* \brief Function that sets the value of MultiFab MF to zero for z between 


### PR DESCRIPTION
This is the first PR for a two-part PR. 
For simulations that run with boosted frame, two types of slices are required. 
1. Slice in the boosted frame. 
2. Slice in the lab frame. 

This PR write out the data for a slice in the boosted frame (i.e. without conversion to lab frame.)
In the next PR, I will add capability to write slice in the lab frame. 

The inputs for the slice data written in boosted frame is same as the previous PR. 
i.e.
################################
####### DIAGNOSTICS  ############
###############################
slice.dom_lo =  -0.00020480000000000002 -0.00020480000000000002 -0.00016018285714285716
slice.dom_hi =  0.00020480000000000002 0.00020480000000000002  0.0
slice.coarsening_ratio = 1 1 1
slice.plot_int = 20

The slice lo and hi are provided in the lab-frame of reference. 
In WarpXUtils.cpp, we convert lab params to boost frame. 
After an interval of slice.plot_int, the data in the boosted frame is extracted and copied to the slice and written out using vismf. 
Can be visualized using ./amrvis3d.gnu.ex -mf vismf_jy_slice_XXXXX

Note : the yt-compliant output format was added in a separate PR. #157. 



