### PR TITLE
Fix matplotlib error on battra

### DIFF
--- a/Examples/Modules/laser_injection_from_file/analysis.py
+++ b/Examples/Modules/laser_injection_from_file/analysis.py
@@ -10,6 +10,8 @@
 
 import yt ; yt.funcs.mylog.setLevel(50)
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from scipy.signal import hilbert
 import glob


### PR DESCRIPTION
The `laser_injection_from_file` test is failing on battra:
https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2020-01-17/LaserInjectionFromTXYEFile.html
This is due to a matplotlib error:
https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2020-01-17/LaserInjectionFromTXYEFile.err.out

From memory, this can be fixed by setting the matplotlib backend (which is what we do in the other analysis scripts). Therefore, this PR should fix the issue.