### PR TITLE
Launch RZ tests on a separate Travis instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: true
 env:
   matrix:
     - WARPX_TEST_DIM=3 HAS_QED=FALSE
+    - WARPX_TEST_DIM=RZ HAS_QED=FALSE
     - WARPX_TEST_DIM=2 HAS_QED=FALSE
     - HAS_QED=TRUE
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,8 @@ it can be convenient to run the tests on your local machine with
 ./run_tests.sh
 ```
 from WarpX root folder. The tests can be influenced by environment variables:
-- `export WARPX_TEST_DIM=3` or `export WARPX_TEST_DIM=2` in order to select
-only the tests that correspond to this dimension
+- `export WARPX_TEST_DIM=3`, `export WARPX_TEST_DIM=2` or `export WARPX_TEST_DIM=RZ` 
+in order to select only the tests that correspond to this dimensionality
 - `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order to
 run the tests on CPU or GPU respectively.
 - `export WARPX_TEST_COMMIT=...` in order to test a specific commit.

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -56,7 +56,7 @@ test_blocks =  [ match[0] for match in re.findall(select_test_regex, text) ]
 # - Remove the test blocks from `text` (only the selected ones will be added back)
 text = re.sub( select_test_regex, '', text )
 
-# Keep tests that do not have the right dimension
+# Keep tests that have the right dimension
 if dim is not None:
     print('Selecting tests with dim = %s' %dim)
     # Cartesian tests

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -35,10 +35,11 @@ print('Compiling for %s' %arch)
 
 # Use only 2 cores for compiling
 text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )
-
 # Use only 1 MPI and 1 thread proc for tests
 text = re.sub( 'numprocs = \d+', 'numprocs = 1', text)
 text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
+# Prevent emails from being sent
+text = re.sub( 'sendEmailWhenFail = 1', 'sendEmailWhenFail = 0', text )
 
 # Remove Python test (does not compile)
 text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
@@ -46,22 +47,37 @@ text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
 # Remove Langmuir_x/y/z test (too long; not that useful)
 text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*', '', text)
 
-# Remove tests that do not have the right dimension
+# Select the tests to be run
+# --------------------------
+
+# - Extract test blocks (they are identified by the fact that they contain "inputFile")
+select_test_regex = r'(\[(.+\n)*inputFile(.+\n)*)'
+test_blocks =  [ match[0] for match in re.findall(select_test_regex, text) ]
+# - Remove the test blocks from `text` (only the selected ones will be added back)
+text = re.sub( select_test_regex, '', text )
+
+# Keep tests that do not have the right dimension
 if dim is not None:
     print('Selecting tests with dim = %s' %dim)
-    text = re.sub('\[.+\n(.+\n)*dim = [^%s]\n(.+\n)*' %dim, '', text)
+    # Cartesian tests
+    if dim in ['2', '3']:
+        test_blocks = [ block for block in test_blocks \
+             if ('dim = %s'%dim in block) and not ('USE_RZ' in block) ]
+    elif dim == 'RZ':
+        test_blocks = [ block for block in test_blocks if 'USE_RZ' in block ]
+    else:
+        raise ValueError('Unkown dimension: %s' %dim)
 
 # Remove or keep QED tests according to 'qed' variable
 if qed is not None:
     print('Selecting tests with QED = %s' %qed)
     if (qed == "FALSE"):
-        text = re.sub('\[qed.+\n(.+\n)*\n*', '', text)
+        test_blocks = [ block for block in test_blocks if not block.startswith('[qed') ]
     else:
-        text = re.sub('^\[(?!qed).*$\n(.+\n)*(dim = .+\n)(.+\n)*\n*', '', text, flags=re.MULTILINE)
+        test_blocks = [ block for block in test_blocks if block.startswith('[qed') ]
 
-
-# Prevent emails from being sent
-text = re.sub( 'sendEmailWhenFail = 1', 'sendEmailWhenFail = 0', text )
+# - Add the selected test blocks to the text
+text = text + '\n' + '\n'.join(test_blocks)
 
 with open('travis-tests.ini', 'w') as f:
     f.write(text)

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -72,9 +72,9 @@ if dim is not None:
 if qed is not None:
     print('Selecting tests with QED = %s' %qed)
     if (qed == "FALSE"):
-        test_blocks = [ block for block in test_blocks if not block.startswith('[qed') ]
+        test_blocks = [ block for block in test_blocks if not 'QED=TRUE' in block ]
     else:
-        test_blocks = [ block for block in test_blocks if block.startswith('[qed') ]
+        test_blocks = [ block for block in test_blocks if 'QED=TRUE' in block ]
 
 # - Add the selected test blocks to the text
 text = text + '\n' + '\n'.join(test_blocks)


### PR DESCRIPTION
This adds the option to do `export WARPX_TEST_DIM=RZ` in order to select only the RZ tests.

Because this was not easy to do with regex, I refactor/simplified some of the code, so as to do some of the selection with simple Python instead of regex. (Although I am truly in admiration of some of the regex that were use for the qed selection!)