### PR TITLE
[mini-PR] do not check double newline in WarpX-tests.ini

### DIFF
--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -41,15 +41,15 @@ text = re.sub( 'numprocs = \d+', 'numprocs = 1', text)
 text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
 
 # Remove Python test (does not compile)
-text = re.sub( '\[Python_Langmuir\]\n(.+\n)*\n', '', text)
+text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
 
 # Remove Langmuir_x/y/z test (too long; not that useful)
-text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*\n', '', text)
+text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*', '', text)
 
 # Remove tests that do not have the right dimension
 if dim is not None:
     print('Selecting tests with dim = %s' %dim)
-    text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*\n' %dim, '', text)
+    text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*' %dim, '', text)
 
 # Remove or keep QED tests according to 'qed' variable
 if qed is not None:


### PR DESCRIPTION
PR https://github.com/ECP-WarpX/WarpX/pull/472 made (among other things) three changes like replacing
```py
text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
```
by
```py
text = re.sub( '\[Python_Langmuir\]\n(.+\n)*\n', '', text)
```
One consequence is that the last test may not be properly located among `TEST_DIM_3D` or `TEST_DIM_2D` if there are not two newlines at the end of file `WarpX-tests.ini`. Because of that I ended up with a 2D test in the 3D list, thus requiring an additional compilation.

This PR just reverts these changes.