### PR TITLE
openPMD: ED-PIC Extension Support

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -96,7 +96,7 @@ private:
   void Init(//const std::string& filename,
         openPMD::AccessType accessType);
 
-  /** This function sets up the entries for storing the particle positions and constant records (charge, mass)
+  /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *
   * @param[in] pc          WarpX particle container
   * @param[in] currSpecies Corresponding openPMD species

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -1,9 +1,19 @@
 #ifndef WARPX_OPEN_PMD_H_
 #define WARPX_OPEN_PMD_H_
 
-#include <MultiParticleContainer.H> // has AMReX Vector etc used below
+#include "WarpXParticleContainer.H"
+#include "MultiParticleContainer.H" // PIdx
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
 
 #include <openPMD/openPMD.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
 
 //
 // helper class
@@ -61,10 +71,14 @@ private:
 class WarpXOpenPMDPlot
 {
 public:
-  // not  using const string, to  allow std::move to be effective
-  WarpXOpenPMDPlot(bool, std::string& filetype);
+  /** Initialize openPMD I/O routines
+   *
+   * @param oneFilePerTS write one file per timestep
+   * @param filetype file backend, e.g. "bp" or "h5"
+   * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
+   */
+  WarpXOpenPMDPlot(bool oneFilePerTS, std::string filetype, std::vector<bool> fieldPMLdirections);
 
-  //WarpXOpenPMDPlot(const std::string& dir, const std::string& fileType);
   ~WarpXOpenPMDPlot();
 
   void SetStep(int ts);
@@ -82,12 +96,14 @@ private:
   void Init(//const std::string& filename,
         openPMD::AccessType accessType);
 
-  /** This function sets up the entries for storing the particle positions in an openPMD  species
+  /** This function sets up the entries for storing the particle positions and constant records (charge, mass)
   *
-  * @param[in]  currSpecies The openPMD species
-  * @param[in]  np  Number of particles
+  * @param[in] pc          WarpX particle container
+  * @param[in] currSpecies Corresponding openPMD species
+  * @param[in] np          Number of particles
   */
-  void SetupPos(openPMD::ParticleSpecies& currSpecies,
+  void SetupPos(const std::unique_ptr<WarpXParticleContainer>& pc,
+        openPMD::ParticleSpecies& currSpecies,
         const unsigned long long& np) const ;
 
   /** This function sets up the entries for particle properties
@@ -149,6 +165,9 @@ private:
   bool m_OneFilePerTS = true;  //! write in openPMD fileBased manner for individual time steps
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5
   int m_CurrentStep  = -1;
+
+  // meta data
+  std::vector< bool > m_fieldPMLdirections; //! @see WarpX::getPMLdirections()
 };
 
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1,6 +1,12 @@
 #include "WarpXOpenPMD.H"
+#include "WarpXAlgorithmSelection.H"
 #include "FieldIO.H"  // for getReversedVec
 
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <sstream>
 #include <tuple>
 #include <utility>
 
@@ -25,14 +31,55 @@ namespace detail
         }
         return make_pair(record_name, component_name);
     }
+
+    /** Get the openPMD physical dimensionality of a record
+     *
+     * @param record_name name of the openPMD record
+     * @return map with base quantities and power scaling
+     */
+    std::map< openPMD::UnitDimension, double >
+    getUnitDimension( std::string const & record_name )
+    {
+
+        if( record_name == "position" ) return {
+            {openPMD::UnitDimension::L,  1.}
+        };
+        else if( record_name == "positionOffset" ) return {
+            {openPMD::UnitDimension::L,  1.}
+        };
+        else if( record_name == "momentum" ) return {
+            {openPMD::UnitDimension::L,  1.},
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::T, -1.}
+        };
+        else if( record_name == "charge" ) return {
+            {openPMD::UnitDimension::T,  1.},
+            {openPMD::UnitDimension::I,  1.}
+        };
+        else if( record_name == "mass" ) return {
+            {openPMD::UnitDimension::M,  1.}
+        };
+        else if( record_name == "E" ) return {
+            {openPMD::UnitDimension::L,  1.},
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::T, -3.},
+            {openPMD::UnitDimension::I, -1.},
+        };
+        else if( record_name == "B" ) return {
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::I, -1.},
+            {openPMD::UnitDimension::T, -2.}
+        };
+        else return {};
+    }
 }
 
 WarpXOpenPMDPlot::WarpXOpenPMDPlot(bool oneFilePerTS,
-                   std::string& openPMDFileType)
+    std::string openPMDFileType, std::vector<bool> fieldPMLdirections)
   :m_Series(nullptr),
    m_OneFilePerTS(oneFilePerTS),
