### PR TITLE
fix_warnings

### DIFF
--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -22,6 +22,8 @@ InjectorDensity::~InjectorDensity ()
         object.predefined.clear();
         break;
     }
+    default:
+        return;
     }
 }
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -56,7 +56,7 @@ struct InjectorMomentumBoltzmann
     // boost velocity/c beta,
     // and boost direction dir respectively.
     InjectorMomentumBoltzmann(amrex::Real t, amrex::Real b, int d) noexcept
-        : vave(std::sqrt(2*t)), beta(b), dir(d)
+        : dir(d), beta(b), vave(std::sqrt(2.*t))
         {}
 
     AMREX_GPU_HOST_DEVICE
@@ -116,7 +116,7 @@ struct InjectorMomentumJuttner
     // boost velocity/c beta,
     // and boost direction dir respectively.
     InjectorMomentumJuttner(amrex::Real t, amrex::Real b, int d) noexcept
-        : theta(t), beta(b), dir(d)
+        : dir(d), beta(b), theta(t)
         {}
 
     AMREX_GPU_HOST_DEVICE

--- a/Source/Particles/ParticleCreation/ElementaryProcess.H
+++ b/Source/Particles/ParticleCreation/ElementaryProcess.H
@@ -164,7 +164,9 @@ public:
 
             // --- product runtime integer attribs
             int pid_product;
+#ifdef _OPENMP
 #pragma omp critical (doParticleCreation_nextid)
+#endif
             {
                 // ID of first newly-created product particle
                 pid_product = pc_product->NextID();


### PR DESCRIPTION
Fix warnings: unknown pragma, reorder in class member initialization, and no default switch case.
