### PR TITLE
Python update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install -y gcc gfortran g++ openmpi-bin libopenmpi-dev libfftw3-dev libfftw3-mpi-dev
     # Install miniconda and python dependencies
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-    - bash Miniconda-latest-Linux-x86_64.sh -b
-    - export PATH=/home/travis/miniconda2/bin:$PATH
+    - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    - bash Miniconda3-latest-Linux-x86_64.sh -b
+    - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt
 
 script:

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -392,7 +392,11 @@ def get_particle_arrays(species_number, comp):
     particle_data = []
     for i in range(num_tiles.value):
         arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
-        arr.setflags(write=1)
+        try:
+            # This fails on some versions of numpy
+            arr.setflags(write=1)
+        except ValueError:
+            pass
         particle_data.append(arr)
 
     _libc.free(particles_per_tile)
@@ -623,7 +627,11 @@ def _get_mesh_field_list(warpx_func, level, direction, include_ghosts):
         shape = tuple([shapes[shapesize*i + d] for d in range(shapesize)])
         # --- The data is stored in Fortran order, hence shape is reversed and a transpose is taken.
         arr = np.ctypeslib.as_array(data[i], shape[::-1]).T
-        arr.setflags(write=1)
+        try:
+            # This fails on some versions of numpy
+            arr.setflags(write=1)
+        except ValueError:
+            pass
         if include_ghosts:
             grid_data.append(arr)
         else:


### PR DESCRIPTION
This switches the travis tests to use Python3.

It also protects against a bug that appeared in recent versions of numpy, and which only appears with Python2.