### PR TITLE
Perftest2

### DIFF
--- a/Tools/performance_tests/automated_test_5_loadimbalance
+++ b/Tools/performance_tests/automated_test_5_loadimbalance
@@ -17,7 +17,7 @@ geometry.prob_lo     = -20.e-6   -20.e-6   -20.e-6    # physical domain
 geometry.prob_hi     =  20.e-6    20.e-6    20.e-6
 
 warpx.verbose = 1
-warpx.load_balance_int = 5
+warpx.load_balance_int = -5
 interpolation.nox = 3
 interpolation.noy = 3
 interpolation.noz = 3

--- a/Tools/performance_tests/functions_perftest.py
+++ b/Tools/performance_tests/functions_perftest.py
@@ -174,6 +174,7 @@ def get_nsteps(run_name):
 def extract_dataframe(filename, n_steps):
     # Get init time and total time through Inclusive time
     partition_limit_start = 'NCalls  Incl. Min  Incl. Avg  Incl. Max   Max %'
+    print(filename)
     with open(filename) as file_handler:
         output_text = file_handler.read()
     # get total simulation time

--- a/Tools/performance_tests/run_automated.py
+++ b/Tools/performance_tests/run_automated.py
@@ -95,9 +95,10 @@ if args.automated == True:
     update_perf_log_repo = True
     push_on_perf_log_repo = False
     pull_3_repos = True
-    recompile = True
+    # recompile = True
+    recompile = False
     if machine == 'summit':
-        compiler = 'pgi'
+        compiler = 'gnu'
         architecture = 'gpu'
 
 # List of tests to perform
@@ -122,11 +123,12 @@ compiler_name = {'intel': 'intel', 'gnu': 'gcc', 'pgi':'pgi'}
 module_Cname = {'cpu': 'haswell', 'knl': 'knl,quad,cache', 'gpu':''}
 csv_file = {'cori':'cori_knl.csv', 'summit':'summit.csv'}
 cwd = os.getcwd() + '/'
+cwd = warpx_dir + 'Tools/performance_tests/'
+print('cwd = ' + cwd)
 bin_dir = cwd + 'Bin/'
 bin_name = executable_name(compiler, architecture)
 
 log_dir  = cwd
-perf_database_file = cwd + perf_database_file
 day = time.strftime('%d')
 month = time.strftime('%m')
 year = time.strftime('%Y')
@@ -149,8 +151,8 @@ if args.mode == 'run':
             git_repo.pull()
             git_repo = git.cmd.Git( amrex_dir  )
             git_repo.pull()
-            git_repo = git.cmd.Git( warpx_dir  )
-            git_repo.pull()
+            # git_repo = git.cmd.Git( warpx_dir  )
+            # git_repo.pull()
 
         # Copy WarpX/GNUmakefile to current directory and recompile
         # with specific options for automated performance tests.
@@ -247,15 +249,14 @@ for n_node in n_node_list:
                 df_newline['inputs_content'] = get_file_content( filename=cwd+current_run.input_file )
             # Load file perf_database_file if exists, and
             # append with results from this scan
-            if os.path.exists(perf_database_file):
-                # df_base = pd.read_hdf(perf_database_file, 'all_data', format='table')
-                df_base = pd.read_hdf(perf_database_file, 'all_data')
+            if os.path.exists(perf_logs_repo + '/logs_hdf5/' + perf_database_file):
+                df_base = pd.read_hdf(perf_logs_repo + '/logs_hdf5/' + perf_database_file, 'all_data')
                 updated_df = df_base.append(df_newline, ignore_index=True)
             else:
                 updated_df = df_newline
             # Write dataframe to file perf_database_file
             # (overwrite if file exists)
-            updated_df.to_hdf(perf_database_file, key='all_data', mode='w')
+            updated_df.to_hdf(perf_logs_repo + '/logs_hdf5/' + perf_database_file, key='all_data', mode='w', format='table')
 
 # Extract sub-set of pandas data frame, write it to
 # csv file and copy this file to perf_logs repo
@@ -267,7 +268,7 @@ if update_perf_log_repo:
         git_repo.git.stash('save')
         git_repo.git.pull()
     # move csv file to perf_logs repon and commit the new version
-    shutil.move( perf_database_file, perf_logs_repo + '/logs_hdf5/' + perf_database_file )
+    # shutil.copyfile( perf_database_file, perf_logs_repo + '/logs_hdf5/' + perf_database_file )
     os.chdir( perf_logs_repo )
     sys.path.append('./')
     import generate_index_html

