### PR TITLE
[mini-PR] Fix current deposition in buffers

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -506,35 +506,35 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
 
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov) {
         if        (WarpX::nox == 1){
-            doEsirkepovDepositionShapeN<1>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                           uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doEsirkepovDepositionShapeN<1>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                           uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                            jz_arr, np_to_depose, dt, dx,
                                            xyzmin, lo, q);
         } else if (WarpX::nox == 2){
-            doEsirkepovDepositionShapeN<2>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                           uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doEsirkepovDepositionShapeN<2>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                           uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                            jz_arr, np_to_depose, dt, dx,
                                            xyzmin, lo, q);
         } else if (WarpX::nox == 3){
-            doEsirkepovDepositionShapeN<3>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                           uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doEsirkepovDepositionShapeN<3>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                           uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                            jz_arr, np_to_depose, dt, dx,
                                            xyzmin, lo, q);
         }
     } else {
         if        (WarpX::nox == 1){
-            doDepositionShapeN<1>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                  uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doDepositionShapeN<1>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                  uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                   jz_arr, np_to_depose, dt, dx,
                                   xyzmin, lo, stagger_shift, q);
         } else if (WarpX::nox == 2){
-            doDepositionShapeN<2>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                  uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doDepositionShapeN<2>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                  uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                   jz_arr, np_to_depose, dt, dx,
                                   xyzmin, lo, stagger_shift, q);
         } else if (WarpX::nox == 3){
-            doDepositionShapeN<3>(xp, yp, zp, wp.dataPtr(), uxp.dataPtr(), 
-                                  uyp.dataPtr(), uzp.dataPtr(), jx_arr, jy_arr, 
+            doDepositionShapeN<3>(xp, yp, zp, wp.dataPtr() + offset, uxp.dataPtr() + offset, 
+                                  uyp.dataPtr() + offset, uzp.dataPtr() + offset, jx_arr, jy_arr, 
                                   jz_arr, np_to_depose, dt, dx,
                                   xyzmin, lo, stagger_shift, q);
         }


### PR DESCRIPTION
As pointed out by @dpgrote, the current deposition in buffers was broken. This proposes a fix.
Results are identical with `algo.use_picsar_deposition=1` or `0`, with and without CD buffers (it was not the case before this PR).