### PR TITLE
Parser now understands >= , <=, ==, !=, and, or

### DIFF
--- a/Examples/Physics_applications/plasma_mirror/inputs.2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs.2d
@@ -48,7 +48,7 @@ electrons.uz_th = .01
 electrons.zmin = 19.520e-6
 electrons.zmax = 25.47931e-6
 electrons.profile = parse_density_function
-electrons.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>zp)*(z<zp2)*2.*nc+(z>zp2)*nc*exp(-(z-zc2)/lgrad)"
+electrons.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>=zp)*(z<=zp2)*2.*nc+(z>zp2)*nc*exp(-(z-zc2)/lgrad)"
 
 ions.charge = q_e
 ions.mass = m_p
@@ -60,7 +60,7 @@ ions.uz_th = 0.
 ions.zmin = 19.520e-6
 ions.zmax = 25.47931e-6
 ions.profile = parse_density_function
-ions.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>zp)*(z<zp2)*2.*nc+(z>zp2)*nc*exp(-(z-zc2)/lgrad)"
+ions.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>=zp)*(z<=zp2)*2.*nc+(z>zp2)*nc*exp(-(z-zc2)/lgrad)"
 
 #################################
 ############# LASER #############

--- a/Source/Parser/wp_parser.l
+++ b/Source/Parser/wp_parser.l
@@ -21,6 +21,9 @@ EXP	([Ee][-+]?[0-9]+)
 "," |
 "<" |
 ">" |
+"<=" |
+">=" |
+"==" |
 "(" |
 ")"     { return yytext[0]; } /* simply pass through */
 
@@ -57,8 +60,8 @@ EXP	([Ee][-+]?[0-9]+)
 "."?[0-9]+{EXP}?  { yylval.d = atof(yytext);   return NUMBER; }
 
  /* Special characters */
-"//".*  
-[ \t]   /* ignore white space */ 
+"//".*
+[ \t]   /* ignore white space */
 \\\n    /* ignore line continuation */
 "\n"    { return EOL; }
 

--- a/Source/Parser/wp_parser.l
+++ b/Source/Parser/wp_parser.l
@@ -21,8 +21,6 @@ EXP	([Ee][-+]?[0-9]+)
 "," |
 "<" |
 ">" |
-"<=" |
-">=" |
 "(" |
 ")"     { return yytext[0]; } /* simply pass through */
 
@@ -46,6 +44,8 @@ EXP	([Ee][-+]?[0-9]+)
 "fabs"        { yylval.f1 = WP_ABS;       return F1; }
 "**"          { yylval.f2 = WP_POW;       return POW;}
 "^"           { yylval.f2 = WP_POW;       return POW;}
+">="          { yylval.f2 = WP_GEQ;       return GEQ;}
+"<="          { yylval.f2 = WP_LEQ;       return LEQ;}
 "pow"         { yylval.f2 = WP_POW;       return F2; }
 "heaviside"   { yylval.f2 = WP_HEAVISIDE; return F2; }
 "min"         { yylval.f2 = WP_MIN;       return F2; }

--- a/Source/Parser/wp_parser.l
+++ b/Source/Parser/wp_parser.l
@@ -46,6 +46,10 @@ EXP	([Ee][-+]?[0-9]+)
 "^"           { yylval.f2 = WP_POW;       return POW;}
 ">="          { yylval.f2 = WP_GEQ;       return GEQ;}
 "<="          { yylval.f2 = WP_LEQ;       return LEQ;}
+"=="          { yylval.f2 = WP_EQ;        return EQ;}
+"!="          { yylval.f2 = WP_NEQ;       return NEQ;}
+"and"         { yylval.f2 = WP_AND;       return AND;}
+"or"          { yylval.f2 = WP_OR;        return OR;}
 "pow"         { yylval.f2 = WP_POW;       return F2; }
 "heaviside"   { yylval.f2 = WP_HEAVISIDE; return F2; }
 "min"         { yylval.f2 = WP_MIN;       return F2; }

--- a/Source/Parser/wp_parser.l
+++ b/Source/Parser/wp_parser.l
@@ -23,7 +23,6 @@ EXP	([Ee][-+]?[0-9]+)
 ">" |
 "<=" |
 ">=" |
-"==" |
 "(" |
 ")"     { return yytext[0]; } /* simply pass through */
 

--- a/Source/Parser/wp_parser.lex.c
+++ b/Source/Parser/wp_parser.lex.c
@@ -9,7 +9,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -84,60 +84,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -167,14 +155,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -191,7 +179,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -206,7 +193,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -234,7 +221,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -262,7 +249,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -273,7 +260,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -282,10 +268,10 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -294,65 +280,59 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
 #define yywrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
@@ -361,26 +341,22 @@ extern char *yytext;
 #endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
-#define YY_NUM_RULES 41
-#define YY_END_OF_BUFFER 42
+#define YY_NUM_RULES 44
+#define YY_END_OF_BUFFER 45
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -388,22 +364,22 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[95] =
+static const flex_int16_t yy_accept[98] =
     {   0,
-        0,    0,   42,   40,   37,   39,   10,   11,    3,    1,
-        7,    2,   40,    4,   35,    8,    5,    9,   33,   40,
-       28,   33,   33,   33,   33,   33,   33,   33,   33,   33,
-       33,    6,   27,   35,   36,   34,   35,    0,   33,   38,
-       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
-       33,   33,   33,   33,   33,   36,   34,    0,    0,   35,
-       25,   33,   33,   33,   17,   13,   33,   33,   14,   32,
-       31,   29,   16,   33,   18,    0,   34,   20,   19,   21,
-       23,   26,   33,   33,   22,   12,   24,   33,   15,   33,
-       33,   33,   30,    0
+        0,    0,   45,   43,   40,   42,   13,   14,    3,    1,
+        7,    2,   43,    4,   38,    8,    5,    9,   36,   43,
+       31,   36,   36,   36,   36,   36,   36,   36,   36,   36,
+       36,    6,   30,   38,   39,   37,   38,    0,   10,   12,
+       11,   36,   41,   36,   36,   36,   36,   36,   36,   36,
+       36,   36,   36,   36,   36,   36,   36,   36,   39,   37,
+        0,    0,   38,   28,   36,   36,   36,   20,   16,   36,
+       36,   17,   35,   34,   32,   19,   36,   21,    0,   37,
+       23,   22,   24,   26,   29,   36,   36,   25,   15,   27,
+       36,   18,   36,   36,   36,   33,    0
 
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -435,7 +411,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[44] =
+static const YY_CHAR yy_meta[44] =
     {   0,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
         1,    3,    3,    3,    1,    1,    1,    3,    3,    1,
@@ -444,85 +420,85 @@ static yyconst YY_CHAR yy_meta[44] =
         3,    3,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[97] =
+static const flex_int16_t yy_base[100] =
     {   0,
-        0,    0,  148,  149,  149,  149,  149,  149,  141,  149,
-      149,  149,   32,  135,   37,  149,  149,  149,    0,  142,
-      149,   29,  110,  101,  120,  115,  106,   32,  105,   25,
-      116,  149,  149,   45,    0,   60,   68,   76,    0,  149,
-       99,  102,  105,  112,   95,   97,  108,  108,  101,   86,
-       94,   85,   92,   87,   90,    0,   79,   88,   63,   94,
-        0,   84,   88,   87,   90,    0,   80,   76,   91,    0,
-        0,    0,   74,   60,   67,   97,  100,    0,    0,    0,
-        0,    0,   54,   58,    0,    0,    0,   31,    0,   36,
-       40,   34,    0,  149,   45,  114
+        0,    0,  151,  152,  152,  152,  152,  152,  144,  152,
+      152,  152,   32,  138,   37,  132,  131,  130,    0,  142,
+      152,   29,  110,  101,  120,  115,  106,   32,  105,   25,
+      116,  152,  152,   45,    0,   60,   68,   76,  152,  152,
+      152,    0,  152,   99,  102,  105,  112,   95,   97,  108,
+      108,  101,   86,   94,   85,   92,   87,   90,    0,   79,
+       88,   63,   94,    0,   84,   88,   87,   90,    0,   80,
+       76,   91,    0,    0,    0,   74,   60,   67,   97,  100,
+        0,    0,    0,    0,    0,   54,   58,    0,    0,    0,
+       31,    0,   36,   40,   34,    0,  152,   45,  114
 
     } ;
 
-static yyconst flex_int16_t yy_def[97] =
+static const flex_int16_t yy_def[100] =
     {   0,
-       94,    1,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   95,   94,
-       94,   95,   95,   95,   95,   95,   95,   95,   95,   95,
-       95,   94,   94,   94,   96,   94,   94,   94,   95,   94,
-       95,   95,   95,   95,   95,   95,   95,   95,   95,   95,
-       95,   95,   95,   95,   95,   96,   94,   94,   94,   94,
-       95,   95,   95,   95,   95,   95,   95,   95,   95,   95,
-       95,   95,   95,   95,   95,   94,   94,   95,   95,   95,
-       95,   95,   95,   95,   95,   95,   95,   95,   95,   95,
-       95,   95,   95,    0,   94,   94
+       97,    1,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   98,   97,
+       97,   98,   98,   98,   98,   98,   98,   98,   98,   98,
+       98,   97,   97,   97,   99,   97,   97,   97,   97,   97,
+       97,   98,   97,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,   98,   98,   98,   98,   98,   99,   97,
+       97,   97,   97,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,   98,   98,   98,   98,   98,   97,   97,
+       98,   98,   98,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,   98,   98,   98,    0,   97,   97
 
     } ;
 
-static yyconst flex_uint16_t yy_nxt[193] =
+static const flex_int16_t yy_nxt[196] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   15,   15,   16,   17,   18,   19,   19,   20,
        21,   22,   19,   23,   19,   24,   25,   19,   26,   19,
        27,   28,   19,   19,   29,   19,   19,   30,   31,   19,
-       19,   19,   32,   34,   34,   34,   36,   39,   37,   37,
-       37,   41,   42,   50,   53,   38,   34,   34,   34,   93,
-       54,   51,   38,   38,   92,   91,   43,   44,   90,   89,
-       38,   57,   57,   57,   60,   60,   60,   36,   58,   37,
-       37,   37,   59,   88,   59,   58,   38,   60,   60,   60,
-       57,   57,   57,   38,   76,   87,   76,   58,   86,   77,
+       19,   19,   32,   34,   34,   34,   36,   42,   37,   37,
+       37,   44,   45,   53,   56,   38,   34,   34,   34,   96,
+       57,   54,   38,   38,   95,   94,   46,   47,   93,   92,
+       38,   60,   60,   60,   63,   63,   63,   36,   61,   37,
+       37,   37,   62,   91,   62,   61,   38,   63,   63,   63,
+       60,   60,   60,   38,   79,   90,   79,   61,   89,   80,
 
-       77,   77,   85,   84,   58,   60,   60,   60,   77,   77,
-       77,   77,   77,   77,   56,   83,   56,   82,   81,   80,
-       79,   78,   75,   74,   73,   72,   71,   70,   69,   68,
-       67,   66,   65,   64,   63,   62,   61,   55,   52,   49,
-       48,   47,   46,   45,   40,   35,   33,   94,    3,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94
+       80,   80,   88,   87,   61,   63,   63,   63,   80,   80,
+       80,   80,   80,   80,   59,   86,   59,   85,   84,   83,
+       82,   81,   78,   77,   76,   75,   74,   73,   72,   71,
+       70,   69,   68,   67,   66,   65,   64,   58,   55,   52,
+       51,   50,   49,   48,   43,   41,   40,   39,   35,   33,
+       97,    3,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97
 
     } ;
 
-static yyconst flex_int16_t yy_chk[193] =
+static const flex_int16_t yy_chk[196] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,   13,   13,   13,   15,   95,   15,   15,
-       15,   22,   22,   28,   30,   15,   34,   34,   34,   92,
-       30,   28,   15,   34,   91,   90,   22,   22,   88,   84,
-       34,   36,   36,   36,   59,   59,   59,   37,   36,   37,
-       37,   37,   38,   83,   38,   36,   37,   38,   38,   38,
-       57,   57,   57,   37,   58,   75,   58,   57,   74,   58,
+        1,    1,    1,   13,   13,   13,   15,   98,   15,   15,
+       15,   22,   22,   28,   30,   15,   34,   34,   34,   95,
+       30,   28,   15,   34,   94,   93,   22,   22,   91,   87,
+       34,   36,   36,   36,   62,   62,   62,   37,   36,   37,
+       37,   37,   38,   86,   38,   36,   37,   38,   38,   38,
+       60,   60,   60,   37,   61,   78,   61,   60,   77,   61,
 
-       58,   58,   73,   69,   57,   60,   60,   60,   76,   76,
-       76,   77,   77,   77,   96,   68,   96,   67,   65,   64,
-       63,   62,   55,   54,   53,   52,   51,   50,   49,   48,
-       47,   46,   45,   44,   43,   42,   41,   31,   29,   27,
-       26,   25,   24,   23,   20,   14,    9,    3,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94,   94,   94,   94,   94,   94,   94,   94,   94,
-       94,   94
+       61,   61,   76,   72,   60,   63,   63,   63,   79,   79,
+       79,   80,   80,   80,   99,   71,   99,   70,   68,   67,
+       66,   65,   58,   57,   56,   55,   54,   53,   52,   51,
+       50,   49,   48,   47,   46,   45,   44,   31,   29,   27,
+       26,   25,   24,   23,   20,   18,   17,   16,   14,    9,
+        3,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97
 
     } ;
 
@@ -544,10 +520,12 @@ char *yytext;
 #line 3 "wp_parser.l"
 #include "wp_parser_y.h"
 #include "wp_parser.tab.h"
-/* Tokens NUMBER, SYMBOL, F1, POW, F2, etc. are defined in wp_parser.y. */
-/* Types WP_SQRT, WP_SQRT, etc. are defined in wp_parser_y.h. */
-/* Used leater to define NUMBER */
-#line 551 "wp_parser.lex.c"
+#line 524 "wp_parser.lex.c"
+#line 8 "wp_parser.l"
+ /* Tokens NUMBER, SYMBOL, F1, POW, F2, etc. are defined in wp_parser.y. */
+ /* Types WP_SQRT, WP_SQRT, etc. are defined in wp_parser_y.h. */
+ /* Used leater to define NUMBER */
+#line 529 "wp_parser.lex.c"
 
 #define INITIAL 0
 
