### PR TITLE
automated tests must not modify html file

### DIFF
--- a/Tools/performance_tests/run_automated.py
+++ b/Tools/performance_tests/run_automated.py
@@ -290,8 +290,7 @@ if args.mode=='read' and update_perf_log_repo:
         git_repo.git.pull()
     os.chdir( perf_logs_repo )
     sys.path.append('./')
-    import generate_index_html
-    git_repo.git.add('./index.html')
+    import write_csv
     git_repo.git.add('./logs_csv/' + csv_file[machine])
     git_repo.git.add('./logs_hdf5/' + perf_database_file)
     index = git_repo.index


### PR DESCRIPTION
It results in conflicts between Cori and Summit performance tests. The user should do it themselves.

Instead, the automated tests update `csv` files and commit them. The user should then do:
```
cd perf_logs
git pull
python generate_index_html.py
git add index.html
git commit -m "update performance tests results from Cori/Summit"
```
An alternative would be to write into two different html files.