### PR TITLE
openPMD-api: v0.9.0 provides .pc files

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -95,8 +95,10 @@ First, load the appropriate modules:
 
     module swap craype-haswell craype-mic-knl
     module swap PrgEnv-intel PrgEnv-gnu
-    module load cmake/3.11.4
+    module load cmake/3.14.4
     module load cray-hdf5-parallel
+    module load adios/1.13.1 zlib
+    export CRAYPE_LINK_TYPE=dynamic
 
 Then, in the `warpx_directory`, download and build the openPMD API:
 
@@ -105,7 +107,7 @@ Then, in the `warpx_directory`, download and build the openPMD API:
     git clone https://github.com/openPMD/openPMD-api.git
     mkdir openPMD-api-build
     cd openPMD-api-build
-    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DopenPMD_USE_JSON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DBUILD_SHARED_LIBS=OFF
+    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
     cmake --build . --target install
 
 Finally, compile WarpX:
@@ -113,6 +115,7 @@ Finally, compile WarpX:
 ::
 
     cd ../WarpX
-    export OPENPMD_LIB_PATH=../openPMD-install/lib64
-    export OPENPMD_INCLUDE_PATH=../openPMD-install/include
+    export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib64/pkgconfig:$PKG_CONFIG_PATH
     make -j 16 COMP=gnu USE_OPENPMD=TRUE
+
+In order to run WarpX, load the same modules again.

--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -7,7 +7,7 @@ therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library <https://openpmd-api.readthedocs.io/en/0.8.0-alpha/>`__
+`openPMD-api library 0.9.0a or newer <https://openpmd-api.readthedocs.io/en/0.9.0-alpha/>`__
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.
@@ -30,14 +30,13 @@ First, install the openPMD-api library:
 
 ::
 
-    spack install openpmd-api -shared -json -python ^hdf5+mpi ^openmpi
+    spack install openpmd-api -python +adios1
 
 Then, ``cd`` into the ``WarpX`` folder, and type:
 
 ::
 
-    spack load openmpi
-    spack load hdf5
+    spack load mpi
     spack load openpmd-api
     make -j 4 USE_OPENPMD=TRUE
 
@@ -45,8 +44,7 @@ You will also need to load the same spack environment when running WarpX, for in
 
 ::
 
-    spack load openmpi
-    spack load hdf5
+    spack load mpi
     spack load openpmd-api
 
     mpirun -np 4 ./warpx.exe inputs
@@ -58,9 +56,10 @@ First, install the openPMD-api library, and load it in your environment:
 
 ::
 
-    spack install hdf5+mpi ^openmpi
-    spack load openmpi
-    spack load hdf5
+    spack install hdf5
+    spack install adios
+    spack load -r hdf5
+    spack load -r adios
 
 Then, in the `warpx_directory`, download and build the openPMD API:
 
@@ -69,7 +68,7 @@ Then, in the `warpx_directory`, download and build the openPMD API:
     git clone https://github.com/openPMD/openPMD-api.git
     mkdir openPMD-api-build
     cd openPMD-api-build
-    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DopenPMD_USE_JSON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DBUILD_SHARED_LIBS=OFF
+    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
     cmake --build . --target install
 
 Finally, compile WarpX:
@@ -77,8 +76,7 @@ Finally, compile WarpX:
 ::
 
     cd ../WarpX
-    export OPENPMD_LIB_PATH=../openPMD-install/lib
-    export OPENPMD_INCLUDE_PATH=../openPMD-install/include
+    export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib/pkgconfig:$PKG_CONFIG_PATH
     make -j 4 USE_OPENPMD=TRUE
 
 You will also need to load the same spack environment when running WarpX, for instance:
@@ -87,5 +85,6 @@ You will also need to load the same spack environment when running WarpX, for in
 
     spack load openmpi
     spack load hdf5
+    spack load adios
 
     mpirun -np 4 ./warpx.exe inputs

--- a/Docs/source/latex_theory/allbibs.bib
+++ b/Docs/source/latex_theory/allbibs.bib
@@ -461,8 +461,8 @@ year = {2001}
 }
 @misc{Huebl2015,
 author = {Huebl, Axel and Lehe, Remi and Vay, Jean-Luc and Grote, David P. and Sbalzarini, Ivo and Kuschel, Stephan and Bussmann, Michael},
-title = {{The OpenPMD standard 1.0.0}},
-url = {http://dx.doi.org/10.5281/zenodo.33624},
+title = {{openPMD: A meta data standard for particle and mesh based data.}},
+url = {http://dx.doi.org/10.5281/zenodo.591699},
 year = {2015}
 }
 @article{Vayarxiv10_1,

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -97,16 +97,24 @@ ifeq ($(USE_OPENBC_POISSON),TRUE)
 endif
 
 ifeq ($(USE_OPENPMD), TRUE)
-   OPENPMD_LIB_PATH ?= NOT_SET
-   ifneq ($(OPENPMD_LIB_PATH),NOT_SET)
-     LIBRARY_LOCATIONS += $(OPENPMD_LIB_PATH)
+   # try pkg-config query
+   ifeq (0, $(shell pkg-config "openPMD >= 0.9.0"; echo $$?))
+       CXXFLAGS += $(shell pkg-config --cflags openPMD)
+       LDFLAGS += $(shell pkg-config --libs openPMD)
+       LDFLAGS += -Wl,-rpath,$(shell pkg-config --variable=libdir openPMD)
+   # fallback to manual settings
+   else
+       OPENPMD_LIB_PATH ?= NOT_SET
+       ifneq ($(OPENPMD_LIB_PATH),NOT_SET)
+         LIBRARY_LOCATIONS += $(OPENPMD_LIB_PATH)
+       endif
+       OPENPMD_INCLUDE_PATH ?= NOT_SET
+       ifneq ($(OPENPMD_INCLUDE_PATH),NOT_SET)
+         INCLUDE_LOCATIONS += $(OPENPMD_INCLUDE_PATH)
+       endif
+       LIBRARIES += -lopenPMD
    endif
-   OPENPMD_INCLUDE_PATH ?= NOT_SET
-   ifneq ($(OPENPMD_INCLUDE_PATH),NOT_SET)
-     INCLUDE_LOCATIONS += $(OPENPMD_INCLUDE_PATH)
-   endif
-   DEFINES += -DWARPX_USE_OPENPMD -DopenPMD_HAVE_MPI=1
-   LIBRARIES += -lopenPMD -lhdf5
+   DEFINES += -DWARPX_USE_OPENPMD
 endif
    
 


### PR DESCRIPTION
In order to build with openPMD-api, we can rely on the installed [`pkg-config`](https://people.freedesktop.org/~dbn/pkg-config-guide.html) (`.pc`) file provided in [openPMD-api 0.9.0](https://openpmd-api.readthedocs.io/en/0.9.0-alpha/install/changelog.html) or newer.

We also set an RPATH in the WarpX executable to avoid having to load the shared depending library via `LD_LIBRARY_PATH` at runtime. Further dependencies, if provided by spack, have an RPATH set by default as well.

### To Do

- [x] runtime tests (cori is already down for its weekend-long maintenance)

### Follow-Up PRs

- enable all available backends
- add particle dumps
- add in spack recipe
- add in CI