### PR TITLE
LaserParticleContainer: Const Correctness

### DIFF
--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -59,7 +59,7 @@ public:
     void update_laser_particle (const int np, amrex::Real * AMREX_RESTRICT const puxp,
                                 amrex::Real * AMREX_RESTRICT const puyp,
                                 amrex::Real * AMREX_RESTRICT const puzp,
-                                amrex::Real * AMREX_RESTRICT const pwp,
+                                amrex::Real const * AMREX_RESTRICT const pwp,
                                 amrex::Real const * AMREX_RESTRICT const amplitude,
                                 const amrex::Real dt, const int thread_num);
 

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -663,7 +663,7 @@ LaserParticleContainer::calculate_laser_plane_coordinates (
 void
 LaserParticleContainer::update_laser_particle(
     const int np, Real * AMREX_RESTRICT const puxp, Real * AMREX_RESTRICT const puyp,
-    Real * AMREX_RESTRICT const puzp, Real * AMREX_RESTRICT const pwp,
+    Real * AMREX_RESTRICT const puzp, Real const * AMREX_RESTRICT const pwp,
     Real const * AMREX_RESTRICT const amplitude, const Real dt,
     const int thread_num)
 {


### PR DESCRIPTION
A parameter here can be declared more strict with `const`. Somehow the only [const-correctness](https://clang.llvm.org/extra/clang-tidy/checks/readability-non-const-parameter.html) place I found with clang-tidy.