### PR TITLE
Fix number of guard cells copied to the PML

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -844,11 +844,10 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
 void
 PML::CopyToPML (MultiFab& pml, MultiFab& reg, const Geometry& geom)
 {
-  const IntVect& ngr = reg.nGrowVect();
   const IntVect& ngp = pml.nGrowVect();
   const auto& period = geom.periodicity();
 
-  pml.ParallelCopy(reg, 0, 0, 1, ngr, ngp, period);
+  pml.ParallelCopy(reg, 0, 0, 1, IntVect(0), ngp, period);
 }
 
 void


### PR DESCRIPTION
When using `deposit_in_pml=1` and `pml_in_domain=1`, a strange bug showed up, where the results depend on the MPI decomposition.

Here is an example of the bug: in this example, two charged particles propagate in opposite directions and reach the PML (input script here:
[inputs.txt](https://github.com/ECP-WarpX/WarpX/files/3953034/inputs.txt))

After 26 timestep, the electric field looks like this, and depends on whether the simulation was split into 2 boxes or unsplit (1 single box):
![Current](https://user-images.githubusercontent.com/6685781/70669207-88599d80-1c2a-11ea-9808-c6f761bbffe1.png)

After talking with @WeiqunZhang, it became clear that this is because `ParallelCopy` can lead to incorrect results if the guard cells of the source are not consistent with the physical cells *and* if a non-zero number of guard cells is passed for the source.

This PR fixes this issue by passing zero guard cells for the source.

Here is the test for this PR:
![Current](https://user-images.githubusercontent.com/6685781/70669370-1170d480-1c2b-11ea-9d23-0e757ffd7002.png)
