### PR TITLE
no need to be virtual

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -181,32 +181,32 @@ public:
                        bool local = false);
     std::unique_ptr<amrex::MultiFab> GetChargeDensity(int lev, bool local = false);
 
-    virtual void DepositCharge(WarpXParIter& pti,
-                               RealVector& wp,
-                               const int * const ion_lev,
-                               amrex::MultiFab* rho,
-                               int icomp,
-                               const long offset,
-                               const long np_to_depose,
-                               int thread_num,
-                               int lev,
-                               int depos_lev);
+    void DepositCharge(WarpXParIter& pti,
+                       RealVector& wp,
+                       const int * const ion_lev,
+                       amrex::MultiFab* rho,
+                       int icomp,
+                       const long offset,
+                       const long np_to_depose,
+                       int thread_num,
+                       int lev,
+                       int depos_lev);
 
-    virtual void DepositCurrent(WarpXParIter& pti,
-                                RealVector& wp,
-                                RealVector& uxp,
-                                RealVector& uyp,
-                                RealVector& uzp,
-                                const int * const ion_lev,
-                                amrex::MultiFab* jx,
-                                amrex::MultiFab* jy,
-                                amrex::MultiFab* jz,
-                                const long offset,
-                                const long np_to_depose,
-                                int thread_num,
-                                int lev,
-                                int depos_lev,
-                                amrex::Real dt);
+    void DepositCurrent(WarpXParIter& pti,
+                        RealVector& wp,
+                        RealVector& uxp,
+                        RealVector& uyp,
+                        RealVector& uzp,
+                        const int * const ion_lev,
+                        amrex::MultiFab* jx,
+                        amrex::MultiFab* jy,
+                        amrex::MultiFab* jz,
+                        const long offset,
+                        const long np_to_depose,
+                        int thread_num,
+                        int lev,
+                        int depos_lev,
+                        amrex::Real dt);
 
     // If particles start outside of the domain, ContinuousInjection 
     // makes sure that they are initialized when they enter the domain, and 


### PR DESCRIPTION
`WarpXParticleContainer::DepositCurrent` and `DepositCharge` do not need to be virtual.
