### PR TITLE
forgot amrex scope for Geometry in Diagnostics/FieldIO.H

### DIFF
--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -99,7 +99,7 @@ getReversedVec( const amrex::Real* v );
 void
 WriteOpenPMDFields( const std::string& filename,
                     const std::vector<std::string>& varnames,
-                    const amrex::MultiFab& mf, const Geometry& geom,
+                    const amrex::MultiFab& mf, const amrex::Geometry& geom,
                     const int iteration, const double time );
 #endif // WARPX_USE_OPENPMD
 


### PR DESCRIPTION
guess the scope `amrex::`  was overseen for Geometry after `using namespace amrex;` had been removed. Could not compile without it