### PR TITLE
Remove compilation of Fortran files in EM mode

### DIFF
--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -1,5 +1,7 @@
-F90EXE_sources += interpolate_cic.F90
-F90EXE_sources += push_particles_ES.F90
+ifeq ($(DO_ELECTROSTATIC),TRUE)
+    F90EXE_sources += interpolate_cic.F90
+    F90EXE_sources += push_particles_ES.F90
+endif
 
 CEXE_sources += MultiParticleContainer.cpp
 CEXE_sources += WarpXParticleContainer.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -1,4 +1,6 @@
-F90EXE_sources += utils_ES.F90
+ifeq ($(DO_ELECTROSTATIC),TRUE)
+    F90EXE_sources += utils_ES.F90
+endif    
 CEXE_headers += WarpX_Complex.H
 CEXE_sources += WarpXMovingWindow.cpp
 CEXE_sources += WarpXTagging.cpp


### PR DESCRIPTION
These files are only used for the electrostatic mode.