### PR TITLE
No need to use PGI/OpenACC when building WarpX

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -68,9 +68,9 @@ Then, you need to load the following modules:
 
 ::
 
-    module load modules esslurm pgi cuda mvapich2
+    module load modules esslurm gcc/7.3.0 cuda mvapich2
 
-You can also use OpenMPI-UCX instead of mvapich: openmpi/4.0.1-ucx-1.6
+You can also use OpenMPI-UCX instead of mvapich: openmpi/4.0.1-ucx-1.6.
 
 Then, you need to use slurm to request access to a GPU node:
 
@@ -87,7 +87,7 @@ Finally, navigate to the base of the WarpX repository and compile in GPU mode:
 
 ::
 
-    make -j 16 COMP=pgi USE_GPU=TRUE
+    make -j 16 USE_GPU=TRUE
 
 
 Building WarpX with openPMD support

--- a/Docs/source/building/gpu_local.rst
+++ b/Docs/source/building/gpu_local.rst
@@ -7,39 +7,10 @@ Building WarpX with GPU support (Linux only)
   look for the corresponding specific instructions, instead
   of those on this page.
 
-In order to build WarpX with GPU support, it necessary to install:
+In order to build WarpX with GPU support, make sure that you have `cuda`
+and `mpich` installed on your system. (Compiling with `openmpi` currently
+fails.) Then compile WarpX with the option `USE_GPU=TRUE`, e.g.
 
-- The PGI compiler. The free PGI Community Edition can be installed from
-  `this page <https://www.pgroup.com/products/community.htm>`__.
+::
 
-- `Spack <https://spack.readthedocs.io/en/latest/index.html>`__:
-
-  ::
-
-    git clone https://github.com/spack/spack.git
-    export SPACK_ROOT=/path/to/spack
-    . $SPACK_ROOT/share/spack/setup-env.sh
-
-(You may want to add the last 2 lines to your ``.bashrc`` file.)
-
-Next, you will to install of version of MPI which is compatible with the PGI
-compiler (using Spack). First of all, make sure that Spack is aware of the PGI
-compiler:
-
-  ::
-
-    spack compiler find
-    spack compilers
-
-Then run:
-
-  ::
-
-    spack install mvapich2 fabrics=sock %pgi ^libpciaccess%gcc
-
-Finally, WarpX can be compiled with
-
-  ::
-
-    spack load mvapich2%pgi
-    make -j 4 USE_GPU=TRUE COMP=pgi
+  make -j 4 USE_GPU=TRUE

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -19,9 +19,9 @@ Then, ``cd`` into the directory ``WarpX`` and use the following set of commands 
 
 ::
 
-    module load pgi
+    module load gcc
     module load cuda
-    make -j 4 USE_GPU=TRUE COMP=pgi
+    make -j 4 USE_GPU=TRUE
 
 See :doc:`../running_cpp/platforms` for more information on how to run
 WarpX on Summit.

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -8,7 +8,7 @@ USE_PARTICLES = TRUE
 ifeq ($(USE_GPU),TRUE)
   USE_OMP  = FALSE
   USE_CUDA = TRUE
-  USE_ACC  = TRUE
+  USE_ACC  = FALSE
   NVCC_HOST_COMP = gcc
 endif
 


### PR DESCRIPTION
This PR changes `USE_ACC` from `TRUE` to `FALSE` when using `USE_GPU=TRUE`, and updates the installation instructions on various plateforms.