### PR TITLE
[WIP] Fix deposit_on_main_grid

### DIFF
--- a/Examples/Tests/deposit_on_main_grid/inputs
+++ b/Examples/Tests/deposit_on_main_grid/inputs
@@ -10,7 +10,7 @@ amr.plot_file = "plotfiles/plt"
 amr.plot_int = 100
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = 0 0      # Is periodic?
-geometry.prob_lo     = -125.e-6 -149.e-6 
+geometry.prob_lo     = -125.e-6 -149.e-6
 geometry.prob_hi     =  125.e-6    1.e-6
 
 # warpx.fine_tag_lo =  -50.e-6 -70.e-6

--- a/Examples/Tests/deposit_on_main_grid/inputs
+++ b/Examples/Tests/deposit_on_main_grid/inputs
@@ -1,0 +1,121 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+# stop_time = 4.03658656286e-11
+max_step = 400
+amr.n_cell = 64 256 # 1280
+amr.max_grid_size = 128
+amr.blocking_factor = 32
+amr.plot_file = "plotfiles/plt"
+amr.plot_int = 100
+geometry.coord_sys   = 0                  # 0: Cartesian
+geometry.is_periodic = 0 0      # Is periodic?
+geometry.prob_lo     = -125.e-6 -149.e-6 
+geometry.prob_hi     =  125.e-6    1.e-6
+
+# warpx.fine_tag_lo =  -50.e-6 -70.e-6
+# warpx.fine_tag_hi =   50.e-6 -50.e-6
+warpx.fine_tag_lo = -1 -1
+warpx.fine_tag_hi =  1  1
+
+# GATHER FROM MAIN GRID
+# use either one of the two lines below.
+# They do not give the same result, and THIS IS the problem
+# warpx.n_field_gather_buffer = 512
+particles.gather_from_main_grid = driver plasma_e plasma_p
+
+# DEPOSIT ON MAIN GRID
+# use either one of the two lines below.
+# They do not give the same result, and THIS IS the problem
+# warpx.n_current_deposition_buffer = 512
+particles.deposit_on_main_grid = driver plasma_e plasma_p
+
+# warpx.plot_raw_fields = 1
+warpx.plot_raw_fields = 1
+warpx.plot_finepatch = 1
+warpx.plot_crsepatch = 1
+
+#################################
+############ NUMERICS ###########
+#################################
+algo.maxwell_fdtd_solver = yee
+warpx.verbose = 1
+warpx.do_dive_cleaning = 0
+warpx.use_filter = 0
+warpx.do_pml = 1
+warpx.pml_ncell = 10
+warpx.cfl = 1.0
+# warpx.cfl = 0.5
+warpx.do_moving_window = 0
+warpx.moving_window_dir = z
+warpx.moving_window_v = 1. # in units of the speed of light
+interpolation.nox = 3
+interpolation.noy = 3
+interpolation.noz = 3
+
+#################################
+######### BOOSTED FRAME #########
+#################################
+warpx.gamma_boost = 2.0
+warpx.boost_direction = z
+# warpx.do_boosted_frame_diagnostic = 0
+# warpx.num_snapshots_lab = 22
+# warpx.dt_snapshots_lab = 3.335640951981521e-11
+
+#################################
+############ PLASMA #############
+#################################
+particles.nspecies = 3
+particles.species_names = driver plasma_e plasma_p
+particles.use_fdtd_nci_corr = 0
+
+driver.charge = -q_e
+driver.mass = m_e
+driver.injection_style = "gaussian_beam"
+driver.x_rms = 2.e-6
+driver.y_rms = 2.e-6
+driver.z_rms = 4.e-6
+driver.x_m = 0.
+driver.y_m = 0.
+driver.z_m = -130.e-6
+driver.npart = 1000
+driver.q_tot = -1.e-11
+driver.momentum_distribution_type = "gaussian"
+driver.ux_m = 0.0
+driver.uy_m = 0.0
+driver.uz_m = 200000.
+driver.ux_th = 2.
+driver.uy_th = 2.
+driver.uz_th = 20000.
+
+plasma_e.charge = -q_e
+plasma_e.mass = m_e
+plasma_e.injection_style = "NUniformPerCell"
+plasma_e.zmin = -1. # -110.e-6
+plasma_e.zmax = 0.2
+plasma_e.xmin = -70.e-6
+plasma_e.xmax =  70.e-6
+plasma_e.profile = constant
+plasma_e.density = 1.e23
+plasma_e.num_particles_per_cell_each_dim = 1 1
+plasma_e.momentum_distribution_type = "constant"
+plasma_e.ux = 0.0
+plasma_e.uy = 0.0
+plasma_e.uz = 0.0
+plasma_e.do_continuous_injection = 1
+
+plasma_p.charge = q_e
+plasma_p.mass = m_p
+plasma_p.injection_style = "NUniformPerCell"
+plasma_p.zmin = -1. # -110.e-6
+plasma_p.zmax = 0.2
+plasma_p.profile = constant
+plasma_p.density = 1.e23
+plasma_p.xmin = -70.e-6
+plasma_p.xmax =  70.e-6
+plasma_p.num_particles_per_cell_each_dim = 1 1
+plasma_p.momentum_distribution_type = "constant"
+plasma_p.ux = 0.0
+plasma_p.uy = 0.0
+plasma_p.uz = 0.0
+plasma_p.do_continuous_injection = 1

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1323,7 +1323,7 @@ PhysicalParticleContainer::Evolve (int lev,
                                0, np_current, thread_num,
                                lev, lev, dt);
                 if (has_buffer){
-                    // Deposit in buffers
+                    // Deposit in buffers or on coarse grid
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                    np_current, np-np_current, thread_num,
                                    lev, lev-1, dt);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -953,6 +953,26 @@ PhysicalParticleContainer::Evolve (int lev,
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
     const std::array<Real,3>& cdx = WarpX::CellSize(std::max(lev-1,0));
 
+    // If needed, check that cEx is initialized
+    if (WarpX::m_use_buffers && WarpX::n_field_gather_buffer>0){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(cEx,
+            "Field gather buffers requested but cEx not initialized!");
+    }
+    if (m_gather_from_main_grid){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(cEx,
+            "gather_from_main_grid requested but cEx not initialized!");
+    }
+
+    // If needed, check that cjx is initialized
+    if (WarpX::m_use_buffers && WarpX::n_current_deposition_buffer>0){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(cjx,
+            "Current deposition buffers requested but cjx not initialized!");
+    }
+    if (m_deposit_on_main_grid){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(cjx,
+            "deposit_on_main_grid requested but cjx not initialized!");
+    }
+
     // Get instances of NCI Godfrey filters
     const auto& nci_godfrey_filter_exeybz = WarpX::GetInstance().nci_godfrey_filter_exeybz;
     const auto& nci_godfrey_filter_bxbyez = WarpX::GetInstance().nci_godfrey_filter_bxbyez;
@@ -1087,7 +1107,7 @@ PhysicalParticleContainer::Evolve (int lev,
 
             long nfine_current = np; //! number of particles depositing to fine grid
             long nfine_gather = np;  //! number of particles gathering from fine grid
-            if (m_use_buffers && !do_not_push)
+            if (WarpX::m_use_buffers && !do_not_push)
             {
                 BL_PROFILE_VAR_START(blp_partition);
                 inexflag.resize(np);
@@ -1199,7 +1219,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 }
                 DepositCharge(pti, wp, ion_lev, rho, 0, 0,
                               np_current, thread_num, lev, lev);
-                if (m_use_buffers || m_deposit_on_main_grid){
+                if (WarpX::m_use_buffers || m_deposit_on_main_grid){
                     DepositCharge(pti, wp, ion_lev, crho, 0, np_current,
                                   np-np_current, thread_num, lev, lev-1);
                 }
@@ -1320,7 +1340,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                0, np_current, thread_num,
                                lev, lev, dt);
-                if (m_use_buffers || m_deposit_on_main_grid){
+                if (WarpX::m_use_buffers || m_deposit_on_main_grid){
                     // Deposit in buffers or on coarse grid
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                    np_current, np-np_current, thread_num,
@@ -1346,7 +1366,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 }
                 DepositCharge(pti, wp, ion_lev, rho, 1, 0,
                               np_current, thread_num, lev, lev);
-                if (m_use_buffers || m_deposit_on_main_grid){
+                if (WarpX::m_use_buffers || m_deposit_on_main_grid){
                     DepositCharge(pti, wp, ion_lev, crho, 1, np_current,
                                   np-np_current, thread_num, lev, lev-1);
                 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -964,8 +964,6 @@ PhysicalParticleContainer::Evolve (int lev,
     const iMultiFab* current_masks = WarpX::CurrentBufferMasks(lev);
     const iMultiFab* gather_masks = WarpX::GatherBufferMasks(lev);
 
-    bool has_buffer = cEx || cjx;
-
     if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
     {
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -1089,7 +1087,7 @@ PhysicalParticleContainer::Evolve (int lev,
 
             long nfine_current = np; //! number of particles depositing to fine grid
             long nfine_gather = np;  //! number of particles gathering from fine grid
-            if (has_buffer && !do_not_push)
+            if (m_use_buffers && !do_not_push)
             {
                 BL_PROFILE_VAR_START(blp_partition);
                 inexflag.resize(np);
@@ -1201,7 +1199,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 }
                 DepositCharge(pti, wp, ion_lev, rho, 0, 0,
                               np_current, thread_num, lev, lev);
-                if (has_buffer){
+                if (m_use_buffers || m_deposit_on_main_grid){
                     DepositCharge(pti, wp, ion_lev, crho, 0, np_current,
                                   np-np_current, thread_num, lev, lev-1);
                 }
@@ -1322,7 +1320,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                0, np_current, thread_num,
                                lev, lev, dt);
-                if (has_buffer){
+                if (m_use_buffers || m_deposit_on_main_grid){
                     // Deposit in buffers or on coarse grid
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                    np_current, np-np_current, thread_num,
@@ -1348,7 +1346,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 }
                 DepositCharge(pti, wp, ion_lev, rho, 1, 0,
                               np_current, thread_num, lev, lev);
-                if (has_buffer){
+                if (m_use_buffers || m_deposit_on_main_grid){
                     DepositCharge(pti, wp, ion_lev, crho, 1, np_current,
                                   np-np_current, thread_num, lev, lev-1);
                 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -298,8 +298,6 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
-    bool m_use_buffers = false;
-
     static int do_not_push;
 
     // Whether to allow particles outside of the simulation domain to be

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -298,6 +298,8 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
+    bool m_use_buffers = false;
+
     static int do_not_push;
 
     // Whether to allow particles outside of the simulation domain to be

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -128,7 +128,7 @@ public:
     static int n_field_gather_buffer;       //! in number of cells from the edge (identical for each dimension)
     static int n_current_deposition_buffer; //! in number of cells from the edge (identical for each dimension)
     //! Whether the number of cells in deposition or gather buffer is > 0
-    static bool m_use_buffers = false;
+    static bool m_use_buffers;
 
     // do nodal
     static int do_nodal;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -127,6 +127,8 @@ public:
     // buffers
     static int n_field_gather_buffer;       //! in number of cells from the edge (identical for each dimension)
     static int n_current_deposition_buffer; //! in number of cells from the edge (identical for each dimension)
+    //! Whether the number of cells in deposition or gather buffer is > 0
+    static bool m_use_buffers = false;
 
     // do nodal
     static int do_nodal;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -730,6 +730,8 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         n_current_deposition_buffer = ngJ.max();
     }
 
+    m_use_buffers = n_current_deposition_buffer>0 || n_field_gather_buffer>0;
+
     int ngF = (do_moving_window) ? 2 : 0;
     // CKC solver requires one additional guard cell
     if (maxwell_fdtd_solver_id == 1) ngF = std::max( ngF, 1 );


### PR DESCRIPTION
Fixes for deposit and gather to/from main grid:
- initialize coarse grids even if no buffers, if deposit_on_main_grid

### Input File for Testing:

<details>
  <summary>Click to expand!</summary>
  
```
#################################
####### GENERAL PARAMETERS ######
#################################
# stop_time = 4.03658656286e-11
max_step = 400
amr.n_cell = 64 256 # 1280
amr.max_grid_size = 128
amr.blocking_factor = 32
amr.plot_file = "plotfiles/plt"
amr.plot_int = 100
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 0 0      # Is periodic?
geometry.prob_lo     = -125.e-6 -149.e-6
geometry.prob_hi     =  125.e-6    1.e-6

# warpx.fine_tag_lo =  -50.e-6 -70.e-6
# warpx.fine_tag_hi =   50.e-6 -50.e-6
warpx.fine_tag_lo = -1 -1
warpx.fine_tag_hi =  1  1

# GATHER FROM MAIN GRID
# use either one of the two lines below.
# They do not give the same result, and THIS IS the problem
# warpx.n_field_gather_buffer = 512
particles.gather_from_main_grid = driver plasma_e plasma_p

# DEPOSIT ON MAIN GRID
# use either one of the two lines below.
# They do not give the same result, and THIS IS the problem
# warpx.n_current_deposition_buffer = 512
particles.deposit_on_main_grid = driver plasma_e plasma_p

# warpx.plot_raw_fields = 1
warpx.plot_raw_fields = 1
warpx.plot_finepatch = 1
warpx.plot_crsepatch = 1

#################################
############ NUMERICS ###########
#################################
algo.maxwell_fdtd_solver = yee
warpx.verbose = 1
warpx.do_dive_cleaning = 0
warpx.use_filter = 0
warpx.do_pml = 1
warpx.pml_ncell = 10
warpx.cfl = 1.0
# warpx.cfl = 0.5
warpx.do_moving_window = 0
warpx.moving_window_dir = z
warpx.moving_window_v = 1. # in units of the speed of light
interpolation.nox = 3
interpolation.noy = 3
interpolation.noz = 3

#################################
######### BOOSTED FRAME #########
#################################
warpx.gamma_boost = 2.0
warpx.boost_direction = z
# warpx.do_boosted_frame_diagnostic = 0
# warpx.num_snapshots_lab = 22
# warpx.dt_snapshots_lab = 3.335640951981521e-11

#################################
############ PLASMA #############
#################################
particles.nspecies = 3
particles.species_names = driver plasma_e plasma_p
particles.use_fdtd_nci_corr = 0

driver.charge = -q_e
driver.mass = m_e
driver.injection_style = "gaussian_beam"
driver.x_rms = 2.e-6
driver.y_rms = 2.e-6
driver.z_rms = 4.e-6
driver.x_m = 0.
driver.y_m = 0.
driver.z_m = -130.e-6
driver.npart = 1000
driver.q_tot = -1.e-11
driver.momentum_distribution_type = "gaussian"
driver.ux_m = 0.0
driver.uy_m = 0.0
driver.uz_m = 200000.
driver.ux_th = 2.
driver.uy_th = 2.
driver.uz_th = 20000.

plasma_e.charge = -q_e
plasma_e.mass = m_e
plasma_e.injection_style = "NUniformPerCell"
plasma_e.zmin = -1. # -110.e-6
plasma_e.zmax = 0.2
plasma_e.xmin = -70.e-6
plasma_e.xmax =  70.e-6
plasma_e.profile = constant
plasma_e.density = 1.e23
plasma_e.num_particles_per_cell_each_dim = 1 1
plasma_e.momentum_distribution_type = "constant"
plasma_e.ux = 0.0
plasma_e.uy = 0.0
plasma_e.uz = 0.0
plasma_e.do_continuous_injection = 1

plasma_p.charge = q_e
plasma_p.mass = m_p
plasma_p.injection_style = "NUniformPerCell"
plasma_p.zmin = -1. # -110.e-6
plasma_p.zmax = 0.2
plasma_p.profile = constant
plasma_p.density = 1.e23
plasma_p.xmin = -70.e-6
plasma_p.xmax =  70.e-6
plasma_p.num_particles_per_cell_each_dim = 1 1
plasma_p.momentum_distribution_type = "constant"
plasma_p.ux = 0.0
plasma_p.uy = 0.0
plasma_p.uz = 0.0
```
</details>