### PR TITLE
specify a user install when running the python regtests on battra

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -472,7 +472,7 @@ inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.p
 runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 4
@@ -586,7 +586,7 @@ inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
 runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rt.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -796,7 +796,7 @@ buildDir = .
 inputFile = Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
 customRunCmd = python PICMI_inputs_gaussian_beam.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -827,7 +827,7 @@ buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
 customRunCmd = python PICMI_inputs_plasma_acceleration.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -844,7 +844,7 @@ buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
 customRunCmd = python PICMI_inputs_plasma_acceleration_mr.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -923,7 +923,7 @@ buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
 customRunCmd = python PICMI_inputs_laser_acceleration.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -940,7 +940,7 @@ buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
 customRunCmd = python PICMI_inputs_langmuir2d.py
 dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1
 numprocs = 2


### PR DESCRIPTION
I made some changes to the python installation on battra. We can now do `#!/usr/bin/python3` at the top of analysis scripts on battra. But, I need to pass in these additional options when running the test suite. 