### PR TITLE
Temporarily enable PICSAR's PSATD for the Travis tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -238,7 +238,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params = psatd.fftw_plan_measure=0
+runtime_params = psatd.fftw_plan_measure=0 psatd.hybrid_mpi_decomposition=1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_analysis.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -256,7 +256,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_analysis.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -292,7 +292,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params = psatd.fftw_plan_measure=0
+runtime_params = psatd.fftw_plan_measure=0 psatd.hybrid_mpi_decomposition=1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
 analysisOutputImage = langmuir_multi_2d_analysis.png


### PR DESCRIPTION
The Travis CI tests are currently failing because the PSATD tests seem to hand indefinitely.

While we are investigating the issues, the current PR is a temporary fix that uses the PICSAR PSATD instead of the new C++ one. For some reason, this prevents the tests from hanging.