### PR TITLE
Fix to RZ scalar moving window

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -326,13 +326,14 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         pywarpx.geometry.prob_hi = self.upper_bound
         pywarpx.warpx.n_rz_azimuthal_modes = self.n_azimuthal_modes
 
-        if self.moving_window_velocity is not None and np.any(np.not_equal(self.moving_window_velocity, 0.)):
-            pywarpx.warpx.do_moving_window = 1
-            if self.moving_window_velocity[0] != 0.:
-                raise Exception('In cylindrical coordinates, a moving window in r can not be done')
-            if self.moving_window_velocity[1] != 0.:
-                pywarpx.warpx.moving_window_dir = 'z'
-                pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
+        if self.moving_window_velocity is not None:
+            if np.isscalar(self.moving_window_velocity):
+                if self.moving_window_velocity !=0:
+                    pywarpx.warpx.do_moving_window = 1
+                    pywarpx.warpx.moving_window_dir = 'z'
+                    pywarpx.warpx.moving_window_v = self.moving_window_velocity/constants.c  # in units of the speed of light
+            else:
+                raise Exception('RZ PICMI moving_window_velocity (only available in z direction) should be a scalar')
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -334,9 +334,6 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
                     pywarpx.warpx.moving_window_v = self.moving_window_zvelocity/constants.c  # in units of the speed of light
             else:
                 raise Exception('RZ PICMI moving_window_velocity (only available in z direction) should be a scalar')
-
-        if self.moving_window_velocity is not None:
-            raise Exception('PICMI RZ geometry uses moving_window_zvelocity (scalar) instead of moving_window_velocity (vector)')
     
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -326,15 +326,18 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         pywarpx.geometry.prob_hi = self.upper_bound
         pywarpx.warpx.n_rz_azimuthal_modes = self.n_azimuthal_modes
 
-        if self.moving_window_velocity is not None:
-            if np.isscalar(self.moving_window_velocity):
-                if self.moving_window_velocity !=0:
+        if self.moving_window_zvelocity is not None:
+            if np.isscalar(self.moving_window_zvelocity):
+                if self.moving_window_zvelocity !=0:
                     pywarpx.warpx.do_moving_window = 1
                     pywarpx.warpx.moving_window_dir = 'z'
-                    pywarpx.warpx.moving_window_v = self.moving_window_velocity/constants.c  # in units of the speed of light
+                    pywarpx.warpx.moving_window_v = self.moving_window_zvelocity/constants.c  # in units of the speed of light
             else:
                 raise Exception('RZ PICMI moving_window_velocity (only available in z direction) should be a scalar')
 
+        if self.moving_window_velocity is not None:
+            raise Exception('PICMI RZ geometry uses moving_window_zvelocity (scalar) instead of moving_window_velocity (vector)')
+    
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
             assert self.refined_regions[0][0] == 1, Exception('The one refined region can only be level 1')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -334,7 +334,7 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
                     pywarpx.warpx.moving_window_v = self.moving_window_zvelocity/constants.c  # in units of the speed of light
             else:
                 raise Exception('RZ PICMI moving_window_velocity (only available in z direction) should be a scalar')
-    
+
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
             assert self.refined_regions[0][0] == 1, Exception('The one refined region can only be level 1')


### PR DESCRIPTION
Hi all,
I am not sure if this is the smartest way to solve the incompatibility between codes and PICMI  in the definition of the moving window velocity.
But I decided to already prepare this PR in case you think it is a good approach.
Please feel free to ask for changes to/delete this PR if you don't think so.


With this PR, WarpX users can follow the PICMI standard instructions in:
https://picmi-standard.github.io/standard/grid.html#picmistandard.PICMI_CylindricalGrid
regarding the ***scalar*** parameter `moving_window_velocity` that is described in the Cylindrical geometry section as:
```
moving_window_velocity: Moving frame Z velocity [m/s]
```

Then WarpX uses the PICMI variable to determine the input parameters:
```
warpx.do_moving_window = 1
warpx.moving_window_dir = z
warpx.moving_window_v = moving_window_velocity/c
```

The code breaks with an error message if the user sets the PICMI `moving_window_velocity` parameter as a ***vector*** (instead of a ***scalar***).

