### PR TITLE
`warpx.openpmd_backend`: Expose backends 

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -97,7 +97,7 @@ First, load the appropriate modules:
     module swap PrgEnv-intel PrgEnv-gnu
     module load cmake/3.14.4
     module load cray-hdf5-parallel
-    module load adios/1.13.1 zlib
+    module load adios/1.13.1
     export CRAYPE_LINK_TYPE=dynamic
 
 Then, in the `warpx_directory`, download and build the openPMD API:

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -684,7 +684,13 @@ Diagnostics and output
     `openPMD <https://github.com/openPMD>`__ format.
     When WarpX is compiled with openPMD support, this is ``1`` by default.
 
-* ``warpx.do_boosted_frame_diagnostic`` (`0 or 1`)
+* ``warpx.openpmd_backend`` (``h5``, ``bp`` or ``json``) optional
+    I/O backend for
+    `openPMD <https://github.com/openPMD>`__ dumps.
+    When WarpX is compiled with openPMD support, this is ``h5`` by default.
+    ``json`` only works with serial/single-rank jobs.
+
+* ``warpx.do_boosted_frame_diagnostic`` (`0` or `1`)
     Whether to use the **back-transformed diagnostics** (i.e. diagnostics that
     perform on-the-fly conversion to the laboratory frame, when running
     boosted-frame simulations)

--- a/Docs/source/visualization/visualization.rst
+++ b/Docs/source/visualization/visualization.rst
@@ -8,7 +8,8 @@ Particle-In-Cell codes).
 .. note::
 
     This is controlled by the parameters ``warpx.dump_plotfiles`` and
