### PR TITLE
do not use WarpX::quantum_xi inside ParallelFor

### DIFF
--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -152,6 +152,8 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, Real a_dt)
             { tmpEz(i,j,k,n) = Ezfab(i,j,k,n); }
         );
 
+        // Make local copy of xi, to use on device.
+        const Real xi = WarpX::quantum_xi;
         // Apply QED correction to electric field, using temporary arrays.
         amrex::ParallelFor(
             tbx,
@@ -159,7 +161,7 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, Real a_dt)
             {
                 warpx_hybrid_QED_push(j,k,l, Exfab, Eyfab, Ezfab, Bxfab, Byfab,
                                       Bzfab, tmpEx, tmpEy, tmpEz, dx, dy, dz,
-                                      a_dt);
+                                      a_dt, xi);
             }
         );
 

--- a/Source/FieldSolver/WarpX_QED_K.H
+++ b/Source/FieldSolver/WarpX_QED_K.H
@@ -78,7 +78,6 @@ void warpx_hybrid_QED_push (int j, int k, int l, Array4<Real> const& Ex, Array4<
 // Defining constants to be used in the calculations
 
 constexpr amrex::Real c2 = PhysConst::c * PhysConst::c;
-const amrex::Real xi = WarpX::quantum_xi;
 const amrex::Real dxi = 1./dx;
 const amrex::Real dzi = 1./dz;
 

--- a/Source/FieldSolver/WarpX_QED_K.H
+++ b/Source/FieldSolver/WarpX_QED_K.H
@@ -63,13 +63,15 @@ void calc_M(Real arr [], Real ex, Real ey, Real ez, Real bx, Real by, Real bz, R
  * \param[in] dy The y spatial step, used for calculating curls
  * \param[in] dz The z spatial step, used for calulating curls
  * \param[in] dt The temporal step, used for the half push/correction to the E-fields at the end of the function
+ * \param[in] xi Quantum parameter
  */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void warpx_hybrid_QED_push (int j, int k, int l, Array4<Real> const& Ex, Array4<Real>
                             const& Ey, Array4<Real> const& Ez, Array4<Real> const& Bx,
                             Array4<Real> const& By, Array4<Real const> const& Bz,
                             Array4<Real> const& tmpEx, Array4<Real> const& tmpEy,
-                            Array4<Real> const& tmpEz, Real dx, Real dy, Real dz, Real dt)
+                            Array4<Real> const& tmpEz, Real dx, Real dy, Real dz, Real dt,
+                            const Real xi)
 {
 
 


### PR DESCRIPTION
With this fix, WarpX compiles on Summit.