### PR TITLE
Build Doc Update: Suggest running make realclean after AMReX or PICSAR dir updates

### DIFF
--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -56,7 +56,8 @@ This will generate an executable file in the ``Bin`` directory.
 
         make -j 4 USE_OMP=FALSE
 
-In order to clean a previously compiled version:
+If you updated the AMReX or PICSAR files in your `warpx_directory` through
+a `git pull` or if you would like to clean a previously compiled version:
 
 ::
 

--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -56,12 +56,22 @@ This will generate an executable file in the ``Bin`` directory.
 
         make -j 4 USE_OMP=FALSE
 
-If you updated the AMReX or PICSAR files in your `warpx_directory` through
-a `git pull` or if you would like to clean a previously compiled version:
+In order to clean a previously compiled version:
 
 ::
 
     make realclean
+
+Troubleshooting
+---------------
+
+If you are having trouble compiling WarpX, you should try to run:
+
+::
+
+   make realclean
+
+before re-attempting compilation.
 
 Advanced building instructions
 ------------------------------


### PR DESCRIPTION
 Updates the WarpX build instructions to suggest that `make realclean` should be run after any `git pull` operations on the local AMReX or PICSAR subdirectories in the `warpx_directory`.