### PR TITLE
Minor refactoring of space-charge calculation

### DIFF
--- a/Source/FieldSolver/Make.package
+++ b/Source/FieldSolver/Make.package
@@ -1,6 +1,7 @@
 CEXE_headers += WarpX_K.H
 CEXE_headers += WarpX_FDTD.H
 CEXE_sources += WarpXPushFieldsEM.cpp
+CEXE_sources += ElectrostaticSolver.cpp
 ifeq ($(USE_PSATD),TRUE)
   include $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/Make.package
   ifeq ($(USE_PSATD_PICSAR),TRUE)

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -14,7 +14,5 @@ CEXE_sources += InjectorMomentum.cpp
 CEXE_headers += CustomDensityProb.H
 CEXE_headers += CustomMomentumProb.H
 
-CEXE_sources += InitSpaceChargeField.cpp
-
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Initialization
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Initialization

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -133,12 +133,8 @@ WarpX::InitFromScratch ()
     mypc->InitData();
 
     // Loop through species and calculate their space-charge field
-    for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
-        WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
-        if (species.initialize_self_fields) {
-            InitSpaceChargeField(species);
-        }
-    }
+    bool const reset_fields = false; // Do not erase previous user-specified values on the grid
+    ComputeSpaceChargeField(reset_fields);
 
     InitPML();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -395,7 +395,8 @@ public:
     const amrex::IntVect getngE() const { return guard_cells.ng_alloc_EB; };
     const amrex::IntVect getngF() const { return guard_cells.ng_alloc_F; };
 
-    void InitSpaceChargeField (WarpXParticleContainer& pc);
+    void ComputeSpaceChargeField (bool const reset_fields);
+    void AddSpaceChargeField (WarpXParticleContainer& pc);
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},


### PR DESCRIPTION
This is a minor refactoring of the functions for space-charge calculation (which are right now used in the EM code for initialization of the fields at t=0).

The aim is that these functions can be used more easily in the ES mode, in upcoming PRs.

Here is a list of the changes:
- The functions for space-charge calculation were moved from the folder `Initialization` to the folder `FieldSolver`. (This is because these functions will be used at every iteration in the ES mode, and so it does make sense to have them in the `Initialization` solver)
- There is a new option `reset_fields` which zeros out the fields before calculating the space-charge. 
    * When using the space-charge computation for **initialization of the EM mode** this option is set to `false` ; this is because the fields are sometimes first initialized with the parser, before calling the space-charge computation.
    * In upcoming PRs, where the space-charge computation is used **at every iteration in the ES mode**, the same function will be called inside the PIC loop, but with `reset_fields=true`, because we wanr to erase the space-charge fields from the previous iteration.