### PR TITLE
gitignore: Sphinx & Bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Bin/
 main?d.*.ex
 Python/pywarpx/libwarpx*.so
 d/
@@ -22,6 +23,13 @@ chk*
 ##########
 *.pyc
 __pycache__
+
+##########
+# Sphinx #
+##########
+Docs/doxyhtml/
+Docs/doxyxml/
+Docs/source/_static/
 
 #######
 # IDE #


### PR DESCRIPTION
Add temporary Sphinx doc directories and the `Bin/` directory to `.gitignore` .

Avoids accidentally adding and/or checking in files in those locations.