### PR TITLE
Simplify I/O Options

### DIFF
--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -1,3 +1,5 @@
+.. _building-openpmd:
+
 Building WarpX with support for openPMD output
 ==============================================
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -969,25 +969,21 @@ Boundary conditions
 Diagnostics and output
 ----------------------
 
-* ``amr.plot_int`` (`integer`)
-    The number of PIC cycles inbetween two consecutive data dumps. Use a
-    negative number to disable data dumping.
+* ``amr.plot_int`` (`integer`) optional
+    The number of PIC cycles (interval) in between two consecutive `plotfile` data dumps.
+    Use a negative number to disable data dumping.
+    This is ``-1`` (disabled) by default.
 
-* ``warpx.dump_plotfiles`` (`0` or `1`) optional
-    Whether to dump the simulation data in
-    `AMReX plotfile <https://amrex-codes.github.io/amrex/docs_html/IO.html>`__
-    format. This is ``1`` by default, unless WarpX is compiled with openPMD support.
+* ``warpx.openpmd_int`` (`integer`) optional
+    The number of PIC cycles (interval) in between two consecutive `openPMD <https://www.openPMD.org>`_ data dumps.
+    Requires to build WarpX with ``USE_OPENPMD=TRUE`` (see :ref:`instructions <building-openpmd>`).
+    This is ``-1`` (disabled) by default.
 
-* ``warpx.dump_openpmd`` (`0` or `1`) optional
-    Whether to dump the simulation data in
-    `openPMD <https://github.com/openPMD>`__ format.
-    When WarpX is compiled with openPMD support, this is ``1`` by default.
-
-* ``warpx.openpmd_backend`` (``h5``, ``bp`` or ``json``) optional
-    I/O backend for
-    `openPMD <https://github.com/openPMD>`__ dumps.
-    When WarpX is compiled with openPMD support, this is ``h5`` by default.
+* ``warpx.openpmd_backend`` (``bp``, ``h5`` or ``json``) optional
+    `I/O backend <https://openpmd-api.readthedocs.io/en/latest/backends/overview.html>`_ for `openPMD <https://www.openPMD.org>`_ data dumps.
+    ``bp`` is the `ADIOS I/O library <https://csmd.ornl.gov/adios>`_, ``h5`` is the `HDF5 format <https://www.hdfgroup.org/solutions/hdf5/>`, and ``json`` is a `simple text format <https://en.wikipedia.org/wiki/JSON>`_.
     ``json`` only works with serial/single-rank jobs.
