### PR TITLE
Added optical depth among plot_vars

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -337,6 +337,7 @@ Particle initialization
     * ``ux`` ``uy`` ``uz`` for the particle momentum,
     * ``Ex`` ``Ey`` ``Ez`` for the electric field on particles,
     * ``Bx`` ``By`` ``Bz`` for the magnetic field on particles.
+    * ``tau`` for the optical depth of the particles (if QED processes are enabled).
     The particle positions are always included. Use
     ``<species>.plot_vars = none`` to plot no particle data, except
     particle position.


### PR DESCRIPTION
QED processes use an additional real component for the particles (the optical depth, which is called "tau" in the code). This quantity can be plotted. This PR updates the documentation.