### PR TITLE
Call GpuSynchronize() to temporarily fix gpu bug

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1112,6 +1112,9 @@ PhysicalParticleContainer::FieldGather (int lev,
                                        costarr(i,j,k) += wt;
                                    });
             }
+            // synchronize avoids cudaStreams from over-writing the temporary arrays used to 
+            // store positions
+            Gpu::synchronize();
         }
     }
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1112,7 +1112,7 @@ PhysicalParticleContainer::FieldGather (int lev,
                                        costarr(i,j,k) += wt;
                                    });
             }
-            // synchronize avoids cudaStreams from over-writing the temporary arrays used to 
+            // synchronize avoids cudaStreams from over-writing the temporary arrays used to
             // store positions
             Gpu::synchronize();
         }


### PR DESCRIPTION
This PR temporarily fixes a GPU bug in the call to GetPosition in FieldGather( lev ..).
The cudaStreams over-write the shared temporary arrays that store particle positions. 
A call to Gpu::Synchronize, at the end of the Iterator solves the issue.


