### PR TITLE
Fix Langmuir tests analysis scripts

### DIFF
--- a/Examples/Tests/Langmuir/langmuir_analysis.py
+++ b/Examples/Tests/Langmuir/langmuir_analysis.py
@@ -25,12 +25,8 @@ ds = yt.load(fn)
 t = ds.current_time.to_ndarray().mean() # in order to extract a single scalar
 data = ds.covering_grid( 0, ds.domain_left_edge, ds.domain_dimensions )
 
-# Check the J fields that are 0
-for coord in ['x', 'y', 'z']:
-    if coord != direction:
-        assert np.allclose( data['j'+coord].to_ndarray(), 0, atol=1.e-2 )
 # Check the J field along the direction of the wave, which oscillates at wp
-    j_predicted = -n0*e*c*u*np.cos( wp*t*39.5/40 ) # 40 timesteps / j at half-timestep
+j_predicted = -n0*e*c*u*np.cos( wp*t*39.5/40 ) # 40 timesteps / j at half-timestep
 # Because of the shape factor, there are 2 cells that are incorrect
 # at the edges of the plasma
 if direction == 'x':
@@ -46,10 +42,6 @@ elif direction == 'z':
     assert np.allclose( j[:,:,2:30], j_predicted, rtol=0.2 )
     assert np.allclose( j[:,:,34:-2], 0, atol=1.e-2 )
 
-# Check the E fields that are 0
-for coord in ['x', 'y', 'z']:
-    if coord != direction:
-        assert np.allclose( data['E'+coord].to_ndarray(), 0, atol=5.e-5 )
 # Check the E field along the direction of the wave, which oscillates at wp
 E_predicted = m_e * wp * u * c / e * np.sin(wp*t)
 # Because of the shape factor, there are 2 cells that are incorrect

--- a/Examples/Tests/Langmuir/langmuir_analysis.py
+++ b/Examples/Tests/Langmuir/langmuir_analysis.py
@@ -55,7 +55,7 @@ if direction == 'x':
     print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
     # assert small errors
     assert np.allclose( E[2:30,:,:], E_predicted, rtol=0.1 )
-    assert np.allclose( E[34:-2,:,:], 0, atol=1.e-5 )
+    assert np.allclose( E[34:-2,:,:], 0, atol=2.e-5 )
 elif direction == 'y':
     E = data[ 'Ey' ].to_ndarray()
     # compute and print errors
@@ -65,7 +65,7 @@ elif direction == 'y':
     print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
     # assert small errors
     assert np.allclose( E[:,2:30,:], E_predicted, rtol=0.1 )
-    assert np.allclose( E[:,34:-2,:], 0, atol=1.e-5 )
+    assert np.allclose( E[:,34:-2,:], 0, atol=2.e-5 )
 elif direction == 'z':
     E = data[ 'Ez' ].to_ndarray()
     # compute and print errors
@@ -75,7 +75,7 @@ elif direction == 'z':
     print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
     # assert small errors
     assert np.allclose( E[:,:,2:30], E_predicted, rtol=0.1 )
-    assert np.allclose( E[:,:,34:-2], 0, atol=1.e-5 )
+    assert np.allclose( E[:,:,34:-2], 0, atol=2.e-5 )
 
 # Save an image to be displayed on the website
 t_plot = np.linspace(0.0, t, 200)

--- a/Examples/Tests/Langmuir/langmuir_analysis.py
+++ b/Examples/Tests/Langmuir/langmuir_analysis.py
@@ -48,14 +48,32 @@ E_predicted = m_e * wp * u * c / e * np.sin(wp*t)
 # at the edges of the plasma
 if direction == 'x':
     E = data[ 'Ex' ].to_ndarray()
+    # compute and print errors
+    max_rel_error_nonzero = np.max(np.abs((E[2:30,:,:]-E_predicted)/E_predicted))
+    max_rel_error_zero = np.max(E[34:-2,:,:])
+    print('relative error: %s' %max_rel_error_nonzero)
+    print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
+    # assert small errors
     assert np.allclose( E[2:30,:,:], E_predicted, rtol=0.1 )
     assert np.allclose( E[34:-2,:,:], 0, atol=1.e-5 )
 elif direction == 'y':
     E = data[ 'Ey' ].to_ndarray()
+    # compute and print errors
+    max_rel_error_nonzero = np.max(np.abs((E[:,2:30,:]-E_predicted)/E_predicted))
+    max_rel_error_zero = np.max(E[:,34:-2,:])
+    print('relative error: %s' %max_rel_error_nonzero)
+    print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
+    # assert small errors
     assert np.allclose( E[:,2:30,:], E_predicted, rtol=0.1 )
     assert np.allclose( E[:,34:-2,:], 0, atol=1.e-5 )
 elif direction == 'z':
     E = data[ 'Ez' ].to_ndarray()
+    # compute and print errors
+    max_rel_error_nonzero = np.max(np.abs((E[:,:,2:30]-E_predicted)/E_predicted))
+    max_rel_error_zero = np.max(E[:,:,34:-2])
+    print('relative error: %s' %max_rel_error_nonzero)
+    print('absolute field error (where field should be 0): %s' %max_rel_error_zero)
+    # assert small errors
     assert np.allclose( E[:,:,2:30], E_predicted, rtol=0.1 )
     assert np.allclose( E[:,:,34:-2], 0, atol=1.e-5 )
 


### PR DESCRIPTION
do not check fields that are zeros, as they are not dumped.