### PR TITLE
Choose pml direction

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -661,6 +661,12 @@ Boundary conditions
     The characteristic depth, in number of cells, over which
     the absorption coefficients of the PML increases.
 
+* ``warpx.do_pml_Lo`` (`2 ints in 2D`, `3 ints in 3D`; default: `1 1 1`)
+    The directions along which one wants a pml boundary condition for lower boundaries on mother grid.
+
+* ``warpx.do_pml_Hi`` (`2 floats in 2D`, `3 floats in 3D`;; default: `1 1 1`)
+    The directions along which one wants a pml boundary condition for upper boundaries on mother grid.
+
 Diagnostics and output
 ----------------------
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -664,7 +664,7 @@ Boundary conditions
 * ``warpx.do_pml_Lo`` (`2 ints in 2D`, `3 ints in 3D`; default: `1 1 1`)
     The directions along which one wants a pml boundary condition for lower boundaries on mother grid.
 
-* ``warpx.do_pml_Hi`` (`2 floats in 2D`, `3 floats in 3D`;; default: `1 1 1`)
+* ``warpx.do_pml_Hi`` (`2 floats in 2D`, `3 floats in 3D`; default: `1 1 1`)
     The directions along which one wants a pml boundary condition for upper boundaries on mother grid.
 
 Diagnostics and output

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -101,7 +101,9 @@ public:
 #ifdef WARPX_USE_PSATD
          amrex::Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
 #endif
-         int do_dive_cleaning, int do_moving_window);
+         int do_dive_cleaning, int do_moving_window,
+         const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
+         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
 
     void ComputePMLFactors (amrex::Real dt);
 
@@ -172,7 +174,9 @@ private:
 #endif
 
     static amrex::BoxArray MakeBoxArray (const amrex::Geometry& geom,
-                                         const amrex::BoxArray& grid_ba, int ncell);
+                                         const amrex::BoxArray& grid_ba, int ncell,
+                                         const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
+                                         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
 
     static void Exchange (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom);
 };

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -102,8 +102,7 @@ public:
          amrex::Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
 #endif
          int do_dive_cleaning, int do_moving_window,
-         const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
-         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
+         const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi);
 
     void ComputePMLFactors (amrex::Real dt);
 
@@ -175,8 +174,8 @@ private:
 
     static amrex::BoxArray MakeBoxArray (const amrex::Geometry& geom,
                                          const amrex::BoxArray& grid_ba, int ncell,
-                                         const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
-                                         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
+                                         const amrex::IntVect do_pml_Lo,
+                                         const amrex::IntVect do_pml_Hi);
 
     static void Exchange (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom);
 };

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -324,7 +324,7 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& grid_dm,
     : m_geom(geom),
       m_cgeom(cgeom)
 {
-    const BoxArray& ba = MakeBoxArray(*geom, grid_ba, ncell);
+    const BoxArray& ba = MakeBoxArray(*geom, grid_ba, ncell, do_pml_Lo, do_pml_Hi);
     if (ba.size() == 0) {
         m_ok = false;
         return;
@@ -400,7 +400,7 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& grid_dm,
 
         BoxArray grid_cba = grid_ba;
         grid_cba.coarsen(ref_ratio);
-        const BoxArray& cba = MakeBoxArray(*cgeom, grid_cba, ncell);
+        const BoxArray& cba = MakeBoxArray(*cgeom, grid_cba, ncell, do_pml_Lo, do_pml_Hi);
 
         DistributionMapping cdm{cba};
 
@@ -445,7 +445,12 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba, 
     Box domain = geom.Domain();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         if ( ! geom.isPeriodic(idim) ) {
-            domain.grow(idim, ncell);
+            if (do_pml_Lo[idim]){
+                domain.growLo(idim, ncell);
+            }
+            if (do_pml_Hi[idim]){
+                domain.growHi(idim, ncell);
+            }
         }
     }
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -319,7 +319,8 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& grid_dm,
 #ifdef WARPX_USE_PSATD
           Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
 #endif
-          int do_dive_cleaning, int do_moving_window)
+          int do_dive_cleaning, int do_moving_window,
+          const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
     : m_geom(geom),
       m_cgeom(cgeom)
 {
@@ -438,7 +439,8 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& grid_dm,
 }
 
 BoxArray
-PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba, int ncell)
+PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba, int ncell,
+                   const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
 {
     Box domain = geom.Domain();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -258,14 +258,7 @@ SigmaBox::ComputePMLFactorsB (const Real* dx, Real dt)
     {
         for (int i = 0, N = sigma_star[idim].size(); i < N; ++i)
         {
-            if (sigma_star[idim][i] == 0.0)
-            {
-                sigma_star_fac[idim][i] = 1.0;
-            }
-            else
-            {
-                sigma_star_fac[idim][i] = std::exp(-sigma_star[idim][i]*dt);
-            }
+            sigma_star_fac[idim][i] = std::exp(-sigma_star[idim][i]*dt);
         }
     }
 }
@@ -277,14 +270,7 @@ SigmaBox::ComputePMLFactorsE (const Real* dx, Real dt)
     {
         for (int i = 0, N = sigma[idim].size(); i < N; ++i)
         {
-            if (sigma[idim][i] == 0.0)
-            {
-                sigma_fac[idim][i] = 1.0;
-            }
-            else
-            {
-                sigma_fac[idim][i] = std::exp(-sigma[idim][i]*dt);
-            }
+            sigma_fac[idim][i] = std::exp(-sigma[idim][i]*dt);
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -131,15 +131,27 @@ WarpX::InitPML ()
 {
     if (do_pml)
     {
+        amrex::IntVect do_pml_Lo_corrected = do_pml_Lo;
+        // amrex::IntVect do_pml_Hi_corrected = do_pml_Hi;
+
+#ifdef WARPX_DIM_RZ
+        do_pml_Lo_corrected[0] = 0; //no PML along z-axis
+#endif
         pml[0].reset(new PML(boxArray(0), DistributionMap(0), &Geom(0), nullptr,
                              pml_ncell, pml_delta, 0,
 #ifdef WARPX_USE_PSATD
                              dt[0], nox_fft, noy_fft, noz_fft, do_nodal,
 #endif
                              do_dive_cleaning, do_moving_window,
-                             do_pml_Lo, do_pml_Hi));
+                             do_pml_Lo_corrected, do_pml_Hi));
         for (int lev = 1; lev <= finest_level; ++lev)
         {
+            amrex::IntVect do_pml_Lo_MR = amrex::IntVect::TheUnitVector();
+#ifdef WARPX_DIM_RZ
+            if ((max_level > 0) && (fine_tag_lo[0]==0.)) { //if the border of the patch matches with the z-axis
+                do_pml_Lo_MR[0] = 0;
+            }
+#endif
             pml[lev].reset(new PML(boxArray(lev), DistributionMap(lev),
                                    &Geom(lev), &Geom(lev-1),
                                    pml_ncell, pml_delta, refRatio(lev-1)[0],
@@ -147,7 +159,7 @@ WarpX::InitPML ()
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
 #endif
                                    do_dive_cleaning, do_moving_window,
-                                   amrex::IntVect::TheUnitVector(), amrex::IntVect::TheUnitVector()));
+                                   do_pml_Lo_MR, amrex::IntVect::TheUnitVector()));
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -132,10 +132,9 @@ WarpX::InitPML ()
     if (do_pml)
     {
         amrex::IntVect do_pml_Lo_corrected = do_pml_Lo;
-        // amrex::IntVect do_pml_Hi_corrected = do_pml_Hi;
 
 #ifdef WARPX_DIM_RZ
-        do_pml_Lo_corrected[0] = 0; //no PML along z-axis
+        do_pml_Lo_corrected[0] = 0; // no PML at r=0, in cylindrical geometry
 #endif
         pml[0].reset(new PML(boxArray(0), DistributionMap(0), &Geom(0), nullptr,
                              pml_ncell, pml_delta, 0,
@@ -148,7 +147,8 @@ WarpX::InitPML ()
         {
             amrex::IntVect do_pml_Lo_MR = amrex::IntVect::TheUnitVector();
 #ifdef WARPX_DIM_RZ
-            if ((max_level > 0) && (fine_tag_lo[0]==0.)) { //if the border of the patch matches with the z-axis
+            //In cylindrical geometry, if the edge of the patch is at r=0, do not add PML
+            if ((max_level > 0) && (fine_tag_lo[0]==0.)) {
                 do_pml_Lo_MR[0] = 0;
             }
 #endif

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -145,7 +145,8 @@ WarpX::InitPML ()
 #ifdef WARPX_USE_PSATD
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
 #endif
-                                   do_dive_cleaning, do_moving_window));
+                                   do_dive_cleaning, do_moving_window,
+                                   do_pml_Lo, do_pml_Hi));
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -136,7 +136,8 @@ WarpX::InitPML ()
 #ifdef WARPX_USE_PSATD
                              dt[0], nox_fft, noy_fft, noz_fft, do_nodal,
 #endif
-                             do_dive_cleaning, do_moving_window));
+                             do_dive_cleaning, do_moving_window,
+                             do_pml_Lo, do_pml_Hi));
         for (int lev = 1; lev <= finest_level; ++lev)
         {
             pml[lev].reset(new PML(boxArray(lev), DistributionMap(lev),

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -147,7 +147,7 @@ WarpX::InitPML ()
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
 #endif
                                    do_dive_cleaning, do_moving_window,
-                                   do_pml_Lo, do_pml_Hi));
+                                   amrex::IntVect::TheUnitVector(), amrex::IntVect::TheUnitVector()));
         }
     }
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -489,6 +489,8 @@ private:
     int do_pml = 1;
     int pml_ncell = 10;
     int pml_delta = 10;
