### PR TITLE
Removing redundant initialization of E and B fields on particles 

### DIFF
--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -90,13 +90,6 @@ void doGatherShapeN(const amrex::ParticleReal * const xp,
             const int l0 = compute_shape_factor<depos_order - lower_in_v>(
                 sz0, z-stagger_shift);
 
-            // Set fields on particle to zero
-            Exp[ip] = 0;
-            Eyp[ip] = 0;
-            Ezp[ip] = 0;
-            Bxp[ip] = 0;
-            Byp[ip] = 0;
-            Bzp[ip] = 0;
             // Each field is gathered in a separate block of
             // AMREX_SPACEDIM nested loops because the deposition
             // order can differ for each component of each field


### PR DESCRIPTION
The E and B fields are initialized to 0 or B_external before FieldGather is called in Source/Particles/PhysicalParticleContainer.cpp.
Setting these values to 0 in FieldGather.H is redundant and in this PR, we remove this redundancy as it also over-rides the initialization to the externally applied B-field.

