### PR TITLE
Allow compilation of WarpX without MPI

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -211,6 +211,24 @@ runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex 
 analysisRoutine = Examples/Tests/Langmuir/langmuir2d_analysis.py
 analysisOutputImage = langmuir2d_analysis.png
 
+[Langmuir_2d_nompi]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs.rt
+dim = 2
+addToCompileString =
+restartTest = 0
+useMPI = 0
+numprocs = 1
+useOMP = 2
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
+analysisRoutine = Examples/Tests/Langmuir/langmuir2d_analysis.py
+analysisOutputImage = langmuir2d_analysis.png
+
 [Langmuir_x]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -12,12 +12,14 @@ using namespace amrex;
 
 int main(int argc, char* argv[])
 {
+#if defined AMREX_USE_MPI
 #if defined(_OPENMP) && defined(WARPX_USE_PSATD)
     int provided;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
     assert(provided >= MPI_THREAD_FUNNELED);
 #else
     MPI_Init(&argc, &argv);
+#endif
 #endif
 
     amrex::Initialize(argc,argv);
@@ -48,5 +50,7 @@ int main(int argc, char* argv[])
     BL_PROFILE_VAR_STOP(pmain);
 
     amrex::Finalize();
+#if defined AMREX_USE_MPI
     MPI_Finalize();
+#endif
 }


### PR DESCRIPTION
WarpX's internal functions do not strictly require MPI anymore.

With this PR, WarpX can now be compiled without MPI.