### PR TITLE
[WIP] functors to select particles

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -134,7 +134,7 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             bool do_random_filter = true;
             bool do_uniform_filter = false;
             Real random_fraction = 0.25;
-            Real uniform_stride = 3;
+            long uniform_stride = 3;
 
             RandomFilter const random_filter(do_random_filter, random_fraction);
             UniformFilter const uniform_filter(do_uniform_filter, uniform_stride);

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -134,7 +134,7 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             bool do_random_filter = true;
             bool do_uniform_filter = false;
             Real random_fraction = 0.25;
-            long uniform_stride = 3;
+            int uniform_stride = 3;
 
             RandomFilter const random_filter(do_random_filter, random_fraction);
             UniformFilter const uniform_filter(do_uniform_filter, uniform_stride);

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -6,6 +6,8 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+
+#include "FilterFunctors.H"
 #include <MultiParticleContainer.H>
 #include <WarpX.H>
 
@@ -127,11 +129,26 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
 
             // Convert momentum to SI
             pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
+
+            // build filter functors
+            bool do_random_filter = true;
+            bool do_uniform_filter = false;
+            Real random_fraction = 0.5;
+            Real uniform_stride = 3;
+
+            RandomFilter random_filter(do_random_filter, random_fraction);
+            UniformFilter uniform_filter(do_uniform_filter, uniform_stride);
+
             // real_names contains a list of all particle attributes.
             // pc->plot_flags is 1 or 0, whether quantity is dumped or not.
-            pc->WritePlotFile(dir, species_names[i],
-                              pc->plot_flags, int_flags,
-                              real_names, int_names);
+            pc->WritePlotFile(
+                dir, species_names[i],
+                pc->plot_flags, int_flags,
+                real_names, int_names,
+                [=] (const ParticleType& p)
+                {
+                    return random_filter(p) * uniform_filter(p) ;
+                });
             // Convert momentum back to WarpX units
             pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
         }

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -133,11 +133,11 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             // build filter functors
             bool do_random_filter = true;
             bool do_uniform_filter = false;
-            Real random_fraction = 0.5;
+            Real random_fraction = 0.25;
             Real uniform_stride = 3;
 
-            RandomFilter random_filter(do_random_filter, random_fraction);
-            UniformFilter uniform_filter(do_uniform_filter, uniform_stride);
+            RandomFilter const random_filter(do_random_filter, random_fraction);
+            UniformFilter const uniform_filter(do_uniform_filter, uniform_stride);
 
             // real_names contains a list of all particle attributes.
             // pc->plot_flags is 1 or 0, whether quantity is dumped or not.

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -145,7 +145,7 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
                 dir, species_names[i],
                 pc->plot_flags, int_flags,
                 real_names, int_names,
-                [=] (const ParticleType& p)
+                [=] (const SuperParticleType& p)
                 {
                     return random_filter(p) * uniform_filter(p) ;
                 });

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -34,8 +34,8 @@ struct RandomFilter
         return 0;
     }
 private:
