### PR TITLE
Add Copyright header in all source files

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,3 +1,9 @@
+# Copyright 2019-2020 Axel Huebl, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 name: source
 
 on: [push, pull_request]

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,9 @@
+# Copyright 2019 Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 extraction:
   cpp:
     prepare:

--- a/.mailmap
+++ b/.mailmap
@@ -1,35 +1,47 @@
-Andrew Myers <atmyers@lbl.gov>              Andrew Myers <atmyers2@gmail.com>
-Andrew Myers <atmyers@lbl.gov>              atmyers <atmyers2@gmail.com>
-Aurore Blelly <ablelly@lbl.gov>             ablelly <aurore.blelly@ensta-paristech.fr>
-Aurore Blelly <ablelly@lbl.gov>             ablelly <48810880+ablelly@users.noreply.github.com>
-Axel Huebl <axelhuebl@lbl.gov>              Axel Huebl <axel.huebl@plasma.ninja>
-David Grote <dpgrote@lbl.gov>               grote <dpgrote@lbl.gov>
-David Grote <dpgrote@lbl.gov>               Dave <grote1@llnl.gov>
-David Grote <dpgrote@lbl.gov>               Dave Grote <grote1@llnl.gov>
-David Grote <dpgrote@lbl.gov>               Grote <grote1@n9459722.llnl.gov>
-Edoardo Zoni <ezoni@lbl.gov>                Edoardo Zoni <edoardo.zoni@ipp.mpg.de>
-Ligia Diana Amorim <ldianaamorim@lbl.gov>   L. Diana Amorim <LDianaAmorim@lbl.gov>
-Ligia Diana Amorim <ldianaamorim@lbl.gov>   Diana Amorim <diana@henrivincenti.dhcp.lbl.gov>
-Ligia Diana Amorim <ldianaamorim@lbl.gov>   Ligia Diana Amorim <ligiada@cori01.nersc.gov>
-Ligia Diana Amorim <ldianaamorim@lbl.gov>   Ligia Diana Amorim <ligiada@cori11.nersc.gov>
-Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca.fedeli.88@gmail.com>
-Luca Fedeli <luca.fedeli@cea.fr>            lucafedeli88 <luca.fedeli@cea.fr>
-Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca@DEB.station>
-Luca Fedeli <luca.fedeli@cea.fr>            Luca Fedeli <luca.fedeli@for.unipi.it>
-Luca Fedeli <luca.fedeli@cea.fr>            Luca <luca@localhost.localdomain>
-Mathieu Lobet <mathieu.lobet@cea.fr>        Mathieu Lobet <mathieu.lobet@gmail.com>
-Mathieu Lobet <mathieu.lobet@cea.fr>        mathieu_lobet <mathieu.lobet@gmail.com>
-Maxence Thevenet <mthevenet@lbl.gov>        MaxThevenet <mthevenet@lbl.gov>
-Maxence Thevenet <mthevenet@lbl.gov>        Maxence Thévenet <mthevenet@lbl.gov>
-Maxence Thevenet <mthevenet@lbl.gov>        mthevenet <mthevenet@lbl.gov>
-Remi Lehe <rlehe@lbl.gov>                   Remi Lehe <remi.lehe@normalesup.org>
-Revathi Jambunathan <rjambunathan@lbl.gov>  RevathiJambunathan <revanathan@gmail.com>
-Revathi Jambunathan <rjambunathan@lbl.gov>  RevathiJambunathan <rjnathan@cori12.nersc.gov>
-Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login2.summit.olcf.ornl.gov>
-Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login3.summit.olcf.ornl.gov>
-Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login4.summit.olcf.ornl.gov>
-Revathi Jambunathan <rjambunathan@lbl.gov>  Revathi Jambunathan <revanathan@login5.summit.olcf.ornl.gov>
-Weiqun Zhang <weiqunzhang@lbl.gov>          Weiqun Zhang <WeiqunZhang@lbl.gov>
-Weiqun Zhang <weiqunzhang@lbl.gov>          WeiqunZhang <WeiqunZhang@lbl.gov
-Yinjian Zhao <yinjianzhao@lbl.gov>          Yin-YinjianZhao <yinjianzhao@lbl.gov>
-Yinjian Zhao <yinjianzhao@lbl.gov>          Yin-YinjianZhao <56095356+Yin-YinjianZhao@users.noreply.github.com>
+Andrew Myers <atmyers@lbl.gov>               Andrew Myers <atmyers2@gmail.com>
+Andrew Myers <atmyers@lbl.gov>               atmyers <atmyers2@gmail.com>
+Aurore Blelly <ablelly@lbl.gov>              ablelly <aurore.blelly@ensta-paristech.fr>
+Aurore Blelly <ablelly@lbl.gov>              ablelly <48810880+ablelly@users.noreply.github.com>
+Axel Huebl <axelhuebl@lbl.gov>               Axel Huebl <axel.huebl@plasma.ninja>
+David Bizzozero <dbizzozero@lbl.gov>         dbizzozero <dbizzozero@users.noreply.github.com>
+David Grote <dpgrote@lbl.gov>                grote <dpgrote@lbl.gov>
+David Grote <dpgrote@lbl.gov>                Dave <grote1@llnl.gov>
+David Grote <dpgrote@lbl.gov>                Dave Grote <grote1@llnl.gov>
+David Grote <dpgrote@lbl.gov>                Grote <grote1@n9459722.llnl.gov>
+Edoardo Zoni <ezoni@lbl.gov>                 Edoardo Zoni <edoardo.zoni@ipp.mpg.de>
+Edoardo Zoni <ezoni@lbl.gov>                 Edoardo Zoni <59625522+EZoni@users.noreply.github.com>
+Glenn Richardson <gtrichardson@berkeley.edu> gtrichardson <gtrichardson@berkeley.edu>
+Jaehong Park <jaehongpark@lbl.gov>           jaehongp <jaehong@jaehongs-mbp-10.attlocal.net>
+Jean-Luc Vay <jlvay@lbl.gov>                 Jean-Luc Vay <jlvay@Jean-Lucs-MacBook-Pro.local>
+Jean-Luc Vay <jlvay@lbl.gov>                 Jean-Luc Vay <jlvay@Jean-Lucs-MBP.dhcp.lbnl.us>
+Jean-Luc Vay <jlvay@lbl.gov>                 Jean-Luc Vay <jlvay@jlvay2.lbl.gov>
+Junmin Gu <jgu@lbl.gov>                      guj <guj@users.noreply.github.com>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>    L. Diana Amorim <LDianaAmorim@lbl.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>    Diana Amorim <diana@henrivincenti.dhcp.lbl.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>    Ligia Diana Amorim <ligiada@cori01.nersc.gov>
+Ligia Diana Amorim <ldianaamorim@lbl.gov>    Ligia Diana Amorim <ligiada@cori11.nersc.gov>
+Lixin Ge <lge@slac.stanford.edu>             lixin <lge@slac.stanford.edu>
+Luca Fedeli <luca.fedeli@cea.fr>             Luca Fedeli <luca.fedeli.88@gmail.com>
+Luca Fedeli <luca.fedeli@cea.fr>             lucafedeli88 <luca.fedeli@cea.fr>
+Luca Fedeli <luca.fedeli@cea.fr>             Luca Fedeli <luca@DEB.station>
+Luca Fedeli <luca.fedeli@cea.fr>             Luca Fedeli <luca.fedeli@for.unipi.it>
+Luca Fedeli <luca.fedeli@cea.fr>             Luca <luca@localhost.localdomain>
+Kevin Gott <kngott@lbl.gov>                  kngott <30483578+kngott@users.noreply.github.com>
+Mathieu Lobet <mathieu.lobet@cea.fr>         Mathieu Lobet <mathieu.lobet@gmail.com>
+Mathieu Lobet <mathieu.lobet@cea.fr>         mathieu_lobet <mathieu.lobet@gmail.com>
+Maxence Thevenet <mthevenet@lbl.gov>         MaxThevenet <mthevenet@lbl.gov>
+Maxence Thevenet <mthevenet@lbl.gov>         Maxence Thévenet <mthevenet@lbl.gov>
+Maxence Thevenet <mthevenet@lbl.gov>         mthevenet <mthevenet@lbl.gov>
+Remi Lehe <rlehe@lbl.gov>                    Remi Lehe <remi.lehe@normalesup.org>
+Revathi Jambunathan <rjambunathan@lbl.gov>   RevathiJambunathan <revanathan@gmail.com>
+Revathi Jambunathan <rjambunathan@lbl.gov>   RevathiJambunathan <rjnathan@cori12.nersc.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <revanathan@login2.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <revanathan@login3.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <revanathan@login4.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <revanathan@login5.summit.olcf.ornl.gov>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <41089244+RevathiJambunathan@users.noreply.github.com>
+Revathi Jambunathan <rjambunathan@lbl.gov>   Revathi Jambunathan <rjnathan@cori12.nersc.gov>
+Weiqun Zhang <weiqunzhang@lbl.gov>           Weiqun Zhang <WeiqunZhang@lbl.gov>
+Weiqun Zhang <weiqunzhang@lbl.gov>           WeiqunZhang <WeiqunZhang@lbl.gov
+Yinjian Zhao <yinjianzhao@lbl.gov>           Yin-YinjianZhao <yinjianzhao@lbl.gov>
+Yinjian Zhao <yinjianzhao@lbl.gov>           Yin-YinjianZhao <56095356+Yin-YinjianZhao@users.noreply.github.com>

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,9 @@
+# Copyright 2019-2020 Axel Huebl, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 requirements_file: Docs/requirements.txt
 
 formats:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Copyright 2018-2019 Axel Huebl, David Grote, Luca Fedeli
