### PR TITLE
Fix back-transformed diagnostics + subcycling

### DIFF
--- a/Source/Evolve/Make.package
+++ b/Source/Evolve/Make.package
@@ -1,3 +1,4 @@
+CEXE_headers += WarpXDtType.H
 CEXE_sources += WarpXEvolveEM.cpp
 ifeq ($(DO_ELECTROSTATIC),TRUE)
   CEXE_sources += WarpXEvolveES.cpp

--- a/Source/Evolve/WarpXDtType.H
+++ b/Source/Evolve/WarpXDtType.H
@@ -1,0 +1,11 @@
+#ifndef WARPX_DTTYPE_H_
+#define WARPX_DTTYPE_H_
+
+enum struct DtType : int
+{
+    Full = 0,
+    FirstHalf,
+    SecondHalf
+};
+
+#endif // WARPX_DTTYPE_H_

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -358,7 +358,7 @@ WarpX::OneStep_sub1 (Real curtime)
     const int coarse_lev = 0;
 
     // i) Push particles and fields on the fine patch (first fine step)
-    PushParticlesandDepose(fine_lev, curtime);
+    PushParticlesandDepose(fine_lev, curtime, DtType::FirstHalf);
     RestrictCurrentFromFineToCoarsePatch(fine_lev);
     RestrictRhoFromFineToCoarsePatch(fine_lev);
     ApplyFilterandSumBoundaryJ(fine_lev, PatchType::fine);
@@ -387,7 +387,7 @@ WarpX::OneStep_sub1 (Real curtime)
     // ii) Push particles on the coarse patch and mother grid.
     // Push the fields on the coarse patch and mother grid
     // by only half a coarse step (first half)
-    PushParticlesandDepose(coarse_lev, curtime);
+    PushParticlesandDepose(coarse_lev, curtime, DtType::Full);
     StoreCurrent(coarse_lev);
     AddCurrentFromFineLevelandSumBoundary(coarse_lev);
     AddRhoFromFineLevelandSumBoundary(coarse_lev, 0, ncomps);
@@ -412,7 +412,7 @@ WarpX::OneStep_sub1 (Real curtime)
     UpdateAuxilaryData();
 
     // iv) Push particles and fields on the fine patch (second fine step)
-    PushParticlesandDepose(fine_lev, curtime+dt[fine_lev]);
+    PushParticlesandDepose(fine_lev, curtime+dt[fine_lev], DtType::SecondHalf);
     RestrictCurrentFromFineToCoarsePatch(fine_lev);
     RestrictRhoFromFineToCoarsePatch(fine_lev);
     ApplyFilterandSumBoundaryJ(fine_lev, PatchType::fine);
@@ -485,7 +485,7 @@ WarpX::PushParticlesandDepose (Real cur_time)
 }
 
 void
-WarpX::PushParticlesandDepose (int lev, Real cur_time)
+WarpX::PushParticlesandDepose (int lev, Real cur_time, DtType a_dt_type)
 {
     mypc->Evolve(lev,
                  *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
@@ -495,7 +495,7 @@ WarpX::PushParticlesandDepose (int lev, Real cur_time)
                  rho_fp[lev].get(), charge_buf[lev].get(),
                  Efield_cax[lev][0].get(), Efield_cax[lev][1].get(), Efield_cax[lev][2].get(),
                  Bfield_cax[lev][0].get(), Bfield_cax[lev][1].get(), Bfield_cax[lev][2].get(),
-                 cur_time, dt[lev]);
+                 cur_time, dt[lev], a_dt_type);
 #ifdef WARPX_DIM_RZ
     // This is called after all particles have deposited their current and charge.
     ApplyInverseVolumeScalingToCurrentDensity(current_fp[lev][0].get(), current_fp[lev][1].get(), current_fp[lev][2].get(), lev);

--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -32,7 +32,7 @@ public:
                          amrex::MultiFab* rho, amrex::MultiFab* crho,
                          const amrex::MultiFab*, const amrex::MultiFab*, const amrex::MultiFab*,
                          const amrex::MultiFab*, const amrex::MultiFab*, const amrex::MultiFab*,
-                         amrex::Real t, amrex::Real dt) final;
+                         amrex::Real t, amrex::Real dt, DtType a_dt_type=DtType::Full) final;
 
     virtual void PushP (int lev, amrex::Real dt,
                         const amrex::MultiFab& ,

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -397,7 +397,7 @@ LaserParticleContainer::Evolve (int lev,
                                 MultiFab* rho, MultiFab* crho,
                                 const MultiFab*, const MultiFab*, const MultiFab*,
                                 const MultiFab*, const MultiFab*, const MultiFab*,
-                                Real t, Real dt)
+                                Real t, Real dt, DtType a_dt_type)
 {
     BL_PROFILE("Laser::Evolve()");
     BL_PROFILE_VAR_NS("Laser::Evolve::Copy", blp_copy);

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -103,7 +103,7 @@ public:
                  amrex::MultiFab* rho, amrex::MultiFab* crho,
                  const amrex::MultiFab* cEx, const amrex::MultiFab* cEy, const amrex::MultiFab* cEz,
                  const amrex::MultiFab* cBx, const amrex::MultiFab* cBy, const amrex::MultiFab* cBz,
-                 amrex::Real t, amrex::Real dt);
+                 amrex::Real t, amrex::Real dt, DtType a_dt_type=DtType::Full);
 
     ///
     /// This pushes the particle positions by one half time step for all the species in the

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -248,7 +248,7 @@ MultiParticleContainer::Evolve (int lev,
                                 MultiFab* rho, MultiFab* crho,
                                 const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
                                 const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                Real t, Real dt)
