### PR TITLE
Link: Use RPATH by Default

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -4,6 +4,7 @@ OPENBC_HOME ?= ../../../openbc_poisson
 
 USE_MPI       = TRUE
 USE_PARTICLES = TRUE
+USE_RPATH     = TRUE
 
 ifeq ($(USE_GPU),TRUE)
   USE_OMP  = FALSE


### PR DESCRIPTION
Enable linking with [RPATH](https://en.wikipedia.org/wiki/Rpath) hints set by default. This remembers the location of dependent shared libraries as seen at link-time.

Follow-up to #460.

- [ ] Depends on https://github.com/AMReX-Codes/amrex/pull/590 being merged into AMReX.