+# Maxence Thevenet, Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 dist: xenial
 language: c++
 sudo: true

--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -1,3 +1,9 @@
+# Copyright 2019 Axel Huebl, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx>=2.0

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+
+# Copyright 2017-2020 Andrew Myers, Axel Huebl, Burlen Loring
+# Maxence Thevenet, Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # -*- coding: utf-8 -*-
 #
 # WarpX documentation build configuration file, created by

--- a/Docs/source/latex_theory/AMR/AMR.tex
+++ b/Docs/source/latex_theory/AMR/AMR.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Jean-Luc Vay, Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 \input{newcommands}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Docs/source/latex_theory/Boosted_frame/Boosted_frame.tex
+++ b/Docs/source/latex_theory/Boosted_frame/Boosted_frame.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Burlen Loring, Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 \input{newcommands}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Docs/source/latex_theory/PML/PML.tex
+++ b/Docs/source/latex_theory/PML/PML.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Jean-Luc Vay, Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 \input{newcommands}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Docs/source/latex_theory/input_output/input_output.tex
+++ b/Docs/source/latex_theory/input_output/input_output.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 \input{newcommands}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Docs/source/latex_theory/intro.tex
+++ b/Docs/source/latex_theory/intro.tex
@@ -1,3 +1,9 @@
+% Copyright 2017 Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Introduction}

--- a/Docs/source/latex_theory/newcommands.tex
+++ b/Docs/source/latex_theory/newcommands.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Jean-Luc Vay, Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 
 \usepackage{bm}
 \usepackage{amsmath}

--- a/Docs/source/latex_theory/theory.tex
+++ b/Docs/source/latex_theory/theory.tex
@@ -1,3 +1,9 @@
+% Copyright 2017-2019 Jean-Luc Vay, Remi Lehe
+%
+% This file is part of WarpX.
+%
+% License: BSD-3-Clause-LBNL
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Reviews of Accelerator Science and Technology
 %% Trim Size: 11in x 8.5in

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019-2020 Luca Fedeli, Maxence Thevenet, Revathi Jambunathan
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 '''
 Analysis script of a WarpX simulation of rigid injection in a boosted frame.
 

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 '''
 Analysis script of a WarpX simulation of rigid injection.
 

