### PR TITLE
Fix the issue of 'AddParticles is slow on GPU'

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -138,6 +138,17 @@ public:
     void CheckAndAddParticle(amrex::Real x, amrex::Real y, amrex::Real z,
                              std::array<amrex::Real, 3> u, amrex::Real weight);
 
+    void CheckAndAddParticle(amrex::Real x, amrex::Real y, amrex::Real z,
+                             std::array<amrex::Real, 3> u,
+                             amrex::Real weight,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_x,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_y,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_z,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_ux,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uy,
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uz,
+			     amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w);
+
     virtual void GetParticleSlice(const int direction, const amrex::Real z_old,
                                   const amrex::Real z_new, const amrex::Real t_boost,
                                   const amrex::Real t_lab, const amrex::Real dt,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -147,7 +147,7 @@ public:
                              amrex::Gpu::HostVector<amrex::ParticleReal>& particle_ux,
                              amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uy,
                              amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uz,
-			     amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w);
+                             amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w);
 
     virtual void GetParticleSlice(const int direction, const amrex::Real z_old,
                                   const amrex::Real z_new, const amrex::Real t_boost,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -136,9 +136,6 @@ public:
                          amrex::Real q_tot, long npart, int do_symmetrize);
 
     void CheckAndAddParticle(amrex::Real x, amrex::Real y, amrex::Real z,
-                             std::array<amrex::Real, 3> u, amrex::Real weight);
-
-    void CheckAndAddParticle(amrex::Real x, amrex::Real y, amrex::Real z,
                              std::array<amrex::Real, 3> u,
                              amrex::Real weight,
                              amrex::Gpu::HostVector<amrex::ParticleReal>& particle_x,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -236,6 +236,9 @@ PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
                                                Gpu::HostVector<ParticleReal>& particle_uz,
                                                Gpu::HostVector<ParticleReal>& particle_w)
 {
+    if (WarpX::gamma_boost > 1.) {
+        MapParticletoBoostedFrame(x, y, z, u);
+    }
     particle_x.push_back(x);
     particle_y.push_back(y);
     particle_z.push_back(z);
@@ -243,33 +246,6 @@ PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
     particle_uy.push_back(u[1]);
     particle_uz.push_back(u[2]);
     particle_w.push_back(weight);
-}
-
-void
-PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
-                                               std::array<Real, 3> u,
-                                               Real weight)
-{
-    std::array<ParticleReal,PIdx::nattribs> attribs;
-    attribs.fill(0.0);
-
-    // update attribs with input arguments
-    if (WarpX::gamma_boost > 1.) {
-        MapParticletoBoostedFrame(x, y, z, u);
-    }
-    attribs[PIdx::ux] = u[0];
-    attribs[PIdx::uy] = u[1];
-    attribs[PIdx::uz] = u[2];
-    attribs[PIdx::w ] = weight;
-
-    if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) )
-    {
-        // need to create old values
-        auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
-    }
-
-    // add particle
-    AddOneParticle(0, 0, 0, x, y, z, attribs);
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -156,15 +156,17 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
     std::normal_distribution<double> disty(y_m, y_rms);
     std::normal_distribution<double> distz(z_m, z_rms);
 
