### PR TITLE
Minor fix to slice parameters in Docs

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1042,7 +1042,7 @@ Diagnostics and output
     time interval is expressed in the laboratory frame).
 
 * ``slice.particle_slice_width_lab`` (`float`, in meters)
-    Only used when ``warpx.do_boosted_frame_diagnostic`` is ``1`` and
+    Only used when ``warpx.do_back_transformed_diagnostics`` is ``1`` and
     ``slice.num_slice_snapshots_lab`` is non-zero. Particles are
     copied from the full back-transformed diagnostic to the reduced
     slice diagnostic if there are within the user-defined width from


### PR DESCRIPTION
This is a super minor fix to the slice diagnostics information in the Docs.
It seemed to me that it still refers to the old label of `warpx.do_boosted_frame_diagnostic` instead of the new one: `warpx.do_back_transformed_diagnostics`.
But I might be misreading it, so please feel free to correct me if this is wrong!