### PR TITLE
Crash if unused variables only for TravisCI tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -105,7 +105,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs.LabFrame
-runtime_params = 
+runtime_params =
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -121,7 +121,7 @@ analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFr
 [RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs.BoostedFrame
-runtime_params = 
+runtime_params =
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -156,7 +156,7 @@ analysisRoutine = Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag
 [nci_corrector]
 buildDir = .
 inputFile = Examples/Modules/nci_corrector/inputs.2d
-runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1 
+runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -188,7 +188,7 @@ analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
 [ionization_lab]
 buildDir = .
 inputFile = Examples/Modules/ionization/inputs.rt
-runtime_params = 
+runtime_params =
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -203,7 +203,7 @@ analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
 [ionization_boost]
 buildDir = .
 inputFile = Examples/Modules/ionization/inputs.bf.rt
-runtime_params = 
+runtime_params =
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -218,7 +218,7 @@ analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
 [bilinear_filter]
 buildDir = .
 inputFile = Examples/Tests/SingleParticle/inputs
-runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5 
+runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -233,7 +233,7 @@ analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
 [Langmuir_2d]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex 
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -251,7 +251,7 @@ analysisOutputImage = langmuir2d_analysis.png
 [Langmuir_2d_nompi]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex 
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
 dim = 2
 addToCompileString =
 restartTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -60,7 +60,7 @@ branch = master
 [pml_x_yee]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs.2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=yee amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=yee
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -75,7 +75,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_yee.py
 [pml_x_ckc]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs.2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=ckc amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=ckc
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -90,7 +90,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
 [pml_x_psatd]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs.2d
-runtime_params = warpx.do_dynamic_scheduling=0 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -105,7 +105,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs.LabFrame
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params = 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -121,7 +121,7 @@ analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFr
 [RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs.BoostedFrame
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params = 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -156,7 +156,7 @@ analysisRoutine = Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag
 [nci_corrector]
 buildDir = .
 inputFile = Examples/Modules/nci_corrector/inputs.2d
-runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1 amrex.abort_on_unused_inputs=1
+runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -172,7 +172,7 @@ analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
 [nci_correctorMR]
 buildDir = .
 inputFile = Examples/Modules/nci_corrector/inputs.2d
-runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 amrex.abort_on_unused_inputs=1 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
+runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -188,7 +188,7 @@ analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
 [ionization_lab]
 buildDir = .
 inputFile = Examples/Modules/ionization/inputs.rt
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params = 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -203,7 +203,7 @@ analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
 [ionization_boost]
 buildDir = .
 inputFile = Examples/Modules/ionization/inputs.bf.rt
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params = 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -218,7 +218,7 @@ analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
 [bilinear_filter]
 buildDir = .
 inputFile = Examples/Tests/SingleParticle/inputs
-runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -233,7 +233,7 @@ analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
 [Langmuir_2d]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex amrex.abort_on_unused_inputs=1
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -251,7 +251,7 @@ analysisOutputImage = langmuir2d_analysis.png
 [Langmuir_2d_nompi]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex amrex.abort_on_unused_inputs=1
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex 
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -269,7 +269,7 @@ analysisOutputImage = langmuir2d_analysis.png
 [Langmuir_x]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ex jx electrons.plot_vars=w ux Ex amrex.abort_on_unused_inputs=1
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ex jx electrons.plot_vars=w ux Ex
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -287,7 +287,7 @@ analysisOutputImage = langmuir_x_analysis.png
 [Langmuir_y]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.uy=0.01 electrons.ymax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ey jy electrons.plot_vars=w uy Ey amrex.abort_on_unused_inputs=1
+runtime_params = electrons.uy=0.01 electrons.ymax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ey jy electrons.plot_vars=w uy Ey
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -305,7 +305,7 @@ analysisOutputImage = langmuir_y_analysis.png
 [Langmuir_z]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.rt
-runtime_params = electrons.uz=0.01 electrons.zmax=0.e-6 warpx.do_dynamic_scheduling=0  warpx.fields_to_plot = Ez jz electrons.plot_vars=w uz Ez amrex.abort_on_unused_inputs=1
+runtime_params = electrons.uz=0.01 electrons.zmax=0.e-6 warpx.do_dynamic_scheduling=0  warpx.fields_to_plot = Ez jz electrons.plot_vars=w uz Ez
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -323,7 +323,7 @@ analysisOutputImage = langmuir_z_analysis.png
 [Langmuir_multi]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.rt
-runtime_params = warpx.do_dynamic_scheduling=0 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -341,7 +341,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -359,7 +359,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.rt
-runtime_params = psatd.fftw_plan_measure=0 amrex.abort_on_unused_inputs=1
+runtime_params = psatd.fftw_plan_measure=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -378,7 +378,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.rt
-runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 amrex.abort_on_unused_inputs=1
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -397,7 +397,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_2d_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
-runtime_params = warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -415,7 +415,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
-runtime_params = psatd.fftw_plan_measure=0 electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell amrex.abort_on_unused_inputs=1
+runtime_params = psatd.fftw_plan_measure=0 electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -433,7 +433,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.2d.rt
-runtime_params = psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell amrex.abort_on_unused_inputs=1
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -451,7 +451,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_rz]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs.multi.rz.rt
-runtime_params = electrons.plot_vars=w ux uy uz Ex Ey Ez Bx By ions.plot_vars=w ux uy uz Ex Ey Ez Bx By amrex.abort_on_unused_inputs=1
+runtime_params = electrons.plot_vars=w ux uy uz Ex Ey Ez Bx By ions.plot_vars=w ux uy uz Ex Ey Ez Bx By
 dim = 2
 addToCompileString = USE_RZ=TRUE
 restartTest = 0
@@ -469,7 +469,7 @@ analysisOutputImage = langmuir_multi_rz_analysis.png
 [Python_Langmuir_rz_multimode]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
@@ -487,7 +487,7 @@ outputFile = diags/plotfiles/plt00040
 [LaserInjection]
 buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs.rt
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -504,7 +504,7 @@ analysisOutputImage = laser_analysis.png
 [LaserInjection_2d]
 buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs.2d.rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -519,7 +519,7 @@ compareParticles = 0
 [LaserAcceleration]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs.3d
-runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -535,7 +535,7 @@ particleTypes = electrons
 [subcyclingMR]
 buildDir = .
 inputFile = Examples/Tests/subcycling/inputs.2d
-runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0 amrex.abort_on_unused_inputs=1
+runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -551,7 +551,7 @@ compareParticles = 0
 [LaserAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs.2d
-runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 amrex.abort_on_unused_inputs=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
+runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -567,7 +567,7 @@ particleTypes = electrons beam
 [PlasmaAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs.2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0 amrex.abort_on_unused_inputs=1
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -583,7 +583,7 @@ particleTypes = beam driver plasma_e
 [Python_Langmuir]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rt.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
@@ -601,7 +601,7 @@ outputFile = diags/plotfiles/plt00040
 [uniform_plasma_restart]
 buildDir = .
 inputFile = Examples/Physics_applications/uniform_plasma/inputs.3d
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 3
 addToCompileString =
 restartTest = 1
@@ -619,7 +619,7 @@ tolerance = 1.e-14
 [particles_in_pml_2d]
 buildDir = .
 inputFile = Examples/Tests/particles_in_PML/inputs.2d
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 2
 restartTest = 0
 useMPI = 1
@@ -634,7 +634,7 @@ analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 [particles_in_pml]
 buildDir = .
 inputFile = Examples/Tests/particles_in_PML/inputs
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 3
 restartTest = 0
 useMPI = 1
@@ -649,7 +649,7 @@ analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 [photon_pusher]
 buildDir = .
 inputFile = Examples/Tests/photon_pusher/inputs
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 3
 restartTest = 0
 useMPI = 1
@@ -679,7 +679,7 @@ analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/ana
 [qed_breit_wheeler_tau_init]
 buildDir = .
 inputFile = Examples/Modules/qed/breit_wheeler/inputs.2d_test_tau_init
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 2
 addToCompileString = QED=TRUE
 restartTest = 0
@@ -695,7 +695,7 @@ analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
 [qed_quantum_sync_tau_init]
 buildDir = .
 inputFile = Examples/Modules/qed/quantum_synchrotron/inputs.2d_test_tau_init
-runtime_params = amrex.abort_on_unused_inputs=1
+runtime_params =
 dim = 2
 addToCompileString = QED=TRUE
 restartTest = 0

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -29,9 +29,14 @@ text = re.sub( '\[(?P<name>.*)\]\nbuildDir = ',
 # Change compile options when running on GPU
 if arch == 'GPU':
     text = re.sub( 'addToCompileString =',
-                    'addToCompileString = USE_GPU=TRUE USE_OMP=FALSE USE_ACC=TRUE', text)
+                    'addToCompileString = USE_GPU=TRUE USE_OMP=FALSE USE_ACC=TRUE ', text)
     text = re.sub( 'COMP\s*=.*', 'COMP = pgi', text )
 print('Compiling for %s' %arch)
+
+# Add runtime option: crash for unused variables
+test = re.sub('runtime_params =',
+              'runtime_params = amrex.abort_on_unused_inputs=1 ',
+              test)
 
 # Use only 2 cores for compiling
 text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -34,9 +34,9 @@ if arch == 'GPU':
 print('Compiling for %s' %arch)
 
 # Add runtime option: crash for unused variables
-test = re.sub('runtime_params =',
+text = re.sub('runtime_params =',
               'runtime_params = amrex.abort_on_unused_inputs=1 ',
-              test)
+              text)
 
 # Use only 2 cores for compiling
 text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )


### PR DESCRIPTION
This should fix nightly regression tests, but still make TravisCI tests crash if unused variables are present in input files.