### PR TITLE
Change default values/checks for regression tests

### DIFF
--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -58,7 +58,7 @@ electrons.ymin = -20.e-6
 electrons.ymax = 20.e-6
 electrons.zmin = -20.e-6
 electrons.zmax = 20.e-6
-electrons.plot_vars = w ux Bz Ey
+electrons.plot_vars = w ux Ey
 
 electrons.profile = constant
 electrons.density = 2.e24   # number of electrons per m^3
@@ -77,7 +77,7 @@ positrons.ymin = -20.e-6
 positrons.ymax = 20.e-6
 positrons.zmin = -20.e-6
 positrons.zmax = 20.e-6
-positrons.plot_vars = w ux Bz Ey
+positrons.plot_vars = w ux Ey
 
 positrons.profile = constant
 positrons.density = 2.e24   # number of positrons per m^3

--- a/Examples/Tests/Langmuir/langmuir_multi_analysis.py
+++ b/Examples/Tests/Langmuir/langmuir_multi_analysis.py
@@ -66,13 +66,13 @@ ds = yt.load(fn)
 for species in ['electrons', 'positrons']:
     for field in ['particle_weight',
                   'particle_momentum_x',
-                  'particle_Bz',
                   'particle_Ey']:
         assert (species, field) in ds.field_list
     for field in ['particle_momentum_y',
                   'particle_momentum_z',
                   'particle_Bx',
                   'particle_By',
+                  'particle_Bz',
                   'particle_Ex',
                   'particle_Ez']:
         assert (species, field) not in ds.field_list

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -397,7 +397,7 @@ compareParticles = 0
 [LaserAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs.2d
-runtime_params = amr.max_level=1 max_step=100 warpx.serialize_ics=1
+runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -413,7 +413,7 @@ particleTypes = electrons beam
 [PlasmaAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs.2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=100 plasma_e.zmin=-200.e-6 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
 restartTest = 0


### PR DESCRIPTION
In the regression tests, certain fields are 0 by constructions, and therefore, the amplitude of these fields is dictated by machine precision errors. This causes large relative differences in regression tests. This is the case for:

- The `Langmuir_multi` tests: for these tests, the field `Bz` is 0 by constructions at the edges of the simulation box. The regression tests check the `Bz` field of a particle which is at a point where `Bz` is 0. In order to avoid this, this PR prevents `Bz` from being written to disk (and thus compared)

- The `LaserAccelerationMR` and `PlasmaAccelerationMR` tests: In these cases, the simulation was not run for long enough, and thus the driver (laser or electron beam) did not reach the plasma yet - resulting in 0 fields on the plasma particles. This PR prevents this by making the simulation longer.