### PR TITLE
Reactivate 2D PSATD tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -332,7 +332,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_analysis.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -355,41 +355,41 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
-# [Langmuir_multi_2d_psatd]
-# buildDir = .
-# inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
-# dim = 2
-# addToCompileString = USE_PSATD=TRUE
-# restartTest = 0
-# useMPI = 1
-# numprocs = 2
-# useOMP = 1
-# numthreads = 1
-# compileTest = 0
-# doVis = 0
-# compareParticles = 1
-# runtime_params = psatd.fftw_plan_measure=0
-# particleTypes = electrons positrons
-# analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
-# analysisOutputImage = langmuir_multi_2d_analysis.png
+[Langmuir_multi_2d_psatd]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+runtime_params = psatd.fftw_plan_measure=0
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
 
-# [Langmuir_multi_2d_psatd_nodal]
-# buildDir = .
-# inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
-# dim = 2
-# addToCompileString = USE_PSATD=TRUE
-# restartTest = 0
-# useMPI = 1
-# numprocs = 4
-# useOMP = 1
-# numthreads = 1
-# compileTest = 0
-# doVis = 0
-# compareParticles = 1
-# runtime_params =  psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct
-# particleTypes = electrons positrons
-# analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
-# analysisOutputImage = langmuir_multi_2d_analysis.png
+[Langmuir_multi_2d_psatd_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+runtime_params =  psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_rz]
 buildDir = .
@@ -562,4 +562,3 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis.py
-


### PR DESCRIPTION
The 2D PSATD tests used to fail randomly on Travis CI. 
It seems that this is no longer the case. 
My guess is that this random failure was maybe due to conflicts between the FFTW initialization/destruction in Fortran and C++. I am guessing that this got fixed because we are not compiling the Fortran FFTW anymore.

However, it is difficult to be certain about the above, since the crash was happening randomly.

In any case, I think that the 2D PSATD tests can now be reactivated.