### PR TITLE
Fix external field on particle with time dependence.

### DIFF
--- a/Source/Parser/WarpXParserWrapper.H
+++ b/Source/Parser/WarpXParserWrapper.H
@@ -32,7 +32,7 @@ struct ParserWrapper
     amrex::Real
     getField (amrex::Real x, amrex::Real y, amrex::Real z, amrex::Real t=0.0) const noexcept
     {
-       return m_parser(x,y,z);
+        return m_parser(x,y,z,t);
     }
 
     GpuParser m_parser;


### PR DESCRIPTION
Must pass t in call to GpuParser () operator.