+                                Real t, Real dt, DtType a_dt_type)
 {
     jx.setVal(0.0);
     jy.setVal(0.0);
@@ -260,7 +260,7 @@ MultiParticleContainer::Evolve (int lev,
     if (crho) crho->setVal(0.0);
     for (auto& pc : allcontainers) {
         pc->Evolve(lev, Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, cjx, cjy, cjz,
-                   rho, crho, cEx, cEy, cEz, cBx, cBy, cBz, t, dt);
+                   rho, crho, cEx, cEy, cEz, cBx, cBy, cBz, t, dt, a_dt_type);
     }
 }
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -37,13 +37,14 @@ public:
                          const amrex::MultiFab* cBy,
                          const amrex::MultiFab* cBz,
                          amrex::Real t,
-                         amrex::Real dt) override;
+                         amrex::Real dt,
+                         DtType a_dt_type=DtType::Full) override;
 
     virtual void PushPX(WarpXParIter& pti,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& xp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& yp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& zp,
-                        amrex::Real dt) override;
+                        amrex::Real dt, DtType a_dt_type=DtType::Full) override;
 
 
 

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -37,7 +37,7 @@ PhotonParticleContainer::PushPX(WarpXParIter& pti,
                                 Cuda::ManagedDeviceVector<Real>& xp,
                                 Cuda::ManagedDeviceVector<Real>& yp,
                                 Cuda::ManagedDeviceVector<Real>& zp,
-                                Real dt)
+                                Real dt, DtType a_dt_type)
 {
 
     // This wraps the momentum and position advance so that inheritors can modify the call.
@@ -76,14 +76,14 @@ PhotonParticleContainer::PushPX(WarpXParIter& pti,
 
 void
 PhotonParticleContainer::Evolve (int lev,
-                                        const MultiFab& Ex, const MultiFab& Ey, const MultiFab& Ez,
-                                        const MultiFab& Bx, const MultiFab& By, const MultiFab& Bz,
-                                        MultiFab& jx, MultiFab& jy, MultiFab& jz,
-                                        MultiFab* cjx, MultiFab* cjy, MultiFab* cjz,
-                                        MultiFab* rho, MultiFab* crho,
-                                        const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
-                                        const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                        Real t, Real dt)
+                                 const MultiFab& Ex, const MultiFab& Ey, const MultiFab& Ez,
+                                 const MultiFab& Bx, const MultiFab& By, const MultiFab& Bz,
+                                 MultiFab& jx, MultiFab& jy, MultiFab& jz,
+                                 MultiFab* cjx, MultiFab* cjy, MultiFab* cjz,
+                                 MultiFab* rho, MultiFab* crho,
+                                 const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
+                                 const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
+                                 Real t, Real dt, DtType a_dt_type)
 {
     // This does gather, push and depose.
     // Push and depose have been re-written for photon,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -83,13 +83,14 @@ public:
                          const amrex::MultiFab* cBy,
                          const amrex::MultiFab* cBz,
                          amrex::Real t,
-                         amrex::Real dt) override;
+                         amrex::Real dt,
+                         DtType a_dt_type=DtType::Full) override;
 
     virtual void PushPX(WarpXParIter& pti,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& xp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& yp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& zp,
-                        amrex::Real dt);
+                        amrex::Real dt, DtType a_dt_type=DtType::Full);
 
     virtual void PushP (int lev, amrex::Real dt,
                         const amrex::MultiFab& Ex,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -942,7 +942,7 @@ PhysicalParticleContainer::Evolve (int lev,
                                    MultiFab* rho, MultiFab* crho,
                                    const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
                                    const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                   Real t, Real dt)
+                                   Real t, Real dt, DtType a_dt_type)
 {
     BL_PROFILE("PPC::Evolve()");
     BL_PROFILE_VAR_NS("PPC::Evolve::Copy", blp_copy);
@@ -1301,7 +1301,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 // Particle Push
                 //
                 BL_PROFILE_VAR_START(blp_ppc_pp);
-                PushPX(pti, m_xp[thread_num], m_yp[thread_num], m_zp[thread_num], dt);
+                PushPX(pti, m_xp[thread_num], m_yp[thread_num], m_zp[thread_num], dt, a_dt_type);
                 BL_PROFILE_VAR_STOP(blp_ppc_pp);
 
                 //
@@ -1526,7 +1526,7 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
                                   Cuda::ManagedDeviceVector<Real>& xp,
                                   Cuda::ManagedDeviceVector<Real>& yp,
                                   Cuda::ManagedDeviceVector<Real>& zp,
-                                  Real dt)
+                                  Real dt, DtType a_dt_type)
 {
 
     // This wraps the momentum and position advance so that inheritors can modify the call.
@@ -1545,8 +1545,10 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
     const Real* const AMREX_RESTRICT By = attribs[PIdx::By].dataPtr();
     const Real* const AMREX_RESTRICT Bz = attribs[PIdx::Bz].dataPtr();
 
-    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags)
+    Print()<<"a_dt_type "<<int( a_dt_type )<<'\n';
+    if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags && (a_dt_type!=DtType::SecondHalf))
     {
+        Print()<<"copy attribs\n";
         copy_attribs(pti, x, y, z);
     }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1545,10 +1545,8 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
     const Real* const AMREX_RESTRICT By = attribs[PIdx::By].dataPtr();
     const Real* const AMREX_RESTRICT Bz = attribs[PIdx::Bz].dataPtr();
 
