### PR TITLE
Mini-PR: fix pushP for photons

### DIFF
--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -53,7 +53,7 @@ public:
                         const amrex::MultiFab& Ey,
                         const amrex::MultiFab& Ez,
                         const amrex::MultiFab& Bx,
-                        const amrex::MultiFab& By, 
+                        const amrex::MultiFab& By,
                         const amrex::MultiFab& Bz) override {};
 
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -46,6 +46,15 @@ public:
                         amrex::Cuda::ManagedDeviceVector<amrex::ParticleReal>& zp,
                         amrex::Real dt, DtType a_dt_type=DtType::Full) override;
 
+    // Don't push momenta for photons
+    virtual void PushP (int lev,
+                        amrex::Real dt,
+                        const amrex::MultiFab& Ex,
+                        const amrex::MultiFab& Ey,
+                        const amrex::MultiFab& Ez,
+                        const amrex::MultiFab& Bx,
+                        const amrex::MultiFab& By, 
+                        const amrex::MultiFab& Bz) override {};
 
 
     // DepositCurrent should do nothing for photons


### PR DESCRIPTION
While ``` PushPX ``` had been overridden for photons (i.e. momenta do not change, positions are evolved according to photon pusher), ``` PushP``` had not. I discovered this while writing a unit test for another PR.

I've simply added 
```
    // Don't push momenta for photons
    virtual void PushP (int lev,
                        amrex::Real dt,
                        const amrex::MultiFab& Ex,
                        const amrex::MultiFab& Ey,
                        const amrex::MultiFab& Ez,
                        const amrex::MultiFab& Bx,
                        const amrex::MultiFab& By, 
                        const amrex::MultiFab& Bz) override {};
```

In the ```PhotonParticleContainer.H``` file.