### PR TITLE
Add outputFile to Python tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -807,6 +807,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons
+outputFile = diags/plotfiles/plt00010
 
 [PlasmaAccelerationBoost2d]
 buildDir = .
@@ -837,6 +838,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = beam
+outputFile = diags/plotfiles/plt00010
 
 [Python_PlasmaAccelerationMR]
 buildDir = .
@@ -853,6 +855,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = beam
+outputFile = diags/plotfiles/plt00010
 
 [PlasmaAccelerationBoost3d]
 buildDir = .
@@ -930,6 +933,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons
+outputFile = diags/plotfiles/plt00010
 
 [Python_Langmuir_2d]
 buildDir = .


### PR DESCRIPTION
This PR is similar to #540 ; it adds the `outputFile` information to prevent errors in regression tests. 

For each of these different tests, the `max_steps` is `10`, and thus the chosen compared `outputFile` is the last one (`plt00010`).