### PR TITLE
Update back transformed diagnostics fields parameter

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1014,10 +1014,10 @@ Diagnostics and output
 * ``warpx.do_back_transformed_fields`` (`0 or 1`)
     Whether to use the **back-transformed diagnostics** for the fields.
 
-* ``warpx.boosted_frame_diag_fields`` (space-separated list of `string`)
+* ``warpx.back_transformed_diag_fields`` (space-separated list of `string`)
     Which fields to dumped in back-transformed diagnostics. Choices are
     'Ex', 'Ey', Ez', 'Bx', 'By', Bz', 'jx', 'jy', jz' and 'rho'. Example:
-    ``warpx.boosted_frame_diag_fields = Ex Ez By``. By default, all fields
+    ``warpx.back_transformed_diag_fields = Ex Ez By``. By default, all fields
     are dumped.
 
 * ``warpx.plot_raw_fields`` (`0` or `1`) optional (default `0`)

--- a/Examples/Modules/boosted_diags/inputs_3d_slice
+++ b/Examples/Modules/boosted_diags/inputs_3d_slice
@@ -33,7 +33,7 @@ warpx.boost_direction = z
 warpx.do_back_transformed_diagnostics = 1
 warpx.num_snapshots_lab = 4
 warpx.dz_snapshots_lab = 0.001
-warpx.boosted_frame_diag_fields= Ex Ey Ez By rho
+warpx.back_transformed_diag_fields= Ex Ey Ez By rho
 
 particles.nspecies = 3
 particles.species_names = electrons ions beam

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -566,7 +566,7 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
     std::vector<std::string> user_fields_to_dump;
     ParmParse pp("warpx");
     bool do_user_fields;
-    do_user_fields = pp.queryarr("boosted_frame_diag_fields",
+    do_user_fields = pp.queryarr("back_transformed_diag_fields",
                                  user_fields_to_dump);
     // If user specifies fields to dump, overwrite ncomp_to_dump,
     // map_actual_fields_to_dump and mesh_field_names.


### PR DESCRIPTION
Hi,

This PR is done to follow up the changes done to the majority of the back transformed diagnostics options and keep the input parameters consistent.

This very minor PR switches the old query label of:
`warpx.boosted_frame_diag_fields`
into:
`warpx.back_transformed_diag_fields`

Cheers,
Diana