### PR TITLE
[mini-PR] splitting distance depends on ppc only if uniform per cell

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -109,6 +109,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
                    part_pos_s.end(),
                    part_pos_s.begin(),
                    ::tolower);
+    num_particles_per_cell_each_dim.assign(3, 0);
     if (part_pos_s == "python") {
         return;
     } else if (part_pos_s == "singleparticle") {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1433,9 +1433,9 @@ PhysicalParticleContainer::SplitParticles(int lev)
 
         const amrex::Vector<int> ppc_nd = plasma_injector->num_particles_per_cell_each_dim;
         const std::array<Real,3>& dx = WarpX::CellSize(lev);
-        amrex::Vector<Real> split_offset = {dx[0]/2._rt/ppc_nd[0],
-                                            dx[1]/2._rt/ppc_nd[1],
-                                            dx[2]/2._rt/ppc_nd[2]};
+        amrex::Vector<Real> split_offset = {dx[0]/2._rt,
+                                            dx[1]/2._rt,
+                                            dx[2]/2._rt};
         if (ppc_nd[0] > 0){
             // offset for split particles is computed as a function of cell size
             // and number of particles per cell, so that a uniform distribution

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1431,15 +1431,19 @@ PhysicalParticleContainer::SplitParticles(int lev)
     {
         pti.GetPosition(xp, yp, zp);
 
-        // offset for split particles is computed as a function of cell size
-        // and number of particles per cell, so that a uniform distribution
-        // before splitting results in a uniform distribution after splitting
         const amrex::Vector<int> ppc_nd = plasma_injector->num_particles_per_cell_each_dim;
         const std::array<Real,3>& dx = WarpX::CellSize(lev);
         amrex::Vector<Real> split_offset = {dx[0]/2._rt/ppc_nd[0],
                                             dx[1]/2._rt/ppc_nd[1],
                                             dx[2]/2._rt/ppc_nd[2]};
-
+        if (ppc_nd[0] > 0){
+            // offset for split particles is computed as a function of cell size
+            // and number of particles per cell, so that a uniform distribution
+            // before splitting results in a uniform distribution after splitting
+            split_offset[0] /= ppc_nd[0];
+            split_offset[1] /= ppc_nd[1];
+            split_offset[2] /= ppc_nd[2];
+        }
         // particle Array Of Structs data
         auto& particles = pti.GetArrayOfStructs();
         // particle Struct Of Arrays data


### PR DESCRIPTION
When using splitting, we can currently reduce the distance between the split particles depending on the number of initial particles per cell for the source species. There was a bug in this (it worked only with `NUniformPerCell` injection, anything else would lead to a division by zero). This PR proposes a fix.