### PR TITLE
CI: Doxygen Build

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -17,3 +17,7 @@ jobs:
       run: .github/workflows/source/wrongFileNameInExamples
     - name: Examples are tested
       run: .github/workflows/source/inputsNotTested
+    - name: Doxygen
+      run: |
+        sudo apt-get install -y --no-install-recommends doxygen
+        .github/workflows/source/doxygen

--- a/.github/workflows/source/doxygen
+++ b/.github/workflows/source/doxygen
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+
+# search recursive inside a folder if a file contains tabs
+#
+# @result 0 if no files are found, else 1
+#
+
+set -eu -o pipefail
+
+cd Docs
+doxygen

--- a/.github/workflows/source/hasEOLwhiteSpace
+++ b/.github/workflows/source/hasEOLwhiteSpace
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2019 Axel Huebl
+# Copyright 2016-2020 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
 
 # search recursive inside a folder if a file contains end-of-line
 #   (EOL) white spaces

--- a/.github/workflows/source/hasTabs
+++ b/.github/workflows/source/hasTabs
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2019 Axel Huebl
+# Copyright 2016-2020 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
 
 # search recursive inside a folder if a file contains tabs
 #


### PR DESCRIPTION
Ensure running `doxygen` does not return a non-zero status message. This still allows warnings, unless we change this in the `doxyfile`, but at least ensures no other problems occurred.