-    Print()<<"a_dt_type "<<int( a_dt_type )<<'\n';
     if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags && (a_dt_type!=DtType::SecondHalf))
     {
-        Print()<<"copy attribs\n";
         copy_attribs(pti, x, y, z);
     }
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -40,13 +40,14 @@ public:
                          const amrex::MultiFab* cBy,
                          const amrex::MultiFab* cBz,
                          amrex::Real t,
-                         amrex::Real dt) override;
+                         amrex::Real dt,
+                         DtType a_dt_type=DtType::Full) override;
 
     virtual void PushPX(WarpXParIter& pti,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& xp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& yp,
                         amrex::Cuda::ManagedDeviceVector<amrex::Real>& zp,
-                        amrex::Real dt) override;
+                        amrex::Real dt, DtType a_dt_type=DtType::Full) override;
 
     virtual void PushP (int lev, amrex::Real dt,
                         const amrex::MultiFab& Ex,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -210,7 +210,7 @@ RigidInjectedParticleContainer::PushPX(WarpXParIter& pti,
                                        Cuda::ManagedDeviceVector<Real>& xp,
                                        Cuda::ManagedDeviceVector<Real>& yp,
                                        Cuda::ManagedDeviceVector<Real>& zp,
-                                       Real dt)
+                                       Real dt, DtType a_dt_type)
 {
 
     // This wraps the momentum and position advance so that inheritors can modify the call.
@@ -314,7 +314,7 @@ RigidInjectedParticleContainer::Evolve (int lev,
                                         MultiFab* rho, MultiFab* crho,
                                         const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
                                         const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                        Real t, Real dt)
+                                        Real t, Real dt, DtType a_dt_type)
 {
 
     // Update location of injection plane in the boosted frame

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -1,10 +1,12 @@
 #ifndef WARPX_WarpXParticleContainer_H_
 #define WARPX_WarpXParticleContainer_H_
 
-#include <memory>
+#include "WarpXDtType.H"
 
 #include <AMReX_Particles.H>
 #include <AMReX_AmrCore.H>
+
+#include <memory>
 
 enum struct ConvertDirection{WarpX_to_SI, SI_to_WarpX};
 
@@ -138,7 +140,7 @@ public:
                          amrex::MultiFab* rho, amrex::MultiFab* crho,
                          const amrex::MultiFab* cEx, const amrex::MultiFab* cEy, const amrex::MultiFab* cEz,
                          const amrex::MultiFab* cBx, const amrex::MultiFab* cBy, const amrex::MultiFab* cBz,
-                         amrex::Real t, amrex::Real dt) = 0;
+                         amrex::Real t, amrex::Real dt, DtType a_dt_type=DtType::Full) = 0;
 
     virtual void PostRestart () = 0;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1,6 +1,7 @@
 #ifndef WARPX_H_
 #define WARPX_H_
 
+#include "WarpXDtType.H"
 #include <MultiParticleContainer.H>
 #include <PML.H>
 #include <BoostedFrameDiagnostic.H>
@@ -37,13 +38,6 @@ namespace amrex {
 class AmrMeshInSituBridge;
 }
 #endif
-
-enum struct DtType : int
-{
-    Full = 0,
-    FirstHalf,
-    SecondHalf
-};
 
 enum struct PatchType : int
 {
@@ -201,7 +195,7 @@ public:
 
     void CopyJPML ();
 
-    void PushParticlesandDepose (int lev, amrex::Real cur_time);
+    void PushParticlesandDepose (int lev, amrex::Real cur_time, DtType a_dt_type=DtType::Full);
     void PushParticlesandDepose (         amrex::Real cur_time);
 
     // This function does aux(lev) = fp(lev) + I(aux(lev-1)-cp(lev)).


### PR DESCRIPTION
Do not store old attribs in second particle push when subcycling.

This has an effect, but it does not fix the bug totally so far. Maybe some more things to look at when particles enter/exit the patch.