### PR TITLE
Choose fields and components in plotfiles

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -723,14 +723,12 @@ Diagnostics and output
 * ``amr.plot_file`` (`string`)
     Root for output file names. Supports sub-directories. Default `diags/plotfiles/plt`
 
-* ``warpx.plot_J_field`` (`0` or `1` optional; default `1`)
-    Whether to plot the current density.
-
-* ``warpx.plot_E_field`` (`0` or `1` optional; default `1`)
-    Whether to plot the electric field.
-
-* ``warpx.plot_B_field`` (`0` or `1` optional; default `1`)
-    Whether to plot the magnetic field.
+* ``warpx.fields_to_plot`` (`list of strings`)
+    Fields written to plotfiles. Possible values: ``Ex`` ``Ey`` ``Ez``
+    ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho``
+    ``F`` ``part_per_grid`` ``part_per_proc`` ``divE`` ``divB``.
+    Default is
+    ``warpx_fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell``.
 
 * ``slice.dom_lo`` and ``slice.dom_hi`` (`2 floats in 2D`, `3 floats in 3D`; in meters similar to the units of the simulation box.)
     The extent of the slice are defined by the co-ordinates of the lower corner (``slice.dom_lo``) and upper corner (``slice.dom_hi``). The slice could be 1D, 2D, or 3D, aligned with the co-ordinate axes and the first axis of the coordinates is x. For example: if for a 3D simulation, an x-z slice is to be extracted at y = 0.0, then the y-value of slice.dom_lo and slice.dom_hi must be equal to 0.0
@@ -742,8 +740,6 @@ Diagnostics and output
 * ``slice.plot_int`` (`integer`)
     The number of PIC cycles inbetween two consecutive data dumps for the slice. Use a
     negative number to disable slice generation and slice data dumping.
-
-
 
 Checkpoints and restart
 -----------------------

--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -12,7 +12,7 @@ amr.max_grid_size = 32
 amr.max_level = 0
 
 amr.plot_int = 20   # How often to write plotfiles.  "<= 0" means no plotfiles.
-warpx.plot_rho = 1
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Larmor/inputs
+++ b/Examples/Tests/Larmor/inputs
@@ -20,10 +20,9 @@ warpx.fine_tag_hi =  0.8   0.8
 amr.plot_int = 1   # How often to write plotfiles.  "<= 0" means no plotfiles.
 
 warpx.plot_raw_fields = 1
-warpx.plot_dive = 1
-warpx.plot_divb = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell dive divb
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Larmor/inputs
+++ b/Examples/Tests/Larmor/inputs
@@ -22,7 +22,7 @@ amr.plot_int = 1   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_raw_fields = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
-warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell dive divb
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divE divB
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Larmor/inputs.ml
+++ b/Examples/Tests/Larmor/inputs.ml
@@ -20,10 +20,9 @@ warpx.fine_tag_hi =  0.8   0.8
 amr.plot_int = 2   # How often to write plotfiles.  "<= 0" means no plotfiles.
 
 warpx.plot_raw_fields = 1
-warpx.plot_dive = 1
-warpx.plot_divb = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell dive divb
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/Larmor/inputs.ml
+++ b/Examples/Tests/Larmor/inputs.ml
@@ -22,7 +22,7 @@ amr.plot_int = 2   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_raw_fields = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
-warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell dive divb
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divE divB
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/laser_on_fine/inputs
+++ b/Examples/Tests/laser_on_fine/inputs
@@ -22,7 +22,7 @@ amr.plot_int = 10   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_raw_fields = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
-warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divb
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divB
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/laser_on_fine/inputs
+++ b/Examples/Tests/laser_on_fine/inputs
@@ -20,9 +20,9 @@ warpx.fine_tag_hi =  10.e-6    10.e-6    0.4e-6
 amr.plot_int = 10   # How often to write plotfiles.  "<= 0" means no plotfiles.
 
 warpx.plot_raw_fields = 1