+    // Allocate temporary vectors on the CPU
+    Gpu::HostVector<ParticleReal> particle_x;
+    Gpu::HostVector<ParticleReal> particle_y;
+    Gpu::HostVector<ParticleReal> particle_z;
+    Gpu::HostVector<ParticleReal> particle_ux;
+    Gpu::HostVector<ParticleReal> particle_uy;
+    Gpu::HostVector<ParticleReal> particle_uz;
+    Gpu::HostVector<ParticleReal> particle_w;
+    int np = 0;
+
     if (ParallelDescriptor::IOProcessor()) {
-	// Allocate temporary vectors on the CPU
-        Gpu::HostVector<ParticleReal> particle_x;
-        Gpu::HostVector<ParticleReal> particle_y;
-        Gpu::HostVector<ParticleReal> particle_z;
-        Gpu::HostVector<ParticleReal> particle_ux;
-        Gpu::HostVector<ParticleReal> particle_uy;
-        Gpu::HostVector<ParticleReal> particle_uz;
-        Gpu::HostVector<ParticleReal> particle_w;
         // If do_symmetrize, create 4x fewer particles, and
         // Replicate each particle 4 times (x,y) (-x,y) (x,-y) (-x,-y)
         if (do_symmetrize){
@@ -189,17 +191,59 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
                 u.z *= PhysConst::c;
                 if (do_symmetrize){
                     // Add four particles to the beam:
-                    CheckAndAddParticle( x, y, z, { u.x, u.y, u.z}, weight/4. );
-                    CheckAndAddParticle( x,-y, z, { u.x,-u.y, u.z}, weight/4. );
-                    CheckAndAddParticle(-x, y, z, {-u.x, u.y, u.z}, weight/4. );
-                    CheckAndAddParticle(-x,-y, z, {-u.x,-u.y, u.z}, weight/4. );
+		    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight/4.,
+				        particle_x,  particle_y,  particle_z,
+					particle_ux, particle_uy, particle_uz,
+					particle_w);
+		    CheckAndAddParticle(x, -y, z, { u.x, -u.y, u.z}, weight/4.,
+				        particle_x,  particle_y,  particle_z,
+					particle_ux, particle_uy, particle_uz,
+					particle_w);
+		    CheckAndAddParticle(-x, y, z, { -u.x, u.y, u.z}, weight/4.,
+				        particle_x,  particle_y,  particle_z,
+					particle_ux, particle_uy, particle_uz,
+					particle_w);
+		    CheckAndAddParticle(-x, -y, z, { -u.x, -u.y, u.z}, weight/4.,
+				        particle_x,  particle_y,  particle_z,
+					particle_ux, particle_uy, particle_uz,
+					particle_w);
+
                 } else {
-                    CheckAndAddParticle(x, y, z, {u.x,u.y,u.z}, weight);
+		    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight,
+				        particle_x,  particle_y,  particle_z,
+					particle_ux, particle_uy, particle_uz,
+					particle_w);
                 }
             }
         }
     }
-    Redistribute();
+    // Add the temporary CPU vectors to the particle structure
+    np = particle_z.size();
+    AddNParticles(0,np,
+		  particle_x.dataPtr(),  particle_y.dataPtr(),  particle_z.dataPtr(),
+		  particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
+		  1, particle_w.dataPtr(),1);
+}
+
+void
+PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
+                                               std::array<Real, 3> u,
+                                               Real weight,
+                                               Gpu::HostVector<ParticleReal>& particle_x,
+                                               Gpu::HostVector<ParticleReal>& particle_y,
+                                               Gpu::HostVector<ParticleReal>& particle_z,
+                                               Gpu::HostVector<ParticleReal>& particle_ux,
+                                               Gpu::HostVector<ParticleReal>& particle_uy,
+                                               Gpu::HostVector<ParticleReal>& particle_uz,
+					       Gpu::HostVector<ParticleReal>& particle_w)
+{
+    particle_x.push_back(x);
+    particle_y.push_back(y);
+    particle_z.push_back(z);
+    particle_ux.push_back(u[0]);
+    particle_uy.push_back(u[1]);
+    particle_uz.push_back(u[2]);
+    particle_w.push_back(weight);
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -235,7 +235,7 @@ PhysicalParticleContainer::CheckAndAddParticle(Real x, Real y, Real z,
                                                Gpu::HostVector<ParticleReal>& particle_ux,
                                                Gpu::HostVector<ParticleReal>& particle_uy,
                                                Gpu::HostVector<ParticleReal>& particle_uz,
-					       Gpu::HostVector<ParticleReal>& particle_w)
+                                               Gpu::HostVector<ParticleReal>& particle_w)
 {
     particle_x.push_back(x);
     particle_y.push_back(y);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -157,6 +157,14 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
     std::normal_distribution<double> distz(z_m, z_rms);
 
     if (ParallelDescriptor::IOProcessor()) {
+	// Allocate temporary vectors on the CPU
+        Gpu::HostVector<ParticleReal> particle_x;
+        Gpu::HostVector<ParticleReal> particle_y;
+        Gpu::HostVector<ParticleReal> particle_z;
+        Gpu::HostVector<ParticleReal> particle_ux;
+        Gpu::HostVector<ParticleReal> particle_uy;
+        Gpu::HostVector<ParticleReal> particle_uz;
+        Gpu::HostVector<ParticleReal> particle_w;
         // If do_symmetrize, create 4x fewer particles, and
         // Replicate each particle 4 times (x,y) (-x,y) (x,-y) (-x,-y)
         if (do_symmetrize){

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -191,28 +191,27 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
                 u.z *= PhysConst::c;
                 if (do_symmetrize){
                     // Add four particles to the beam:
-		    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight/4.,
-				        particle_x,  particle_y,  particle_z,
-					particle_ux, particle_uy, particle_uz,
-					particle_w);
-		    CheckAndAddParticle(x, -y, z, { u.x, -u.y, u.z}, weight/4.,
-				        particle_x,  particle_y,  particle_z,
-					particle_ux, particle_uy, particle_uz,
-					particle_w);
-		    CheckAndAddParticle(-x, y, z, { -u.x, u.y, u.z}, weight/4.,
-				        particle_x,  particle_y,  particle_z,
-					particle_ux, particle_uy, particle_uz,
-					particle_w);
-		    CheckAndAddParticle(-x, -y, z, { -u.x, -u.y, u.z}, weight/4.,
-				        particle_x,  particle_y,  particle_z,
-					particle_ux, particle_uy, particle_uz,
-					particle_w);
-
+                    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight/4.,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(x, -y, z, { u.x, -u.y, u.z}, weight/4.,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-x, y, z, { -u.x, u.y, u.z}, weight/4.,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-x, -y, z, { -u.x, -u.y, u.z}, weight/4.,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
                 } else {
-		    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight,
-				        particle_x,  particle_y,  particle_z,
-					particle_ux, particle_uy, particle_uz,
-					particle_w);
+                    CheckAndAddParticle(x, y, z, { u.x, u.y, u.z}, weight,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
                 }
             }
         }
@@ -220,9 +219,9 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
     // Add the temporary CPU vectors to the particle structure
     np = particle_z.size();
     AddNParticles(0,np,
-		  particle_x.dataPtr(),  particle_y.dataPtr(),  particle_z.dataPtr(),
-		  particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
-		  1, particle_w.dataPtr(),1);
+                  particle_x.dataPtr(),  particle_y.dataPtr(),  particle_z.dataPtr(),
+                  particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
+                  1, particle_w.dataPtr(),1);
 }
 
 void

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -236,14 +236,6 @@ public:
                         const amrex::ParticleReal* vx, const amrex::ParticleReal* vy, const amrex::ParticleReal* vz,
                         int nattr, const amrex::ParticleReal* attr, int uniqueparticles, int id=-1);
 
