### PR TITLE
Add Reset Random Seed Feature

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -44,15 +44,14 @@ Overall simulation parameters
 * ``warpx.verbose`` (`0` or `1`)
     Controls how much information is printed to the terminal, when running WarpX.
 
-* ``warpx.random_seed`` (`string`) optional
+* ``warpx.random_seed`` (`string` or `int` >= 1) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined
-    using `std::clock()`, thus every simulation run produces different random numbers.
-    If provided ``warpx.random_seed = n``, and `n >= 0`,
-    the random_seed will be reset based on `n`.
-    If ``warpx.random_seed = default`` is provided, or ``warpx.random_seed`` is not provided at all,
-    the default fixed random seed will be used.
-    When the default random seed is not used,
-    the actual random seed used will be printed on screen.
+    using `std::random_device` and `std::clock()`,
+    thus every simulation run produces different random numbers.
+    If provided ``warpx.random_seed = n``, and it is required that `n >= 1`,
+    the random seed for each MPI rank is `(mpi_rank+1) * n`,
+    where `mpi_rank` starts from 0.
+    Note that `n = 1` produces the default random seed.
     Note that when GPU threading is used, one should not expect to obtain the same random numbers,
     even if a fixed ``warpx.random_seed`` is provided.
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -44,6 +44,15 @@ Overall simulation parameters
 * ``warpx.verbose`` (`0` or `1`)
     Controls how much information is printed to the terminal, when running WarpX.
 
+* ``warpx.random_seed`` (`integer`) optional
+    If provided ``warpx.random_seed = 0``, the random seed will be determined
+    using `std::clock()`, thus every simulation run produces different random numbers.
+    If provided ``warpx.random_seed = n``, and `n > 0`,
+    the random_seed will be reset based on `n`.
+    If `n < 0` is provided, or ``warpx.random_seed`` is not provided, the default fixed random_seed will be used.
+    Note that when GPU threading is used, one should not expect to obtain the same random numbers,
+    even if a positive ``warpx.random_seed`` is provided.
+
 Setting up the field mesh
 -------------------------
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -44,15 +44,17 @@ Overall simulation parameters
 * ``warpx.verbose`` (`0` or `1`)
     Controls how much information is printed to the terminal, when running WarpX.
 
-* ``warpx.random_seed`` (`string` or `int` >= 1) optional
+* ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined
     using `std::random_device` and `std::clock()`,
     thus every simulation run produces different random numbers.
-    If provided ``warpx.random_seed = n``, and it is required that `n >= 1`,
+    If provided ``warpx.random_seed = n``, and it is required that `n > 0`,
     the random seed for each MPI rank is `(mpi_rank+1) * n`,
     where `mpi_rank` starts from 0.
-    Note that `n = 1` produces the default random seed.
-    Note that when GPU threading is used, one should not expect to obtain the same random numbers,
+    `n = 1` and ``warpx.random_seed = default``
+    produce the default random seed.
+    Note that when GPU threading is used,
+    one should not expect to obtain the same random numbers,
     even if a fixed ``warpx.random_seed`` is provided.
 
 Setting up the field mesh

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -44,14 +44,16 @@ Overall simulation parameters
 * ``warpx.verbose`` (`0` or `1`)
     Controls how much information is printed to the terminal, when running WarpX.
 
-* ``warpx.random_seed`` (`integer`) optional
-    If provided ``warpx.random_seed = 0``, the random seed will be determined
-    using `std::clock()`, thus every simulation run produces different random numbers.
-    If provided ``warpx.random_seed = n``, and `n > 0`,
+* ``warpx.random_seed`` (`string`) optional
+    If provided ``warpx.random_seed = random``, the random seed will be determined
+    using `std::clock()`, thus every simulation run produces different random numbers,
+    and the actual random seed used will be printed on screen.
+    If provided ``warpx.random_seed = n``, and `n >= 0`,
     the random_seed will be reset based on `n`.
