### PR TITLE
openPMD: avoid writing last step twice

### DIFF
--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -538,6 +538,8 @@ WarpX::WriteOpenPMDFile () const
 
 #ifdef WARPX_USE_OPENPMD
     const auto step = istep[0];
+    if (!m_OpenPMDPlotWriter->SetStep(step))
+        return;
 
     Vector<std::string> varnames; // Name of the written fields
     Vector<MultiFab> mf_avg; // contains the averaged, cell-centered fields
@@ -545,8 +547,6 @@ WarpX::WriteOpenPMDFile () const
     Vector<Geometry> output_geom;
 
     prepareFields(step, varnames, mf_avg, output_mf, output_geom);
-
-    m_OpenPMDPlotWriter->SetStep(step);
     // fields: only dumped for coarse level
     m_OpenPMDPlotWriter->WriteOpenPMDFields(
         varnames, *output_mf[0], output_geom[0], step, t_new[0]);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -88,7 +88,7 @@ public:
 
   ~WarpXOpenPMDPlot();
 
-  void SetStep(int ts);
+  bool SetStep(int ts);
 
   void WriteOpenPMDParticles(const std::unique_ptr<MultiParticleContainer>&);
 
@@ -172,6 +172,7 @@ private:
   bool m_OneFilePerTS = true;  //! write in openPMD fileBased manner for individual time steps
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5
   int m_CurrentStep  = -1;
+  bool m_OK = false;
 
   // meta data
   std::vector< bool > m_fieldPMLdirections; //! @see WarpX::getPMLdirections()

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -88,6 +88,11 @@ public:
 
   ~WarpXOpenPMDPlot();
 
+  /** Set Iteration Step for the series
+   *                                                                                                                                      
+   * @note If an iteration has been written, then it will return false;
+   *       Subsequent call to write fields & particles will not take effect.
+   */
   bool SetStep(int ts);
 
   void WriteOpenPMDParticles(const std::unique_ptr<MultiParticleContainer>&);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -89,7 +89,7 @@ public:
   ~WarpXOpenPMDPlot();
 
   /** Set Iteration Step for the series
-   *                                                                                                                                      
+   *
    * @note If an iteration has been written, then it will return false;
    *       Subsequent call to write fields & particles will not take effect.
    */

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -149,13 +149,13 @@ bool WarpXOpenPMDPlot::SetStep(int ts)
     m_OK = true;
     m_CurrentStep =  ts;
     Init(openPMD::AccessType::CREATE);
-  } 
+  }
   return  m_OK;
 }
 
 void
 WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
-{ 
+{
   // closing the previous m_Series is needed.
   // adios1 will crash for example.
    if (m_Series != nullptr) {

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -138,19 +138,31 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 }
 
 
-void WarpXOpenPMDPlot::SetStep(int ts)
+bool WarpXOpenPMDPlot::SetStep(int ts)
 {
   if (ts < 0)
-    return;
+    return false;
 
-  m_CurrentStep =  ts;
-
-  Init(openPMD::AccessType::CREATE);
+  if (m_CurrentStep >= ts) {
+     m_OK = false;
+  } else {
+    m_OK = true;
+    m_CurrentStep =  ts;
+    Init(openPMD::AccessType::CREATE);
+  } 
+  return  m_OK;
 }
 
 void
 WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
-{
+{ 
+  // closing the previous m_Series is needed.
+  // adios1 will crash for example.
+   if (m_Series != nullptr) {
+     m_Series->flush();
+     m_Series = nullptr;
+  }
+
     // either for the next ts file,
     // or init a single file for all ts
     std::string filename;
@@ -193,6 +205,9 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
 void
 WarpXOpenPMDPlot::WriteOpenPMDParticles(const std::unique_ptr<MultiParticleContainer>& mpc)
 {
+  if (!m_OK)
+     return;
+
   BL_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDParticles()");
   std::vector<std::string> species_names = mpc->GetSpeciesNames();
 
@@ -529,6 +544,9 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
                       const int iteration,
                       const double time ) const
 {
+  if (!m_OK)
+    return;
+
   //This is AMReX's tiny profiler. Possibly will apply it later
   BL_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDFields()");
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -270,7 +270,7 @@ WarpX::EvolveEM (int numsteps)
 
     bool write_plot_file = plot_int > 0 && istep[0] > last_plot_file_step
         && (max_time_reached || istep[0] >= max_step);
-    bool write_openPMD = openpmd_int > 0 && (max_time_reached || istep[0] >= max_step);
+    bool write_openPMD = (openpmd_int > 0) && (istep[0] > last_plot_file_step) && (max_time_reached || istep[0] >= max_step);
 
     bool do_insitu = (insitu_start >= istep[0]) && (insitu_int > 0) &&
         (istep[0] > last_insitu_step) && (max_time_reached || istep[0] >= max_step);

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -270,7 +270,7 @@ WarpX::EvolveEM (int numsteps)
 
     bool write_plot_file = plot_int > 0 && istep[0] > last_plot_file_step
         && (max_time_reached || istep[0] >= max_step);
-    bool write_openPMD = (openpmd_int > 0) && (istep[0] > last_plot_file_step) && (max_time_reached || istep[0] >= max_step);
+    bool write_openPMD = (openpmd_int > 0) && (max_time_reached || istep[0] >= max_step);
 
     bool do_insitu = (insitu_start >= istep[0]) && (insitu_int > 0) &&
         (istep[0] > last_insitu_step) && (max_time_reached || istep[0] >= max_step);


### PR DESCRIPTION
Avoids writing the last time step twice with openPMD output.