### PR TITLE
Do not request python3 in radiation reaction analysis scripts

### DIFF
--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # This script contains few simple tests for the radiation reaction pusher
 # It initializes an electron or a positron with normalized momentum in different


### PR DESCRIPTION
The fact that this test requests `python3` in the shebang line causes it to fail on battra:
https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2019-12-03/radiation_reaction.analysis.out