### PR TITLE
Port the particle partition in buffers to GPU

### DIFF
--- a/Source/Particles/Sorting/Make.package
+++ b/Source/Particles/Sorting/Make.package
@@ -1,3 +1,4 @@
+CEXE_headers += SortingUtils.H
 CEXE_sources += Partition.cpp
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Sorting
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Sorting

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -43,9 +43,9 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     BL_PROFILE("PPC::Evolve::partition");
 
     // Initialize temporary arrays
-    Gpu::ManagedDeviceVector<int> inexflag;
+    Gpu::DeviceVector<int> inexflag;
     inexflag.resize(np);
-    Gpu::ManagedDeviceVector<long> pid;
+    Gpu::DeviceVector<long> pid;
     pid.resize(np);
 
     // First, partition particles into the larger buffer
@@ -138,5 +138,12 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
         std::swap(uyp, tmp);
         amrex::ParallelFor( np, copyAndReorder<Real>( uzp, tmp, pid ) );
         std::swap(uzp, tmp);
+
+        // Make sure that the temporary arrays are not destroyed before
+        // the GPU kernels finish running
+        Gpu::streamSynchronize();
     }
+    // Make sure that the temporary arrays are not destroyed before
+    // the GPU kernels finish running
+    Gpu::streamSynchronize();
 }

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -115,22 +115,14 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     // Reorder the actual particle array, using the `pid` indices
     if (nfine_current != np || nfine_gather != np)
     {
-        // Extract simple pointer
-        long* AMREX_RESTRICT pid_ptr = pid.dataPtr();
-
         // Temporary array for particle AoS
         ParticleVector particle_tmp;
         particle_tmp.resize(np);
-        ParticleType* AMREX_RESTRICT particle_tmp_ptr = particle_tmp.dataPtr();
 
-        // Copy the particle AoS
+        // Copy particle AoS
         auto& aos = pti.GetArrayOfStructs();
-        ParticleType* AMREX_RESTRICT aos_ptr = &(aos()[0]);
         amrex::ParallelFor( np,
-            [=] AMREX_GPU_DEVICE (long ip) {
-                particle_tmp_ptr[ip] = aos_ptr[pid_ptr[ip]];
-            }
-        );
+            copyAndReorder<ParticleType>( aos(), particle_tmp, pid ) );
         std::swap(aos(), particle_tmp);
 
         // Temporary array for particle individual attributes

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -54,9 +54,20 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     auto& aos = pti.GetArrayOfStructs();
     ParticleType * AMREX_RESTRICT pstructs = &(aos[0]);
     int * inexflag_ptr = inexflag.dataPtr();