--- a/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
+++ b/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Maxence Thevenet, Revathi Jambunathan
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 '''
 Analysis script of a WarpX simulation in a boosted frame.
 

--- a/Examples/Modules/ionization/analysis_ionization.py
+++ b/Examples/Modules/ionization/analysis_ionization.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 """
 This script tests the result of the ionization module in WarpX.
 

--- a/Examples/Modules/laser_injection/analysis_laser.py
+++ b/Examples/Modules/laser_injection/analysis_laser.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
+# Remi Lehe, Weiqun Zhang
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import matplotlib
 matplotlib.use('Agg')

--- a/Examples/Modules/laser_injection_from_file/analysis.py
+++ b/Examples/Modules/laser_injection_from_file/analysis.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 
+# Copyright 2020 Andrew Myers, Axel Huebl, Luca Fedeli
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the WarpX automated test suite. It is used to test the
 # injection of a laser pulse from an external binary file.
 #

--- a/Examples/Modules/nci_corrector/analysis_ncicorr.py
+++ b/Examples/Modules/nci_corrector/analysis_ncicorr.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
+# Weiqun Zhang
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import yt
 import re

--- a/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
@@ -1,4 +1,11 @@
 #! /usr/bin/env python
+
+# Copyright 2019 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import yt
 import numpy as np
 import scipy.stats as st

--- a/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
@@ -1,4 +1,11 @@
 #! /usr/bin/env python
+
+# Copyright 2019 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # -*- coding: utf-8 -*-
 
 import yt

--- a/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
@@ -1,4 +1,11 @@
 #! /usr/bin/env python
+
+# Copyright 2019 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import yt
 import numpy as np
 import scipy.stats as st

--- a/Examples/Modules/relativistic_space_charge_initialization/analysis.py
+++ b/Examples/Modules/relativistic_space_charge_initialization/analysis.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+
+# Copyright 2019-2020 Axel Huebl, Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 This script checks the space-charge initialization routine, by
 verifying that the space-charge field of a Gaussian beam corresponds to

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+
+# Copyright 2019-2020 Axel Huebl, Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 This script checks the space-charge initialization routine, by
 verifying that the space-charge field of a Gaussian beam corresponds to

--- a/Examples/Tests/Langmuir/analysis_langmuir.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import re
 import matplotlib

--- a/Examples/Tests/Langmuir/analysis_langmuir2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir2d.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Andrew Myers, David Grote, Jean-Luc Vay
+# Maxence Thevenet, Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import matplotlib
 matplotlib.use('Agg')

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This is a script that analyses the simulation results from
 # the script `inputs.multi.rt`. This simulates a 3D periodic plasma wave.
 # The electric field in the simulation is given (in theory) by:

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This is a script that analyses the simulation results from
 # the script `inputs.multi.rt`. This simulates a 3D periodic plasma wave.
 # The electric field in the simulation is given (in theory) by:

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019 David Grote, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This is a script that analyses the simulation results from
 # the script `inputs.multi.rz.rt`. This simulates a RZ periodic plasma wave.
 # The electric field in the simulation is given (in theory) by:

--- a/Examples/Tests/PML/analysis_pml_ckc.py
+++ b/Examples/Tests/PML/analysis_pml_ckc.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np

--- a/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
+++ b/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np

--- a/Examples/Tests/collision/analysis_collision.py
+++ b/Examples/Tests/collision/analysis_collision.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019-2020 Yin-YinjiaZhao, Yinjian Zhao
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This script tests the collision module
 # using electron-ion temperature relaxation.
 # Initially, electrons and ions are both in equilibrium

--- a/Examples/Tests/particle_pusher/analysis_pusher.py
+++ b/Examples/Tests/particle_pusher/analysis_pusher.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Yinjian Zhao
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This script tests the particle pusher (HC)
 # using a force-free field,
 # in which position x should remain 0.

--- a/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+++ b/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
@@ -1,4 +1,12 @@
 #! /usr/bin/env python
+
+# Copyright 2019-2020 Luca Fedeli, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 This script tests the absorption of particles in the PML.
 

--- a/Examples/Tests/photon_pusher/analysis_photon_pusher.py
+++ b/Examples/Tests/photon_pusher/analysis_photon_pusher.py
@@ -1,4 +1,12 @@
 #! /usr/bin/env python
+
+# Copyright 2019 Luca Fedeli, Maxence Thevenet, Weiqun Zhang
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import yt
 import numpy as np
 import sys

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2019 Luca Fedeli, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This script contains few simple tests for the radiation reaction pusher
 # It initializes an electron or a positron with normalized momentum in different
 # directions, propagating in a static magnetic field (along [2/7,3/7,6/7]).

--- a/Python/pywarpx/Algo.py
+++ b/Python/pywarpx/Algo.py
@@ -1,3 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 algo = Bucket('algo')

--- a/Python/pywarpx/Amr.py
+++ b/Python/pywarpx/Amr.py
@@ -1,3 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 amr = Bucket('amr')

--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -1,3 +1,10 @@
+# Copyright 2016-2020 Andrew Myers, David Grote, Maxence Thevenet
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import numpy as np
 
 class Bucket(object):

--- a/Python/pywarpx/Constants.py
+++ b/Python/pywarpx/Constants.py
@@ -1,3 +1,9 @@
+# Copyright 2018-2019 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 class Constants(Bucket):

--- a/Python/pywarpx/Geometry.py
+++ b/Python/pywarpx/Geometry.py
@@ -1,3 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 geometry = Bucket('geometry')

--- a/Python/pywarpx/Interpolation.py
+++ b/Python/pywarpx/Interpolation.py
@@ -1,3 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 interpolation = Bucket('interpolation')

--- a/Python/pywarpx/Langmuirwave.py
+++ b/Python/pywarpx/Langmuirwave.py
@@ -1,3 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 langmuirwave = Bucket('langmuirwave')

--- a/Python/pywarpx/Lasers.py
+++ b/Python/pywarpx/Lasers.py
@@ -1,3 +1,9 @@
+# Copyright 2019-2020 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 lasers = Bucket('lasers', nlasers=0, names=[])

--- a/Python/pywarpx/PGroup.py
+++ b/Python/pywarpx/PGroup.py
@@ -1,3 +1,9 @@
+# Copyright 2017-2019 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import numpy as np
 from . import _libwarpx
 

--- a/Python/pywarpx/Particles.py
+++ b/Python/pywarpx/Particles.py
@@ -1,3 +1,9 @@
+# Copyright 2017-2020 Andrew Myers, David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 
 particles = Bucket('particles', nspecies=0, species_names=[])

--- a/Python/pywarpx/WarpInterface.py
+++ b/Python/pywarpx/WarpInterface.py
@@ -1,3 +1,9 @@
+# Copyright 2019 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import warp
 from . import fields
 from pywarpx import PGroup

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -1,3 +1,10 @@
+# Copyright 2016-2020 Andrew Myers, David Grote, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .Bucket import Bucket
 from .Constants import my_constants
 from .Amr import amr

--- a/Python/pywarpx/WarpXPIC.py
+++ b/Python/pywarpx/WarpXPIC.py
@@ -1,3 +1,9 @@
+# Copyright 2017 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from warp.run_modes.timestepper import PICAPI
 from ._libwarpx import libwarpx
 

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -1,3 +1,9 @@
+# Copyright 2016-2019 Andrew Myers, David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from .WarpX import warpx
 from .Constants import my_constants
 from .Amr import amr

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -1,3 +1,10 @@
+# Copyright 2017-2019 Andrew Myers, David Grote, Remi Lehe
+# Weiqun Zhang
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # --- This defines the wrapper functions that directly call the underlying compiled routines
 import os
 import sys

--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -1,3 +1,9 @@
+# Copyright 2017 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """call back operations
 =====================
 

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -1,3 +1,9 @@
+# Copyright 2017-2019 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """Provides wrappers around field and current density on multiFABs
 
 Available routines:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1,3 +1,11 @@
+# Copyright 2018-2020 Andrew Myers, David Grote, Ligia Diana Amorim
+# Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 """Classes following the PICMI standard
 """
 import re

--- a/Python/pywarpx/timestepper.py
+++ b/Python/pywarpx/timestepper.py
@@ -1,3 +1,10 @@
+# Copyright 2017-2018 Andrew Myers, David Grote, Weiqun Zhang
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from ._libwarpx import libwarpx
 from . import callbacks
 

--- a/Python/pywarpx/wx.py
+++ b/Python/pywarpx/wx.py
@@ -1,3 +1,9 @@
+# Copyright 2018 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from ._libwarpx import *
 
 from .timestepper import TimeStepper

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+# Copyright 2016-2020 Andrew Myers, David Grote, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 """
 setup.py file for WarpX
 """

--- a/Regression/TestFillBoundary/compare_guard_cells.sh
+++ b/Regression/TestFillBoundary/compare_guard_cells.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Copyright 2020 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This script compares runs WarpX with (i) default guard cell exchanges and
 # (ii) exchanging all guard cells, and check that they match to a certain
 # tolerance level (typically 2.e-15). For a large number of configurations

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -1,3 +1,10 @@
+# Copyright 2018-2019 Andrew Myers, Luca Fedeli, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # This script modifies `WarpX-test.ini` (which is used for nightly builds)
 # and creates the file `travis-test.ini` (which is used for continous
 # integration on TravisCI (https://travis-ci.org/)

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Aurore Blelly, Axel Huebl
+ * Maxence Thevenet, Remi Lehe, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <array>
 
 #ifndef WARPX_PML_H_

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Aurore Blelly, Axel Huebl
+ * Maxence Thevenet, Remi Lehe, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <PML.H>
 #include <WarpX.H>
 #include <WarpXConst.H>

--- a/Source/BoundaryConditions/PML_current.H
+++ b/Source/BoundaryConditions/PML_current.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Aurore Blelly, Axel Huebl, Maxence Thevenet
+ * Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef PML_CURRENT_H_
 #define PML_CURRENT_H_
 

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Aurore Blelly, Axel Huebl, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <cmath>
 #include <limits>
 

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Remi Lehe, Revathi Jambunathan, Revathi Jambunathan
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PML_KERNELS_H_
 #define WARPX_PML_KERNELS_H_
 

--- a/Source/Diagnostics/BackTransformedDiagnostic.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, Maxence Thevenet
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_BackTransformedDiagnostic_H_
 #define WARPX_BackTransformedDiagnostic_H_
 

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, Maxence Thevenet
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_MultiFabUtil_C.H>
 

--- a/Source/Diagnostics/ElectrostaticIO.cpp
+++ b/Source/Diagnostics/ElectrostaticIO.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Bizzozero
+ * Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <WarpX_f.H>
 

--- a/Source/Diagnostics/FieldIO.H
+++ b/Source/Diagnostics/FieldIO.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Igor Andriyash
+ * Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_FielIO_H_
 #define WARPX_FielIO_H_
 

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <WarpX.H>
 #include <FieldIO.H>

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Grote
+ * Luca Fedeli, Maxence Thevenet, Revathi Jambunathan
+ * Weiqun Zhang, levinem
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <MultiParticleContainer.H>
 #include <WarpX.H>
 

--- a/Source/Diagnostics/SliceDiagnostic.H
+++ b/Source/Diagnostics/SliceDiagnostic.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SliceDiagnostic_H_
 #define WARPX_SliceDiagnostic_H_
 

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Luca Fedeli, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "SliceDiagnostic.H"
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Ann Almgren, Axel Huebl
+ * Burlen Loring, David Grote, Gunther H. Weber
+ * Junmin Gu, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_FillPatchUtil_F.H>

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Axel Huebl, Junmin Gu, Maxence Thevenet
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_OPEN_PMD_H_
 #define WARPX_OPEN_PMD_H_
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Axel Huebl, Junmin Gu
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "WarpXOpenPMD.H"
 #include "WarpXAlgorithmSelection.H"
 #include "FieldIO.H"  // for getReversedVec

--- a/Source/Diagnostics/requirements.txt
+++ b/Source/Diagnostics/requirements.txt
@@ -1,2 +1,8 @@
+# Copyright 2020 Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # keep this entry for GitHub's dependency graph
 openPMD-api>=0.10.3

--- a/Source/Evolve/WarpXDtType.H
+++ b/Source/Evolve/WarpXDtType.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_DTTYPE_H_
 #define WARPX_DTTYPE_H_
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -1,3 +1,13 @@
+/* Copyright 2019-2020 Andrew Myers, Ann Almgren, Aurore Blelly
+ * Axel Huebl, Burlen Loring, David Grote
+ * Glenn Richardson, Jean-Luc Vay, Luca Fedeli
+ * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ * Weiqun Zhang, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <cmath>
 #include <limits>
 

--- a/Source/Evolve/WarpXEvolveES.cpp
+++ b/Source/Evolve/WarpXEvolveES.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Bizzozero
+ * David Grote, Maxence Thevenet, Remi Lehe
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <WarpX_f.H>
 

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridFFTData.H
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridFFTData.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PICSAR_HYBRID_FFTDATA_H_
 #define WARPX_PICSAR_HYBRID_FFTDATA_H_
 

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <WarpX.H>
 #include <WarpX_f.H>

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/picsar_hybrid_spectral.F90
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/picsar_hybrid_spectral.F90
@@ -1,3 +1,10 @@
+! Copyright 2019 Andrew Myers, Maxence Thevenet, Remi Lehe
+! Weiqun Zhang
+!
+! This file is part of WarpX.
+!
+! License: BSD-3-Clause-LBNL
+
 
 module warpx_fft_module
   use amrex_error_module, only : amrex_error, amrex_abort

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PML_PSATD_ALGORITHM_H_
 #define WARPX_PML_PSATD_ALGORITHM_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <PMLPsatdAlgorithm.H>
 #include <WarpXConst.H>
 #include <cmath>

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PSATD_ALGORITHM_H_
 #define WARPX_PSATD_ALGORITHM_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe, Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <PsatdAlgorithm.H>
 #include <WarpXConst.H>
 #include <cmath>

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SPECTRAL_BASE_ALGORITHM_H_
 #define WARPX_SPECTRAL_BASE_ALGORITHM_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SPECTRAL_FIELD_DATA_H_
 #define WARPX_SPECTRAL_FIELD_DATA_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <SpectralFieldData.H>
 
 using namespace amrex;

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SPECTRAL_K_SPACE_H_
 #define WARPX_SPECTRAL_K_SPACE_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Andrew Myers, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpXConst.H>
 #include <SpectralKSpace.H>
 #include <cmath>

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Maxence Thevenet, Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SPECTRAL_SOLVER_H_
 #define WARPX_SPECTRAL_SOLVER_H_
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <SpectralKSpace.H>
 #include <SpectralSolver.H>
 #include <PsatdAlgorithm.H>

--- a/Source/FieldSolver/SpectralSolver/WarpX_ComplexForFFT.H
+++ b/Source/FieldSolver/SpectralSolver/WarpX_ComplexForFFT.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 David Grote
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_COMPLEXFORFFT_H_
 #define WARPX_COMPLEXFORFFT_H_
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Aurore Blelly, Axel Huebl
+ * David Grote, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <cmath>
 #include <limits>

--- a/Source/FieldSolver/WarpX_FDTD.H
+++ b/Source/FieldSolver/WarpX_FDTD.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, David Grote
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_FDTD_H_
 #define WARPX_FDTD_H_
 

--- a/Source/FieldSolver/WarpX_K.H
+++ b/Source/FieldSolver/WarpX_K.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_K_H_
 #define WARPX_K_H_
 

--- a/Source/Filter/BilinearFilter.H
+++ b/Source/Filter/BilinearFilter.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <Filter.H>
 
 #ifndef WARPX_BILIN_FILTER_H_

--- a/Source/Filter/BilinearFilter.cpp
+++ b/Source/Filter/BilinearFilter.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <BilinearFilter.H>
 #include <WarpX_f.H>

--- a/Source/Filter/Filter.H
+++ b/Source/Filter/Filter.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <AMReX_MultiFab.H>
 
 #ifndef WARPX_FILTER_H_

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <Filter.H>
 

--- a/Source/Filter/NCIGodfreyFilter.H
+++ b/Source/Filter/NCIGodfreyFilter.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <Filter.H>
 
 #ifndef WARPX_GODFREY_FILTER_H_

--- a/Source/Filter/NCIGodfreyFilter.cpp
+++ b/Source/Filter/NCIGodfreyFilter.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <NCIGodfreyFilter.H>
 #include <NCIGodfreyTables.H>

--- a/Source/FortranInterface/WarpX_f.F90
+++ b/Source/FortranInterface/WarpX_f.F90
@@ -1,3 +1,11 @@
+! Copyright 2019 Andrew Myers, Axel Huebl, David Grote
+! Ligia Diana Amorim, Mathieu Lobet, Maxence Thevenet
+! Remi Lehe, Weiqun Zhang
+!
+! This file is part of WarpX.
+!
+! License: BSD-3-Clause-LBNL
+
 
 module warpx_module
 

--- a/Source/FortranInterface/WarpX_f.H
+++ b/Source/FortranInterface/WarpX_f.H
@@ -1,3 +1,13 @@
+/* Copyright 2019 Andrew Myers, Aurore Blelly, Axel Huebl
+ * David Grote, Jean-Luc Vay, Ligia Diana Amorim
+ * Luca Fedeli, Mathieu Lobet, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_F_H_
 #define WARPX_F_H_
 

--- a/Source/Initialization/CustomDensityProb.H
+++ b/Source/Initialization/CustomDensityProb.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef CUSTOM_DENSITY_PROB_H_
 #define CUSTOM_DENSITY_PROB_H_
 

--- a/Source/Initialization/CustomMomentumProb.H
+++ b/Source/Initialization/CustomMomentumProb.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef CUSTOM_MOMENTUM_PROB_H
 #define CUSTOM_MOMENTUM_PROB_H
 

--- a/Source/Initialization/InitSpaceChargeField.cpp
+++ b/Source/Initialization/InitSpaceChargeField.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_MLMG.H>

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef INJECTOR_DENSITY_H_
 #define INJECTOR_DENSITY_H_
 

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Axel Huebl, Ligia Diana Amorim, Maxence Thevenet
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <InjectorDensity.H>
 #include <PlasmaInjector.H>
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Cameron Yang, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef INJECTOR_MOMENTUM_H_
 #define INJECTOR_MOMENTUM_H_
 

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Axel Huebl, Maxence Thevenet, Revathi Jambunathan
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <InjectorMomentum.H>
 #include <PlasmaInjector.H>
 

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef INJECTOR_POSITION_H_
 #define INJECTOR_POSITION_H_
 

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Grote
+ * Maxence Thevenet, Remi Lehe, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef PLASMA_INJECTOR_H_
 #define PLASMA_INJECTOR_H_
 

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, Cameron Yang
+ * David Grote, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "PlasmaInjector.H"
 
 #include <WarpXConst.H>

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Ann Almgren, Aurore Blelly
+ * Axel Huebl, Burlen Loring, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <WarpX_f.H>
 #include <BilinearFilter.H>

--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Grote
+ * Luca Fedeli, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_LaserParticleContainer_H_
 #define WARPX_LaserParticleContainer_H_
 

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Luca Fedeli, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <limits>
 #include <cmath>
 #include <algorithm>

--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_LaserProfiles_H_
 #define WARPX_LaserProfiles_H_
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <LaserProfiles.H>
 
 #include <WarpX_Complex.H>

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <LaserProfiles.H>
 
 #include <WarpX_Complex.H>

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Luca Fedeli, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <LaserProfiles.H>
 
 #include <WarpX_Complex.H>

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <LaserProfiles.H>
 
 #include <WarpX_Complex.H>

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef GUARDCELLMANAGER_H_
 #define GUARDCELLMANAGER_H_
 

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "GuardCellManager.H"
 #include "NCIGodfreyFilter.H"
 #include <AMReX_Print.H>

--- a/Source/Parallelization/InterpolateCurrentFineToCoarse.H
+++ b/Source/Parallelization/InterpolateCurrentFineToCoarse.H
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Weiqun Zhang
+/* Copyright 2019-2020 Axel Huebl
  *
  * This file is part of WarpX.
  *

--- a/Source/Parallelization/InterpolateDensityFineToCoarse.H
+++ b/Source/Parallelization/InterpolateDensityFineToCoarse.H
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Weiqun Zhang
+/* Copyright 2019 Axel Huebl
  *
  * This file is part of WarpX.
  *

--- a/Source/Parallelization/WarpXComm.H
+++ b/Source/Parallelization/WarpXComm.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARALLELIZATION_COMM_H_
 #define WARPX_PARALLELIZATION_COMM_H_
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Aurore Blelly, Axel Huebl
+ * David Grote, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpXComm.H>
 #include <WarpXComm_K.H>
 #include <WarpX.H>

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_COMM_K_H_
 #define WARPX_COMM_K_H_
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Ann Almgren, Axel Huebl
+ * David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang, levinem
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <AMReX_BLProfiler.H>
 

--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Maxence Thevenet, Remi Lehe, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_SUM_GUARD_CELLS_H_
 #define WARPX_SUM_GUARD_CELLS_H_
 

--- a/Source/Parser/GpuParser.H
+++ b/Source/Parser/GpuParser.H
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Maxence Thevenet, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_GPU_PARSER_H_
 #define WARPX_GPU_PARSER_H_
 

--- a/Source/Parser/GpuParser.cpp
+++ b/Source/Parser/GpuParser.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Maxence Thevenet, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <GpuParser.H>
 
 GpuParser::GpuParser (WarpXParser const& wp)

--- a/Source/Parser/WarpXParser.H
+++ b/Source/Parser/WarpXParser.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARSER_H_
 #define WARPX_PARSER_H_
 

--- a/Source/Parser/WarpXParser.cpp
+++ b/Source/Parser/WarpXParser.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <algorithm>
 #include "WarpXParser.H"

--- a/Source/Parser/WarpXParserWrapper.H
+++ b/Source/Parser/WarpXParserWrapper.H
@@ -1,3 +1,9 @@
+/* Copyright 2020 Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARSER_WRAPPER_H_
 #define WARPX_PARSER_WRAPPER_H_
 

--- a/Source/Particles/Collision/CollisionType.H
+++ b/Source/Particles/Collision/CollisionType.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_COLLISION_COLLISIONTYPE_H_
 #define WARPX_PARTICLES_COLLISION_COLLISIONTYPE_H_
 

--- a/Source/Particles/Collision/CollisionType.cpp
+++ b/Source/Particles/Collision/CollisionType.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "CollisionType.H"
 #include "ShuffleFisherYates.H"
 #include "ElasticCollisionPerez.H"

--- a/Source/Particles/Collision/ComputeTemperature.H
+++ b/Source/Particles/Collision/ComputeTemperature.H
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020 Andrew Myers, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_COLLISION_COMPUTE_TEMPERATURE_H_
 #define WARPX_PARTICLES_COLLISION_COMPUTE_TEMPERATURE_H_
 

--- a/Source/Particles/Collision/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/ElasticCollisionPerez.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_COLLISION_ELASTIC_COLLISION_PEREZ_H_
 #define WARPX_PARTICLES_COLLISION_ELASTIC_COLLISION_PEREZ_H_
 

--- a/Source/Particles/Collision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/ShuffleFisherYates.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_COLLISION_SHUFFLE_FISHER_YATES_H_
 #define WARPX_PARTICLES_COLLISION_SHUFFLE_FISHER_YATES_H_
 

--- a/Source/Particles/Collision/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/UpdateMomentumPerezElastic.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_COLLISION_UPDATE_MOMENTUM_PEREZ_ELASTIC_H_
 #define WARPX_PARTICLES_COLLISION_UPDATE_MOMENTUM_PEREZ_ELASTIC_H_
 

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef CHARGEDEPOSITION_H_
 #define CHARGEDEPOSITION_H_
 

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Remi Lehe, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef CURRENTDEPOSITION_H_
 #define CURRENTDEPOSITION_H_
 

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef FIELDGATHER_H_
 #define FIELDGATHER_H_
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -1,3 +1,13 @@
+/* Copyright 2019-2020 Andrew Myers, Ann Almgren, Axel Huebl
+ * David Grote, Jean-Luc Vay, Junmin Gu
+ * Luca Fedeli, Mathieu Lobet, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ * Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_ParticleContainer_H_
 #define WARPX_ParticleContainer_H_
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1,3 +1,13 @@
+/* Copyright 2019-2020 Andrew Myers, Ann Almgren, Axel Huebl
+ * David Grote, Jean-Luc Vay, Luca Fedeli
+ * Mathieu Lobet, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang, Yinjian Zhao
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <MultiParticleContainer.H>
 
 #include <AMReX_Vector.H>

--- a/Source/Particles/ParticleCreation/CopyParticle.H
+++ b/Source/Particles/ParticleCreation/CopyParticle.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef COPYPARTICLE_H_
 #define COPYPARTICLE_H_
 

--- a/Source/Particles/ParticleCreation/ElementaryProcess.H
+++ b/Source/Particles/ParticleCreation/ElementaryProcess.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef ELEMENTARYPROCESS_H_
 #define ELEMENTARYPROCESS_H_
 

--- a/Source/Particles/ParticleCreation/TransformParticle.H
+++ b/Source/Particles/ParticleCreation/TransformParticle.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef TRANSFORMPARTICLE_H_
 #define TRANSFORMPARTICLE_H_
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, David Grote, Luca Fedeli
+ * Maxence Thevenet, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PhotonParticleContainer_H_
 #define WARPX_PhotonParticleContainer_H_
 

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Luca Fedeli, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <limits>
 #include <sstream>
 #include <algorithm>

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Ligia Diana Amorim, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ * Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PhysicalParticleContainer_H_
 #define WARPX_PhysicalParticleContainer_H_
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1,3 +1,13 @@
+/* Copyright 2019-2020 Andrew Myers, Aurore Blelly, Axel Huebl
+ * David Grote, Glenn Richardson, Jean-Luc Vay
+ * Ligia Diana Amorim, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ * Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <limits>
 #include <sstream>
 

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 

--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_H_
 

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_WITHRR_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_WITHRR_H_

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_HIGUERACARY_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_HIGUERACARY_H_
 

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_VAY_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_VAY_H_
 

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 

--- a/Source/Particles/Pusher/UpdatePositionPhoton.H
+++ b/Source/Particles/Pusher/UpdatePositionPhoton.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITIONPHOTON_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITIONPHOTON_H_
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, David Grote, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_RigidInjectedParticleContainer_H_
 #define WARPX_RigidInjectedParticleContainer_H_
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, David Grote, Glenn Richardson
+ * Ligia Diana Amorim, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ * Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <limits>
 #include <sstream>
 #include <algorithm>

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef SHAPEFACTORS_H_
 #define SHAPEFACTORS_H_
 

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <SortingUtils.H>
 #include <PhysicalParticleContainer.H>
 #include <WarpX.H>

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Andrew Myers, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 #define WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Jean-Luc Vay, Junmin Gu, Luca Fedeli
+ * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ * Weiqun Zhang, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_WarpXParticleContainer_H_
 #define WARPX_WarpXParticleContainer_H_
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1,3 +1,12 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Jean-Luc Vay, Luca Fedeli, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ * Yinjian Zhao, levinem
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <limits>
 
 #include <MultiParticleContainer.H>

--- a/Source/Particles/interpolate_cic.F90
+++ b/Source/Particles/interpolate_cic.F90
@@ -1,3 +1,9 @@
+! Copyright 2019 Maxence Thevenet, Weiqun Zhang
+!
+! This file is part of WarpX.
+!
+! License: BSD-3-Clause-LBNL
+
 module warpx_ES_interpolate_cic
 
   use iso_c_binding

--- a/Source/Particles/push_particles_ES.F90
+++ b/Source/Particles/push_particles_ES.F90
@@ -1,3 +1,9 @@
+! Copyright 2019 Maxence Thevenet, Weiqun Zhang
+!
+! This file is part of WarpX.
+!
+! License: BSD-3-Clause-LBNL
+
 module warpx_ES_push_particles
 
   use iso_c_binding

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019 Andrew Myers, Axel Huebl, David Grote
+ * Luca Fedeli, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <WarpXWrappers.h>
 #include <WarpXParticleContainer.H>

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, David Grote, Maxence Thevenet
+ * Remi Lehe, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_WRAPPERS_H_
 #define WARPX_WRAPPERS_H_
 

--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_PY_H_
 #define WARPX_PY_H_
 

--- a/Source/Python/WarpX_py.cpp
+++ b/Source/Python/WarpX_py.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX_py.H>
 
 extern "C" {

--- a/Source/QED/BreitWheelerDummyTable.H
+++ b/Source/QED/BreitWheelerDummyTable.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_breit_wheeler_dummy_tables_h_
 #define WARPX_breit_wheeler_dummy_tables_h_
 

--- a/Source/QED/BreitWheelerEngineInnards.H
+++ b/Source/QED/BreitWheelerEngineInnards.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_breit_wheeler_engine_innards_h_
 #define WARPX_breit_wheeler_engine_innards_h_
 

--- a/Source/QED/BreitWheelerEngineTableBuilder.H
+++ b/Source/QED/BreitWheelerEngineTableBuilder.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_breit_wheeler_engine_table_builder_h_
 #define WARPX_breit_wheeler_engine_table_builder_h_
 

--- a/Source/QED/BreitWheelerEngineTableBuilder.cpp
+++ b/Source/QED/BreitWheelerEngineTableBuilder.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BreitWheelerEngineTableBuilder.H"
 
 //Include the full Breit Wheeler engine with table generation support

--- a/Source/QED/BreitWheelerEngineWrapper.H
+++ b/Source/QED/BreitWheelerEngineWrapper.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_breit_wheeler_engine_wrapper_h_
 #define WARPX_breit_wheeler_engine_wrapper_h_
 

--- a/Source/QED/BreitWheelerEngineWrapper.cpp
+++ b/Source/QED/BreitWheelerEngineWrapper.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BreitWheelerEngineWrapper.H"
 
 #include "QedTableParserHelperFunctions.H"

--- a/Source/QED/QedChiFunctions.H
+++ b/Source/QED/QedChiFunctions.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_amrex_qed_chi_functions_h_
 #define WARPX_amrex_qed_chi_functions_h_
 

--- a/Source/QED/QedTableParserHelperFunctions.H
+++ b/Source/QED/QedTableParserHelperFunctions.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_amrex_qed_table_parser_helper_functions_h_
 #define WARPX_amrex_qed_table_parser_helper_functions_h_
 

--- a/Source/QED/QedWrapperCommons.H
+++ b/Source/QED/QedWrapperCommons.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_amrex_qed_wrapper_commons_h_
 #define WARPX_amrex_qed_wrapper_commons_h_
 

--- a/Source/QED/QuantumSyncDummyTable.H
+++ b/Source/QED/QuantumSyncDummyTable.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_quantum_sync_dummy_tables_h_
 #define WARPX_quantum_sync_dummy_tables_h_
 

--- a/Source/QED/QuantumSyncEngineInnards.H
+++ b/Source/QED/QuantumSyncEngineInnards.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_quantum_sync_engine_innards_h_
 #define WARPX_quantum_sync_engine_innards_h_
 

--- a/Source/QED/QuantumSyncEngineTableBuilder.H
+++ b/Source/QED/QuantumSyncEngineTableBuilder.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_quantum_sync_engine_table_builder_h_
 #define WARPX_quantum_sync_engine_table_builder_h_
 

--- a/Source/QED/QuantumSyncEngineTableBuilder.cpp
+++ b/Source/QED/QuantumSyncEngineTableBuilder.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "QuantumSyncEngineTableBuilder.H"
 
 //Include the full Quantum Synchrotron engine with table generation support

--- a/Source/QED/QuantumSyncEngineWrapper.H
+++ b/Source/QED/QuantumSyncEngineWrapper.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_quantum_sync_engine_wrapper_h_
 #define WARPX_quantum_sync_engine_wrapper_h_
 

--- a/Source/QED/QuantumSyncEngineWrapper.cpp
+++ b/Source/QED/QuantumSyncEngineWrapper.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019 Luca Fedeli, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "QuantumSyncEngineWrapper.H"
 
 #include "QedTableParserHelperFunctions.H"

--- a/Source/Utils/IonizationEnergiesTable.H
+++ b/Source/Utils/IonizationEnergiesTable.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 // This script was automatically generated!
 // Edit dev/Source/Utils/write_atomic_data_cpp.py instead!
 #ifndef WARPX_IONIZATION_TABLE_H_

--- a/Source/Utils/NCIGodfreyTables.H
+++ b/Source/Utils/NCIGodfreyTables.H
@@ -1,3 +1,9 @@
+/* Copyright 2019 Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <AMReX_AmrCore.H>
 
 #ifndef WARPX_GODFREY_COEFF_TABLE_H_

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 David Grote, Luca Fedeli, Remi Lehe
+ * Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef UTILS_WARPXALGORITHMSELECTION_H_
 #define UTILS_WARPXALGORITHMSELECTION_H_
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019-2020 Axel Huebl, David Grote, Luca Fedeli
+ * Remi Lehe, Weiqun Zhang, Yinjian Zhao
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpXAlgorithmSelection.H>
 
 #include <map>

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Andrew Myers, Luca Fedeli, Maxence Thevenet
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_CONST_H_
 #define WARPX_CONST_H_
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, Maxence Thevenet
+ * Remi Lehe, Revathi Jambunathan, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "GuardCellManager.H"
 #include <WarpX.H>
 #include <WarpXUtil.H>

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, Maxence Thevenet, Weiqun Zhang
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include <WarpX.H>
 #include <AMReX_BoxIterator.H>

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Andrew Myers, Luca Fedeli, Maxence Thevenet
+ * Revathi Jambunathan, Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_UTILS_H_
 #define WARPX_UTILS_H_
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2019-2020 Andrew Myers, Burlen Loring, Luca Fedeli
+ * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ * Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpXUtil.H>
 #include <WarpXConst.H>
 #include <AMReX_ParmParse.H>

--- a/Source/Utils/WarpX_Complex.H
+++ b/Source/Utils/WarpX_Complex.H
@@ -1,3 +1,10 @@
+/* Copyright 2019-2020 Andrew Myers, David Grote, Maxence Thevenet
+ * Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_COMPLEX_H_
 #define WARPX_COMPLEX_H_
 

--- a/Source/Utils/atomic_data.txt
+++ b/Source/Utils/atomic_data.txt
@@ -1,3 +1,9 @@
+# Copyright 2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # Reference:
 # Kramida, A., Ralchenko, Yu., Reader, J., and NIST ASD Team (2014).
 # NIST Atomic Spectra Database (ver. 5.2), [Online].

--- a/Source/Utils/utils_ES.F90
+++ b/Source/Utils/utils_ES.F90
@@ -1,3 +1,9 @@
+! Copyright 2019 Maxence Thevenet, Remi Lehe
+!
+! This file is part of WarpX.
+!
+! License: BSD-3-Clause-LBNL
+
 module warpx_ES_utils
 
   use iso_c_binding

--- a/Source/Utils/write_atomic_data_cpp.py
+++ b/Source/Utils/write_atomic_data_cpp.py
@@ -1,3 +1,10 @@
+# Copyright 2019-2020 Axel Huebl, Luca Fedeli, Maxence Thevenet
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 '''
 This python script reads ionization tables in atomic_data.txt (generated from
 the NIST website) and extracts ionization levels into C++ file

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1,3 +1,14 @@
+/* Copyright 2016-2020 Andrew Myers, Ann Almgren, Aurore Blelly
+ * Axel Huebl, Burlen Loring, David Grote
+ * Glenn Richardson, Junmin Gu, Luca Fedeli
+ * Mathieu Lobet, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang, Yinjian Zhao
+ *
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef WARPX_H_
 #define WARPX_H_
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1,3 +1,14 @@
+/* Copyright 2016-2020 Andrew Myers, Ann Almgren, Aurore Blelly
+ * Axel Huebl, Burlen Loring, David Grote
+ * Glenn Richardson, Jean-Luc Vay, Junmin Gu
+ * Mathieu Lobet, Maxence Thevenet, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang, Yinjian Zhao
+ * levinem
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <WarpX_f.H>
 #include <WarpXConst.H>

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2016-2020 Andrew Myers, Ann Almgren, Axel Huebl
+ * David Grote, Jean-Luc Vay, Remi Lehe
+ * Revathi Jambunathan, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include <WarpX.H>
 #include <WarpXUtil.H>
 

--- a/Tools/batchScripts/batch_cori.sh
+++ b/Tools/batchScripts/batch_cori.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -l
 
+# Copyright 2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 #SBATCH -N 2
 #SBATCH -t 01:00:00
 #SBATCH -q regular

--- a/Tools/batchScripts/batch_summit.sh
+++ b/Tools/batchScripts/batch_summit.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright 2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 #BSUB -P <allocation ID>
 #BSUB -W 00:10
 #BSUB -nnodes 2

--- a/Tools/batchScripts/script_profiling_summit.sh
+++ b/Tools/batchScripts/script_profiling_summit.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright 2019 Andrew Myers, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 #BSUB -P GEN109
 #BSUB -W 0:10
 #BSUB -nnodes 1

--- a/Tools/compute_domain.py
+++ b/Tools/compute_domain.py
@@ -1,3 +1,9 @@
+# Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import numpy as np
 
 '''

--- a/Tools/cori_postproc_script.sh
+++ b/Tools/cori_postproc_script.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright 2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 #SBATCH --job-name=postproc
 #SBATCH --time=00:20:00
 #SBATCH -C haswell

--- a/Tools/performance_tests/cori.py
+++ b/Tools/performance_tests/cori.py
@@ -1,3 +1,10 @@
+# Copyright 2019 Axel Huebl, Luca Fedeli, Maxence Thevenet
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os, copy
 
 from functions_perftest import test_element

--- a/Tools/performance_tests/functions_perftest.py
+++ b/Tools/performance_tests/functions_perftest.py
@@ -1,3 +1,10 @@
+# Copyright 2018-2019 Axel Huebl, Luca Fedeli, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os, shutil, re, copy
 import pandas as pd
 import numpy as np

--- a/Tools/performance_tests/run_alltests.py
+++ b/Tools/performance_tests/run_alltests.py
@@ -1,3 +1,10 @@
+# Copyright 2017-2020 Luca Fedeli, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os, sys, shutil
 import argparse, re, time
 from functions_perftest import *

--- a/Tools/performance_tests/run_alltests_1node.py
+++ b/Tools/performance_tests/run_alltests_1node.py
@@ -1,3 +1,9 @@
+# Copyright 2018-2020 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os, shutil, datetime
 import argparse, re, time
 from functions_perftest import *

--- a/Tools/performance_tests/run_automated.py
+++ b/Tools/performance_tests/run_automated.py
@@ -1,3 +1,10 @@
+# Copyright 2018-2019 Axel Huebl, Luca Fedeli, Maxence Thevenet
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os, sys, shutil, datetime, git
 import argparse, re, time, copy
 import pandas as pd

--- a/Tools/performance_tests/summit.py
+++ b/Tools/performance_tests/summit.py
@@ -1,3 +1,10 @@
+# Copyright 2019 Axel Huebl, Luca Fedeli, Maxence Thevenet
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # requirements:
 # - module load python/3.7.0-anaconda3-5.3.0
 

--- a/Tools/plot_parallel.py
+++ b/Tools/plot_parallel.py
@@ -1,3 +1,9 @@
+# Copyright 2019 David Grote, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import os
 import glob
 import matplotlib

--- a/Tools/plot_particle_path.py
+++ b/Tools/plot_particle_path.py
@@ -1,3 +1,10 @@
+# Copyright 2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
+# Remi Lehe, Weiqun Zhang
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import numpy as np
 
 class AMReXParticleHeader(object):

--- a/Tools/read_lab_particles.py
+++ b/Tools/read_lab_particles.py
@@ -1,3 +1,9 @@
+# Copyright 2018-2019 Andrew Myers, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 import numpy as np
 from glob import glob
 import os

--- a/Tools/read_raw_data.py
+++ b/Tools/read_raw_data.py
@@ -1,3 +1,10 @@
+# Copyright 2017-2019 Andrew Myers, Axel Huebl, Maxence Thevenet
+# Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 from glob import glob
 import os
 import numpy as np

--- a/Tools/script_profiling_summit.sh
+++ b/Tools/script_profiling_summit.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright 2019 Andrew Myers, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 #BSUB -P GEN109
 #BSUB -W 0:10
 #BSUB -nnodes 1

--- a/Tools/update_copyright.sh
+++ b/Tools/update_copyright.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# This file loops over all WarpX source files, uses git to get the list of
+# contributors, and writes a copyright header at the beginning of each file
+# with the list of contributors.
+#
+# To use it, execute from the WarpX directory.
+# Warning: it'll delete and create file tmp.txt
+# It uses the gnu-sed (sed on Linux, gsed on MacOS)
+
+rm -r tmp.txt
+set -e
+
+# Loop over all source files
+pattern="\.c$|\.cpp$|\.F90$|\.h$|\.H$|\.py$|"\
+"\.sh$|\.tex$|\.txt$|\.yml$|"\
+"CMakeLists\.txt|inputs"
+for i in $(find . \
+                -not -path "./.git/*" \
+                -not -path "./.idea/*" \
+                -not -path "./Docs/source/api/*" \
+                -not -path "./Docs/build/*" \
+                -not -path "./Docs/doxyxml/*" \
+                -not -path "*wp_parse*" \
+                -not -path "*LEGAL.txt" \
+                -not -path "*LICENSE.txt" \
+                -not -path "./tmp_build_dir/*" \
+                -not -path "*/inputs*" \
+                -not -path "*/PICMI_inputs*" \
+                -not -path "./Tools/performance_tests/performance_log.txt" \
+                -type f | \
+               grep -P "${pattern}")
+do
+    echo "   ---   " $i
+    # If Copyright information is present, remove it.
+    # WARNING: This only works for C++ files.
+    gsed -i '/^\/\* Copyright/,/\*\//{/^#/!{/^\$/!d}}' $i ; sleep 0.01
+    # Get year of first modification of the file
+    year_line=`git log --format=%aD $i | tail -1`
+    year_first=($year_line)
+    year_first=${year_first[3]}
+    # Get year of last modification of the file
+    year_line=`git log --format=%aD $i | head -1`
+    year_last=($year_line)
+    year_last=${year_last[3]}
+    # Format year string, something like "2020" or "2016-2020"
+    if [ $year_first == $year_last ]; then year_string=$year_first; else year_string=$year_first-$year_last; fi
+    cp $i tmp.txt
+    # If bash or python or txt or yml file, comment character is #
+    if [ "${i: -2}" == "sh" ] || [ "${i: -2}" == "py" ] || [ "${i: -3}" == "txt" ] || [ "${i: -3}" == "yml" ]; then
+        echo "sh or py or txt"
+        pattern1="#"
+        pattern2="#"
+        pattern3="
+"
+    # If C or C++ file, comment characters are /*, * and */
+    elif [ "${i: -1}" == "H" ] || [ "${i: -3}" == "cpp" ] || [ "${i: -1}" == "c" ] || [ "${i: -1}" == "h" ]; then
+        echo "cpp"
+        pattern1="/*"
+        pattern2=" *"
+        pattern3="
+ */"
+    # If Fortran file, comment character is !
+    elif [ "${i: -3}" == "F90" ]; then
+        echo "Fortran"
+        pattern1="!"
+        pattern2="!"
+        pattern3="
+"
+    # If Latex, comment character is %
+    elif [ "${i: -3}" == "tex" ]; then
+        echo "tex"
+        pattern1="%"
+        pattern2="%"
+        pattern3="
+"
+    else
+        echo "error: unknown file type"
+        exit
+    fi
+    # Get formatted authors list
+    # sorted, unique, delete authors "Tools" (used by ax3l), and remove newlines
+    authors_list=`git log --follow --pretty=format:'%aN' $i | sort | uniq | grep -v Tools | gsed 's/$/, /g'`
+    # Put 2 authors per line, to avoid very long lines.
+    authors_list=`echo $authors_list | gsed 's/\([^,]*,[^,]*,[^,]*\),/\1,\n'"$pattern2"'/g' | gsed s/,$//g`
+    # Copy current file + Copyright to tmp.txt
+    # rm -rf tmp.txt
+    cp $i tmp.txt
+    first_line=`head -n1 $i`
+    # If a shebang is present, keep it as first line
+    if [ "${first_line:0:2}" == "#!" ]; then
+        echo "keeping shebang"
+        echo "$first_line" > tmp.txt
+        echo "" >> tmp.txt
+    else
+        truncate -s 0 tmp.txt
+    fi
+    # Write copyright
+    echo "$pattern1 Copyright $year_string $authors_list
+$pattern2
+$pattern2 This file is part of WarpX.
+$pattern2
+$pattern2 License: BSD-3-Clause-LBNL$pattern3" >> tmp.txt
+    # If no shebang, put first line after Copyright
+    if [ "${first_line:0:2}" != "#!" ]; then
+        echo "$first_line" >> tmp.txt
+    fi
+    # Then copy the content of the file
+    tail -n +2 $i >> tmp.txt
+    # Then overwrite current file with tmp.txt
+    mv tmp.txt $i
+done

