### PR TITLE
Handle two-way processes and multiplicity

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -642,6 +642,8 @@ MultiParticleContainer::doFieldIonization ()
 {
     BL_PROFILE("MPC::doFieldIonization");
 
+	constexpr int multiplicity = 1;
+	
     // Loop over all species.
     // Ionized particles in pc_source create particles in pc_product
     for (auto& pc_source : allcontainers)
@@ -673,7 +675,7 @@ MultiParticleContainer::doFieldIonization ()
                 auto& dst_tile = pc_product->ParticlesAt(lev, mfi);
 
                 auto np_dst = dst_tile.numParticles();
-                auto num_added = filterCopyTransformParticles(dst_tile, src_tile, np_dst,
+                auto num_added = filterCopyTransformParticles(dst_tile, src_tile, np_dst, multiplicity,
                                                               Filter, Copy, Transform);
 
                 setNewParticleIDs(dst_tile, np_dst, num_added);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -674,7 +674,7 @@ MultiParticleContainer::doFieldIonization ()
 
                 auto np_dst = dst_tile.numParticles();
                 auto num_added = filterCopyTransformParticles<1>(dst_tile, src_tile, np_dst,
-																 Filter, Copy, Transform);
+                                                                 Filter, Copy, Transform);
 
                 setNewParticleIDs(dst_tile, np_dst, num_added);
             }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -642,8 +642,6 @@ MultiParticleContainer::doFieldIonization ()
 {
     BL_PROFILE("MPC::doFieldIonization");
 
-	constexpr int multiplicity = 1;
-	
     // Loop over all species.
     // Ionized particles in pc_source create particles in pc_product
     for (auto& pc_source : allcontainers)
@@ -675,8 +673,8 @@ MultiParticleContainer::doFieldIonization ()
                 auto& dst_tile = pc_product->ParticlesAt(lev, mfi);
 
                 auto np_dst = dst_tile.numParticles();
-                auto num_added = filterCopyTransformParticles(dst_tile, src_tile, np_dst, multiplicity,
-                                                              Filter, Copy, Transform);
+                auto num_added = filterCopyTransformParticles<1>(dst_tile, src_tile, np_dst,
+																 Filter, Copy, Transform);
 
                 setNewParticleIDs(dst_tile, np_dst, num_added);
             }

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -60,6 +60,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
+	Gpu::streamSynchronize();
     const Index num_added = last_mask + last_offset;
     dst.resize(std::max(dst_index + num_added, dst.numParticles()));
 
@@ -191,6 +192,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
+	Gpu::streamSynchronize();
     Index num_added = last_mask + last_offset;
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -29,6 +29,7 @@
  * \param src the source tile
  * \param mask pointer to the mask - 1 means copy, 0 means don't copy
  * \param dst_index the location at which to starting writing the result to dst
+ * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
  *
@@ -46,7 +47,7 @@ template <typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc,
           amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
 Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Index dst_index,
-                                    CopyFunc&& copy, TransFunc&& transform) noexcept
+                                    Index multiplicity, CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
 
@@ -61,7 +62,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
 	Gpu::streamSynchronize();
-    const Index num_added = last_mask + last_offset;
+    const Index num_added = multiplicity * (last_mask + last_offset);
     dst.resize(std::max(dst_index + num_added, dst.numParticles()));
 
     const auto p_offsets = offsets.dataPtr();
@@ -73,8 +74,9 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     {
         if (mask[i])
         {
-            copy(dst_data, src_data, i, p_offsets[i] + dst_index);
-            transform(dst_data, src_data, i, p_offsets[i] + dst_index);
+			for (int j = 0; j < multiplicity; ++j)
+				copy(dst_data, src_data, i, multiplicity*p_offsets[i] + dst_index + j);
+            transform(dst_data, src_data, i, multiplicity*p_offsets[i] + dst_index);
         }
     });
 
@@ -100,6 +102,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
  * \param dst the destination tile
  * \param src the source tile
  * \param dst_index the location at which to starting writing the result to dst
+ * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param filter a callable returning true if that particle is to be copied and transformed
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
@@ -116,7 +119,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
  */
 template <typename DstTile, typename SrcTile, typename Index,
           typename PredFunc, typename TransFunc, typename CopyFunc>
-Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
+Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index, Index multiplicity,
                                     PredFunc&& filter, CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -134,7 +137,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
         p_mask[i] = filter(src_data, i);
     });
 
-    return filterCopyTransformParticles(dst, src, mask.dataPtr(), dst_index,
+    return filterCopyTransformParticles(dst, src, mask.dataPtr(), dst_index, multiplicity,
                                         std::forward<CopyFunc>(copy),
                                         std::forward<TransFunc>(transform));
 }
@@ -160,6 +163,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
  * \param mask pointer to the mask - 1 means copy, 0 means don't copy
  * \param dst1_index the location at which to starting writing the result to dst1
  * \param dst2_index the location at which to starting writing the result to dst2
+ * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
  *
@@ -177,7 +181,7 @@ template <typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc,
           amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
 Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, Index* mask,
-                                    Index dst1_index, Index dst2_index,
+                                    Index dst1_index, Index dst2_index, Index multiplicity,
                                     CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -193,7 +197,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
 	Gpu::streamSynchronize();
-    Index num_added = last_mask + last_offset;
+    Index num_added = multiplicity*(last_mask + last_offset);
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
 
@@ -207,10 +211,14 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     {
         if (mask[i])
         {
-            copy(dst1_data, src_data, i, p_offsets[i] + dst1_index);
-            copy(dst2_data, src_data, i, p_offsets[i] + dst2_index);
+			for (int j = 0; j < multiplicity; ++j)
+			{
+				copy(dst1_data, src_data, i, multiplicity*p_offsets[i] + dst1_index + j);
+				copy(dst2_data, src_data, i, multiplicity*p_offsets[i] + dst2_index + j);
+			}
             transform(dst1_data, dst2_data, src_data, i,
-                      p_offsets[i] + dst1_index, p_offsets[i] + dst2_index);
+                      multiplicity*p_offsets[i] + dst1_index,
+					  multiplicity*p_offsets[i] + dst2_index);
         }
     });
 
@@ -239,6 +247,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
  * \param src the source tile
  * \param dst1_index the location at which to starting writing the result to dst1
  * \param dst2_index the location at which to starting writing the result to dst2
+ * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param filter a callable returning true if that particle is to be copied and transformed
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
@@ -256,7 +265,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
 template <typename DstTile, typename SrcTile, typename Index,
           typename PredFunc, typename TransFunc, typename CopyFunc>
 Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
-                                    Index dst1_index, Index dst2_index,
+                                    Index dst1_index, Index dst2_index, Index multiplicity,
                                     PredFunc&& filter, CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -275,7 +284,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
     });
 
     return filterCopyTransformParticles(dst1, dst2, src, mask.dataPtr(),
-                                        dst1_index, dst2_index,
+                                        dst1_index, dst2_index, multiplicity,
                                         std::forward<CopyFunc>(copy),
                                         std::forward<TransFunc>(transform));
 }

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -19,6 +19,7 @@
  * Note that the transform function operates on both the src and the dst,
  * so both can be modified.
  *
+ * \tparam N number of particles created in the dst(s) for each filtered src particle
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
@@ -29,7 +30,6 @@
  * \param src the source tile
  * \param mask pointer to the mask - 1 means copy, 0 means don't copy
  * \param dst_index the location at which to starting writing the result to dst
- * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
  *
@@ -43,11 +43,11 @@
  *
  * \return num_added the number of particles that were written to dst.
  */
-template <typename DstTile, typename SrcTile, typename Index,
+template <int N, typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc,
           amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
 Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Index dst_index,
-                                    Index multiplicity, CopyFunc&& copy, TransFunc&& transform) noexcept
+                                    CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
 
