### PR TITLE
Fixed field names for RZ modes in plot files

### DIFF
--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -476,6 +476,15 @@ AddToVarNames (Vector<std::string>& varnames,
     for(auto coord:coords) varnames.push_back(name+coord+suffix);
 }
 
+/** \brief Add RZ variable names to the list.
+ */
+void
+AddToVarNamesRZ (Vector<std::string>& varnames,
+                 std::string name, std::string suffix) {
+    auto coords = {"r", "theta", "z"};
+    for(auto coord:coords) varnames.push_back(name+coord+suffix);
+}
+
 /** \brief Write the different fields that are meant for output,
  * into the vector of MultiFab `mf_avg` (one MultiFab per level)
  * after averaging them to the cell centers.
@@ -551,31 +560,31 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             if(lev==0) varnames.push_back(fieldname);
             if        (fieldname == "Ex"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_E, 0, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 0, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 0, dcomp, ngrow, "Er", varnames);
             } else if (fieldname == "Ey"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_E, 1, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 1, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 1, dcomp, ngrow, "Etheta", varnames);
             } else if (fieldname == "Ez"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_E, 2, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 2, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_E, 2, dcomp, ngrow, "Ez", varnames);
             } else if (fieldname == "Bx"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_B, 0, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 0, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 0, dcomp, ngrow, "Br", varnames);
             } else if (fieldname == "By"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_B, 1, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 1, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 1, dcomp, ngrow, "Btheta", varnames);
             } else if (fieldname == "Bz"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_B, 2, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 2, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_B, 2, dcomp, ngrow, "Bz", varnames);
             } else if (fieldname == "jx"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_J, 0, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 0, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 0, dcomp, ngrow, "jr", varnames);
             } else if (fieldname == "jy"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_J, 1, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 1, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 1, dcomp, ngrow, "jtheta", varnames);
             } else if (fieldname == "jz"){
                 MultiFab::Copy( mf_avg[lev], mf_tmp_J, 2, dcomp++, 1, ngrow);
-                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 2, dcomp, ngrow, fieldname, varnames);
+                CopyVectorFieldComponentsToMultiFab(lev, mf_avg, mf_tmp_J, 2, dcomp, ngrow, "jz", varnames);
             } else if (fieldname == "rho"){
                 AverageAndPackScalarField( mf_avg[lev], *rho_fp[lev], dcomp++, ngrow );
                 CopyScalarFieldComponentsToMultiFab(lev, mf_avg, *rho_fp[lev], dcomp, ngrow, n_rz_azimuthal_modes,
@@ -651,10 +660,10 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             if (lev == 0) {
                 AddToVarNames(varnames, "E", "_fp");
                 if (n_rz_azimuthal_modes > 1) {
-                    AddToVarNames(varnames, "E", ComponentName("_fp", 0, "real"));
+                    AddToVarNamesRZ(varnames, "E", ComponentName("_fp", 0, "real"));
                     for (int mode=1 ; mode < n_rz_azimuthal_modes ; mode++) {
-                        AddToVarNames(varnames, "E", ComponentName("_fp", mode, "real"));
-                        AddToVarNames(varnames, "E", ComponentName("_fp", mode, "imag"));
+                        AddToVarNamesRZ(varnames, "E", ComponentName("_fp", mode, "real"));
+                        AddToVarNamesRZ(varnames, "E", ComponentName("_fp", mode, "imag"));
                     }
                 }
             }
@@ -664,10 +673,10 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             if (lev == 0) {
                 AddToVarNames(varnames, "B", "_fp");
                 if (n_rz_azimuthal_modes > 1) {
-                    AddToVarNames(varnames, "B", ComponentName("_fp", 0, "real"));
+                    AddToVarNamesRZ(varnames, "B", ComponentName("_fp", 0, "real"));
                     for (int mode=1 ; mode < n_rz_azimuthal_modes ; mode++) {
-                        AddToVarNames(varnames, "B", ComponentName("_fp", mode, "real"));
-                        AddToVarNames(varnames, "B", ComponentName("_fp", mode, "imag"));
+                        AddToVarNamesRZ(varnames, "B", ComponentName("_fp", mode, "real"));
+                        AddToVarNamesRZ(varnames, "B", ComponentName("_fp", mode, "imag"));
                     }
                 }
             }


### PR DESCRIPTION
This replaces Ex and Ey with Er and Etheta for the RZ modes. Same with B and j.