### PR TITLE
Reactivate PSATD PML test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -87,20 +87,20 @@ compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
 
-#[pml_x_psatd]
-#buildDir = .
-#inputFile = Examples/Tests/PML/inputs2d
-#runtime_params = warpx.do_dynamic_scheduling=0
-#dim = 2
-#addToCompileString = USE_PSATD=TRUE
-#restartTest = 0
-#useMPI = 1
-#numprocs = 2
-#useOMP = 1
-#numthreads = 2
-#compileTest = 0
-#doVis = 0
-#analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
+[pml_x_psatd]
+buildDir = .
+inputFile = Examples/Tests/PML/inputs2d
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
 
 [nci_corrector]
 buildDir = .


### PR DESCRIPTION
These tests were deactivated because they used to cause a `SegFault`. I think that this problem has been fixed by not compiling the Hybrid spectral solver.