### PR TITLE
add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,35 @@
+Andrew Myers <atmyers@lbl.gov>              Andrew Myers <atmyers2@gmail.com>
+Andrew Myers <atmyers@lbl.gov>              atmyers <atmyers2@gmail.com>
+Aurore Blelly <ablelly@lbl.gov>             ablelly <aurore.blelly@ensta-paristech.fr>
+Aurore Blelly <ablelly@lbl.gov>             ablelly <48810880+ablelly@users.noreply.github.com>
+Axel Huebl <axelhuebl@lbl.gov>              Axel Huebl <axel.huebl@plasma.ninja>
+David Grote <dpgrote@lbl.gov>               grote <dpgrote@lbl.gov>
+David Grote <dpgrote@lbl.gov>               Dave <grote1@llnl.gov>
+David Grote <dpgrote@lbl.gov>               Dave Grote <grote1@llnl.gov>
+David Grote <dpgrote@lbl.gov>               Grote <grote1@n9459722.llnl.gov>
+Edoardo Zoni <ezoni@lbl.gov>                Edoardo Zoni <edoardo.zoni@ipp.mpg.de>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>   L. Diana Amorim <LDianaAmorim@lbl.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>   Diana Amorim <diana@henrivincenti.dhcp.lbl.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>   Ligia Diana Amorim <ligiada@cori01.nersc.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>   Ligia Diana Amorim <ligiada@cori11.nersc.gov>
+Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca.fedeli.88@gmail.com>
+Luca Fedeli <luca.fedeli@cea.fr>            lucafedeli88 <luca.fedeli@cea.fr>
+Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca@DEB.station>
+Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca.fedeli@for.unipi.it>
+Luca Fedeli <luca.fedeli@cea.fr>            Luca <luca@localhost.localdomain>
+Mathieu Lobet <mathieu.lobet@cea.fr>        Mathieu Lobet <mathieu.lobet@gmail.com>
+Mathieu Lobet <mathieu.lobet@cea.fr>        mathieu_lobet <mathieu.lobet@gmail.com>
+Maxence Thevenet <mthevenet@lbl.gov>        MaxThevenet <mthevenet@lbl.gov>
+Maxence Thevenet <mthevenet@lbl.gov>        Maxence Thévenet <mthevenet@lbl.gov>
+Maxence Thevenet <mthevenet@lbl.gov>        mthevenet <mthevenet@lbl.gov>
+Remi Lehe <rlehe@lbl.gov>                   Remi Lehe <remi.lehe@normalesup.org>
+Revathi Jambunathan <rjambunathan@lbl.gov>  RevathiJambunathan <revanathan@gmail.com>
+Revathi Jambunathan <rjambunathan@lbl.gov>  RevathiJambunathan <rjnathan@cori12.nersc.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login2.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login3.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login4.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login5.summit.olcf.ornl.gov>
+Weiqun Zhang <weiqunzhang@lbl.gov>          Weiqun Zhang <WeiqunZhang@lbl.gov>
+Weiqun Zhang <weiqunzhang@lbl.gov>          WeiqunZhang <WeiqunZhang@lbl.gov
+Yinjian Zhao <yinjianzhao@lbl.gov>          Yin-YinjianZhao <yinjianzhao@lbl.gov>
+Yinjian Zhao <yinjianzhao@lbl.gov>          Yin-YinjianZhao <56095356+Yin-YinjianZhao@users.noreply.github.com>


### PR DESCRIPTION
We currently add copyright lines to files via scripts that read the git history.

A mailmap is useful when trying to sort out unique users that contributed under various local name and e-mail settings to our repo's git history.
See e.g. https://github.com/spack/spack/blob/develop/.mailmap

privacy note: these names are already searchable in the git history of the same repo :)

P.S.: Please set the configs in your GitHub profile for Name & E-Mail as well as your development machines (all machines where you commit) consistently:
- GitHub: [name](https://github.com/settings/profile) and [e-mail](https://github.com/settings/emails) setting
- Local Git Development: [name](https://help.github.com/en/github/using-git/setting-your-username-in-git) and [e-mail](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address#setting-your-commit-email-address-in-git) setting