-    amrex::ParallelFor( pti.numParticles(),
+    const Geometry& geom = Geom(lev);
+    const Real prob_lo_x = geom.ProbLo(0);
+    const Real prob_lo_y = geom.ProbLo(1);
+    const Real prob_lo_z = geom.ProbLo(2);
+    const Real inv_dx = geom.InvCellSize(0);
+    const Real inv_dy = geom.InvCellSize(1);
+    const Real inv_dz = geom.InvCellSize(2);
+    const IntVect domain_small_end = geom.Domain().smallEnd();
+    amrex::ParallelFor( np,
          [=] AMREX_GPU_DEVICE (long i) {
-             const IntVect& iv = Index(pstructs[i], lev);
+
+             const IntVect& iv = findParticleIndex(pstructs[i],
+                 prob_lo_x, prob_lo_y, prob_lo_z,
+                 inv_dx, inv_dy, inv_dz, domain_small_end );
              inexflag_ptr[i] = msk(iv);
          }
      );

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -50,7 +50,7 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     Gpu::ManagedDeviceVector<long> pid;
     pid.resize(np);
 
-    // First, partition particles in the larger buffer
+    // First, partition particles into the larger buffer
 
     // - Select the larger buffer
     iMultiFab const* bmasks =
@@ -68,16 +68,22 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     // separates the particles that deposit/gather on the fine patch (first part)
     // and the particles that deposit/gather in the buffers (last part)
 
+    // Second, among particles that are in the larger buffer, partition
+    // particles into the smaller buffer
     if (WarpX::n_current_deposition_buffer == WarpX::n_field_gather_buffer) {
-        nfine_current = nfine_gather = std::distance(pid.begin(), sep);
-    } else if (sep != pid.end()) {
+        // No need to do anything if the buffers have the same size
+        nfine_current = nfine_gather = iteratorDistance(pid.begin(), sep);
+    } else if (sep == pid.end()) {
+        // No need to do anything if there are no particles in the larger buffer
+        nfine_current = nfine_gather = np;
+    } else {
         int n_buf;
         if (bmasks == gather_masks) {
-            nfine_gather = std::distance(pid.begin(), sep);
+            nfine_gather = iteratorDistance(pid.begin(), sep);
             bmasks = current_masks;
             n_buf = WarpX::n_current_deposition_buffer;
         } else {
-            nfine_current = std::distance(pid.begin(), sep);
+            nfine_current = iteratorDistance(pid.begin(), sep);
             bmasks = gather_masks;
             n_buf = WarpX::n_field_gather_buffer;
         }

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -60,12 +60,12 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     // - Find the indices that reorder particles so that the last particles
     //   are in the larger buffer
     fillWithConsecutiveIntegers( pid );
-    auto sep = stablePartition( pid.begin(), pid.end(), inexflag );
+    auto const sep = stablePartition( pid.begin(), pid.end(), inexflag );
     // At the end of this step, `pid` contains the indices that should be used to
     // reorder the particles, and `sep` is the position in the array that
     // separates the particles that deposit/gather on the fine patch (first part)
     // and the particles that deposit/gather in the buffers (last part)
-    long n_fine = iteratorDistance(pid.begin(), sep);
+    long const n_fine = iteratorDistance(pid.begin(), sep);
     // Number of particles on fine patch, i.e. outside of the larger buffer
 
     // Second, among particles that are in the larger buffer, partition
@@ -94,7 +94,7 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
             // the smaller buffer, by looking up the mask. Store the answer in `inexflag`.
             amrex::ParallelFor( np - n_fine,
                fillBufferFlag(pti, bmasks, inexflag, Geom(lev), n_fine) );
-            auto sep2 = stablePartition( sep, pid.end(), inexflag );
+            auto const sep2 = stablePartition( sep, pid.end(), inexflag );
 
             if (bmasks == gather_masks) {
                 nfine_gather = iteratorDistance(pid.begin(), sep2);

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -6,7 +6,8 @@
 #include <AMReX_Gpu.H>
 
 // TODO: Add documentation
-void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
+void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v )
+{
 #ifdef AMREX_USE_GPU
     // On GPU: Use thrust
     thrust::sequence( v.begin(), v.end() );
@@ -14,6 +15,31 @@ void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
     // On CPU: Use std library
     std::iota( v.begin(), v.end(), 0L );
 #endif
+}
+
+// TODO: Add documentation
+template< typename ForwardIterator >
+ForwardIterator stablePartition(ForwardIterator index_begin,
+                               ForwardIterator index_end,
+                               amrex::Gpu::ManagedDeviceVector<int>& predicate)
+{
+#ifdef AMREX_USE_GPU
+    // On GPU: Use thrust
+    int* AMREX_RESTRICT predicate_ptr = predicate.dataPtr();
+    ForwardIterator sep = thrust::stable_partition(
+                    thrust::cuda::par(Cuda::The_ThrustCachedAllocator()),
+                    index_begin, index_end,
+                    AMREX_GPU_HOST_DEVICE
+                    [predicate_ptr](long i) { return predicate_ptr[i]; }
+                );
+#else
+    // On CPU: Use std library
+    ForwardIterator sep = std::stable_partition(
+                    index_begin, index_end,
+                    [&predicate](long i) { return predicate[i]; }
+                );
+#endif
+    return sep;
 }
 
 // TODO: Add documentation

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -27,7 +27,7 @@ ForwardIterator stablePartition(ForwardIterator index_begin,
     // On GPU: Use thrust
     int* AMREX_RESTRICT predicate_ptr = predicate.dataPtr();
     ForwardIterator sep = thrust::stable_partition(
-        thrust::cuda::par(Cuda::The_ThrustCachedAllocator()),
+        thrust::cuda::par(amrex::Cuda::The_ThrustCachedAllocator()),
         index_begin, index_end,
         [predicate_ptr] AMREX_GPU_DEVICE (long i) { return predicate_ptr[i]; }
     );

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -15,4 +15,26 @@ void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
 #endif
 }
 
+// TODO: Add documentation
+template< typename PType >
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+amrex::IntVect findParticleIndex ( PType p,
+                    const amrex::Real prob_lo_x,
+                    const amrex::Real prob_lo_y,
+                    const amrex::Real prob_lo_z,
+                    const amrex::Real inv_dx,
+                    const amrex::Real inv_dy,
+                    const amrex::Real inv_dz,
+                    const amrex::IntVect domain_small_end )
+{
+    amrex::IntVect iv;
+    AMREX_D_TERM(iv[0]=static_cast<int>(floor((p.m_rdata.pos[0]-prob_lo_x)*inv_dx));,
+                 iv[1]=static_cast<int>(floor((p.m_rdata.pos[1]-prob_lo_y)*inv_dy));,
+                 iv[2]=static_cast<int>(floor((p.m_rdata.pos[2]-prob_lo_z)*inv_dz)););
+
+    iv += domain_small_end;
+
+    return iv;
+};
+
 #endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -61,7 +61,7 @@ class fillBufferFlag
     public:
         fillBufferFlag( WarpXParIter& pti, const amrex::iMultiFab* bmasks,
                         amrex::Gpu::ManagedDeviceVector<int>& inexflag,
-                        const amrex::Geometry& geom ) {
+                        const amrex::Geometry& geom, long start_index=0 ) {
 
             // Extract simple structure that can be used directly on the GPU
             m_particles = &(pti.GetArrayOfStructs()[0]);
@@ -72,13 +72,14 @@ class fillBufferFlag
                 m_prob_lo[idim] = geom.ProbLo(idim);
                 m_inv_cell_size[idim] = geom.InvCellSize(idim);
             }
+            m_start_index = start_index;
         };
 
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator()( const long i ) const {
             // Select a particle
-            auto& p = m_particles[i];
+            auto& p = m_particles[i+m_start_index];
             // Find the index of the cell where this particle is located
             amrex::IntVect iv;
             for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
@@ -88,7 +89,7 @@ class fillBufferFlag
             }
             // Find the value of the buffer flag in this cell and
             // store it at the corresponding particle position in the array `inexflag`
-            m_inexflag_ptr[i] = m_buffer_mask(iv);
+            m_inexflag_ptr[i+m_start_index] = m_buffer_mask(iv);
         };
 
     private:
