### PR TITLE
Fix compilation of Doc on ReadTheDocs

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx_rtd_theme>=0.3.1
 recommonmark
-sphinx
+sphinx>=2.0
 pygments
 breathe
 exhale


### PR DESCRIPTION
The latest version of the documentation gives a compilation error on ReadTheDocs since merging https://github.com/ECP-WarpX/WarpX/pull/572:
```sh
ERROR: breathe 4.14.0 has requirement Sphinx>=2.0, but you'll have sphinx 1.8.5 which is incompatible.
```
The error can be seen at https://readthedocs.org/projects/warpx/builds/10147228/

This PR proposes a fix, by requesting a sphinx version >= 2.0.