-   m_OpenPMDFileType(std::move(openPMDFileType))
-   //m_OpenPMDFileType(openPMDFileType)
+   m_OpenPMDFileType(std::move(openPMDFileType)),
+   m_fieldPMLdirections(std::move(fieldPMLdirections))
 {}
 
 WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
@@ -104,13 +151,13 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
     if( WarpX::authors.size() > 0u )
         m_Series->setAuthor( WarpX::authors );
     // more natural naming for PIC
-    m_Series->setMeshesPath("fields");
-    // TODO conform to ED-PIC extension of openPMD
-    // uint32_t const openPMD_ED_PIC = 1u;
-    // m_Series->setOpenPMDextension(openPMD_ED_PIC);
+    m_Series->setMeshesPath( "fields" );
+    // conform to ED-PIC extension of openPMD
+    uint32_t const openPMD_ED_PIC = 1u;
+    m_Series->setOpenPMDextension( openPMD_ED_PIC );
     // meta info
-    m_Series->setSoftware("WarpX");
-    m_Series->setSoftwareVersion(WARPX_GIT_VERSION);
+    m_Series->setSoftware( "WarpX" );
+    m_Series->setSoftwareVersion( WarpX::Version() ) ;
 }
 
 
@@ -124,6 +171,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles(const std::unique_ptr<MultiParticleConta
     auto& pc  = mpc->GetUniqueContainer(i);
     if (pc->plot_species) {
 
+      // names of amrex::Real and int particle attributes in SoA data
       amrex::Vector<std::string> real_names;
       amrex::Vector<std::string> int_names;
       amrex::Vector<int> int_flags;
@@ -197,10 +245,41 @@ WarpXOpenPMDPlot::SavePlotFile (const std::unique_ptr<WarpXParticleContainer>& p
 
   openPMD::Iteration currIteration = m_Series->iterations[iteration];
   openPMD::ParticleSpecies currSpecies = currIteration.particles[name];
+  // meta data for ED-PIC extension
+  currSpecies.setAttribute( "particleShape", [](){
+      return double( WarpX::noz );
+  }() );
+  // TODO allow this per direction in the openPMD standard, ED-PIC extension?
+  currSpecies.setAttribute( "particleShapes", [](){
+      return std::vector< double >{ double(WarpX::nox), double(WarpX::noy), double(WarpX::noz) };
+  }() );
+  currSpecies.setAttribute( "particlePush", [](){
+      switch( WarpX::particle_pusher_algo ) {
+          case ParticlePusherAlgo::Boris : return "Boris";
+          case ParticlePusherAlgo::Vay : return "Vay";
+          case ParticlePusherAlgo::HigueraCary : return "HigueraCary";
+          default: return "other";
+      }
+  }() );
+  currSpecies.setAttribute( "particleInterpolation", [](){
+      switch( WarpX::field_gathering_algo ) {
+          case GatheringAlgo::EnergyConserving : return "energyConserving";
+          case GatheringAlgo::MomentumConserving : return "momentumConserving";
+          default: return "other";
+      }
+  }() );
+  currSpecies.setAttribute( "particleSmoothing", "none" );
+  currSpecies.setAttribute( "currentDeposition", [](){
+      switch( WarpX::current_deposition_algo ) {
+          case CurrentDepositionAlgo::Esirkepov : return "Esirkepov";
+          default: return "directMorseNielson";
+      }
+  }() );
+
   //
   // define positions & offsets
   //
-  SetupPos(currSpecies, counter.GetTotalNumParticles());
+  SetupPos(pc, currSpecies, counter.GetTotalNumParticles());
   SetupRealProperties(currSpecies, write_real_comp, real_comp_names, counter.GetTotalNumParticles());
 
   // forces the files created by all processors! this is the key to resolve RZ storage issue!!
@@ -274,39 +353,40 @@ WarpXOpenPMDPlot::SetupRealProperties(openPMD::ParticleSpecies& currSpecies,
 void
 WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
                        openPMD::ParticleSpecies& currSpecies,
-                       unsigned long long offset,
-                       const amrex::Vector<int>& write_real_comp,
-                       const amrex::Vector<std::string>& real_comp_names) const
+                       unsigned long long const offset,
+                       amrex::Vector<int> const& write_real_comp,
+                       amrex::Vector<std::string> const& real_comp_names) const
 
 {
   int numOutputReal = 0;
   int const totalRealAttrs = m_NumAoSRealAttributes + m_NumSoARealAttributes;
 
-  for (int i = 0; i < totalRealAttrs; ++i)
-    if (write_real_comp[i])
+  for( int i = 0; i < totalRealAttrs; ++i )
+    if( write_real_comp[i] )
       ++numOutputReal;
 
-  auto numParticleOnTile = pti.numParticles();
-  const auto& aos = pti.GetArrayOfStructs();  // size =  numParticlesOnTile
-  const auto& soa = pti.GetStructOfArrays();
+  auto const numParticleOnTile = pti.numParticles();
+  auto const& aos = pti.GetArrayOfStructs();  // size =  numParticlesOnTile
+  auto const& soa = pti.GetStructOfArrays();
 
   // properties are saved separately
   {
-    for (auto idx=0; idx<m_NumAoSRealAttributes; idx++) {
-      if (write_real_comp[idx]) {
+    for( auto idx=0; idx<m_NumAoSRealAttributes; idx++ ) {
+      if( write_real_comp[idx] ) {
           // handle scalar and non-scalar records by name
           std::string record_name, component_name;
           std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[idx]);
+          auto& currRecord = currSpecies[record_name];
+          auto& currRecordComp = currRecord[component_name];
 
-          auto& currVar = currSpecies[record_name][component_name];
-          typename amrex::ParticleReal *d =
-                 static_cast<typename amrex::ParticleReal*> (malloc(sizeof(typename amrex::ParticleReal) *  numParticleOnTile));
+          amrex::ParticleReal *d =
+              static_cast<amrex::ParticleReal*>( malloc(sizeof(amrex::ParticleReal) *  numParticleOnTile) );
 
-          for (auto kk=0; kk<numParticleOnTile; kk++)
+          for( auto kk=0; kk<numParticleOnTile; kk++ )
                d[kk] = aos[kk].m_rdata.arr[AMREX_SPACEDIM+idx];
 
-          std::shared_ptr <typename amrex::ParticleReal> data(d, free);
-          currVar.storeChunk(data,
+          std::shared_ptr<amrex::ParticleReal> data(d, free);
+          currRecordComp.storeChunk(data,
                {offset}, {static_cast<unsigned long long>(numParticleOnTile)});
           m_Series->flush();
       }
@@ -314,16 +394,30 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
   }
 
   {
+    std::set< std::string > addedRecords; // add meta-data per record only once
     for (auto idx=0; idx<m_NumSoARealAttributes; idx++) {
       auto ii = m_NumAoSRealAttributes + idx;
       if (write_real_comp[ii]) {
           // handle scalar and non-scalar records by name
           std::string record_name, component_name;
           std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[ii]);
+          auto& currRecord = currSpecies[record_name];
+          auto& currRecordComp = currRecord[component_name];
 
-          auto& currVar = currSpecies[record_name][component_name];
-          currVar.storeChunk(openPMD::shareRaw(soa.GetRealData(idx)),
-                             {offset}, {static_cast<unsigned long long>(numParticleOnTile)});
+          // meta data for ED-PIC extension
+          bool newRecord = false;
+          std::tie(std::ignore, newRecord) = addedRecords.insert(record_name);
+          if( newRecord ) {
+              currRecord.setAttribute( "macroWeighted", 0u );
+              if( record_name == "momentum" )
+                  currRecord.setAttribute( "weightingPower", 1.0 );
+              else
+                  currRecord.setAttribute( "weightingPower", 0.0 );
+              currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
+          }
+
+          currRecordComp.storeChunk(openPMD::shareRaw(soa.GetRealData(idx)),
+              {offset}, {static_cast<unsigned long long>(numParticleOnTile)});
       }
     }
     m_Series->flush();
@@ -333,25 +427,45 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
 
 
 void
-WarpXOpenPMDPlot::SetupPos(openPMD::ParticleSpecies& currSpecies,
-               const unsigned long long& np) const
+WarpXOpenPMDPlot::SetupPos(const std::unique_ptr<WarpXParticleContainer>& pc,
+    openPMD::ParticleSpecies& currSpecies,
+    const unsigned long long& np) const
 {
-  auto particleLineup = openPMD::Dataset(openPMD::determineDatatype<amrex::ParticleReal>(), {np});
+  auto const particleLineup = openPMD::Dataset(openPMD::determineDatatype<amrex::ParticleReal>(), {np});
 
-  currSpecies["positionOffset"]["x"].resetDataset(particleLineup);
-  currSpecies["positionOffset"]["x"].makeConstant(0);
-  currSpecies["positionOffset"]["y"].resetDataset(particleLineup);
-  currSpecies["positionOffset"]["y"].makeConstant(0);
-  currSpecies["positionOffset"]["z"].resetDataset(particleLineup);
-  currSpecies["positionOffset"]["z"].makeConstant(0);
+  for( auto const& comp : {"x", "y", "z"} ) {
+      currSpecies["positionOffset"][comp].resetDataset( particleLineup );
+      currSpecies["positionOffset"][comp].makeConstant( 0. );
+      currSpecies["position"][comp].resetDataset( particleLineup );
+      // meta data
+      //currSpecies["position"][comp].setUnitSI();
+      //currSpecies["positionOffset"][comp].setUnitSI();
+  }
 
-  //auto positions = openPMD::Dataset(openPMD::determineDatatype<amrex::ParticleReal>(), {np});
-  currSpecies["position"]["x"].resetDataset(particleLineup);
-  currSpecies["position"]["y"].resetDataset(particleLineup);
-  currSpecies["position"]["z"].resetDataset(particleLineup);
+  auto const scalar = openPMD::RecordComponent::SCALAR;
+  currSpecies["charge"][scalar].resetDataset( particleLineup );
+  currSpecies["charge"][scalar].makeConstant( pc->getCharge() );
+  currSpecies["mass"][scalar].resetDataset( particleLineup );
+  currSpecies["mass"][scalar].makeConstant( pc->getMass() );
+  //currSpecies["charge"][comp].setUnitSI();
+  //currSpecies["mass"][comp].setUnitSI();
+
+  // meta data
+  currSpecies["position"].setUnitDimension( detail::getUnitDimension("position") );
+  currSpecies["positionOffset"].setUnitDimension( detail::getUnitDimension("positionOffset") );
+  currSpecies["charge"].setUnitDimension( detail::getUnitDimension("charge") );
+  currSpecies["mass"].setUnitDimension( detail::getUnitDimension("mass") );
+
+  // meta data for ED-PIC extension
+  currSpecies["position"].setAttribute( "macroWeighted", 0u );
+  currSpecies["position"].setAttribute( "weightingPower", 0.0 );
+  currSpecies["positionOffset"].setAttribute( "macroWeighted", 0u );
+  currSpecies["positionOffset"].setAttribute( "weightingPower", 0.0 );
+  currSpecies["charge"].setAttribute( "macroWeighted", 0u );
+  currSpecies["charge"].setAttribute( "weightingPower", 1.0 );
+  currSpecies["mass"].setAttribute( "macroWeighted", 0u );
+  currSpecies["mass"].setAttribute( "weightingPower", 1.0 );
 }
-
-
 
 
 //
@@ -365,48 +479,109 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
                       const int iteration,
                       const double time ) const
 {
-  //This is AmrEx's tiny profiler. Possibly will apply it later
+  //This is AMReX's tiny profiler. Possibly will apply it later
   BL_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDFields()");
 
   if ( nullptr == m_Series)
     return;
 
-  const int ncomp = mf.nComp();
+  int const ncomp = mf.nComp();
 
   // Create a few vectors that store info on the global domain
   // Swap the indices for each of them, since AMReX data is Fortran order
   // and since the openPMD API assumes contiguous C order
   // - Size of the box, in integer number of cells
-  const amrex::Box& global_box = geom.Domain();
-  auto global_size = getReversedVec(global_box.size());
+  amrex::Box const & global_box = geom.Domain();
+  auto const global_size = getReversedVec(global_box.size());
   // - Grid spacing
-  std::vector<double> grid_spacing = getReversedVec(geom.CellSize());
+  std::vector<double> const grid_spacing = getReversedVec(geom.CellSize());
   // - Global offset
-  std::vector<double> global_offset = getReversedVec(geom.ProbLo());
+  std::vector<double> const global_offset = getReversedVec(geom.ProbLo());
   // - AxisLabels
 #if AMREX_SPACEDIM==3
-  std::vector<std::string> axis_labels{"x", "y", "z"};
+  std::vector<std::string> const axis_labels{"x", "y", "z"};
 #else
-  std::vector<std::string> axis_labels{"x", "z"};
+  std::vector<std::string> const axis_labels{"x", "z"};
 #endif
 
   // Prepare the type of dataset that will be written
-  openPMD::Datatype datatype = openPMD::determineDatatype<amrex::Real>();
-  auto dataset = openPMD::Dataset(datatype, global_size);
+  openPMD::Datatype const datatype = openPMD::determineDatatype<amrex::Real>();
+  auto const dataset = openPMD::Dataset(datatype, global_size);
 
+  // meta data
   auto series_iteration = m_Series->iterations[iteration];
   series_iteration.setTime( time );
+
+  // meta data for ED-PIC extension
+  auto const period = geom.periodicity(); // TODO double-check: is this the proper global bound or of some level?
+  std::vector< std::string > fieldBoundary( 6, "reflecting" );
+  std::vector< std::string > particleBoundary( 6, "absorbing" );
+#if AMREX_SPACEDIM!=3
+    fieldBoundary.resize(4);
+    particleBoundary.resize(4);
+#endif
+
+  for( auto i = 0u; i < fieldBoundary.size() / 2u; ++i )
+      if( m_fieldPMLdirections.at( i ) )
+          fieldBoundary.at( i ) = "open";
+
+  for( auto i = 0u; i < fieldBoundary.size() / 2u; ++i )
+      if( period.isPeriodic( i ) ) {
+          fieldBoundary.at(2u*i     ) = "periodic";
+          fieldBoundary.at(2u*i + 1u) = "periodic";
+          particleBoundary.at(2u*i     ) = "periodic";
+          particleBoundary.at(2u*i + 1u) = "periodic";
+      }
+
+  auto meshes = series_iteration.meshes;
+  meshes.setAttribute( "fieldSolver", [](){
+#ifdef WARPX_USE_PSATD
+      return "PSATD"; // TODO double-check if WARPX_USE_PSATD_HYBRID is covered
+#else
+      switch( WarpX::particle_pusher_algo ) {
+          case MaxwellSolverAlgo::Yee : return "Yee";
+          case MaxwellSolverAlgo::CKC : return "CK";
+          default: return "other";
+      }
+#endif
+  }() );
+  meshes.setAttribute( "fieldBoundary", fieldBoundary );
+  meshes.setAttribute( "particleBoundary", particleBoundary );
+  meshes.setAttribute( "currentSmoothing", [](){
+      if( WarpX::use_filter ) return "Binomial";
+          else return "none";
+  }() );
+    if( WarpX::use_filter )
+        meshes.setAttribute( "currentSmoothingParameters", [](){
+            std::stringstream ss;
+            ss << "period=1;compensator=false";
+            ss << ";numPasses_x=" << WarpX::filter_npass_each_dir[0];
+#if (AMREX_SPACEDIM == 3)
+            ss << ";numPasses_y=" << WarpX::filter_npass_each_dir[1];
+            ss << ";numPasses_z=" << WarpX::filter_npass_each_dir[2];
+#else
+            ss << ";numPasses_z=" << WarpX::filter_npass_each_dir[1];
+#endif
+            std::string currentSmoothingParameters = ss.str();
+            return std::move(currentSmoothingParameters);
+        }() );
+  meshes.setAttribute("chargeCorrection", [](){
+      if( WarpX::do_dive_cleaning ) return "hyperbolic"; // TODO or "spectral" or something? double-check
+      else return "none";
+  }() );
+  if( WarpX::do_dive_cleaning )
+    meshes.setAttribute("chargeCorrectionParameters", "period=1");
 
   // Loop through the different components, i.e. different fields stored in mf
   for (int icomp=0; icomp<ncomp; icomp++){
 
     // Check if this field is a vector or a scalar, and extract the field name
-    const std::string& varname = varnames[icomp];
+    std::string const & varname = varnames[icomp];
     std::string field_name = varname;
     std::string comp_name = openPMD::MeshRecordComponent::SCALAR;
-    for (const char* vector_field: {"E", "B", "j"}){
-        for (const char* comp: {"x", "y", "z"}){
-            if (varname[0] == *vector_field && varname[1] == *comp ){
+    for( char const* vector_field: {"E", "B", "j"} ) {
+        for( char const* comp: {"x", "y", "z"} ) {
+            if( varname[0] == *vector_field && varname[1] == *comp ) {
                 field_name = varname[0] + varname.substr(2); // Strip component
                 comp_name = varname[1];
             }
@@ -414,35 +589,36 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
     }
 
     // Setup the mesh record accordingly
-    auto mesh = series_iteration.meshes[field_name];
-    mesh.setDataOrder(openPMD::Mesh::DataOrder::F); // MultiFab: Fortran order
+    auto mesh = meshes[field_name];
+    mesh.setDataOrder( openPMD::Mesh::DataOrder::F ); // MultiFab: Fortran order of indices and axes
     mesh.setAxisLabels( axis_labels );
     mesh.setGridSpacing( grid_spacing );
     mesh.setGridGlobalOffset( global_offset );
+    mesh.setAttribute( "fieldSmoothing", "none" );
     setOpenPMDUnit( mesh, field_name );
 
     // Create a new mesh record component, and store the associated metadata
     auto mesh_comp = mesh[comp_name];
     mesh_comp.resetDataset( dataset );
     // Cell-centered data: position is at 0.5 of a cell size.
-    mesh_comp.setPosition(std::vector<double>{AMREX_D_DECL(0.5, 0.5, 0.5)});
+    mesh_comp.setPosition( std::vector<double>{AMREX_D_DECL(0.5, 0.5, 0.5)} );
 
     // Loop through the multifab, and store each box as a chunk,
     // in the openPMD file.
-    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
+    for( amrex::MFIter mfi(mf); mfi.isValid(); ++mfi ) {
 
-      const amrex::FArrayBox& fab = mf[mfi];
-      const amrex::Box& local_box = fab.box();
+      amrex::FArrayBox const& fab = mf[mfi];
+      amrex::Box const& local_box = fab.box();
 
       // Determine the offset and size of this chunk
-      amrex::IntVect box_offset = local_box.smallEnd() - global_box.smallEnd();
-      auto chunk_offset = getReversedVec(box_offset);
-      auto chunk_size = getReversedVec(local_box.size());
+      amrex::IntVect const box_offset = local_box.smallEnd() - global_box.smallEnd();
+      auto const chunk_offset = getReversedVec( box_offset );
+      auto const chunk_size = getReversedVec( local_box.size() );
 
       // Write local data
-      const double* local_data = fab.dataPtr(icomp);
-      mesh_comp.storeChunk(openPMD::shareRaw(local_data),
-                           chunk_offset, chunk_size);
+      double const * local_data = fab.dataPtr( icomp );
+      mesh_comp.storeChunk( openPMD::shareRaw(local_data),
+                            chunk_offset, chunk_size );
     }
   }
   // Flush data to disk after looping over all components

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -123,6 +123,9 @@ public:
     static long particle_pusher_algo;
     static int maxwell_fdtd_solver_id;
 
+    // div E cleaning
+    static int do_dive_cleaning;
+
     // Interpolation order
     static long nox;
     static long noy;
@@ -180,6 +183,9 @@ public:
     const amrex::MultiFab& getcurrent_fp (int lev, int direction) {return *current_fp[lev][direction];}
     const amrex::MultiFab& getEfield_fp  (int lev, int direction) {return *Efield_fp[lev][direction];}
     const amrex::MultiFab& getBfield_fp  (int lev, int direction) {return *Bfield_fp[lev][direction];}
+
+    /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */
+    std::vector<bool> getPMLdirections() const;
 
     static amrex::MultiFab* getCosts (int lev) {
         if (m_instance) {
@@ -576,9 +582,6 @@ private:
     // If charge/current deposition buffers are used
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > current_buf;
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > charge_buf;
-
-    // div E cleaning
-    int do_dive_cleaning = 0;
 
     // PML
     int do_pml = 1;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -58,6 +58,7 @@ long WarpX::charge_deposition_algo;
 long WarpX::field_gathering_algo;
 long WarpX::particle_pusher_algo;
 int WarpX::maxwell_fdtd_solver_id;
+int WarpX::do_dive_cleaning = 0;
 
 long WarpX::n_rz_azimuthal_modes = 1;
 long WarpX::ncomps = 1;
@@ -155,7 +156,7 @@ WarpX::WarpX ()
     ReadParameters();
 
 #ifdef WARPX_USE_OPENPMD
-    m_OpenPMDPlotWriter = new WarpXOpenPMDPlot(openpmd_tspf, openpmd_backend);
+    m_OpenPMDPlotWriter = new WarpXOpenPMDPlot(openpmd_tspf, openpmd_backend, WarpX::getPMLdirections());
 #endif
 
     // Geometry on all levels has been defined already.
@@ -1221,6 +1222,24 @@ WarpX::GetPML (int lev)
     } else {
         return nullptr;
     }
+}
+
+std::vector< bool >
+WarpX::getPMLdirections() const
+{
+    std::vector< bool > dirsWithPML( 6, false );
+#if AMREX_SPACEDIM!=3
+    dirsWithPML.resize( 4 );
+#endif
+    if( do_pml )
+    {
+        for( auto i = 0u; i < dirsWithPML.size() / 2u; ++i )
+        {
+            dirsWithPML.at( 2u*i      ) = bool(do_pml_Lo[i]);
+            dirsWithPML.at( 2u*i + 1u ) = bool(do_pml_Hi[i]);
+        }
+    }
+    return dirsWithPML;
 }
 
 void


### PR DESCRIPTION
Add all required attributes to support the openPMD `1.1.*` ED-PIC extension.
Close #619

## References

- [openPMD base standard 1.1.0](https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md)
- [openPMD ED-PIC extension 1.1.0](https://github.com/openPMD/openPMD-standard/blob/1.1.0/EXT_ED-PIC.md)

## To Do

- [x] particle species: add `id` record for particle tracking
- [x] add `warpx.authors` input option
- [x] rebase after #644 was merged
- [x] double check `TODO` notes in code

## Follow-Up PRs

- [ ] mesh records: add `do_nodal` handling for `position` attribute