### PR TITLE
Fix a typo of BeamRelevant reduced diagnostic.

### DIFF
--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -61,7 +61,6 @@ EFyt = 0.5*Es*scc.epsilon_0*dV + 0.5*Bs/scc.mu_0*dV
 
 # PART2: get results from reduced diagnostics
 
-EF = 0.0
 with open('./diags/reducedfiles/EF.txt') as csv_file:
     csv_reader = csv.reader(csv_file, delimiter=',')
     line_count = 0
@@ -70,7 +69,6 @@ with open('./diags/reducedfiles/EF.txt') as csv_file:
             EF = np.array(row[2]).astype(np.float)
         line_count += 1
 
-EP = 0.0
 with open('./diags/reducedfiles/EP.txt') as csv_file:
     csv_reader = csv.reader(csv_file, delimiter=',')
     line_count = 0

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -61,6 +61,7 @@ EFyt = 0.5*Es*scc.epsilon_0*dV + 0.5*Bs/scc.mu_0*dV
 
 # PART2: get results from reduced diagnostics
 
+EF = 0.0
 with open('./diags/reducedfiles/EF.txt') as csv_file:
     csv_reader = csv.reader(csv_file, delimiter=',')
     line_count = 0
@@ -69,6 +70,7 @@ with open('./diags/reducedfiles/EF.txt') as csv_file:
             EF = np.array(row[2]).astype(np.float)
         line_count += 1
 
+EP = 0.0
 with open('./diags/reducedfiles/EP.txt') as csv_file:
     csv_reader = csv.reader(csv_file, delimiter=',')
     line_count = 0

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -358,9 +358,9 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[7]  = std::sqrt(x_ms);
         m_data[8]  = std::sqrt(y_ms);
         m_data[9]  = std::sqrt(z_ms);
-        m_data[10] = std::sqrt(ux_ms * m);
-        m_data[11] = std::sqrt(uy_ms * m);
-        m_data[12] = std::sqrt(uz_ms * m);
+        m_data[10] = std::sqrt(ux_ms) * m;
+        m_data[11] = std::sqrt(uy_ms) * m;
+        m_data[12] = std::sqrt(uz_ms) * m;
         m_data[13] = std::sqrt(gm_ms);
         m_data[14] = std::sqrt(std::abs(x_ms*ux_ms-xux*xux)) / PhysConst::c;
         m_data[15] = std::sqrt(std::abs(y_ms*uy_ms-yuy*yuy)) / PhysConst::c;
@@ -374,9 +374,9 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[5]  = gm_mean;
         m_data[6]  = std::sqrt(x_ms);
         m_data[7]  = std::sqrt(z_ms);
-        m_data[8]  = std::sqrt(ux_ms * m);
-        m_data[9]  = std::sqrt(uy_ms * m);
-        m_data[10] = std::sqrt(uz_ms * m);
+        m_data[8]  = std::sqrt(ux_ms) * m;
+        m_data[9]  = std::sqrt(uy_ms) * m;
+        m_data[10] = std::sqrt(uz_ms) * m;
         m_data[11] = std::sqrt(gm_ms);
         m_data[12] = std::sqrt(std::abs(x_ms*ux_ms-xux*xux)) / PhysConst::c;
         m_data[13] = std::sqrt(std::abs(z_ms*uz_ms-zuz*zuz)) / PhysConst::c;

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -362,9 +362,9 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[11] = std::sqrt(uy_ms) * m;
         m_data[12] = std::sqrt(uz_ms) * m;
         m_data[13] = std::sqrt(gm_ms);
-        m_data[14] = std::sqrt(std::abs(x_ms*ux_ms-xux*xux)) / PhysConst::c;
-        m_data[15] = std::sqrt(std::abs(y_ms*uy_ms-yuy*yuy)) / PhysConst::c;
-        m_data[16] = std::sqrt(std::abs(z_ms*uz_ms-zuz*zuz)) / PhysConst::c;
+        m_data[14] = std::sqrt(x_ms*ux_ms-xux*xux) / PhysConst::c;
+        m_data[15] = std::sqrt(y_ms*uy_ms-yuy*yuy) / PhysConst::c;
+        m_data[16] = std::sqrt(z_ms*uz_ms-zuz*zuz) / PhysConst::c;
 #elif (AMREX_SPACEDIM == 2)
         m_data[0]  = x_mean;
         m_data[1]  = z_mean;
@@ -378,8 +378,8 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[9]  = std::sqrt(uy_ms) * m;
         m_data[10] = std::sqrt(uz_ms) * m;
         m_data[11] = std::sqrt(gm_ms);
-        m_data[12] = std::sqrt(std::abs(x_ms*ux_ms-xux*xux)) / PhysConst::c;
-        m_data[13] = std::sqrt(std::abs(z_ms*uz_ms-zuz*zuz)) / PhysConst::c;
+        m_data[12] = std::sqrt(x_ms*ux_ms-xux*xux) / PhysConst::c;
+        m_data[13] = std::sqrt(z_ms*uz_ms-zuz*zuz) / PhysConst::c;
 #endif
 
     }


### PR DESCRIPTION
This is a tiny PR that fixes a typo in BeamRelevant reduced diagnostic.
The typo is:
```   
        m_data[10] = std::sqrt(ux_ms * m);
        m_data[11] = std::sqrt(uy_ms * m);
        m_data[12] = std::sqrt(uz_ms * m);
```
It should be:
```    
        m_data[10] = std::sqrt(ux_ms) * m;
        m_data[11] = std::sqrt(uy_ms) * m;
        m_data[12] = std::sqrt(uz_ms) * m;
```