### PR TITLE
exchange F guard cells at the end of PIC loop

### DIFF
--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -319,6 +319,7 @@ WarpX::OneStep_nosub (Real cur_time)
     EvolveE(dt[0]); // We now have E^{n+1}
     FillBoundaryE();
     EvolveF(0.5*dt[0], DtType::SecondHalf);
+    FillBoundaryF();
     EvolveB(0.5*dt[0]); // We now have B^{n+1}
     if (do_pml) {
         DampPML();


### PR DESCRIPTION
I think there is a call to `FillBoundaryF` that is missing in the main PIC loop. @WeiqunZhang do you agree it should be there?

I noticed it when trying to reduce the calls to FillBoundary, as I could not reproduce the results from the `dev` branch.