### PR TITLE
Use WarpX current deposition for laser particles as well

### DIFF
--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -504,15 +504,15 @@ LaserParticleContainer::Evolve (int lev,
             // Current Deposition
             //
             // Deposit inside domains
-            DepositCurrentFortran(pti, wp, uxp, uyp, uzp, &jx, &jy, &jz,
-                                  0, np_current, thread_num,
-                                  lev, lev, dt);
+            DepositCurrent(pti, wp, uxp, uyp, uzp, &jx, &jy, &jz,
+                           0, np_current, thread_num,
+                           lev, lev, dt);
             bool has_buffer = cjx;
             if (has_buffer){
                 // Deposit in buffers
-                DepositCurrentFortran(pti, wp, uxp, uyp, uzp, cjx, cjy, cjz,
-                                      np_current, np-np_current, thread_num,
-                                      lev, lev-1, dt);
+                DepositCurrent(pti, wp, uxp, uyp, uzp, cjx, cjy, cjz,
+                               np_current, np-np_current, thread_num,
+                               lev, lev-1, dt);
             }
 
             //


### PR DESCRIPTION
This is a small PR to use the C++ current deposition `DepositCurrent` instead of `DepositCurrentFortran` (that calls PICSAR's).

It may break regression tests.