### PR TITLE
Fix compilation flag for openPMD with nvcc

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -101,7 +101,7 @@ ifeq ($(USE_OPENPMD), TRUE)
    ifeq (0, $(shell pkg-config "openPMD >= 0.9.0"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LDFLAGS += $(shell pkg-config --libs openPMD)
-       LDFLAGS += -Wl,-rpath,$(shell pkg-config --variable=libdir openPMD)
+       LDFLAGS += -Xlinker -rpath -Xlinker $(shell pkg-config --variable=libdir openPMD)
    # fallback to manual settings
    else
        OPENPMD_LIB_PATH ?= NOT_SET


### PR DESCRIPTION
When compiling with `USE_GPU=TRUE` and `USE_OPENPMD=TRUE`, WarpX returns the following error: 
```
nvcc fatal   : Unknown option 'Wl,-rpath,/home/rlehe/spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-7.2.0/openpmd-api-develop-2b3hkqevid66a3uk76xu5buqqojcdjeb/lib'
```
As suggested by @ax3l in off-line discuss, the `Make.WarpX` file can be modified to avoid this.