### PR TITLE
Bug fix for Issue #601

### DIFF
--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -1377,7 +1377,7 @@ AddPartDataToParticleBuffer(
     int nspeciesBoostedFrame) {
     for (int isp = 0; isp < nspeciesBoostedFrame; ++isp) {
         auto np = tmp_particle_buffer[isp].GetRealData(DiagIdx::w).size();
-        if (np == 0) return;
+        if (np == 0) continue;
 
         // allocate size of particle buffer array to np
         // This is a growing array. Each time we add np elements
@@ -1442,7 +1442,7 @@ AddPartDataToParticleBuffer(
     for (int isp = 0; isp < nSpeciesBackTransformedDiagnostics; ++isp) {
         auto np = tmp_particle_buffer[isp].GetRealData(DiagIdx::w).size();
 
-        if (np == 0) return;
+        if (np == 0) continue;
 
         Real const* const AMREX_RESTRICT wp_temp =
              tmp_particle_buffer[isp].GetRealData(DiagIdx::w).data();


### PR DESCRIPTION
This PR fixes the issue of missing beam data for back-transformed diagnostics in Issue #601 

After the fix, the snapshot output contains beam data information for the test case in Examples/Physics_applications/plasma_acceleration 

du -h lab_frame_data/snapshots/*/beam
60K     lab_frame_data/snapshots/snapshot00000/beam
60K     lab_frame_data/snapshots/snapshot00001/beam
60K     lab_frame_data/snapshots/snapshot00002/beam
60K     lab_frame_data/snapshots/snapshot00003/beam
60K     lab_frame_data/snapshots/snapshot00004/beam
60K     lab_frame_data/snapshots/snapshot00005/beam
60K     lab_frame_data/snapshots/snapshot00006/beam
60K     lab_frame_data/snapshots/snapshot00007/beam
60K     lab_frame_data/snapshots/snapshot00008/beam
60K     lab_frame_data/snapshots/snapshot00009/beam
60K     lab_frame_data/snapshots/snapshot00010/beam
60K     lab_frame_data/snapshots/snapshot00011/beam
60K     lab_frame_data/snapshots/snapshot00012/beam
60K     lab_frame_data/snapshots/snapshot00013/beam
60K     lab_frame_data/snapshots/snapshot00014/beam
60K     lab_frame_data/snapshots/snapshot00015/beam
60K     lab_frame_data/snapshots/snapshot00016/beam
60K     lab_frame_data/snapshots/snapshot00017/beam
60K     lab_frame_data/snapshots/snapshot00018/beam
60K     lab_frame_data/snapshots/snapshot00019/beam
60K     lab_frame_data/snapshots/snapshot00020/beam
60K     lab_frame_data/snapshots/snapshot00021/beam

du -h lab_frame_data/snapshots/*/plasma_e
32K     lab_frame_data/snapshots/snapshot00000/plasma_e
32K     lab_frame_data/snapshots/snapshot00001/plasma_e
32K     lab_frame_data/snapshots/snapshot00002/plasma_e
32K     lab_frame_data/snapshots/snapshot00003/plasma_e
32K     lab_frame_data/snapshots/snapshot00004/plasma_e
32K     lab_frame_data/snapshots/snapshot00005/plasma_e
32K     lab_frame_data/snapshots/snapshot00006/plasma_e
32K     lab_frame_data/snapshots/snapshot00007/plasma_e
32K     lab_frame_data/snapshots/snapshot00008/plasma_e
32K     lab_frame_data/snapshots/snapshot00009/plasma_e
32K     lab_frame_data/snapshots/snapshot00010/plasma_e
32K     lab_frame_data/snapshots/snapshot00011/plasma_e
32K     lab_frame_data/snapshots/snapshot00012/plasma_e
32K     lab_frame_data/snapshots/snapshot00013/plasma_e
32K     lab_frame_data/snapshots/snapshot00014/plasma_e
32K     lab_frame_data/snapshots/snapshot00015/plasma_e
32K     lab_frame_data/snapshots/snapshot00016/plasma_e
32K     lab_frame_data/snapshots/snapshot00017/plasma_e
32K     lab_frame_data/snapshots/snapshot00018/plasma_e
32K     lab_frame_data/snapshots/snapshot00019/plasma_e
32K     lab_frame_data/snapshots/snapshot00020/plasma_e
4.0K    lab_frame_data/snapshots/snapshot00021/plasma_e

du -h lab_frame_data/snapshots/*/plasma_p
32K     lab_frame_data/snapshots/snapshot00000/plasma_p
32K     lab_frame_data/snapshots/snapshot00001/plasma_p
32K     lab_frame_data/snapshots/snapshot00002/plasma_p
32K     lab_frame_data/snapshots/snapshot00003/plasma_p
32K     lab_frame_data/snapshots/snapshot00004/plasma_p
32K     lab_frame_data/snapshots/snapshot00005/plasma_p
32K     lab_frame_data/snapshots/snapshot00006/plasma_p
32K     lab_frame_data/snapshots/snapshot00007/plasma_p
32K     lab_frame_data/snapshots/snapshot00008/plasma_p
32K     lab_frame_data/snapshots/snapshot00009/plasma_p
32K     lab_frame_data/snapshots/snapshot00010/plasma_p
32K     lab_frame_data/snapshots/snapshot00011/plasma_p
32K     lab_frame_data/snapshots/snapshot00012/plasma_p
32K     lab_frame_data/snapshots/snapshot00013/plasma_p
32K     lab_frame_data/snapshots/snapshot00014/plasma_p
32K     lab_frame_data/snapshots/snapshot00015/plasma_p
32K     lab_frame_data/snapshots/snapshot00016/plasma_p
32K     lab_frame_data/snapshots/snapshot00017/plasma_p
32K     lab_frame_data/snapshots/snapshot00018/plasma_p
32K     lab_frame_data/snapshots/snapshot00019/plasma_p
32K     lab_frame_data/snapshots/snapshot00020/plasma_p
4.0K    lab_frame_data/snapshots/snapshot00021/plasma_p

du -h lab_frame_data/snapshots/*/driver
60K     lab_frame_data/snapshots/snapshot00000/driver
60K     lab_frame_data/snapshots/snapshot00001/driver
60K     lab_frame_data/snapshots/snapshot00002/driver
60K     lab_frame_data/snapshots/snapshot00003/driver
60K     lab_frame_data/snapshots/snapshot00004/driver
60K     lab_frame_data/snapshots/snapshot00005/driver
60K     lab_frame_data/snapshots/snapshot00006/driver
60K     lab_frame_data/snapshots/snapshot00007/driver
60K     lab_frame_data/snapshots/snapshot00008/driver
60K     lab_frame_data/snapshots/snapshot00009/driver
60K     lab_frame_data/snapshots/snapshot00010/driver
60K     lab_frame_data/snapshots/snapshot00011/driver
60K     lab_frame_data/snapshots/snapshot00012/driver
60K     lab_frame_data/snapshots/snapshot00013/driver
60K     lab_frame_data/snapshots/snapshot00014/driver
60K     lab_frame_data/snapshots/snapshot00015/driver
60K     lab_frame_data/snapshots/snapshot00016/driver
60K     lab_frame_data/snapshots/snapshot00017/driver
60K     lab_frame_data/snapshots/snapshot00018/driver
60K     lab_frame_data/snapshots/snapshot00019/driver
60K     lab_frame_data/snapshots/snapshot00020/driver
60K     lab_frame_data/snapshots/snapshot00021/driver

du -h lab_frame_data/snapshots/*/driverback
4.0K    lab_frame_data/snapshots/snapshot00000/driverback
4.0K    lab_frame_data/snapshots/snapshot00001/driverback
4.0K    lab_frame_data/snapshots/snapshot00002/driverback
4.0K    lab_frame_data/snapshots/snapshot00003/driverback
4.0K    lab_frame_data/snapshots/snapshot00004/driverback
4.0K    lab_frame_data/snapshots/snapshot00005/driverback
4.0K    lab_frame_data/snapshots/snapshot00006/driverback
4.0K    lab_frame_data/snapshots/snapshot00007/driverback
4.0K    lab_frame_data/snapshots/snapshot00008/driverback
4.0K    lab_frame_data/snapshots/snapshot00009/driverback
4.0K    lab_frame_data/snapshots/snapshot00010/driverback
4.0K    lab_frame_data/snapshots/snapshot00011/driverback
4.0K    lab_frame_data/snapshots/snapshot00012/driverback
4.0K    lab_frame_data/snapshots/snapshot00013/driverback
4.0K    lab_frame_data/snapshots/snapshot00014/driverback
4.0K    lab_frame_data/snapshots/snapshot00015/driverback
4.0K    lab_frame_data/snapshots/snapshot00016/driverback
4.0K    lab_frame_data/snapshots/snapshot00017/driverback
4.0K    lab_frame_data/snapshots/snapshot00018/driverback
4.0K    lab_frame_data/snapshots/snapshot00019/driverback
4.0K    lab_frame_data/snapshots/snapshot00020/driverback
4.0K    lab_frame_data/snapshots/snapshot00021/driverback

