### PR TITLE
[mini-PR] Do not compile the pdf version of the doc on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,5 +2,4 @@ requirements_file: Docs/requirements.txt
 
 formats:
     - htmlzip
-    - pdf
     - epub


### PR DESCRIPTION
RTD build currently fails due to
```
Error
Build exited due to time out
```
This PR proposes to save time by not compiling the 400-page PDF version of the doc.