### PR TITLE
Disable htmlzip to reduce RTD build time

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,4 +7,3 @@
 requirements_file: Docs/requirements.txt
 
 formats:
-    - htmlzip


### PR DESCRIPTION
ReadTheDocs support was kind enough to increase resources to our project, hopefully our RTD build will stop failing due to timeout!

To accelerate our RTD build, they suggested to disable htmlzip, which is what this PR proposes.