### PR TITLE
For RigidInjection, fixed calculation of done_injecting

### DIFF
--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -348,7 +348,8 @@ RigidInjectedParticleContainer::Evolve (int lev,
     const Real* plo = Geom(lev).ProbLo();
     const Real* phi = Geom(lev).ProbHi();
     const int zdir = AMREX_SPACEDIM-1;
-    done_injecting[lev] = (zinject_plane_levels[lev] < plo[zdir] || zinject_plane_levels[lev] > phi[zdir]);
+    done_injecting[lev] = ((zinject_plane_levels[lev] < plo[zdir] && WarpX::moving_window_v > 0.) ||
+                           (zinject_plane_levels[lev] > phi[zdir] && WarpX::moving_window_v < 0.));
     done_injecting_lev = done_injecting[lev];
 
     PhysicalParticleContainer::Evolve (lev,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -348,8 +348,8 @@ RigidInjectedParticleContainer::Evolve (int lev,
     const Real* plo = Geom(lev).ProbLo();
     const Real* phi = Geom(lev).ProbHi();
     const int zdir = AMREX_SPACEDIM-1;
-    done_injecting[lev] = ((zinject_plane_levels[lev] < plo[zdir] && WarpX::moving_window_v > 0.) ||
-                           (zinject_plane_levels[lev] > phi[zdir] && WarpX::moving_window_v < 0.));
+    done_injecting[lev] = ((zinject_plane_levels[lev] < plo[zdir] && WarpX::moving_window_v + WarpX::beta_boost*PhysConst::c >= 0.) ||
+                           (zinject_plane_levels[lev] > phi[zdir] && WarpX::moving_window_v + WarpX::beta_boost*PhysConst::c <= 0.));
     done_injecting_lev = done_injecting[lev];
 
     PhysicalParticleContainer::Evolve (lev,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -257,6 +257,7 @@ public:
 
     static int do_moving_window;
     static int moving_window_dir;
+    static amrex::Real moving_window_v;
 
     // slice generation //
     void InitializeSliceMultiFabs ();
@@ -504,7 +505,6 @@ private:
     amrex::Vector<std::unique_ptr<PML> > pml;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();
-    amrex::Real moving_window_v = std::numeric_limits<amrex::Real>::max();
     amrex::Real current_injection_position = 0;
 
     // Plasma injection parameters

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -30,6 +30,7 @@ Vector<Real> WarpX::B_external(3, 0.0);
 
 int WarpX::do_moving_window = 0;
 int WarpX::moving_window_dir = -1;
+Real WarpX::moving_window_v = std::numeric_limits<amrex::Real>::max();
 
 Real WarpX::gamma_boost = 1.;
 Real WarpX::beta_boost = 0.;


### PR DESCRIPTION
The variable done_injecting was not being calculated correctly if the injection plane started outside of the simulation domain.