### PR TITLE
Run single tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Once your new feature is ready, you can check that you did not break anything.
 WarpX has automated tests running for each Pull Request. For easier debugging,
 it can be convenient to run the tests on your local machine with
 ```
-./run_tests.sh
+./run_test.sh
 ```
 from WarpX root folder. The tests can be influenced by environment variables:
 - `export WARPX_TEST_DIM=3`, `export WARPX_TEST_DIM=2` or `export WARPX_TEST_DIM=RZ` 
@@ -103,6 +103,11 @@ in order to select only the tests that correspond to this dimensionality
 - `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order to
 run the tests on CPU or GPU respectively.
 - `export WARPX_TEST_COMMIT=...` in order to test a specific commit.
+
+The command above (without command line arguments) runs all the tests defined in [Regression/WarpX-tests.ini](./Regression/WarpX-tests.ini). In order to run single tests, pass the test names as command line arguments:
+```
+./run_test.sh test1 test2
+```
 
 ### Submit a Pull Request
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -38,7 +38,7 @@ cd test_dir
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
 # Use QED brach for QED tests
-if [ ${HAS_QED} = "TRUE" ]; then
+if [[ ${HAS_QED} = "TRUE" ]]; then
     git clone --branch QED https://bitbucket.org/berkeleylab/picsar.git
 else
     git clone --branch master https://bitbucket.org/berkeleylab/picsar.git

--- a/run_test.sh
+++ b/run_test.sh
@@ -12,9 +12,11 @@
 # Use `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order
 # to run the tests on CPU or GPU respectively.
 
-# Parse command line arguments: put all command line arguments into single string
-# (passed as additional command line argument when calling regtest.py)
-args="$*"
+# Parse command line arguments: if test names are given as command line arguments,
+# store them in variable tests_arg and define new command line argument to call
+# regtest.py with option --tests (works also for single test)
+tests_arg=$*
+tests_run=${tests_arg:+--tests=${tests_arg}}
 
 # Remove contents and link to a previous test directory (intentionally two arguments)
 rm -rf test_dir/* test_dir
@@ -53,6 +55,12 @@ cd warpx/Regression
 python prepare_file_travis.py
 cp travis-tests.ini ../../rt-WarpX
 
-# Run the tests
+# Run tests
 cd ../../regression_testing/
-python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} $args
+# run only tests specified in variable tests_arg (single test or multiple tests)
+if [[ ! -z "${tests_arg}" ]]; then
+python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} "${tests_run}"
+# run all tests (variables tests_arg and tests_run are empty)
+else
+python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}
+fi

--- a/run_test.sh
+++ b/run_test.sh
@@ -40,7 +40,7 @@ cd test_dir
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
 # Use QED brach for QED tests
-if [[ ${HAS_QED} = "TRUE" ]]; then
+if [ "${HAS_QED}" = "TRUE" ]; then
     git clone --branch QED https://bitbucket.org/berkeleylab/picsar.git
 else
     git clone --branch master https://bitbucket.org/berkeleylab/picsar.git

--- a/run_test.sh
+++ b/run_test.sh
@@ -12,6 +12,10 @@
 # Use `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order
 # to run the tests on CPU or GPU respectively.
 
+# Parse command line arguments: put all command line arguments into single string
+# (passed as additional command line argument when calling regtest.py)
+args="$*"
+
 # Remove contents and link to a previous test directory (intentionally two arguments)
 rm -rf test_dir/* test_dir
 # Create a temporary test directory
@@ -51,4 +55,4 @@ cp travis-tests.ini ../../rt-WarpX
 
 # Run the tests
 cd ../../regression_testing/
-python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}
+python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} $args


### PR DESCRIPTION
Add possibility of running only single tests (instead of all tests defined in `Regression/WarpX-tests.ini`): test names can be now passed as command line arguments when running `run_test.sh` (uses the `--tests` option of parser called by `regtest.py`). New feature briefly documented in `CONTRIBUTING.md`.