### PR TITLE
Summit: Auto-Calc Nodes from Jobscript

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -39,7 +39,9 @@ the following text (replace bracketed variables):
 
     omp=1
     export OMP_NUM_THREADS=${omp}
-    jsrun -n <numberOfNodes> -a 6 -g 6 -c 6 --bind=packed:${omp} --smpiargs="-gpu" <warpxExecutable> <inputScript>
+    num_nodes=$(( $(printf '%s\n' ${LSB_HOSTS} | sort -u | wc -l) - 1 ))
+
+    jsrun -n ${num_nodes} -a 6 -g 6 -c 6 --bind=packed:${omp} --smpiargs="-gpu" <warpxExecutable> <inputScript>
 
 
 Then run


### PR DESCRIPTION
In order to avoid to set the number of nodes twice in a Summit job script, let us calculate the number from the environment before startup.