### PR TITLE
Minor change of Examples/Tests/collision/analysis_collision.py.

### DIFF
--- a/Examples/Tests/collision/analysis_collision.py
+++ b/Examples/Tests/collision/analysis_collision.py
@@ -19,7 +19,7 @@ import sys
 import yt
 import re
 import math
-import statistics
+import numpy
 from glob import glob
 
 tolerance = 0.001
@@ -53,8 +53,8 @@ for fn in fn_list:
     buf = temp.match(fn).groups()
     j = int(buf[1])
     # compute error
-    vxe = statistics.mean(px[ 0:ne])/me/c
-    vxi = statistics.mean(px[ne:np])/mi/c
+    vxe = numpy.mean(px[ 0:ne])/me/c
+    vxi = numpy.mean(px[ne:np])/mi/c
     vxd = vxe - vxi
     fit = a*math.exp(b*j)
     error = error + abs(fit-vxd)


### PR DESCRIPTION
This PR simply changes the use of `import statistics` to `import numpy` in the file `Examples/Tests/collision/analysis_collision.py` to use `numpy.mean()` instead of `statistics.mean()`, because the use of `statistics` may require additional installation like `sudo pip install statistics`.