### PR TITLE
Use 2 MPI rank for each Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     - bash Miniconda3-latest-Linux-x86_64.sh -b
     - export PATH=/home/travis/miniconda3/bin:$PATH
-    - pip install --upgrade pip && pip install numpy scipy matplotlib yt mpi4py
+    - pip install --upgrade pip && pip install numpy scipy matplotlib mpi4py cython
+    - pip install git+https://github.com/yt-project/yt.git
 
 script:
     - export FFTW_HOME=/usr/

--- a/Examples/Tests/Larmor/inputs.mr
+++ b/Examples/Tests/Larmor/inputs.mr
@@ -2,7 +2,7 @@
 max_step = 400
 
 # number of grid points
-amr.n_cell =  32  32
+amr.n_cell =  64  64
 
 # The lo and hi ends of grids are multipliers of blocking factor
 amr.blocking_factor = 16

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -37,7 +37,7 @@ print('Compiling for %s' %arch)
 text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )
 
 # Use only 1 MPI and 1 thread proc for tests
-text = re.sub( 'numprocs = \d+', 'numprocs = 1', text)
+text = re.sub( 'numprocs = \d+', 'numprocs = 2', text)
 text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
 
 # Remove Python test (does not compile)


### PR DESCRIPTION
The Travis tests were using only one MPI rank up to now.
In order to test the robustness of the MPI implementation, it makes sense to use 2 MPI ranks.