### PR TITLE
Move finestLevel() calculation outside of for loop condition statements

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -172,8 +172,7 @@ PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
     }
 
     const int nLevels = finestLevel();
-
-    for (int lev=0; lev<=nLevels; ++lev){
+    for (int lev=0; lev<=nLevels; lev++){
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -171,8 +171,9 @@ PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
         factor = 1./mass;
     }
 
-    const auto& finestLevel = finestLevel();
-    for (int lev=0; lev<=finestLevel; ++lev){
+    const int nLevels = finestLevel();
+
+    for (int lev=0; lev<=nLevels; ++lev){
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -1,4 +1,3 @@
-
 #include <MultiParticleContainer.H>
 #include <WarpX.H>
 
@@ -172,7 +171,8 @@ PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
         factor = 1./mass;
     }
 
-    for (int lev=0; lev<=finestLevel(); lev++){
+    const auto& finestLevel = finestLevel();
+    for (int lev=0; lev<=finestLevel; ++lev){
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -1,4 +1,3 @@
-
 #include <WarpX.H>
 #include <AMReX_BLProfiler.H>
 
@@ -12,7 +11,9 @@ WarpX::LoadBalance ()
 
     AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
 
-    for (int lev = 0; lev <= finestLevel(); ++lev)
+    const int nLevels = finestLevel();
+
+    for (int lev = 0; lev <= nLevels; ++lev)
     {
         const Real nboxes = costs[lev]->size();
         const Real nprocs = ParallelDescriptor::NProcs();

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -12,7 +12,6 @@ WarpX::LoadBalance ()
     AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
 
     const int nLevels = finestLevel();
-
     for (int lev = 0; lev <= nLevels; ++lev)
     {
         const Real nboxes = costs[lev]->size();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -513,7 +513,7 @@ WarpXParticleContainer::DepositCharge (Vector<std::unique_ptr<MultiFab> >& rho,
                                         bool do_rz_volume_scaling)
 {
     // Loop over the refinement levels
-    const int finest_level = rho.size() - 1;
+    int const finest_level = rho.size() - 1;
     for (int lev = 0; lev <= finest_level; ++lev) {
 
         // Reset the `rho` array if `reset` is True
@@ -566,7 +566,7 @@ WarpXParticleContainer::DepositCharge (Vector<std::unique_ptr<MultiFab> >& rho,
         MultiFab coarsened_fine_data(coarsened_fine_BA, fine_dm, rho[lev+1]->nComp(), 0);
         coarsened_fine_data.setVal(0.0);
 
-        const int refinement_ratio = 2;
+        int const refinement_ratio = 2;
 
         interpolateDensityFineToCoarse( *rho[lev+1], coarsened_fine_data, refinement_ratio );
         rho[lev]->ParallelAdd( coarsened_fine_data, m_gdb->Geom(lev).periodicity() );
@@ -632,7 +632,6 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
     amrex::Real total_charge = 0.0;
 
     const int nLevels = finestLevel();
-
     for (int lev = 0; lev < nLevels; ++lev)
     {
 
@@ -664,7 +663,6 @@ std::array<Real, 3> WarpXParticleContainer::meanParticleVelocity(bool local) {
     amrex::Real inv_clight_sq = 1.0/PhysConst::c/PhysConst::c;
 
     const int nLevels = finestLevel();
-
     for (int lev = 0; lev <= nLevels; ++lev) {
 
 #ifdef _OPENMP
@@ -710,7 +708,6 @@ Real WarpXParticleContainer::maxParticleVelocity(bool local) {
     amrex::ParticleReal max_v = 0.0;
 
     const int nLevels = finestLevel();
-
     for (int lev = 0; lev <= nLevels; ++lev)
     {
 
@@ -767,7 +764,6 @@ void
 WarpXParticleContainer::PushX (Real dt)
 {
     const int nLevels = finestLevel();
-
     for (int lev = 0; lev <= nLevels; ++lev) {
         PushX(lev, dt);
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1,4 +1,3 @@
-
 #include <limits>
 
 #include <MultiParticleContainer.H>
@@ -514,7 +513,7 @@ WarpXParticleContainer::DepositCharge (Vector<std::unique_ptr<MultiFab> >& rho,
                                         bool do_rz_volume_scaling)
 {
     // Loop over the refinement levels
-    int const finest_level = rho.size() - 1;
+    const int finest_level = rho.size() - 1;
     for (int lev = 0; lev <= finest_level; ++lev) {
 
         // Reset the `rho` array if `reset` is True
@@ -567,7 +566,7 @@ WarpXParticleContainer::DepositCharge (Vector<std::unique_ptr<MultiFab> >& rho,
         MultiFab coarsened_fine_data(coarsened_fine_BA, fine_dm, rho[lev+1]->nComp(), 0);
         coarsened_fine_data.setVal(0.0);
 
-        int const refinement_ratio = 2;
+        const int refinement_ratio = 2;
 
         interpolateDensityFineToCoarse( *rho[lev+1], coarsened_fine_data, refinement_ratio );
         rho[lev]->ParallelAdd( coarsened_fine_data, m_gdb->Geom(lev).periodicity() );
@@ -632,7 +631,8 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
 
     amrex::Real total_charge = 0.0;
 
-    for (int lev = 0; lev < finestLevel(); ++lev)
+    const int nlevels = finestLevel();
+    for (int lev = 0; lev < nlevels; ++lev)
     {
 
 #ifdef _OPENMP
@@ -662,7 +662,9 @@ std::array<Real, 3> WarpXParticleContainer::meanParticleVelocity(bool local) {
 
     amrex::Real inv_clight_sq = 1.0/PhysConst::c/PhysConst::c;
 
-    for (int lev = 0; lev <= finestLevel(); ++lev) {
+    const int nLevels = finestLevel();
+
+    for (int lev = 0; lev <= nLevels; ++lev) {
 
 #ifdef _OPENMP
 #pragma omp parallel reduction(+:vx_total, vy_total, vz_total, np_total)
@@ -706,7 +708,9 @@ Real WarpXParticleContainer::maxParticleVelocity(bool local) {
 
     amrex::ParticleReal max_v = 0.0;
 
-    for (int lev = 0; lev <= finestLevel(); ++lev)
+    const int nLevels = finestLevel();
+
+    for (int lev = 0; lev <= nLevels; ++lev)
     {
 
 #ifdef _OPENMP
@@ -732,7 +736,7 @@ WarpXParticleContainer::PushXES (Real dt)
 {
     BL_PROFILE("WPC::PushXES()");
 
-    int num_levels = finestLevel() + 1;
+    const int num_levels = finestLevel() + 1;
 
     for (int lev = 0; lev < num_levels; ++lev) {
         const auto& gm = m_gdb->Geom(lev);
@@ -761,7 +765,9 @@ WarpXParticleContainer::PushXES (Real dt)
 void
 WarpXParticleContainer::PushX (Real dt)
 {
-    for (int lev = 0; lev <= finestLevel(); ++lev) {
+    const int nLevels = finestLevel();
+
+    for (int lev = 0; lev <= nLevels; ++lev) {
         PushX(lev, dt);
     }
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -631,8 +631,9 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
 
     amrex::Real total_charge = 0.0;
 
-    const int nlevels = finestLevel();
-    for (int lev = 0; lev < nlevels; ++lev)
+    const int nLevels = finestLevel();
+
+    for (int lev = 0; lev < nLevels; ++lev)
     {
 
 #ifdef _OPENMP


### PR DESCRIPTION
This PR moves the finestLevel() calculations from inside the for loop conditional statements so that they are only calculated once per for loop.

I changed a type declaration from an `int const` to a `const int` in one case.

I added a `const` prefixes to two int type declarations used in similar for loops.

I changed a level increment in one for loop to a prefix unary increment operator since it is typically faster than the postfix version.