### PR TITLE
openPMD-api: One Series at a Time

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -156,6 +156,10 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
     std::string filename;
     GetFileName(filename);
 
+    // close a previously open series before creating a new one
+    // see ADIOS1 limitation: https://github.com/openPMD/openPMD-api/pull/686
+    m_Series = nullptr;
+
     if( amrex::ParallelDescriptor::NProcs() > 1 )
     {
         m_Series = std::make_unique<openPMD::Series>(


### PR DESCRIPTION
Make sure that only one Series is open at a time in case `Init` is called again.

In previous logic, at the moment of assignment of a new Series, the old and the new `openPMD::Series` were briefly active for a short time. ADIOS1 does not support this and its anyway not what we want to do here.

Discovered by Junmin.

Isolated as independent issue from: #691 
Bug introduced in: #653

Refs.:
- https://github.com/openPMD/openPMD-api/pull/685
- https://github.com/openPMD/openPMD-api/pull/686