### PR TITLE
Fix GPU performance, by changing host compiler from `gcc` to `gnu`

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -9,7 +9,7 @@ ifeq ($(USE_GPU),TRUE)
   USE_OMP  = FALSE
   USE_CUDA = TRUE
   USE_ACC  = FALSE
-  NVCC_HOST_COMP = gcc
+  NVCC_HOST_COMP = gnu
 endif
 
 ifeq ($(USE_RZ),TRUE)


### PR DESCRIPTION
As explained by @atmyers and @WeiqunZhang on Slack, when using `gcc`, the flag `-O2` is not passed to the host compiler, for `USE_GPU=TRUE`. 

It turns out that this results in the CPU doing a large amount of work, whenever a new, temporary `MultiFab` is created. (This is essentially because [this line](https://github.com/AMReX-Codes/amrex/blob/master/Src/Base/AMReX_BaseFab.H#L157) is not converted to a no-op by the compiler.)

This PR fixes this issue.

I did some timing on a single V100 GPU, for a typical 3D simulation:
- with `gcc` (current `dev` branch): ~1.5s per iteration (for the whole PIC loop)
- with `gnu` (current PR): ~0.11s per iteration (for the whole PIC loop)
- with `COMP=pgi` + current `dev` branch (i.e. previous setting for FOM runs): ~0.11s per iteration (for the whole PIC loop)