-    If `n < 0` is provided, or ``warpx.random_seed`` is not provided, the default fixed random_seed will be used.
+    If ``warpx.random_seed = default`` is provided, or ``warpx.random_seed`` is not provided at all,
+    the default fixed random seed will be used.
     Note that when GPU threading is used, one should not expect to obtain the same random numbers,
-    even if a positive ``warpx.random_seed`` is provided.
+    even if a fixed ``warpx.random_seed`` is provided.
 
 Setting up the field mesh
 -------------------------

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -46,12 +46,13 @@ Overall simulation parameters
 
 * ``warpx.random_seed`` (`string`) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined
-    using `std::clock()`, thus every simulation run produces different random numbers,
-    and the actual random seed used will be printed on screen.
+    using `std::clock()`, thus every simulation run produces different random numbers.
     If provided ``warpx.random_seed = n``, and `n >= 0`,
     the random_seed will be reset based on `n`.
     If ``warpx.random_seed = default`` is provided, or ``warpx.random_seed`` is not provided at all,
     the default fixed random seed will be used.
+    When the default random seed is not used,
+    the actual random seed used will be printed on screen.
     Note that when GPU threading is used, one should not expect to obtain the same random numbers,
     even if a fixed ``warpx.random_seed`` is provided.
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -343,23 +343,18 @@ WarpX::ReadParameters ()
         // set random seed
         std::string random_seed = "default";
         pp.query("random_seed", random_seed);