+    When WarpX is compiled with openPMD support, the first available backend in the order given above is taken.
 
 * ``warpx.do_back_transformed_diagnostics`` (`0` or `1`)
     Whether to use the **back-transformed diagnostics** (i.e. diagnostics that

--- a/Docs/source/visualization/visualization.rst
+++ b/Docs/source/visualization/visualization.rst
@@ -2,13 +2,13 @@ Visualizing the simulation results
 ==================================
 
 WarpX can write data either in `plotfile` format (AMReX's native format), or
-in `openPMD format <https://www.openpmd.org/>`_ (a common data format for
-Particle-In-Cell codes).
+in `openPMD format <https://www.openpmd.org/>`_ (a common data schema on top of
+HDF5 or ADIOS files for particle-in-cell codes).
 
 .. note::
 
-    This is controlled by the parameters ``warpx.dump_plotfiles`` and
-    ``warpx.dump_openpmd`` & ``warpx.openpmd_backend`` in the section
+    This is controlled by the parameters ``warpx.plot_int`` (AMReX) or the
+    ``warpx.openpmd_int`` & ``warpx.openpmd_backend`` options in the section
     :doc:`../running_cpp/parameters`.
 
 This section describes some of the tools available to visualize the data:

--- a/Examples/Tests/particles_in_PML/inputs_2d
+++ b/Examples/Tests/particles_in_PML/inputs_2d
@@ -6,8 +6,6 @@ amr.blocking_factor = 8
 amr.max_grid_size = 1024
 amr.max_level = 0
 
-warpx.dump_plotfiles = 1
-
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = 0     0          # Is periodic?

--- a/Examples/Tests/particles_in_PML/inputs_3d
+++ b/Examples/Tests/particles_in_PML/inputs_3d
@@ -6,8 +6,6 @@ amr.blocking_factor = 8
 amr.max_grid_size = 1024
 amr.max_level = 0
 
-warpx.dump_plotfiles = 1
-
 # Geometry
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = 0     0     0     # Is periodic?

--- a/Python/pywarpx/timestepper.py
+++ b/Python/pywarpx/timestepper.py
@@ -66,8 +66,10 @@ class TimeStepper(object):
 
         max_time_reached = ((self.cur_time >= libwarpx.warpx_stopTime() - 1.e-6*dt) or (self.istep >= libwarpx.warpx_maxStep()))
 
-        if libwarpx.warpx_plotInt() > 0 and (self.istep+1)%libwarpx.warpx_plotInt() == 0 or max_time_reached:
+        if (libwarpx.warpx_plotInt() > 0 and (self.istep+1)%libwarpx.warpx_plotInt() == 0) or max_time_reached:
             libwarpx.warpx_WritePlotFile()
+        if (libwarpx.warpx_openpmdInt() > 0 and (self.istep+1)%libwarpx.warpx_openpmdInt() == 0) or max_time_reached:
+            libwarpx.warpx_WriteOpenPMDFile()
 
         if libwarpx.warpx_checkInt() > 0 and (self.istep+1)%libwarpx.warpx_plotInt() == 0 or max_time_reached:
             libwarpx.warpx_WriteCheckPointFile()

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -2,7 +2,7 @@
 #include <WarpX.H>
 #include <FieldIO.H>
 #ifdef WARPX_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
+#   include <openPMD/openPMD.hpp>
 #endif
 
 #include <AMReX_FillPatchUtil_F.H>

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #ifdef WARPX_USE_OPENPMD
-#include "WarpXOpenPMD.H"
+#   include "WarpXOpenPMD.H"
 #endif
 
 
@@ -499,45 +499,68 @@ WarpX::UpdateInSitu () const
 }
 
 void
-WarpX::WritePlotFile () const
-{
-    BL_PROFILE("WarpX::WritePlotFile()");
-
-    const std::string& plotfilename = amrex::Concatenate(plot_file,istep[0]);
-    amrex::Print() << "  Writing plotfile " << plotfilename << "\n";
-
+WarpX::prepareFields(
+        int const step,
+        Vector<std::string>& varnames,
+        Vector<MultiFab>& mf_avg,
+        Vector<const MultiFab*>& output_mf,
+        Vector<Geometry>& output_geom
+) const {
     // Average the fields from the simulation grid to the cell centers
     const int ngrow = 0;
-    Vector<std::string> varnames; // Name of the written fields
-    // mf_avg will contain the averaged, cell-centered fields
-    Vector<MultiFab> mf_avg;
     WarpX::AverageAndPackFields( varnames, mf_avg, ngrow );
 
     // Coarsen the fields, if requested by the user
-    Vector<const MultiFab*> output_mf; // will point to the data to be written
     Vector<MultiFab> coarse_mf; // will remain empty if there is no coarsening
-    Vector<Geometry> output_geom;
     if (plot_coarsening_ratio != 1) {
         coarsenCellCenteredFields( coarse_mf, output_geom, mf_avg, Geom(),
-                                    plot_coarsening_ratio, finest_level );
+                                   plot_coarsening_ratio, finest_level );
         output_mf = amrex::GetVecOfConstPtrs(coarse_mf);
     } else {  // No averaging necessary, simply point to mf_avg
         output_mf = amrex::GetVecOfConstPtrs(mf_avg);
         output_geom = Geom();
     }
+}
+
+void
+WarpX::WriteOpenPMDFile () const
+{
+    BL_PROFILE("WarpX::WriteOpenPMDFile()");
 
 #ifdef WARPX_USE_OPENPMD
-    if (dump_openpmd) {
-        m_OpenPMDPlotWriter->SetStep(istep[0]);
-        // fields: only dumped for coarse level
-        m_OpenPMDPlotWriter->WriteOpenPMDFields(
-            varnames, *output_mf[0], output_geom[0], istep[0], t_new[0]);
-        // particles: all (reside only on locally finest level)
-        m_OpenPMDPlotWriter->WriteOpenPMDParticles(mypc);
-    }
-#endif
+    const auto step = istep[0];
 
-    if (dump_plotfiles) {
+    Vector<std::string> varnames; // Name of the written fields
+    Vector<MultiFab> mf_avg; // contains the averaged, cell-centered fields
+    Vector<const MultiFab*> output_mf; // will point to the data to be written
+    Vector<Geometry> output_geom;
+
+    prepareFields(step, varnames, mf_avg, output_mf, output_geom);
+
+    m_OpenPMDPlotWriter->SetStep(step);
+    // fields: only dumped for coarse level
+    m_OpenPMDPlotWriter->WriteOpenPMDFields(
+        varnames, *output_mf[0], output_geom[0], step, t_new[0]);
+    // particles: all (reside only on locally finest level)
+    m_OpenPMDPlotWriter->WriteOpenPMDParticles(mypc);
+#endif
+}
+
+void
+WarpX::WritePlotFile () const
+{
+    BL_PROFILE("WarpX::WritePlotFile()");
+
+    const auto step = istep[0];
+    const std::string& plotfilename = amrex::Concatenate(plot_file,step);
+    amrex::Print() << "  Writing plotfile " << plotfilename << "\n";
+
+    Vector<std::string> varnames; // Name of the written fields
+    Vector<MultiFab> mf_avg; // contains the averaged, cell-centered fields
+    Vector<const MultiFab*> output_mf; // will point to the data to be written
+    Vector<Geometry> output_geom;
+
+    prepareFields(step, varnames, mf_avg, output_mf, output_geom);
 
     // Write the fields contained in `mf_avg`, and corresponding to the
     // names `varnames`, into a plotfile.
@@ -620,18 +643,13 @@ WarpX::WritePlotFile () const
         }
     }
 
-    // leaving the option of binary output through AMREx around
-    // regardless of openPMD. This can be adjusted later
-    {
-      mypc->WritePlotFile(plotfilename);
-    }
+    mypc->WritePlotFile(plotfilename);
 
     WriteJobInfo(plotfilename);
 
     WriteWarpXHeader(plotfilename);
 
     VisMF::SetHeaderVersion(current_version);
-    } // endif: dump_plotfiles
 
 }
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -106,8 +106,10 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot(bool oneFilePerTS,
 
 WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
 {
-  if (nullptr != m_Series) {
+  if( m_Series )
+  {
     m_Series->flush();
+    m_Series.reset( nullptr );
   }
 }
 
@@ -143,31 +145,26 @@ void WarpXOpenPMDPlot::SetStep(int ts)
 void
 WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
 {
-  if (!m_OneFilePerTS) {// one file
-    if (nullptr != m_Series) {
-      return;
+    // either for the next ts file,
+    // or init a single file for all ts
+    std::string filename;
+    GetFileName(filename);
+
+    if( amrex::ParallelDescriptor::NProcs() > 1 )
+    {
+        m_Series = std::make_unique<openPMD::Series>(
+            filename, accessType,
+            amrex::ParallelDescriptor::Communicator()
+        );
+        m_MPISize = amrex::ParallelDescriptor::NProcs();
+        m_MPIRank = amrex::ParallelDescriptor::MyProc();
     }
-  }
-
-  // either for the next ts file,
-  // or init a single file for all ts
-  std::string filename;
-  GetFileName(filename);
-
-  if (m_Series != nullptr) {
-    m_Series->flush();
-    m_Series = nullptr;
-  }
-
-  if (amrex::ParallelDescriptor::NProcs() > 1) {
-    m_Series = std::make_unique<openPMD::Series>(filename,
-                   accessType,
-                   amrex::ParallelDescriptor::Communicator());
-    m_MPISize = amrex::ParallelDescriptor::NProcs();
-    m_MPIRank = amrex::ParallelDescriptor::MyProc();
-  }
     else
-    m_Series = std::make_unique<openPMD::Series>(filename, accessType);
+    {
+        m_Series = std::make_unique<openPMD::Series>(filename, accessType);
+        m_MPISize = 1;
+        m_MPIRank = 1;
+    }
 
     // input file / simulation setup author
     if( WarpX::authors.size() > 0u )
@@ -178,8 +175,12 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
     uint32_t const openPMD_ED_PIC = 1u;
     m_Series->setOpenPMDextension( openPMD_ED_PIC );
     // meta info
+#if (OPENPMDAPI_VERSION_MAJOR>=0) && (OPENPMDAPI_VERSION_MINOR>=11)
+    m_Series->setSoftware( "WarpX", WarpX::Version() );
+#else
     m_Series->setSoftware( "WarpX" );
-    m_Series->setSoftwareVersion( WarpX::Version() ) ;
+    m_Series->setSoftwareVersion( WarpX::Version() );
+#endif
 }
 
 
@@ -260,8 +261,7 @@ WarpXOpenPMDPlot::SavePlotFile (const std::unique_ptr<WarpXParticleContainer>& p
                     const amrex::Vector<std::string>& real_comp_names,
                     const amrex::Vector<std::string>&  int_comp_names) const
 {
-  if ( nullptr == m_Series)
-    return;
+  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD series must be initialized");
 
   WarpXParticleCounter counter(pc);
 
@@ -308,50 +308,48 @@ WarpXOpenPMDPlot::SavePlotFile (const std::unique_ptr<WarpXParticleContainer>& p
   SetupPos(pc, currSpecies, counter.GetTotalNumParticles());
   SetupRealProperties(currSpecies, write_real_comp, real_comp_names, counter.GetTotalNumParticles());
 
-  // forces the files created by all processors! this is the key to resolve RZ storage issue!!
+  // open files from all processors, in case some will not contribute below
   m_Series->flush();
+
   for (auto currentLevel = 0; currentLevel <= pc->finestLevel(); currentLevel++)
     {
-      uint64_t const numParticles = static_cast<uint64_t>( counter.m_ParticleSizeAtRank[currentLevel] );
       uint64_t offset = static_cast<uint64_t>( counter.m_ParticleOffsetAtRank[currentLevel] );
-
-      if (0u == numParticles)
-          return;
-
-      // pc->NumIntComp() & NumRealComp() are protected,
-      // from WarpXParIter template class definition, we know that
-      // soa num real attributes = PIdx::nattribs, and num int in soa is 0
 
       for (WarpXParIter pti(*pc, currentLevel); pti.isValid(); ++pti) {
          auto const numParticleOnTile = pti.numParticles();
          uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
 
          // get position and particle ID from aos
-         // note: this implementation iterates the AoS 4x but saves memory... iterating once could be beneficial, too
+         // note: this implementation iterates the AoS 4x...
+         // if we flush late as we do now, we can also copy out the data in one go
          const auto& aos = pti.GetArrayOfStructs();  // size =  numParticlesOnTile
          {
            // Save positions
            std::vector<std::string> axisNames={"x", "y", "z"};
            for (auto currDim = 0; currDim < AMREX_SPACEDIM; currDim++) {
-                std::vector<amrex::ParticleReal> curr(numParticleOnTile, 0.);
+                std::shared_ptr< amrex::ParticleReal > curr(
+                    new amrex::ParticleReal[numParticleOnTile],
+                    [](amrex::ParticleReal const *p){ delete[] p; }
+                );
                 for (auto i=0; i<numParticleOnTile; i++) {
-                     curr[i] = aos[i].m_rdata.pos[currDim];
+                     curr.get()[i] = aos[i].m_rdata.pos[currDim];
                 }
                 currSpecies["position"][axisNames[currDim]].storeChunk(curr, {offset}, {numParticleOnTile64});
-                m_Series->flush();
            }
 
            // save particle ID after converting it to a globally unique ID
-           std::vector<uint64_t> ids(numParticleOnTile, 0.);
+           std::shared_ptr< uint64_t > ids(
+               new uint64_t[numParticleOnTile],
+               [](uint64_t const *p){ delete[] p; }
+           );
            for (auto i=0; i<numParticleOnTile; i++) {
                detail::GlobalID const nextID = { aos[i].m_idata.id, aos[i].m_idata.cpu };
-               ids[i] = nextID.global_id;
+               ids.get()[i] = nextID.global_id;
            }
            auto const scalar = openPMD::RecordComponent::SCALAR;
            currSpecies["id"][scalar].storeChunk(ids, {offset}, {numParticleOnTile64});
-           m_Series->flush();
         }
-         //  save properties
+         //  save "extra" particle properties in AoS and SoA
          SaveRealProperty(pti,
              currSpecies,
              offset,
@@ -360,6 +358,7 @@ WarpXOpenPMDPlot::SavePlotFile (const std::unique_ptr<WarpXParticleContainer>& p
          offset += numParticleOnTile64;
       }
     }
+    m_Series->flush();
 }
 
 void
@@ -381,7 +380,7 @@ WarpXOpenPMDPlot::SetupRealProperties(openPMD::ParticleSpecies& currSpecies,
       std::string record_name, component_name;
       std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[i]);
 
-      auto& particleVarComp = currSpecies[record_name][component_name];
+      auto particleVarComp = currSpecies[record_name][component_name];
       particleVarComp.resetDataset(particlesLineup);
     }
 
@@ -392,19 +391,18 @@ WarpXOpenPMDPlot::SetupRealProperties(openPMD::ParticleSpecies& currSpecies,
       // handle scalar and non-scalar records by name
       std::string record_name, component_name;
       std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[ii]);
-      auto& currRecord = currSpecies[record_name];
-      //auto& currRecordComp = currRecord[component_name];
+      auto currRecord = currSpecies[record_name];
 
       // meta data for ED-PIC extension
       bool newRecord = false;
       std::tie(std::ignore, newRecord) = addedRecords.insert(record_name);
       if( newRecord ) {
-    currRecord.setAttribute( "macroWeighted", 0u );
-    if( record_name == "momentum" )
-      currRecord.setAttribute( "weightingPower", 1.0 );
-    else
-          currRecord.setAttribute( "weightingPower", 0.0 );
         currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
+        currRecord.setAttribute( "macroWeighted", 0u );
+        if( record_name == "momentum" )
+            currRecord.setAttribute( "weightingPower", 1.0 );
+        else
+            currRecord.setAttribute( "weightingPower", 0.0 );
       }
     }
   }
@@ -426,6 +424,7 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
       ++numOutputReal;
 
   auto const numParticleOnTile = pti.numParticles();
+  uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
   auto const& aos = pti.GetArrayOfStructs();  // size =  numParticlesOnTile
   auto const& soa = pti.GetStructOfArrays();
 
@@ -436,19 +435,19 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
           // handle scalar and non-scalar records by name
           std::string record_name, component_name;
           std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[idx]);
-          auto& currRecord = currSpecies[record_name];
-          auto& currRecordComp = currRecord[component_name];
+          auto currRecord = currSpecies[record_name];
+          auto currRecordComp = currRecord[component_name];
 
-          amrex::ParticleReal *d =
-              static_cast<amrex::ParticleReal*>( malloc(sizeof(amrex::ParticleReal) *  numParticleOnTile) );
+          std::shared_ptr< amrex::ParticleReal > d(
+              new amrex::ParticleReal[numParticleOnTile],
+              [](amrex::ParticleReal const *p){ delete[] p; }
+          );
 
           for( auto kk=0; kk<numParticleOnTile; kk++ )
-               d[kk] = aos[kk].m_rdata.arr[AMREX_SPACEDIM+idx];
+               d.get()[kk] = aos[kk].m_rdata.arr[AMREX_SPACEDIM+idx];
 
-          std::shared_ptr<amrex::ParticleReal> data(d, free);
-          currRecordComp.storeChunk(data,
-               {offset}, {static_cast<unsigned long long>(numParticleOnTile)});
-          m_Series->flush();
+          currRecordComp.storeChunk(d,
+               {offset}, {numParticleOnTile64});
       }
     }
   }