@@ -62,7 +62,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
 	Gpu::streamSynchronize();
-    const Index num_added = multiplicity * (last_mask + last_offset);
+    const Index num_added = N * (last_mask + last_offset);
     dst.resize(std::max(dst_index + num_added, dst.numParticles()));
 
     const auto p_offsets = offsets.dataPtr();
@@ -74,9 +74,9 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     {
         if (mask[i])
         {
-			for (int j = 0; j < multiplicity; ++j)
-				copy(dst_data, src_data, i, multiplicity*p_offsets[i] + dst_index + j);
-            transform(dst_data, src_data, i, multiplicity*p_offsets[i] + dst_index);
+			for (int j = 0; j < N; ++j)
+				copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j);
+            transform(dst_data, src_data, i, N*p_offsets[i] + dst_index);
         }
     });
 
@@ -92,6 +92,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
  * Note that the transform function operates on both the src and the dst,
  * so both can be modified.
  *
+ * \tparam N number of particles created in the dst(s) for each filtered src particle
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
@@ -102,7 +103,6 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
  * \param dst the destination tile
  * \param src the source tile
  * \param dst_index the location at which to starting writing the result to dst
- * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param filter a callable returning true if that particle is to be copied and transformed
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
@@ -117,9 +117,9 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
  *
  * \return num_added the number of particles that were written to dst.
  */
-template <typename DstTile, typename SrcTile, typename Index,
+template <int N, typename DstTile, typename SrcTile, typename Index,
           typename PredFunc, typename TransFunc, typename CopyFunc>
-Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index, Index multiplicity,
+Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
                                     PredFunc&& filter, CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -137,9 +137,9 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
         p_mask[i] = filter(src_data, i);
     });
 
-    return filterCopyTransformParticles(dst, src, mask.dataPtr(), dst_index, multiplicity,
-                                        std::forward<CopyFunc>(copy),
-                                        std::forward<TransFunc>(transform));
+    return filterCopyTransformParticles<N>(dst, src, mask.dataPtr(), dst_index,
+													  std::forward<CopyFunc>(copy),
+													  std::forward<TransFunc>(transform));
 }
 
 /**
@@ -151,6 +151,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
  * Note that the transform function operates on all of src, dst1, and dst2,
  * so all of them can be modified.
  *
+ * \tparam N number of particles created in the dst(s) for each filtered src particle
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
@@ -163,7 +164,6 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
  * \param mask pointer to the mask - 1 means copy, 0 means don't copy
  * \param dst1_index the location at which to starting writing the result to dst1
  * \param dst2_index the location at which to starting writing the result to dst2
- * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
  *
@@ -177,11 +177,11 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
  *
  * \return num_added the number of particles that were written to dst.
  */
-template <typename DstTile, typename SrcTile, typename Index,
+template <int N, typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc,
           amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
 Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, Index* mask,
-                                    Index dst1_index, Index dst2_index, Index multiplicity,
+                                    Index dst1_index, Index dst2_index,
                                     CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -197,7 +197,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
 	Gpu::streamSynchronize();
-    Index num_added = multiplicity*(last_mask + last_offset);
+    Index num_added = N*(last_mask + last_offset);
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
 
@@ -211,14 +211,14 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     {
         if (mask[i])
         {
-			for (int j = 0; j < multiplicity; ++j)
+			for (int j = 0; j < N; ++j)
 			{
-				copy(dst1_data, src_data, i, multiplicity*p_offsets[i] + dst1_index + j);
-				copy(dst2_data, src_data, i, multiplicity*p_offsets[i] + dst2_index + j);
+				copy(dst1_data, src_data, i, N*p_offsets[i] + dst1_index + j);
+				copy(dst2_data, src_data, i, N*p_offsets[i] + dst2_index + j);
 			}
             transform(dst1_data, dst2_data, src_data, i,
-                      multiplicity*p_offsets[i] + dst1_index,
-					  multiplicity*p_offsets[i] + dst2_index);
+                      N*p_offsets[i] + dst1_index,
+					  N*p_offsets[i] + dst2_index);
         }
     });
 
