### PR TITLE
Separate QED automated tests and remove Boost dependency (at least for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ sudo: true
 
 env:
   matrix:
-    - WARPX_TEST_DIM=3
-    - WARPX_TEST_DIM=2
+    - WARPX_TEST_DIM=3 HAS_QED=FALSE
+    - WARPX_TEST_DIM=2 HAS_QED=FALSE
+    - HAS_QED=TRUE
 
 before_install:
     - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,7 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
-    - tar xf boost_1_71_0.tar.gz
-    - cd boost_1_71_0
-    - ./bootstrap.sh --with-libraries=math
-    - sudo ./b2 -d0 install
-    - cd ..
+    - conda install boost
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
-    - tar xf boost_1_71_0.tar.gz
-    - cd boost_1_71_0
-    - ./bootstrap.sh --with-libraries=math
-    - sudo ./b2 -d0 install
-    - cd ..
+    - if [ $HAS_QED = "TRUE" ]; then wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz ; fi
+    - if [ $HAS_QED = "TRUE" ]; then  tar xf boost_1_71_0.tar.gz ; fi
+    - if [ $HAS_QED = "TRUE" ]; then  cd boost_1_71_0 ; fi
+    - if [ $HAS_QED = "TRUE" ]; then  ./bootstrap.sh --with-libraries=math ; fi
+    - if [ $HAS_QED = "TRUE" ]; then  sudo ./b2 -d0 install ; fi
+    - if [ $HAS_QED = "TRUE" ]; then  cd .. ; fi
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,12 @@ before_install:
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
     # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - conda install boost
+    - wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+    - tar xf boost_1_71_0.tar.gz
+    - cd boost_1_71_0
+    - ./bootstrap.sh --with-libraries=math
+    - sudo ./b2 -d0 install
+    - cd ..
 
 script:
     - export FFTW_HOME=/usr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,6 @@ before_install:
     - bash Miniconda3-latest-Linux-x86_64.sh -b
     - export PATH=/home/travis/miniconda3/bin:$PATH
     - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
-    # Install an up-to-date version of the Boost library (>= 1.67 should be ok)
-    - if [ $HAS_QED = "TRUE" ]; then wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz ; fi
-    - if [ $HAS_QED = "TRUE" ]; then  tar xf boost_1_71_0.tar.gz ; fi
-    - if [ $HAS_QED = "TRUE" ]; then  cd boost_1_71_0 ; fi
-    - if [ $HAS_QED = "TRUE" ]; then  ./bootstrap.sh --with-libraries=math ; fi
-    - if [ $HAS_QED = "TRUE" ]; then  sudo ./b2 -d0 install ; fi
-    - if [ $HAS_QED = "TRUE" ]; then  cd .. ; fi
 
 script:
     - export FFTW_HOME=/usr/

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -633,10 +633,11 @@ doVis = 0
 compareParticles = 0
 analysisRoutine =  Examples/Tests/photon_pusher/check.py
 
-[breit_wheeler_tau_init]
+[qed_breit_wheeler_tau_init]
 buildDir = .
 inputFile = Examples/Modules/qed/breit_wheeler/inputs.2d_test_tau_init
 dim = 2
+qed = TRUE
 addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1
@@ -648,10 +649,11 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/breit_wheeler/check_2d_tau_init.py
 
-[quantum_sync_tau_init]
+[qed_quantum_sync_tau_init]
 buildDir = .
 inputFile = Examples/Modules/qed/quantum_synchrotron/inputs.2d_test_tau_init
 dim = 2
+qed = TRUE
 addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -637,7 +637,6 @@ analysisRoutine =  Examples/Tests/photon_pusher/check.py
 buildDir = .
 inputFile = Examples/Modules/qed/breit_wheeler/inputs.2d_test_tau_init
 dim = 2
-qed = TRUE
 addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1
@@ -653,7 +652,6 @@ analysisRoutine = Examples/Modules/qed/breit_wheeler/check_2d_tau_init.py
 buildDir = .
 inputFile = Examples/Modules/qed/quantum_synchrotron/inputs.2d_test_tau_init
 dim = 2
-qed = TRUE
 addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -7,6 +7,7 @@ import re
 import os
 # Get relevant environment variables
 dim = os.environ.get('WARPX_TEST_DIM', None)
+qed = os.environ.get('HAS_QED', None)
 arch = os.environ.get('WARPX_TEST_ARCH', 'CPU')
 
 # Find the directory in which the tests should be run
@@ -49,6 +50,15 @@ text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*', '', text)
 if dim is not None:
     print('Selecting tests with dim = %s' %dim)
     text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*' %dim, '', text)
+
+# Remove or keep QED tests according to 'qed' variable
+if qed is not None:
+    print('Selecting tests with QED = %s' %qed)
+    if (qed == "TRUE"):
+        text = re.sub('\[.+\n(^((?!QED).)+$\n)+^$\n', '', text, flags=re.MULTILINE)
+    else:
+        text = re.sub('\[.+\n(.+\n)*addToCompileString.+QED=TRUE.*\n(.+\n)*', '', text)
+
 
 # Prevent emails from being sent
 text = re.sub( 'sendEmailWhenFail = 1', 'sendEmailWhenFail = 0', text )

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -55,9 +55,9 @@ if dim is not None:
 if qed is not None:
     print('Selecting tests with QED = %s' %qed)
     if (qed == "TRUE"):
-        text = re.sub('\[.+\n(^((?!QED).)+$\n)+^$\n', '', text, flags=re.MULTILINE)
+        text = re.sub('\[.+\n(^((?!QED).)+$\n)+analysisRoutine.+\n', '', text, flags=re.MULTILINE)
     else:
-        text = re.sub('\[.+\n(.+\n)*addToCompileString.+QED=TRUE.*\n(.+\n)*', '', text)
+        text = re.sub('\[.+\n(.+\n)*addToCompileString.+QED=TRUE.*\n(.+\n)*analysisRoutine.+', '', text)
 
 
 # Prevent emails from being sent

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -41,23 +41,23 @@ text = re.sub( 'numprocs = \d+', 'numprocs = 1', text)
 text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
 
 # Remove Python test (does not compile)
-text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
+text = re.sub( '\[Python_Langmuir\]\n(.+\n)*\n', '', text)
 
 # Remove Langmuir_x/y/z test (too long; not that useful)
-text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*', '', text)
+text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*\n', '', text)
 
 # Remove tests that do not have the right dimension
 if dim is not None:
     print('Selecting tests with dim = %s' %dim)
-    text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*' %dim, '', text)
+    text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*\n' %dim, '', text)
 
 # Remove or keep QED tests according to 'qed' variable
 if qed is not None:
     print('Selecting tests with QED = %s' %qed)
-    if (qed == "TRUE"):
-        text = re.sub('\[.+\n(^((?!QED).)+$\n)+analysisRoutine.+\n', '', text, flags=re.MULTILINE)
+    if (qed == "FALSE"):
+        text = re.sub('\[qed.+\n(.+\n)*\n', '', text)
     else:
-        text = re.sub('\[.+\n(.+\n)*addToCompileString.+QED=TRUE.*\n(.+\n)*analysisRoutine.+', '', text)
+        text = re.sub('^\[(?!qed).*$\n(.+\n)*(dim = .+\n)(.+\n)*\n', '', text, flags=re.MULTILINE)
 
 
 # Prevent emails from being sent

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -55,9 +55,9 @@ if dim is not None:
 if qed is not None:
     print('Selecting tests with QED = %s' %qed)
     if (qed == "FALSE"):
-        text = re.sub('\[qed.+\n(.+\n)*\n', '', text)
+        text = re.sub('\[qed.+\n(.+\n)*\n*', '', text)
     else:
-        text = re.sub('^\[(?!qed).*$\n(.+\n)*(dim = .+\n)(.+\n)*\n', '', text, flags=re.MULTILINE)
+        text = re.sub('^\[(?!qed).*$\n(.+\n)*(dim = .+\n)(.+\n)*\n*', '', text, flags=re.MULTILINE)
 
 
 # Prevent emails from being sent

--- a/Source/QED/BreitWheelerEngineWrapper.H
+++ b/Source/QED/BreitWheelerEngineWrapper.H
@@ -4,6 +4,7 @@
 #include "QedWrapperCommons.H"
 
 //BW ENGINE from PICSAR
+#define PXRMP_CORE_ONLY
 #include "breit_wheeler_engine.hpp"
 
 using WarpXBreitWheelerWrapper =

--- a/Source/QED/QuantumSyncEngineWrapper.H
+++ b/Source/QED/QuantumSyncEngineWrapper.H
@@ -4,6 +4,7 @@
 #include "QedWrapperCommons.H"
 
 //QS ENGINE from PICSAR
+#define PXRMP_CORE_ONLY
 #include "quantum_sync_engine.hpp"
 
 using WarpXQuantumSynchrotronWrapper =

--- a/run_test.sh
+++ b/run_test.sh
@@ -33,7 +33,11 @@ cd test_dir
 
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
-git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+if [ ${HAS_QED} = "TRUE" ]; then
+    git clone --branch QED https://bitbucket.org/berkeleylab/picsar.git
+else
+    git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
+fi
 
 # Clone the AMReX regression test utility
 git clone https://github.com/RemiLehe/regression_testing.git

--- a/run_test.sh
+++ b/run_test.sh
@@ -33,6 +33,7 @@ cd test_dir
 
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
+# Use QED brach for QED tests
 if [ ${HAS_QED} = "TRUE" ]; then
     git clone --branch QED https://bitbucket.org/berkeleylab/picsar.git
 else


### PR DESCRIPTION
Compiling WarpX requires a lot of time.  Now that some QED modules have been merged into the dev branch, WarpX has to be recompiled another time with QED=TRUE. This causes the tests with DIM=2 to last ~ 50 minutes, which is dangerously close to the  limit allowed by Travis. For this reason I've separated the tests with QED=TRUE in a different job. 

Since there might be some issues related to the inclusion of the Boost library (included by the PICSAR QED module), I've modified the QED modules so that they can be compiled without including Boost. This is enough to perform simulations (Boost is only needed to generate some lookup tables). For now, these changes are on the QED branch of picsar, not on the master branch. For this reason I had to modify also run_test.sh, so that this branch is chosen when QED=TRUE.  
