### PR TITLE
Python ReadRaw: Add Header

### DIFF
--- a/Tools/read_raw_data.py
+++ b/Tools/read_raw_data.py
@@ -297,4 +297,4 @@ def _read_buffer(snapshot, header_fn, _component_names):
 
 
 if __name__ == "__main__":
-    data = read_lab_snapshot("lab_frame_data/snapshot00012");
+    data = read_lab_snapshot("lab_frame_data/snapshot00012", "lab_frame_data/Header");


### PR DESCRIPTION
Add new 2nd argument.
This uses the global `Header` of all snapshots as example, maybe using the individual snapshot instead is better?