### PR TITLE
warpx.plot_costs

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -874,7 +874,7 @@ doVis = 0
 [PlasmaMirror]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_mirror/inputs.2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=256 128 max_step=20
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=256 128 max_step=20 warpx.plot_costs=0
 dim = 2
 addToCompileString =
 restartTest = 0

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -399,7 +399,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
     const int ncomp = fields_to_plot.size()
         + static_cast<int>(plot_finepatch)*6
         + static_cast<int>(plot_crsepatch)*6
-        + static_cast<int>(costs[0] != nullptr);
+        + static_cast<int>(costs[0] != nullptr and plot_costs);
 
     // Loop over levels of refinement
     for (int lev = 0; lev <= finest_level; ++lev)
@@ -558,7 +558,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             dcomp += 3;
         }
 
-        if (costs[0] != nullptr)
+        if (costs[0] != nullptr and plot_costs)
         {
             AverageAndPackScalarField( mf_avg[lev], *costs[lev], dcomp, ngrow );
             if(lev==0) varnames.push_back("costs");

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -554,6 +554,7 @@ private:
     bool dump_openpmd = false;
 #endif
     bool plot_rho           = false;
+    bool plot_costs         = true;
     bool plot_finepatch     = false;
     bool plot_crsepatch     = false;
     bool plot_raw_fields    = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -434,6 +434,7 @@ WarpX::ReadParameters ()
         pp.query("dump_openpmd", dump_openpmd);
         pp.query("openpmd_backend", openpmd_backend);
         pp.query("dump_plotfiles", dump_plotfiles);
+        pp.query("plot_costs", plot_costs);
         pp.query("plot_raw_fields", plot_raw_fields);
         pp.query("plot_raw_fields_guards", plot_raw_fields_guards);
         pp.query("plot_coarsening_ratio", plot_coarsening_ratio);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -379,7 +379,7 @@ WarpX::ReadParameters ()
 
         // Read filter and fill IntVect filter_npass_each_dir with
         // proper size for AMREX_SPACEDIM
-            pp.query("use_filter", use_filter);
+        pp.query("use_filter", use_filter);
         Vector<int> parse_filter_npass_each_dir(AMREX_SPACEDIM,1);
         pp.queryarr("filter_npass_each_dir", parse_filter_npass_each_dir);
         filter_npass_each_dir[0] = parse_filter_npass_each_dir[0];


### PR DESCRIPTION
A new runtime parameter, `warpx.plot_costs=true`, is added.  This does not change the default behavior of saving walltime costs in plotfiles when doing dynamic load balance.  It allows us the option to remove `costs` from plotfiles so that PlasmaMirror regression test can pass.
