### PR TITLE
Add laser particles on level 0 instead of max level

### DIFF
--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -244,6 +244,8 @@ LaserParticleContainer::UpdateContinuousInjectionPosition(Real dt)
 void
 LaserParticleContainer::InitData ()
 {
+    // Call InitData on max level to inject one laser particle per
+    // finest cell.
     InitData(maxLevel());
 }
 
@@ -379,7 +381,8 @@ LaserParticleContainer::InitData (int lev)
     RealVector particle_uz(np, 0.0);
 
     if (Verbose()) amrex::Print() << "Adding laser particles\n";
-    AddNParticles(lev,
+    // Add particles on level 0. They will be redistributed afterwards
+    AddNParticles(0,
                   np, particle_x.dataPtr(), particle_y.dataPtr(), particle_z.dataPtr(),
                   particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
                   1, particle_w.dataPtr(), 1);


### PR DESCRIPTION
Current code resulted in Segfault when running with MR and a laser antenna, because, as explained by @atmyers, laser particles were added to the max level before that level was created in the ParticleContainer.

This PR proposes to add laser particles on level 0. The laser particle initial positions are still computed using the finest level resolution, so as to have 1 particle per cell on the finest level. This way, even if the antenna is initialized on level 0 and drifts to a refinement patch later in the simulation, there will always be at least 1 particle per cell.