### PR TITLE
Split particles only during second half-push when subcycling

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1364,7 +1364,7 @@ PhysicalParticleContainer::Evolve (int lev,
         }
     }
     // Split particles
-    if (do_splitting && a_dt_type == DtType::SecondHalf){
+    if (do_splitting && a_dt_type == DtType::SecondHalf && WarpX::do_subcycling == 1){
         SplitParticles(lev);
     }
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1367,7 +1367,7 @@ PhysicalParticleContainer::Evolve (int lev,
     // When subcycling is ON, the splitting is done on the last call to
     // PhysicalParticleContainer::Evolve on the finest level, i.e., at the
     // end of the large timestep. Otherwise, the pushes on different levels
-    // are not consistent, and the call to Redistribute (inside 
+    // are not consistent, and the call to Redistribute (inside
     // SplitParticles) may result in split particles to deposit twice on the
     // coarse level.
     if (do_splitting && (a_dt_type == DtType::SecondHalf || a_dt_type == DtType::Full) ){

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1364,7 +1364,9 @@ PhysicalParticleContainer::Evolve (int lev,
         }
     }
     // Split particles
-    if (do_splitting){ SplitParticles(lev); }
+    if (do_splitting && a_dt_type == DtType::SecondHalf){
+        SplitParticles(lev);
+    }
 }
 
 // Loop over all particles in the particle container and

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1363,8 +1363,14 @@ PhysicalParticleContainer::Evolve (int lev,
             }
         }
     }
-    // Split particles
-    if (do_splitting && a_dt_type == DtType::SecondHalf && WarpX::do_subcycling == 1){
+    // Split particles at the end of the timestep.
+    // When subcycling is ON, the splitting is done on the last call to
+    // PhysicalParticleContainer::Evolve on the finest level, i.e., at the
+    // end of the large timestep. Otherwise, the pushes on different levels
+    // are not consistent, and the call to Redistribute (inside 
+    // SplitParticles) may result in split particles to deposit twice on the
+    // coarse level.
+    if (do_splitting && (a_dt_type == DtType::SecondHalf || a_dt_type == DtType::Full) ){
         SplitParticles(lev);
     }
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -118,6 +118,8 @@ public:
 
     static int sort_int;
 
+    static int do_subcycling;
+
     // buffers
     static int n_field_gather_buffer;       //! in number of cells from the edge (identical for each dimension)
     static int n_current_deposition_buffer; //! in number of cells from the edge (identical for each dimension)
@@ -526,8 +528,6 @@ private:
 
     // Other runtime parameters
     int verbose = 1;
-
-    int do_subcycling = 0;
 
     int max_step   = std::numeric_limits<int>::max();
     amrex::Real stop_time = std::numeric_limits<amrex::Real>::max();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -69,6 +69,8 @@ bool WarpX::do_boosted_frame_particles = true;
 
 bool WarpX::do_dynamic_scheduling = true;
 
+int WarpX::do_subcycling = 0;
+
 #if (AMREX_SPACEDIM == 3)
 IntVect WarpX::Bx_nodal_flag(1,0,0);
 IntVect WarpX::By_nodal_flag(0,1,0);


### PR DESCRIPTION
When sub cycling is on, the split particles are added at the end of a full time step instead of at the end of the first half-push.

`WarpX::do_subcycling` is made `static` in this PR for easy access from `PhysicalParticleContainer`.