### PR TITLE
add GPU regression test setups to repo

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -1,0 +1,655 @@
+# This file is used both for the nightly regression tests
+# on the battra server, and for the CI tests on Travis CI
+# In the case of Travis CI, some of the parameters entered
+# below are overwritten, see prepare_file_travis.py
+[main]
+testTopDir     = /home/regtester/RegTesting/rt-WarpX/
+webTopDir      = /home/regtester/RegTesting/rt-WarpX/web
+
+sourceTree = C_Src
+
+# suiteName is the name prepended to all output directories
+suiteName = WarpX-GPU
+
+COMP = g++
+FCOMP = gfortran
+add_to_c_make_command = TEST=TRUE USE_ASSERTION=TRUE WarpxBinDir=
+
+purge_output = 1
+
+MAKE = make
+numMakeJobs = 8
+
+# MPIcommand should use the placeholders:
+#   @host@ to indicate where to put the hostname to run on
+#   @nprocs@ to indicate where to put the number of processors
+#   @command@ to indicate where to put the command to run
+#
+# only tests with useMPI = 1 will run in parallel
+# nprocs is problem dependent and specified in the individual problem
+# sections.
+
+#MPIcommand = mpiexec -host @host@ -n @nprocs@ @command@
+MPIcommand = mpiexec -n @nprocs@ @command@
+MPIhost =
+
+reportActiveTestsOnly = 1
+
+# Add "GO UP" link at the top of the web page?
+goUpLink = 1
+
+# email
+sendEmailWhenFail = 1
+emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, mthevenet@lbl.gov, oshapoval@lbl.gov, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, axelhuebl@lbl.gov
+emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more details.
+
+[AMReX]
+dir = /home/regtester/git/amrex/
+branch = development
+
+[source]
+dir = /home/regtester/git/WarpX
+branch = dev
+
+[extra-PICSAR]
+dir = /home/regtester/git/picsar/
+branch = master
+
+# individual problems follow
+
+[pml_x_yee]
+buildDir = .
+inputFile = Examples/Tests/PML/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=yee
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/PML/analysis_pml_yee.py
+
+[pml_x_ckc]
+buildDir = .
+inputFile = Examples/Tests/PML/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_fdtd_solver=ckc
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
+
+#[pml_x_psatd]
+#buildDir = .
+#inputFile = Examples/Tests/PML/inputs_2d
+#runtime_params = warpx.do_dynamic_scheduling=0
+#dim = 2
+#addToCompileString = USE_PSATD=TRUE USE_GPU=TRUE
+#restartTest = 0
+#useMPI = 1
+#numprocs = 2
+#useOMP = 0
+#numthreads = 2
+#compileTest = 0
+#doVis = 0
+#analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
+
+[RigidInjection_lab]
+buildDir = .
+inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 1e-12
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
+
+[RigidInjection_boost_backtransformed]
+buildDir = .
+inputFile = Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+doComparison = 0
+aux1File = Tools/read_raw_data.py
+analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
+
+[nci_corrector]
+buildDir = .
+inputFile = Examples/Modules/nci_corrector/inputs_2d
+runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+doComparison = 0
+analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
+
+# [nci_correctorMR]
+# buildDir = .
+# inputFile = Examples/Modules/nci_corrector/inputs_2d
+# runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1
+# dim = 2
+# addToCompileString = USE_GPU=TRUE
+# restartTest = 0
+# useMPI = 1
+# numprocs = 2
+# useOMP = 0
+# numthreads = 2
+# compileTest = 0
+# doVis = 0
+# doComparison = 0
+# analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
+
+# [ionization_lab]
+# buildDir = .
+# inputFile = Examples/Modules/ionization/inputs_2d_rt
+# dim = 2
+# addToCompileString = USE_GPU=TRUE
+# restartTest = 0
+# useMPI = 1
+# numprocs = 2
+# useOMP = 0
+# numthreads = 1
+# compileTest = 0
+# doVis = 0
+# analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
+
+# [ionization_boost]
+# buildDir = .
+# inputFile = Examples/Modules/ionization/inputs_2d_bf_rt
+# dim = 2 
+# addToCompileString = USE_GPU=TRUE
+# restartTest = 0
+# useMPI = 1
+# numprocs = 2
+# useOMP = 0
+# numthreads = 1
+# compileTest = 0
+# doVis = 0
+# analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
+
+[bilinear_filter]
+buildDir = .
+inputFile = Examples/Tests/SingleParticle/inputs_2d
+runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
+
+[Langmuir_2d]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 1e-12
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
+analysisOutputImage = langmuir2d_analysis.png
+
+[Langmuir_2d_nompi]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 0
+numprocs = 1
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 1e-12
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
+analysisOutputImage = langmuir2d_analysis.png
+
+[Langmuir_x]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+tolerance = 5e-11
+compareParticles = 0
+particleTypes = electrons
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ex jx electrons.plot_vars=w ux Ex
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
+analysisOutputImage = langmuir_x_analysis.png
+
+[Langmuir_y]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+runtime_params = electrons.uy=0.01 electrons.ymax=0.e-6 warpx.do_dynamic_scheduling=0 warpx.fields_to_plot = Ey jy electrons.plot_vars=w uy Ey
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
+analysisOutputImage = langmuir_y_analysis.png
+
+[Langmuir_z]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+runtime_params = electrons.uz=0.01 electrons.zmax=0.e-6 warpx.do_dynamic_scheduling=0  warpx.fields_to_plot = Ez jz electrons.plot_vars=w uz Ez
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
+analysisOutputImage = langmuir_z_analysis.png
+
+[Langmuir_multi]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+dim = 3
+addToCompileString = USE_PSATD=TRUE USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+tolerance = 5.e-11
+runtime_params = psatd.fftw_plan_measure=0
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+dim = 3
+addToCompileString = USE_PSATD=TRUE USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+tolerance = 5.e-11
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_2d_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 1
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+[Langmuir_multi_2d_psatd]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+dim = 2
+addToCompileString = USE_PSATD=TRUE USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 1
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+runtime_params = psatd.fftw_plan_measure=0 electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+[Langmuir_multi_2d_psatd_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+dim = 2
+addToCompileString = USE_PSATD=TRUE USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 1
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+runtime_params =  psatd.fftw_plan_measure=0 warpx.do_nodal=1 algo.current_deposition=direct electrons.plot_vars=w ux uy uz Ex Ey Ez positrons.plot_vars=w ux uy uz Ex Ey Ez warpx.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+# [Langmuir_multi_rz]
+# buildDir = .
+# inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+# dim = 2
+# addToCompileString = USE_RZ=TRUE USE_GPU=TRUE
+# restartTest = 0
+# useMPI = 1
+# numprocs = 4
+# useOMP = 0
+# numthreads = 1
+# compileTest = 0
+# tolerance = 5e-11
+# doVis = 0
+# runtime_params = electrons.plot_vars=w ux uy uz Ex Ey Ez Bx By ions.plot_vars=w ux uy uz Ex Ey Ez Bx By
+# compareParticles = 0
+# particleTypes = electrons ions
+# analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+# analysisOutputImage = langmuir_multi_rz_analysis.png
+
+# [Langmuir_rz_multimode]
+# buildDir = .
+# inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+# customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
+# dim = 2
+# addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE USE_GPU=TRUE PYINSTALLOPTIONS=--user
+# restartTest = 0
+# useMPI = 1
+# numprocs = 4
+# useOMP = 0
+# numthreads = 1
+# compileTest = 0
+# tolerance = 5e-11
+# doVis = 0
+# compareParticles = 0
+# particleTypes = electrons protons
+# outputFile = diags/plotfiles/plt00040
+
+[LaserInjection]
+buildDir = .
+inputFile = Examples/Modules/laser_injection/inputs_3d_rt
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Modules/laser_injection/analysis_laser.py
+analysisOutputImage = laser_analysis.png
+
+[LaserInjection_2d]
+buildDir = .
+inputFile = Examples/Modules/laser_injection/inputs_2d_rt
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+compareParticles = 0
+
+#xxxxx
+#[LaserAcceleration]
+#buildDir = .
+#inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
+#runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1
+#dim = 3
+#addToCompileString = USE_GPU=TRUE
+#restartTest = 0
+#useMPI = 1
+#numprocs = 2
+#useOMP = 0
+#numthreads = 2
+#compileTest = 0
+#tolerance = 5e-11
+#doVis = 0
+#compareParticles = 0
+#particleTypes = electrons
+#
+[subcyclingMR]
+buildDir = .
+inputFile = Examples/Tests/subcycling/inputs_2d
+runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 1.e-10
+doVis = 0
+compareParticles = 0
+
+[LaserAccelerationMR]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
+runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+tolerance = 5e-11
+doVis = 0
+compareParticles = 0
+particleTypes = electrons beam
+
+[PlasmaAccelerationMR]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+tolerance = 5e-11
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = beam driver plasma_e
+
+[Python_Langmuir]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
+customRunCmd = python PICMI_inputs_langmuir_rt.py
+dim = 3 
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_GPU=TRUE PYINSTALLOPTIONS=--user
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 1
+compileTest = 0
+doVis = 0
+tolerance = 5e-11
+compareParticles = 0
+particleTypes = electrons
+outputFile = diags/plotfiles/plt00040
+
+[uniform_plasma_restart]
+buildDir = .
+inputFile = Examples/Physics_applications/uniform_plasma/inputs_3d
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 1
+restartFileNum = 6
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+tolerance = 1.e-12
+
+[particles_in_pml_2d]
+buildDir = .
+inputFile = Examples/Tests/particles_in_PML/inputs_2d
+dim = 2
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+
+[particles_in_pml]
+buildDir = .
+inputFile = Examples/Tests/particles_in_PML/inputs_3d
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+
+[photon_pusher]
+buildDir = .
+inputFile = Examples/Tests/photon_pusher/inputs_3d
+dim = 3
+addToCompileString = USE_GPU=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine =  Examples/Tests/photon_pusher/analysis_photon_pusher.py

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -184,7 +184,7 @@ analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
 # [ionization_boost]
 # buildDir = .
 # inputFile = Examples/Modules/ionization/inputs_2d_bf_rt
-# dim = 2 
+# dim = 2
 # addToCompileString = USE_GPU=TRUE
 # restartTest = 0
 # useMPI = 1
@@ -578,7 +578,7 @@ particleTypes = beam driver plasma_e
 buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
 customRunCmd = python PICMI_inputs_langmuir_rt.py
-dim = 3 
+dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_GPU=TRUE PYINSTALLOPTIONS=--user
 restartTest = 0
 useMPI = 1


### PR DESCRIPTION
Recently some inputs files were named, so I needed to update the `Warpx-tests.ini` for the GPU tests on Garuda. This adds this file to repo so they can be more easily synced in the future. 