### PR TITLE
Move NCI filter to separate function

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -145,7 +145,7 @@ public:
 
     virtual void ConvertUnits (ConvertDirection convert_dir) override;
 
-/** 
+/**
  * \brief Apply NCI Godfrey filter to all components of E and B before gather
  * \param lev MR level
  * \param box box onto which the filter is applied

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -145,16 +145,19 @@ public:
 
     virtual void ConvertUnits (ConvertDirection convert_dir) override;
 
-void applyNCIFilter (
-    int lev, const amrex::Box& box, 
-    amrex::Elixir& exeli, amrex::Elixir& eyeli, amrex::Elixir& ezeli,
-    amrex::Elixir& bxeli, amrex::Elixir& byeli, amrex::Elixir& bzeli,
-    amrex::FArrayBox& filtered_Ex, amrex::FArrayBox& filtered_Ey, amrex::FArrayBox& filtered_Ez, 
-    amrex::FArrayBox& filtered_Bx, amrex::FArrayBox& filtered_By, amrex::FArrayBox& filtered_Bz, 
-    const amrex::FArrayBox& Ex_pti, const amrex::FArrayBox& Ey_pti, const amrex::FArrayBox& Ez_pti, 
-    const amrex::FArrayBox& Bx_pti, const amrex::FArrayBox& By_pti, const amrex::FArrayBox& Bz_pti, 
-    amrex::FArrayBox const * & exfab, amrex::FArrayBox const * & eyfab, amrex::FArrayBox const * & ezfab, 
-    amrex::FArrayBox const * & bxfab, amrex::FArrayBox const * & byfab, amrex::FArrayBox const * & bzfab);
+    void applyNCIFilter (
+        int lev, const amrex::Box& box, 
+        amrex::Elixir& exeli, amrex::Elixir& eyeli, amrex::Elixir& ezeli,
+        amrex::Elixir& bxeli, amrex::Elixir& byeli, amrex::Elixir& bzeli,
+        amrex::FArrayBox& filtered_Ex, amrex::FArrayBox& filtered_Ey, 
+        amrex::FArrayBox& filtered_Ez, amrex::FArrayBox& filtered_Bx, 
+        amrex::FArrayBox& filtered_By, amrex::FArrayBox& filtered_Bz, 
+        const amrex::FArrayBox& Ex, const amrex::FArrayBox& Ey, 
+        const amrex::FArrayBox& Ez, const amrex::FArrayBox& Bx, 
+        const amrex::FArrayBox& By, const amrex::FArrayBox& Bz, 
+        amrex::FArrayBox const * & exfab, amrex::FArrayBox const * & eyfab, 
+        amrex::FArrayBox const * & ezfab, amrex::FArrayBox const * & bxfab, 
+        amrex::FArrayBox const * & byfab, amrex::FArrayBox const * & bzfab);
 
 protected:
 

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -1,12 +1,13 @@
 #ifndef WARPX_PhysicalParticleContainer_H_
 #define WARPX_PhysicalParticleContainer_H_
 
-#include <map>
+#include <PlasmaInjector.H>
+#include <WarpXParticleContainer.H>
+#include <NCIGodfreyFilter.H>
 
 #include <AMReX_IArrayBox.H>
 
-#include <PlasmaInjector.H>
-#include <WarpXParticleContainer.H>
+#include <map>
 
 class PhysicalParticleContainer
     : public WarpXParticleContainer
@@ -143,6 +144,17 @@ public:
                                   DiagnosticParticles& diagnostic_particles) final;
 
     virtual void ConvertUnits (ConvertDirection convert_dir) override;
+
+void applyNCIFilter (
+    int lev, const amrex::Box& box, 
+    amrex::Elixir& exeli, amrex::Elixir& eyeli, amrex::Elixir& ezeli,
+    amrex::Elixir& bxeli, amrex::Elixir& byeli, amrex::Elixir& bzeli,
+    amrex::FArrayBox& filtered_Ex, amrex::FArrayBox& filtered_Ey, amrex::FArrayBox& filtered_Ez, 
+    amrex::FArrayBox& filtered_Bx, amrex::FArrayBox& filtered_By, amrex::FArrayBox& filtered_Bz, 
+    const amrex::FArrayBox& Ex_pti, const amrex::FArrayBox& Ey_pti, const amrex::FArrayBox& Ez_pti, 
+    const amrex::FArrayBox& Bx_pti, const amrex::FArrayBox& By_pti, const amrex::FArrayBox& Bz_pti, 
+    amrex::FArrayBox const * & exfab, amrex::FArrayBox const * & eyfab, amrex::FArrayBox const * & ezfab, 
+    amrex::FArrayBox const * & bxfab, amrex::FArrayBox const * & byfab, amrex::FArrayBox const * & bzfab);
 
 protected:
 

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -145,7 +145,8 @@ public:
 
     virtual void ConvertUnits (ConvertDirection convert_dir) override;
 
-/* \brief Apply NCI Godfrey filter to all components of E and B before gather
+/** 
+ * \brief Apply NCI Godfrey filter to all components of E and B before gather
  * \param lev MR level
  * \param box box onto which the filter is applied
  * \param exeli safeguard to avoid destructing arrays between ParIter iterations on GPU

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -151,24 +151,24 @@ public:
  * \param exeli safeguard to avoid destructing arrays between ParIter iterations on GPU
  * \param filtered_Ex Array containing filtered value
  * \param Ex Field array before filtering (not modified)
- * \param ex_ptr pointer to the array used for field gather. 
- * 
+ * \param ex_ptr pointer to the array used for field gather.
+ *
  * The NCI Godfrey filter is applied on Ex, the result is stored in filtered_Ex
  * and the pointer is modified (before this function is called, it points to Ex
  * and after this function is called, it points to Ex_filtered)
  */
     void applyNCIFilter (
-        int lev, const amrex::Box& box, 
+        int lev, const amrex::Box& box,
         amrex::Elixir& exeli, amrex::Elixir& eyeli, amrex::Elixir& ezeli,
         amrex::Elixir& bxeli, amrex::Elixir& byeli, amrex::Elixir& bzeli,
-        amrex::FArrayBox& filtered_Ex, amrex::FArrayBox& filtered_Ey, 
-        amrex::FArrayBox& filtered_Ez, amrex::FArrayBox& filtered_Bx, 
-        amrex::FArrayBox& filtered_By, amrex::FArrayBox& filtered_Bz, 
-        const amrex::FArrayBox& Ex, const amrex::FArrayBox& Ey, 
-        const amrex::FArrayBox& Ez, const amrex::FArrayBox& Bx, 
-        const amrex::FArrayBox& By, const amrex::FArrayBox& Bz, 
-        amrex::FArrayBox const * & exfab, amrex::FArrayBox const * & eyfab, 
-        amrex::FArrayBox const * & ezfab, amrex::FArrayBox const * & bxfab, 
+        amrex::FArrayBox& filtered_Ex, amrex::FArrayBox& filtered_Ey,
+        amrex::FArrayBox& filtered_Ez, amrex::FArrayBox& filtered_Bx,
+        amrex::FArrayBox& filtered_By, amrex::FArrayBox& filtered_Bz,
+        const amrex::FArrayBox& Ex, const amrex::FArrayBox& Ey,
+        const amrex::FArrayBox& Ez, const amrex::FArrayBox& Bx,
+        const amrex::FArrayBox& By, const amrex::FArrayBox& Bz,
+        amrex::FArrayBox const * & exfab, amrex::FArrayBox const * & eyfab,
+        amrex::FArrayBox const * & ezfab, amrex::FArrayBox const * & bxfab,
         amrex::FArrayBox const * & byfab, amrex::FArrayBox const * & bzfab);
 
 protected:

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -145,6 +145,18 @@ public:
 
     virtual void ConvertUnits (ConvertDirection convert_dir) override;
 
