### PR TITLE
Doc: openPMD-api 0.10.3+

### DIFF
--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -7,7 +7,7 @@ therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library 0.9.0a or newer <https://openpmd-api.readthedocs.io/en/0.9.0-alpha/>`__
+`openPMD-api library 0.10.3a or newer <https://openpmd-api.readthedocs.io/en/0.10.3-alpha/>`__
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -124,7 +124,7 @@ endif
 
 ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
-   ifeq (0, $(shell pkg-config "openPMD >= 0.9.0"; echo $$?))
+   ifeq (0, $(shell pkg-config "openPMD >= 0.10.3"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
        libraries += $(shell pkg-config --libs-only-l openPMD)


### PR DESCRIPTION
Require the newest release of openPMD-api which includes stability improvements and bug fixes.