### PR TITLE
Fix index error in WarpXSumGuardCells

### DIFF
--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -15,7 +15,7 @@
  *    updates both the *valid* cells and *guard* cells. (This is because a
  *    spectral solver requires the value of the sources over a large stencil.)
  */
-void
+inline void
 WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
                    const int icomp=0, const int ncomp=1){
 #ifdef WARPX_USE_PSATD
@@ -43,7 +43,7 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
  * Note: `i_comp` is the component where the results will be stored in `dst`;
  *       The component from which we copy in `src` is always 0.
  */
-void
+inline void
 WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
                    const amrex::Periodicity& period,
                    const int icomp=0, const int ncomp=1){
@@ -54,7 +54,7 @@ WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
     // Update only the valid cells
     const amrex::IntVect n_updated_guards = amrex::IntVect::TheZeroVector();
 #endif
-    src.SumBoundary(icomp, ncomp, n_updated_guards, period);
+    src.SumBoundary(0, ncomp, n_updated_guards, period);
     amrex::Copy( dst, src, 0, icomp, ncomp, n_updated_guards );
 }
 


### PR DESCRIPTION
The component from which we copy in `src` is always 0. 
