### PR TITLE
[WIP] Fix FillBoundary calls

### DIFF
--- a/Regression/TestFillBoundary/compare_guard_cells.sh
+++ b/Regression/TestFillBoundary/compare_guard_cells.sh
@@ -38,7 +38,7 @@ COMPILE_fcompare=true
 CLEAN=true
 DIM=2d
 REL_TOL=2e-15
-plotfile=plt00002
+plotfile=plt00010
 OMP_NUM_THREADS=1
 
 # Some general variables

--- a/Regression/TestFillBoundary/inputs.2d
+++ b/Regression/TestFillBoundary/inputs.2d
@@ -1,7 +1,7 @@
 #################################
 ####### GENERAL PARAMETERS ######
 #################################
-max_step = 2 # 30
+max_step = 10
 amr.n_cell = 32 32 # 128 128 # 32 32
 amr.max_grid_size = 16 # 64 # 16
 amr.blocking_factor = 16 # 64 # 16

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -18,6 +18,15 @@
 using namespace amrex;
 
 void
+WarpX::all_FillBoundary()
+{
+    FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+    FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+    FillBoundaryF(guard_cells.ng_alloc_F);
+    FillBoundaryAux(guard_cells.ng_UpdateAux);
+}
+
+void
 WarpX::EvolveEM (int numsteps)
 {
     BL_PROFILE("WarpX::EvolveEM()");
@@ -355,11 +364,17 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryF(guard_cells.ng_alloc_F);
         DampPML();
         FillBoundaryE(guard_cells.ng_MovingWindow, IntVect::TheZeroVector());
+        FillBoundaryF(guard_cells.ng_MovingWindow);
         FillBoundaryB(guard_cells.ng_MovingWindow, IntVect::TheZeroVector());
     }
     // E and B are up-to-date in the domain, but all guard cells are
     // outdated.
 #endif
