### PR TITLE
[mini-PR] Address C++ issues found by LGTM

### DIFF
--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -583,7 +583,7 @@ WarpX::ComputeDt ()
  * simulation box passes input parameter zmax_plasma_to_compute_max_step.
  */
 void
-WarpX::computeMaxStepBoostAccelerator(amrex::Geometry a_geom){
+WarpX::computeMaxStepBoostAccelerator(const amrex::Geometry& a_geom){
     // Sanity checks: can use zmax_plasma_to_compute_max_step only if
     // the moving window and the boost are all in z direction.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/FortranInterface/WarpX_f.H
+++ b/Source/FortranInterface/WarpX_f.H
@@ -1,3 +1,6 @@
+#ifndef WARPX_F_H_
+#define WARPX_F_H_
+
 #include <AMReX_BLFort.H>
 
 #ifdef __cplusplus
@@ -130,3 +133,5 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+#endif //WARPX_F_H_

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -21,7 +21,7 @@ namespace {
         amrex::Abort(string.c_str());
     }
 
-    Real parseChargeName(const ParmParse pp, const std::string& name) {
+    Real parseChargeName(const ParmParse& pp, const std::string& name) {
         Real result;
         if (name == "q_e") {
             return PhysConst::q_e;
@@ -33,13 +33,13 @@ namespace {
         }
     }
 
-    Real parseChargeString(const ParmParse pp, const std::string& name) {
+    Real parseChargeString(const ParmParse& pp, const std::string& name) {
         if(name.substr(0, 1) == "-")
             return -1.0 * parseChargeName(pp, name.substr(1, name.size() - 1));
         return parseChargeName(pp, name);
     }
 
-    Real parseMassString(const ParmParse pp, const std::string& name) {
+    Real parseMassString(const ParmParse& pp, const std::string& name) {
         Real result;
         if (name == "m_e") {
             return PhysConst::m_e;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1078,11 +1078,11 @@ PhysicalParticleContainer::Evolve (int lev,
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             const auto np = pti.numParticles();
-            const auto lev = pti.GetLevel();
+            const auto t_lev = pti.GetLevel();
             const auto index = pti.GetPairIndex();
             tmp_particle_data.resize(finestLevel()+1);
             for (int i = 0; i < TmpIdx::nattribs; ++i)
-                tmp_particle_data[lev][index][i].resize(np);
+                tmp_particle_data[t_lev][index][i].resize(np);
         }
     }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -846,8 +846,9 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
     {
         p.m_idata.id = DoSplitParticleID;
     }
-    // For the moment, do not do anything if particles goes
-    // to lower level.
+
     if (pld.m_lev == lev-1){
+        // For the moment, do not do anything if particles goes
+        // to lower level.
     }
 }

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -14,8 +14,9 @@ namespace
         *num_boxes = mf.local_size();
         int shapesize = AMREX_SPACEDIM;
         if (mf.nComp() > 1) shapesize += 1;
-        *shapes = (int*) malloc(shapesize * (*num_boxes) * sizeof(int));
-        amrex::Real** data = (amrex::Real**) malloc((*num_boxes) * sizeof(amrex::Real*));
+        *shapes = static_cast<int*>(malloc(sizeof(int)*shapesize * (*num_boxes)));
+        auto data =
+            static_cast<amrex::Real**>(malloc((*num_boxes) * sizeof(amrex::Real*)));
 
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -1,3 +1,6 @@
+#ifndef WARPX_UTILS_H_
+#define WARPX_UTILS_H_
+
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
@@ -21,3 +24,5 @@ namespace WarpXUtilIO{
      */
     bool WriteBinaryDataOnFile(std::string filename, const amrex::Vector<char>& data);
 }
+
+#endif //WARPX_UTILS_H_

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -171,7 +171,7 @@ public:
 
     void ComputeDt ();
     // Compute max_step automatically for simulations in a boosted frame.
-    void computeMaxStepBoostAccelerator(amrex::Geometry geom);
+    void computeMaxStepBoostAccelerator(const amrex::Geometry& geom);
     int  MoveWindow (bool move_j);
     void UpdatePlasmaInjectionPosition (amrex::Real dt);
 


### PR DESCRIPTION
Thanks to https://github.com/ECP-WarpX/WarpX/pull/564 (thanks @ax3l !) we can use LGTM to perform a static code analysis of WarpX. 
This morning I had some time, so I tried to fix some warnings and to address some recommendations.