@@ -464,10 +463,9 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
           auto& currRecordComp = currRecord[component_name];
 
           currRecordComp.storeChunk(openPMD::shareRaw(soa.GetRealData(idx)),
-              {offset}, {static_cast<unsigned long long>(numParticleOnTile)});
+              {offset}, {numParticleOnTile64});
       }
     }
-    m_Series->flush();
   }
 }
 
@@ -528,8 +526,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
   //This is AMReX's tiny profiler. Possibly will apply it later
   BL_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDFields()");
 
-  if ( nullptr == m_Series)
-    return;
+  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD series must be initialized");
 
   int const ncomp = mf.nComp();
 
@@ -715,13 +712,14 @@ WarpXParticleCounter::WarpXParticleCounter(const std::unique_ptr<WarpXParticleCo
 
 // get the offset in the overall particle id collection
 //
+// note: this is a MPI-collective operation
+//
 // input: num of particles  of from each   processor
 //
 // output:
 //     offset within <all> the particles in the comm
 //     sum of all particles in the comm
 //
-
 void
 WarpXParticleCounter::GetParticleOffsetOfProcessor(const long& numParticles,
                            unsigned long long& offset,

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -90,7 +90,19 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot(bool oneFilePerTS,
    m_OneFilePerTS(oneFilePerTS),
    m_OpenPMDFileType(std::move(openPMDFileType)),
    m_fieldPMLdirections(std::move(fieldPMLdirections))
-{}
+{
+  // pick first available backend if default is chosen
+  if( m_OpenPMDFileType == "default" )
+#if openPMD_HAVE_ADIOS1==1
+    m_OpenPMDFileType = "bp";
+#elif openPMD_HAVE_ADIOS2==1
+    m_OpenPMDFileType = "bp";
+#elif openPMD_HAVE_HDF5==1
+    m_OpenPMDFileType = "h5";
+#else
+    m_OpenPMDFileType = "json";
+#endif
+}
 
 WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
 {

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -146,7 +146,8 @@ WarpX::EvolveEM (int numsteps)
 
         cur_time += dt[0];
 
-        bool to_make_plot = (plot_int > 0) && ((step+1) % plot_int == 0);
+        bool to_make_plot = ( (plot_int > 0) && ((step+1) % plot_int == 0) );
+        bool to_write_openPMD = ( (openpmd_int > 0) && ((step+1) % openpmd_int == 0) );
 
         // slice generation //
         bool to_make_slice_plot = (slice_plot_int > 0) && ( (step+1)% slice_plot_int == 0);
@@ -162,7 +163,7 @@ WarpX::EvolveEM (int numsteps)
             myBFD->writeLabFrameData(cell_centered_data.get(), *mypc, geom[0], cur_time, dt[0]);
         }
 
-        bool move_j = is_synchronized || to_make_plot || do_insitu;
+        bool move_j = is_synchronized || to_make_plot || to_write_openPMD || do_insitu;
         // If is_synchronized we need to shift j too so that next step we can evolve E by dt/2.
         // We might need to move j because we are going to make a plotfile.
 
@@ -196,7 +197,7 @@ WarpX::EvolveEM (int numsteps)
         }
 
         // slice gen //
-        if (to_make_plot || do_insitu || to_make_slice_plot)
+        if (to_make_plot || to_write_openPMD || do_insitu || to_make_slice_plot)
         {
             // This is probably overkill, but it's not called often
             FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
@@ -219,6 +220,8 @@ WarpX::EvolveEM (int numsteps)
 
             if (to_make_plot)
                 WritePlotFile();
+            if (to_write_openPMD)
+                WriteOpenPMDFile();
 
             if (to_make_slice_plot)
             {
@@ -250,11 +253,12 @@ WarpX::EvolveEM (int numsteps)
 
     bool write_plot_file = plot_int > 0 && istep[0] > last_plot_file_step
         && (max_time_reached || istep[0] >= max_step);
+    bool write_openPMD = openpmd_int > 0 && (max_time_reached || istep[0] >= max_step);
 
     bool do_insitu = (insitu_start >= istep[0]) && (insitu_int > 0) &&
         (istep[0] > last_insitu_step) && (max_time_reached || istep[0] >= max_step);
 
-    if (write_plot_file || do_insitu)
+    if (write_plot_file || write_openPMD || do_insitu)
     {
         // This is probably overkill, but it's not called often
         FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
@@ -276,6 +280,8 @@ WarpX::EvolveEM (int numsteps)
 
         if (write_plot_file)
             WritePlotFile();
+        if (write_openPMD)
+            WriteOpenPMDFile();
 
         if (do_insitu)
             UpdateInSitu();

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -74,6 +74,9 @@ WarpX::InitData ()
         if (plot_int > 0)
             WritePlotFile();
 
+        if (openpmd_int > 0)
+            WriteOpenPMDFile();
+
         if (check_int > 0)
             WriteCheckPointFile();
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -404,6 +404,11 @@ extern "C"
         return warpx.plotInt ();
     }
 
+    int warpx_openpmdInt () {
+        WarpX& warpx = WarpX::GetInstance();
+        return warpx.openpmdInt ();
+    }
+
     void warpx_WriteCheckPointFile () {
         WarpX& warpx = WarpX::GetInstance();
         warpx.WriteCheckPointFile ();
@@ -411,6 +416,10 @@ extern "C"
     void warpx_WritePlotFile () {
         WarpX& warpx = WarpX::GetInstance();
         warpx.WritePlotFile ();
+    }
+    void warpx_WriteOpenPMDFile () {
+        WarpX& warpx = WarpX::GetInstance();
+        warpx.WriteOpenPMDFile ();
     }
 
     int warpx_finestLevel () {

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -95,9 +95,11 @@ extern "C" {
 
   int warpx_checkInt ();
   int warpx_plotInt ();
+  int warpx_openpmdInt ();
 
   void warpx_WriteCheckPointFile ();
   void warpx_WritePlotFile ();
+  void warpx_WriteOpenPMDFile ();
 
   int warpx_finestLevel ();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef WARPX_USE_OPENPMD
-#include <WarpXOpenPMD.H>
+#   include <WarpXOpenPMD.H>
 #endif
 
 #include <iostream>
@@ -277,12 +277,18 @@ public:
 
     int checkInt () const {return check_int;}
     int plotInt () const {return plot_int;}
+    int openpmdInt () const {return openpmd_int;}
 
     void WriteCheckPointFile () const;
+    void WriteOpenPMDFile () const;
     void WritePlotFile () const;
     void UpdateInSitu () const;
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,
         amrex::Vector<amrex::MultiFab>& mf_avg, const int ngrow) const;
+    void prepareFields( int const step, amrex::Vector<std::string>& varnames,
+        amrex::Vector<amrex::MultiFab>& mf_avg,
+        amrex::Vector<const amrex::MultiFab*>& output_mf,
+        amrex::Vector<amrex::Geometry>& output_geom ) const;
 
     void WritePlotFileES(const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
@@ -628,18 +634,13 @@ private:
     int check_int = -1;
     int plot_int = -1;
 
-    std::string openpmd_backend {"bp"};
+    std::string openpmd_backend {"default"};
+    int openpmd_int = -1;
+    bool openpmd_tspf = true; //!< one file per timestep (or one file for all steps)
 #ifdef WARPX_USE_OPENPMD
-    bool dump_plotfiles = false;
-    bool dump_openpmd = true;
-    bool openpmd_tspf = true; // one file per timestep
-  //bool openpmd_tspf = false; // one file all timesteps
     WarpXOpenPMDPlot* m_OpenPMDPlotWriter = nullptr;
-
-#else
-    bool dump_plotfiles = true;
-    bool dump_openpmd = false;
 #endif
+
     bool plot_rho           = false;
     bool plot_costs         = true;
     bool plot_finepatch     = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -466,12 +466,11 @@ WarpX::ReadParameters ()
             amrex::Abort("J-damping can only be done when PML are inside simulation domain (do_pml_in_domain=1)");
         }
 
-        pp.query("dump_openpmd", dump_openpmd);
+        pp.query("openpmd_int", openpmd_int);
         pp.query("openpmd_backend", openpmd_backend);
 #ifdef WARPX_USE_OPENPMD
         pp.query("openpmd_tspf", openpmd_tspf);
 #endif
-        pp.query("dump_plotfiles", dump_plotfiles);
         pp.query("plot_costs", plot_costs);
         pp.query("plot_raw_fields", plot_raw_fields);
         pp.query("plot_raw_fields_guards", plot_raw_fields_guards);


### PR DESCRIPTION
Remove the `dump_plotfile` switch and only control via interval value in `plot_int` for plotfiles.

Remove the `dump_openpmd` switch and only control via interval value in `plot_openpmd` for openPMD data dumps.

openPMD: pick first available backend if unspecified.