### PR TITLE
Spack: load with -r

### DIFF
--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -32,22 +32,20 @@ First, install the openPMD-api library:
 
 ::
 
-    spack install openpmd-api -python +adios1
+    spack install openpmd-api -python
 
 Then, ``cd`` into the ``WarpX`` folder, and type:
 
 ::
 
-    spack load mpi
-    spack load openpmd-api
+    spack load -r openpmd-api
     make -j 4 USE_OPENPMD=TRUE
 
 You will also need to load the same spack environment when running WarpX, for instance:
 
 ::
 
-    spack load mpi
-    spack load openpmd-api
+    spack load -r openpmd-api
 
     mpirun -np 4 ./warpx.exe inputs
 
@@ -59,9 +57,9 @@ First, install the openPMD-api library, and load it in your environment:
 ::
 
     spack install hdf5
-    spack install adios
+    spack install adios2
     spack load -r hdf5
-    spack load -r adios
+    spack load -r adios2
 
 Then, in the `warpx_directory`, download and build the openPMD API:
 
@@ -85,8 +83,7 @@ You will also need to load the same spack environment when running WarpX, for in
 
 ::
 
-    spack load openmpi
-    spack load hdf5
-    spack load adios
+    spack load -r hdf5
+    spack load -r adios2
 
     mpirun -np 4 ./warpx.exe inputs


### PR DESCRIPTION
For transitive dependencies and CMake scripts, recusive loading is still the savest bet for a clean environment.

Although we use RPaths, recommend to still load at runtime again to keep e.g. the same MPI commands that were used for build & link.

Also: spack package builds HDF5 *and* ADIOS2 now as default backends.