### PR TITLE
do not use pow in constexpr

### DIFF
--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -30,8 +30,8 @@ namespace PhysConst
     static constexpr amrex::Real hbar  = 1.054571817e-34;
     static constexpr amrex::Real alpha = mu0/(4*MathConst::pi)*q_e*q_e*c/hbar;
     static constexpr amrex::Real r_e   = 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c);
-    static constexpr amrex::Real xi    = (2.*pow(alpha,2)*pow(ep0,2)*pow(hbar,3))/
-                                         (45.*pow(m_e,4)*pow(c,5)); // SI value is 1.3050122.e-52
+    static constexpr amrex::Real xi    = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/
+                                         (45.*m_e*m_e*m_e*m_e*c*c*c*c*c); // SI value is 1.3050122.e-52
 }
 
 #endif


### PR DESCRIPTION
The compilation error on GPU reported by @atmyers was 
```
./Source/Utils/WarpXConst.H(33): error: expression must have a constant value
/usr/include/c++/7/cmath(418): note: cannot call non-constexpr function "pow(double, double)"
/usr/local/cuda/include/crt/math_functions.h(4784): here
```
This PR should fix the issue.