### PR TITLE
[mini-PR] Use C++ deposition as default

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -38,7 +38,7 @@ Vector<int> WarpX::boost_direction = {0,0,0};
 int WarpX::do_compute_max_step_from_zmax = 0;
 Real WarpX::zmax_plasma_to_compute_max_step = 0.;
 
-long WarpX::use_picsar_deposition = 1;
+long WarpX::use_picsar_deposition = 0;
 long WarpX::current_deposition_algo;
 long WarpX::charge_deposition_algo;
 long WarpX::field_gathering_algo;


### PR DESCRIPTION
This will break the regression tests. 
@WeiqunZhang Let us use this as a way to set the tolerance on the regression tests