### PR TITLE
Headers: No Public Scope Using Namespace

### DIFF
--- a/Source/BoundaryConditions/PML_current.H
+++ b/Source/BoundaryConditions/PML_current.H
@@ -3,18 +3,17 @@
 
 #include <AMReX_FArrayBox.H>
 
-using namespace amrex;
-
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void push_ex_pml_current (int j, int k, int l, Array4<Real> const& Ex,
-                          Array4<Real const> const& jx,
-                          Real const * const sigjy,
-                          Real const * const sigjz,
+void push_ex_pml_current (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ex,
+                          amrex::Array4<amrex::Real const> const& jx,
+                          amrex::Real const * const sigjy,
+                          amrex::Real const * const sigjz,
                           int ylo, int zlo,
-                          Real mu_c2_dt)
+                          amrex::Real mu_c2_dt)
 {
 #if (AMREX_SPACEDIM == 3)
-    Real alpha_xy, alpha_xz;
+    amrex::Real alpha_xy, alpha_xz;
     if (sigjy[k-ylo]+sigjz[l-zlo] == 0){
         alpha_xy = 0.5;
         alpha_xz = 0.5;
@@ -31,15 +30,16 @@ void push_ex_pml_current (int j, int k, int l, Array4<Real> const& Ex,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void push_ey_pml_current (int j, int k, int l, Array4<Real> const& Ey,
-                          Array4<Real const> const& jy,
-                          Real const * const sigjx,
-                          Real const * const sigjz,
+void push_ey_pml_current (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ey,
+                          amrex::Array4<amrex::Real const> const& jy,
+                          amrex::Real const * const sigjx,
+                          amrex::Real const * const sigjz,
                           int xlo, int zlo,
-                          Real mu_c2_dt)
+                          amrex::Real mu_c2_dt)
 {
 #if (AMREX_SPACEDIM == 3)
-    Real alpha_yx, alpha_yz;
+    amrex::Real alpha_yx, alpha_yz;
     if (sigjx[j-xlo]+sigjz[l-zlo] == 0){
         alpha_yx = 0.5;
         alpha_yz = 0.5;
@@ -57,15 +57,16 @@ void push_ey_pml_current (int j, int k, int l, Array4<Real> const& Ey,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void push_ez_pml_current (int j, int k, int l, Array4<Real> const& Ez,
-                          Array4<Real const> const& jz,
-                          Real const * const sigjx,
-                          Real const * const sigjy,
+void push_ez_pml_current (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ez,
+                          amrex::Array4<amrex::Real const> const& jz,
+                          amrex::Real const * const sigjx,
+                          amrex::Real const * const sigjy,
                           int xlo, int ylo,
-                          Real mu_c2_dt)
+                          amrex::Real mu_c2_dt)
 {
 #if (AMREX_SPACEDIM == 3)
-    Real alpha_zx, alpha_zy;
+    amrex::Real alpha_zx, alpha_zy;
     if (sigjx[j-xlo]+sigjy[k-ylo]==0){
         alpha_zx = 0.5;
         alpha_zy = 0.5;
@@ -83,10 +84,10 @@ void push_ez_pml_current (int j, int k, int l, Array4<Real> const& Ez,
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void damp_jx_pml (int j, int k, int l,
-                  Array4<Real> const& jx,
-                  Real const* const sigsjx,
-                  Real const* const sigjy,
-                  Real const* const sigjz,
+                  amrex::Array4<amrex::Real> const& jx,
+                  amrex::Real const* const sigsjx,
+                  amrex::Real const* const sigjy,
+                  amrex::Real const* const sigjz,
                   int xlo, int ylo, int zlo)
 {
 #if (AMREX_SPACEDIM == 3)
@@ -98,10 +99,10 @@ void damp_jx_pml (int j, int k, int l,
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void damp_jy_pml (int j, int k, int l,
-                  Array4<Real> const& jy,
-                  Real const * const sigjx,
-                  Real const * const sigsjy,
-                  Real const * const sigjz,
+                  amrex::Array4<amrex::Real> const& jy,
+                  amrex::Real const * const sigjx,
+                  amrex::Real const * const sigsjy,
+                  amrex::Real const * const sigjz,
                   int xlo, int ylo, int zlo)
 {
 #if (AMREX_SPACEDIM == 3)
@@ -113,10 +114,10 @@ void damp_jy_pml (int j, int k, int l,
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void damp_jz_pml (int j, int k, int l,
-                  Array4<Real> const& jz,
-                  Real const * const sigjx,
-                  Real const * const sigjy,
-                  Real const * const sigsjz,
+                  amrex::Array4<amrex::Real> const& jz,
+                  amrex::Real const * const sigjx,
+                  amrex::Real const * const sigjy,
+                  amrex::Real const * const sigsjz,
                   int xlo, int ylo, int zlo)
 {
 #if (AMREX_SPACEDIM == 3)

--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -3,35 +3,35 @@
 
 #include <WarpX.H>
 #ifdef WARPX_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
+#   include <openPMD/openPMD.hpp>
 #endif
 
-using namespace amrex;
+void
+PackPlotDataPtrs (amrex::Vector<const amrex::MultiFab*>& pmf,
+          const std::array<std::unique_ptr<amrex::MultiFab>,3>& data);
 
 void
-PackPlotDataPtrs (Vector<const MultiFab*>& pmf,
-          const std::array<std::unique_ptr<MultiFab>,3>& data);
-
-void
-AverageAndPackVectorField( MultiFab& mf_avg,
-                         const std::array< std::unique_ptr<MultiFab>, 3 >& vector_field,
-                         const DistributionMapping& dm,
+AverageAndPackVectorField( amrex::MultiFab& mf_avg,
+                         const std::array< std::unique_ptr<amrex::MultiFab>, 3 >& vector_field,
+                         const amrex::DistributionMapping& dm,
                          const int dcomp, const int ngrow );
 
 void
-AverageAndPackScalarField( MultiFab& mf_avg,
-                         const MultiFab & scalar_field,
+AverageAndPackScalarField( amrex::MultiFab& mf_avg,
+                         const amrex::MultiFab & scalar_field,
                          const int dcomp, const int ngrow );
 
 void
-WriteRawField( const MultiFab& F, const DistributionMapping& dm,
-             const std::string& filename,
-             const std::string& level_prefix,
-             const std::string& field_name,
-             const int lev, const bool plot_guards );
+WriteRawField( const amrex::MultiFab& F,
+               const amrex::DistributionMapping& dm,
+               const std::string& filename,
+               const std::string& level_prefix,
+               const std::string& field_name,
+               const int lev, const bool plot_guards );
 
 void
-WriteZeroRawField( const MultiFab& F, const DistributionMapping& dm,
+WriteZeroRawField( const amrex::MultiFab& F,
+             const amrex::DistributionMapping& dm,
              const std::string& filename,
              const std::string& level_prefix,
              const std::string& field_name,
@@ -39,9 +39,9 @@ WriteZeroRawField( const MultiFab& F, const DistributionMapping& dm,
 
 void
 WriteCoarseScalar( const std::string field_name,
-    const std::unique_ptr<MultiFab>& F_cp,
-    const std::unique_ptr<MultiFab>& F_fp,
-    const DistributionMapping& dm,
+    const std::unique_ptr<amrex::MultiFab>& F_cp,
+    const std::unique_ptr<amrex::MultiFab>& F_fp,
+    const amrex::DistributionMapping& dm,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards,
@@ -49,39 +49,41 @@ WriteCoarseScalar( const std::string field_name,
 
 void
 WriteCoarseVector( const std::string field_name,
-    const std::unique_ptr<MultiFab>& Fx_cp,
-    const std::unique_ptr<MultiFab>& Fy_cp,
-    const std::unique_ptr<MultiFab>& Fz_cp,
-    const std::unique_ptr<MultiFab>& Fx_fp,
-    const std::unique_ptr<MultiFab>& Fy_fp,
-    const std::unique_ptr<MultiFab>& Fz_fp,
-    const DistributionMapping& dm,
+    const std::unique_ptr<amrex::MultiFab>& Fx_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fy_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fz_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fx_fp,
+    const std::unique_ptr<amrex::MultiFab>& Fy_fp,
+    const std::unique_ptr<amrex::MultiFab>& Fz_fp,
+    const amrex::DistributionMapping& dm,
     const std::string& filename,
     const std::string& level_prefix,
     const int lev, const bool plot_guards );
 
-std::unique_ptr<MultiFab>
+std::unique_ptr<amrex::MultiFab>
 getInterpolatedScalar(
-    const MultiFab& F_cp, const MultiFab& F_fp,
-    const DistributionMapping& dm, const int r_ratio,
-    const Real* dx, const int ngrow );
+    const amrex::MultiFab& F_cp, const amrex::MultiFab& F_fp,
+    const amrex::DistributionMapping& dm, const int r_ratio,
+    const amrex::Real* dx, const int ngrow );
 
-std::array<std::unique_ptr<MultiFab>, 3>
+std::array<std::unique_ptr<amrex::MultiFab>, 3>
 getInterpolatedVector(
-    const std::unique_ptr<MultiFab>& Fx_cp,
-    const std::unique_ptr<MultiFab>& Fy_cp,
-    const std::unique_ptr<MultiFab>& Fz_cp,
-    const std::unique_ptr<MultiFab>& Fx_fp,
-    const std::unique_ptr<MultiFab>& Fy_fp,
-    const std::unique_ptr<MultiFab>& Fz_fp,
-    const DistributionMapping& dm,
-    const int r_ratio, const Real* dx,
+    const std::unique_ptr<amrex::MultiFab>& Fx_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fy_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fz_cp,
+    const std::unique_ptr<amrex::MultiFab>& Fx_fp,
+    const std::unique_ptr<amrex::MultiFab>& Fy_fp,
+    const std::unique_ptr<amrex::MultiFab>& Fz_fp,
+    const amrex::DistributionMapping& dm,
+    const int r_ratio, const amrex::Real* dx,
     const int ngrow );
 
 void
 coarsenCellCenteredFields(
-    Vector<MultiFab>& coarse_mf, Vector<Geometry>& coarse_geom,
-    const Vector<MultiFab>& source_mf, const Vector<Geometry>& source_geom,
+    amrex::Vector<amrex::MultiFab>& coarse_mf,
+    amrex::Vector<amrex::Geometry>& coarse_geom,
+    const amrex::Vector<amrex::MultiFab>& source_mf,
+    const amrex::Vector<amrex::Geometry>& source_geom,
     int coarse_ratio, int finest_level );
 
 #ifdef WARPX_USE_OPENPMD
@@ -89,15 +91,15 @@ void
 setOpenPMDUnit( openPMD::Mesh mesh, const std::string field_name );
 
 std::vector<std::uint64_t>
-getReversedVec( const IntVect& v );
+getReversedVec( const amrex::IntVect& v );
 
 std::vector<double>
-getReversedVec( const Real* v );
+getReversedVec( const amrex::Real* v );
 
 void
 WriteOpenPMDFields( const std::string& filename,
                     const std::vector<std::string>& varnames,
-                    const MultiFab& mf, const Geometry& geom,
+                    const amrex::MultiFab& mf, const Geometry& geom,
                     const int iteration, const double time );
 #endif // WARPX_USE_OPENPMD
 

--- a/Source/FieldSolver/WarpX_FDTD.H
+++ b/Source/FieldSolver/WarpX_FDTD.H
@@ -3,12 +3,13 @@
 
 #include <AMReX_FArrayBox.H>
 
-using namespace amrex;
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_bx_yee(int i, int j, int k, Array4<Real> const& Bx,
-                       Array4<Real const> const& Ey, Array4<Real const> const& Ez,
-                       Real dtsdx, Real dtsdy, Real dtsdz, Real dxinv, Real rmin, const long nmodes)
+void warpx_push_bx_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& Bx,
+                       amrex::Array4<amrex::Real const> const& Ey,
+                       amrex::Array4<amrex::Real const> const& Ez,
+                       amrex::Real dtsdx, amrex::Real dtsdy, amrex::Real dtsdz,
+                       amrex::Real dxinv, amrex::Real rmin, const long nmodes)
 {
 #if defined WARPX_DIM_3D
     Bx(i,j,k) += - dtsdy * (Ez(i,j+1,k  ) - Ez(i,j,k))
@@ -38,7 +39,7 @@ void warpx_push_bx_yee(int i, int j, int k, Array4<Real> const& Bx,
             }
         } else {
             // Br(i,j,m) = Br(i,j,m) + I*m*dt*Ez(i,j,m)/r + dtsdz*(Et(i,j+1,m) - Et(i,j,m))
-            const Real r = rmin*dxinv + i;
+            const amrex::Real r = rmin*dxinv + i;
             Bx(i,j,0,2*imode-1) = Bx(i,j,0,2*imode-1) - imode*dtsdx*Ez(i,j,0,2*imode)/r &
                        + dtsdz*(Ey(i,j+1,0,2*imode-1) - Ey(i,j,0,2*imode-1));
             Bx(i,j,0,2*imode) = Bx(i,j,0,2*imode) + imode*dtsdx*Ez(i,j,0,2*imode-1)/r &
@@ -50,9 +51,12 @@ void warpx_push_bx_yee(int i, int j, int k, Array4<Real> const& Bx,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_by_yee(int i, int j, int k, Array4<Real> const& By,
-                       Array4<Real const> const& Ex, Array4<Real const> const& Ez,
-                       Real dtsdx, Real dtsdz, const long nmodes)
+void warpx_push_by_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& By,
+                       amrex::Array4<amrex::Real const> const& Ex,
+                       amrex::Array4<amrex::Real const> const& Ez,
+                       amrex::Real dtsdx, amrex::Real dtsdz,
+                       const long nmodes)
 {
 #if defined WARPX_DIM_3D
     By(i,j,k) += + dtsdx * (Ez(i+1,j,k  ) - Ez(i,j,k))
@@ -74,9 +78,12 @@ void warpx_push_by_yee(int i, int j, int k, Array4<Real> const& By,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_bz_yee(int i, int j, int k, Array4<Real> const& Bz,
-                       Array4<Real const> const& Ex, Array4<Real const> const& Ey,
-                       Real dtsdx, Real dtsdy, Real dxinv, Real rmin, const long nmodes)
+void warpx_push_bz_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& Bz,
+                       amrex::Array4<amrex::Real const> const& Ex,
+                       amrex::Array4<amrex::Real const> const& Ey,
+                       amrex::Real dtsdx, amrex::Real dtsdy,
+                       amrex::Real dxinv, amrex::Real rmin, const long nmodes)
 {
 #if defined WARPX_DIM_3D
     Bz(i,j,k) += - dtsdx * (Ey(i+1,j  ,k) - Ey(i,j,k))
@@ -84,9 +91,9 @@ void warpx_push_bz_yee(int i, int j, int k, Array4<Real> const& Bz,
 #elif defined WARPX_DIM_XZ
     Bz(i,j,0) += - dtsdx * (Ey(i+1,j,0) - Ey(i,j,0));
 #elif defined WARPX_DIM_RZ
-    const Real r = rmin*dxinv + i + 0.5;
-    const Real ru = 1. + 0.5/(rmin*dxinv + i + 0.5);
-    const Real rd = 1. - 0.5/(rmin*dxinv + i + 0.5);
+    const amrex::Real r = rmin*dxinv + i + 0.5;
+    const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i + 0.5);
+    const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i + 0.5);
     Bz(i,j,0,0) += - dtsdx*(ru*Ey(i+1,j,0,0) - rd*Ey(i,j,0,0));
     for (int imode=1 ; imode < nmodes ; imode++) {
         // Bz(i,j,m) = Bz(i,j,m) - dtsdr*(ru*Et(i+1,j,m) - rd*Et(i,j,m)) - I*m*dt*Er(i,j,m)/r
@@ -97,9 +104,15 @@ void warpx_push_bz_yee(int i, int j, int k, Array4<Real> const& Bz,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ex_yee(int i, int j, int k, Array4<Real> const& Ex,
-                       Array4<Real const> const& By, Array4<Real const> const& Bz, Array4<Real const> const& Jx,
-                       Real mu_c2_dt, Real dtsdx_c2, Real dtsdy_c2, Real dtsdz_c2, Real dxinv, Real rmin, const long nmodes)
+void warpx_push_ex_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& Ex,
+                       amrex::Array4<amrex::Real const> const& By,
+                       amrex::Array4<amrex::Real const> const& Bz,
+                       amrex::Array4<amrex::Real const> const& Jx,
+                       amrex::Real mu_c2_dt, amrex::Real dtsdx_c2,
+                       amrex::Real dtsdy_c2, amrex::Real dtsdz_c2,
+                       amrex::Real dxinv, amrex::Real rmin,
+                       const long nmodes)
 {
 #if defined WARPX_DIM_3D
     Ex(i,j,k) += + dtsdy_c2 * (Bz(i,j,k) - Bz(i,j-1,k  ))
@@ -110,7 +123,7 @@ void warpx_push_ex_yee(int i, int j, int k, Array4<Real> const& Ex,
     Ex(i,j,0,0) += - dtsdz_c2 * (By(i,j,0,0) - By(i,j-1,0,0))
                    - mu_c2_dt  * Jx(i,j,0,0);
 #if (defined WARPX_DIM_RZ)
-    const Real r = rmin*dxinv+ i + 0.5;
+    const amrex::Real r = rmin*dxinv+ i + 0.5;
     for (int imode=1 ; imode < nmodes ; imode++) {
         // Er(i,j,m) = Er(i,j,m) - I*m*dt*Bz(i,j,m)/r - dtsdz*(Bt(i,j,m) - Bt(i,j-1,m)) - mudt*Jr(i,j,m)
         Ex(i,j,0,2*imode-1) += - dtsdz_c2*(By(i,j,0,2*imode-1) - By(i,j-1,0,2*imode-1)) + imode*dtsdx_c2*Bz(i,j,0,2*imode)/r
@@ -123,10 +136,15 @@ void warpx_push_ex_yee(int i, int j, int k, Array4<Real> const& Ex,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ey_yee(int i, int j, int k, Array4<Real> const& Ey,
-                       Array4<Real const> const& Bx, Array4<Real const> const& Bz, Array4<Real const> const& Jy,
-                       Array4<Real> const& Ex,
-                       Real mu_c2_dt, Real dtsdx_c2, Real dtsdz_c2, Real rmin, const long nmodes)
+void warpx_push_ey_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& Ey,
+                       amrex::Array4<amrex::Real const> const& Bx,
+                       amrex::Array4<amrex::Real const> const& Bz,
+                       amrex::Array4<amrex::Real const> const& Jy,
+                       amrex::Array4<amrex::Real> const& Ex,
+                       amrex::Real mu_c2_dt, amrex::Real dtsdx_c2,
+                       amrex::Real dtsdz_c2, amrex::Real rmin,
+                       const long nmodes)
 {
 #if defined WARPX_DIM_3D
     Ey(i,j,k) += - dtsdx_c2 * (Bz(i,j,k) - Bz(i-1,j,k))
@@ -177,9 +195,15 @@ void warpx_push_ey_yee(int i, int j, int k, Array4<Real> const& Ey,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ez_yee(int i, int j, int k, Array4<Real> const& Ez,
-                       Array4<Real const> const& Bx, Array4<Real const> const& By, Array4<Real const> const& Jz,
-                       Real mu_c2_dt, Real dtsdx_c2, Real dtsdy_c2, Real dxinv, Real rmin, const long nmodes)
+void warpx_push_ez_yee(int i, int j, int k,
+                       amrex::Array4<amrex::Real> const& Ez,
+                       amrex::Array4<amrex::Real const> const& Bx,
+                       amrex::Array4<amrex::Real const> const& By,
+                       amrex::Array4<amrex::Real const> const& Jz,
+                       amrex::Real mu_c2_dt,
+                       amrex::Real dtsdx_c2, amrex::Real dtsdy_c2,
+                       amrex::Real dxinv, amrex::Real rmin,
+                       const long nmodes)
 {
 #if defined WARPX_DIM_3D
     Ez(i,j,k) += + dtsdx_c2 * (By(i,j,k) - By(i-1,j  ,k))
@@ -190,8 +214,8 @@ void warpx_push_ez_yee(int i, int j, int k, Array4<Real> const& Ez,
                  - mu_c2_dt  * Jz(i,j,0);
 #elif defined WARPX_DIM_RZ
     if (i != 0 || rmin != 0.) {
-        const Real ru = 1. + 0.5/(rmin*dxinv + i);
-        const Real rd = 1. - 0.5/(rmin*dxinv + i);
+        const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i);
+        const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i);
         Ez(i,j,0,0) += + dtsdx_c2 * (ru*By(i,j,0,0) - rd*By(i-1,j,0,0))
                        - mu_c2_dt  * Jz(i,j,0,0);
     } else {
@@ -203,9 +227,9 @@ void warpx_push_ez_yee(int i, int j, int k, Array4<Real> const& Ez,
             Ez(i,j,0,2*imode-1) = 0.;
             Ez(i,j,0,2*imode) = 0.;
         } else {
-            const Real r = rmin*dxinv + i + 0.5;
-            const Real ru = 1. + 0.5/(rmin*dxinv + i);
-            const Real rd = 1. - 0.5/(rmin*dxinv + i);
+            const amrex::Real r = rmin*dxinv + i + 0.5;
+            const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i);
+            const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i);
             // Ez(i,j,m) = Ez(i,j,m) + dtsdr*(ru*Bt(i,j,m) - rd*Bt(i-1,j,m)) + I*m*dt*Br(i,j,m)/r - mudt*Jz(i,j,m)
             Ez(i,j,0,2*imode-1) += + dtsdx_c2 * (ru*By(i,j,0,2*imode-1) - rd*By(i-1,j,0,2*imode-1))
                                  - imode*dtsdx_c2*Bx(i,j,0,2*imode)/r
@@ -219,8 +243,10 @@ void warpx_push_ez_yee(int i, int j, int k, Array4<Real> const& Ez,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ex_f_yee(int j, int k, int l, Array4<Real> const& Ex,
-                         Array4<Real const> const& F, Real dtsdx_c2)
+void warpx_push_ex_f_yee(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ex,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real dtsdx_c2)
 {
 #if defined WARPX_DIM_3D
     Ex(j,k,l) += + dtsdx_c2 * (F(j+1,k,l) - F(j,k,l));
@@ -230,8 +256,10 @@ void warpx_push_ex_f_yee(int j, int k, int l, Array4<Real> const& Ex,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ey_f_yee(int j, int k, int l, Array4<Real> const& Ey,
-                         Array4<Real const> const& F, Real dtsdy_c2)
+void warpx_push_ey_f_yee(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ey,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real dtsdy_c2)
 {
 #if defined WARPX_DIM_3D
     Ey(j,k,l) += + dtsdy_c2 * (F(j,k+1,l) - F(j,k,l));
@@ -239,8 +267,10 @@ void warpx_push_ey_f_yee(int j, int k, int l, Array4<Real> const& Ey,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ez_f_yee(int j, int k, int l, Array4<Real> const& Ez,
-                         Array4<Real const> const& F, Real dtsdz_c2)
+void warpx_push_ez_f_yee(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ez,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real dtsdz_c2)
 {
 #if defined WARPX_DIM_3D
     Ez(j,k,l) += + dtsdz_c2 * (F(j,k,l+1) - F(j,k,l));
@@ -249,11 +279,14 @@ void warpx_push_ez_f_yee(int j, int k, int l, Array4<Real> const& Ez,
 #endif
 }
 
-static void warpx_calculate_ckc_coefficients(Real dtsdx, Real dtsdy, Real dtsdz,
-                                             Real &betaxy, Real &betaxz, Real &betayx, Real &betayz, Real &betazx, Real &betazy,
-                                             Real &gammax, Real &gammay, Real &gammaz,
-                                             Real &alphax, Real &alphay, Real &alphaz)
+static void warpx_calculate_ckc_coefficients(amrex::Real dtsdx, amrex::Real dtsdy, amrex::Real dtsdz,
+                                             amrex::Real &betaxy, amrex::Real &betaxz, amrex::Real &betayx,
+                                             amrex::Real &betayz, amrex::Real &betazx, amrex::Real &betazy,
+                                             amrex::Real &gammax, amrex::Real &gammay, amrex::Real &gammaz,
+                                             amrex::Real &alphax, amrex::Real &alphay, amrex::Real &alphaz)
 {
+    using namespace amrex;
+
     // Cole-Karkkainen-Cowan push
     // computes coefficients according to Cowan - PRST-AB 16, 041303 (2013)
 #if defined WARPX_DIM_3D
@@ -304,11 +337,14 @@ static void warpx_calculate_ckc_coefficients(Real dtsdx, Real dtsdy, Real dtsdz,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_bx_ckc(int j, int k, int l, Array4<Real> const& Bx,
-                       Array4<Real const> const& Ey, Array4<Real const> const& Ez,
-                       Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                       Real gammax, Real gammay, Real gammaz,
-                       Real alphax, Real alphay, Real alphaz)
+void warpx_push_bx_ckc(int j, int k, int l,
+                       amrex::Array4<amrex::Real> const& Bx,
+                       amrex::Array4<amrex::Real const> const& Ey,
+                       amrex::Array4<amrex::Real const> const& Ez,
+                       amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                       amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                       amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                       amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     Bx(j,k,l) += - alphay * (Ez(j  ,k+1,l  ) - Ez(j,  k  ,l  ))
@@ -337,11 +373,14 @@ void warpx_push_bx_ckc(int j, int k, int l, Array4<Real> const& Bx,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_by_ckc(int j, int k, int l, Array4<Real> const& By,
-                       Array4<Real const> const& Ex, Array4<Real const> const& Ez,
-                       Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                       Real gammax, Real gammay, Real gammaz,
-                       Real alphax, Real alphay, Real alphaz)
+void warpx_push_by_ckc(int j, int k, int l,
+                       amrex::Array4<amrex::Real> const& By,
+                       amrex::Array4<amrex::Real const> const& Ex,
+                       amrex::Array4<amrex::Real const> const& Ez,
+                       amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                       amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                       amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                       amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     By(j,k,l) += + alphax * (Ez(j+1,k  ,l  ) - Ez(j,  k,  l  ))
@@ -373,11 +412,14 @@ void warpx_push_by_ckc(int j, int k, int l, Array4<Real> const& By,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_bz_ckc(int j, int k, int l, Array4<Real> const& Bz,
-                       Array4<Real const> const& Ex, Array4<Real const> const& Ey,
-                       Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                       Real gammax, Real gammay, Real gammaz,
-                       Real alphax, Real alphay, Real alphaz)
+void warpx_push_bz_ckc(int j, int k, int l,
+                       amrex::Array4<amrex::Real> const& Bz,
+                       amrex::Array4<amrex::Real const> const& Ex,
+                       amrex::Array4<amrex::Real const> const& Ey,
+                       amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                       amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                       amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                       amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     Bz(j,k,l) += - alphax * (Ey(j+1,k  ,l  ) - Ey(j  ,k  ,l  ))
@@ -406,11 +448,13 @@ void warpx_push_bz_ckc(int j, int k, int l, Array4<Real> const& Bz,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ex_f_ckc(int j, int k, int l, Array4<Real> const& Ex,
-                         Array4<Real const> const& F,
-                         Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                         Real gammax, Real gammay, Real gammaz,
-                         Real alphax, Real alphay, Real alphaz)
+void warpx_push_ex_f_ckc(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ex,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                         amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                         amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                         amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     Ex(j,k,l) += + alphax * (F(j+1,k  ,l  ) - F(j,  k,  l  ))
@@ -430,11 +474,13 @@ void warpx_push_ex_f_ckc(int j, int k, int l, Array4<Real> const& Ex,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ey_f_ckc(int j, int k, int l, Array4<Real> const& Ey,
-                         Array4<Real const> const& F,
-                         Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                         Real gammax, Real gammay, Real gammaz,
-                         Real alphax, Real alphay, Real alphaz)
+void warpx_push_ey_f_ckc(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ey,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                         amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                         amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                         amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     Ey(j,k,l) += + alphay * (F(j  ,k+1,l  ) - F(j  ,k,l  ))
@@ -450,11 +496,13 @@ void warpx_push_ey_f_ckc(int j, int k, int l, Array4<Real> const& Ey,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_push_ez_f_ckc(int j, int k, int l, Array4<Real> const& Ez,
-                         Array4<Real const> const& F,
-                         Real betaxy, Real betaxz, Real betayx, Real betayz, Real betazx, Real betazy,
-                         Real gammax, Real gammay, Real gammaz,
-                         Real alphax, Real alphay, Real alphaz)
+void warpx_push_ez_f_ckc(int j, int k, int l,
+                         amrex::Array4<amrex::Real> const& Ez,
+                         amrex::Array4<amrex::Real const> const& F,
+                         amrex::Real betaxy, amrex::Real betaxz, amrex::Real betayx,
+                         amrex::Real betayz, amrex::Real betazx, amrex::Real betazy,
+                         amrex::Real gammax, amrex::Real gammay, amrex::Real gammaz,
+                         amrex::Real alphax, amrex::Real alphay, amrex::Real alphaz)
 {
 #if defined WARPX_DIM_3D
     Ez(j,k,l) += + alphaz * (F(j  ,k  ,l+1) - F(j,  k,  l))
@@ -474,11 +522,16 @@ void warpx_push_ez_f_ckc(int j, int k, int l, Array4<Real> const& Ez,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_computedivb(int i, int j, int k, int dcomp, Array4<Real> const& divB,
-                       Array4<Real const> const& Bx, Array4<Real const> const& By, Array4<Real const> const& Bz,
-                       Real dxinv, Real dyinv, Real dzinv
+void warpx_computedivb(int i, int j, int k, int dcomp,
+                       amrex::Array4<amrex::Real> const& divB,
+                       amrex::Array4<amrex::Real const> const& Bx,
+                       amrex::Array4<amrex::Real const> const& By,
+                       amrex::Array4<amrex::Real const> const& Bz,
+                       amrex::Real dxinv,
+                       amrex::Real dyinv,
+                       amrex::Real dzinv
 #ifdef WARPX_DIM_RZ
-                       ,const Real rmin
+                       , amrex::Real const rmin
 #endif
                        )
 {
@@ -490,19 +543,23 @@ void warpx_computedivb(int i, int j, int k, int dcomp, Array4<Real> const& divB,
     divB(i,j,0,dcomp) = (Bx(i+1,j  ,0) - Bx(i,j,0))*dxinv
                +        (Bz(i  ,j+1,0) - Bz(i,j,0))*dzinv;
 #elif defined WARPX_DIM_RZ
-    const Real ru = 1. + 0.5/(rmin*dxinv + i + 0.5);
-    const Real rd = 1. - 0.5/(rmin*dxinv + i + 0.5);
+    const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i + 0.5);
+    const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i + 0.5);
     divB(i,j,0,dcomp) = (ru*Bx(i+1,j,0) - rd*Bx(i,j,0))*dxinv
                        + (Bz(i,j+1,0) - Bz(i,j,0))*dzinv;
 #endif
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void warpx_computedive(int i, int j, int k, int dcomp, Array4<Real> const& divE,
-                       Array4<Real const> const& Ex, Array4<Real const> const& Ey, Array4<Real const> const& Ez,
-                       Real dxinv, Real dyinv, Real dzinv
+void warpx_computedive(int i, int j, int k, int dcomp,
+                       amrex::Array4<amrex::Real> const& divE,
+                       amrex::Array4<amrex::Real const> const& Ex,
+                       amrex::Array4<amrex::Real const> const& Ey,
+                       amrex::Array4<amrex::Real const> const& Ez,
+                       amrex::Real dxinv, amrex::Real dyinv,
+                       amrex::Real dzinv
 #ifdef WARPX_DIM_RZ
-                       ,const Real rmin
+                       , amrex::Real const rmin
 #endif
                        )
 {
@@ -521,8 +578,8 @@ void warpx_computedive(int i, int j, int k, int dcomp, Array4<Real> const& divE,
         divE(i,j,0,dcomp) = 4.*Ex(i,j,0)*dxinv
                             + (Ez(i,j,0) - Ez(i,j-1,0))*dzinv;
     } else {
-        const Real ru = 1. + 0.5/(rmin*dxinv + i);
-        const Real rd = 1. - 0.5/(rmin*dxinv + i);
+        const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i);
+        const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i);
         divE(i,j,0,dcomp) = (ru*Ex(i,j,0) - rd*Ex(i-1,j,0))*dxinv
                            + (Ez(i,j,0) - Ez(i,j-1,0))*dzinv;
     }

--- a/Source/FieldSolver/WarpX_K.H
+++ b/Source/FieldSolver/WarpX_K.H
@@ -3,12 +3,12 @@
 
 #include <AMReX_FArrayBox.H>
 
-using namespace amrex;
-
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_bx_nodal (int j, int k, int l, Array4<Real> const& Bx,
-                          Array4<Real const> const& Ey, Array4<Real const> const& Ez,
-                          Real dtsdy, Real dtsdz)
+void warpx_push_bx_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Bx,
+                          amrex::Array4<amrex::Real const> const& Ey,
+                          amrex::Array4<amrex::Real const> const& Ez,
+                          amrex::Real dtsdy, amrex::Real dtsdz)
 {
 #if (AMREX_SPACEDIM == 3)
     Bx(j,k,l) = Bx(j,k,l) - 0.5*dtsdy * (Ez(j,k+1,l  ) - Ez(j,k-1,l  ))
@@ -19,9 +19,12 @@ void warpx_push_bx_nodal (int j, int k, int l, Array4<Real> const& Bx,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_by_nodal (int j, int k, int l, Array4<Real> const& By,
-                          Array4<Real const> const& Ex, Array4<Real const> const& Ez,
-                          Real dtsdx, Real dtsdz)
+void warpx_push_by_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& By,
+                          amrex::Array4<amrex::Real const> const& Ex,
+                          amrex::Array4<amrex::Real const> const& Ez,
+                          amrex::Real dtsdx,
+                          amrex::Real dtsdz)
 {
 #if (AMREX_SPACEDIM == 3)
     By(j,k,l) = By(j,k,l) + 0.5*dtsdx * (Ez(j+1,k,l  ) - Ez(j-1,k,l  ))
@@ -33,9 +36,11 @@ void warpx_push_by_nodal (int j, int k, int l, Array4<Real> const& By,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_bz_nodal (int j, int k, int l, Array4<Real> const& Bz,
-                          Array4<Real const> const& Ex, Array4<Real const> const& Ey,
-                          Real dtsdx, Real dtsdy)
+void warpx_push_bz_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Bz,
+                          amrex::Array4<amrex::Real const> const& Ex,
+                          amrex::Array4<amrex::Real const> const& Ey,
+                          amrex::Real dtsdx, amrex::Real dtsdy)
 {
 #if (AMREX_SPACEDIM == 3)
     Bz(j,k,l) = Bz(j,k,l) - 0.5*dtsdx * (Ey(j+1,k  ,l) - Ey(j-1,k  ,l))
@@ -46,10 +51,12 @@ void warpx_push_bz_nodal (int j, int k, int l, Array4<Real> const& Bz,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_ex_nodal (int j, int k, int l, Array4<Real> const& Ex,
-                          Array4<Real const> const& By, Array4<Real const> const& Bz,
-                          Array4<Real const> const& jx,
-                          Real mudt, Real dtsdy, Real dtsdz)
+void warpx_push_ex_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ex,
+                          amrex::Array4<amrex::Real const> const& By,
+                          amrex::Array4<amrex::Real const> const& Bz,
+                          amrex::Array4<amrex::Real const> const& jx,
+                          amrex::Real mudt, amrex::Real dtsdy, amrex::Real dtsdz)
 {
 #if (AMREX_SPACEDIM == 3)
     Ex(j,k,l) = Ex(j,k,l) + 0.5*dtsdy * (Bz(j,k+1,l  ) - Bz(j,k-1,l  ))
@@ -62,10 +69,12 @@ void warpx_push_ex_nodal (int j, int k, int l, Array4<Real> const& Ex,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_ey_nodal (int j, int k, int l, Array4<Real> const& Ey,
-                          Array4<Real const> const& Bx, Array4<Real const> const& Bz,
-                          Array4<Real const> const& jy,
-                          Real mudt, Real dtsdx, Real dtsdz)
+void warpx_push_ey_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ey,
+                          amrex::Array4<amrex::Real const> const& Bx,
+                          amrex::Array4<amrex::Real const> const& Bz,
+                          amrex::Array4<amrex::Real const> const& jy,
+                          amrex::Real mudt, amrex::Real dtsdx, amrex::Real dtsdz)
 {
 #if (AMREX_SPACEDIM == 3)
     Ey(j,k,l) = Ey(j,k,l) - 0.5*dtsdx * (Bz(j+1,k,l  ) - Bz(j-1,k,l  ))
@@ -79,10 +88,12 @@ void warpx_push_ey_nodal (int j, int k, int l, Array4<Real> const& Ey,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void warpx_push_ez_nodal (int j, int k, int l, Array4<Real> const& Ez,
-                          Array4<Real const> const& Bx, Array4<Real const> const& By,
-                          Array4<Real const> const& jz,
-                          Real mudt, Real dtsdx, Real dtsdy)
+void warpx_push_ez_nodal (int j, int k, int l,
+                          amrex::Array4<amrex::Real> const& Ez,
+                          amrex::Array4<amrex::Real const> const& Bx,
+                          amrex::Array4<amrex::Real const> const& By,
+                          amrex::Array4<amrex::Real const> const& jz,
+                          amrex::Real mudt, amrex::Real dtsdx, amrex::Real dtsdy)
 {
 #if (AMREX_SPACEDIM == 3)
     Ez(j,k,l) = Ez(j,k,l) + 0.5*dtsdx * (By(j+1,k  ,l) - By(j-1,k  ,l))


### PR DESCRIPTION
Writing `using namespace XY;` in public scope of a header file pollutes downstream namespaces that include that file directly or even indirectly.

This can be cumbersome and lead to nifty naming conflicts that cause unclear selection of classes or ADL lookup issues. So one just avoids this as good practice and we did not do it in many places anyway.