+        std::random_device rd;
+        std::uniform_int_distribution<int> dist(0, 32767);
         if ( random_seed != "default" ) {
             unsigned long myproc_1 = ParallelDescriptor::MyProc() + 1;
-            unsigned long x = 2;
             if ( random_seed == "random" ) {
-                unsigned long seed = myproc_1 * std::clock();
+                unsigned long seed = myproc_1 * dist(rd) + std::clock();
                 ResetRandomSeed(seed);
-                AllPrint() << "Actual Random Seed Used: " << seed
-                           << " for MPI process " << myproc_1 - 1 << "\n";
-            } else if ( std::stoul("999"+random_seed) == 999 ) {
-                Abort("Unknown warpx.random_seed value.");
-            } else if ( std::stoi(random_seed) >= 0 ) {
-                unsigned long seed = myproc_1 * ( std::stoul(random_seed) + x );
+            } else if ( std::stoi(random_seed) > 0 ) {
+                unsigned long seed = myproc_1 * std::stoul(random_seed);
                 ResetRandomSeed(seed);
-                AllPrint() << "Actual Random Seed Used: " << seed
-                           << " for MPI process " << myproc_1 - 1 << "\n";
             } else {
-                Abort("Unknown warpx.random_seed value.");
+                Abort("warpx.random_seed must be \"random\" or a number.");
             }
         }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -353,7 +353,7 @@ WarpX::ReadParameters ()
                            << " for MPI process " << myproc_1 - 1 << "\n";
             } else if ( std::stoul("999"+random_seed) == 999 ) {
                 Abort("Unknown warpx.random_seed value.");
-            } else if ( std::stoul(random_seed) >= 0 ) {
+            } else if ( std::stoi(random_seed) >= 0 ) {
                 unsigned long seed = myproc_1 * ( std::stoul(random_seed) + x );
                 ResetRandomSeed(seed);
                 AllPrint() << "Actual Random Seed Used: " << seed

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -344,19 +344,20 @@ WarpX::ReadParameters ()
         std::string random_seed = "default";
         pp.query("random_seed", random_seed);
         if ( random_seed != "default" ) {
-            int myproc = ParallelDescriptor::MyProc();
+            unsigned long myproc_1 = ParallelDescriptor::MyProc() + 1;
+            unsigned long x = 2;
             if ( random_seed == "random" ) {
-                unsigned long seed = (myproc+1) * std::clock();
+                unsigned long seed = myproc_1 * std::clock();
                 ResetRandomSeed(seed);
                 AllPrint() << "Actual Random Seed Used: " << seed
-                           << " for MPI process " << myproc << "\n";
-            } else if ( std::stoi("999"+random_seed) == 999 ) {
+                           << " for MPI process " << myproc_1 - 1 << "\n";
+            } else if ( std::stoul("999"+random_seed) == 999 ) {
                 Abort("Unknown warpx.random_seed value.");
-            } else if ( std::stoi(random_seed) >= 0 ) {
-                unsigned long seed = (myproc+1) * (std::stoi(random_seed)+2);
+            } else if ( std::stoul(random_seed) >= 0 ) {
+                unsigned long seed = myproc_1 * ( std::stoul(random_seed) + x );
                 ResetRandomSeed(seed);
                 AllPrint() << "Actual Random Seed Used: " << seed
-                           << " for MPI process " << myproc << "\n";
+                           << " for MPI process " << myproc_1 - 1 << "\n";
             } else {
                 Abort("Unknown warpx.random_seed value.");
             }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -340,6 +340,26 @@ WarpX::ReadParameters ()
     {
         ParmParse pp("warpx");
 
+        // set random seed
+        std::string random_seed = "default";
+        pp.query("random_seed", random_seed);
+        if ( random_seed != "default" ) {
+            int myproc = ParallelDescriptor::MyProc();
+            if ( random_seed == "random" ) {
+                unsigned long seed = (myproc+1) * std::clock();
+                ResetRandomSeed(seed);
+                AllPrint() << "Random Seed Used: " << seed
+                           << " for MPI process " << myproc << "\n";
+            } else if ( std::stoi("999"+random_seed) == 999 ) {
+                Abort("Unknown warpx.random_seed value.");
+            } else if ( std::stoi(random_seed) >= 0 ) {
+                unsigned long seed = (myproc+1) * (std::stoi(random_seed)+2);
+                ResetRandomSeed(seed);
+            } else {
+                Abort("Unknown warpx.random_seed value.");
+            }
+        }
+
         pp.query("cfl", cfl);
         pp.query("verbose", verbose);
         pp.query("regrid_int", regrid_int);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -348,13 +348,15 @@ WarpX::ReadParameters ()
             if ( random_seed == "random" ) {
                 unsigned long seed = (myproc+1) * std::clock();
                 ResetRandomSeed(seed);
-                AllPrint() << "Random Seed Used: " << seed
+                AllPrint() << "Actual Random Seed Used: " << seed
                            << " for MPI process " << myproc << "\n";
             } else if ( std::stoi("999"+random_seed) == 999 ) {
                 Abort("Unknown warpx.random_seed value.");
             } else if ( std::stoi(random_seed) >= 0 ) {
                 unsigned long seed = (myproc+1) * (std::stoi(random_seed)+2);
                 ResetRandomSeed(seed);
+                AllPrint() << "Actual Random Seed Used: " << seed
+                           << " for MPI process " << myproc << "\n";
             } else {
                 Abort("Unknown warpx.random_seed value.");
             }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -344,11 +344,11 @@ WarpX::ReadParameters ()
         std::string random_seed = "default";
         pp.query("random_seed", random_seed);
         std::random_device rd;
-        std::uniform_int_distribution<int> dist(0, 32767);
+        std::uniform_int_distribution<int> dist(0, INT_MAX);
         if ( random_seed != "default" ) {
             unsigned long myproc_1 = ParallelDescriptor::MyProc() + 1;
             if ( random_seed == "random" ) {
-                unsigned long seed = myproc_1 * dist(rd) + std::clock();
+                unsigned long seed = myproc_1 * dist(rd);
                 ResetRandomSeed(seed);
             } else if ( std::stoi(random_seed) > 0 ) {
                 unsigned long seed = myproc_1 * std::stoul(random_seed);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -343,18 +343,18 @@ WarpX::ReadParameters ()
         // set random seed
         std::string random_seed = "default";
         pp.query("random_seed", random_seed);
-        std::random_device rd;
-        std::uniform_int_distribution<int> dist(0, INT_MAX);
         if ( random_seed != "default" ) {
             unsigned long myproc_1 = ParallelDescriptor::MyProc() + 1;
             if ( random_seed == "random" ) {
+                std::random_device rd;
+                std::uniform_int_distribution<int> dist(2, INT_MAX);
                 unsigned long seed = myproc_1 * dist(rd);
                 ResetRandomSeed(seed);
             } else if ( std::stoi(random_seed) > 0 ) {
                 unsigned long seed = myproc_1 * std::stoul(random_seed);
                 ResetRandomSeed(seed);
             } else {
-                Abort("warpx.random_seed must be \"random\" or a number.");
+                Abort("warpx.random_seed must be \"default\", \"random\" or an integer > 0.");
             }
         }
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -32,6 +32,17 @@ int main(int argc, char* argv[])
 
     amrex::Initialize(argc,argv);
 
+    // set random seed
+    int random_seed = -1;
+    amrex::ParmParse pp("warpx");
+    pp.query("random_seed", random_seed);
+    int myproc = amrex::ParallelDescriptor::MyProc();
+    if ( random_seed > 0 ) {
+        amrex::ResetRandomSeed( (myproc+1) * random_seed );
+    } else if ( random_seed == 0 ) {
+        amrex::ResetRandomSeed( (myproc+1) * std::clock() );
+    }
+
     ConvertLabParamsToBoost();
 
     BL_PROFILE_VAR("main()", pmain);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -32,17 +32,6 @@ int main(int argc, char* argv[])
 
     amrex::Initialize(argc,argv);
 
-    // set random seed
-    int random_seed = -1;
-    amrex::ParmParse pp("warpx");
-    pp.query("random_seed", random_seed);
-    int myproc = amrex::ParallelDescriptor::MyProc();
-    if ( random_seed > 0 ) {
-        amrex::ResetRandomSeed( (myproc+1) * random_seed );
-    } else if ( random_seed == 0 ) {
-        amrex::ResetRandomSeed( (myproc+1) * std::clock() );
-    }
-
     ConvertLabParamsToBoost();
 
     BL_PROFILE_VAR("main()", pmain);


### PR DESCRIPTION
This PR adds a new feature which allows users to reset the random seed.

The instruction of how to use it is described in the documentation:
```
* ``warpx.random_seed`` (`string`) optional
    If provided ``warpx.random_seed = random``, the random seed will be determined
    using `std::clock()`, thus every simulation run produces different random numbers.
    If provided ``warpx.random_seed = n``, and `n >= 0`,
    the random_seed will be reset based on `n`.
    If ``warpx.random_seed = default`` is provided, or ``warpx.random_seed`` is not provided at all,
    the default fixed random seed will be used.
    When the default random seed is not used,
    the actual random seed used will be printed on screen.
    Note that when GPU threading is used, one should not expect to obtain the same random numbers,
    even if a fixed ``warpx.random_seed`` is provided.
```

A little bit more about the code:

(1)
```
else if ( std::stoi("999"+random_seed) == 999 ) {
                Abort("Unknown warpx.random_seed value.");
```
This is used to avoid user typing characters other than numbers, e.g. `warpx.random_seed = lsdflskdf`. Using this if statement, `Unknown warpx.random_seed value.` will be printed on screen. Without this if statement, the next if statement `std::stoi("lsdflskdf")` will produce an `invalid_argument` error which is harder for users to locate the bug.

(2)
```
else if ( std::stoi(random_seed) >= 0 ) {
                unsigned long seed = (myproc+1) * (std::stoi(random_seed)+2);
```
Plus 2 here is to make sure that, any nonnegative integer random seed provided by the user will not produce the same result as the default random seed.