### PR TITLE
Remove runtime parameters from the lab frame diagnostics

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -102,17 +102,6 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             real_names.push_back("theta");
 #endif
             
-            if (WarpX::do_boosted_frame_diagnostic && pc->DoBoostedFrameDiags())
-            {
-                real_names.push_back("xold");
-                real_names.push_back("yold");
-                real_names.push_back("zold");
-                
-                real_names.push_back("uxold");
-                real_names.push_back("uyold");
-                real_names.push_back("uzold");
-            }
-                        
             // Convert momentum to SI
             pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
             // real_names contains a list of all particle attributes.

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -140,6 +140,14 @@ WarpX::EvolveEM (int numsteps)
         bool do_insitu = ((step+1) >= insitu_start) &&
             (insitu_int > 0) && ((step+1) % insitu_int == 0);
 
+        if (do_boosted_frame_diagnostic) {
+            std::unique_ptr<MultiFab> cell_centered_data = nullptr;
+            if (WarpX::do_boosted_frame_fields) {
+                cell_centered_data = GetCellCenteredData();
+            }
+            myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
+        }
+        
         bool move_j = is_synchronized || to_make_plot || do_insitu;
         // If is_synchronized we need to shift j too so that next step we can evolve E by dt/2.
         // We might need to move j because we are going to make a plotfile.
@@ -171,14 +179,6 @@ WarpX::EvolveEM (int numsteps)
         // sync up time
         for (int i = 0; i <= max_level; ++i) {
             t_new[i] = cur_time;
-        }
-
-        if (do_boosted_frame_diagnostic) {
-            std::unique_ptr<MultiFab> cell_centered_data = nullptr;
-            if (WarpX::do_boosted_frame_fields) {
-                cell_centered_data = GetCellCenteredData();
-            }
-            myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
         }
 
         // slice gen //

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -42,26 +42,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             nspecies_boosted_frame_diags += 1;
         }
     }
-
-    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-    {
-        for (int i = 0; i < nspecies_boosted_frame_diags; ++i)
-        {
-            int is = map_species_boosted_frame_diags[i];
-            allcontainers[is]->AddRealComp("xold");
-            allcontainers[is]->AddRealComp("yold");
-            allcontainers[is]->AddRealComp("zold");
-            allcontainers[is]->AddRealComp("uxold");
-            allcontainers[is]->AddRealComp("uyold");
-            allcontainers[is]->AddRealComp("uzold");
-        }
-        pc_tmp->AddRealComp("xold");
-        pc_tmp->AddRealComp("yold");
-        pc_tmp->AddRealComp("zold");
-        pc_tmp->AddRealComp("uxold");
-        pc_tmp->AddRealComp("uyold");
-        pc_tmp->AddRealComp("uzold");
-    }
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -277,9 +277,6 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const int grid_id = mfi.index();
         const int tile_id = mfi.LocalTileIndex();
         GetParticles(lev)[std::make_pair(grid_id, tile_id)];
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags) {
-            DefineAndReturnParticleTile(lev, grid_id, tile_id);
-        }
     }
 #endif
 
@@ -403,11 +400,6 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const int cpuid = ParallelDescriptor::MyProc();
 
         auto& particle_tile = GetParticles(lev)[std::make_pair(grid_id,tile_id)];
-        bool do_boosted = false;
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags) {
-            do_boosted = true;
-            DefineAndReturnParticleTile(lev, grid_id, tile_id);
-        }
         auto old_size = particle_tile.GetArrayOfStructs().size();
         auto new_size = old_size + max_new_particles;
         particle_tile.resize(new_size);
