### PR TITLE
Always synchronize the value of nodal points

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -529,7 +529,7 @@ private:
     amrex::Real load_balance_knapsack_factor = 1.24;
 
     // Override sync every ? steps
-    int override_sync_int = 10;
+    int override_sync_int = 1;
 
     // Other runtime parameters
     int verbose = 1;


### PR DESCRIPTION
Synchronizing the values of nodal points seem to be critical on certain GPU runs:
- The 2D NCI test on GPU is unstable if we do not synchronize those values (see #551)
- Some large 3D runs on GPUs also seem to be unstable in the absence of synchronization (see #466 )