### PR TITLE
run_test.sh: in /tmp, fix OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ d/
 f/
 o/
 tmp_build_dir/
+test_dir
+test_dir/
 AMReX_buildInfo.cpp
 Backtrace.*
 *.vth

--- a/run_test.sh
+++ b/run_test.sh
@@ -12,14 +12,24 @@
 # Use `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order
 # to run the tests on CPU or GPU respectively.
 
-# Create test directory
-rm -rf test_dir
-mkdir test_dir
-cd test_dir
+# Remove contents and link to a previous test directory (intentionally two arguments)
+rm -rf test_dir/* test_dir
+# Create a temporary test directory
+tmp_dir=$(mktemp --help >/dev/null 2>&1 && mktemp -d -t ci-XXXXXXXXXX || mktemp -d "${TMPDIR:-/tmp}"/ci-XXXXXXXXXX)
+if [ $? -ne 0 ]; then
+    echo "Cannot create temporary directory"
+    exit 1
+fi
 
 # Copy WarpX into current test directory
-mkdir warpx
-cp -r ../* warpx
+mkdir ${tmp_dir}/warpx
+cp -r ./* ${tmp_dir}/warpx
+
+# Link the test directory
+ln -s ${tmp_dir} test_dir
+
+# Switch to the test directory
+cd test_dir
 
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
@@ -36,4 +46,4 @@ cp travis-tests.ini ../../rt-WarpX
 
 # Run the tests
 cd ../../regression_testing/
-python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=$WARPX_TEST_COMMIT
+python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}


### PR DESCRIPTION
`cp -r ../* warpx/` copies itself recursively and indefinitely on OSX. This makes sense, the longer one looks at it.

Instead, we create a temporary dir in `/tmp` for our compiles and runs, which potentially is even faster due to RAM-fs on most systems. We then copy our current sources to it and then link the directory back into `test_dir/` in-source (not cool, not cool to build in-source generally) so nobody notices what magic we did.

- [ ] Fixes a report by Jean-Luc on Slack.