### PR TITLE
Marke the strt_total variable as a constexpr.

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
     BL_PROFILE_VAR("main()", pmain);
 
-    const Real strt_total = amrex::second();
+    constexpr Real strt_total = amrex::second();
 
     {
         WarpX warpx;


### PR DESCRIPTION
Since the strt_total variable can be determined at compile time, I updated the variable to a constexpr.