### PR TITLE
do not dump zero fields for reg tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -405,6 +405,7 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
+runtime_params = electrons.plot_vars=w ux uy uz Ex Ey Ez Bx By ions.plot_vars=w ux uy uz Ex Ey Ez Bx By
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_rz_analysis.py

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -314,6 +314,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
+tolerance = 5.e-11
 runtime_params = psatd.fftw_plan_measure=0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_analysis.py
@@ -332,6 +333,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
+tolerance = 5.e-11
 runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_analysis.py
@@ -368,7 +370,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params = psatd.fftw_plan_measure=0
+runtime_params = psatd.fftw_plan_measure=0 electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
@@ -386,7 +388,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-runtime_params =  psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct
+runtime_params =  psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/langmuir_multi_2d_analysis.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
@@ -484,6 +486,7 @@ numprocs = 2
 useOMP = 1
 numthreads = 2
 compileTest = 0
+tolerance = 5.e-6
 doVis = 0
 compareParticles = 0
 


### PR DESCRIPTION
Increase tolerance and avoid dumping null fields for PSATD tests