### PR TITLE
[mini-PR] User can specify time interval OR distance between snapshots

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -703,6 +703,11 @@ Diagnostics and output
     The time interval inbetween the lab-frame snapshots (where this
     time interval is expressed in the laboratory frame).
 
+* ``warpx.dz_snapshots_lab`` (`float`, in meters)
+    Only used when ``warpx.do_boosted_frame_diagnostic`` is ``1``.
+    Distance between the lab-frame snapshots (expressed in the laboratory
+    frame). Either `dt_snapshots_lab` or `dz_snapshot_lab` is required.
+
 * ``warpx.do_boosted_frame_fields`` (`0 or 1`)
     Whether to use the **back-transformed diagnostics** for the fields.
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -706,7 +706,9 @@ Diagnostics and output
 * ``warpx.dz_snapshots_lab`` (`float`, in meters)
     Only used when ``warpx.do_boosted_frame_diagnostic`` is ``1``.
     Distance between the lab-frame snapshots (expressed in the laboratory
-    frame). Either `dt_snapshots_lab` or `dz_snapshot_lab` is required.
+    frame). ``dt_snapshots_lab`` is then computed by
+    ``dt_snapshots_lab = dz_snapshots_lab/c``. Either `dt_snapshots_lab`
+    or `dz_snapshot_lab` is required.
 
 * ``warpx.do_boosted_frame_fields`` (`0 or 1`)
     Whether to use the **back-transformed diagnostics** for the fields.

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -334,7 +334,20 @@ WarpX::ReadParameters ()
                "The boosted frame diagnostic currently only works if the boost is in the z direction.");
 
         pp.get("num_snapshots_lab", num_snapshots_lab);
-        pp.get("dt_snapshots_lab", dt_snapshots_lab);
+
+        // Read either dz_snapshots_lab or dt_snapshots_lab
+        bool snapshot_interval_is_specified = 0;
+        Real dz_snapshots_lab = 0;
+        snapshot_interval_is_specified += pp.query("dt_snapshots_lab", dt_snapshots_lab);
+        if ( pp.query("dz_snapshots_lab", dz_snapshots_lab) ){
+            // dt_snapshots_lab = dz_snapshots_lab/gamma_boost/moving_window_v;
+            dt_snapshots_lab = dz_snapshots_lab/moving_window_v;
+            snapshot_interval_is_specified = 1;
+        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            snapshot_interval_is_specified,
+            "When using back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab.");
+
         pp.get("gamma_boost", gamma_boost);
 
         pp.query("do_boosted_frame_fields", do_boosted_frame_fields);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -340,7 +340,6 @@ WarpX::ReadParameters ()
         Real dz_snapshots_lab = 0;
         snapshot_interval_is_specified += pp.query("dt_snapshots_lab", dt_snapshots_lab);
         if ( pp.query("dz_snapshots_lab", dz_snapshots_lab) ){
-            // dt_snapshots_lab = dz_snapshots_lab/gamma_boost/moving_window_v;
             dt_snapshots_lab = dz_snapshots_lab/moving_window_v;
             snapshot_interval_is_specified = 1;
         }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -340,7 +340,7 @@ WarpX::ReadParameters ()
         Real dz_snapshots_lab = 0;
         snapshot_interval_is_specified += pp.query("dt_snapshots_lab", dt_snapshots_lab);
         if ( pp.query("dz_snapshots_lab", dz_snapshots_lab) ){
-            dt_snapshots_lab = dz_snapshots_lab/moving_window_v;
+            dt_snapshots_lab = dz_snapshots_lab/PhysConst::c;
             snapshot_interval_is_specified = 1;
         }
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(


### PR DESCRIPTION
So far, when running a simulation in a boosted frame, the user had to specify the number of snapshots and the time between consecutive snapshots for back-transformed diagnostics.

When running simulations for plasma acceleration, we usually have a better feeling on distances (for a 20 cm plasma accelerator, I want a back-transformed snapshot every, say, 1 cm).

This PR adds the option to specify `warpx.dz_snapshots_lab` instead of `warpx.dt_snapshots_lab`. Users most specify one of these parameters.