### PR TITLE
Fix particle partition in buffers

### DIFF
--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -56,7 +56,7 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
         gather_masks : current_masks;
     // - For each particle, find whether it is in the larger buffer,
     //   by looking up the mask. Store the answer in `inexflag`.
-    amrex::ParallelFor( np, fillBufferFlag(pti, bmasks, inexflag, Geom(lev), 0) );
+    amrex::ParallelFor( np, fillBufferFlag(pti, bmasks, inexflag, Geom(lev)) );
     // - Find the indices that reorder particles so that the last particles
     //   are in the larger buffer
     fillWithConsecutiveIntegers( pid );
@@ -93,7 +93,7 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
             // - For each particle in the large buffer, find whether it is in
             // the smaller buffer, by looking up the mask. Store the answer in `inexflag`.
             amrex::ParallelFor( np - n_fine,
-               fillBufferFlag(pti, bmasks, inexflag, Geom(lev), n_fine) );
+               fillBufferFlagRemainingParticles(pti, bmasks, inexflag, Geom(lev), pid, n_fine) );
             auto const sep2 = stablePartition( sep, pid.end(), inexflag );
 
             if (bmasks == gather_masks) {

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -78,22 +78,19 @@ int iteratorDistance(ForwardIterator const first,
 /* \brief Functor that fills the elements of the particle array `inexflag`
  *  with the value of the spatial array `bmasks`, at the corresponding particle position.
  *
- * This is done only for the elements from `start_index` to the end of `inexflag`
- *
  * \param[in] pti Contains information on the particle positions
  * \param[in] bmasks Spatial array, that contains a flag indicating
  *         whether each cell is part of the gathering/deposition buffers
  * \param[out] inexflag Vector to be filled with the value of `bmasks`
  * \param[in] geom Geometry object, necessary to locate particles within the array `bmasks`
- * \param[in] start_index Index that which elements start to be modified
+ *
  */
 class fillBufferFlag
 {
     public:
         fillBufferFlag( WarpXParIter const& pti, amrex::iMultiFab const* bmasks,
                         amrex::Gpu::DeviceVector<int>& inexflag,
-                        amrex::Geometry const& geom, long const start_index=0 ) :
-                        m_start_index(start_index) {
+                        amrex::Geometry const& geom ) {
 
             // Extract simple structure that can be used directly on the GPU
             m_particles = &(pti.GetArrayOfStructs()[0]);
@@ -110,13 +107,73 @@ class fillBufferFlag
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator()( const long i ) const {
             // Select a particle
-            auto const& p = m_particles[i+m_start_index];
+            auto const& p = m_particles[i];
             // Find the index of the cell where this particle is located
             amrex::IntVect const iv = amrex::getParticleCell( p,
                                 m_prob_lo, m_inv_cell_size, m_domain );
             // Find the value of the buffer flag in this cell and
             // store it at the corresponding particle position in the array `inexflag`
-            m_inexflag_ptr[i+m_start_index] = m_buffer_mask(iv);
+            m_inexflag_ptr[i] = m_buffer_mask(iv);
+        };
+
+    private:
+        amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_prob_lo;
+        amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_inv_cell_size;
+        amrex::Box m_domain;
+        int* m_inexflag_ptr;
+        WarpXParticleContainer::ParticleType const* m_particles;
+        amrex::Array4<int const> m_buffer_mask;
+};
+
+/* \brief Functor that fills the elements of the particle array `inexflag`
+ *  with the value of the spatial array `bmasks`, at the corresponding particle position.
+ *
+ * Contrary to `fillBufferFlag`, here this is done only for the particles that
+ * the last elements of `particle_indices` point to (from the element at
+ * index `start_index` in `particle_indices`, to the last element of `particle_indices`)
+ *
+ * \param[in] pti Contains information on the particle positions
+ * \param[in] bmasks Spatial array, that contains a flag indicating
+ *         whether each cell is part of the gathering/deposition buffers
+ * \param[out] inexflag Vector to be filled with the value of `bmasks`
+ * \param[in] geom Geometry object, necessary to locate particles within the array `bmasks`
+ * \param[in] start_index Index that which elements start to be modified
+ */
+class fillBufferFlagRemainingParticles
+{
+    public:
+        fillBufferFlagRemainingParticles(
+                        WarpXParIter const& pti,
+                        amrex::iMultiFab const* bmasks,
+                        amrex::Gpu::DeviceVector<int>& inexflag,
+                        amrex::Geometry const& geom,
+                        amrex::Gpu::DeviceVector<long> const& particle_indices,
+                        long const start_index ) :
+                        m_start_index(start_index) {
+
+            // Extract simple structure that can be used directly on the GPU
+            m_particles = &(pti.GetArrayOfStructs()[0]);
+            m_buffer_mask = (*bmasks)[pti].array();
+            m_inexflag_ptr = inexflag.dataPtr();
+            m_indices_ptr = particle_indices.dataPtr();
+            m_domain = geom.Domain();
+            for (int idim=0; idim<AMREX_SPACEDIM; idim++) {
+                m_prob_lo[idim] = geom.ProbLo(idim);
+                m_inv_cell_size[idim] = geom.InvCellSize(idim);
+            }
+        };
+
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator()( const long i ) const {
+            // Select a particle
+            auto const& p = m_particles[m_indices_ptr[i+m_start_index]];
+            // Find the index of the cell where this particle is located
+            amrex::IntVect const iv = amrex::getParticleCell( p,
+                                m_prob_lo, m_inv_cell_size, m_domain );
+            // Find the value of the buffer flag in this cell and
+            // store it at the corresponding particle position in the array `inexflag`
+            m_inexflag_ptr[m_indices_ptr[i+m_start_index]] = m_buffer_mask(iv);
         };
 
     private:
@@ -127,6 +184,7 @@ class fillBufferFlag
         WarpXParticleContainer::ParticleType const* m_particles;
         amrex::Array4<int const> m_buffer_mask;
         long const m_start_index;
+        long const* m_indices_ptr;
 };
 
 /* \brief Functor that copies the elements of `src` into `dst`,


### PR DESCRIPTION
This fixes an issue introduced in #409.

# Summary of the fix

When we partition particles into the second buffer (the smaller), we should only update the flag `inexflag` for those particles that are inside the large buffer (i.e. the particles that are pointed to by the last elements of the array `pid`). 

Here, this is done by creating a separate functor to fill `inexflag` for the large buffer (`fillBufferFlag`) and for the small buffer (`fillBufferFlagRemainingParticles`). In the latter functor, we only look at the particles that are pointed to by the last elements of `pid`.

# Test

With the input script from #461 (modified to have 2 particles per cell along x), I get:

- Before PR #409:
<img width="862" alt="Screen Shot 2019-10-11 at 4 03 07 PM" src="https://user-images.githubusercontent.com/6685781/66689773-35bb2f80-ec41-11e9-87ab-36e58ac6703d.png">

- After PR #409 (buggy: looks more noisy):
<img width="870" alt="Screen Shot 2019-10-11 at 4 03 26 PM" src="https://user-images.githubusercontent.com/6685781/66689771-305de500-ec41-11e9-9189-6420665eafea.png">

- With this PR (fixed):
<img width="862" alt="Screen Shot 2019-10-11 at 4 03 07 PM" src="https://user-images.githubusercontent.com/6685781/66689759-18866100-ec41-11e9-96f4-0170e285adec.png">

 