@@ -98,6 +99,7 @@ class fillBufferFlag
         int* m_inexflag_ptr;
         WarpXParticleContainer::ParticleType* m_particles;
         amrex::Array4<const int> m_buffer_mask;
+        long m_start_index;
 };
 
 #endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -1,8 +1,9 @@
 #ifndef WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 #define WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 
-#include <AMReX_Gpu.H>
+#include <WarpXParticleContainer.H>
 #include <AMReX_CudaContainers.H>
+#include <AMReX_Gpu.H>
 
 // TODO: Add documentation
 void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
@@ -16,25 +17,48 @@ void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
 }
 
 // TODO: Add documentation
-template< typename PType >
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-amrex::IntVect findParticleIndex ( PType p,
-                    const amrex::Real prob_lo_x,
-                    const amrex::Real prob_lo_y,
-                    const amrex::Real prob_lo_z,
-                    const amrex::Real inv_dx,
-                    const amrex::Real inv_dy,
-                    const amrex::Real inv_dz,
-                    const amrex::IntVect domain_small_end )
+class fillBufferFlag
 {
-    amrex::IntVect iv;
-    AMREX_D_TERM(iv[0]=static_cast<int>(floor((p.m_rdata.pos[0]-prob_lo_x)*inv_dx));,
-                 iv[1]=static_cast<int>(floor((p.m_rdata.pos[1]-prob_lo_y)*inv_dy));,
-                 iv[2]=static_cast<int>(floor((p.m_rdata.pos[2]-prob_lo_z)*inv_dz)););
+    public:
+        fillBufferFlag( WarpXParIter& pti, const amrex::iMultiFab* bmasks,
+                        amrex::Gpu::ManagedDeviceVector<int>& inexflag,
+                        const amrex::Geometry& geom ) {
 
-    iv += domain_small_end;
+            // Extract simple structure that can be used directly on the GPU
+            m_particles = &(pti.GetArrayOfStructs()[0]);
+            m_buffer_mask = (*bmasks)[pti].array();
+            m_inexflag_ptr = inexflag.dataPtr();
+            m_domain_small_end = geom.Domain().smallEnd();
+            for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
+                m_prob_lo[idim] = geom.ProbLo(idim);
+                m_inv_cell_size[idim] = geom.InvCellSize(idim);
+            }
+        };
 
