### PR TITLE
Interpolate Current: Fix Shadow Warning

### DIFF
--- a/Source/Parallelization/InterpolateCurrentFineToCoarse.H
+++ b/Source/Parallelization/InterpolateCurrentFineToCoarse.H
@@ -63,9 +63,9 @@ public:
 
         // return zero for out-of-bounds accesses during interpolation
         // this is efficiently used as a method to add neutral elements beyond guards in the average below
-        auto const fine = [fine_unsafe] AMREX_GPU_DEVICE (int const j, int const k, int const l) noexcept
+        auto const fine = [fine_unsafe] AMREX_GPU_DEVICE (int const jj, int const kk, int const ll) noexcept
         {
-            return fine_unsafe.contains(j, k, l) ? fine_unsafe(j, k, l) :  amrex::Real{0.};
+            return fine_unsafe.contains(jj, kk, ll) ? fine_unsafe(jj, kk, ll) :  amrex::Real{0.};
         };
 
         int const ii = i * m_refinement_ratio;


### PR DESCRIPTION
Fix a variable shadowing warning in InterpolateCurrentFineToCoarse.