### PR TITLE
Cleanup: Include Order

### DIFF
--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -1,11 +1,12 @@
 #ifndef INJECTOR_DENSITY_H_
 #define INJECTOR_DENSITY_H_
 
-#include <AMReX_Gpu.H>
-#include <AMReX_Dim3.H>
 #include <GpuParser.H>
 #include <CustomDensityProb.H>
 #include <WarpXConst.H>
+
+#include <AMReX_Gpu.H>
+#include <AMReX_Dim3.H>
 
 // struct whose getDensity returns constant density.
 struct InjectorDensityConstant

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -1,3 +1,4 @@
+#include <InjectorDensity.H>
 #include <PlasmaInjector.H>
 
 using namespace amrex;

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -1,10 +1,11 @@
 #ifndef INJECTOR_MOMENTUM_H_
 #define INJECTOR_MOMENTUM_H_
 
+#include <CustomMomentumProb.H>
+#include <GpuParser.H>
+
 #include <AMReX_Gpu.H>
 #include <AMReX_Dim3.H>
-#include <GpuParser.H>
-#include <CustomMomentumProb.H>
 
 // struct whose getMomentum returns constant momentum.
 struct InjectorMomentumConstant

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -1,3 +1,4 @@
+#include <InjectorMomentum.H>
 #include <PlasmaInjector.H>
 
 using namespace amrex;

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -5,12 +5,14 @@
 #include <InjectorDensity.H>
 #include <InjectorMomentum.H>
 
-#include <array>
-#include <AMReX_Vector.H>
 #include <WarpXConst.H>
 #include <WarpXParser.H>
+
+#include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Utility.H>
+
+#include <array>
 
 ///
 /// The PlasmaInjector class parses and stores information about the plasma

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -1,12 +1,13 @@
 #include "PlasmaInjector.H"
 
-#include <sstream>
-#include <functional>
-
 #include <WarpXConst.H>
 #include <WarpX_f.H>
-#include <AMReX.H>
 #include <WarpX.H>
+
+#include <AMReX.H>
+
+#include <sstream>
+#include <functional>
 
 using namespace amrex;
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1,11 +1,11 @@
 
-#include <AMReX_ParallelDescriptor.H>
-#include <AMReX_ParmParse.H>
-
 #include <WarpX.H>
 #include <WarpX_f.H>
 #include <BilinearFilter.H>
 #include <NCIGodfreyFilter.H>
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
 
 #ifdef BL_USE_SENSEI_INSITU
 #include <AMReX_AmrMeshInSituBridge.H>

--- a/Source/Utils/IonizationEnergiesTable.H
+++ b/Source/Utils/IonizationEnergiesTable.H
@@ -1,8 +1,9 @@
-#include <map>
-#include <AMReX_AmrCore.H>
-
 #ifndef WARPX_IONIZATION_TABLE_H_
 #define WARPX_IONIZATION_TABLE_H_
+
+#include <AMReX_AmrCore.H>
+
+#include <map>
 
 std::map<std::string, int> ion_map_ids = {
     {"H", 0},

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -1,4 +1,5 @@
 #include <WarpXAlgorithmSelection.H>
+
 #include <map>
 #include <algorithm>
 #include <cstring>

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -1,4 +1,3 @@
-
 #include <WarpX.H>
 #include <WarpXConst.H>
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1,12 +1,17 @@
 #ifndef WARPX_H_
 #define WARPX_H_
 
-#include <iostream>
-#include <memory>
-#include <array>
+#include <MultiParticleContainer.H>
+#include <PML.H>
+#include <BoostedFrameDiagnostic.H>
+#include <BilinearFilter.H>
+#include <NCIGodfreyFilter.H>
 
-#ifdef _OPENMP
-#include <omp.h>
+#ifdef WARPX_USE_PSATD
+#   include <SpectralSolver.H>
+#endif
+#ifdef WARPX_USE_PSATD_HYBRID
+#   include <PicsarHybridFFTData.H>
 #endif
 
 #include <AMReX_AmrCore.H>
@@ -19,18 +24,13 @@
 #include <AMReX_Interpolater.H>
 #include <AMReX_FillPatchUtil.H>
 
-#include <MultiParticleContainer.H>
-#include <PML.H>
-#include <BoostedFrameDiagnostic.H>
-#include <BilinearFilter.H>
-#include <NCIGodfreyFilter.H>
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
 
-#ifdef WARPX_USE_PSATD
-#include <SpectralSolver.H>
-#endif
-#ifdef WARPX_USE_PSATD_HYBRID
-#include <PicsarHybridFFTData.H>
-#endif
+#include <iostream>
+#include <memory>
+#include <array>
 
 #if defined(BL_USE_SENSEI_INSITU)
 namespace amrex {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1,17 +1,3 @@
-
-#include <limits>
-#include <algorithm>
-#include <cctype>
-#include <cmath>
-#include <numeric>
-
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
-#include <AMReX_ParmParse.H>
-#include <AMReX_MultiFabUtil.H>
-
 #include <WarpX.H>
 #include <WarpX_f.H>
 #include <WarpXConst.H>
@@ -20,9 +6,21 @@
 #include <WarpXAlgorithmSelection.H>
 #include <WarpX_FDTD.H>
 
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFabUtil.H>
 #ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
+#   include <AMReX_AmrMeshInSituBridge.H>
 #endif
+
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
+
+#include <limits>
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <numeric>
 
 using namespace amrex;
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,13 +1,12 @@
-
-#include <iostream>
+#include <WarpX.H>
+#include <WarpXUtil.H>
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
 
-#include <WarpX.H>
-#include <WarpXUtil.H>
+#include <iostream>
 
 using namespace amrex;
 


### PR DESCRIPTION
A typical include order in C++ is:

- `"module header"` (local header)
- `"own headers"` (WarpX)
- `<close library headers>` (AMReX)
- `<other third party headers>` (e.g. omp)
- `<stdlib headers>`

This avoids that a "forgotten include" will silently compile in some compilers and crash in others (because it will crash in all).

References:
- https://llvm.org/docs/CodingStandards.html#include-style
- https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md