### PR TITLE
[mini-PR] Add digit separators to PhysConst::c

### DIFF
--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -13,7 +13,7 @@ namespace MathConst
 // https://physics.nist.gov/cuu/Constants/index.html
 namespace PhysConst
 {
-    static constexpr amrex::Real c     = 299792458.;
+    static constexpr amrex::Real c     = 299'792'458.;
     static constexpr amrex::Real ep0   = 8.8541878128e-12;
     static constexpr amrex::Real mu0   = 1.25663706212e-06;
     static constexpr amrex::Real q_e   = 1.602176634e-19;


### PR DESCRIPTION
This is really a min-PR! Since WarpX is now using C++14, we can use this new feature to make long numbers more readable