### PR TITLE
Call RedistributeGPU on GPU

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -321,11 +321,7 @@ void
 MultiParticleContainer::Redistribute ()
 {
     for (auto& pc : allcontainers) {
-        if ( (pc->NumRuntimeRealComps()>0) || (pc->NumRuntimeIntComps()>0) ) {
-            pc->RedistributeCPU();
-        } else {
-            pc->Redistribute();
-        }
+        pc->Redistribute();
     }
 }
 
@@ -333,11 +329,7 @@ void
 MultiParticleContainer::RedistributeLocal (const int num_ghost)
 {
     for (auto& pc : allcontainers) {
-        if ( (pc->NumRuntimeRealComps()>0) || (pc->NumRuntimeIntComps()>0) ) {
-            pc->RedistributeCPU(0, 0, 0, num_ghost);
-        } else {
-            pc->Redistribute(0, 0, 0, num_ghost);
-        }
+        pc->Redistribute(0, 0, 0, num_ghost);
     }
 }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -62,16 +62,6 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         "Radiation reaction can be enabled only if Boris pusher is used");
     //_____________________________
 
-#ifdef AMREX_USE_GPU
-    Print()<<"\n-----------------------------------------------------\n";
-    Print()<<"WARNING: field ionization on GPU uses RedistributeCPU\n";
-    Print()<<"-----------------------------------------------------\n\n";
-    //AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        //do_field_ionization == 0,
-        //"Field ionization does not work on GPU so far, because the current "
-        //"version of Redistribute in AMReX does not work with runtime parameters");
-#endif
-
 #ifdef WARPX_QED
     //Add real component if QED is enabled
     pp.query("do_qed", m_do_qed);


### PR DESCRIPTION
The previous version of AMReX's `RedistributeGPU` was not compatible with runtime particle attributes, so we always used `RedistributeCPU` for species with runtime attributes.
Since @atmyers fixed that in AMReX, we can call `RedistributeGPU` instead, and remove the warning. Upon merging this PR, we should also close issue https://github.com/ECP-WarpX/WarpX/issues/498.