-    void AddOneParticle (int lev, int grid, int tile,
-                         amrex::ParticleReal x, amrex::ParticleReal y, amrex::ParticleReal z,
-                         std::array<amrex::ParticleReal,PIdx::nattribs>& attribs);
-
-    void AddOneParticle (ParticleTileType& particle_tile,
-                         amrex::ParticleReal x, amrex::ParticleReal y, amrex::ParticleReal z,
-                         std::array<amrex::ParticleReal,PIdx::nattribs>& attribs);
-
     virtual void ReadHeader (std::istream& is);
 
     virtual void WriteHeader (std::ostream& os) const;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -135,45 +135,6 @@ WarpXParticleContainer::AllocData ()
 }
 
 void
-WarpXParticleContainer::AddOneParticle (int lev, int grid, int tile,
-                                        ParticleReal x, ParticleReal y, ParticleReal z,
-                                        std::array<ParticleReal,PIdx::nattribs>& attribs)
-{
-    auto& particle_tile = DefineAndReturnParticleTile(lev, grid, tile);
-    AddOneParticle(particle_tile, x, y, z, attribs);
-}
-
-void
-WarpXParticleContainer::AddOneParticle (ParticleTileType& particle_tile,
-                                        ParticleReal x, ParticleReal y, ParticleReal z,
-                                        std::array<ParticleReal,PIdx::nattribs>& attribs)
-{
-    ParticleType p;
-    p.id()  = ParticleType::NextID();
-    p.cpu() = ParallelDescriptor::MyProc();
-#if (AMREX_SPACEDIM == 3)
-    p.pos(0) = x;
-    p.pos(1) = y;
-    p.pos(2) = z;
-#elif (AMREX_SPACEDIM == 2)
-#ifdef WARPX_DIM_RZ
-    attribs[PIdx::theta] = std::atan2(y, x);
-    x = std::sqrt(x*x + y*y);
-#endif
-    p.pos(0) = x;
-    p.pos(1) = z;
-#endif
-
-    particle_tile.push_back(p);
-    particle_tile.push_back_real(attribs);
-
-    for (int i = PIdx::nattribs; i < NumRealComps(); ++i)
-    {
-        particle_tile.push_back_real(i, 0.0);
-    }
-}
-
-void
 WarpXParticleContainer::AddNParticles (int lev,
                                        int n, const ParticleReal* x, const ParticleReal* y, const ParticleReal* z,
                                        const ParticleReal* vx, const ParticleReal* vy, const ParticleReal* vz,


### PR DESCRIPTION
The issue of ['AddParticles' is slow on GPU, at the beginning of the simulation] may be fixed, by adding temporary arrays on the host (CPU) to store the information of added particles, then copy the host arrays direct to GPU all at once.