@@ -563,36 +541,36 @@ char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -600,32 +578,31 @@ void yyset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -645,7 +622,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -656,7 +633,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -669,7 +646,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -758,17 +735,17 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 13 "wp_parser.l"
+#line 14 "wp_parser.l"
 
 
-#line 772 "wp_parser.lex.c"
+#line 749 "wp_parser.lex.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -795,13 +772,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 95 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+				if ( yy_current_state >= 98 )
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 149 );
+		while ( yy_base[yy_current_state] != 152 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -826,186 +803,192 @@ do_action:	/* This label is used only to access EOF actions. */
 			goto yy_find_action;
 
 case 1:
-#line 16 "wp_parser.l"
-case 2:
 #line 17 "wp_parser.l"
-case 3:
+case 2:
 #line 18 "wp_parser.l"
-case 4:
+case 3:
 #line 19 "wp_parser.l"
-case 5:
+case 4:
 #line 20 "wp_parser.l"
-case 6:
+case 5:
 #line 21 "wp_parser.l"
-case 7:
+case 6:
 #line 22 "wp_parser.l"
-case 8:
+case 7:
 #line 23 "wp_parser.l"
-case 9:
+case 8:
 #line 24 "wp_parser.l"
+case 9:
+#line 25 "wp_parser.l"
 case 10:
-#line 25 "wp_parser.l"
+#line 26 "wp_parser.l"
 case 11:
+#line 27 "wp_parser.l"
+case 12:
+#line 28 "wp_parser.l"
+case 13:
+#line 29 "wp_parser.l"
+case 14:
 YY_RULE_SETUP
-#line 25 "wp_parser.l"
+#line 29 "wp_parser.l"
 { return yytext[0]; } /* simply pass through */
 	YY_BREAK
 /* yylval is union type defined in wp_parser.tab.h that is generated
   * by bison with wp_parser.y */
-case 12:
-YY_RULE_SETUP
-#line 30 "wp_parser.l"
-{ yylval.f1 = WP_SQRT;      return F1; }
-	YY_BREAK
-case 13:
-YY_RULE_SETUP
-#line 31 "wp_parser.l"
-{ yylval.f1 = WP_EXP;       return F1; }
-	YY_BREAK
-case 14:
-YY_RULE_SETUP
-#line 32 "wp_parser.l"
-{ yylval.f1 = WP_LOG;       return F1; }
-	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 33 "wp_parser.l"
-{ yylval.f1 = WP_LOG10;     return F1; }
+#line 34 "wp_parser.l"
+{ yylval.f1 = WP_SQRT;      return F1; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 34 "wp_parser.l"
-{ yylval.f1 = WP_SIN;       return F1; }
+#line 35 "wp_parser.l"
+{ yylval.f1 = WP_EXP;       return F1; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 35 "wp_parser.l"
-{ yylval.f1 = WP_COS;       return F1; }
+#line 36 "wp_parser.l"
+{ yylval.f1 = WP_LOG;       return F1; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 36 "wp_parser.l"
-{ yylval.f1 = WP_TAN;       return F1; }
+#line 37 "wp_parser.l"
+{ yylval.f1 = WP_LOG10;     return F1; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 37 "wp_parser.l"
-{ yylval.f1 = WP_ASIN;      return F1; }
+#line 38 "wp_parser.l"
+{ yylval.f1 = WP_SIN;       return F1; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 38 "wp_parser.l"
-{ yylval.f1 = WP_ACOS;      return F1; }
+#line 39 "wp_parser.l"
+{ yylval.f1 = WP_COS;       return F1; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 39 "wp_parser.l"
-{ yylval.f1 = WP_ATAN;      return F1; }
+#line 40 "wp_parser.l"
+{ yylval.f1 = WP_TAN;       return F1; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 40 "wp_parser.l"
-{ yylval.f1 = WP_SINH;      return F1; }
+#line 41 "wp_parser.l"
+{ yylval.f1 = WP_ASIN;      return F1; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 41 "wp_parser.l"
-{ yylval.f1 = WP_COSH;      return F1; }
+#line 42 "wp_parser.l"
+{ yylval.f1 = WP_ACOS;      return F1; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 42 "wp_parser.l"
-{ yylval.f1 = WP_TANH;      return F1; }
+#line 43 "wp_parser.l"
+{ yylval.f1 = WP_ATAN;      return F1; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 43 "wp_parser.l"
-{ yylval.f1 = WP_ABS;       return F1; }
+#line 44 "wp_parser.l"
+{ yylval.f1 = WP_SINH;      return F1; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 44 "wp_parser.l"
-{ yylval.f1 = WP_ABS;       return F1; }
+#line 45 "wp_parser.l"
+{ yylval.f1 = WP_COSH;      return F1; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 45 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return POW;}
+#line 46 "wp_parser.l"
+{ yylval.f1 = WP_TANH;      return F1; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 46 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return POW;}
+#line 47 "wp_parser.l"
+{ yylval.f1 = WP_ABS;       return F1; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 47 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return F2; }
+#line 48 "wp_parser.l"
+{ yylval.f1 = WP_ABS;       return F1; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 48 "wp_parser.l"
-{ yylval.f2 = WP_HEAVISIDE; return F2; }
+#line 49 "wp_parser.l"
+{ yylval.f2 = WP_POW;       return POW;}
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 49 "wp_parser.l"
-{ yylval.f2 = WP_MIN;       return F2; }
+#line 50 "wp_parser.l"
+{ yylval.f2 = WP_POW;       return POW;}
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 50 "wp_parser.l"
+#line 51 "wp_parser.l"
+{ yylval.f2 = WP_POW;       return F2; }
+	YY_BREAK
+case 33:
+YY_RULE_SETUP
+#line 52 "wp_parser.l"
+{ yylval.f2 = WP_HEAVISIDE; return F2; }
+	YY_BREAK
+case 34:
+YY_RULE_SETUP
+#line 53 "wp_parser.l"
+{ yylval.f2 = WP_MIN;       return F2; }
+	YY_BREAK
+case 35:
+YY_RULE_SETUP
+#line 54 "wp_parser.l"
 { yylval.f2 = WP_MAX;       return F2; }
 	YY_BREAK
 /* We use SYMBOL to hold variables and constants */
-case 33:
+case 36:
 YY_RULE_SETUP
-#line 53 "wp_parser.l"
+#line 57 "wp_parser.l"
 { yylval.s = wp_makesymbol(yytext); return SYMBOL; }
 	YY_BREAK
 /* Number */
-case 34:
-#line 57 "wp_parser.l"
-case 35:
+case 37:
+#line 61 "wp_parser.l"
+case 38:
 YY_RULE_SETUP
-#line 57 "wp_parser.l"
+#line 61 "wp_parser.l"
 { yylval.d = atof(yytext);   return NUMBER; }
 	YY_BREAK
 /* Special characters */
-case 36:
+case 39:
 YY_RULE_SETUP
-#line 60 "wp_parser.l"
+#line 64 "wp_parser.l"
 
 	YY_BREAK
-case 37:
+case 40:
 YY_RULE_SETUP
-#line 61 "wp_parser.l"
-/* ignore white space */ 
+#line 65 "wp_parser.l"
+/* ignore white space */
 	YY_BREAK
-case 38:
-/* rule 38 can match eol */
+case 41:
+/* rule 41 can match eol */
 YY_RULE_SETUP
-#line 62 "wp_parser.l"
+#line 66 "wp_parser.l"
 /* ignore line continuation */
 	YY_BREAK
-case 39:
-/* rule 39 can match eol */
+case 42:
+/* rule 42 can match eol */
 YY_RULE_SETUP
-#line 63 "wp_parser.l"
+#line 67 "wp_parser.l"
 { return EOL; }
 	YY_BREAK
 /* everything else */
-case 40:
+case 43:
 YY_RULE_SETUP
-#line 66 "wp_parser.l"
+#line 70 "wp_parser.l"
 { yyerror("Unknow character %c\n", *yytext); }
 	YY_BREAK
-case 41:
+case 44:
 YY_RULE_SETUP
-#line 68 "wp_parser.l"
+#line 72 "wp_parser.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1009 "wp_parser.lex.c"
+#line 992 "wp_parser.lex.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1083,7 +1066,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1150,7 +1133,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1179,7 +1162,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1192,7 +1175,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1206,7 +1189,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1215,11 +1198,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1247,7 +1231,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1261,12 +1245,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1298,10 +1285,10 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 95 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+			if ( yy_current_state >= 98 )
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1326,11 +1313,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 95 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+		if ( yy_current_state >= 98 )
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
-	yy_is_jam = (yy_current_state == 94);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_is_jam = (yy_current_state == 97);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1349,7 +1336,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -1361,7 +1348,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1400,7 +1387,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1417,14 +1404,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1461,11 +1448,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1493,7 +1480,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1521,22 +1508,22 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1555,9 +1542,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -1569,7 +1556,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1612,7 +1599,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1643,7 +1630,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1662,7 +1649,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1680,15 +1667,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1717,7 +1704,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1727,23 +1714,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1756,10 +1743,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -1769,16 +1756,16 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1787,7 +1774,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1803,9 +1790,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1833,7 +1820,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1856,7 +1843,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -1912,10 +1899,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -1924,8 +1911,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -1940,7 +1927,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -1961,7 +1948,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -1971,7 +1958,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -1983,7 +1970,7 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
@@ -1996,7 +1983,7 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
@@ -2006,7 +1993,6 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 68 "wp_parser.l"
-
+#line 72 "wp_parser.l"
 
 

--- a/Source/Parser/wp_parser.lex.c
+++ b/Source/Parser/wp_parser.lex.c
@@ -366,16 +366,16 @@ struct yy_trans_info
 	};
 static const flex_int16_t yy_accept[97] =
     {   0,
-        0,    0,   44,   42,   39,   41,   12,   13,    3,    1,
+        0,    0,   44,   42,   39,   41,   10,   11,    3,    1,
         7,    2,   42,    4,   37,    8,    5,    9,   35,   42,
-       30,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,    6,   29,   37,   38,   36,   37,    0,   10,   11,
+       28,   35,   35,   35,   35,   35,   35,   35,   35,   35,
+       35,    6,   27,   37,   38,   36,   37,    0,   30,   29,
        35,   40,   35,   35,   35,   35,   35,   35,   35,   35,
        35,   35,   35,   35,   35,   35,   35,   38,   36,    0,
-        0,   37,   27,   35,   35,   35,   19,   15,   35,   35,
-       16,   34,   33,   31,   18,   35,   20,    0,   36,   22,
-       21,   23,   25,   28,   35,   35,   24,   14,   26,   35,
-       17,   35,   35,   35,   32,    0
+        0,   37,   25,   35,   35,   35,   17,   13,   35,   35,
+       14,   34,   33,   31,   16,   35,   18,    0,   36,   20,
+       19,   21,   23,   26,   35,   35,   22,   12,   24,   35,
+       15,   35,   35,   35,   32,    0
 
     } ;
 
@@ -823,100 +823,106 @@ case 9:
 case 10:
 #line 26 "wp_parser.l"
 case 11:
-#line 27 "wp_parser.l"
-case 12:
-#line 28 "wp_parser.l"
-case 13:
 YY_RULE_SETUP
-#line 28 "wp_parser.l"
+#line 26 "wp_parser.l"
 { return yytext[0]; } /* simply pass through */
 	YY_BREAK
 /* yylval is union type defined in wp_parser.tab.h that is generated
   * by bison with wp_parser.y */
+case 12:
+YY_RULE_SETUP
+#line 31 "wp_parser.l"
+{ yylval.f1 = WP_SQRT;      return F1; }
+	YY_BREAK
+case 13:
+YY_RULE_SETUP
+#line 32 "wp_parser.l"
+{ yylval.f1 = WP_EXP;       return F1; }
+	YY_BREAK
 case 14:
 YY_RULE_SETUP
 #line 33 "wp_parser.l"
-{ yylval.f1 = WP_SQRT;      return F1; }
+{ yylval.f1 = WP_LOG;       return F1; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
 #line 34 "wp_parser.l"
-{ yylval.f1 = WP_EXP;       return F1; }
+{ yylval.f1 = WP_LOG10;     return F1; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
 #line 35 "wp_parser.l"
-{ yylval.f1 = WP_LOG;       return F1; }
+{ yylval.f1 = WP_SIN;       return F1; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
 #line 36 "wp_parser.l"
-{ yylval.f1 = WP_LOG10;     return F1; }
+{ yylval.f1 = WP_COS;       return F1; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
 #line 37 "wp_parser.l"
-{ yylval.f1 = WP_SIN;       return F1; }
+{ yylval.f1 = WP_TAN;       return F1; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
 #line 38 "wp_parser.l"
-{ yylval.f1 = WP_COS;       return F1; }
+{ yylval.f1 = WP_ASIN;      return F1; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
 #line 39 "wp_parser.l"
-{ yylval.f1 = WP_TAN;       return F1; }
+{ yylval.f1 = WP_ACOS;      return F1; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
 #line 40 "wp_parser.l"
-{ yylval.f1 = WP_ASIN;      return F1; }
+{ yylval.f1 = WP_ATAN;      return F1; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
 #line 41 "wp_parser.l"
-{ yylval.f1 = WP_ACOS;      return F1; }
+{ yylval.f1 = WP_SINH;      return F1; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
 #line 42 "wp_parser.l"
-{ yylval.f1 = WP_ATAN;      return F1; }
+{ yylval.f1 = WP_COSH;      return F1; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
 #line 43 "wp_parser.l"
-{ yylval.f1 = WP_SINH;      return F1; }
+{ yylval.f1 = WP_TANH;      return F1; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
 #line 44 "wp_parser.l"
-{ yylval.f1 = WP_COSH;      return F1; }
+{ yylval.f1 = WP_ABS;       return F1; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
 #line 45 "wp_parser.l"
-{ yylval.f1 = WP_TANH;      return F1; }
+{ yylval.f1 = WP_ABS;       return F1; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
 #line 46 "wp_parser.l"
-{ yylval.f1 = WP_ABS;       return F1; }
+{ yylval.f2 = WP_POW;       return POW;}
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
 #line 47 "wp_parser.l"
-{ yylval.f1 = WP_ABS;       return F1; }
+{ yylval.f2 = WP_POW;       return POW;}
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
 #line 48 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return POW;}
+{ yylval.f2 = WP_GEQ;       return GEQ;}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
 #line 49 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return POW;}
+{ yylval.f2 = WP_LEQ;       return LEQ;}
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
@@ -986,7 +992,7 @@ YY_RULE_SETUP
 #line 71 "wp_parser.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 990 "wp_parser.lex.c"
+#line 996 "wp_parser.lex.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 

--- a/Source/Parser/wp_parser.lex.c
+++ b/Source/Parser/wp_parser.lex.c
@@ -355,8 +355,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 44
-#define YY_END_OF_BUFFER 45
+#define YY_NUM_RULES 43
+#define YY_END_OF_BUFFER 44
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -364,18 +364,18 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[98] =
+static const flex_int16_t yy_accept[97] =
     {   0,
-        0,    0,   45,   43,   40,   42,   13,   14,    3,    1,
-        7,    2,   43,    4,   38,    8,    5,    9,   36,   43,
-       31,   36,   36,   36,   36,   36,   36,   36,   36,   36,
-       36,    6,   30,   38,   39,   37,   38,    0,   10,   12,
-       11,   36,   41,   36,   36,   36,   36,   36,   36,   36,
-       36,   36,   36,   36,   36,   36,   36,   36,   39,   37,
-        0,    0,   38,   28,   36,   36,   36,   20,   16,   36,
-       36,   17,   35,   34,   32,   19,   36,   21,    0,   37,
-       23,   22,   24,   26,   29,   36,   36,   25,   15,   27,
-       36,   18,   36,   36,   36,   33,    0
+        0,    0,   44,   42,   39,   41,   12,   13,    3,    1,
+        7,    2,   42,    4,   37,    8,    5,    9,   35,   42,
+       30,   35,   35,   35,   35,   35,   35,   35,   35,   35,
+       35,    6,   29,   37,   38,   36,   37,    0,   10,   11,
+       35,   40,   35,   35,   35,   35,   35,   35,   35,   35,
+       35,   35,   35,   35,   35,   35,   35,   38,   36,    0,
+        0,   37,   27,   35,   35,   35,   19,   15,   35,   35,
+       16,   34,   33,   31,   18,   35,   20,    0,   36,   22,
+       21,   23,   25,   28,   35,   35,   24,   14,   26,   35,
+       17,   35,   35,   35,   32,    0
 
     } ;
 
@@ -420,85 +420,85 @@ static const YY_CHAR yy_meta[44] =
         3,    3,    1
     } ;
 
-static const flex_int16_t yy_base[100] =
+static const flex_int16_t yy_base[99] =
     {   0,
-        0,    0,  151,  152,  152,  152,  152,  152,  144,  152,
-      152,  152,   32,  138,   37,  132,  131,  130,    0,  142,
-      152,   29,  110,  101,  120,  115,  106,   32,  105,   25,
-      116,  152,  152,   45,    0,   60,   68,   76,  152,  152,
-      152,    0,  152,   99,  102,  105,  112,   95,   97,  108,
-      108,  101,   86,   94,   85,   92,   87,   90,    0,   79,
-       88,   63,   94,    0,   84,   88,   87,   90,    0,   80,
-       76,   91,    0,    0,    0,   74,   60,   67,   97,  100,
-        0,    0,    0,    0,    0,   54,   58,    0,    0,    0,
-       31,    0,   36,   40,   34,    0,  152,   45,  114
+        0,    0,  150,  151,  151,  151,  151,  151,  143,  151,
+      151,  151,   32,  137,   37,  131,  151,  130,    0,  142,
+      151,   29,  110,  101,  120,  115,  106,   32,  105,   25,
+      116,  151,  151,   45,    0,   60,   68,   76,  151,  151,
+        0,  151,   99,  102,  105,  112,   95,   97,  108,  108,
+      101,   86,   94,   85,   92,   87,   90,    0,   79,   88,
+       63,   94,    0,   84,   88,   87,   90,    0,   80,   76,
+       91,    0,    0,    0,   74,   60,   67,   97,  100,    0,
+        0,    0,    0,    0,   54,   58,    0,    0,    0,   31,
+        0,   36,   40,   34,    0,  151,   45,  114
 
     } ;
 
-static const flex_int16_t yy_def[100] =
+static const flex_int16_t yy_def[99] =
     {   0,
-       97,    1,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   98,   97,
-       97,   98,   98,   98,   98,   98,   98,   98,   98,   98,
-       98,   97,   97,   97,   99,   97,   97,   97,   97,   97,
-       97,   98,   97,   98,   98,   98,   98,   98,   98,   98,
-       98,   98,   98,   98,   98,   98,   98,   98,   99,   97,
-       97,   97,   97,   98,   98,   98,   98,   98,   98,   98,
-       98,   98,   98,   98,   98,   98,   98,   98,   97,   97,
-       98,   98,   98,   98,   98,   98,   98,   98,   98,   98,
-       98,   98,   98,   98,   98,   98,    0,   97,   97
+       96,    1,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   97,   96,
+       96,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   96,   96,   96,   98,   96,   96,   96,   96,   96,
+       97,   96,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   98,   96,   96,
+       96,   96,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,   97,   97,   96,   96,   97,
+       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,   97,   97,    0,   96,   96
 
     } ;
 
-static const flex_int16_t yy_nxt[196] =
+static const flex_int16_t yy_nxt[195] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   15,   15,   16,   17,   18,   19,   19,   20,
        21,   22,   19,   23,   19,   24,   25,   19,   26,   19,
        27,   28,   19,   19,   29,   19,   19,   30,   31,   19,
-       19,   19,   32,   34,   34,   34,   36,   42,   37,   37,
-       37,   44,   45,   53,   56,   38,   34,   34,   34,   96,
-       57,   54,   38,   38,   95,   94,   46,   47,   93,   92,
-       38,   60,   60,   60,   63,   63,   63,   36,   61,   37,
-       37,   37,   62,   91,   62,   61,   38,   63,   63,   63,
-       60,   60,   60,   38,   79,   90,   79,   61,   89,   80,
+       19,   19,   32,   34,   34,   34,   36,   41,   37,   37,
+       37,   43,   44,   52,   55,   38,   34,   34,   34,   95,
+       56,   53,   38,   38,   94,   93,   45,   46,   92,   91,
+       38,   59,   59,   59,   62,   62,   62,   36,   60,   37,
+       37,   37,   61,   90,   61,   60,   38,   62,   62,   62,
+       59,   59,   59,   38,   78,   89,   78,   60,   88,   79,
 
-       80,   80,   88,   87,   61,   63,   63,   63,   80,   80,
-       80,   80,   80,   80,   59,   86,   59,   85,   84,   83,
-       82,   81,   78,   77,   76,   75,   74,   73,   72,   71,
-       70,   69,   68,   67,   66,   65,   64,   58,   55,   52,
-       51,   50,   49,   48,   43,   41,   40,   39,   35,   33,
-       97,    3,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97
+       79,   79,   87,   86,   60,   62,   62,   62,   79,   79,
+       79,   79,   79,   79,   58,   85,   58,   84,   83,   82,
+       81,   80,   77,   76,   75,   74,   73,   72,   71,   70,
+       69,   68,   67,   66,   65,   64,   63,   57,   54,   51,
+       50,   49,   48,   47,   42,   40,   39,   35,   33,   96,
+        3,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96
 
     } ;
 
-static const flex_int16_t yy_chk[196] =
+static const flex_int16_t yy_chk[195] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,   13,   13,   13,   15,   98,   15,   15,
-       15,   22,   22,   28,   30,   15,   34,   34,   34,   95,
-       30,   28,   15,   34,   94,   93,   22,   22,   91,   87,
-       34,   36,   36,   36,   62,   62,   62,   37,   36,   37,
-       37,   37,   38,   86,   38,   36,   37,   38,   38,   38,
-       60,   60,   60,   37,   61,   78,   61,   60,   77,   61,
+        1,    1,    1,   13,   13,   13,   15,   97,   15,   15,
+       15,   22,   22,   28,   30,   15,   34,   34,   34,   94,
+       30,   28,   15,   34,   93,   92,   22,   22,   90,   86,
+       34,   36,   36,   36,   61,   61,   61,   37,   36,   37,
+       37,   37,   38,   85,   38,   36,   37,   38,   38,   38,
+       59,   59,   59,   37,   60,   77,   60,   59,   76,   60,
 
-       61,   61,   76,   72,   60,   63,   63,   63,   79,   79,
-       79,   80,   80,   80,   99,   71,   99,   70,   68,   67,
-       66,   65,   58,   57,   56,   55,   54,   53,   52,   51,
-       50,   49,   48,   47,   46,   45,   44,   31,   29,   27,
-       26,   25,   24,   23,   20,   18,   17,   16,   14,    9,
-        3,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97
+       60,   60,   75,   71,   59,   62,   62,   62,   78,   78,
+       78,   79,   79,   79,   98,   70,   98,   69,   67,   66,
+       65,   64,   57,   56,   55,   54,   53,   52,   51,   50,
+       49,   48,   47,   46,   45,   44,   43,   31,   29,   27,
+       26,   25,   24,   23,   20,   18,   16,   14,    9,    3,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   96,   96
 
     } ;
 
@@ -772,13 +772,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 98 )
+				if ( yy_current_state >= 97 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 152 );
+		while ( yy_base[yy_current_state] != 151 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -827,78 +827,81 @@ case 11:
 case 12:
 #line 28 "wp_parser.l"
 case 13:
-#line 29 "wp_parser.l"
-case 14:
 YY_RULE_SETUP
-#line 29 "wp_parser.l"
+#line 28 "wp_parser.l"
 { return yytext[0]; } /* simply pass through */
 	YY_BREAK
 /* yylval is union type defined in wp_parser.tab.h that is generated
   * by bison with wp_parser.y */
+case 14:
+YY_RULE_SETUP
+#line 33 "wp_parser.l"
+{ yylval.f1 = WP_SQRT;      return F1; }
+	YY_BREAK
 case 15:
 YY_RULE_SETUP
 #line 34 "wp_parser.l"
-{ yylval.f1 = WP_SQRT;      return F1; }
+{ yylval.f1 = WP_EXP;       return F1; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
 #line 35 "wp_parser.l"
-{ yylval.f1 = WP_EXP;       return F1; }
+{ yylval.f1 = WP_LOG;       return F1; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
 #line 36 "wp_parser.l"
-{ yylval.f1 = WP_LOG;       return F1; }
+{ yylval.f1 = WP_LOG10;     return F1; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
 #line 37 "wp_parser.l"
-{ yylval.f1 = WP_LOG10;     return F1; }
+{ yylval.f1 = WP_SIN;       return F1; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
 #line 38 "wp_parser.l"
-{ yylval.f1 = WP_SIN;       return F1; }
+{ yylval.f1 = WP_COS;       return F1; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
 #line 39 "wp_parser.l"
-{ yylval.f1 = WP_COS;       return F1; }
+{ yylval.f1 = WP_TAN;       return F1; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
 #line 40 "wp_parser.l"
-{ yylval.f1 = WP_TAN;       return F1; }
+{ yylval.f1 = WP_ASIN;      return F1; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
 #line 41 "wp_parser.l"
-{ yylval.f1 = WP_ASIN;      return F1; }
+{ yylval.f1 = WP_ACOS;      return F1; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
 #line 42 "wp_parser.l"
-{ yylval.f1 = WP_ACOS;      return F1; }
+{ yylval.f1 = WP_ATAN;      return F1; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
 #line 43 "wp_parser.l"
-{ yylval.f1 = WP_ATAN;      return F1; }
+{ yylval.f1 = WP_SINH;      return F1; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
 #line 44 "wp_parser.l"
-{ yylval.f1 = WP_SINH;      return F1; }
+{ yylval.f1 = WP_COSH;      return F1; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
 #line 45 "wp_parser.l"
-{ yylval.f1 = WP_COSH;      return F1; }
+{ yylval.f1 = WP_TANH;      return F1; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
 #line 46 "wp_parser.l"
-{ yylval.f1 = WP_TANH;      return F1; }
+{ yylval.f1 = WP_ABS;       return F1; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
@@ -908,7 +911,7 @@ YY_RULE_SETUP
 case 29:
 YY_RULE_SETUP
 #line 48 "wp_parser.l"
-{ yylval.f1 = WP_ABS;       return F1; }
+{ yylval.f2 = WP_POW;       return POW;}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
@@ -918,77 +921,72 @@ YY_RULE_SETUP
 case 31:
 YY_RULE_SETUP
 #line 50 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return POW;}
+{ yylval.f2 = WP_POW;       return F2; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
 #line 51 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return F2; }
+{ yylval.f2 = WP_HEAVISIDE; return F2; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
 #line 52 "wp_parser.l"
-{ yylval.f2 = WP_HEAVISIDE; return F2; }
+{ yylval.f2 = WP_MIN;       return F2; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
 #line 53 "wp_parser.l"
-{ yylval.f2 = WP_MIN;       return F2; }
-	YY_BREAK
-case 35:
-YY_RULE_SETUP
-#line 54 "wp_parser.l"
 { yylval.f2 = WP_MAX;       return F2; }
 	YY_BREAK
 /* We use SYMBOL to hold variables and constants */
-case 36:
+case 35:
 YY_RULE_SETUP
-#line 57 "wp_parser.l"
+#line 56 "wp_parser.l"
 { yylval.s = wp_makesymbol(yytext); return SYMBOL; }
 	YY_BREAK
 /* Number */
+case 36:
+#line 60 "wp_parser.l"
 case 37:
-#line 61 "wp_parser.l"
-case 38:
 YY_RULE_SETUP
-#line 61 "wp_parser.l"
+#line 60 "wp_parser.l"
 { yylval.d = atof(yytext);   return NUMBER; }
 	YY_BREAK
 /* Special characters */
+case 38:
+YY_RULE_SETUP
+#line 63 "wp_parser.l"
+
+	YY_BREAK
 case 39:
 YY_RULE_SETUP
 #line 64 "wp_parser.l"
-
+/* ignore white space */
 	YY_BREAK
 case 40:
+/* rule 40 can match eol */
 YY_RULE_SETUP
 #line 65 "wp_parser.l"
-/* ignore white space */
+/* ignore line continuation */
 	YY_BREAK
 case 41:
 /* rule 41 can match eol */
 YY_RULE_SETUP
 #line 66 "wp_parser.l"
-/* ignore line continuation */
-	YY_BREAK
-case 42:
-/* rule 42 can match eol */
-YY_RULE_SETUP
-#line 67 "wp_parser.l"
 { return EOL; }
 	YY_BREAK
 /* everything else */
-case 43:
+case 42:
 YY_RULE_SETUP
-#line 70 "wp_parser.l"
+#line 69 "wp_parser.l"
 { yyerror("Unknow character %c\n", *yytext); }
 	YY_BREAK
-case 44:
+case 43:
 YY_RULE_SETUP
-#line 72 "wp_parser.l"
+#line 71 "wp_parser.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 992 "wp_parser.lex.c"
+#line 990 "wp_parser.lex.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1285,7 +1283,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 98 )
+			if ( yy_current_state >= 97 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1313,11 +1311,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 98 )
+		if ( yy_current_state >= 97 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 97);
+	yy_is_jam = (yy_current_state == 96);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1993,6 +1991,6 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 72 "wp_parser.l"
+#line 71 "wp_parser.l"
 
 

--- a/Source/Parser/wp_parser.lex.c
+++ b/Source/Parser/wp_parser.lex.c
@@ -355,8 +355,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 43
-#define YY_END_OF_BUFFER 44
+#define YY_NUM_RULES 47
+#define YY_END_OF_BUFFER 48
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -364,19 +364,20 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[97] =
+static const flex_int16_t yy_accept[104] =
     {   0,
-        0,    0,   44,   42,   39,   41,   10,   11,    3,    1,
-        7,    2,   42,    4,   37,    8,    5,    9,   35,   42,
-       28,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,    6,   27,   37,   38,   36,   37,    0,   30,   29,
-       35,   40,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   38,   36,    0,
-        0,   37,   25,   35,   35,   35,   17,   13,   35,   35,
-       14,   34,   33,   31,   16,   35,   18,    0,   36,   20,
-       19,   21,   23,   26,   35,   35,   22,   12,   24,   35,
-       15,   35,   35,   35,   32,    0
+        0,    0,   48,   46,   43,   45,   46,   10,   11,    3,
+        1,    7,    2,   46,    4,   41,    8,    5,    9,   39,
+       46,   28,   39,   39,   39,   39,   39,   39,   39,   39,
+       39,   39,   39,    6,   32,   27,   41,   42,   40,   41,
+        0,   30,   31,   29,   39,   44,   39,   39,   39,   39,
+       39,   39,   39,   39,   39,   39,   39,   39,   34,   39,
+       39,   39,   39,   42,   40,    0,    0,   41,   25,   39,
+       33,   39,   39,   17,   13,   39,   39,   14,   38,   37,
+       35,   16,   39,   18,    0,   40,   20,   19,   21,   23,
+       26,   39,   39,   22,   12,   24,   39,   15,   39,   39,
 
+       39,   36,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -384,17 +385,17 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    2,    1,    1,    1,    1,    1,    1,    1,    4,
-        5,    6,    7,    8,    9,   10,   11,   12,   13,   14,
-       14,   14,   14,   14,   14,   14,   14,    1,    1,   15,
-       16,   17,    1,    1,   18,   18,   18,   18,   19,   18,
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-        1,   20,    1,   21,   18,    1,   22,   23,   24,   25,
+        1,    2,    4,    1,    1,    1,    1,    1,    1,    5,
+        6,    7,    8,    9,   10,   11,   12,   13,   14,   15,
+       15,   15,   15,   15,   15,   15,   15,    1,    1,   16,
+       17,   18,    1,    1,   19,   19,   19,   19,   20,   19,
+       19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
+       19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
+        1,   21,    1,   22,   19,    1,   23,   24,   25,   26,
 
-       26,   27,   28,   29,   30,   18,   18,   31,   32,   33,
-       34,   35,   36,   37,   38,   39,   18,   40,   41,   42,
-       18,   18,    1,   43,    1,    1,    1,    1,    1,    1,
+       27,   28,   29,   30,   31,   19,   19,   32,   33,   34,
+       35,   36,   37,   38,   39,   40,   19,   41,   42,   43,
+       19,   19,    1,   44,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -411,95 +412,99 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[44] =
+static const YY_CHAR yy_meta[45] =
     {   0,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
-        1,    3,    3,    3,    1,    1,    1,    3,    3,    1,
-        1,    3,    3,    3,    3,    3,    3,    3,    3,    3,
+        1,    1,    3,    3,    3,    1,    1,    1,    3,    3,
+        1,    1,    3,    3,    3,    3,    3,    3,    3,    3,
         3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        3,    3,    1
+        3,    3,    3,    1
     } ;
 
-static const flex_int16_t yy_base[99] =
+static const flex_int16_t yy_base[106] =
     {   0,
-        0,    0,  150,  151,  151,  151,  151,  151,  143,  151,
-      151,  151,   32,  137,   37,  131,  151,  130,    0,  142,
-      151,   29,  110,  101,  120,  115,  106,   32,  105,   25,
-      116,  151,  151,   45,    0,   60,   68,   76,  151,  151,
-        0,  151,   99,  102,  105,  112,   95,   97,  108,  108,
-      101,   86,   94,   85,   92,   87,   90,    0,   79,   88,
-       63,   94,    0,   84,   88,   87,   90,    0,   80,   76,
-       91,    0,    0,    0,   74,   60,   67,   97,  100,    0,
-        0,    0,    0,    0,   54,   58,    0,    0,    0,   31,
-        0,   36,   40,   34,    0,  151,   45,  114
+        0,    0,  156,  157,  157,  157,  138,  157,  157,  147,
+      157,  157,  157,   32,  141,   37,  135,  134,  133,    0,
+      146,  157,   29,  113,  104,  123,  118,  109,   35,  105,
+      107,   18,  118,  157,  157,  157,   47,    0,   57,   65,
+       73,  157,  157,  157,    0,  157,  101,  104,  112,  106,
+      113,   96,   98,  109,  109,  102,   87,   95,    0,   86,
+       93,   88,   91,    0,   76,   85,   91,   94,    0,   85,
+        0,   89,   88,   91,    0,   81,   78,  103,    0,    0,
+        0,   72,   61,   67,   97,  100,    0,    0,    0,    0,
+        0,   63,   69,    0,    0,    0,   36,    0,   42,   39,
 
+       32,    0,  157,   53,  115
     } ;
 
-static const flex_int16_t yy_def[99] =
+static const flex_int16_t yy_def[106] =
     {   0,
-       96,    1,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   97,   96,
-       96,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   96,   96,   96,   98,   96,   96,   96,   96,   96,
-       97,   96,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   98,   96,   96,
-       96,   96,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,   97,   97,   96,   96,   97,
-       97,   97,   97,   97,   97,   97,   97,   97,   97,   97,
-       97,   97,   97,   97,   97,    0,   96,   96
+      103,    1,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  104,
+      103,  103,  104,  104,  104,  104,  104,  104,  104,  104,
+      104,  104,  104,  103,  103,  103,  103,  105,  103,  103,
+      103,  103,  103,  103,  104,  103,  104,  104,  104,  104,
+      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
+      104,  104,  104,  105,  103,  103,  103,  103,  104,  104,
+      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
+      104,  104,  104,  104,  103,  103,  104,  104,  104,  104,
+      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
 
+      104,  104,    0,  103,  103
     } ;
 
-static const flex_int16_t yy_nxt[195] =
+static const flex_int16_t yy_nxt[202] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
-       14,   15,   15,   15,   16,   17,   18,   19,   19,   20,
-       21,   22,   19,   23,   19,   24,   25,   19,   26,   19,
-       27,   28,   19,   19,   29,   19,   19,   30,   31,   19,
-       19,   19,   32,   34,   34,   34,   36,   41,   37,   37,
-       37,   43,   44,   52,   55,   38,   34,   34,   34,   95,
-       56,   53,   38,   38,   94,   93,   45,   46,   92,   91,
-       38,   59,   59,   59,   62,   62,   62,   36,   60,   37,
-       37,   37,   61,   90,   61,   60,   38,   62,   62,   62,
-       59,   59,   59,   38,   78,   89,   78,   60,   88,   79,
+       14,   15,   16,   16,   16,   17,   18,   19,   20,   20,
+       21,   22,   23,   20,   24,   20,   25,   26,   20,   27,
+       20,   28,   29,   20,   30,   31,   20,   20,   32,   33,
+       20,   20,   20,   34,   37,   37,   37,   39,   61,   40,
+       40,   40,   47,   48,   62,   45,   41,   57,  102,   37,
+       37,   37,   49,   41,  101,   58,   41,   50,   51,   65,
+       65,   65,  100,   41,   99,   39,   66,   40,   40,   40,
+       67,   98,   67,   66,   41,   68,   68,   68,   65,   65,
+       65,   41,   85,   97,   85,   66,   96,   86,   86,   86,
 
-       79,   79,   87,   86,   60,   62,   62,   62,   79,   79,
-       79,   79,   79,   79,   58,   85,   58,   84,   83,   82,
-       81,   80,   77,   76,   75,   74,   73,   72,   71,   70,
-       69,   68,   67,   66,   65,   64,   63,   57,   54,   51,
-       50,   49,   48,   47,   42,   40,   39,   35,   33,   96,
-        3,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96
+       95,   94,   66,   68,   68,   68,   68,   68,   68,   86,
+       86,   86,   86,   86,   86,   64,   93,   64,   92,   91,
+       90,   89,   88,   87,   84,   83,   82,   81,   80,   79,
+       78,   77,   76,   75,   74,   73,   72,   71,   70,   69,
+       63,   60,   59,   56,   55,   54,   53,   52,   46,   44,
+       43,   42,   38,   36,   35,  103,    3,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
 
+      103
     } ;
 
-static const flex_int16_t yy_chk[195] =
+static const flex_int16_t yy_chk[202] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,   13,   13,   13,   15,   97,   15,   15,
-       15,   22,   22,   28,   30,   15,   34,   34,   34,   94,
-       30,   28,   15,   34,   93,   92,   22,   22,   90,   86,
-       34,   36,   36,   36,   61,   61,   61,   37,   36,   37,
-       37,   37,   38,   85,   38,   36,   37,   38,   38,   38,
-       59,   59,   59,   37,   60,   77,   60,   59,   76,   60,
+        1,    1,    1,    1,   14,   14,   14,   16,   32,   16,
+       16,   16,   23,   23,   32,  104,   16,   29,  101,   37,
+       37,   37,   23,   16,  100,   29,   37,   23,   23,   39,
+       39,   39,   99,   37,   97,   40,   39,   40,   40,   40,
+       41,   93,   41,   39,   40,   41,   41,   41,   65,   65,
+       65,   40,   66,   92,   66,   65,   84,   66,   66,   66,
 
-       60,   60,   75,   71,   59,   62,   62,   62,   78,   78,
-       78,   79,   79,   79,   98,   70,   98,   69,   67,   66,
-       65,   64,   57,   56,   55,   54,   53,   52,   51,   50,
-       49,   48,   47,   46,   45,   44,   43,   31,   29,   27,
-       26,   25,   24,   23,   20,   18,   16,   14,    9,    3,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   96,   96,   96
+       83,   82,   65,   67,   67,   67,   68,   68,   68,   85,
+       85,   85,   86,   86,   86,  105,   78,  105,   77,   76,
+       74,   73,   72,   70,   63,   62,   61,   60,   58,   57,
+       56,   55,   54,   53,   52,   51,   50,   49,   48,   47,
+       33,   31,   30,   28,   27,   26,   25,   24,   21,   19,
+       18,   17,   15,   10,    7,    3,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
 
+      103
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -520,12 +525,12 @@ char *yytext;
 #line 3 "wp_parser.l"
 #include "wp_parser_y.h"
 #include "wp_parser.tab.h"
-#line 524 "wp_parser.lex.c"
+#line 529 "wp_parser.lex.c"
 #line 8 "wp_parser.l"
  /* Tokens NUMBER, SYMBOL, F1, POW, F2, etc. are defined in wp_parser.y. */
  /* Types WP_SQRT, WP_SQRT, etc. are defined in wp_parser_y.h. */
  /* Used leater to define NUMBER */
-#line 529 "wp_parser.lex.c"
+#line 534 "wp_parser.lex.c"
 
 #define INITIAL 0
 
@@ -745,7 +750,7 @@ YY_DECL
 #line 14 "wp_parser.l"
 
 
-#line 749 "wp_parser.lex.c"
+#line 754 "wp_parser.lex.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -772,13 +777,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 97 )
+				if ( yy_current_state >= 104 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 151 );
+		while ( yy_base[yy_current_state] != 157 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -927,72 +932,92 @@ YY_RULE_SETUP
 case 31:
 YY_RULE_SETUP
 #line 50 "wp_parser.l"
-{ yylval.f2 = WP_POW;       return F2; }
+{ yylval.f2 = WP_EQ;        return EQ;}
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
 #line 51 "wp_parser.l"
-{ yylval.f2 = WP_HEAVISIDE; return F2; }
+{ yylval.f2 = WP_NEQ;       return NEQ;}
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
 #line 52 "wp_parser.l"
-{ yylval.f2 = WP_MIN;       return F2; }
+{ yylval.f2 = WP_AND;       return AND;}
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
 #line 53 "wp_parser.l"
+{ yylval.f2 = WP_OR;        return OR;}
+	YY_BREAK
+case 35:
+YY_RULE_SETUP
+#line 54 "wp_parser.l"
+{ yylval.f2 = WP_POW;       return F2; }
+	YY_BREAK
+case 36:
+YY_RULE_SETUP
+#line 55 "wp_parser.l"
+{ yylval.f2 = WP_HEAVISIDE; return F2; }
+	YY_BREAK
+case 37:
+YY_RULE_SETUP
+#line 56 "wp_parser.l"
+{ yylval.f2 = WP_MIN;       return F2; }
+	YY_BREAK
+case 38:
+YY_RULE_SETUP
+#line 57 "wp_parser.l"
 { yylval.f2 = WP_MAX;       return F2; }
 	YY_BREAK
 /* We use SYMBOL to hold variables and constants */
-case 35:
+case 39:
 YY_RULE_SETUP
-#line 56 "wp_parser.l"
+#line 60 "wp_parser.l"
 { yylval.s = wp_makesymbol(yytext); return SYMBOL; }
 	YY_BREAK
 /* Number */
-case 36:
-#line 60 "wp_parser.l"
-case 37:
+case 40:
+#line 64 "wp_parser.l"
+case 41:
 YY_RULE_SETUP
-#line 60 "wp_parser.l"
+#line 64 "wp_parser.l"
 { yylval.d = atof(yytext);   return NUMBER; }
 	YY_BREAK
 /* Special characters */
-case 38:
-YY_RULE_SETUP
-#line 63 "wp_parser.l"
-
-	YY_BREAK
-case 39:
-YY_RULE_SETUP
-#line 64 "wp_parser.l"
-/* ignore white space */
-	YY_BREAK
-case 40:
-/* rule 40 can match eol */
-YY_RULE_SETUP
-#line 65 "wp_parser.l"
-/* ignore line continuation */
-	YY_BREAK
-case 41:
-/* rule 41 can match eol */
-YY_RULE_SETUP
-#line 66 "wp_parser.l"
-{ return EOL; }
-	YY_BREAK
-/* everything else */
 case 42:
 YY_RULE_SETUP
-#line 69 "wp_parser.l"
-{ yyerror("Unknow character %c\n", *yytext); }
+#line 67 "wp_parser.l"
+
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 71 "wp_parser.l"
+#line 68 "wp_parser.l"
+/* ignore white space */
+	YY_BREAK
+case 44:
+/* rule 44 can match eol */
+YY_RULE_SETUP
+#line 69 "wp_parser.l"
+/* ignore line continuation */
+	YY_BREAK
+case 45:
+/* rule 45 can match eol */
+YY_RULE_SETUP
+#line 70 "wp_parser.l"
+{ return EOL; }
+	YY_BREAK
+/* everything else */
+case 46:
+YY_RULE_SETUP
+#line 73 "wp_parser.l"
+{ yyerror("Unknow character %c\n", *yytext); }
+	YY_BREAK
+case 47:
+YY_RULE_SETUP
+#line 75 "wp_parser.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 996 "wp_parser.lex.c"
+#line 1021 "wp_parser.lex.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1289,7 +1314,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 97 )
+			if ( yy_current_state >= 104 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1317,11 +1342,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 97 )
+		if ( yy_current_state >= 104 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 96);
+	yy_is_jam = (yy_current_state == 103);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1997,6 +2022,6 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 71 "wp_parser.l"
+#line 75 "wp_parser.l"
 
 

--- a/Source/Parser/wp_parser.lex.h
+++ b/Source/Parser/wp_parser.lex.h
@@ -13,7 +13,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -88,29 +88,23 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Size of default input buffer. */
@@ -136,7 +130,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
@@ -152,7 +146,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -180,7 +174,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -191,21 +185,21 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 /* Begin user sect3 */
 
@@ -240,31 +234,31 @@ extern char *yytext;
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -272,18 +266,18 @@ void yyset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
@@ -330,9 +324,154 @@ extern int yylex (void);
 #undef YY_DECL
 #endif
 
-#line 68 "wp_parser.l"
+#ifndef yy_create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef yy_delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef yy_scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef yy_scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef yy_scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef yy_init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef yy_flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef yy_load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef yy_switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef yypush_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef yypop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef yyensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef yylex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef yyrestart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef yylex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef yylex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef yylex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef yyget_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef yyset_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef yyget_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef yyset_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef yyget_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef yyset_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef yyget_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef yyset_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef yyget_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef yyget_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef yyget_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef yyset_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef yyget_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef yyset_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef yywrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef yyget_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef yyset_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef yyget_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef yyset_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef yyalloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef yyrealloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef yyfree_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef yytext_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef yyleng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef yyin_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef yyout_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef yy_flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef yylineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef yytables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef yytables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef yyTABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
+#line 72 "wp_parser.l"
 
 
-#line 337 "wp_parser.lex.h"
+#line 476 "wp_parser.lex.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/Source/Parser/wp_parser.lex.h
+++ b/Source/Parser/wp_parser.lex.h
@@ -469,7 +469,7 @@ extern int yylex (void);
 #undef yyTABLES_NAME
 #endif
 
-#line 72 "wp_parser.l"
+#line 71 "wp_parser.l"
 
 
 #line 476 "wp_parser.lex.h"

--- a/Source/Parser/wp_parser.lex.h
+++ b/Source/Parser/wp_parser.lex.h
@@ -469,7 +469,7 @@ extern int yylex (void);
 #undef yyTABLES_NAME
 #endif
 
-#line 71 "wp_parser.l"
+#line 75 "wp_parser.l"
 
 
 #line 476 "wp_parser.lex.h"

--- a/Source/Parser/wp_parser.tab.c
+++ b/Source/Parser/wp_parser.tab.c
@@ -385,19 +385,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   149
+#define YYLAST   122
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  26
+#define YYNTOKENS  25
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  3
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  20
+#define YYNRULES  19
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  44
+#define YYNSTATES  42
 
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   269
+#define YYMAXUTOK   268
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
@@ -412,7 +412,7 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      22,    23,    14,    12,    25,    13,     2,    15,     2,     2,
+      22,    23,    14,    12,    24,    13,     2,    15,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
       16,    11,    17,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -434,7 +434,7 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    18,    19,    20,    21,    24
+       5,     6,     7,     8,     9,    18,    19,    20,    21
 };
 
 #if YYDEBUG
@@ -442,8 +442,7 @@ static const yytype_uint8 yytranslate[] =
 static const yytype_uint8 yyrline[] =
 {
        0,    59,    59,    60,    69,    70,    71,    72,    73,    74,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
-      85
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84
 };
 #endif
 
@@ -454,8 +453,8 @@ static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "NODE", "NUMBER", "SYMBOL", "F1", "F2",
   "EOL", "\"**\"", "'^'", "'='", "'+'", "'-'", "'*'", "'/'", "'<'", "'>'",
-  "\"<=\"", "\">=\"", "NEG", "UPLUS", "'('", "')'", "\"==\"", "','",
-  "$accept", "input", "exp", YY_NULLPTR
+  "\"<=\"", "\">=\"", "NEG", "UPLUS", "'('", "')'", "','", "$accept",
+  "input", "exp", YY_NULLPTR
 };
 #endif
 
@@ -466,7 +465,7 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
       94,    61,    43,    45,    42,    47,    60,    62,   265,   266,
-     267,   268,    40,    41,   269,    44
+     267,   268,    40,    41,    44
 };
 # endif
 
@@ -484,11 +483,11 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-     -20,    20,   -20,   -20,   -20,   -19,   -15,    24,    24,    24,
-      35,    24,    24,    -3,    -3,    62,   -20,    24,    24,    24,
-      24,    24,    24,    24,    24,    24,    24,    75,    48,   -20,
-      -3,   112,   112,   123,   123,   125,   125,    -3,    -3,   101,
-     -20,    24,    88,   -20
+     -20,    21,   -20,   -20,   -20,   -19,   -16,    32,    32,    32,
+      92,    32,    32,    -2,    -2,    56,   -20,    32,    32,    32,
+      32,    32,    32,    32,    32,    32,    68,    43,   -20,    -2,
+     103,   103,    31,    31,    11,    11,    -2,    -2,   -20,    32,
+      80,   -20
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -497,10 +496,10 @@ static const yytype_int8 yypact[] =
 static const yytype_uint8 yydefact[] =
 {
        2,     0,     1,     4,     5,     0,     0,     0,     0,     0,
-       0,     0,     0,    17,    16,     0,     3,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    10,
-      18,     6,     7,     8,     9,    11,    12,    13,    14,    15,
-      19,     0,     0,    20
+       0,     0,     0,    16,    15,     0,     3,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    10,    17,
+       6,     7,     8,     9,    11,    12,    13,    14,    18,     0,
+       0,    19
 };
 
   /* YYPGOTO[NTERM-NUM].  */
@@ -520,67 +519,61 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      13,    14,    15,    11,    27,    28,    17,    12,     0,     0,
-      30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
-       2,    26,     0,     0,     3,     4,     5,     6,     3,     4,
-       5,     6,     7,     8,    42,     0,     7,     8,     0,     0,
-       0,     0,     9,    16,    17,     0,     9,    18,    19,    20,
-      21,    22,    23,    24,    25,     0,     0,    17,     0,    26,
-      18,    19,    20,    21,    22,    23,    24,    25,     0,     0,
-       0,    17,    26,    41,    18,    19,    20,    21,    22,    23,
-      24,    25,     0,     0,    17,    29,    26,    18,    19,    20,
-      21,    22,    23,    24,    25,     0,     0,    17,    40,    26,
-      18,    19,    20,    21,    22,    23,    24,    25,     0,     0,
-      17,    43,    26,    18,    19,    20,    21,    22,    23,    24,
-      25,    17,     0,     0,     0,    26,    20,    21,    22,    23,
-      24,    25,    17,     0,    17,     0,    26,     0,     0,    22,
-      23,    24,    25,    24,    25,     0,     0,    26,     0,    26
+      13,    14,    15,    11,    26,    27,    12,    17,     0,     0,
+      29,    30,    31,    32,    33,    34,    35,    36,    37,     0,
+      17,     2,     0,     0,     0,     3,     4,     5,     6,    24,
+      25,     0,    40,     7,     8,     0,     3,     4,     5,     6,
+      17,     0,     0,     9,     7,     8,     0,    22,    23,    24,
+      25,     0,    17,     0,     9,    18,    19,    20,    21,    22,
+      23,    24,    25,     0,     0,    17,     0,    39,    18,    19,
+      20,    21,    22,    23,    24,    25,     0,    17,     0,    28,
+      18,    19,    20,    21,    22,    23,    24,    25,     0,    17,
+       0,    38,    18,    19,    20,    21,    22,    23,    24,    25,
+      16,    17,     0,    41,    18,    19,    20,    21,    22,    23,
+      24,    25,    17,     0,     0,     0,     0,    20,    21,    22,
+      23,    24,    25
 };
 
 static const yytype_int8 yycheck[] =
 {
-       7,     8,     9,    22,    11,    12,     9,    22,    -1,    -1,
-      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
-       0,    24,    -1,    -1,     4,     5,     6,     7,     4,     5,
-       6,     7,    12,    13,    41,    -1,    12,    13,    -1,    -1,
-      -1,    -1,    22,     8,     9,    -1,    22,    12,    13,    14,
-      15,    16,    17,    18,    19,    -1,    -1,     9,    -1,    24,
-      12,    13,    14,    15,    16,    17,    18,    19,    -1,    -1,
-      -1,     9,    24,    25,    12,    13,    14,    15,    16,    17,
-      18,    19,    -1,    -1,     9,    23,    24,    12,    13,    14,
-      15,    16,    17,    18,    19,    -1,    -1,     9,    23,    24,
-      12,    13,    14,    15,    16,    17,    18,    19,    -1,    -1,
-       9,    23,    24,    12,    13,    14,    15,    16,    17,    18,
-      19,     9,    -1,    -1,    -1,    24,    14,    15,    16,    17,
-      18,    19,     9,    -1,     9,    -1,    24,    -1,    -1,    16,
-      17,    18,    19,    18,    19,    -1,    -1,    24,    -1,    24
+       7,     8,     9,    22,    11,    12,    22,     9,    -1,    -1,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    -1,
+       9,     0,    -1,    -1,    -1,     4,     5,     6,     7,    18,
+      19,    -1,    39,    12,    13,    -1,     4,     5,     6,     7,
+       9,    -1,    -1,    22,    12,    13,    -1,    16,    17,    18,
+      19,    -1,     9,    -1,    22,    12,    13,    14,    15,    16,
+      17,    18,    19,    -1,    -1,     9,    -1,    24,    12,    13,
+      14,    15,    16,    17,    18,    19,    -1,     9,    -1,    23,
+      12,    13,    14,    15,    16,    17,    18,    19,    -1,     9,
+      -1,    23,    12,    13,    14,    15,    16,    17,    18,    19,
+       8,     9,    -1,    23,    12,    13,    14,    15,    16,    17,
+      18,    19,     9,    -1,    -1,    -1,    -1,    14,    15,    16,
+      17,    18,    19
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    27,     0,     4,     5,     6,     7,    12,    13,    22,
-      28,    22,    22,    28,    28,    28,     8,     9,    12,    13,
-      14,    15,    16,    17,    18,    19,    24,    28,    28,    23,
-      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
-      23,    25,    28,    23
+       0,    26,     0,     4,     5,     6,     7,    12,    13,    22,
+      27,    22,    22,    27,    27,    27,     8,     9,    12,    13,
+      14,    15,    16,    17,    18,    19,    27,    27,    23,    27,
+      27,    27,    27,    27,    27,    27,    27,    27,    23,    24,
+      27,    23
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    26,    27,    27,    28,    28,    28,    28,    28,    28,
-      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
-      28
+       0,    25,    26,    26,    27,    27,    27,    27,    27,    27,
+      27,    27,    27,    27,    27,    27,    27,    27,    27,    27
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
        0,     2,     0,     3,     1,     1,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     2,     2,     3,     4,
-       6
+       3,     3,     3,     3,     3,     2,     2,     3,     4,     6
 };
 
 
@@ -1270,113 +1263,107 @@ yyreduce:
     {
     wp_defexpr((yyvsp[-1].n));
   }
-#line 1274 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1267 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 4:
 #line 69 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnumber((yyvsp[0].d)); }
-#line 1280 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1273 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 5:
 #line 70 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newsymbol((yyvsp[0].s)); }
-#line 1286 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1279 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 6:
 #line 71 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_ADD, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1292 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1285 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 7:
 #line 72 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_SUB, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1298 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1291 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 8:
 #line 73 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_MUL, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1304 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1297 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 9:
 #line 74 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_DIV, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1310 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1303 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 10:
 #line 75 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = (yyvsp[-1].n); }
-#line 1316 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1309 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 11:
 #line 76 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_LT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1322 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1315 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 12:
 #line 77 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_GT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1328 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1321 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 13:
 #line 78 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_LEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1334 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1327 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 14:
 #line 79 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_GEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1340 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1333 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 15:
 #line 80 "wp_parser.y" /* yacc.c:1652  */
-    { (yyval.n) = wp_newf2(WP_EQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1346 "wp_parser.tab.c" /* yacc.c:1652  */
+    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
+#line 1339 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 16:
 #line 81 "wp_parser.y" /* yacc.c:1652  */
-    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
-#line 1352 "wp_parser.tab.c" /* yacc.c:1652  */
+    { (yyval.n) = (yyvsp[0].n); }
+#line 1345 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 17:
 #line 82 "wp_parser.y" /* yacc.c:1652  */
-    { (yyval.n) = (yyvsp[0].n); }
-#line 1358 "wp_parser.tab.c" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1351 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 18:
 #line 83 "wp_parser.y" /* yacc.c:1652  */
-    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1364 "wp_parser.tab.c" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
+#line 1357 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 19:
 #line 84 "wp_parser.y" /* yacc.c:1652  */
-    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
-#line 1370 "wp_parser.tab.c" /* yacc.c:1652  */
-    break;
-
-  case 20:
-#line 85 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2((yyvsp[-5].f2), (yyvsp[-3].n), (yyvsp[-1].n)); }
-#line 1376 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1363 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
 
-#line 1380 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1367 "wp_parser.tab.c" /* yacc.c:1652  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1607,5 +1594,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 88 "wp_parser.y" /* yacc.c:1918  */
+#line 87 "wp_parser.y" /* yacc.c:1918  */
 

--- a/Source/Parser/wp_parser.tab.c
+++ b/Source/Parser/wp_parser.tab.c
@@ -1,9 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.3.2.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
-   Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -41,14 +40,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
-
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.3.2"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -65,8 +61,8 @@
 
 
 
-/* First part of user prologue.  */
-#line 2 "wp_parser.y" /* yacc.c:337  */
+/* Copy the first part of user declarations.  */
+#line 2 "wp_parser.y" /* yacc.c:339  */
 
     #include <stdio.h>
     #include <stdlib.h>
@@ -74,16 +70,13 @@
     #include "wp_parser_y.h"
     int yylex (void);
 
-#line 78 "wp_parser.tab.c" /* yacc.c:337  */
+#line 74 "wp_parser.tab.c" /* yacc.c:339  */
+
 # ifndef YY_NULLPTR
-#  if defined __cplusplus
-#   if 201103L <= __cplusplus
-#    define YY_NULLPTR nullptr
-#   else
-#    define YY_NULLPTR 0
-#   endif
+#  if defined __cplusplus && 201103L <= __cplusplus
+#   define YY_NULLPTR nullptr
 #  else
-#   define YY_NULLPTR ((void*)0)
+#   define YY_NULLPTR 0
 #  endif
 # endif
 
@@ -119,6 +112,8 @@ extern int yydebug;
     F2 = 262,
     EOL = 263,
     POW = 264,
+    GEQ = 265,
+    LEQ = 266,
     NEG = 267,
     UPLUS = 268
   };
@@ -129,7 +124,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:352  */
+#line 19 "wp_parser.y" /* yacc.c:355  */
 
     struct wp_node* n;
     double d;
@@ -137,7 +132,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 141 "wp_parser.tab.c" /* yacc.c:352  */
+#line 136 "wp_parser.tab.c" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -152,7 +147,9 @@ int yyparse (void);
 
 #endif /* !YY_YY_WP_PARSER_TAB_H_INCLUDED  */
 
+/* Copy the second part of user declarations.  */
 
+#line 153 "wp_parser.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -173,13 +170,13 @@ typedef signed char yytype_int8;
 #ifdef YYTYPE_UINT16
 typedef YYTYPE_UINT16 yytype_uint16;
 #else
-typedef unsigned short yytype_uint16;
+typedef unsigned short int yytype_uint16;
 #endif
 
 #ifdef YYTYPE_INT16
 typedef YYTYPE_INT16 yytype_int16;
 #else
-typedef short yytype_int16;
+typedef short int yytype_int16;
 #endif
 
 #ifndef YYSIZE_T
@@ -191,7 +188,7 @@ typedef short yytype_int16;
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned
+#  define YYSIZE_T unsigned int
 # endif
 #endif
 
@@ -227,6 +224,15 @@ typedef short yytype_int16;
 # define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
 #endif
 
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+# endif
+#endif
+
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
 # define YYUSE(E) ((void) (E))
@@ -234,7 +240,7 @@ typedef short yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
 # define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
     _Pragma ("GCC diagnostic push") \
@@ -385,7 +391,7 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   122
+#define YYLAST   126
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  25
@@ -396,25 +402,25 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  42
 
+/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
+   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   268
 
-/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex.  */
+   as returned by yylex, without out-of-bounds checking.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      22,    23,    14,    12,    24,    13,     2,    15,     2,     2,
+      22,    23,    16,    14,    24,    15,     2,    17,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      16,    11,    17,     2,     2,     2,     2,     2,     2,     2,
+      18,    13,    19,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,    10,     2,     2,     2,     2,     2,
@@ -434,15 +440,15 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    18,    19,    20,    21
+       5,     6,     7,     8,     9,    11,    12,    20,    21
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    59,    59,    60,    69,    70,    71,    72,    73,    74,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84
+       0,    62,    62,    63,    72,    73,    74,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87
 };
 #endif
 
@@ -452,8 +458,8 @@ static const yytype_uint8 yyrline[] =
 static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "NODE", "NUMBER", "SYMBOL", "F1", "F2",
-  "EOL", "\"**\"", "'^'", "'='", "'+'", "'-'", "'*'", "'/'", "'<'", "'>'",
-  "\"<=\"", "\">=\"", "NEG", "UPLUS", "'('", "')'", "','", "$accept",
+  "EOL", "\"**\"", "'^'", "\">=\"", "\"<=\"", "'='", "'+'", "'-'", "'*'",
+  "'/'", "'<'", "'>'", "NEG", "UPLUS", "'('", "')'", "','", "$accept",
   "input", "exp", YY_NULLPTR
 };
 #endif
@@ -464,7 +470,7 @@ static const char *const yytname[] =
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-      94,    61,    43,    45,    42,    47,    60,    62,   265,   266,
+      94,   265,   266,    61,    43,    45,    42,    47,    60,    62,
      267,   268,    40,    41,    44
 };
 # endif
@@ -483,11 +489,11 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-     -20,    21,   -20,   -20,   -20,   -19,   -16,    32,    32,    32,
-      92,    32,    32,    -2,    -2,    56,   -20,    32,    32,    32,
-      32,    32,    32,    32,    32,    32,    68,    43,   -20,    -2,
-     103,   103,    31,    31,    11,    11,    -2,    -2,   -20,    32,
-      80,   -20
+     -20,    19,   -20,   -20,   -20,   -19,   -15,    23,    23,    23,
+      85,    23,    23,    -3,    -3,    46,   -20,    23,    23,    23,
+      23,    23,    23,    23,    23,    23,    59,    35,   -20,    -3,
+       9,    10,    96,    96,   107,   107,    -3,    -3,   -20,    23,
+      72,   -20
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -498,7 +504,7 @@ static const yytype_uint8 yydefact[] =
        2,     0,     1,     4,     5,     0,     0,     0,     0,     0,
        0,     0,     0,    16,    15,     0,     3,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,    10,    17,
-       6,     7,     8,     9,    11,    12,    13,    14,    18,     0,
+      14,    13,     6,     7,     8,     9,    11,    12,    18,     0,
        0,    19
 };
 
@@ -519,44 +525,44 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      13,    14,    15,    11,    26,    27,    12,    17,     0,     0,
-      29,    30,    31,    32,    33,    34,    35,    36,    37,     0,
-      17,     2,     0,     0,     0,     3,     4,     5,     6,    24,
-      25,     0,    40,     7,     8,     0,     3,     4,     5,     6,
-      17,     0,     0,     9,     7,     8,     0,    22,    23,    24,
-      25,     0,    17,     0,     9,    18,    19,    20,    21,    22,
-      23,    24,    25,     0,     0,    17,     0,    39,    18,    19,
-      20,    21,    22,    23,    24,    25,     0,    17,     0,    28,
-      18,    19,    20,    21,    22,    23,    24,    25,     0,    17,
-       0,    38,    18,    19,    20,    21,    22,    23,    24,    25,
-      16,    17,     0,    41,    18,    19,    20,    21,    22,    23,
-      24,    25,    17,     0,     0,     0,     0,    20,    21,    22,
-      23,    24,    25
+      13,    14,    15,    11,    26,    27,    17,    12,    18,    19,
+      29,    30,    31,    32,    33,    34,    35,    36,    37,     2,
+      18,    19,    19,     3,     4,     5,     6,     3,     4,     5,
+       6,     0,    40,     7,     8,     0,     0,     7,     8,     0,
+       0,     9,     0,     0,    17,     9,    18,    19,     0,    20,
+      21,    22,    23,    24,    25,    17,     0,    18,    19,    39,
+      20,    21,    22,    23,    24,    25,     0,     0,    17,    28,
+      18,    19,     0,    20,    21,    22,    23,    24,    25,     0,
+       0,    17,    38,    18,    19,     0,    20,    21,    22,    23,
+      24,    25,     0,    16,    17,    41,    18,    19,     0,    20,
+      21,    22,    23,    24,    25,    17,     0,    18,    19,     0,
+       0,     0,    22,    23,    24,    25,    17,     0,    18,    19,
+       0,     0,     0,     0,     0,    24,    25
 };
 
 static const yytype_int8 yycheck[] =
 {
-       7,     8,     9,    22,    11,    12,    22,     9,    -1,    -1,
-      17,    18,    19,    20,    21,    22,    23,    24,    25,    -1,
-       9,     0,    -1,    -1,    -1,     4,     5,     6,     7,    18,
-      19,    -1,    39,    12,    13,    -1,     4,     5,     6,     7,
-       9,    -1,    -1,    22,    12,    13,    -1,    16,    17,    18,
-      19,    -1,     9,    -1,    22,    12,    13,    14,    15,    16,
-      17,    18,    19,    -1,    -1,     9,    -1,    24,    12,    13,
-      14,    15,    16,    17,    18,    19,    -1,     9,    -1,    23,
-      12,    13,    14,    15,    16,    17,    18,    19,    -1,     9,
-      -1,    23,    12,    13,    14,    15,    16,    17,    18,    19,
-       8,     9,    -1,    23,    12,    13,    14,    15,    16,    17,
-      18,    19,     9,    -1,    -1,    -1,    -1,    14,    15,    16,
-      17,    18,    19
+       7,     8,     9,    22,    11,    12,     9,    22,    11,    12,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,     0,
+      11,    12,    12,     4,     5,     6,     7,     4,     5,     6,
+       7,    -1,    39,    14,    15,    -1,    -1,    14,    15,    -1,
+      -1,    22,    -1,    -1,     9,    22,    11,    12,    -1,    14,
+      15,    16,    17,    18,    19,     9,    -1,    11,    12,    24,
+      14,    15,    16,    17,    18,    19,    -1,    -1,     9,    23,
+      11,    12,    -1,    14,    15,    16,    17,    18,    19,    -1,
+      -1,     9,    23,    11,    12,    -1,    14,    15,    16,    17,
+      18,    19,    -1,     8,     9,    23,    11,    12,    -1,    14,
+      15,    16,    17,    18,    19,     9,    -1,    11,    12,    -1,
+      -1,    -1,    16,    17,    18,    19,     9,    -1,    11,    12,
+      -1,    -1,    -1,    -1,    -1,    18,    19
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    26,     0,     4,     5,     6,     7,    12,    13,    22,
-      27,    22,    22,    27,    27,    27,     8,     9,    12,    13,
+       0,    26,     0,     4,     5,     6,     7,    14,    15,    22,
+      27,    22,    22,    27,    27,    27,     8,     9,    11,    12,
       14,    15,    16,    17,    18,    19,    27,    27,    23,    27,
       27,    27,    27,    27,    27,    27,    27,    27,    23,    24,
       27,    23
@@ -589,22 +595,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                    \
-  do                                                              \
-    if (yychar == YYEMPTY)                                        \
-      {                                                           \
-        yychar = (Token);                                         \
-        yylval = (Value);                                         \
-        YYPOPSTACK (yylen);                                       \
-        yystate = *yyssp;                                         \
-        goto yybackup;                                            \
-      }                                                           \
-    else                                                          \
-      {                                                           \
-        yyerror (YY_("syntax error: cannot back up")); \
-        YYERROR;                                                  \
-      }                                                           \
-  while (0)
+#define YYBACKUP(Token, Value)                                  \
+do                                                              \
+  if (yychar == YYEMPTY)                                        \
+    {                                                           \
+      yychar = (Token);                                         \
+      yylval = (Value);                                         \
+      YYPOPSTACK (yylen);                                       \
+      yystate = *yyssp;                                         \
+      goto yybackup;                                            \
+    }                                                           \
+  else                                                          \
+    {                                                           \
+      yyerror (YY_("syntax error: cannot back up")); \
+      YYERROR;                                                  \
+    }                                                           \
+while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -644,37 +650,37 @@ do {                                                                      \
 } while (0)
 
 
-/*-----------------------------------.
-| Print this symbol's value on YYO.  |
-`-----------------------------------*/
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyoutput = yyo;
-  YYUSE (yyoutput);
+  FILE *yyo = yyoutput;
+  YYUSE (yyo);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
 # endif
   YYUSE (yytype);
 }
 
 
-/*---------------------------.
-| Print this symbol on YYO.  |
-`---------------------------*/
+/*--------------------------------.
+| Print this symbol on YYOUTPUT.  |
+`--------------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyo, "%s %s (",
+  YYFPRINTF (yyoutput, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep);
-  YYFPRINTF (yyo, ")");
+  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
+  YYFPRINTF (yyoutput, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -708,7 +714,7 @@ do {                                                            \
 static void
 yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
-  unsigned long yylno = yyrline[yyrule];
+  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
@@ -719,7 +725,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
+                       &(yyvsp[(yyi + 1) - (yynrhs)])
                                               );
       YYFPRINTF (stderr, "\n");
     }
@@ -823,10 +829,7 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
+            /* Fall through.  */
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -844,7 +847,7 @@ yytnamerr (char *yyres, const char *yystr)
   if (! yyres)
     return yystrlen (yystr);
 
-  return (YYSIZE_T) (yystpcpy (yyres, yystr) - yyres);
+  return yystpcpy (yyres, yystr) - yyres;
 }
 # endif
 
@@ -922,10 +925,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yyarg[yycount++] = yytname[yyx];
                 {
                   YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
+                  if (! (yysize <= yysize1
+                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
                     return 2;
+                  yysize = yysize1;
                 }
               }
         }
@@ -937,7 +940,6 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
-    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -949,10 +951,9 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 
   {
     YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
+    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
       return 2;
+    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1078,31 +1079,23 @@ yyparse (void)
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
-
 /*------------------------------------------------------------.
-| yynewstate -- push a new state, which is found in yystate.  |
+| yynewstate -- Push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
-yynewstate:
+ yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
-
-/*--------------------------------------------------------------------.
-| yynewstate -- set current state (the top of the stack) to yystate.  |
-`--------------------------------------------------------------------*/
-yysetstate:
-  *yyssp = (yytype_int16) yystate;
+ yysetstate:
+  *yyssp = yystate;
 
   if (yyss + yystacksize - 1 <= yyssp)
-#if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
-#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = (YYSIZE_T) (yyssp - yyss + 1);
+      YYSIZE_T yysize = yyssp - yyss + 1;
 
-# if defined yyoverflow
+#ifdef yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
@@ -1118,10 +1111,14 @@ yysetstate:
                     &yyss1, yysize * sizeof (*yyssp),
                     &yyvs1, yysize * sizeof (*yyvsp),
                     &yystacksize);
+
         yyss = yyss1;
         yyvs = yyvs1;
       }
-# else /* defined YYSTACK_RELOCATE */
+#else /* no yyoverflow */
+# ifndef YYSTACK_RELOCATE
+      goto yyexhaustedlab;
+# else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1137,22 +1134,22 @@ yysetstate:
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
+#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long) yystacksize));
+                  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
-#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
@@ -1161,11 +1158,11 @@ yysetstate:
 
   goto yybackup;
 
-
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
+
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1238,7 +1235,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- do a reduction.  |
+| yyreduce -- Do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1259,111 +1256,111 @@ yyreduce:
   switch (yyn)
     {
         case 3:
-#line 60 "wp_parser.y" /* yacc.c:1652  */
+#line 63 "wp_parser.y" /* yacc.c:1646  */
     {
     wp_defexpr((yyvsp[-1].n));
   }
-#line 1267 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1264 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 69 "wp_parser.y" /* yacc.c:1652  */
+#line 72 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnumber((yyvsp[0].d)); }
-#line 1273 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1270 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 70 "wp_parser.y" /* yacc.c:1652  */
+#line 73 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newsymbol((yyvsp[0].s)); }
-#line 1279 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1276 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 71 "wp_parser.y" /* yacc.c:1652  */
+#line 74 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnode(WP_ADD, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1285 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1282 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 72 "wp_parser.y" /* yacc.c:1652  */
+#line 75 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnode(WP_SUB, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1291 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1288 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 73 "wp_parser.y" /* yacc.c:1652  */
+#line 76 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnode(WP_MUL, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1297 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1294 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 74 "wp_parser.y" /* yacc.c:1652  */
+#line 77 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnode(WP_DIV, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1303 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1300 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 75 "wp_parser.y" /* yacc.c:1652  */
+#line 78 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = (yyvsp[-1].n); }
-#line 1309 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1306 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 76 "wp_parser.y" /* yacc.c:1652  */
+#line 79 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2(WP_LT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1315 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1312 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 77 "wp_parser.y" /* yacc.c:1652  */
+#line 80 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2(WP_GT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1321 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1318 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 78 "wp_parser.y" /* yacc.c:1652  */
+#line 81 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2(WP_LEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1327 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1324 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 79 "wp_parser.y" /* yacc.c:1652  */
+#line 82 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2(WP_GEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1333 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1330 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 80 "wp_parser.y" /* yacc.c:1652  */
+#line 83 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
-#line 1339 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1336 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 81 "wp_parser.y" /* yacc.c:1652  */
+#line 84 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = (yyvsp[0].n); }
-#line 1345 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1342 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 82 "wp_parser.y" /* yacc.c:1652  */
+#line 85 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1351 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1348 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 83 "wp_parser.y" /* yacc.c:1652  */
+#line 86 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
-#line 1357 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1354 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 84 "wp_parser.y" /* yacc.c:1652  */
+#line 87 "wp_parser.y" /* yacc.c:1646  */
     { (yyval.n) = wp_newf2((yyvsp[-5].f2), (yyvsp[-3].n), (yyvsp[-1].n)); }
-#line 1363 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1360 "wp_parser.tab.c" /* yacc.c:1646  */
     break;
 
 
-#line 1367 "wp_parser.tab.c" /* yacc.c:1652  */
+#line 1364 "wp_parser.tab.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1388,13 +1385,14 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-  {
-    const int yylhs = yyr1[yyn] - YYNTOKENS;
-    const int yyi = yypgoto[yylhs] + *yyssp;
-    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
-               ? yytable[yyi]
-               : yydefgoto[yylhs]);
-  }
+
+  yyn = yyr1[yyn];
+
+  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
+  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
+    yystate = yytable[yystate];
+  else
+    yystate = yydefgoto[yyn - YYNTOKENS];
 
   goto yynewstate;
 
@@ -1477,10 +1475,12 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-  /* Pacify compilers when the user code never invokes YYERROR and the
-     label yyerrorlab therefore never appears in user code.  */
-  if (0)
-    YYERROR;
+
+  /* Pacify compilers like GCC when the user code never invokes
+     YYERROR and the label yyerrorlab therefore never appears in user
+     code.  */
+  if (/*CONSTCOND*/ 0)
+     goto yyerrorlab;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1542,14 +1542,12 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
-
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
-
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -1561,10 +1559,6 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
-
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -1594,5 +1588,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 87 "wp_parser.y" /* yacc.c:1918  */
+#line 90 "wp_parser.y" /* yacc.c:1906  */
 

--- a/Source/Parser/wp_parser.tab.c
+++ b/Source/Parser/wp_parser.tab.c
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.3.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -40,11 +41,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.3.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -61,8 +65,8 @@
 
 
 
-/* Copy the first part of user declarations.  */
-#line 2 "wp_parser.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 2 "wp_parser.y" /* yacc.c:337  */
 
     #include <stdio.h>
     #include <stdlib.h>
@@ -70,13 +74,16 @@
     #include "wp_parser_y.h"
     int yylex (void);
 
-#line 74 "wp_parser.tab.c" /* yacc.c:339  */
-
+#line 78 "wp_parser.tab.c" /* yacc.c:337  */
 # ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
 #  else
-#   define YY_NULLPTR 0
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
@@ -112,8 +119,8 @@ extern int yydebug;
     F2 = 262,
     EOL = 263,
     POW = 264,
-    NEG = 265,
-    UPLUS = 266
+    NEG = 267,
+    UPLUS = 268
   };
 #endif
 
@@ -122,7 +129,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:355  */
+#line 19 "wp_parser.y" /* yacc.c:352  */
 
     struct wp_node* n;
     double d;
@@ -130,7 +137,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 134 "wp_parser.tab.c" /* yacc.c:355  */
+#line 141 "wp_parser.tab.c" /* yacc.c:352  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -145,9 +152,7 @@ int yyparse (void);
 
 #endif /* !YY_YY_WP_PARSER_TAB_H_INCLUDED  */
 
-/* Copy the second part of user declarations.  */
 
-#line 151 "wp_parser.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -168,13 +173,13 @@ typedef signed char yytype_int8;
 #ifdef YYTYPE_UINT16
 typedef YYTYPE_UINT16 yytype_uint16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef unsigned short yytype_uint16;
 #endif
 
 #ifdef YYTYPE_INT16
 typedef YYTYPE_INT16 yytype_int16;
 #else
-typedef short int yytype_int16;
+typedef short yytype_int16;
 #endif
 
 #ifndef YYSIZE_T
@@ -186,7 +191,7 @@ typedef short int yytype_int16;
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
@@ -222,15 +227,6 @@ typedef short int yytype_int16;
 # define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
 #endif
 
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
-# else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
-# endif
-#endif
-
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
 # define YYUSE(E) ((void) (E))
@@ -238,7 +234,7 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
 # define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
     _Pragma ("GCC diagnostic push") \
@@ -389,34 +385,34 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   96
+#define YYLAST   149
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  23
+#define YYNTOKENS  26
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  3
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  17
+#define YYNRULES  20
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  38
+#define YYNSTATES  44
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   266
+#define YYMAXUTOK   269
 
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
+   as returned by yylex.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      20,    21,    14,    12,    22,    13,     2,    15,     2,     2,
+      22,    23,    14,    12,    25,    13,     2,    15,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
       16,    11,    17,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -438,15 +434,16 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    18,    19
+       5,     6,     7,     8,     9,    18,    19,    20,    21,    24
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    58,    58,    59,    68,    69,    70,    71,    72,    73,
-      74,    75,    76,    77,    78,    79,    80,    81
+       0,    59,    59,    60,    69,    70,    71,    72,    73,    74,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85
 };
 #endif
 
@@ -457,7 +454,8 @@ static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "NODE", "NUMBER", "SYMBOL", "F1", "F2",
   "EOL", "\"**\"", "'^'", "'='", "'+'", "'-'", "'*'", "'/'", "'<'", "'>'",
-  "NEG", "UPLUS", "'('", "')'", "','", "$accept", "input", "exp", YY_NULLPTR
+  "\"<=\"", "\">=\"", "NEG", "UPLUS", "'('", "')'", "\"==\"", "','",
+  "$accept", "input", "exp", YY_NULLPTR
 };
 #endif
 
@@ -468,14 +466,14 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
       94,    61,    43,    45,    42,    47,    60,    62,   265,   266,
-      40,    41,    44
+     267,   268,    40,    41,   269,    44
 };
 # endif
 
-#define YYPACT_NINF -18
+#define YYPACT_NINF -20
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-18)))
+  (!!((Yystate) == (-20)))
 
 #define YYTABLE_NINF -1
 
@@ -486,10 +484,11 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-     -18,    17,   -18,   -18,   -18,   -17,   -14,    27,    27,    27,
-      70,    27,    27,    -2,    -2,    40,   -18,    27,    27,    27,
-      27,    27,    27,    27,    50,    29,   -18,    -2,    79,    79,
-       9,     9,    -2,    -2,   -18,    27,    60,   -18
+     -20,    20,   -20,   -20,   -20,   -19,   -15,    24,    24,    24,
+      35,    24,    24,    -3,    -3,    62,   -20,    24,    24,    24,
+      24,    24,    24,    24,    24,    24,    24,    75,    48,   -20,
+      -3,   112,   112,   123,   123,   125,   125,    -3,    -3,   101,
+     -20,    24,    88,   -20
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -498,15 +497,16 @@ static const yytype_int8 yypact[] =
 static const yytype_uint8 yydefact[] =
 {
        2,     0,     1,     4,     5,     0,     0,     0,     0,     0,
-       0,     0,     0,    14,    13,     0,     3,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    10,    15,     6,     7,
-       8,     9,    11,    12,    16,     0,     0,    17
+       0,     0,     0,    17,    16,     0,     3,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    10,
+      18,     6,     7,     8,     9,    11,    12,    13,    14,    15,
+      19,     0,     0,    20
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -18,   -18,    -7
+     -20,   -20,    -7
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
@@ -520,54 +520,67 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      13,    14,    15,    11,    24,    25,    12,    17,     0,     0,
-      27,    28,    29,    30,    31,    32,    33,     2,    17,     0,
-       0,     3,     4,     5,     6,    22,    23,     0,    36,     7,
-       8,     3,     4,     5,     6,     0,     0,     9,    17,     7,
-       8,    18,    19,    20,    21,    22,    23,     9,     0,    17,
-       0,    35,    18,    19,    20,    21,    22,    23,     0,    17,
-       0,    26,    18,    19,    20,    21,    22,    23,     0,    17,
-       0,    34,    18,    19,    20,    21,    22,    23,    16,    17,
-       0,    37,    18,    19,    20,    21,    22,    23,    17,     0,
-       0,     0,     0,    20,    21,    22,    23
+      13,    14,    15,    11,    27,    28,    17,    12,     0,     0,
+      30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+       2,    26,     0,     0,     3,     4,     5,     6,     3,     4,
+       5,     6,     7,     8,    42,     0,     7,     8,     0,     0,
+       0,     0,     9,    16,    17,     0,     9,    18,    19,    20,
+      21,    22,    23,    24,    25,     0,     0,    17,     0,    26,
+      18,    19,    20,    21,    22,    23,    24,    25,     0,     0,
+       0,    17,    26,    41,    18,    19,    20,    21,    22,    23,
+      24,    25,     0,     0,    17,    29,    26,    18,    19,    20,
+      21,    22,    23,    24,    25,     0,     0,    17,    40,    26,
+      18,    19,    20,    21,    22,    23,    24,    25,     0,     0,
+      17,    43,    26,    18,    19,    20,    21,    22,    23,    24,
+      25,    17,     0,     0,     0,    26,    20,    21,    22,    23,
+      24,    25,    17,     0,    17,     0,    26,     0,     0,    22,
+      23,    24,    25,    24,    25,     0,     0,    26,     0,    26
 };
 
 static const yytype_int8 yycheck[] =
 {
-       7,     8,     9,    20,    11,    12,    20,     9,    -1,    -1,
-      17,    18,    19,    20,    21,    22,    23,     0,     9,    -1,
-      -1,     4,     5,     6,     7,    16,    17,    -1,    35,    12,
-      13,     4,     5,     6,     7,    -1,    -1,    20,     9,    12,
-      13,    12,    13,    14,    15,    16,    17,    20,    -1,     9,
-      -1,    22,    12,    13,    14,    15,    16,    17,    -1,     9,
-      -1,    21,    12,    13,    14,    15,    16,    17,    -1,     9,
-      -1,    21,    12,    13,    14,    15,    16,    17,     8,     9,
-      -1,    21,    12,    13,    14,    15,    16,    17,     9,    -1,
-      -1,    -1,    -1,    14,    15,    16,    17
+       7,     8,     9,    22,    11,    12,     9,    22,    -1,    -1,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+       0,    24,    -1,    -1,     4,     5,     6,     7,     4,     5,
+       6,     7,    12,    13,    41,    -1,    12,    13,    -1,    -1,
+      -1,    -1,    22,     8,     9,    -1,    22,    12,    13,    14,
+      15,    16,    17,    18,    19,    -1,    -1,     9,    -1,    24,
+      12,    13,    14,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,     9,    24,    25,    12,    13,    14,    15,    16,    17,
+      18,    19,    -1,    -1,     9,    23,    24,    12,    13,    14,
+      15,    16,    17,    18,    19,    -1,    -1,     9,    23,    24,
+      12,    13,    14,    15,    16,    17,    18,    19,    -1,    -1,
+       9,    23,    24,    12,    13,    14,    15,    16,    17,    18,
+      19,     9,    -1,    -1,    -1,    24,    14,    15,    16,    17,
+      18,    19,     9,    -1,     9,    -1,    24,    -1,    -1,    16,
+      17,    18,    19,    18,    19,    -1,    -1,    24,    -1,    24
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    24,     0,     4,     5,     6,     7,    12,    13,    20,
-      25,    20,    20,    25,    25,    25,     8,     9,    12,    13,
-      14,    15,    16,    17,    25,    25,    21,    25,    25,    25,
-      25,    25,    25,    25,    21,    22,    25,    21
+       0,    27,     0,     4,     5,     6,     7,    12,    13,    22,
+      28,    22,    22,    28,    28,    28,     8,     9,    12,    13,
+      14,    15,    16,    17,    18,    19,    24,    28,    28,    23,
+      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
+      23,    25,    28,    23
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    23,    24,    24,    25,    25,    25,    25,    25,    25,
-      25,    25,    25,    25,    25,    25,    25,    25
+       0,    26,    27,    27,    28,    28,    28,    28,    28,    28,
+      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
+      28
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
        0,     2,     0,     3,     1,     1,     3,     3,     3,     3,
-       3,     3,     3,     2,     2,     3,     4,     6
+       3,     3,     3,     3,     3,     3,     2,     2,     3,     4,
+       6
 };
 
 
@@ -583,22 +596,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -638,37 +651,37 @@ do {                                                                      \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
   YYUSE (yytype);
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
+  YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -702,7 +715,7 @@ do {                                                            \
 static void
 yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
@@ -713,7 +726,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       &yyvsp[(yyi + 1) - (yynrhs)]
                                               );
       YYFPRINTF (stderr, "\n");
     }
@@ -817,7 +830,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -835,7 +851,7 @@ yytnamerr (char *yyres, const char *yystr)
   if (! yyres)
     return yystrlen (yystr);
 
-  return yystpcpy (yyres, yystr) - yyres;
+  return (YYSIZE_T) (yystpcpy (yyres, yystr) - yyres);
 }
 # endif
 
@@ -913,10 +929,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yyarg[yycount++] = yytname[yyx];
                 {
                   YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
                     return 2;
-                  yysize = yysize1;
                 }
               }
         }
@@ -928,6 +944,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -939,9 +956,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 
   {
     YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
       return 2;
-    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1067,23 +1085,31 @@ yyparse (void)
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yynewstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  *yyssp = (yytype_int16) yystate;
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYSIZE_T yysize = (YYSIZE_T) (yyssp - yyss + 1);
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
@@ -1099,14 +1125,10 @@ yyparse (void)
                     &yyss1, yysize * sizeof (*yyssp),
                     &yyvs1, yysize * sizeof (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1122,22 +1144,22 @@ yyparse (void)
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-#  undef YYSTACK_RELOCATE
+# undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+                  (unsigned long) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
@@ -1146,11 +1168,11 @@ yyparse (void)
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1223,7 +1245,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1244,99 +1266,117 @@ yyreduce:
   switch (yyn)
     {
         case 3:
-#line 59 "wp_parser.y" /* yacc.c:1646  */
+#line 60 "wp_parser.y" /* yacc.c:1652  */
     {
     wp_defexpr((yyvsp[-1].n));
   }
-#line 1252 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1274 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 4:
-#line 68 "wp_parser.y" /* yacc.c:1646  */
+#line 69 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnumber((yyvsp[0].d)); }
-#line 1258 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1280 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 5:
-#line 69 "wp_parser.y" /* yacc.c:1646  */
+#line 70 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newsymbol((yyvsp[0].s)); }
-#line 1264 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1286 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 6:
-#line 70 "wp_parser.y" /* yacc.c:1646  */
+#line 71 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_ADD, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1270 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1292 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 7:
-#line 71 "wp_parser.y" /* yacc.c:1646  */
+#line 72 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_SUB, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1276 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1298 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 8:
-#line 72 "wp_parser.y" /* yacc.c:1646  */
+#line 73 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_MUL, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1282 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1304 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 9:
-#line 73 "wp_parser.y" /* yacc.c:1646  */
+#line 74 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_DIV, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1288 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1310 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 10:
-#line 74 "wp_parser.y" /* yacc.c:1646  */
+#line 75 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = (yyvsp[-1].n); }
-#line 1294 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1316 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 11:
-#line 75 "wp_parser.y" /* yacc.c:1646  */
+#line 76 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_LT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1300 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1322 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 12:
-#line 76 "wp_parser.y" /* yacc.c:1646  */
+#line 77 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_GT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1306 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1328 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 13:
-#line 77 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
-#line 1312 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 78 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_LEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1334 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 14:
-#line 78 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = (yyvsp[0].n); }
-#line 1318 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 79 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_GEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1340 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 15:
-#line 79 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1324 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 80 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_EQ, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1346 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 16:
-#line 80 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
-#line 1330 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 81 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
+#line 1352 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 17:
-#line 81 "wp_parser.y" /* yacc.c:1646  */
+#line 82 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = (yyvsp[0].n); }
+#line 1358 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 18:
+#line 83 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1364 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 19:
+#line 84 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
+#line 1370 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 20:
+#line 85 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2((yyvsp[-5].f2), (yyvsp[-3].n), (yyvsp[-1].n)); }
-#line 1336 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1376 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
 
-#line 1340 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1380 "wp_parser.tab.c" /* yacc.c:1652  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1361,14 +1401,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -1451,12 +1490,10 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1518,12 +1555,14 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
+
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -1535,6 +1574,10 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -1564,5 +1607,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 84 "wp_parser.y" /* yacc.c:1906  */
+#line 88 "wp_parser.y" /* yacc.c:1918  */
 

--- a/Source/Parser/wp_parser.tab.c
+++ b/Source/Parser/wp_parser.tab.c
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.3.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -40,11 +41,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.3.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -61,8 +65,8 @@
 
 
 
-/* Copy the first part of user declarations.  */
-#line 2 "wp_parser.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 2 "wp_parser.y" /* yacc.c:337  */
 
     #include <stdio.h>
     #include <stdlib.h>
@@ -70,13 +74,16 @@
     #include "wp_parser_y.h"
     int yylex (void);
 
-#line 74 "wp_parser.tab.c" /* yacc.c:339  */
-
+#line 78 "wp_parser.tab.c" /* yacc.c:337  */
 # ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
 #  else
-#   define YY_NULLPTR 0
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
@@ -114,8 +121,12 @@ extern int yydebug;
     POW = 264,
     GEQ = 265,
     LEQ = 266,
-    NEG = 267,
-    UPLUS = 268
+    EQ = 267,
+    NEQ = 268,
+    AND = 269,
+    OR = 270,
+    NEG = 271,
+    UPLUS = 272
   };
 #endif
 
@@ -124,7 +135,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:355  */
+#line 19 "wp_parser.y" /* yacc.c:352  */
 
     struct wp_node* n;
     double d;
@@ -132,7 +143,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 136 "wp_parser.tab.c" /* yacc.c:355  */
+#line 147 "wp_parser.tab.c" /* yacc.c:352  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -147,9 +158,7 @@ int yyparse (void);
 
 #endif /* !YY_YY_WP_PARSER_TAB_H_INCLUDED  */
 
-/* Copy the second part of user declarations.  */
 
-#line 153 "wp_parser.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -170,13 +179,13 @@ typedef signed char yytype_int8;
 #ifdef YYTYPE_UINT16
 typedef YYTYPE_UINT16 yytype_uint16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef unsigned short yytype_uint16;
 #endif
 
 #ifdef YYTYPE_INT16
 typedef YYTYPE_INT16 yytype_int16;
 #else
-typedef short int yytype_int16;
+typedef short yytype_int16;
 #endif
 
 #ifndef YYSIZE_T
@@ -188,7 +197,7 @@ typedef short int yytype_int16;
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
@@ -224,15 +233,6 @@ typedef short int yytype_int16;
 # define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
 #endif
 
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
-# else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
-# endif
-#endif
-
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
 # define YYUSE(E) ((void) (E))
@@ -240,7 +240,7 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
 # define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
     _Pragma ("GCC diagnostic push") \
@@ -391,36 +391,36 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   126
+#define YYLAST   180
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  25
+#define YYNTOKENS  29
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  3
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  19
+#define YYNRULES  23
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  42
+#define YYNSTATES  50
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   268
+#define YYMAXUTOK   272
 
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
+   as returned by yylex.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      22,    23,    16,    14,    24,    15,     2,    17,     2,     2,
+      26,    27,    22,    20,    28,    21,     2,    23,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      18,    13,    19,     2,     2,     2,     2,     2,     2,     2,
+      18,    17,    19,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,    10,     2,     2,     2,     2,     2,
@@ -440,15 +440,17 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    11,    12,    20,    21
+       5,     6,     7,     8,     9,    11,    12,    13,    14,    15,
+      16,    24,    25
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    62,    62,    63,    72,    73,    74,    75,    76,    77,
-      78,    79,    80,    81,    82,    83,    84,    85,    86,    87
+       0,    67,    67,    68,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    92,
+      93,    94,    95,    96
 };
 #endif
 
@@ -458,9 +460,9 @@ static const yytype_uint8 yyrline[] =
 static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "NODE", "NUMBER", "SYMBOL", "F1", "F2",
-  "EOL", "\"**\"", "'^'", "\">=\"", "\"<=\"", "'='", "'+'", "'-'", "'*'",
-  "'/'", "'<'", "'>'", "NEG", "UPLUS", "'('", "')'", "','", "$accept",
-  "input", "exp", YY_NULLPTR
+  "EOL", "\"**\"", "'^'", "\">=\"", "\"<=\"", "\"==\"", "\"!=\"",
+  "\"and\"", "\"or\"", "'='", "'<'", "'>'", "'+'", "'-'", "'*'", "'/'",
+  "NEG", "UPLUS", "'('", "')'", "','", "$accept", "input", "exp", YY_NULLPTR
 };
 #endif
 
@@ -470,15 +472,15 @@ static const char *const yytname[] =
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-      94,   265,   266,    61,    43,    45,    42,    47,    60,    62,
-     267,   268,    40,    41,    44
+      94,   265,   266,   267,   268,   269,   270,    61,    60,    62,
+      43,    45,    42,    47,   271,   272,    40,    41,    44
 };
 # endif
 
-#define YYPACT_NINF -20
+#define YYPACT_NINF -24
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-20)))
+  (!!((Yystate) == (-24)))
 
 #define YYTABLE_NINF -1
 
@@ -487,13 +489,13 @@ static const yytype_uint16 yytoknum[] =
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
      STATE-NUM.  */
-static const yytype_int8 yypact[] =
+static const yytype_int16 yypact[] =
 {
-     -20,    19,   -20,   -20,   -20,   -19,   -15,    23,    23,    23,
-      85,    23,    23,    -3,    -3,    46,   -20,    23,    23,    23,
-      23,    23,    23,    23,    23,    23,    59,    35,   -20,    -3,
-       9,    10,    96,    96,   107,   107,    -3,    -3,   -20,    23,
-      72,   -20
+     -24,    23,   -24,   -24,   -24,   -23,   -20,    27,    27,    27,
+     112,    27,    27,    -2,    -2,    61,   -24,    27,    27,    27,
+      27,    27,    27,    27,    27,    27,    27,    27,    27,    27,
+      78,    43,   -24,    -2,    15,    15,   157,   157,   142,   127,
+      15,    15,   135,   135,    -2,    -2,   -24,    27,    95,   -24
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -502,16 +504,16 @@ static const yytype_int8 yypact[] =
 static const yytype_uint8 yydefact[] =
 {
        2,     0,     1,     4,     5,     0,     0,     0,     0,     0,
-       0,     0,     0,    16,    15,     0,     3,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    10,    17,
-      14,    13,     6,     7,     8,     9,    11,    12,    18,     0,
-       0,    19
+       0,     0,     0,    20,    19,     0,     3,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    10,    21,    14,    13,    15,    16,    17,    18,
+      11,    12,     6,     7,     8,     9,    22,     0,     0,    23
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -20,   -20,    -7
+     -24,   -24,    -7
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
@@ -525,61 +527,75 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      13,    14,    15,    11,    26,    27,    17,    12,    18,    19,
-      29,    30,    31,    32,    33,    34,    35,    36,    37,     2,
-      18,    19,    19,     3,     4,     5,     6,     3,     4,     5,
-       6,     0,    40,     7,     8,     0,     0,     7,     8,     0,
-       0,     9,     0,     0,    17,     9,    18,    19,     0,    20,
-      21,    22,    23,    24,    25,    17,     0,    18,    19,    39,
-      20,    21,    22,    23,    24,    25,     0,     0,    17,    28,
-      18,    19,     0,    20,    21,    22,    23,    24,    25,     0,
-       0,    17,    38,    18,    19,     0,    20,    21,    22,    23,
-      24,    25,     0,    16,    17,    41,    18,    19,     0,    20,
-      21,    22,    23,    24,    25,    17,     0,    18,    19,     0,
-       0,     0,    22,    23,    24,    25,    17,     0,    18,    19,
-       0,     0,     0,     0,     0,    24,    25
+      13,    14,    15,    11,    30,    31,    12,    17,     0,     0,
+      33,    34,    35,    36,    37,    38,    39,    40,    41,    42,
+      43,    44,    45,     2,    17,     0,     0,     3,     4,     5,
+       6,     3,     4,     5,     6,    26,    27,    28,    29,     0,
+      48,     0,     0,     7,     8,     0,     0,     7,     8,     9,
+       0,     0,    17,     9,    18,    19,    20,    21,    22,    23,
+       0,    24,    25,    26,    27,    28,    29,     0,     0,     0,
+      17,    47,    18,    19,    20,    21,    22,    23,     0,    24,
+      25,    26,    27,    28,    29,     0,     0,    17,    32,    18,
+      19,    20,    21,    22,    23,     0,    24,    25,    26,    27,
+      28,    29,     0,     0,    17,    46,    18,    19,    20,    21,
+      22,    23,     0,    24,    25,    26,    27,    28,    29,     0,
+      16,    17,    49,    18,    19,    20,    21,    22,    23,     0,
+      24,    25,    26,    27,    28,    29,    17,     0,    18,    19,
+      20,    21,    22,     0,    17,    24,    25,    26,    27,    28,
+      29,    17,     0,    18,    19,    20,    21,    28,    29,     0,
+      24,    25,    26,    27,    28,    29,    17,     0,    18,    19,
+       0,     0,     0,     0,     0,    24,    25,    26,    27,    28,
+      29
 };
 
 static const yytype_int8 yycheck[] =
 {
-       7,     8,     9,    22,    11,    12,     9,    22,    11,    12,
-      17,    18,    19,    20,    21,    22,    23,    24,    25,     0,
-      11,    12,    12,     4,     5,     6,     7,     4,     5,     6,
-       7,    -1,    39,    14,    15,    -1,    -1,    14,    15,    -1,
-      -1,    22,    -1,    -1,     9,    22,    11,    12,    -1,    14,
-      15,    16,    17,    18,    19,     9,    -1,    11,    12,    24,
-      14,    15,    16,    17,    18,    19,    -1,    -1,     9,    23,
-      11,    12,    -1,    14,    15,    16,    17,    18,    19,    -1,
-      -1,     9,    23,    11,    12,    -1,    14,    15,    16,    17,
-      18,    19,    -1,     8,     9,    23,    11,    12,    -1,    14,
-      15,    16,    17,    18,    19,     9,    -1,    11,    12,    -1,
-      -1,    -1,    16,    17,    18,    19,     9,    -1,    11,    12,
-      -1,    -1,    -1,    -1,    -1,    18,    19
+       7,     8,     9,    26,    11,    12,    26,     9,    -1,    -1,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,     0,     9,    -1,    -1,     4,     5,     6,
+       7,     4,     5,     6,     7,    20,    21,    22,    23,    -1,
+      47,    -1,    -1,    20,    21,    -1,    -1,    20,    21,    26,
+      -1,    -1,     9,    26,    11,    12,    13,    14,    15,    16,
+      -1,    18,    19,    20,    21,    22,    23,    -1,    -1,    -1,
+       9,    28,    11,    12,    13,    14,    15,    16,    -1,    18,
+      19,    20,    21,    22,    23,    -1,    -1,     9,    27,    11,
+      12,    13,    14,    15,    16,    -1,    18,    19,    20,    21,
+      22,    23,    -1,    -1,     9,    27,    11,    12,    13,    14,
+      15,    16,    -1,    18,    19,    20,    21,    22,    23,    -1,
+       8,     9,    27,    11,    12,    13,    14,    15,    16,    -1,
+      18,    19,    20,    21,    22,    23,     9,    -1,    11,    12,
+      13,    14,    15,    -1,     9,    18,    19,    20,    21,    22,
+      23,     9,    -1,    11,    12,    13,    14,    22,    23,    -1,
+      18,    19,    20,    21,    22,    23,     9,    -1,    11,    12,
+      -1,    -1,    -1,    -1,    -1,    18,    19,    20,    21,    22,
+      23
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    26,     0,     4,     5,     6,     7,    14,    15,    22,
-      27,    22,    22,    27,    27,    27,     8,     9,    11,    12,
-      14,    15,    16,    17,    18,    19,    27,    27,    23,    27,
-      27,    27,    27,    27,    27,    27,    27,    27,    23,    24,
-      27,    23
+       0,    30,     0,     4,     5,     6,     7,    20,    21,    26,
+      31,    26,    26,    31,    31,    31,     8,     9,    11,    12,
+      13,    14,    15,    16,    18,    19,    20,    21,    22,    23,
+      31,    31,    27,    31,    31,    31,    31,    31,    31,    31,
+      31,    31,    31,    31,    31,    31,    27,    28,    31,    27
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    25,    26,    26,    27,    27,    27,    27,    27,    27,
-      27,    27,    27,    27,    27,    27,    27,    27,    27,    27
+       0,    29,    30,    30,    31,    31,    31,    31,    31,    31,
+      31,    31,    31,    31,    31,    31,    31,    31,    31,    31,
+      31,    31,    31,    31
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
        0,     2,     0,     3,     1,     1,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     2,     2,     3,     4,     6
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     2,
+       2,     3,     4,     6
 };
 
 
@@ -595,22 +611,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -650,37 +666,37 @@ do {                                                                      \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
   YYUSE (yytype);
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
+  YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -714,7 +730,7 @@ do {                                                            \
 static void
 yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
@@ -725,7 +741,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       &yyvsp[(yyi + 1) - (yynrhs)]
                                               );
       YYFPRINTF (stderr, "\n");
     }
@@ -829,7 +845,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -847,7 +866,7 @@ yytnamerr (char *yyres, const char *yystr)
   if (! yyres)
     return yystrlen (yystr);
 
-  return yystpcpy (yyres, yystr) - yyres;
+  return (YYSIZE_T) (yystpcpy (yyres, yystr) - yyres);
 }
 # endif
 
@@ -925,10 +944,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yyarg[yycount++] = yytname[yyx];
                 {
                   YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
                     return 2;
-                  yysize = yysize1;
                 }
               }
         }
@@ -940,6 +959,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -951,9 +971,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 
   {
     YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
       return 2;
-    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1079,23 +1100,31 @@ yyparse (void)
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yynewstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  *yyssp = (yytype_int16) yystate;
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYSIZE_T yysize = (YYSIZE_T) (yyssp - yyss + 1);
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
@@ -1111,14 +1140,10 @@ yyparse (void)
                     &yyss1, yysize * sizeof (*yyssp),
                     &yyvs1, yysize * sizeof (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1134,22 +1159,22 @@ yyparse (void)
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-#  undef YYSTACK_RELOCATE
+# undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+                  (unsigned long) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
@@ -1158,11 +1183,11 @@ yyparse (void)
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1235,7 +1260,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1256,111 +1281,135 @@ yyreduce:
   switch (yyn)
     {
         case 3:
-#line 63 "wp_parser.y" /* yacc.c:1646  */
+#line 68 "wp_parser.y" /* yacc.c:1652  */
     {
     wp_defexpr((yyvsp[-1].n));
   }
-#line 1264 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1289 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 4:
-#line 72 "wp_parser.y" /* yacc.c:1646  */
+#line 77 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnumber((yyvsp[0].d)); }
-#line 1270 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1295 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 5:
-#line 73 "wp_parser.y" /* yacc.c:1646  */
+#line 78 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newsymbol((yyvsp[0].s)); }
-#line 1276 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1301 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 6:
-#line 74 "wp_parser.y" /* yacc.c:1646  */
+#line 79 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_ADD, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1282 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1307 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 7:
-#line 75 "wp_parser.y" /* yacc.c:1646  */
+#line 80 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_SUB, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1288 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1313 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 8:
-#line 76 "wp_parser.y" /* yacc.c:1646  */
+#line 81 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_MUL, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1294 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1319 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 9:
-#line 77 "wp_parser.y" /* yacc.c:1646  */
+#line 82 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newnode(WP_DIV, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1300 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1325 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 10:
-#line 78 "wp_parser.y" /* yacc.c:1646  */
+#line 83 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = (yyvsp[-1].n); }
-#line 1306 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1331 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 11:
-#line 79 "wp_parser.y" /* yacc.c:1646  */
+#line 84 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_LT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1312 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1337 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 12:
-#line 80 "wp_parser.y" /* yacc.c:1646  */
+#line 85 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_GT, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1318 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1343 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 13:
-#line 81 "wp_parser.y" /* yacc.c:1646  */
+#line 86 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_LEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1324 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1349 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 14:
-#line 82 "wp_parser.y" /* yacc.c:1646  */
+#line 87 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2(WP_GEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1330 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1355 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 15:
-#line 83 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
-#line 1336 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 88 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_EQ, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1361 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 16:
-#line 84 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = (yyvsp[0].n); }
-#line 1342 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 89 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_NEQ, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1367 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 17:
-#line 85 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
-#line 1348 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 90 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_AND, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1373 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 18:
-#line 86 "wp_parser.y" /* yacc.c:1646  */
-    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
-#line 1354 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 91 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_OR, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1379 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
   case 19:
-#line 87 "wp_parser.y" /* yacc.c:1646  */
+#line 92 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newnode(WP_NEG, (yyvsp[0].n), NULL); }
+#line 1385 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 20:
+#line 93 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = (yyvsp[0].n); }
+#line 1391 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 21:
+#line 94 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf2(WP_POW, (yyvsp[-2].n), (yyvsp[0].n)); }
+#line 1397 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 22:
+#line 95 "wp_parser.y" /* yacc.c:1652  */
+    { (yyval.n) = wp_newf1((yyvsp[-3].f1), (yyvsp[-1].n)); }
+#line 1403 "wp_parser.tab.c" /* yacc.c:1652  */
+    break;
+
+  case 23:
+#line 96 "wp_parser.y" /* yacc.c:1652  */
     { (yyval.n) = wp_newf2((yyvsp[-5].f2), (yyvsp[-3].n), (yyvsp[-1].n)); }
-#line 1360 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1409 "wp_parser.tab.c" /* yacc.c:1652  */
     break;
 
 
-#line 1364 "wp_parser.tab.c" /* yacc.c:1646  */
+#line 1413 "wp_parser.tab.c" /* yacc.c:1652  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1385,14 +1434,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -1475,12 +1523,10 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1542,12 +1588,14 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
+
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -1559,6 +1607,10 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -1588,5 +1640,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 90 "wp_parser.y" /* yacc.c:1906  */
+#line 99 "wp_parser.y" /* yacc.c:1918  */
 

--- a/Source/Parser/wp_parser.tab.h
+++ b/Source/Parser/wp_parser.tab.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.3.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -30,6 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 #ifndef YY_YY_WP_PARSER_TAB_H_INCLUDED
 # define YY_YY_WP_PARSER_TAB_H_INCLUDED
 /* Debug traces.  */
@@ -52,8 +56,8 @@ extern int yydebug;
     F2 = 262,
     EOL = 263,
     POW = 264,
-    NEG = 265,
-    UPLUS = 266
+    NEG = 267,
+    UPLUS = 268
   };
 #endif
 
@@ -62,7 +66,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:1909  */
+#line 19 "wp_parser.y" /* yacc.c:1921  */
 
     struct wp_node* n;
     double d;
@@ -70,7 +74,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 74 "wp_parser.tab.h" /* yacc.c:1909  */
+#line 78 "wp_parser.tab.h" /* yacc.c:1921  */
 };
 
 typedef union YYSTYPE YYSTYPE;

--- a/Source/Parser/wp_parser.tab.h
+++ b/Source/Parser/wp_parser.tab.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.3.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -30,6 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 #ifndef YY_YY_WP_PARSER_TAB_H_INCLUDED
 # define YY_YY_WP_PARSER_TAB_H_INCLUDED
 /* Debug traces.  */
@@ -54,8 +58,12 @@ extern int yydebug;
     POW = 264,
     GEQ = 265,
     LEQ = 266,
-    NEG = 267,
-    UPLUS = 268
+    EQ = 267,
+    NEQ = 268,
+    AND = 269,
+    OR = 270,
+    NEG = 271,
+    UPLUS = 272
   };
 #endif
 
@@ -64,7 +72,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:1909  */
+#line 19 "wp_parser.y" /* yacc.c:1921  */
 
     struct wp_node* n;
     double d;
@@ -72,7 +80,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 76 "wp_parser.tab.h" /* yacc.c:1909  */
+#line 84 "wp_parser.tab.h" /* yacc.c:1921  */
 };
 
 typedef union YYSTYPE YYSTYPE;

--- a/Source/Parser/wp_parser.tab.h
+++ b/Source/Parser/wp_parser.tab.h
@@ -1,9 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.3.2.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
-   Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -31,9 +30,6 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
-
 #ifndef YY_YY_WP_PARSER_TAB_H_INCLUDED
 # define YY_YY_WP_PARSER_TAB_H_INCLUDED
 /* Debug traces.  */
@@ -56,6 +52,8 @@ extern int yydebug;
     F2 = 262,
     EOL = 263,
     POW = 264,
+    GEQ = 265,
+    LEQ = 266,
     NEG = 267,
     UPLUS = 268
   };
@@ -66,7 +64,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 19 "wp_parser.y" /* yacc.c:1921  */
+#line 19 "wp_parser.y" /* yacc.c:1909  */
 
     struct wp_node* n;
     double d;
@@ -74,7 +72,7 @@ union YYSTYPE
     enum wp_f1_t f1;
     enum wp_f2_t f2;
 
-#line 78 "wp_parser.tab.h" /* yacc.c:1921  */
+#line 76 "wp_parser.tab.h" /* yacc.c:1909  */
 };
 
 typedef union YYSTYPE YYSTYPE;

--- a/Source/Parser/wp_parser.y
+++ b/Source/Parser/wp_parser.y
@@ -77,7 +77,6 @@ exp:
 | exp '>' exp                { $$ = wp_newf2(WP_GT, $1, $3); }
 | exp "<=" exp               { $$ = wp_newf2(WP_LEQ, $1, $3); }
 | exp ">=" exp               { $$ = wp_newf2(WP_GEQ, $1, $3); }
-| exp "==" exp               { $$ = wp_newf2(WP_EQ, $1, $3); }
 | '-'exp %prec NEG           { $$ = wp_newnode(WP_NEG, $2, NULL); }
 | '+'exp %prec UPLUS         { $$ = $2; }
 | exp POW exp                { $$ = wp_newf2(WP_POW, $1, $3); }

--- a/Source/Parser/wp_parser.y
+++ b/Source/Parser/wp_parser.y
@@ -34,16 +34,21 @@
 %token POW "**" '^'
 %token GEQ ">="
 %token LEQ "<="
+%token EQ "=="
+%token NEQ "!="
+%token AND "and"
+%token OR "or"
 
 %nonassoc F1 F2
 %right '='
+%left OR
+%left AND
+%left EQ NEQ
+%left '<' '>' GEQ LEQ
 %left '+' '-'
 %left '*' '/'
-%left '<' '>'
 %nonassoc NEG UPLUS
 %right POW
-%right GEQ
-%right LEQ
 
 /* This specifies the type of `exp` (i.e., struct wp_node*).  Rules
    specified later pass `exp` to wp_new* functions declared in
@@ -78,8 +83,12 @@ exp:
 | '(' exp ')'                { $$ = $2; }
 | exp '<' exp                { $$ = wp_newf2(WP_LT, $1, $3); }
 | exp '>' exp                { $$ = wp_newf2(WP_GT, $1, $3); }
-| exp LEQ exp               { $$ = wp_newf2(WP_LEQ, $1, $3); }
-| exp GEQ exp               { $$ = wp_newf2(WP_GEQ, $1, $3); }
+| exp LEQ exp                { $$ = wp_newf2(WP_LEQ, $1, $3); }
+| exp GEQ exp                { $$ = wp_newf2(WP_GEQ, $1, $3); }
+| exp EQ exp                 { $$ = wp_newf2(WP_EQ, $1, $3); }
+| exp NEQ exp                { $$ = wp_newf2(WP_NEQ, $1, $3); }
+| exp AND exp                { $$ = wp_newf2(WP_AND, $1, $3); }
+| exp OR exp                 { $$ = wp_newf2(WP_OR, $1, $3); }
 | '-'exp %prec NEG           { $$ = wp_newnode(WP_NEG, $2, NULL); }
 | '+'exp %prec UPLUS         { $$ = $2; }
 | exp POW exp                { $$ = wp_newf2(WP_POW, $1, $3); }

--- a/Source/Parser/wp_parser.y
+++ b/Source/Parser/wp_parser.y
@@ -32,15 +32,18 @@
 %token <f2> F2
 %token EOL
 %token POW "**" '^'
+%token GEQ ">="
+%token LEQ "<="
 
 %nonassoc F1 F2
 %right '='
 %left '+' '-'
 %left '*' '/'
 %left '<' '>'
-%left "<=" ">="
 %nonassoc NEG UPLUS
 %right POW
+%right GEQ
+%right LEQ
 
 /* This specifies the type of `exp` (i.e., struct wp_node*).  Rules
    specified later pass `exp` to wp_new* functions declared in
@@ -75,8 +78,8 @@ exp:
 | '(' exp ')'                { $$ = $2; }
 | exp '<' exp                { $$ = wp_newf2(WP_LT, $1, $3); }
 | exp '>' exp                { $$ = wp_newf2(WP_GT, $1, $3); }
-| exp "<=" exp               { $$ = wp_newf2(WP_LEQ, $1, $3); }
-| exp ">=" exp               { $$ = wp_newf2(WP_GEQ, $1, $3); }
+| exp LEQ exp               { $$ = wp_newf2(WP_LEQ, $1, $3); }
+| exp GEQ exp               { $$ = wp_newf2(WP_GEQ, $1, $3); }
 | '-'exp %prec NEG           { $$ = wp_newnode(WP_NEG, $2, NULL); }
 | '+'exp %prec UPLUS         { $$ = $2; }
 | exp POW exp                { $$ = wp_newf2(WP_POW, $1, $3); }

--- a/Source/Parser/wp_parser.y
+++ b/Source/Parser/wp_parser.y
@@ -38,6 +38,7 @@
 %left '+' '-'
 %left '*' '/'
 %left '<' '>'
+%left "<=" ">="
 %nonassoc NEG UPLUS
 %right POW
 
@@ -74,6 +75,9 @@ exp:
 | '(' exp ')'                { $$ = $2; }
 | exp '<' exp                { $$ = wp_newf2(WP_LT, $1, $3); }
 | exp '>' exp                { $$ = wp_newf2(WP_GT, $1, $3); }
+| exp "<=" exp               { $$ = wp_newf2(WP_LEQ, $1, $3); }
+| exp ">=" exp               { $$ = wp_newf2(WP_GEQ, $1, $3); }
+| exp "==" exp               { $$ = wp_newf2(WP_EQ, $1, $3); }
 | '-'exp %prec NEG           { $$ = wp_newnode(WP_NEG, $2, NULL); }
 | '+'exp %prec UPLUS         { $$ = $2; }
 | exp POW exp                { $$ = wp_newf2(WP_POW, $1, $3); }

--- a/Source/Parser/wp_parser_y.c
+++ b/Source/Parser/wp_parser_y.c
@@ -189,6 +189,14 @@ wp_call_f2 (enum wp_f2_t type, double a, double b)
         return (a >= b) ? 1.0 : 0.0;
     case WP_LEQ:
         return (a <= b) ? 1.0 : 0.0;
+    case WP_EQ:
+        return (a == b) ? 1.0 : 0.0;
+    case WP_NEQ:
+        return (a != b) ? 1.0 : 0.0;
+    case WP_AND:
+        return (a && b) ? 1.0 : 0.0;
+    case WP_OR:
+        return (a || b) ? 1.0 : 0.0;
     case WP_HEAVISIDE:
         return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
     case WP_MIN:
@@ -814,6 +822,18 @@ wp_ast_print_f2 (struct wp_f2* f2)
         break;
     case WP_LEQ:
         printf("LEQ\n");
+        break;
+    case WP_EQ:
+        printf("EQ\n");
+        break;
+    case WP_NEQ:
+        printf("NEQ\n");
+        break;
+    case WP_AND:
+        printf("AND\n");
+        break;
+    case WP_OR:
+        printf("OR\n");
         break;
     case WP_HEAVISIDE:
         printf("HEAVISIDE\n");

--- a/Source/Parser/wp_parser_y.c
+++ b/Source/Parser/wp_parser_y.c
@@ -189,8 +189,6 @@ wp_call_f2 (enum wp_f2_t type, double a, double b)
         return (a >= b) ? 1.0 : 0.0;
     case WP_LEQ:
         return (a <= b) ? 1.0 : 0.0;
-    case WP_EQ:
-        return (a == b) ? 1.0 : 0.0;
     case WP_HEAVISIDE:
         return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
     case WP_MIN:
@@ -816,9 +814,6 @@ wp_ast_print_f2 (struct wp_f2* f2)
         break;
     case WP_LEQ:
         printf("LEQ\n");
-        break;
-    case WP_EQ:
-        printf("EQ\n");
         break;
     case WP_HEAVISIDE:
         printf("HEAVISIDE\n");

--- a/Source/Parser/wp_parser_y.c
+++ b/Source/Parser/wp_parser_y.c
@@ -185,6 +185,12 @@ wp_call_f2 (enum wp_f2_t type, double a, double b)
         return (a > b) ? 1.0 : 0.0;
     case WP_LT:
         return (a < b) ? 1.0 : 0.0;
+    case WP_GEQ:
+        return (a >= b) ? 1.0 : 0.0;
+    case WP_LEQ:
+        return (a <= b) ? 1.0 : 0.0;
+    case WP_EQ:
+        return (a == b) ? 1.0 : 0.0;
     case WP_HEAVISIDE:
         return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
     case WP_MIN:
@@ -805,6 +811,15 @@ wp_ast_print_f2 (struct wp_f2* f2)
     case WP_LT:
         printf("LT\n");
         break;
+    case WP_GEQ:
+        printf("GEQ\n");
+        break;
+    case WP_LEQ:
+        printf("LEQ\n");
+        break;
+    case WP_EQ:
+        printf("EQ\n");
+        break;
     case WP_HEAVISIDE:
         printf("HEAVISIDE\n");
         break;
@@ -1015,4 +1030,3 @@ wp_parser_setconst (struct wp_parser* parser, char const* name, double c)
     wp_ast_setconst(parser->ast, name, c);
     wp_ast_optimize(parser->ast);
 }
-

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -37,7 +37,6 @@ enum wp_f2_t {  // Built-in functions with two arguments
     WP_LT,
     WP_GEQ,
     WP_LEQ,
-    WP_EQ,
     WP_HEAVISIDE,
     WP_MIN,
     WP_MAX

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -35,6 +35,9 @@ enum wp_f2_t {  // Built-in functions with two arguments
     WP_POW = 1,
     WP_GT,
     WP_LT,
+    WP_GEQ,
+    WP_LEQ,
+    WP_EQ,
     WP_HEAVISIDE,
     WP_MIN,
     WP_MAX

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -37,6 +37,10 @@ enum wp_f2_t {  // Built-in functions with two arguments
     WP_LT,
     WP_GEQ,
     WP_LEQ,
+    WP_EQ,
+    WP_NEQ,
+    WP_AND,
+    WP_OR,
     WP_HEAVISIDE,
     WP_MIN,
     WP_MAX


### PR DESCRIPTION
I've added the symbols >= and <= to the grammar of the parser.
I've updated the example "plasma_mirror" so that >= and <= are actually used.