### PR TITLE
gitignore: More IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.DS_Store
-plt*
-chk*
 main?d.*.ex
 d/
 f/
@@ -11,3 +8,32 @@ Backtrace.*
 *.vth
 *.sw[opqrs]
 
+####################
+# AMReX data files #
+####################
+plt*
+chk*
+
+##########
+# Python #
+##########
+*.pyc
+__pycache__
+
+#######
+# IDE #
+#######
+.idea/
+cmake-build-*/
+.kdev?/
+*.kdev?
+
+# File-based project format:
+*.iws
+
+######
+# OS #
+######
+.DS_Store
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
Add a bit more files to `.gitignore` and sort them a little.
Especially added for support of [CLion](https://www.jetbrains.com/clion/) and [KDevelop](https://www.kdevelop.org/).