### PR TITLE
[mini-PR] Print time step and cell size

### DIFF
--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -562,6 +562,18 @@ WarpX::ComputeDt ()
     if (do_electrostatic) {
         dt[0] = const_dt;
     }
+
+    for (int lev=0; lev <= max_level; lev++) {
+        const Real* dx_lev = geom[lev].CellSize();
+        Print()<<"Level "<<lev<<": dt = "<<dt[lev]
+               <<" ; dx = "<<dx_lev[0]
+#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+               <<" ; dz = "<<dx_lev[1]<<'\n';
+#elif (defined WARPX_DIM_3D)
+               <<" ; dy = "<<dx_lev[1]
+               <<" ; dz = "<<dx_lev[2]<<'\n';
+#endif
+    }
 }
 
 /* \brief computes max_step for wakefield simulation in boosted frame.


### PR DESCRIPTION
It is usually interesting to have the cell size and time step at the beginning of the simulation (in particular when running with/without MR, in a boosted frame). This PR proposes to print additional lines
```
Level 0: dt = 7.370794802e-16 ; dx = 3.125e-07 ; dz = 3.125e-07
Level 1: dt = 3.685397401e-16 ; dx = 1.5625e-07 ; dz = 1.5625e-07
```
at the beginning of the simulation, This is just a suggestion. In the future, we may want to add some verbosity levels.