-    bool m_is_active;
-    amrex::Real m_fraction;
+    bool m_is_active = false; //! select all particles if false
+    amrex::Real m_fraction = 1.0; //! range: [0.0:1.0] where 0 is no & 1 is all particles
 };
 
 /**
@@ -43,12 +43,11 @@ private:
  */
 struct UniformFilter
 {
-public:
     /** constructor
      * \param a_is_active whether the test is active
      * \param a_stride one particle every a_stride is written to file
      */
-    UniformFilter(bool a_is_active, long a_stride)
+    UniformFilter(bool a_is_active, int a_stride)
         : m_is_active(a_is_active), m_stride(a_stride) {};
 
     /**
@@ -66,8 +65,8 @@ public:
         return 0;
     }
 private:
-    bool m_is_active;
-    long m_stride;
+    bool m_is_active = false; //! select all particles if false
+    int m_stride = 0; //! selection of every n-th particle
 };
 
 #endif // FILTERFUNCTORS_H

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -1,0 +1,74 @@
+#ifndef FILTERFUNCTORS_H
+#define FILTERFUNCTORS_H
+
+#include "AMReX_Gpu.H"
+#include "AMReX_Random.H"
+#include "WarpXParticleContainer.H"
+
+using ParticleType = typename WarpXParticleContainer::ParticleType;
+
+/**
+ * \brief Functor that returns 0 or 1 depending on a random draw per particle
+ */
+struct RandomFilter
+{
+public:
+    /** constructor
+     * \param a_is_active whether the test is active
+     * \param a_fraction fraction of particles to select
+     */
+    RandomFilter(bool a_is_active, amrex::Real a_fraction)
+        : m_is_active(a_is_active), m_fraction(a_fraction) {};
+
+    /**
+     * \brief draw random number, return 1 if number < m_fraction, 1 otherwise
+     * \param p one particle
+     * \return whether or not the particle is selected
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool operator () (const ParticleType& p) const noexcept
+    {
+        if ( !m_is_active )
+            return 1;
+        if ( amrex::Random() < m_fraction )
+            return 1;
+        return 0;
+    }
+private:
+    bool m_is_active;
+    amrex::Real m_fraction;
+};
+
+/**
+ * \brief Functor that returns 1 if stride divide particle_id, 0 otherwise
+ */
+struct UniformFilter
+{
+public:
+    /** constructor
+     * \param a_is_active whether the test is active
+     * \param a_stride one particle every a_stride is written to file
+     */
+    UniformFilter(bool a_is_active, long a_stride)
+        : m_is_active(a_is_active), m_stride(a_stride) {};
+
+    /**
+     * \brief return 1 if stride divide particle_id, 0 otherwise
+     * \param p one particle
+     * \return whether or not the particle is selected
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool operator () (const ParticleType& p) const noexcept
+    {
+        if ( !m_is_active )
+            return 1;
+        if ( p.id()%m_stride == 0 )
+            return 1;
+        return 0;
+    }
+private:
+    bool m_is_active;
+    long m_stride;
+};
+
+#endif // FILTERFUNCTORS_H

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -5,7 +5,7 @@
 #include "AMReX_Random.H"
 #include "WarpXParticleContainer.H"
 
-using ParticleType = typename WarpXParticleContainer::ParticleType;
+using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
 
 /**
  * \brief Functor that returns 0 or 1 depending on a random draw per particle
@@ -25,7 +25,7 @@ struct RandomFilter
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const ParticleType& p) const noexcept
+    bool operator () (const SuperParticleType& p) const noexcept
     {
         if ( !m_is_active )
             return 1;
@@ -56,7 +56,7 @@ struct UniformFilter
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const ParticleType& p) const noexcept
+    bool operator () (const SuperParticleType& p) const noexcept
     {
         if ( !m_is_active )
             return 1;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -12,7 +12,6 @@ using ParticleType = typename WarpXParticleContainer::ParticleType;
  */
 struct RandomFilter
 {
-public:
     /** constructor
      * \param a_is_active whether the test is active
      * \param a_fraction fraction of particles to select

--- a/Source/Particles/Filter/Make.package
+++ b/Source/Particles/Filter/Make.package
@@ -1,0 +1,4 @@
+CEXE_headers += FilterFunctors.H
+
+INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Filter
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Filter

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -23,6 +23,7 @@ include $(WARPX_HOME)/Source/Particles/Sorting/Make.package
 include $(WARPX_HOME)/Source/Particles/ParticleCreation/Make.package
 include $(WARPX_HOME)/Source/Particles/ElementaryProcess/Make.package
 include $(WARPX_HOME)/Source/Particles/Collision/Make.package
+include $(WARPX_HOME)/Source/Particles/Filter/Make.package
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles


### PR DESCRIPTION
AMReX function `pc->WritePlotFile` can take (at least on AMReX branch `particle_io_filter`) a lambda function that returns, for each particle, 0 or 1 depending on whether the particle must be written to file. This is clean, probably efficient, and more modular (we could use it for reduced diagnostics and back-transformed diagnostics as well). Thanks @atmyers for the implementation in AMReX and @ax3l for the suggestion!