### PR TITLE
[Mini-PR, WIP] Replace wget+compilation of Boost libraries with conda install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
     - conda install -y boost
+    - conda activate base
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
     - conda install -y boost
+    - source /home/travis/miniconda3/bin/activate
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - conda install boost
+    - conda install -y boost
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - wget http://mirrors.kernel.org/ubuntu/pool/main/b/boost-defaults/libboost-dev_1.67.0.1_amd64.deb
-    - sudo dpkg -i libboost-dev_1.67.0.1_amd64.deb
+    - conda install -y boost
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
     - conda install -y boost
-    - conda activate base
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - conda install -y boost
+    - wget http://mirrors.kernel.org/ubuntu/pool/main/b/boost-defaults/libboost-dev_1.67.0.1_amd64.deb
+    - sudo dpkg -i libboost-dev_1.67.0.1_amd64.deb
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,7 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
-    - tar xf boost_1_71_0.tar.gz
-    - cd boost_1_71_0
-    - ./bootstrap.sh --with-libraries=math
-    - sudo ./b2 -d0 install
-    - cd ..
+    - conda install boost
 
 script:
     - export FFTW_HOME=/usr/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,5 +37,8 @@ USE_RZ = FALSE
 
 DO_ELECTROSTATIC = FALSE
 
+INCLUDE_LOCATIONS += /home/travis/miniconda3/include
+LIBRARY_LOCATIONS += /home/travis/miniconda3/lib
+
 WARPX_HOME := .
 include $(WARPX_HOME)/Source/Make.WarpX

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,8 +37,5 @@ USE_RZ = FALSE
 
 DO_ELECTROSTATIC = FALSE
 
-INCLUDE_LOCATIONS += /home/travis/miniconda3/include
-LIBRARY_LOCATIONS += /home/travis/miniconda3/lib
-
 WARPX_HOME := .
 include $(WARPX_HOME)/Source/Make.WarpX


### PR DESCRIPTION
I've experienced a time out of the Travis tests for one of my latests Pull Requests (https://github.com/ECP-WarpX/WarpX/pull/361/ ). 
Since downloading and compiling the Boost libraries takes  few minutes, I would like to speed up the process using 
```
conda install -y boost
source /home/travis/miniconda3/bin/activate 
```
in the ```.travis.yml``` file.