@@ -235,6 +235,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
  * Note that the transform function operates on all of src, dst1, and dst2,
  * so all of them can be modified.
  *
+ * \tparam N number of particles created in the dst(s) for each filtered src particle
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
@@ -247,7 +248,6 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
  * \param src the source tile
  * \param dst1_index the location at which to starting writing the result to dst1
  * \param dst2_index the location at which to starting writing the result to dst2
- * \param multiplicity the number of particles to create in the destination(s) for each src particle
  * \param filter a callable returning true if that particle is to be copied and transformed
  * \param copy callable that defines what will be done for the "copy" step.
  * \param transform callable that defines the transformation to apply on dst and src.
@@ -262,10 +262,10 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
  *
  * \return num_added the number of particles that were written to dst.
  */
-template <typename DstTile, typename SrcTile, typename Index,
+template <int N, typename DstTile, typename SrcTile, typename Index,
           typename PredFunc, typename TransFunc, typename CopyFunc>
 Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
-                                    Index dst1_index, Index dst2_index, Index multiplicity,
+                                    Index dst1_index, Index dst2_index,
                                     PredFunc&& filter, CopyFunc&& copy, TransFunc&& transform) noexcept
 {
     using namespace amrex;
@@ -283,8 +283,8 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
         p_mask[i] = filter(src_data, i);
     });
 
