### PR TITLE
Add tolerance to the PlasmaAccelerationBoost3d Test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -863,6 +863,7 @@ runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=
 dim = 3
 addToCompileString =
 restartTest = 0
+tolerance = 1e-14
 useMPI = 1
 numprocs = 2
 useOMP = 1


### PR DESCRIPTION
This test fails on battra because the answer randomly fluctuates, but never by more than 1e-14. This will prevent a failure from being registered in that case. 