### PR TITLE
Refactor the SyncRho/SyncCurrent function

### DIFF
--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -293,7 +293,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
     SyncCurrent();
 
-    SyncRho(rho_fp, rho_cp);
+    SyncRho();
 
     // Push E and B from {n} to {n+1}
     // (And update guard cells immediately afterwards)

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -554,8 +554,7 @@ WarpX::SyncCurrent (const std::array<const amrex::MultiFab*,3>& fine,
 }
 
 void
-WarpX::SyncRho (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhof,
-                amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhoc)
+WarpX::SyncRho ()
 {
     if (!rho_fp[0]) return;
     const int ncomp = rho_fp[0]->nComp();
@@ -564,9 +563,9 @@ WarpX::SyncRho (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhof,
     // before summing the guard cells of the fine patch
     for (int lev = 1; lev <= finest_level; ++lev)
     {
-        rhoc[lev]->setVal(0.0);
+        rho_cp[lev]->setVal(0.0);
         const IntVect& refinement_ratio = refRatio(lev-1);
-        SyncRho(*rhof[lev], *rhoc[lev], refinement_ratio[0]);
+        SyncRho(*rho_fp[lev], *rho_cp[lev], refinement_ratio[0]);
     }
 
     // For each level
@@ -772,7 +771,7 @@ WarpX::ApplyFilterandSumBoundaryRho (int lev, PatchType patch_type, int icomp, i
 void
 WarpX::AddRhoFromFineLevelandSumBoundary(int lev, int icomp, int ncomp)
 {
-    if (!rho_fp[0]) return;
+    if (!rho_fp[lev]) return;
 
     if (lev < finest_level){
 
@@ -837,7 +836,7 @@ WarpX::AddRhoFromFineLevelandSumBoundary(int lev, int icomp, int ncomp)
         // In this case, simply apply filter and nodal sync to the fine patch
         ApplyFilterandSumBoundaryRho(lev, PatchType::fine, icomp, ncomp);
         NodalSyncRho(lev, PatchType::fine, icomp, ncomp);
-        
+
     }
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -195,8 +195,8 @@ public:
     void FillBoundaryF (int lev);
 
     void SyncCurrent ();
-    void SyncRho (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhof,
-                  amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rhoc);
+    void SyncRho ();
+
 
     int getistep (int lev) const {return istep[lev];}
     void setistep (int lev, int ii) {istep[lev] = ii;}


### PR DESCRIPTION
This PR reduces code duplication by using the functions `AddCurrentFromFineLevelandSumBoundary`/`AddRhoFromFineLevelandSumBoundary` in `SyncCurrent`/`SyncRho`.

It also fixes a subtle bug in the case of the spectral solver + filtering:
in that case, the current `SyncRho`/`SyncCurrent` do not fill `rho`/`j` in the guard cells, whereas the spectral solver does require these guard cells to be filled. 
(Fundamentally, this is because of the lines:
```
                // Then copy the interior of j_fp to current_fp.
                MultiFab::Copy(*current_fp[lev][idim], *j_fp[lev][idim], 0, 0, 1, 0);
```
)
With this PR, `rho`/`j` are filled in the guard cells (when compiled in spectral mode).