### PR TITLE
[mini-PR] Using abbreviation BTD to shorten names of TravisCI tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -134,7 +134,7 @@ doComparison = 0
 aux1File = Tools/read_raw_data.py
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
 
-[3D_BTD_ReducedDiag]
+[BTD_ReducedSliceDiag]
 buildDir = .
 inputFile = Examples/Modules/boosted_diags/inputs.3d.slice
 dim = 3

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -117,7 +117,7 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
 
-[RigidInjection_boost_backtransformed]
+[RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs.BoostedFrame
 dim = 2
@@ -134,7 +134,7 @@ doComparison = 0
 aux1File = Tools/read_raw_data.py
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
 
-[Boost_3Dbacktransformed_CheckReducedDiagnostics]
+[3D_BTD_ReducedDiag]
 buildDir = .
 inputFile = Examples/Modules/boosted_diags/inputs.3d.slice
 dim = 3


### PR DESCRIPTION
BTD, an abbreviation for back-transformed diagnostics, is used to shorten the name of the regression tests for readability. 