### PR TITLE
Call DefineAndReturnParticleTile when using runtime components

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -196,17 +196,20 @@ PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
     attribs[PIdx::uz] = u[2];
     attribs[PIdx::w ] = weight;
 
-    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+    if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) )
     {
-        // need to create old values
         auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
-        particle_tile.push_back_real(particle_comps["xold"], x);
-        particle_tile.push_back_real(particle_comps["yold"], y);
-        particle_tile.push_back_real(particle_comps["zold"], z);
+        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+        {
+            // need to create old values
+            particle_tile.push_back_real(particle_comps["xold"], x);
+            particle_tile.push_back_real(particle_comps["yold"], y);
+            particle_tile.push_back_real(particle_comps["zold"], z);
                 
-        particle_tile.push_back_real(particle_comps["uxold"], u[0]);
-        particle_tile.push_back_real(particle_comps["uyold"], u[1]);
-        particle_tile.push_back_real(particle_comps["uzold"], u[2]);
+            particle_tile.push_back_real(particle_comps["uxold"], u[0]);
+            particle_tile.push_back_real(particle_comps["uyold"], u[1]);
+            particle_tile.push_back_real(particle_comps["uzold"], u[2]);
+        }
     }
     // add particle
     AddOneParticle(0, 0, 0, x, y, z, attribs);
@@ -289,7 +292,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const int grid_id = mfi.index();
         const int tile_id = mfi.LocalTileIndex();
         GetParticles(lev)[std::make_pair(grid_id, tile_id)];
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags) {
+        if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) ) {
             DefineAndReturnParticleTile(lev, grid_id, tile_id);
         }
     }
@@ -414,10 +417,12 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
         auto& particle_tile = GetParticles(lev)[std::make_pair(grid_id,tile_id)];
         bool do_boosted = false;
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags) {
-            do_boosted = true;
+        if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) ) {
             DefineAndReturnParticleTile(lev, grid_id, tile_id);
         }
+        do_boosted = (WarpX::do_boosted_frame_diagnostic && 
+                      do_boosted_frame_diags);
+
         auto old_size = particle_tile.GetArrayOfStructs().size();
         auto new_size = old_size + max_new_particles;
         particle_tile.resize(new_size);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -237,13 +237,16 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = z[i];
 #endif
 
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        {
-            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);
-            ptile.push_back_real(particle_comps["xold"], x[i]);
-            ptile.push_back_real(particle_comps["yold"], y[i]);
-            ptile.push_back_real(particle_comps["zold"], z[i]);
+        if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) ){
+            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);            
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+            {
+                ptile.push_back_real(particle_comps["xold"], x[i]);
+                ptile.push_back_real(particle_comps["yold"], y[i]);
+                ptile.push_back_real(particle_comps["zold"], z[i]);
+            }
         }
+
 
         particle_tile.push_back(p);
     }
@@ -255,12 +258,14 @@ WarpXParticleContainer::AddNParticles (int lev,
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
 
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        {
-            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);
-            ptile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);
-            ptile.push_back_real(particle_comps["uyold"], vy + ibegin, vy + iend);
-            ptile.push_back_real(particle_comps["uzold"], vz + ibegin, vz + iend);
+        if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) ){
+            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);            
+            if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+            {
+                ptile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);
+                ptile.push_back_real(particle_comps["uyold"], vy + ibegin, vy + iend);
+                ptile.push_back_real(particle_comps["uzold"], vz + ibegin, vz + iend);
+            }
         }
 
         for (int comp = PIdx::uz+1; comp < PIdx::nattribs; ++comp)


### PR DESCRIPTION
WarpX will have a number of optional runtime particle components for:

- boosted frame diagnostics (already implemented)
- ionization
- QED processes

This PR calls `DefineAndReturnParticleTile` whenever using runtime components. 

This PR could be a place to clarify runtime components, so here are two questions related to this question @WeiqunZhang @atmyers:

1. When using boosted frame diagnostics, the constructor of `WarpXParticleContainer` contains
```
particle_comps["xold"]  = PIdx::nattribs;
particle_comps["yold"]  = PIdx::nattribs+1;
```
Should we make this more general, and do the same for other runtime components?

2. Should we update functions like `AddOneParticle` and `AddNParticles`, that do not update runtime component? 

Thank you for you help!