### PR TITLE
Changing the output directory for the boosted frame diag tests from l…

### DIFF
--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
@@ -31,8 +31,8 @@ def get_particle_field(snapshot, species, field):
     return all_data
 
 # Read data from back-transformed diagnostics
-snapshot = './lab_frame_data/snapshot00001'
-header   = './lab_frame_data/Header'
+snapshot = './lab_frame_data/snapshots/snapshot00001'
+header   = './lab_frame_data/snapshots/Header'
 allrd, info = read_raw_data.read_lab_snapshot(snapshot, header)
 z = np.mean( get_particle_field(snapshot, 'beam', 'z') )
 w = np.std ( get_particle_field(snapshot, 'beam', 'x') )


### PR DESCRIPTION
In PR #197, the lab-frame diagnostic data for the full 3D snapshot and slices are written to lab_frame_data/snapshots and lab_frame_data/slices, respectively. 

The automated tests, however, look for the header file and snapshot file in lab_frame_data/

In this PR, the python file for automated analysis is modified such that the header and lab-frame solution files are located in the new lab_frame_data/snapshots directory.

 
