### PR TITLE
Fix regression test configuration file

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -632,6 +632,7 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
+outputFile=space_charge_initialization_2d_plt00000
 
 [space_charge_initialization]
 buildDir = .
@@ -649,6 +650,7 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
+outputFile=space_charge_initialization_plt00000
 
 [relativistic_space_charge_initialization]
 buildDir = .
@@ -666,6 +668,7 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/relativistic_space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
+outputFile=relativistic_space_charge_initialization_plt00000
 
 [particles_in_pml_2d]
 buildDir = .
@@ -943,6 +946,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons
+outputFile = diags/plotfiles/plt00040
 
 [Python_Langmuir_rz_multimode]
 buildDir = .


### PR DESCRIPTION
Add outputFile to a number of tests so that the regression test script knowns the name of plotfile.