### PR TITLE
[mini-PR] fix two bugs related to QED modules and photons

### DIFF
--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -215,8 +215,8 @@ protected:
 
 #ifdef WARPX_QED
     // The QED engines
-    BreitWheelerEngine bw_engine;
-    QuantumSynchrotronEngine qs_engine;
+    std::shared_ptr<BreitWheelerEngine> shr_p_bw_engine;
+    std::shared_ptr<QuantumSynchrotronEngine> shr_p_qs_engine;
     //_______________________________
 
     //Initialize QED engines and provides smart pointers

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -736,14 +736,17 @@ MultiParticleContainer::doFieldIonization ()
 #ifdef WARPX_QED
 void MultiParticleContainer::InitQED ()
 {
+    shr_p_qs_engine = std::make_shared<QuantumSynchrotronEngine>();
+    shr_p_bw_engine = std::make_shared<BreitWheelerEngine>();
+
     for (auto& pc : allcontainers) {
         if(pc->has_quantum_sync()){
             pc->set_quantum_sync_engine_ptr
-                (std::make_shared<QuantumSynchrotronEngine>(qs_engine));
+                (shr_p_qs_engine);
         }
         if(pc->has_breit_wheeler()){
             pc->set_breit_wheeler_engine_ptr
-                (std::make_shared<BreitWheelerEngine>(bw_engine));
+                (shr_p_bw_engine);
         }
     }
 }

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -45,9 +45,8 @@ void PhotonParticleContainer::InitData()
 {
     AddParticles(0); // Note - add on level 0
 
-    if (maxLevel() > 0) {
-        Redistribute();  // We then redistribute
-    }
+    Redistribute();  // We then redistribute
+
 }
 
 void


### PR DESCRIPTION
This mini-PR fixes two distinct bugs:
- incorrect use of smart pointers for QED engines
- incorrect initialization of photons in ``` PhotonParticleContainer::InitData() ```

I have to confess that I do not fully understand the reason why the previous version of ``` PhotonParticleContainer::InitData() ``` was wrong. However, valgrind told me that I was using uninitialized memory (allocated from this routine). Then I noticed that ```InitData()``` was slightly different from the analogous routine in PhysicalParticleContainer.cpp . So I made it identical and now valgrind does not complain anymore. 
 