-    return iv;
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator()( const long i ) const {
+            // Select a particle
+            auto& p = m_particles[i];
+            // Find the index of the cell where this particle is located
+            amrex::IntVect iv;
+            for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
+                iv[idim] = static_cast<int>(floor(
+                    (p.m_rdata.pos[idim]-m_prob_lo[idim])*m_inv_cell_size[idim]
+                ));
+            }
+            // Find the value of the buffer flag in this cell and
+            // store it at the corresponding particle position in the array `inexflag`
+            m_inexflag_ptr[i] = m_buffer_mask(iv);
+        };
+
+    private:
+        amrex::Real m_prob_lo[AMREX_SPACEDIM];
+        amrex::Real m_inv_cell_size[AMREX_SPACEDIM];
+        amrex::IntVect m_domain_small_end;
+        int* m_inexflag_ptr;
+        WarpXParticleContainer::ParticleType* m_particles;
+        amrex::Array4<const int> m_buffer_mask;
 };
 
 #endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -27,17 +27,16 @@ ForwardIterator stablePartition(ForwardIterator index_begin,
     // On GPU: Use thrust
     int* AMREX_RESTRICT predicate_ptr = predicate.dataPtr();
     ForwardIterator sep = thrust::stable_partition(
-                    thrust::cuda::par(Cuda::The_ThrustCachedAllocator()),
-                    index_begin, index_end,
-                    AMREX_GPU_HOST_DEVICE
-                    [predicate_ptr](long i) { return predicate_ptr[i]; }
-                );
+        thrust::cuda::par(Cuda::The_ThrustCachedAllocator()),
+        index_begin, index_end,
+        [predicate_ptr] AMREX_GPU_DEVICE (long i) { return predicate_ptr[i]; }
+    );
 #else
     // On CPU: Use std library
     ForwardIterator sep = std::stable_partition(
-                    index_begin, index_end,
-                    [&predicate](long i) { return predicate[i]; }
-                );
+        index_begin, index_end,
+        [&predicate](long i) { return predicate[i]; }
+    );
 #endif
     return sep;
 }
@@ -100,6 +99,32 @@ class fillBufferFlag
         WarpXParticleContainer::ParticleType* m_particles;
         amrex::Array4<const int> m_buffer_mask;
         long m_start_index;
