### PR TITLE
Fix issues of using static for do_not_push/deposit

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -338,8 +338,8 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
-    static int do_not_push;
-    static int do_not_deposit;
+    int do_not_push = 0;
+    int do_not_deposit = 0;
 
     // Whether to allow particles outside of the simulation domain to be
     // initialized when they enter the domain.

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -16,9 +16,6 @@
 
 using namespace amrex;
 
-int WarpXParticleContainer::do_not_push = 0;
-int WarpXParticleContainer::do_not_deposit = 0;
-
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : ParIter(pc, level, MFItInfo().SetDynamic(WarpX::do_dynamic_scheduling))
 {


### PR DESCRIPTION
This minor PR gets rid of using `static int` of `do_not_push/deposit`, such that they can really be species specific.