### PR TITLE
[WIP] do not use exhale for doc

### DIFF
--- a/Docs/Makefile
+++ b/Docs/Makefile
@@ -24,3 +24,12 @@ clean:
 	doxygen
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cp -r doxyhtml build/html/
+
+Python-build:
+	cd ../Python; make pybuild
+
+Doxygen-build:
+	doxygen Doxyfile
+
+Latex-conversion:
+	cd source/latex_theory; make

--- a/Docs/Makefile
+++ b/Docs/Makefile
@@ -21,13 +21,6 @@ clean:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	doxygen
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-Python-build:
-	cd ../Python; make pybuild
-
-Doxygen-build:
-	doxygen Doxyfile
-
-Latex-conversion:
-	cd source/latex_theory; make
+	cp -r doxyhtml build/html/

--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -3,4 +3,3 @@ recommonmark
 sphinx>=2.0
 pygments
 breathe
-exhale

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -174,3 +174,8 @@ breathe_default_project = "WarpX"
 primary_domain = 'cpp'
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = 'cpp'
+
+read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+if read_the_docs_build:
+    subprocess.call('cd ../; doxygen', shell=True)
+    subprocess.call('cp -r ../doxyhtml ../build/html/', shell=True)

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -35,8 +35,6 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'breathe'
  ]
-# ,
-#     'exhale'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -33,9 +33,10 @@ sys.path.insert(0, os.path.join( os.path.abspath(__file__), '../Python') )
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'breathe',
-    'exhale'
+    'breathe'
  ]
+# ,
+#     'exhale'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -171,27 +172,7 @@ breathe_projects = {
 }
 breathe_default_project = "WarpX"
 
-# Setup the exhale extension
-exhale_args = {
-    # These arguments are required
-    "containmentFolder": "./api",
-    "rootFileName": "library_root.rst",
-    "rootFileTitle": "Doxygen",
-    "doxygenStripFromPath": "..",
-    # Suggested optional arguments
-    "createTreeView": True,
-    # TIP: if using the sphinx-bootstrap-theme, you need
-    # "treeViewIsBootstrap": True,
-    "exhaleExecutesDoxygen": True,
-    "exhaleDoxygenStdin": "INPUT = ../../Source/"
-}
-
 # Tell sphinx what the primary language being documented is.
 primary_domain = 'cpp'
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = 'cpp'
-
-
-read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
-if read_the_docs_build:
-    subprocess.call('cd ../; doxygen', shell=True)

--- a/Docs/source/doxygen.rst
+++ b/Docs/source/doxygen.rst
@@ -1,0 +1,4 @@
+Doxygen
+=======
+
+`Doxygen documentation <./doxyhtml/index.html>`__

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -38,4 +38,4 @@ In order to learn to use the code, please see the sections below:
    visualization/visualization
    theory/theory
    developers/developers
-   api/library_root
+   doxygen


### PR DESCRIPTION
This PR proposes to
- remove the `exhale` dependency to build the doc (`exhale` converts the Doxygen doc to rst).
- Copy the Doxygen-generated html pages to `build/html/` and add a link to it.

If this works, it will remove one dependency in RTD, and may reduce the compilation time (after check, local compilation went from 2 min 20 to 1 min 52).