### PR TITLE
Avoid matplotlib errors in space charge regression tests

### DIFF
--- a/Examples/Modules/relativistic_space_charge_initialization/analysis.py
+++ b/Examples/Modules/relativistic_space_charge_initialization/analysis.py
@@ -5,9 +5,11 @@ verifying that the space-charge field of a Gaussian beam corresponds to
 the expected theoretical field.
 """
 import sys
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import yt
 import numpy as np
-import matplotlib.pyplot as plt
 import scipy.constants as scc
 from scipy.special import gammainc
 yt.funcs.mylog.setLevel(0)

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -5,9 +5,11 @@ verifying that the space-charge field of a Gaussian beam corresponds to
 the expected theoretical field.
 """
 import sys
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import yt
 import numpy as np
-import matplotlib.pyplot as plt
 import scipy.constants as scc
 from scipy.special import gammainc
 yt.funcs.mylog.setLevel(0)


### PR DESCRIPTION
The space charge regression tests throw errors in the analysis script, because of an invalid matplotlib backend:
https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2019-12-04/relativistic_space_charge_initialization.analysis.out

This PR sets the backend to `Agg` in the same as in other analysis scripts that use `matplotlib`, e.g. [this Langmuir analysis script](https://github.com/ECP-WarpX/WarpX/blob/dev/Examples/Tests/Langmuir/analysis_langmuir_multi.py)