### PR TITLE
Abort if the run is peridiodic in the moving window direction

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -327,7 +327,7 @@ WarpX::ReadParameters ()
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(moving_window_dir) == 0,
                        "The problem must be non-periodic in the moving window direction");
-            
+
             moving_window_x = geom[0].ProbLo(moving_window_dir);
 
             pp.get("moving_window_v", moving_window_v);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -325,6 +325,9 @@ WarpX::ReadParameters ()
                 amrex::Abort(msg.c_str());
             }
 
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(moving_window_dir) == 0,
+                       "The problem must be non-periodic in the moving window direction");
+            
             moving_window_x = geom[0].ProbLo(moving_window_dir);
 
             pp.get("moving_window_v", moving_window_v);


### PR DESCRIPTION
Currently, if you set the run to be periodic in the moving window direction, the code will run without complaint but may produce strange results. This caused me some confusion when trying to debug Issue #466. This adds a check and early abort for this mistake. 