### PR TITLE
Authors Input Option

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -9,6 +9,10 @@ Input parameters
 Overall simulation parameters
 -----------------------------
 
+* ``authors`` (`string`: e.g. ``"Jane Doe <jane@example.com>, Jimmy Joe <jimmy@example.com>"``)
+    Authors of an input file / simulation setup.
+    When provided, this information is added as metadata to (openPMD) output files.
+
 * ``max_step`` (`integer`)
     The number of PIC cycles to perform.
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -100,6 +100,9 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
     else
     m_Series = std::make_unique<openPMD::Series>(filename, accessType);
 
+    // input file / simulation setup author
+    if( WarpX::authors.size() > 0u )
+        m_Series->setAuthor( WarpX::authors );
     // more natural naming for PIC
     m_Series->setMeshesPath("fields");
     // TODO conform to ED-PIC extension of openPMD

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -83,6 +83,9 @@ public:
 
     static void GotoNextLine (std::istream& is);
 
+    //! Author of an input file / simulation setup
+    static std::string authors;
+
     // External fields added to particle fields.
     static amrex::Vector<amrex::Real> B_external_particle;
     static amrex::Vector<amrex::Real> E_external_particle;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -30,6 +30,7 @@ Vector<Real> WarpX::E_external_particle(3, 0.0);
 Vector<Real> WarpX::E_external_grid(3, 0.0);
 Vector<Real> WarpX::B_external_grid(3, 0.0);
 
+std::string WarpX::authors = "";
 std::string WarpX::B_ext_grid_s = "default";
 std::string WarpX::E_ext_grid_s = "default";
 
@@ -304,6 +305,7 @@ WarpX::ReadParameters ()
         ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.
         pp.query("max_step", max_step);
         pp.query("stop_time", stop_time);
+        pp.query("authors", authors);
     }
 
     {


### PR DESCRIPTION
Needed for #630.

Add an `authors` input option that we can use to populate output files (#630) with meta-data of the author & runner of a simulation scenario.

Missing: Add all authors from git history to example input files for demonstration (example-driven development).