--- a/Tools/update_copyright.sh
+++ b/Tools/update_copyright.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file loops over all WarpX source files, uses git to get the list of
 # contributors, and writes a copyright header at the beginning of each file
 # with the list of contributors.

--- a/Tools/update_copyright.sh
+++ b/Tools/update_copyright.sh
@@ -6,7 +6,6 @@
 #
 # License: BSD-3-Clause-LBNL
 
-
 # This file loops over all WarpX source files, uses git to get the list of
 # contributors, and writes a copyright header at the beginning of each file
 # with the list of contributors.

--- a/Tools/update_release.sh
+++ b/Tools/update_release.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This script updates release version number in all source files.
 #
 # updates occurences like "version = '??.??'" where ??.?? is the version number

--- a/Tools/video_yt.py
+++ b/Tools/video_yt.py
@@ -1,3 +1,9 @@
+# Copyright 2017-2020 Luca Fedeli, Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 '''
 This script loops over 3D plotfiles plt*****, generates a 3D rendering
 of the data with fields and particles, and saves one image per plotfile to

--- a/Tools/yt3d_mpi.py
+++ b/Tools/yt3d_mpi.py
@@ -1,3 +1,9 @@
+# Copyright 2018-2019 Maxence Thevenet
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 '''
 This script loops over 3D plotfiles plt*****, generates a 3D rendering
 of the data with fields and particles, and saves one image per plotfile to

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+# Copyright 2018-2020 Axel Huebl, David Grote, Edoardo Zoni
+# Luca Fedeli, Maxence Thevenet, Remi Lehe
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
 # This script runs some of WarpX's standard regression tests, but
 # without comparing the output to previously run simulations.
 # This checks that:


### PR DESCRIPTION
This PR adds a copyright header to all source files. Script `Tools/update_copyright.sh` loops over all files, uses git to find the contributors and the years during which modifications occured, creates the header and adds the header to the file. It also updates the `.mailmap` file a bit.

Things to discuss:
- Make this change an anonymous commit?
- Currently, all `py`, `cpp` `sh` etc. files are given a Copyright header. Should we only modify the files in `Source/`?