### PR TITLE
Allow PMLs to run on GPUs

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -10,7 +10,7 @@
 #include <SpectralSolver.H>
 #endif
 
-struct Sigma : amrex::Vector<amrex::Real>
+struct Sigma : amrex::Gpu::ManagedVector<amrex::Real>
 {
     int lo() const { return m_lo; }
     int hi() const { return m_hi; }

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -81,13 +81,13 @@ WarpX::DampPML (int lev, PatchType patch_type)
             amrex::Real const * AMREX_RESTRICT sigma_star_fac_y = nullptr;
             amrex::Real const * AMREX_RESTRICT sigma_star_fac_z = sigba[mfi].sigma_star_fac[1].data();
 #endif
-            auto const& AMREX_RESTRICT x_lo = sigba[mfi].sigma_fac[0].lo();
+            int const x_lo = sigba[mfi].sigma_fac[0].lo();
 #if (AMREX_SPACEDIM == 3)
-            auto const& AMREX_RESTRICT y_lo = sigba[mfi].sigma_fac[1].lo();
-            auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma_fac[2].lo();
+            int const y_lo = sigba[mfi].sigma_fac[1].lo();
+            int const z_lo = sigba[mfi].sigma_fac[2].lo();
 #else
-            int y_lo = 0;
-            auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma_fac[1].lo();
+            int const y_lo = 0;
+            int const z_lo = sigba[mfi].sigma_fac[1].lo();
 #endif
 
             amrex::ParallelFor(tex, tey, tez,
@@ -193,22 +193,22 @@ WarpX::DampJPML (int lev, PatchType patch_type)
             const Box& tjy  = mfi.tilebox(jy_nodal_flag);
             const Box& tjz  = mfi.tilebox(jz_nodal_flag);
 
-            auto const& AMREX_RESTRICT x_lo = sigba[mfi].sigma_cumsum_fac[0].lo();
+            int const x_lo = sigba[mfi].sigma_cumsum_fac[0].lo();
 #if (AMREX_SPACEDIM == 3)
-            auto const& AMREX_RESTRICT y_lo = sigba[mfi].sigma_cumsum_fac[1].lo();
-            auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma_cumsum_fac[2].lo();
+            int const y_lo = sigba[mfi].sigma_cumsum_fac[1].lo();
+            int const z_lo = sigba[mfi].sigma_cumsum_fac[2].lo();
 #else
-            int y_lo = 0;
-            auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma_cumsum_fac[1].lo();
+            int const y_lo = 0;
+            int const z_lo = sigba[mfi].sigma_cumsum_fac[1].lo();
 #endif
 
-            auto const& AMREX_RESTRICT xs_lo = sigba[mfi].sigma_star_cumsum_fac[0].lo();
+            int const xs_lo = sigba[mfi].sigma_star_cumsum_fac[0].lo();
 #if (AMREX_SPACEDIM == 3)
-            auto const& AMREX_RESTRICT ys_lo = sigba[mfi].sigma_star_cumsum_fac[1].lo();
-            auto const& AMREX_RESTRICT zs_lo = sigba[mfi].sigma_star_cumsum_fac[2].lo();
+            int const ys_lo = sigba[mfi].sigma_star_cumsum_fac[1].lo();
+            int const zs_lo = sigba[mfi].sigma_star_cumsum_fac[2].lo();
 #else
-            int ys_lo = 0;
-            auto const& AMREX_RESTRICT zs_lo = sigba[mfi].sigma_star_cumsum_fac[1].lo();
+            int const ys_lo = 0;
+            int const zs_lo = sigba[mfi].sigma_star_cumsum_fac[1].lo();
 #endif
 
             amrex::ParallelFor( tjx, tjy, tjz,

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -535,13 +535,13 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
                 const Real* sigmaj_y = sigba[mfi].sigma[1].data();
                 const Real* sigmaj_z = sigba[mfi].sigma[2].data();
 
-                auto const& AMREX_RESTRICT x_lo = sigba[mfi].sigma[0].lo();
+                int const x_lo = sigba[mfi].sigma[0].lo();
 #if (AMREX_SPACEDIM == 3)
-                auto const& AMREX_RESTRICT y_lo = sigba[mfi].sigma[1].lo();
-                auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma[2].lo();
+                int const y_lo = sigba[mfi].sigma[1].lo();
+                int const z_lo = sigba[mfi].sigma[2].lo();
 #else
-                int y_lo = 0;
-                auto const& AMREX_RESTRICT z_lo = sigba[mfi].sigma[1].lo();
+                int const y_lo = 0;
+                int const z_lo = sigba[mfi].sigma[1].lo();
 #endif
                 amrex::ParallelFor( tex, tey, tez,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) {


### PR DESCRIPTION
In the current `dev` branch, the PML lead to a run time error, when the code is run on GPU.

This is essentially because of the way in which we use the `Sigma` object. The `Sigma` object contains the information about the absorption coefficients (along the "depth" direction of the PMLs: it is a 1D array).

This PR introduces 2 changes:
- The `lo` and `hi` indices of these arrays are not defined as reference anymore. (Defining them as reference was causing the usual member-copy issue on GPU.)
- The array of coefficients themselves are allocated in managed memory, instead of host memory, by using `Gpu::ManagedVector`.

This was tested by successfully running the `particle_in_PMLs` automated test, on GPU.