### PR TITLE
fix libwarpx.so compilation for cuda

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -27,23 +27,23 @@ ifeq ($(USE_ASCENT_INSITU),TRUE)
   USE_ASCENT = TRUE
 endif
 
-include $(AMREX_HOME)/Tools/GNUMake/Make.defs
-
 ifndef USE_PYTHON_MAIN
   USE_PYTHON_MAIN = FALSE
 endif
 
 ifeq ($(USE_PYTHON_MAIN),TRUE)
-  CXXFLAGS += -fPIC
+  XTRA_CXXFLAGS += -fPIC
 ifeq ($(USE_OMP),TRUE)
   LDFLAGS += -fopenmp
 endif
-  CFLAGS   += -fPIC
-  FFLAGS   += -fPIC
-  F90FLAGS += -fPIC
+  XTRA_CFLAGS   += -fPIC
+  XTRA_FFLAGS   += -fPIC
+  XTRA_F90FLAGS += -fPIC
   USERSuffix := .Lib
   DEFINES += -DWARPX_USE_PY
 endif
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 ifeq ($(DIM),3)
   DEFINES += -DWARPX_DIM_3D
@@ -209,7 +209,11 @@ libwarpx$(PYDIM).a: $(objForExecs)
 
 libwarpx$(PYDIM).so: $(objForExecs)
 	@echo Making dynamic library $@ ...
+ifeq ($(USE_CUDA),TRUE)
+	$(SILENT) $(CXX) $(LINKFLAGS) $(SHARED_OPTION) -Xlinker=$(SHARED_OPTION) -Xlinker=-fPIC -o $@ $^ $(LDFLAGS) $(libraries)
+else
 	$(SILENT) $(CXX) $(SHARED_OPTION) -fPIC -o $@ $^ $(LDFLAGS) $(libraries)
+endif
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 	@echo SUCCESS
 


### PR DESCRIPTION
This partially fixes the compilation for this regression test for https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/2019-10-04/Python_Langmuir.html and https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/2019-10-04/Langmuir_rz_multimode.html.  It can successfully generate `libwarpx.so` now.  But on garuda, it fails to install python module because of permission issue.  (https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/2019-10-04-002/Langmuir_rz_multimode.make.out) I will let Andre fix this.


