### PR TITLE
Particles: gather_from_main_grid

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -91,6 +91,11 @@ Setting up the field mesh
     in the list will deposit their charge/current directly on the main grid
     (i.e. the coarsest level), even if they are inside a refinement patch.
 
+* ``particles.gather_from_main_grid`` (`list of strings`)
+    When using mesh refinement: the particle species whose name are included
+    in the list will gather their fields from the main grid
+    (i.e. the coarsest level), even if they are inside a refinement patch.
+
 * ``warpx.n_rz_azimuthal_modes`` (`integer`; 1 by default)
     When using the RZ version, this is the number of azimuthal modes.
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -2,15 +2,16 @@
 #ifndef WARPX_ParticleContainer_H_
 #define WARPX_ParticleContainer_H_
 
-#include <memory>
-#include <map>
-#include <string>
-
 #include <AMReX_Particles.H>
 #include <WarpXParticleContainer.H>
 #include <PhysicalParticleContainer.H>
 #include <RigidInjectedParticleContainer.H>
 #include <LaserParticleContainer.H>
+
+#include <memory>
+#include <map>
+#include <string>
+#include <algorithm>
 
 //
 // MultiParticleContainer holds multiple (nspecies or npsecies+1 when
@@ -167,6 +168,12 @@ public:
         return r;
     }
 
+    int nSpeciesGatherFromMainGrid() const {
+        bool const fromMainGrid = true;
+        auto const & v = m_gather_from_main_grid;
+        return std::count( v.begin(), v.end(), fromMainGrid );
+    }
+
     void GetLabFrameData(const std::string& snapshot_name,
                          const int i_lab, const int direction,
                          const amrex::Real z_old, const amrex::Real z_new,
@@ -194,7 +201,11 @@ protected:
 
     std::vector<std::string> lasers_names;
 
+    //! instead of depositing (current, charge) on the finest patch level, deposit to the coarsest grid
     std::vector<int> deposit_on_main_grid;
+
+    //! instead of gathering fields from the finest patch level, gather from the coarsest
+    std::vector<bool> m_gather_from_main_grid;
 
     std::vector<PCTypes> species_types;
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -21,6 +21,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
             allcontainers[i].reset(new RigidInjectedParticleContainer(amr_core, i, species_names[i]));
         }
         allcontainers[i]->deposit_on_main_grid = deposit_on_main_grid[i];
+        allcontainers[i]->m_gather_from_main_grid = m_gather_from_main_grid[i];
     }
     
     for (int i = nspecies; i < nspecies+nlasers; ++i) {
@@ -67,6 +68,16 @@ MultiParticleContainer::ReadParameters ()
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != species_names.end(), "ERROR: species in particles.deposit_on_main_grid must be part of particles.species_names");
                 int i = std::distance(species_names.begin(), it);
                 deposit_on_main_grid[i] = 1;
+            }
+
+            m_gather_from_main_grid.resize(nspecies, 0);
+            std::vector<std::string> tmp_gather;
+            pp.queryarr("gather_from_main_grid", tmp_gather);
+            for (auto const& name : tmp_gather) {
+                auto it = std::find(species_names.begin(), species_names.end(), name);
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != species_names.end(), "ERROR: species in particles.gather_from_main_grid must be part of particles.species_names");
+                int i = std::distance(species_names.begin(), it);
+                m_gather_from_main_grid.at(i) = true;
             }
 
             species_types.resize(nspecies, PCTypes::Physical);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1142,8 +1142,12 @@ PhysicalParticleContainer::Evolve (int lev,
                     }
                 }
 
+                // only deposit / gather to coarsest grid
                 if (deposit_on_main_grid && lev > 0) {
                     nfine_current = 0;
+                }
+                if (m_gather_from_main_grid && lev > 0) {
+                    nfine_gather = 0;
                 }
 
                 if (nfine_current != np || nfine_gather != np)

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -292,7 +292,11 @@ protected:
     amrex::Real charge;
     amrex::Real mass;
 
+    //! instead of depositing (current, charge) on the finest patch level, deposit to the coarsest grid
     bool deposit_on_main_grid = false;
+
+    //! instead of gathering fields from the finest patch level, gather from the coarsest
+    bool m_gather_from_main_grid = false;
 
     static int do_not_push;
 


### PR DESCRIPTION
Support gather for individual particle species from the main grid.

Very much based on the similar option for deposition :)

### Runtime Tests

- [x] single particle from main grid / fine grid: https://github.com/MaxThevenet/WarpX/pull/2 https://github.com/MaxThevenet/WarpX/pull/4
- [x] MR setup with `particles.deposit_on_main_grid` and `particles.gather_from_main_grid` and no sub-cycling should look identical to non-MR (ok-ish but other sources of noise present for further exploration) https://github.com/MaxThevenet/WarpX/pull/5