### PR TITLE
Clean Up Deposit on Main

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -81,12 +81,12 @@ Setting up the field mesh
 
 * ``warpx.n_current_deposition_buffer`` (`integer`)
     When using mesh refinement: the particles that are located inside
-    a refinement patch, but within ``n_field_gather_buffer`` cells of
+    a refinement patch, but within ``n_current_deposition_buffer`` cells of
     the edge of this patch, will deposit their charge and current to the
     lower refinement level, instead of depositing to the refinement patch
     itself. See the section :doc:`../../theory/amr` for more details.
 
-* ``particles.deposit_on_main_grid`` (list of strings)
+* ``particles.deposit_on_main_grid`` (`list of strings`)
     When using mesh refinement: the particle species whose name are included
     in the list will deposit their charge/current directly on the main grid
     (i.e. the coarsest level), even if they are inside a refinement patch.

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -18,7 +18,7 @@
 // using laser) WarpXParticleContainer.  WarpXParticleContainer is
 // derived from amrex::ParticleContainer, and it is
 // polymorphic. PhysicalParticleContainer and LaserParticleContainer are
-// concrete class dervied from WarpXParticlContainer.
+// concrete class derived from WarpXParticlContainer.
 //
 
 class MultiParticleContainer
@@ -161,11 +161,9 @@ public:
     int doBoostedFrameDiags() const {return do_boosted_frame_diags;}
 
     int nSpeciesDepositOnMainGrid () const {
-        int r = 0;
-        for (int i : deposit_on_main_grid) {
-            if (i) ++r;
-        }
-        return r;
+        bool const onMainGrid = true;
+        auto const & v = m_deposit_on_main_grid;
+        return std::count( v.begin(), v.end(), onMainGrid );
     }
 
     int nSpeciesGatherFromMainGrid() const {
@@ -202,7 +200,7 @@ protected:
     std::vector<std::string> lasers_names;
 
     //! instead of depositing (current, charge) on the finest patch level, deposit to the coarsest grid
-    std::vector<int> deposit_on_main_grid;
+    std::vector<bool> m_deposit_on_main_grid;
 
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     std::vector<bool> m_gather_from_main_grid;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -20,12 +20,12 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
         else if (species_types[i] == PCTypes::RigidInjected) {
             allcontainers[i].reset(new RigidInjectedParticleContainer(amr_core, i, species_names[i]));
         }
-        allcontainers[i]->deposit_on_main_grid = deposit_on_main_grid[i];
+        allcontainers[i]->m_deposit_on_main_grid = m_deposit_on_main_grid[i];
         allcontainers[i]->m_gather_from_main_grid = m_gather_from_main_grid[i];
     }
     
     for (int i = nspecies; i < nspecies+nlasers; ++i) {
-        allcontainers[i].reset(new LaserParticleContainer(amr_core,i, lasers_names[i-nspecies]));
+        allcontainers[i].reset(new LaserParticleContainer(amr_core, i, lasers_names[i-nspecies]));
     }
 
     pc_tmp.reset(new PhysicalParticleContainer(amr_core));
@@ -60,17 +60,17 @@ MultiParticleContainer::ReadParameters ()
             pp.getarr("species_names", species_names);
             BL_ASSERT(species_names.size() == nspecies);
 
-            deposit_on_main_grid.resize(nspecies, 0);
+            m_deposit_on_main_grid.resize(nspecies, false);
             std::vector<std::string> tmp;
             pp.queryarr("deposit_on_main_grid", tmp);
             for (auto const& name : tmp) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != species_names.end(), "ERROR: species in particles.deposit_on_main_grid must be part of particles.species_names");
                 int i = std::distance(species_names.begin(), it);
-                deposit_on_main_grid[i] = 1;
+                m_deposit_on_main_grid[i] = true;
             }
 
-            m_gather_from_main_grid.resize(nspecies, 0);
+            m_gather_from_main_grid.resize(nspecies, false);
             std::vector<std::string> tmp_gather;
             pp.queryarr("gather_from_main_grid", tmp_gather);
             for (auto const& name : tmp_gather) {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1087,8 +1087,8 @@ PhysicalParticleContainer::Evolve (int lev,
 
             m_giv[thread_num].resize(np);
 
-            long nfine_current = np;
-            long nfine_gather = np;
+            long nfine_current = np; //! number of particles depositing to fine grid
+            long nfine_gather = np;  //! number of particles gathering from fine grid
             if (has_buffer && !do_not_push)
             {
                 BL_PROFILE_VAR_START(blp_partition);
@@ -1143,7 +1143,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 }
 
                 // only deposit / gather to coarsest grid
-                if (deposit_on_main_grid && lev > 0) {
+                if (m_deposit_on_main_grid && lev > 0) {
                     nfine_current = 0;
                 }
                 if (m_gather_from_main_grid && lev > 0) {

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -293,7 +293,7 @@ protected:
     amrex::Real mass;
 
     //! instead of depositing (current, charge) on the finest patch level, deposit to the coarsest grid
-    bool deposit_on_main_grid = false;
+    bool m_deposit_on_main_grid = false;
 
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -125,8 +125,8 @@ public:
     static int sort_int;
 
     // buffers
-    static int n_field_gather_buffer;
-    static int n_current_deposition_buffer;
+    static int n_field_gather_buffer;       //! in number of cells from the edge (identical for each dimension)
+    static int n_current_deposition_buffer; //! in number of cells from the edge (identical for each dimension)
 
     // do nodal
     static int do_nodal;


### PR DESCRIPTION
Just some small internal renamings, doc strings and clean-ups for deposit on main grid. Seen during the implementation of #328.

## Todo

- [x] rebase after #328 was merged