### PR TITLE
Remove exhale from our building process

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -9,4 +9,3 @@ recommonmark
 sphinx>=2.0
 pygments
 breathe
-exhale

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -41,8 +41,7 @@ sys.path.insert(0, os.path.join( os.path.abspath(__file__), '../Python') )
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'breathe',
-    'exhale'
+    'breathe'
  ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -178,21 +177,6 @@ breathe_projects = {
     "WarpX": "../doxyxml/"
 }
 breathe_default_project = "WarpX"
-
-# Setup the exhale extension
-exhale_args = {
-    # These arguments are required
-    "containmentFolder": "./api",
-    "rootFileName": "library_root.rst",
-    "rootFileTitle": "Doxygen",
-    "doxygenStripFromPath": "..",
-    # Suggested optional arguments
-    "createTreeView": True,
-    # TIP: if using the sphinx-bootstrap-theme, you need
-    # "treeViewIsBootstrap": True,
-    "exhaleExecutesDoxygen": True,
-    "exhaleDoxygenStdin": "INPUT = ../../Source/"
-}
 
 # Tell sphinx what the primary language being documented is.
 primary_domain = 'cpp'

--- a/Docs/source/developers/documentation.rst
+++ b/Docs/source/developers/documentation.rst
@@ -40,20 +40,15 @@ Your Doxygen documentation is not only useful for people looking into the code, 
 
   .. doxygenclass:: WarpXParticleContainer
 
-Exhale documentation
---------------------
-
-Very similar to Breathe, the Python module `exhale <https://exhale.readthedocs.io/en/latest/>`__ reads the full Doxygen documentation and renders it in `rst <https://en.wikipedia.org/wiki/ReStructuredText>`__ format, and is accessible from the main WarpX ReadTheDocs page.
-
 Building the documentation
 --------------------------
 
-To build the documentation on your local computer, you will need to install Doxygen as well as the Python modules `breathe` and `exhale`. On MacOS this can by done by
+To build the documentation on your local computer, you will need to install Doxygen as well as the Python module `breathe`. On MacOS this can by done by
 
 .. code-block:: sh
 
     brew install doxygen
-    pip install breathe exhale
+    pip install breathe
 
 Then, to compile the documentation, use
 
@@ -62,4 +57,4 @@ Then, to compile the documentation, use
     cd Docs/
     make html
     # This will first compile the Doxygen documentation (execute doxygen)
-    # and then build html pages from rst files using sphinx, breathe and exhale.
+    # and then build html pages from rst files using sphinx and breathe.

--- a/Docs/source/developers/doxygen.rst
+++ b/Docs/source/developers/doxygen.rst
@@ -1,0 +1,6 @@
+.. _doxygen:
+
+Doxygen
+=======
+
+Our Doxygen API documentation in classic formatting `is located here <../_static/doxyhtml/index.html>`_.

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -38,4 +38,4 @@ In order to learn to use the code, please see the sections below:
    visualization/visualization
    theory/theory
    developers/developers
-   api/library_root
+   developers/doxygen


### PR DESCRIPTION
Exhale builds a beautiful rst-formatted Doxygen documentation. However, since we also post the standard Doxygen documentation on RTD (and we have to compile it anyway through breathe), this PR proposes to disable the exhale part to further accelerate our doc build. Now, the `Doxygen` tab visible from the documentation home page will point to the Doxygen doc.