### PR TITLE
Check that incompatible options are not used

### DIFF
--- a/Examples/Tests/Langmuir/inputs.multi.2d.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.2d.rt
@@ -26,6 +26,7 @@ warpx.verbose = 1
 
 # Algorithms
 algo.field_gathering = energy-conserving
+warpx.do_pml = 0
 
 # Interpolation
 interpolation.nox = 1

--- a/Examples/Tests/Langmuir/inputs.multi.rt
+++ b/Examples/Tests/Langmuir/inputs.multi.rt
@@ -28,6 +28,7 @@ warpx.verbose = 1
 # Algorithms
 algo.current_deposition = direct
 algo.field_gathering = energy-conserving
+warpx.do_pml = 0
 
 # Interpolation
 interpolation.nox = 1

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -585,7 +585,7 @@ WarpX::ReadParameters ()
         particle_pusher_algo = GetAlgorithmInteger(pp, "particle_pusher");
         maxwell_fdtd_solver_id = GetAlgorithmInteger(pp, "maxwell_fdtd_solver");
         field_gathering_algo = GetAlgorithmInteger(pp, "field_gathering");
-        if (field_gathering_algo == GatheringAlgo:M:omentumConserving) {
+        if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
             // Use same shape factors in all directions, for gathering
             l_lower_order_in_v = false;
         }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -267,6 +267,10 @@ WarpX::WarpX ()
         not ( do_dive_cleaning & do_nodal ),
         "divE cleaning + do_nodal not implemented"
         );
+#ifdef WARPX_USE_PSATD
+    BL_ASSERT(use_fdtd_nci_corr == 0);
+    BL_ASSERT(do_subcycling == 0);
+#endif
 }
 
 WarpX::~WarpX ()

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -252,11 +252,6 @@ WarpX::WarpX ()
     // constructor, as it reads additional parameters
     // (e.g., use_fdtd_nci_corr)
 
-    bool momentum_conserving = field_gathering_algo == GatheringAlgo::MomentumConserving;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        not ( use_fdtd_nci_corr & momentum_conserving ),
-        "NCI corrector with momentum-conserving gather not implemented"
-        );
 #ifndef WARPX_USE_PSATD
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         not ( do_pml & do_nodal ),
@@ -590,7 +585,7 @@ WarpX::ReadParameters ()
         particle_pusher_algo = GetAlgorithmInteger(pp, "particle_pusher");
         maxwell_fdtd_solver_id = GetAlgorithmInteger(pp, "maxwell_fdtd_solver");
         field_gathering_algo = GetAlgorithmInteger(pp, "field_gathering");
-        if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
+        if (field_gathering_algo == GatheringAlgo:M:omentumConserving) {
             // Use same shape factors in all directions, for gathering
             l_lower_order_in_v = false;
         }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -259,7 +259,7 @@ WarpX::WarpX ()
         );
 #endif
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        not ( do_dive_cleaning & do_nodal ),
+        not ( do_dive_cleaning && do_nodal ),
         "divE cleaning + do_nodal not implemented"
         );
 #ifdef WARPX_USE_PSATD

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -254,7 +254,7 @@ WarpX::WarpX ()
 
 #ifndef WARPX_USE_PSATD
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        not ( do_pml & do_nodal ),
+        not ( do_pml && do_nodal ),
         "PML + do_nodal for finite-difference not implemented"
         );
 #endif

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -263,8 +263,8 @@ WarpX::WarpX ()
         "divE cleaning + do_nodal not implemented"
         );
 #ifdef WARPX_USE_PSATD
-    BL_ASSERT(use_fdtd_nci_corr == 0);
-    BL_ASSERT(do_subcycling == 0);
+    AMREX_ALWAYS_ASSERT(use_fdtd_nci_corr == 0);
+    AMREX_ALWAYS_ASSERT(do_subcycling == 0);
 #endif
 }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -247,6 +247,26 @@ WarpX::WarpX ()
     // at different levels (the stencil depends on c*dt/dz)
     nci_godfrey_filter_exeybz.resize(nlevs_max);
     nci_godfrey_filter_bxbyez.resize(nlevs_max);
+
+    // Sanity checks. Must be done after calling the MultiParticleContainer
+    // constructor, as it reads additional parameters
+    // (e.g., use_fdtd_nci_corr)
+
+    bool momentum_conserving = field_gathering_algo == GatheringAlgo::MomentumConserving;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        not ( use_fdtd_nci_corr & momentum_conserving ),
+        "NCI corrector with momentum-conserving gather not implemented"
+        );
+#ifndef WARPX_USE_PSATD
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        not ( do_pml & do_nodal ),
+        "PML + do_nodal for finite-difference not implemented"
+        );
+#endif
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        not ( do_dive_cleaning & do_nodal ),
+        "divE cleaning + do_nodal not implemented"
+        );
 }
 
 WarpX::~WarpX ()
@@ -633,7 +653,6 @@ WarpX::ReadParameters ()
        }
 
     }
-
 }
 
 // This is a virtual function.


### PR DESCRIPTION
This PR proposes sanity checks to make sure that the user does not try to use options that are not compatible.

This is done at the end of the WarpX constructor, where I believe the main options have already been read from the input file.