+    amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector();
+    amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector();
     amrex::Vector<std::unique_ptr<PML> > pml;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -383,6 +383,22 @@ WarpX::ReadParameters ()
         pp.query("pml_ncell", pml_ncell);
         pp.query("pml_delta", pml_delta);
 
+        Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,1);
+        pp.queryarr("do_pml_Lo", parse_do_pml_Lo);
+        do_pml_Lo[0] = parse_do_pml_Lo[0];
+        do_pml_Lo[1] = parse_do_pml_Lo[1];
+#if (AMREX_SPACEDIM == 3)
+        do_pml_Lo[2] = parse_do_pml_Lo[2];
+#endif
+        Vector<int> parse_do_pml_Hi(AMREX_SPACEDIM,1);
+        pp.queryarr("do_pml_Hi", parse_do_pml_Hi);
+        do_pml_Hi[0] = parse_do_pml_Hi[0];
+        do_pml_Hi[1] = parse_do_pml_Hi[1];
+#if (AMREX_SPACEDIM == 3)
+        do_pml_Hi[2] = parse_do_pml_Hi[2];
+#endif
+
+
         pp.query("dump_openpmd", dump_openpmd);
         pp.query("dump_plotfiles", dump_plotfiles);
         pp.query("plot_raw_fields", plot_raw_fields);
@@ -393,7 +409,7 @@ WarpX::ReadParameters ()
         if (not user_fields_to_plot){
             // If not specified, set default values
             fields_to_plot = {"Ex", "Ey", "Ez", "Bx", "By",
-                              "Bz", "jx", "jy", "jz", 
+                              "Bz", "jx", "jy", "jz",
                               "part_per_cell"};
         }
         // set plot_rho to true of the users requests it, so that
@@ -411,9 +427,9 @@ WarpX::ReadParameters ()
         // If user requests to plot proc_number for a serial run,
         // delete proc_number from fields_to_plot
         if (ParallelDescriptor::NProcs() == 1){
-            fields_to_plot.erase(std::remove(fields_to_plot.begin(), 
-                                             fields_to_plot.end(), 
-                                             "proc_number"), 
+            fields_to_plot.erase(std::remove(fields_to_plot.begin(),
+                                             fields_to_plot.end(),
+                                             "proc_number"),
                                  fields_to_plot.end());
         }
 
@@ -497,7 +513,7 @@ WarpX::ReadParameters ()
     {
         ParmParse pp("algo");
         // If not in RZ mode, read use_picsar_deposition
-        // In RZ mode, use_picsar_deposition is on, as the C++ version 
+        // In RZ mode, use_picsar_deposition is on, as the C++ version
         // of the deposition does not support RZ
 #ifndef WARPX_RZ
         pp.query("use_picsar_deposition", use_picsar_deposition);


### PR DESCRIPTION
Added the possibility to choose in what directions one wants to have PML boundary conditions (for lower and upper boundaries on mother grid only). This enables for instance to have a PML along `+x` and not along `-x`. For the directions along which the PML is desabled, the reflective boundary condition is adopted.

**RZ mode Specificities**:
- pml is automatically disabled along `x=0` on the mother grid
- MR: if MR patch lower boundary `xmin` coincides with `z` axis (i.e. `xmin = 0`), then the pml is automatically disabled for the refined patch along `x = xmin = 0`.

**Modified files**:
- `Source/WarpX.cpp`, `Source/WarpX.H`: added two new input entries `warpx.do_pml_Lo`, `warpx.do_pml_Hi` that correspond to the option
- `Source/BoundaryConditions/PML.cpp`, `Source/BoundaryConditions/PML.H`: PML constructor and `MakeBoxArray` modified in order to take this specificity into account
- ` Source/Initialization/WarpXInitData.cpp`: modified PML initialisation for mother grid only
- `Docs/source/running_cpp/parameters.rst`: added the new parameters in the "Boundary conditions" section.
