### PR TITLE
Use string for algos in PICMI inputs scripts

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -576,19 +576,6 @@ Numerics and algorithms
 
      If ``algo.maxwell_fdtd_solver`` is not specified, ``yee`` is the default.
 
-.. warning::
-
-   Previous versions of WarpX used integers to encode for the algorithms, 
-   instead of strings now. The encoding was as follows: 
-   **algo.current_deposition** could be **0** (**esirkepov**), 
-   **2** (**direct-vectorized**) or **3** (**direct**).
-   **algo.charge_deposition** could be **0** (**vectorized**) or **1** 
-   (**standard**). **algo.field_gathering** could be **0** (**vectorized**)
-   or **1** (**standard**). **algo.particle_pusher** could be **0** (**boris**)
-   or **1** (**vay**). Note that the integer encoding is no longer supported, 
-   This warning is shown to help updating old scripts, and will be removed in 
-   the future.
-
 * ``interpolation.nox``, ``interpolation.noy``, ``interpolation.noz`` (`integer`)
     The order of the shape factors for the macroparticles, for the 3 dimensions of space.
     Lower-order shape factors result in faster simulations, but more noisy results,

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -576,6 +576,19 @@ Numerics and algorithms
 
      If ``algo.maxwell_fdtd_solver`` is not specified, ``yee`` is the default.
 
+.. warning::
+
+   Previous versions of WarpX used integers to encode for the algorithms, 
+   instead of strings now. The encoding was as follows: 
+   **algo.current_deposition** could be **0** (**esirkepov**), 
+   **2** (**direct-vectorized**) or **3** (**direct**).
+   **algo.charge_deposition** could be **0** (**vectorized**) or **1** 
+   (**standard**). **algo.field_gathering** could be **0** (**vectorized**)
+   or **1** (**standard**). **algo.particle_pusher** could be **0** (**boris**)
+   or **1** (**vay**). Note that the integer encoding is no longer supported, 
+   This warning is shown to help updating old scripts, and will be removed in 
+   the future.
+
 * ``interpolation.nox``, ``interpolation.noy``, ``interpolation.noz`` (`integer`)
     The order of the shape factors for the macroparticles, for the 3 dimensions of space.
     Lower-order shape factors result in faster simulations, but more noisy results,

--- a/Examples/Tests/Langmuir/langmuir2d_PICMI.py
+++ b/Examples/Tests/Langmuir/langmuir2d_PICMI.py
@@ -29,10 +29,7 @@ sim = picmi.Simulation(solver = solver,
                        max_steps = 40,
                        verbose = 1,
                        warpx_plot_int = 1,
-                       warpx_current_deposition_algo = 3,
-                       warpx_charge_deposition_algo = 0,
-                       warpx_field_gathering_algo = 0,
-                       warpx_particle_pusher_algo = 0)
+                       warpx_current_deposition_algo = 'direct')
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,2], grid=grid))
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI.py
@@ -34,10 +34,10 @@ sim = picmi.Simulation(solver = solver,
                        max_steps = 40,
                        verbose = 1,
                        warpx_plot_int = 1,
-                       warpx_current_deposition_algo = 3,
-                       warpx_charge_deposition_algo = 0,
-                       warpx_field_gathering_algo = 0,
-                       warpx_particle_pusher_algo = 0)
+                       warpx_current_deposition_algo = 'direct',
+                       warpx_charge_deposition_algo = 'vectorized',
+                       warpx_field_gathering_algo = 'vectorized',
+                       warpx_particle_pusher_algo = 'boris')
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,2,2], grid=grid))
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI_rt.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI_rt.py
@@ -34,10 +34,7 @@ sim = picmi.Simulation(solver = solver,
                        max_steps = 40,
                        verbose = 1,
                        warpx_plot_int = 40,
-                       warpx_current_deposition_algo = 3,
-                       warpx_charge_deposition_algo = 0,
-                       warpx_field_gathering_algo = 0,
-                       warpx_particle_pusher_algo = 0)
+                       warpx_current_deposition_algo = 'direct')
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,2,2], grid=grid))
 

--- a/Examples/Tests/Langmuir/langmuir_PICMI_rz.py
+++ b/Examples/Tests/Langmuir/langmuir_PICMI_rz.py
@@ -29,10 +29,7 @@ sim = picmi.Simulation(solver = solver,
                        max_steps = 40,
                        verbose = 1,
                        warpx_plot_int = 1,
-                       warpx_current_deposition_algo = 3,
-                       warpx_charge_deposition_algo = 0,
-                       warpx_field_gathering_algo = 0,
-                       warpx_particle_pusher_algo = 0)
+                       warpx_current_deposition_algo = 'direct')
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,2], grid=grid))
 


### PR DESCRIPTION
This PR updates PICMI input scripts with new convention for algorithms (`algo.current_deposition = 3` is replaced by `algo.current_deposition = 'direct'`).

@WeiqunZhang this should fix the tests. Should we re-run the Battra tests on this branch, or wait till this is merged to `dev`?