+/* \brief Apply NCI Godfrey filter to all components of E and B before gather
+ * \param lev MR level
+ * \param box box onto which the filter is applied
+ * \param exeli safeguard to avoid destructing arrays between ParIter iterations on GPU
+ * \param filtered_Ex Array containing filtered value
+ * \param Ex Field array before filtering (not modified)
+ * \param ex_ptr pointer to the array used for field gather. 
+ * 
+ * The NCI Godfrey filter is applied on Ex, the result is stored in filtered_Ex
+ * and the pointer is modified (before this function is called, it points to Ex
+ * and after this function is called, it points to Ex_filtered)
+ */
     void applyNCIFilter (
         int lev, const amrex::Box& box, 
         amrex::Elixir& exeli, amrex::Elixir& eyeli, amrex::Elixir& ezeli,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -958,7 +958,7 @@ PhysicalParticleContainer::Evolve (int lev,
     // Get instances of NCI Godfrey filters
     const auto& nci_godfrey_filter_exeybz = WarpX::GetInstance().nci_godfrey_filter_exeybz;
     const auto& nci_godfrey_filter_bxbyez = WarpX::GetInstance().nci_godfrey_filter_bxbyez;
-    
+
     BL_ASSERT(OnSameGrids(lev,jx));
 
     MultiFab* cost = WarpX::getCosts(lev);
@@ -1220,15 +1220,15 @@ PhysicalParticleContainer::Evolve (int lev,
 
 void
 PhysicalParticleContainer::applyNCIFilter (
-    int lev, const Box& box, 
+    int lev, const Box& box,
     Elixir& exeli, Elixir& eyeli, Elixir& ezeli,
     Elixir& bxeli, Elixir& byeli, Elixir& bzeli,
-    FArrayBox& filtered_Ex, FArrayBox& filtered_Ey, FArrayBox& filtered_Ez, 
-    FArrayBox& filtered_Bx, FArrayBox& filtered_By, FArrayBox& filtered_Bz, 
-    const FArrayBox& Ex, const FArrayBox& Ey, const FArrayBox& Ez, 
-    const FArrayBox& Bx, const FArrayBox& By, const FArrayBox& Bz, 
-    FArrayBox const * & ex_ptr, FArrayBox const * & ey_ptr, 
-    FArrayBox const * & ez_ptr, FArrayBox const * & bx_ptr, 
+    FArrayBox& filtered_Ex, FArrayBox& filtered_Ey, FArrayBox& filtered_Ez,
+    FArrayBox& filtered_Bx, FArrayBox& filtered_By, FArrayBox& filtered_Bz,
+    const FArrayBox& Ex, const FArrayBox& Ey, const FArrayBox& Ez,
+    const FArrayBox& Bx, const FArrayBox& By, const FArrayBox& Bz,
+    FArrayBox const * & ex_ptr, FArrayBox const * & ey_ptr,
+    FArrayBox const * & ez_ptr, FArrayBox const * & bx_ptr,
     FArrayBox const * & by_ptr, FArrayBox const * & bz_ptr)
 {
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1026,12 +1026,15 @@ PhysicalParticleContainer::Evolve (int lev,
 
             if (WarpX::use_fdtd_nci_corr)
             {
+                // Filter arrays Ex[pti], store the result in
+                // filtered_Ex and update pointer exfab so that it
+                // points to filtered_Ex (and do the same for all
+                // components of E and B).
                 applyNCIFilter(lev, pti.tilebox(), exeli, eyeli, ezeli, bxeli, byeli, bzeli,
                                filtered_Ex, filtered_Ey, filtered_Ez,
                                filtered_Bx, filtered_By, filtered_Bz,
                                Ex[pti], Ey[pti], Ez[pti], Bx[pti], By[pti], Bz[pti],
                                exfab, eyfab, ezfab, bxfab, byfab, bzfab);
-
             }
 
             Exp.assign(np,0.0);
@@ -1113,6 +1116,10 @@ PhysicalParticleContainer::Evolve (int lev,
 
                     if (WarpX::use_fdtd_nci_corr)
                     {
+                        // Filter arrays (*cEx)[pti], store the result in
+                        // filtered_Ex and update pointer cexfab so that it
+                        // points to filtered_Ex (and do the same for all
+                        // components of E and B)
                         applyNCIFilter(lev-1, cbox, exeli, eyeli, ezeli, bxeli, byeli, bzeli,
                                        filtered_Ex, filtered_Ey, filtered_Ez,
                                        filtered_Bx, filtered_By, filtered_Bz,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -937,6 +937,73 @@ PhysicalParticleContainer::FieldGather (int lev,
 }
 
 void
+PhysicalParticleContainer::applyNCIFilter (
+    int lev, const Box& box, 
+    Elixir& exeli, Elixir& eyeli, Elixir& ezeli,
+    Elixir& bxeli, Elixir& byeli, Elixir& bzeli,
+    FArrayBox& filtered_Ex, FArrayBox& filtered_Ey, FArrayBox& filtered_Ez, 
+    FArrayBox& filtered_Bx, FArrayBox& filtered_By, FArrayBox& filtered_Bz, 
+    const FArrayBox& Ex_pti, const FArrayBox& Ey_pti, const FArrayBox& Ez_pti, 
+    const FArrayBox& Bx_pti, const FArrayBox& By_pti, const FArrayBox& Bz_pti, 
+    FArrayBox const * & exfab, FArrayBox const * & eyfab, FArrayBox const * & ezfab, 
+    FArrayBox const * & bxfab, FArrayBox const * & byfab, FArrayBox const * & bzfab)
+{
+
+    // Get instances of NCI Godfrey filters
+    const auto& nci_godfrey_filter_exeybz = WarpX::GetInstance().nci_godfrey_filter_exeybz;
+    const auto& nci_godfrey_filter_bxbyez = WarpX::GetInstance().nci_godfrey_filter_bxbyez;
+
+#if (AMREX_SPACEDIM == 2)
+    const Box& tbox = amrex::grow(box,{static_cast<int>(WarpX::nox),
+                static_cast<int>(WarpX::noz)});
+#else
+    const Box& tbox = amrex::grow(box,{static_cast<int>(WarpX::nox),
+                static_cast<int>(WarpX::noy),
+                static_cast<int>(WarpX::noz)});
+#endif
+
+    // Filter Ex (Both 2D and 3D)
+    filtered_Ex.resize(amrex::convert(tbox,WarpX::Ex_nodal_flag));
+    // Safeguard for GPU
+    exeli = filtered_Ex.elixir();
+    // Apply filter on Ex, result stored in filtered_Ex
+    nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Ex, Ex_pti, filtered_Ex.box());
+    // Update exfab reference
+    exfab = &filtered_Ex;
+
+    // Filter Ez
+    filtered_Ez.resize(amrex::convert(tbox,WarpX::Ez_nodal_flag));
+    ezeli = filtered_Ez.elixir();
+    nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_Ez, Ez_pti, filtered_Ez.box());
+    ezfab = &filtered_Ez;
+
+    // Filter By
+    filtered_By.resize(amrex::convert(tbox,WarpX::By_nodal_flag));
+    byeli = filtered_By.elixir();
+    nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_By, By_pti, filtered_By.box());
+    byfab = &filtered_By;
+#if (AMREX_SPACEDIM == 3)
+    // Filter Ey
+    filtered_Ey.resize(amrex::convert(tbox,WarpX::Ey_nodal_flag));
+    eyeli = filtered_Ey.elixir();
+    nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Ey, Ey_pti, filtered_Ey.box());
+    eyfab = &filtered_Ey;
+
+    // Filter Bx
+    filtered_Bx.resize(amrex::convert(tbox,WarpX::Bx_nodal_flag));
+    bxeli = filtered_Bx.elixir();
+    nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_Bx, Bx_pti, filtered_Bx.box());
+    bxfab = &filtered_Bx;
+
+    // Filter Bz
+    filtered_Bz.resize(amrex::convert(tbox,WarpX::Bz_nodal_flag));
+    bzeli = filtered_Bz.elixir();
+    nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Bz, Bz_pti, filtered_Bz.box());
+    bzfab = &filtered_Bz;
+#endif
+}
+
+void
 PhysicalParticleContainer::Evolve (int lev,
                                    const MultiFab& Ex, const MultiFab& Ey, const MultiFab& Ez,
                                    const MultiFab& Bx, const MultiFab& By, const MultiFab& Bz,
@@ -958,7 +1025,7 @@ PhysicalParticleContainer::Evolve (int lev,
     // Get instances of NCI Godfrey filters
     const auto& nci_godfrey_filter_exeybz = WarpX::GetInstance().nci_godfrey_filter_exeybz;
     const auto& nci_godfrey_filter_bxbyez = WarpX::GetInstance().nci_godfrey_filter_bxbyez;
-
+    
     BL_ASSERT(OnSameGrids(lev,jx));
 
     MultiFab* cost = WarpX::getCosts(lev);
@@ -1026,54 +1093,12 @@ PhysicalParticleContainer::Evolve (int lev,
 
             if (WarpX::use_fdtd_nci_corr)
             {
-#if (AMREX_SPACEDIM == 2)
-                const Box& tbox = amrex::grow(pti.tilebox(),{static_cast<int>(WarpX::nox),
-                            static_cast<int>(WarpX::noz)});
-#else
-                const Box& tbox = amrex::grow(pti.tilebox(),{static_cast<int>(WarpX::nox),
-                            static_cast<int>(WarpX::noy),
-                            static_cast<int>(WarpX::noz)});
-#endif
+                applyNCIFilter(lev, pti.tilebox(), exeli, eyeli, ezeli, bxeli, byeli, bzeli,
+                               filtered_Ex, filtered_Ey, filtered_Ez,
+                               filtered_Bx, filtered_By, filtered_Bz,
+                               Ex[pti], Ey[pti], Ez[pti], Bx[pti], By[pti], Bz[pti],
+                               exfab, eyfab, ezfab, bxfab, byfab, bzfab);
 
-                // Filter Ex (Both 2D and 3D)
-                filtered_Ex.resize(amrex::convert(tbox,WarpX::Ex_nodal_flag));
-                // Safeguard for GPU
-                exeli = filtered_Ex.elixir();
-                // Apply filter on Ex, result stored in filtered_Ex
-                nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Ex, Ex[pti], filtered_Ex.box());
-                // Update exfab reference
-                exfab = &filtered_Ex;
-
-                // Filter Ez
-                filtered_Ez.resize(amrex::convert(tbox,WarpX::Ez_nodal_flag));
-                ezeli = filtered_Ez.elixir();
-                nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_Ez, Ez[pti], filtered_Ez.box());
-                ezfab = &filtered_Ez;
-
-                // Filter By
-                filtered_By.resize(amrex::convert(tbox,WarpX::By_nodal_flag));
-                byeli = filtered_By.elixir();
-                nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_By, By[pti], filtered_By.box());
-                byfab = &filtered_By;
-#if (AMREX_SPACEDIM == 3)
-                // Filter Ey
-                filtered_Ey.resize(amrex::convert(tbox,WarpX::Ey_nodal_flag));
-                eyeli = filtered_Ey.elixir();
-                nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Ey, Ey[pti], filtered_Ey.box());
-                eyfab = &filtered_Ey;
-
-                // Filter Bx
-                filtered_Bx.resize(amrex::convert(tbox,WarpX::Bx_nodal_flag));
-                bxeli = filtered_Bx.elixir();
-                nci_godfrey_filter_bxbyez[lev]->ApplyStencil(filtered_Bx, Bx[pti], filtered_Bx.box());
-                bxfab = &filtered_Bx;
-
-                // Filter Bz
-                filtered_Bz.resize(amrex::convert(tbox,WarpX::Bz_nodal_flag));
-                bzeli = filtered_Bz.elixir();
-                nci_godfrey_filter_exeybz[lev]->ApplyStencil(filtered_Bz, Bz[pti], filtered_Bz.box());
-                bzfab = &filtered_Bz;
-#endif
             }
 
             Exp.assign(np,0.0);


### PR DESCRIPTION
This PR moves the code to apply NCI filter from `PPC::Evolve` to a separate function, to clean `PPC::Evolve`. It is essentially a copy-paste, similar to PR https://github.com/ECP-WarpX/WarpX/pull/396.

I checked that it gave the same result to machine precision as previous implementation, with and without MR, and with buffers.

I'd like to update the NCI test (add a temperature to have a fixed seed, and test with MR and buffers), but it should probably be in another PR.