@@ -1612,13 +1604,13 @@ void PhysicalParticleContainer::copy_attribs(WarpXParIter& pti,const Real* xp,
     const auto lev = pti.GetLevel();
     const auto index = pti.GetPairIndex();
     tmp_particle_data.resize(finestLevel()+1);
-    for (int i = 0; i < 6; ++i) tmp_particle_data[lev][index][i].resize(np);
-    Real* AMREX_RESTRICT xpold  = tmp_particle_data[lev][index][0].dataPtr();
-    Real* AMREX_RESTRICT ypold  = tmp_particle_data[lev][index][1].dataPtr();
-    Real* AMREX_RESTRICT zpold  = tmp_particle_data[lev][index][2].dataPtr();
-    Real* AMREX_RESTRICT uxpold = tmp_particle_data[lev][index][3].dataPtr();
-    Real* AMREX_RESTRICT uypold = tmp_particle_data[lev][index][4].dataPtr();
-    Real* AMREX_RESTRICT uzpold = tmp_particle_data[lev][index][5].dataPtr();
+    for (int i = 0; i < TmpIdx::nattribs; ++i) tmp_particle_data[lev][index][i].resize(np);
+    Real* AMREX_RESTRICT xpold  = tmp_particle_data[lev][index][TmpIdx::xold ].dataPtr();
+    Real* AMREX_RESTRICT ypold  = tmp_particle_data[lev][index][TmpIdx::yold ].dataPtr();
+    Real* AMREX_RESTRICT zpold  = tmp_particle_data[lev][index][TmpIdx::zold ].dataPtr();
+    Real* AMREX_RESTRICT uxpold = tmp_particle_data[lev][index][TmpIdx::uxold].dataPtr();
+    Real* AMREX_RESTRICT uypold = tmp_particle_data[lev][index][TmpIdx::uyold].dataPtr();
+    Real* AMREX_RESTRICT uzpold = tmp_particle_data[lev][index][TmpIdx::uzold].dataPtr();
     
     ParallelFor( np,
                  [=] AMREX_GPU_DEVICE (long i) {
@@ -1704,12 +1696,12 @@ void PhysicalParticleContainer::GetParticleSlice(const int direction, const Real
                 auto& uyp_new = attribs[PIdx::uy   ];
                 auto& uzp_new = attribs[PIdx::uz   ];
 
-                auto&  xp_old = tmp_particle_data[lev][index][0];
-                auto&  yp_old = tmp_particle_data[lev][index][1];
-                auto&  zp_old = tmp_particle_data[lev][index][2];
-                auto& uxp_old = tmp_particle_data[lev][index][3];
-                auto& uyp_old = tmp_particle_data[lev][index][4];
-                auto& uzp_old = tmp_particle_data[lev][index][5];
+                auto&  xp_old = tmp_particle_data[lev][index][TmpIdx::xold];
+                auto&  yp_old = tmp_particle_data[lev][index][TmpIdx::yold];
+                auto&  zp_old = tmp_particle_data[lev][index][TmpIdx::zold];
+                auto& uxp_old = tmp_particle_data[lev][index][TmpIdx::uxold];
+                auto& uyp_old = tmp_particle_data[lev][index][TmpIdx::uyold];
+                auto& uzp_old = tmp_particle_data[lev][index][TmpIdx::uzold];
 
                 const long np = pti.numParticles();
                 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -274,9 +274,10 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 #ifdef _OPENMP
     // First touch all tiles in the map in serial
     for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi) {
-        const int grid_id = mfi.index();
-        const int tile_id = mfi.LocalTileIndex();
-        GetParticles(lev)[std::make_pair(grid_id, tile_id)];
+        auto index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+        GetParticles(lev)[index];
+        tmp_particle_data.resize(finestLevel()+1);
+        tmp_particle_data[lev][index];
     }
 #endif
 
@@ -1611,7 +1612,7 @@ void PhysicalParticleContainer::copy_attribs(WarpXParIter& pti,const Real* xp,
     Real* AMREX_RESTRICT uxpold = tmp_particle_data[lev][index][TmpIdx::uxold].dataPtr();
     Real* AMREX_RESTRICT uypold = tmp_particle_data[lev][index][TmpIdx::uyold].dataPtr();
     Real* AMREX_RESTRICT uzpold = tmp_particle_data[lev][index][TmpIdx::uzold].dataPtr();
-    
+
     ParallelFor( np,
                  [=] AMREX_GPU_DEVICE (long i) {
                      xpold[i]=xp[i];

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -239,15 +239,13 @@ RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
     Real* const AMREX_RESTRICT Bzp = attribs[PIdx::Bz].dataPtr();
 
     if (!done_injecting_lev) {
-        if (!(WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)) {
-            // If the old values are not already saved, create copies here.
-            xp_save = xp;
-            yp_save = yp;
-            zp_save = zp;
-            uxp_save = uxp;
-            uyp_save = uyp;
-            uzp_save = uzp;
-        }
+        // If the old values are not already saved, create copies here.
+        xp_save = xp;
+        yp_save = yp;
+        zp_save = zp;
+        uxp_save = uxp;
+        uyp_save = uyp;
+        uzp_save = uzp;
 
         // Scale the fields of particles about to cross the injection plane.
         // This only approximates what should be happening. The particles
@@ -275,27 +273,12 @@ RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
 
     if (!done_injecting_lev) {
 
-        Real* AMREX_RESTRICT x_save;
-        Real* AMREX_RESTRICT y_save;
-        Real* AMREX_RESTRICT z_save;
-        Real* AMREX_RESTRICT ux_save;
-        Real* AMREX_RESTRICT uy_save;
-        Real* AMREX_RESTRICT uz_save;
-        if (!(WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)) {
-            x_save = xp_save.dataPtr();
-            y_save = yp_save.dataPtr();
-            z_save = zp_save.dataPtr();
-            ux_save = uxp_save.dataPtr();
-            uy_save = uyp_save.dataPtr();
-            uz_save = uzp_save.dataPtr();
-        } else {
-            x_save = pti.GetAttribs(particle_comps["xold"]).dataPtr();
-            y_save = pti.GetAttribs(particle_comps["yold"]).dataPtr();
-            z_save = pti.GetAttribs(particle_comps["zold"]).dataPtr();
-            ux_save = pti.GetAttribs(particle_comps["uxold"]).dataPtr();
-            uy_save = pti.GetAttribs(particle_comps["uyold"]).dataPtr();
-            uz_save = pti.GetAttribs(particle_comps["uzold"]).dataPtr();
-        }
+        Real* AMREX_RESTRICT x_save = xp_save.dataPtr();
+        Real* AMREX_RESTRICT y_save = yp_save.dataPtr();
+        Real* AMREX_RESTRICT z_save = zp_save.dataPtr();
+        Real* AMREX_RESTRICT ux_save = uxp_save.dataPtr();
+        Real* AMREX_RESTRICT uy_save = uyp_save.dataPtr();
+        Real* AMREX_RESTRICT uz_save = uzp_save.dataPtr();
 
         // Undo the push for particles not injected yet.
         // The zp are advanced a fixed amount.

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -29,6 +29,15 @@ struct DiagIdx
     };
 };
 
+struct TmpIdx
+{
+    enum {
+        xold = 0,
+        yold, zold, uxold, uyold, uzold,
+        nattribs
+    };
+};
+
 namespace ParticleStringNames
 {
     const std::map<std::string, int> to_index = {
@@ -297,7 +306,10 @@ protected:
     amrex::Vector<amrex::FArrayBox> local_jy;
     amrex::Vector<amrex::FArrayBox> local_jz;
 
-    amrex::Vector<amrex::Cuda::ManagedDeviceVector<amrex::Real> > m_xp, m_yp, m_zp, m_giv;
+    using DataContainer = amrex::Gpu::ManagedDeviceVector<amrex::Real>;
+    using PairIndex = std::pair<int, int>;
+    
+    amrex::Vector<DataContainer> m_xp, m_yp, m_zp, m_giv;
 
     // Whether to dump particle quantities. 
     // If true, particle position is always dumped.
@@ -307,8 +319,8 @@ protected:
     amrex::Vector<int> plot_flags;
     // list of names of attributes to dump.
     amrex::Vector<std::string> plot_vars;
-
-    amrex::Vector<std::map<std::pair<int, int>, std::array<amrex::Gpu::ManagedDeviceVector<amrex::Real>, 6> > > tmp_particle_data;
+        
+    amrex::Vector<std::map<PairIndex, std::array<DataContainer, TmpIdx::nattribs> > > tmp_particle_data;
     
 private:
     virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -308,6 +308,8 @@ protected:
     // list of names of attributes to dump.
     amrex::Vector<std::string> plot_vars;
 
+    amrex::Vector<std::map<std::pair<int, int>, std::array<amrex::Gpu::ManagedDeviceVector<amrex::Real>, 6> > > tmp_particle_data;
+    
 private:
     virtual void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld,
                                     const int lev) override;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -85,17 +85,6 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
     particle_comps["theta"] = PIdx::theta;
 #endif
 
-    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-    {
-        particle_comps["xold"]  = PIdx::nattribs;
-        particle_comps["yold"]  = PIdx::nattribs+1;
-        particle_comps["zold"]  = PIdx::nattribs+2;
-        particle_comps["uxold"] = PIdx::nattribs+3;
-        particle_comps["uyold"] = PIdx::nattribs+4;
-        particle_comps["uzold"] = PIdx::nattribs+5;
-
-    }
-
     // Initialize temporary local arrays for charge/current deposition
     int num_threads = 1;
     #ifdef _OPENMP
@@ -238,14 +227,6 @@ WarpXParticleContainer::AddNParticles (int lev,
         p.pos(1) = z[i];
 #endif
 
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        {
-            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);
-            ptile.push_back_real(particle_comps["xold"], x[i]);
-            ptile.push_back_real(particle_comps["yold"], y[i]);
-            ptile.push_back_real(particle_comps["zold"], z[i]);
-        }
-
         particle_tile.push_back(p);
     }
 
@@ -255,14 +236,6 @@ WarpXParticleContainer::AddNParticles (int lev,
         particle_tile.push_back_real(PIdx::ux,     vx + ibegin,     vx + iend);
         particle_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
         particle_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
-
-        if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
-        {
-            auto& ptile = DefineAndReturnParticleTile(0, 0, 0);
-            ptile.push_back_real(particle_comps["uxold"], vx + ibegin, vx + iend);
-            ptile.push_back_real(particle_comps["uyold"], vy + ibegin, vy + iend);
-            ptile.push_back_real(particle_comps["uzold"], vz + ibegin, vz + iend);
-        }
 
         for (int comp = PIdx::uz+1; comp < PIdx::nattribs; ++comp)
         {


### PR DESCRIPTION
The "old" particle positions and momenta don't actually need to be redistributed, but we were doing so anyway. This removes these quantities from the ParticleContainer and treats them as tile-level temporaries that get update each time step. 

This is also a step towards removing the runtime components, as discussed with @MaxThevenet and @RemiLehe yesterday. 

I think the new code is actually a bit simpler as well. 

Tests: 

2D, before:

![plasma_acceleration_2d_old](https://user-images.githubusercontent.com/4329158/63464385-07c12800-c414-11e9-9b52-b6c34fa2e382.png)

2D, after:

![plasma_acceleration_2d_new](https://user-images.githubusercontent.com/4329158/63464395-0b54af00-c414-11e9-93f0-39612962111c.png)

3D, before:

![plasma_acceleration_3d_old](https://user-images.githubusercontent.com/4329158/63464451-29221400-c414-11e9-8c4b-6cdb66a7afcc.png)

3D, after:

![plasma_acceleration_3d_new](https://user-images.githubusercontent.com/4329158/63464470-317a4f00-c414-11e9-8049-7f26c0347e57.png)

2D rigid injection before:

![rigid_2d_old](https://user-images.githubusercontent.com/4329158/63464504-422ac500-c414-11e9-9731-2ace6a1e58c8.png)

2D rigid injection after:

![rigid_2d_new](https://user-images.githubusercontent.com/4329158/63464522-48b93c80-c414-11e9-87cd-81022d7f34ca.png)

Note that there is one small difference between the old and new output. Previously, we moved the window and injected the new plasma prior to updating the lab frame data. Now, we write the lab frame data before. This leads to the right-most column of particles in the above images to be missing in the new implementation. I think this behavior is actually more correct. In the old way, we set the "old" and "new" particle data to be the same for newly injected particles. In the new way, we don't attempt to interpolate the new particles until they have meaningful "old" data. 