+//FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+//FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+//FillBoundaryF(guard_cells.ng_alloc_F);
+//FillBoundaryAux(guard_cells.ng_UpdateAux);
+//all_FillBoundary();
 }
 
 /* /brief Perform one PIC iteration, with subcycling

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -18,15 +18,6 @@
 using namespace amrex;
 
 void
-WarpX::all_FillBoundary()
-{
-    FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-    FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-    FillBoundaryF(guard_cells.ng_alloc_F);
-    FillBoundaryAux(guard_cells.ng_UpdateAux);
-}
-
-void
 WarpX::EvolveEM (int numsteps)
 {
     BL_PROFILE("WarpX::EvolveEM()");

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -370,11 +370,6 @@ WarpX::OneStep_nosub (Real cur_time)
     // E and B are up-to-date in the domain, but all guard cells are
     // outdated.
 #endif
-//FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-//FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-//FillBoundaryF(guard_cells.ng_alloc_F);
-//FillBoundaryAux(guard_cells.ng_UpdateAux);
-//all_FillBoundary();
 }
 
 /* /brief Perform one PIC iteration, with subcycling
@@ -398,7 +393,6 @@ void
 WarpX::OneStep_sub1 (Real curtime)
 {
     // TODO: we could save some charge depositions
-
     // Loop over species. For each ionizable species, create particles in
     // product species.
     mypc->doFieldIonization();
@@ -520,12 +514,12 @@ WarpX::OneStep_sub1 (Real curtime)
     EvolveF(coarse_lev, PatchType::fine, 0.5*dt[coarse_lev], DtType::SecondHalf);
 
     if (do_pml) {
-        if (do_moving_window & field_gathering_algo == GatheringAlgo::MomentumConserving){
+        if (do_moving_window){
             // Exchance guard cells of PMLs only (0 cells are exchanged for the
-            // regular B field MultiFab). This is required as B has just been
-            // evolved and one guard cell is needed for the averaging
-            // in momentum-conserving gather.
+            // regular B field MultiFab). This is required as B and F have just been
+            // evolved.
             FillBoundaryB(coarse_lev, PatchType::fine, IntVect::TheZeroVector());
+            FillBoundaryF(coarse_lev, PatchType::fine, IntVect::TheZeroVector());
         }
         DampPML(coarse_lev, PatchType::fine);
     }

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -128,7 +128,9 @@ guardCellManager::Init(
         ng_FieldSolverF = ng_alloc_F;
         ng_FieldGather = ng_alloc_EB;
         ng_UpdateAux = ng_alloc_EB;
-        ng_MovingWindow = ng_alloc_EB;
+        if (do_moving_window){
+            ng_MovingWindow = ng_alloc_EB;
+        }
     } else {
 
         ng_FieldSolver = ng_FieldSolver.min(ng_alloc_EB);

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -239,7 +239,6 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     MultiFab::Copy(tmpmf, mf, 0, 0, nc, ng);
 
     IntVect ng_mw = IntVect::TheUnitVector();
-    // IntVect ng_mw = IntVect::TheZeroVector();
     // Enough guard cells in the MW direction
     ng_mw[dir] = num_shift;
     // Add the extra cell (if momentum-conserving gather with staggered field solve)
@@ -248,7 +247,6 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     ng_mw = ng_mw.min(ng);
     // Fill guard cells.
     tmpmf.FillBoundary(ng_mw, geom.periodicity());
-    // tmpmf.FillBoundary(ng, geom.periodicity());
 
     // Make a box that covers the region that the window moved into
     const IndexType& typ = ba.ixType();

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -238,7 +238,8 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     MultiFab tmpmf(ba, dm, nc, ng);
     MultiFab::Copy(tmpmf, mf, 0, 0, nc, ng);
 
-    IntVect ng_mw = IntVect::TheZeroVector();
+    IntVect ng_mw = IntVect::TheUnitVector();
+    // IntVect ng_mw = IntVect::TheZeroVector();
     // Enough guard cells in the MW direction
     ng_mw[dir] = num_shift;
     // Add the extra cell (if momentum-conserving gather with staggered field solve)
@@ -247,6 +248,7 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     ng_mw = ng_mw.min(ng);
     // Fill guard cells.
     tmpmf.FillBoundary(ng_mw, geom.periodicity());
+    // tmpmf.FillBoundary(ng, geom.periodicity());
 
     // Make a box that covers the region that the window moved into
     const IndexType& typ = ba.ixType();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -433,8 +433,6 @@ private:
     ///
     void EvolveEM(int numsteps);
 
-    void all_FillBoundary();
-    
     void FillBoundaryB (int lev, PatchType patch_type, amrex::IntVect ng);
     void FillBoundaryE (int lev, PatchType patch_type, amrex::IntVect ng);
     void FillBoundaryF (int lev, PatchType patch_type, amrex::IntVect ng);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -433,6 +433,8 @@ private:
     ///
     void EvolveEM(int numsteps);
 
+    void all_FillBoundary();
+    
     void FillBoundaryB (int lev, PatchType patch_type, amrex::IntVect ng);
     void FillBoundaryE (int lev, PatchType patch_type, amrex::IntVect ng);
     void FillBoundaryF (int lev, PatchType patch_type, amrex::IntVect ng);


### PR DESCRIPTION
PR #504 introduced some bugs and made Battra tests fail. This PR proposes a fix by:
- Adding some calls to `FillBoundaryF` when the moving window is ON.
- Always exchanging at least 1 guard cell in each direction in `shiftMF` (when moving window is ON). This actually reverts to an older version of branch `comm`.

These errors were not caught with the initial test, probably because we used too few iterations.

Note: for debugging, I constantly compare with the version of `dev` branch before merging PR #504. However, this version had missing calls to FillBoundary too, so I added a number of such call before getting reproducible results. For this reason, if we agree that this version is safer, the Battra tests may still fail, in which case we could reset the benchmark. Let's discuss it tomorrow.
FYI, the old `dev` branch with more FillBoundary calls can be seen at https://github.com/ECP-WarpX/WarpX/compare/dev...MaxThevenet:safe_FB.

More precisely, when comparing 
- **old dev with additional calls to FillBoundary** https://github.com/ECP-WarpX/WarpX/compare/dev...MaxThevenet:safe_FB
- **old dev** https://github.com/ECP-WarpX/WarpX/commit/fc98645e5fe7e1bb6a01ea925d87018e4f518419

all simulations with **moving window + PML + divE cleaning + non-nodal** are different (see all simulations that [ran.txt](https://github.com/ECP-WarpX/WarpX/files/4066133/ran.txt) and all comparisons that [failed.txt](https://github.com/ECP-WarpX/WarpX/files/4066134/failed.txt))
