### PR TITLE
[mini-PR] allow threshold for plasma density

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -219,6 +219,14 @@ Particle initialization
       ``electrons.density_function(x,y,z) = "n0+n0*x**2*1.e12"`` where ``n0`` is a
       user-defined constant, see above.
 
+* ``<species_name>.density_min`` (`float`) optional (default `0.`)
+    Minimum plasma density. No particle is injected where the density is below
+    this value.
+
+* ``<species_name>.density_max`` (`float`) optional (default `infinity`)
+    Maximum plasma density. The density at each point is the minimum between
+    the value given in the profile, and `density_max`.
+
 * ``<species_name>.radially_weighted`` (`bool`) optional (default `true`)
     Whether particle's weight is varied with their radius. This only applies to cylindrical geometry.
     The only valid value is true.

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -66,6 +66,8 @@ public:
     amrex::Real xmin, xmax;
     amrex::Real ymin, ymax;
     amrex::Real zmin, zmax;
+    amrex::Real density_min = 0;
+    amrex::Real density_max = std::numeric_limits<amrex::Real>::max();
 
     InjectorPosition* getInjectorPosition ();
     InjectorDensity*  getInjectorDensity ();

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -81,6 +81,9 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     pp.query("ymax", ymax);
     pp.query("zmax", zmax);
 
+    pp.query("density_min", density_min);
+    pp.query("density_max", density_max);
+
     // parse charge and mass
     std::string charge_s;
     pp.get("charge", charge_s);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -522,10 +522,12 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 u = inj_mom->getMomentum(x, y, z);
                 dens = inj_rho->getDensity(x, y, z);
                 // Remove particle if density below threshold
-                if ( (dens < density_min) || (dens > density_max) ){
+                if ( dens < density_min ){
                     p.id() = -1;
                     return;
                 }
+                // Cut density if above threshold
+                dens = amrex::min(dens, density_max);
             } else {
                 // Boosted-frame simulation
                 // Since the user provides the density distribution
@@ -554,10 +556,12 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 // call `getDensity` with lab-frame parameters
                 dens = inj_rho->getDensity(x, y, z0_lab);
                 // Remove particle if density below threshold
-                if ( (dens < density_min) || (dens > density_max) ){
+                if ( dens < density_min ){
                     p.id() = -1;
                     return;
                 }
+                // Cut density if above threshold
+                dens = amrex::min(dens, density_max);
                 // At this point u and dens are the lab-frame quantities
                 // => Perform Lorentz transform
                 dens = gamma_boost * dens * ( 1.0 - beta_boost*betaz_lab );

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -320,6 +320,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     Real gamma_boost = WarpX::gamma_boost;
     Real beta_boost = WarpX::beta_boost;
     Real t = WarpX::GetInstance().gett_new(lev);
+    Real density_min = plasma_injector->density_min;
+    Real density_max = plasma_injector->density_max;
 
 #ifdef WARPX_RZ
     bool radially_weighted = plasma_injector->radially_weighted;
@@ -519,6 +521,11 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 }
                 u = inj_mom->getMomentum(x, y, z);
                 dens = inj_rho->getDensity(x, y, z);
+                // Remove particle if density below threshold
+                if ( (dens < density_min) || (dens > density_max) ){
+                    p.id() = -1;
+                    return;
+                }
             } else {
                 // Boosted-frame simulation
                 // Since the user provides the density distribution
@@ -546,6 +553,11 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 }
                 // call `getDensity` with lab-frame parameters
                 dens = inj_rho->getDensity(x, y, z0_lab);
+                // Remove particle if density below threshold
+                if ( (dens < density_min) || (dens > density_max) ){
+                    p.id() = -1;
+                    return;
+                }
                 // At this point u and dens are the lab-frame quantities
                 // => Perform Lorentz transform
                 dens = gamma_boost * dens * ( 1.0 - beta_boost*betaz_lab );


### PR DESCRIPTION
User can specify a min and max value for the density.

- If the local density is below the min value, no particle is injected.
- If the local density is above the max value, the particle is injected with max value instead.

This makes it simpler for potentially infinite profiles (like exponentially-decreasing density).