--- a/Tools/performance_tests/run_automated.py
+++ b/Tools/performance_tests/run_automated.py
@@ -121,7 +121,7 @@ perf_logs_repo = source_dir_base + 'perf_logs/'
 compiler_name = {'intel': 'intel', 'gnu': 'gcc', 'pgi':'pgi'}
 module_Cname = {'cpu': 'haswell', 'knl': 'knl,quad,cache', 'gpu':''}
 csv_file = {'cori':'cori_knl.csv', 'summit':'summit.csv'}
-cwd = os.getcwd() + '/'
+# cwd = os.getcwd() + '/'
 cwd = warpx_dir + 'Tools/performance_tests/'
 print('cwd = ' + cwd)
 bin_dir = cwd + 'Bin/'
@@ -266,8 +266,6 @@ if update_perf_log_repo:
     if push_on_perf_log_repo:
         git_repo.git.stash('save')
         git_repo.git.pull()
-    # move csv file to perf_logs repon and commit the new version
-    # shutil.copyfile( perf_database_file, perf_logs_repo + '/logs_hdf5/' + perf_database_file )
     os.chdir( perf_logs_repo )
     sys.path.append('./')
     import generate_index_html

--- a/Tools/performance_tests/run_automated.py
+++ b/Tools/performance_tests/run_automated.py
@@ -95,8 +95,7 @@ if args.automated == True:
     update_perf_log_repo = True
     push_on_perf_log_repo = False
     pull_3_repos = True
-    # recompile = True
-    recompile = False
+    recompile = True
     if machine == 'summit':
         compiler = 'gnu'
         architecture = 'gpu'
@@ -151,8 +150,8 @@ if args.mode == 'run':
             git_repo.pull()
             git_repo = git.cmd.Git( amrex_dir  )
             git_repo.pull()
-            # git_repo = git.cmd.Git( warpx_dir  )
-            # git_repo.pull()
+            git_repo = git.cmd.Git( warpx_dir  )
+            git_repo.pull()
 
         # Copy WarpX/GNUmakefile to current directory and recompile
         # with specific options for automated performance tests.

--- a/Tools/performance_tests/summit.py
+++ b/Tools/performance_tests/summit.py
@@ -5,11 +5,11 @@ import os, copy
 from functions_perftest import test_element
 
 def executable_name(compiler,architecture):
-    return 'perf_tests3d.' + compiler + '.TPROF.MPI.ACC.CUDA.ex'
+    return 'perf_tests3d.' + compiler + '.TPROF.MPI.CUDA.ex'
 
 def get_config_command(compiler, architecture):
     config_command = ''
-    config_command += 'module load pgi;'
+    config_command += 'module load gcc;'
     config_command += 'module load cuda;'
     return config_command
 
@@ -66,7 +66,7 @@ def get_batch_string(test_list, job_time_min, Cname, n_node):
     batch_string += '#BSUB -nnodes ' + str(n_node) + '\n'
     batch_string += '#BSUB -J ' + test_list[0].input_file + '\n'
     batch_string += '#BSUB -e error.txt\n'
-    batch_string += 'module load pgi\n'
+    batch_string += 'module load gcc\n'
     batch_string += 'module load cuda\n'
     return batch_string
 
@@ -113,14 +113,14 @@ def get_test_list(n_repeat):
     test_list_unq.append( test_element(input_file='automated_test_4_labdiags_2ppc',
                                        n_mpi_per_node=6,
                                        n_omp=1,
-                                       n_cell=[384, 512, 512],
+                                       n_cell=[384, 256, 512],
                                        max_grid_size=256,
                                        blocking_factor=128,
                                        n_step=50) )
     test_list_unq.append( test_element(input_file='automated_test_5_loadimbalance',
                                        n_mpi_per_node=6,
                                        n_omp=1,
-                                       n_cell=[64, 128, 192],
+                                       n_cell=[64, 64, 192],
                                        max_grid_size=64,
                                        blocking_factor=32,
                                        n_step=10) )


### PR DESCRIPTION
- use GNU instead of PGI compiler on Summit
- turn load balancing off as it gives error on Summit
- cleaner handling of h5 files
- pass option `format='table'` to `pandas.to_hdf` to avoid errors with `numpy>=1.16.0`
- reduce problem size of some tests so that it fits in GPU memory
