### PR TITLE
openPMD hints: fix AMReX build System

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -115,8 +115,8 @@ ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
    ifeq (0, $(shell pkg-config "openPMD >= 0.9.0"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
-       LDFLAGS += $(shell pkg-config --libs openPMD)
-       LDFLAGS += -Xlinker -rpath -Xlinker $(shell pkg-config --variable=libdir openPMD)
+       LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
+       libraries += $(shell pkg-config --libs-only-l openPMD)
    # fallback to manual settings
    else
        OPENPMD_LIB_PATH ?= NOT_SET


### PR DESCRIPTION
When deriving openPMD-api dependency hints via `pkg-config`, adding hints to `LDFLAGS` are added too late in the AMReX GNUmake build system. Since linker flags are order-dependent, this caused undefined symbol issues at link time.

We fix this by just using more specific variables in the AMReX GNUmake build system, which are added last to the final linker command. We also migrate our RPath feature for linking upstream to AMReX: https://github.com/AMReX-Codes/amrex/pull/590