-    ``warpx.dump_openpmd`` in the section :doc:`../running_cpp/parameters`.
+    ``warpx.dump_openpmd`` & ``warpx.openpmd_backend`` in the section
+    :doc:`../running_cpp/parameters`.
 
 This section describes some of the tools available to visualize the data:
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -143,9 +143,16 @@ WriteOpenPMDFields( const std::string& filename,
   auto dataset = openPMD::Dataset(datatype, global_size);
 
   // Create new file and store the time/iteration info
-  auto series = openPMD::Series( filename,
-                                 openPMD::AccessType::CREATE,
-                                 MPI_COMM_WORLD );
+  auto series = [filename](){
+      if( ParallelDescriptor::NProcs() > 1 )
+        return openPMD::Series( filename,
+                                openPMD::AccessType::CREATE,
+                                MPI_COMM_WORLD );
+      else
+          return openPMD::Series( filename,
+                                  openPMD::AccessType::CREATE );
+  }();
+
   auto series_iteration = series.iterations[iteration];
   series_iteration.setTime( time );
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -13,7 +13,7 @@ using namespace amrex;
 namespace
 {
     // Return true if any element in elems is in vect, false otherwise
-    static bool is_in_vector(std::vector<std::string> vect, 
+    static bool is_in_vector(std::vector<std::string> vect,
                              std::vector<std::string> elems)
     {
         bool value = false;
@@ -145,9 +145,9 @@ WriteOpenPMDFields( const std::string& filename,
   // Create new file and store the time/iteration info
   auto series = [filename](){
       if( ParallelDescriptor::NProcs() > 1 )
-        return openPMD::Series( filename,
-                                openPMD::AccessType::CREATE,
-                                MPI_COMM_WORLD );
+          return openPMD::Series( filename,
+                                  openPMD::AccessType::CREATE,
+                                  ParallelDescriptor::Communicator() );
       else
           return openPMD::Series( filename,
                                   openPMD::AccessType::CREATE );
@@ -174,7 +174,7 @@ WriteOpenPMDFields( const std::string& filename,
         }
     }
 
-    // Setup the mesh accordingly
+    // Setup the mesh record accordingly
     auto mesh = series_iteration.meshes[field_name];
     mesh.setDataOrder(openPMD::Mesh::DataOrder::F); // MultiFab: Fortran order
     mesh.setAxisLabels( axis_labels );
@@ -182,11 +182,11 @@ WriteOpenPMDFields( const std::string& filename,
     mesh.setGridGlobalOffset( global_offset );
     setOpenPMDUnit( mesh, field_name );
 
-    // Create a new mesh record, and store the associated metadata
-    auto mesh_record = mesh[comp_name];
-    mesh_record.resetDataset( dataset );
+    // Create a new mesh record component, and store the associated metadata
+    auto mesh_comp = mesh[comp_name];
+    mesh_comp.resetDataset( dataset );
     // Cell-centered data: position is at 0.5 of a cell size.
-    mesh_record.setPosition(std::vector<double>{AMREX_D_DECL(0.5, 0.5, 0.5)});
+    mesh_comp.setPosition(std::vector<double>{AMREX_D_DECL(0.5, 0.5, 0.5)});
 
     // Loop through the multifab, and store each box as a chunk,
     // in the openPMD file.
@@ -202,8 +202,8 @@ WriteOpenPMDFields( const std::string& filename,
 
       // Write local data
       const double* local_data = fab.dataPtr(icomp);
-      mesh_record.storeChunk(openPMD::shareRaw(local_data),
-                             chunk_offset, chunk_size);
+      mesh_comp.storeChunk(openPMD::shareRaw(local_data),
+                           chunk_offset, chunk_size);
     }
   }
   // Flush data to disk after looping over all components
@@ -325,14 +325,14 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
         + static_cast<int>(plot_finepatch)*6
         + static_cast<int>(plot_crsepatch)*6
         + static_cast<int>(costs[0] != nullptr);
-    
+
     // Loop over levels of refinement
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         // Allocate pointers to the `ncomp` fields that will be added
         mf_avg.push_back( MultiFab(grids[lev], dmap[lev], ncomp, ngrow));
 
-        // For E, B and J, if at least one component is requested, 
+        // For E, B and J, if at least one component is requested,
         // build cell-centered temporary MultiFab with 3 comps
         MultiFab mf_tmp_E, mf_tmp_B, mf_tmp_J;
         // Build mf_tmp_E is at least one component of E is requested
@@ -427,7 +427,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
                             {Bfield_aux[lev][0].get(),
                                     Bfield_aux[lev][1].get(),
                                     Bfield_aux[lev][2].get()},
-                            WarpX::CellSize(lev) );                
+                            WarpX::CellSize(lev) );
             } else if (fieldname == "divE"){
                 if (do_nodal) amrex::Abort("TODO: do_nodal && plot dive");
                 const BoxArray& ba = amrex::convert(boxArray(lev),IntVect::TheUnitVector());

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -525,8 +525,10 @@ WarpX::WritePlotFile () const
 #ifdef WARPX_USE_OPENPMD
     if (dump_openpmd){
         // Write openPMD format: only for level 0
-        std::string filename = amrex::Concatenate("diags/hdf5/data", istep[0]);
-        filename += ".h5";
+        std::string filename = std::string("diags/");
+        filename.append(openpmd_backend);
+        filename += amrex::Concatenate("/data", istep[0]);
+        filename += std::string(".") + openpmd_backend;
         WriteOpenPMDFields( filename, varnames,
                       *output_mf[0], output_geom[0], istep[0], t_new[0] );
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -541,6 +541,7 @@ private:
     int check_int = -1;
     int plot_int = -1;
 
+    std::string openpmd_backend {"h5"};
 #ifdef WARPX_USE_OPENPMD
     bool dump_plotfiles = false;
     bool dump_openpmd = true;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -413,6 +413,7 @@ WarpX::ReadParameters ()
 
 
         pp.query("dump_openpmd", dump_openpmd);
+        pp.query("openpmd_backend", openpmd_backend);
         pp.query("dump_plotfiles", dump_plotfiles);
         pp.query("plot_raw_fields", plot_raw_fields);
         pp.query("plot_raw_fields_guards", plot_raw_fields_guards);


### PR DESCRIPTION
Allow to chose alternative file endings with openPMD dumps.

Default available inputs that work with `warpx.dump_openpmd = 1` and e.g. `amr.plot_int = 100`:
```
warpx.openpmd_backend = h5  # serial & parallel HDF5
# this is the default so far, but since parallel HDF5 is very
# slow we might want to change it to bp at some point
```
or
```
warpx.openpmd_backend = bp  # serial & parallel ADIOS1 "bp3"
# this will switch to ADIOS2 "bp4" automatically in the future,
# if available in the linked openPMD-api lib
```
or
```
warpx.openpmd_backend = json  # serial json (text)
# only works when run with one MPI rank, otherwise ignored
```