-    return filterCopyTransformParticles(dst1, dst2, src, mask.dataPtr(),
-                                        dst1_index, dst2_index, multiplicity,
+    return filterCopyTransformParticles<N>(dst1, dst2, src, mask.dataPtr(),
+                                        dst1_index, dst2_index,
                                         std::forward<CopyFunc>(copy),
                                         std::forward<TransFunc>(transform));
 }

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -144,8 +144,8 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
 
 /**
  * \brief Apply a filter, copy, and transform operation to the particles
- * in src, in that order, writing the results to dst1 and dst2, starting 
- * at dst1_index and dst2_index. The dst tiles will be extended so all the 
+ * in src, in that order, writing the results to dst1 and dst2, starting
+ * at dst1_index and dst2_index. The dst tiles will be extended so all the
  * particles will fit, if needed.
  *
  * Note that the transform function operates on all of src, dst1, and dst2,
@@ -206,7 +206,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     const auto src_data  = src.getParticleTileData();
           auto dst1_data = dst1.getParticleTileData();
           auto dst2_data = dst2.getParticleTileData();
-          
+
     AMREX_HOST_DEVICE_FOR_1D( np, i,
     {
         if (mask[i])
@@ -228,8 +228,8 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
 
 /**
  * \brief Apply a filter, copy, and transform operation to the particles
- * in src, in that order, writing the results to dst1 and dst2, starting 
- * at dst1_index and dst2_index. The dst tiles will be extended so all the 
+ * in src, in that order, writing the results to dst1 and dst2, starting
+ * at dst1_index and dst2_index. The dst tiles will be extended so all the
  * particles will fit, if needed.
  *
  * Note that the transform function operates on all of src, dst1, and dst2,

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -138,4 +138,144 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
                                         std::forward<TransFunc>(transform));
 }
 
+/**
+ * \brief Apply a filter, copy, and transform operation to the particles
+ * in src, in that order, writing the results to dst1 and dst2, starting 
+ * at dst1_index and dst2_index. The dst tiles will be extended so all the 
+ * particles will fit, if needed.
+ *
+ * Note that the transform function operates on all of src, dst1, and dst2,
+ * so all of them can be modified.
+ *
+ * \tparam DstTile the dst particle tile type
+ * \tparam SrcTile the src particle tile type
+ * \tparam Index the index type, e.g. unsigned int
+ * \tparam TransFunc the transform function type
+ * \tparam CopyFunc the copy function type
+ *
+ * \param dst1 the destination tile
+ * \param dst2 the destination tile
+ * \param src the source tile
+ * \param mask pointer to the mask - 1 means copy, 0 means don't copy
+ * \param dst1_index the location at which to starting writing the result to dst1
+ * \param dst2_index the location at which to starting writing the result to dst2
+ * \param copy callable that defines what will be done for the "copy" step.
+ * \param transform callable that defines the transformation to apply on dst and src.
+ *
+ *        The form of the callable should model:
+ *            template <typename DstData, typename SrcData>
+ *            AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+ *            void operator() (DstData& dst, SrcData& src, int i_src, int i_dst);
+ *
+ *        where dst and src refer to the destination and source tiles and
+ *        i_src and i_dst and the particle indices in each tile.
+ *
+ * \return num_added the number of particles that were written to dst.
+ */
+template <typename DstTile, typename SrcTile, typename Index,
+          typename TransFunc, typename CopyFunc,
+          amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
+Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, Index* mask,
+                                    Index dst1_index, Index dst2_index,
+                                    CopyFunc&& copy, TransFunc&& transform) noexcept
+{
+    using namespace amrex;
+
+    auto np = src.numParticles();
+    if (np == 0) return 0;
+
+    Gpu::DeviceVector<Index> offsets(np);
+    Gpu::exclusive_scan(mask, mask+np, offsets.begin());
+
+    Index last_mask, last_offset;
+    Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
+    Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
+
+    Index num_added = last_mask + last_offset;
+    dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
+    dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
+
+    auto p_offsets = offsets.dataPtr();
+
+    const auto src_data  = src.getParticleTileData();
+          auto dst1_data = dst1.getParticleTileData();
+          auto dst2_data = dst2.getParticleTileData();
+          
+    AMREX_HOST_DEVICE_FOR_1D( np, i,
+    {
+        if (mask[i])
+        {
+            copy(dst1_data, src_data, i, p_offsets[i] + dst1_index);
+            copy(dst2_data, src_data, i, p_offsets[i] + dst2_index);
+            transform(dst1_data, dst2_data, src_data, i,
+                      p_offsets[i] + dst1_index, p_offsets[i] + dst2_index);
+        }
+    });
+
+    Gpu::streamSynchronize();
+    return num_added;
+}
+
+/**
+ * \brief Apply a filter, copy, and transform operation to the particles
+ * in src, in that order, writing the results to dst1 and dst2, starting 
+ * at dst1_index and dst2_index. The dst tiles will be extended so all the 
+ * particles will fit, if needed.
+ *
+ * Note that the transform function operates on all of src, dst1, and dst2,
+ * so all of them can be modified.
+ *
+ * \tparam DstTile the dst particle tile type
+ * \tparam SrcTile the src particle tile type
+ * \tparam Index the index type, e.g. unsigned int
+ * \tparam Filter the filter function type
+ * \tparam TransFunc the transform function type
+ * \tparam CopyFunc the copy function type
+ *
+ * \param dst1 the destination tile
+ * \param dst2 the destination tile
+ * \param src the source tile
+ * \param dst1_index the location at which to starting writing the result to dst1
+ * \param dst2_index the location at which to starting writing the result to dst2
+ * \param filter a callable returning true if that particle is to be copied and transformed
+ * \param copy callable that defines what will be done for the "copy" step.
+ * \param transform callable that defines the transformation to apply on dst and src.
+ *
+ *        The form of the callable should model:
+ *            template <typename DstData, typename SrcData>
+ *            AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+ *            void operator() (DstData& dst, SrcData& src, int i_src, int i_dst);
+ *
+ *        where dst and src refer to the destination and source tiles and
+ *        i_src and i_dst and the particle indices in each tile.
+ *
+ * \return num_added the number of particles that were written to dst.
+ */
+template <typename DstTile, typename SrcTile, typename Index,
+          typename PredFunc, typename TransFunc, typename CopyFunc>
+Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
+                                    Index dst1_index, Index dst2_index,
+                                    PredFunc&& filter, CopyFunc&& copy, TransFunc&& transform) noexcept
+{
+    using namespace amrex;
+
+    auto np = src.numParticles();
+    if (np == 0) return 0;
+
+    Gpu::DeviceVector<Index> mask(np);
+
+    auto p_mask = mask.dataPtr();
+    const auto src_data = src.getParticleTileData();
+
+    AMREX_HOST_DEVICE_FOR_1D(np, i,
+    {
+        p_mask[i] = filter(src_data, i);
+    });
+
+    return filterCopyTransformParticles(dst1, dst2, src, mask.dataPtr(),
+                                        dst1_index, dst2_index,
+                                        std::forward<CopyFunc>(copy),
+                                        std::forward<TransFunc>(transform));
+}
+
 #endif

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -68,7 +68,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     const auto p_offsets = offsets.dataPtr();
 
     const auto src_data = src.getParticleTileData();
