### PR TITLE
Fix PICSAR Version Macro Check

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -65,8 +65,8 @@ public:
     WarpX ();
     ~WarpX ();
 
-    static std::string Version ();
-    static std::string PicsarVersion ();
+    static std::string Version (); //! Version of WarpX executable
+    static std::string PicsarVersion (); //! Version of PICSAR dependency
 
     int Verbose () const { return verbose; }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1303,7 +1303,7 @@ WarpX::Version ()
 std::string
 WarpX::PicsarVersion ()
 {
-#ifdef WARPX_GIT_VERSION
+#ifdef PICSAR_GIT_VERSION
     return std::string(PICSAR_GIT_VERSION);
 #else
     return std::string("Unknown");


### PR DESCRIPTION
Fixes a slight macro copy-paste error when querying the PICSAR version.