-warpx.plot_divb = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divb
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/laser_on_fine/inputs.2d
+++ b/Examples/Tests/laser_on_fine/inputs.2d
@@ -22,7 +22,7 @@ amr.plot_int = 10   # How often to write plotfiles.  "<= 0" means no plotfiles.
 warpx.plot_raw_fields = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
-warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divb
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divB
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Examples/Tests/laser_on_fine/inputs.2d
+++ b/Examples/Tests/laser_on_fine/inputs.2d
@@ -20,9 +20,9 @@ warpx.fine_tag_hi =  10.e-6    0.4e-6
 amr.plot_int = 10   # How often to write plotfiles.  "<= 0" means no plotfiles.
 
 warpx.plot_raw_fields = 1
-warpx.plot_divb = 1
 warpx.plot_finepatch = 1
 warpx.plot_crsepatch = 1
+warpx.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divb
 
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -325,12 +325,12 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         // Allocate pointers to the `ncomp` fields that will be added
         mf_avg.push_back( MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
 
-        // For E, B and J, if at least one component us required, 
+        // For E, B and J, if at least one component is requested, 
         // build cell-centered temporary MultiFab with 3 comps
         MultiFab mf_tmp_E, mf_tmp_B, mf_tmp_J;
         // Build mf_tmp_E is at least one component of E is requested
         if (is_in_vector(fields_to_plot, {"Ex", "Ey", "Ez"} )){
-            // Allocate memory for MultiFab with 3 components
+            // Allocate temp MultiFab with 3 components
             mf_tmp_E = MultiFab(grids[lev], dmap[lev], 3, ngrow);
             // Fill MultiFab mf_tmp_E with averaged E
             AverageAndPackVectorField(mf_tmp_E, Efield_aux[lev], 0, ngrow);

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -325,8 +325,10 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         // Allocate pointers to the `ncomp` fields that will be added
         mf_avg.push_back( MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
 
+        // For E, B and J, if at least one component us required, 
+        // build cell-centered temporary MultiFab with 3 comps
         MultiFab mf_tmp_E, mf_tmp_B, mf_tmp_J;
-        // If one component is required for E, build temp array with 3 comps
+        // Build mf_tmp_E is at least one component of E is requested
         if (is_in_vector(fields_to_plot, {"Ex", "Ey", "Ez"} )){
             // Allocate memory for MultiFab with 3 components
             mf_tmp_E = MultiFab(grids[lev], dmap[lev], 3, ngrow);
@@ -347,6 +349,8 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         int dcomp;
         // Go through the different fields in fields_to_plot, pack them into
         // mf_avg[lev] add the corresponding names to `varnames`.
+        // plot_fine_patch and plot_coarse_patch are treated separately
+        // (after this for loop).
         for (dcomp=0; dcomp<fields_to_plot.size(); dcomp++){
             std::string fieldname = fields_to_plot[dcomp];
             if(lev==0) varnames.push_back(fieldname);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -551,6 +551,9 @@ private:
     bool plot_crsepatch     = false;
     bool plot_raw_fields    = false;
     bool plot_raw_fields_guards = false;
+    amrex::Vector<std::string> fields_to_plot = {"Ex", "Ey", "Ez", "Bx", "By",
+                                                 "Bz", "jx", "jy", "jz", 
+                                                 "part_per_cell"};
     int plot_coarsening_ratio = 1;
 
     amrex::VisMF::Header::Version checkpoint_headerversion = amrex::VisMF::Header::NoFabHeader_v1;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -536,28 +536,15 @@ private:
     bool dump_plotfiles = true;
     bool dump_openpmd = false;
 #endif
-    bool plot_E_field       = true;
-    bool plot_B_field       = true;
-    bool plot_J_field       = true;
-    bool plot_part_per_cell = true;
-    bool plot_part_per_grid = false;
-    bool plot_part_per_proc = false;
-    bool plot_proc_number   = false;
-    bool plot_dive          = false;
-    bool plot_divb          = false;
     bool plot_rho           = false;
-    bool plot_F             = false;
     bool plot_finepatch     = false;
     bool plot_crsepatch     = false;
     bool plot_raw_fields    = false;
     bool plot_raw_fields_guards = false;
-    amrex::Vector<std::string> fields_to_plot = {"Ex", "Ey", "Ez", "Bx", "By",
-                                                 "Bz", "jx", "jy", "jz", 
-                                                 "part_per_cell"};
+    amrex::Vector<std::string> fields_to_plot;
     int plot_coarsening_ratio = 1;
 
     amrex::VisMF::Header::Version checkpoint_headerversion = amrex::VisMF::Header::NoFabHeader_v1;
-//    amrex::VisMF::Header::Version plotfile_headerversion   = amrex::VisMF::Header::NoFabHeader_v1;
     amrex::VisMF::Header::Version plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
     amrex::VisMF::Header::Version slice_plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -403,6 +403,38 @@ WarpX::ReadParameters ()
         pp.query("plot_rho"          , plot_rho);
         pp.query("plot_F"            , plot_F);
         pp.query("plot_coarsening_ratio", plot_coarsening_ratio);
+        int do_user_plot_vars;
+        do_user_plot_vars = pp.queryarr("fields_to_plot", fields_to_plot);
+        /*
+        if (not do_user_plot_vars){
+            nvars_
+            // By default, all particle variables are dumped to plotfiles,
+            // including {x,y,z,ux,uy,uz}old variables when running in a 
+            // boosted frame
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags){
+                plot_flags.resize(PIdx::nattribs + 6, 1);
+            } else {
+                plot_flags.resize(PIdx::nattribs, 1);
+            }
+        } else {
+            // Set plot_flag to 0 for all attribs
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags){
+                plot_flags.resize(PIdx::nattribs + 6, 0);
+            } else {
+                plot_flags.resize(PIdx::nattribs, 0);
+            }
+            // If not none, set plot_flags values to 1 for elements in plot_vars.
+            if (plot_vars[0] != "none"){
+                for (const auto& var : plot_vars){
+                    // Return error if var not in PIdx. 
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( 
+                        ParticleStringNames::to_index.count(var), 
+                        "plot_vars argument not in ParticleStringNames");
+                    plot_flags[ParticleStringNames::to_index.at(var)] = 1;
+                }
+            }
+        }
+        */
 
         // Check that the coarsening_ratio can divide the blocking factor
         for (int lev=0; lev<maxLevel(); lev++){

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -387,15 +387,10 @@ WarpX::ReadParameters ()
         pp.query("dump_plotfiles", dump_plotfiles);
         pp.query("plot_raw_fields", plot_raw_fields);
         pp.query("plot_raw_fields_guards", plot_raw_fields_guards);
-        /*
-        if (ParallelDescriptor::NProcs() == 1) {
-            plot_proc_number = false;
-        }
-        */
         pp.query("plot_coarsening_ratio", plot_coarsening_ratio);
-        int do_user_plot_vars;
-        do_user_plot_vars = pp.queryarr("fields_to_plot", fields_to_plot);
-        if (not do_user_plot_vars){
+        bool user_fields_to_plot;
+        user_fields_to_plot = pp.queryarr("fields_to_plot", fields_to_plot);
+        if (not user_fields_to_plot){
             // If not specified, set default values
             fields_to_plot = {"Ex", "Ey", "Ez", "Bx", "By",
                               "Bz", "jx", "jy", "jz", 


### PR DESCRIPTION
This PR adds the ability to choose which fields and which components are dumped to plotfiles. The previous way
```
warpx.plot_E_field = 1
warpx.plot_J_field = 1
[...]
```
is replaces by
```
warpx.fields_to_plot = Ex Ey Ez jx jy jz [...]
```
All fields use this syntax (the documentation contains a list of all possible fields), except `warpx.plot_finepatch = 1` and `warpx.plot_crsepatch = 1`, as they are usually not used in production runs, and using them results all components of `E` **and** `B` to be dumped. This can be updated if required.

In the previous implementation, the interpolation from staggered grid to cell-centered data relied on the fact that all three components of each `MultiFab` was written to file. For the sake of simplicity, this PR calls the same routines: if `Ex` or `Ey` or `Ez` is requested, the 3D interpolated array is calculated and only the specified component(s) is (are) written to file. This should not affect performances significantly.