-          auto dst_data = dst.getParticleTileData();
+    const auto dst_data = dst.getParticleTileData();
 
     AMREX_HOST_DEVICE_FOR_1D( np, i,
     {
@@ -197,15 +197,15 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
     Gpu::streamSynchronize();
-    Index num_added = N*(last_mask + last_offset);
+    const Index num_added = N*(last_mask + last_offset);
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
 
     auto p_offsets = offsets.dataPtr();
 
-    const auto src_data  = src.getParticleTileData();
-          auto dst1_data = dst1.getParticleTileData();
-          auto dst2_data = dst2.getParticleTileData();
+    const auto src_data  =  src.getParticleTileData();
+    const auto dst1_data = dst1.getParticleTileData();
+    const auto dst2_data = dst2.getParticleTileData();
 
     AMREX_HOST_DEVICE_FOR_1D( np, i,
     {

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -61,7 +61,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
-	Gpu::streamSynchronize();
+    Gpu::streamSynchronize();
     const Index num_added = N * (last_mask + last_offset);
     dst.resize(std::max(dst_index + num_added, dst.numParticles()));
 
@@ -74,8 +74,8 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     {
         if (mask[i])
         {
-			for (int j = 0; j < N; ++j)
-				copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j);
+            for (int j = 0; j < N; ++j)
+                copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j);
             transform(dst_data, src_data, i, N*p_offsets[i] + dst_index);
         }
     });
@@ -138,8 +138,8 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
     });
 
     return filterCopyTransformParticles<N>(dst, src, mask.dataPtr(), dst_index,
-													  std::forward<CopyFunc>(copy),
-													  std::forward<TransFunc>(transform));
+                                                      std::forward<CopyFunc>(copy),
+                                                      std::forward<TransFunc>(transform));
 }
 
 /**
@@ -196,7 +196,7 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
 
-	Gpu::streamSynchronize();
+    Gpu::streamSynchronize();
     Index num_added = N*(last_mask + last_offset);
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
@@ -211,14 +211,14 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     {
         if (mask[i])
         {
-			for (int j = 0; j < N; ++j)
-			{
-				copy(dst1_data, src_data, i, N*p_offsets[i] + dst1_index + j);
-				copy(dst2_data, src_data, i, N*p_offsets[i] + dst2_index + j);
-			}
+            for (int j = 0; j < N; ++j)
+            {
+                copy(dst1_data, src_data, i, N*p_offsets[i] + dst1_index + j);
+                copy(dst2_data, src_data, i, N*p_offsets[i] + dst2_index + j);
+            }
             transform(dst1_data, dst2_data, src_data, i,
                       N*p_offsets[i] + dst1_index,
-					  N*p_offsets[i] + dst2_index);
+                      N*p_offsets[i] + dst2_index);
         }
     });
 


### PR DESCRIPTION
These modifications to filterCopyTransform will let us handle things like splitting, where 1 particle in the src creates multiple particles in the dst, and pair production, where there are two different destination species.