+};
+
+// TODO: Add documentation
+template <typename T>
+class copyAndReorder
+{
+    public:
+        copyAndReorder(
+            amrex::Gpu::ManagedDeviceVector<T>& src,
+            amrex::Gpu::ManagedDeviceVector<T>& dst,
+            amrex::Gpu::ManagedDeviceVector<long>& indices ) {
+            // Extract simple structure that can be used directly on the GPU
+            m_src_ptr = src.dataPtr();
+            m_dst_ptr = dst.dataPtr();
+            m_indices_ptr = indices.dataPtr();
+        };
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator()( const long ip ) const {
+            m_dst_ptr[ip] = m_src_ptr[ m_indices_ptr[ip] ];
+        };
+
+    private:
+        T* m_src_ptr;
+        T* m_dst_ptr;
+        long* m_indices_ptr;
 };
 
 #endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -99,7 +99,7 @@ class fillBufferFlag
             m_particles = &(pti.GetArrayOfStructs()[0]);
             m_buffer_mask = (*bmasks)[pti].array();
             m_inexflag_ptr = inexflag.dataPtr();
-            m_domain_small_end = geom.Domain().smallEnd();
+            m_domain = geom.Domain();
             for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
                 m_prob_lo[idim] = geom.ProbLo(idim);
                 m_inv_cell_size[idim] = geom.InvCellSize(idim);
@@ -110,23 +110,19 @@ class fillBufferFlag
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator()( const long i ) const {
             // Select a particle
-            auto& p = m_particles[i+m_start_index];
+            auto const& p = m_particles[i+m_start_index];
             // Find the index of the cell where this particle is located
-            amrex::IntVect iv;
-            for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
-                iv[idim] = static_cast<int>(floor(
-                    (p.m_rdata.pos[idim]-m_prob_lo[idim])*m_inv_cell_size[idim]
-                ));
-            }
+            amrex::IntVect const iv = amrex::getParticleCell( p,
+                                m_prob_lo, m_inv_cell_size, m_domain );
             // Find the value of the buffer flag in this cell and
             // store it at the corresponding particle position in the array `inexflag`
             m_inexflag_ptr[i+m_start_index] = m_buffer_mask(iv);
         };
 
     private:
-        amrex::Real m_prob_lo[AMREX_SPACEDIM];
-        amrex::Real m_inv_cell_size[AMREX_SPACEDIM];
-        amrex::IntVect m_domain_small_end;
+        amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_prob_lo;
+        amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_inv_cell_size;
+        amrex::Box m_domain;
         int* m_inexflag_ptr;
         WarpXParticleContainer::ParticleType const* m_particles;
         amrex::Array4<int const> m_buffer_mask;

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -43,6 +43,19 @@ ForwardIterator stablePartition(ForwardIterator index_begin,
 }
 
 // TODO: Add documentation
