### PR TITLE
LWFA 2D example in boosted frame - Esirkepov

### DIFF
--- a/Examples/Physics_applications/laser_acceleration/inputs.2d.boost
+++ b/Examples/Physics_applications/laser_acceleration/inputs.2d.boost
@@ -19,7 +19,7 @@ geometry.prob_hi     =  128.e-6     0.96e-6
 #################################
 warpx.verbose = 1
 amrex.v = 1
-algo.current_deposition = direct
+algo.current_deposition = esirkepov
 algo.charge_deposition = standard
 algo.field_gathering = standard
 algo.particle_pusher = vay


### PR DESCRIPTION
Changed the current deposition algorithm to Esrikepov to have charge conservation and avoid the numerical artifacts found in the 2D boosted frame LWFA example (see figures below).
(Using direct algorithm)
![image](https://user-images.githubusercontent.com/15057096/63048185-dfbd4c00-be8a-11e9-82c6-67940d8a1b3c.png)
(Using esirkepov algorithm)
![image](https://user-images.githubusercontent.com/15057096/63048212-ee0b6800-be8a-11e9-9366-b40fc152369d.png)

Will test other examples afterwards.