+template< typename ForwardIterator >
+int iteratorDistance(ForwardIterator first,
+                     ForwardIterator last)
+{
+#ifdef AMREX_USE_GPU
+    // On GPU: Use thrust
+    return thrust::distance( first, last );
+#else
+    return std::distance( first, last );
+#endif
+}
+
+// TODO: Add documentation
 class fillBufferFlag
 {
     public:

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -4,6 +4,10 @@
 #include <WarpXParticleContainer.H>
 #include <AMReX_CudaContainers.H>
 #include <AMReX_Gpu.H>
+#ifdef AMREX_USE_GPU
+    #include <thrust/partition.h>
+    #include <thrust/distance.h>
+#endif
 
 /* \brief Fill the elements of the input vector with consecutive integer,
  *        starting from 0
@@ -24,28 +28,28 @@ void fillWithConsecutiveIntegers( amrex::Gpu::DeviceVector<long>& v )
 /* \brief Find the indices that would reorder the elements of `predicate`
  * so that the elements with non-zero value precede the other elements
  *
- * \param[in] index_begin Point to the beginning of the vector which is
+ * \param[in, out] index_begin Point to the beginning of the vector which is
  *            to be filled with these indices
- * \param[in] index_begin Point to the end of the vector which is
+ * \param[in, out] index_begin Point to the end of the vector which is
  *            to be filled with these indices
  * \param[in] Vector that indicates the elements that need to be reordered first
  */
 template< typename ForwardIterator >
-ForwardIterator stablePartition(ForwardIterator index_begin,
-                               ForwardIterator index_end,
-                               amrex::Gpu::DeviceVector<int>& predicate)
+ForwardIterator stablePartition(ForwardIterator const index_begin,
+                               ForwardIterator const index_end,
+                               amrex::Gpu::DeviceVector<int> const& predicate)
 {
 #ifdef AMREX_USE_GPU
     // On GPU: Use thrust
-    int* AMREX_RESTRICT predicate_ptr = predicate.dataPtr();
-    ForwardIterator sep = thrust::stable_partition(
+    int const* AMREX_RESTRICT predicate_ptr = predicate.dataPtr();
+    ForwardIterator const sep = thrust::stable_partition(
         thrust::cuda::par(amrex::Cuda::The_ThrustCachedAllocator()),
         index_begin, index_end,
         [predicate_ptr] AMREX_GPU_DEVICE (long i) { return predicate_ptr[i]; }
     );
 #else
     // On CPU: Use std library
-    ForwardIterator sep = std::stable_partition(
+    ForwardIterator const sep = std::stable_partition(
         index_begin, index_end,
         [&predicate](long i) { return predicate[i]; }
     );
@@ -60,8 +64,8 @@ ForwardIterator stablePartition(ForwardIterator index_begin,
  * \return The number of elements between `first` and `last`
  */
 template< typename ForwardIterator >
-int iteratorDistance(ForwardIterator first,
-                     ForwardIterator last)
+int iteratorDistance(ForwardIterator const first,
+                     ForwardIterator const last)
 {
 #ifdef AMREX_USE_GPU
     // On GPU: Use thrust
@@ -86,9 +90,10 @@ int iteratorDistance(ForwardIterator first,
 class fillBufferFlag
 {
     public:
-        fillBufferFlag( WarpXParIter& pti, const amrex::iMultiFab* bmasks,
+        fillBufferFlag( WarpXParIter const& pti, amrex::iMultiFab const* bmasks,
                         amrex::Gpu::DeviceVector<int>& inexflag,
-                        const amrex::Geometry& geom, long start_index=0 ) {
+                        amrex::Geometry const& geom, long const start_index=0 ) :
+                        m_start_index(start_index) {
 
             // Extract simple structure that can be used directly on the GPU
             m_particles = &(pti.GetArrayOfStructs()[0]);
@@ -99,7 +104,6 @@ class fillBufferFlag
                 m_prob_lo[idim] = geom.ProbLo(idim);
                 m_inv_cell_size[idim] = geom.InvCellSize(idim);
             }
-            m_start_index = start_index;
         };
 
 
@@ -124,26 +128,26 @@ class fillBufferFlag
         amrex::Real m_inv_cell_size[AMREX_SPACEDIM];
         amrex::IntVect m_domain_small_end;
         int* m_inexflag_ptr;
-        WarpXParticleContainer::ParticleType* m_particles;
-        amrex::Array4<const int> m_buffer_mask;
-        long m_start_index;
+        WarpXParticleContainer::ParticleType const* m_particles;
+        amrex::Array4<int const> m_buffer_mask;
+        long const m_start_index;
 };
 
 /* \brief Functor that copies the elements of `src` into `dst`,
  *       while reordering them according to `indices`
  *
- * \param src Source vector
- * \param dst Destination vector
- * \param indices Array of indices that indicate how to reorder elements
+ * \param[in] src Source vector
+ * \param[out] dst Destination vector
+ * \param[in] indices Array of indices that indicate how to reorder elements
  */
 template <typename T>
 class copyAndReorder
 {
     public:
         copyAndReorder(
-            amrex::Gpu::ManagedDeviceVector<T>& src,
+            amrex::Gpu::ManagedDeviceVector<T> const& src,
             amrex::Gpu::ManagedDeviceVector<T>& dst,
-            amrex::Gpu::DeviceVector<long>& indices ) {
+            amrex::Gpu::DeviceVector<long> const& indices ) {
             // Extract simple structure that can be used directly on the GPU
             m_src_ptr = src.dataPtr();
             m_dst_ptr = dst.dataPtr();
@@ -156,9 +160,9 @@ class copyAndReorder
         };
 
     private:
-        T* m_src_ptr;
+        T const* m_src_ptr;
         T* m_dst_ptr;
-        long* m_indices_ptr;
+        long const* m_indices_ptr;
 };
 
 #endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -5,7 +5,11 @@
 #include <AMReX_CudaContainers.H>
 #include <AMReX_Gpu.H>
 
-// TODO: Add documentation
+/* \brief Fill the elements of the input vector with consecutive integer,
+ *        starting from 0
+ *
+ * \param[inout] v Vector of integers, to be filled by this routine
+ */
 void fillWithConsecutiveIntegers( amrex::Gpu::DeviceVector<long>& v )
 {
 #ifdef AMREX_USE_GPU
@@ -17,7 +21,15 @@ void fillWithConsecutiveIntegers( amrex::Gpu::DeviceVector<long>& v )
 #endif
 }
 
-// TODO: Add documentation
+/* \brief Find the indices that would reorder the elements of `predicate`
+ * so that the elements with non-zero value precede the other elements
+ *
+ * \param[in] index_begin Point to the beginning of the vector which is
+ *            to be filled with these indices
+ * \param[in] index_begin Point to the end of the vector which is
+ *            to be filled with these indices
+ * \param[in] Vector that indicates the elements that need to be reordered first
+ */
 template< typename ForwardIterator >
 ForwardIterator stablePartition(ForwardIterator index_begin,
                                ForwardIterator index_end,
@@ -41,7 +53,12 @@ ForwardIterator stablePartition(ForwardIterator index_begin,
     return sep;
 }
 
-// TODO: Add documentation
+/* \brief Return the number of elements between `first` and `last`
+ *
+ * \param[in] fist Points to a position in a vector
+ * \param[in] last Points to another position in a vector
+ * \return The number of elements between `first` and `last`
+ */
 template< typename ForwardIterator >
 int iteratorDistance(ForwardIterator first,
                      ForwardIterator last)
@@ -54,7 +71,18 @@ int iteratorDistance(ForwardIterator first,
 #endif
 }
 
-// TODO: Add documentation
+/* \brief Functor that fills the elements of the particle array `inexflag`
+ *  with the value of the spatial array `bmasks`, at the corresponding particle position.
+ *
+ * This is done only for the elements from `start_index` to the end of `inexflag`
+ *
+ * \param[in] pti Contains information on the particle positions
+ * \param[in] bmasks Spatial array, that contains a flag indicating
+ *         whether each cell is part of the gathering/deposition buffers
+ * \param[out] inexflag Vector to be filled with the value of `bmasks`
+ * \param[in] geom Geometry object, necessary to locate particles within the array `bmasks`
+ * \param[in] start_index Index that which elements start to be modified
+ */
 class fillBufferFlag
 {
     public:
@@ -101,7 +129,13 @@ class fillBufferFlag
         long m_start_index;
 };
 
-// TODO: Add documentation
+/* \brief Functor that copies the elements of `src` into `dst`,
+ *       while reordering them according to `indices`
+ *
+ * \param src Source vector
+ * \param dst Destination vector
+ * \param indices Array of indices that indicate how to reorder elements
+ */
 template <typename T>
 class copyAndReorder
 {

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -1,0 +1,18 @@
+#ifndef WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
+#define WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
+
+#include <AMReX_Gpu.H>
+#include <AMReX_CudaContainers.H>
+
+// TODO: Add documentation
+void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v ) {
+#ifdef AMREX_USE_GPU
+    // On GPU: Use thrust
+    thrust::sequence( v.begin(), v.end() );
+#else
+    // On CPU: Use std library
+    std::iota( v.begin(), v.end(), 0L );
+#endif
+}
+
+#endif // WARPX_PARTICLES_SORTING_SORTINGUTILS_H_

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -6,7 +6,7 @@
 #include <AMReX_Gpu.H>
 
 // TODO: Add documentation
-void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v )
+void fillWithConsecutiveIntegers( amrex::Gpu::DeviceVector<long>& v )
 {
 #ifdef AMREX_USE_GPU
     // On GPU: Use thrust
@@ -21,7 +21,7 @@ void fillWithConsecutiveIntegers( amrex::Gpu::ManagedDeviceVector<long>& v )
 template< typename ForwardIterator >
 ForwardIterator stablePartition(ForwardIterator index_begin,
                                ForwardIterator index_end,
-                               amrex::Gpu::ManagedDeviceVector<int>& predicate)
+                               amrex::Gpu::DeviceVector<int>& predicate)
 {
 #ifdef AMREX_USE_GPU
     // On GPU: Use thrust
@@ -59,7 +59,7 @@ class fillBufferFlag
 {
     public:
         fillBufferFlag( WarpXParIter& pti, const amrex::iMultiFab* bmasks,
-                        amrex::Gpu::ManagedDeviceVector<int>& inexflag,
+                        amrex::Gpu::DeviceVector<int>& inexflag,
                         const amrex::Geometry& geom, long start_index=0 ) {
 
             // Extract simple structure that can be used directly on the GPU
@@ -109,14 +109,14 @@ class copyAndReorder
         copyAndReorder(
             amrex::Gpu::ManagedDeviceVector<T>& src,
             amrex::Gpu::ManagedDeviceVector<T>& dst,
-            amrex::Gpu::ManagedDeviceVector<long>& indices ) {
+            amrex::Gpu::DeviceVector<long>& indices ) {
             // Extract simple structure that can be used directly on the GPU
             m_src_ptr = src.dataPtr();
             m_dst_ptr = dst.dataPtr();
             m_indices_ptr = indices.dataPtr();
         };
 
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
         void operator()( const long ip ) const {
             m_dst_ptr[ip] = m_src_ptr[ m_indices_ptr[ip] ];
         };


### PR DESCRIPTION
This PR ports the particle partition to GPU.

# Implementation

I added a few helper function that hide away the details of how this is done on CPU and GPU respectively. These helper function are in a new file `SortingUtils.H`. @atmyers Should some of these function be replaced by `amrex` equivalents?

# Performance tests

In a simple 2D test (see figure below), the performance numbers confirm that `partition` now fully runs on GPU:

- With the `dev` branch:
```
---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
PPC::Evolve::partition                          2256      5.535      5.535      5.535   8.59%
```
```
TinyProfiler total time across processes [min...avg...max]: 64.4 ... 64.4 ... 64.4
```

- With this PR:
```
---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
PPC::Evolve::partition                          2256     0.3138     0.3138     0.3138   0.52%
```
```
TinyProfiler total time across processes [min...avg...max]: 60.14 ... 60.14 ... 60.14
```

i.e. the current PR is faster because the `partition` now takes negligible time (0.52%)

# Accuracy tests

I also checked that the results looked correct, in the case where current deposition buffers are used:
![Screenshot from 2019-09-30 15-04-50](https://user-images.githubusercontent.com/6685781/65920446-ded96e80-e393-11e9-85d0-697f960e6d8a.png)
Here, the current `Jz` in the patch is lower at the edges, because the particles located there are in the current buffers and deposit on the mother grid below.

When zooming in on the patch, the `dev` branch and this PR show the same results:
![Screenshot from 2019-09-30 15-05-43](https://user-images.githubusercontent.com/6685781/65920524-134d2a80-e394-11e9-9046-d4209ad38eff.png)
