### PR TITLE
Heuristic load balance based on number of particles and number of cells

### DIFF
--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -501,10 +501,11 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
                               amrex::Vector<MultiFab>& mf_avg, const int ngrow) const
 {
     // Count how many different fields should be written (ncomp)
+    MultiFab* cost = WarpX::getCosts(0);
     int ncomp = fields_to_plot.size()
         + static_cast<int>(plot_finepatch)*6
         + static_cast<int>(plot_crsepatch)*6
-        + static_cast<int>(costs[0] != nullptr and plot_costs);
+        + static_cast<int>(cost != nullptr and plot_costs);
 
     // Add in the RZ modes
     if (n_rz_azimuthal_modes > 1) {
@@ -717,13 +718,15 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
             dcomp += 3;
         }
 
-        if (costs[0] != nullptr and plot_costs)
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
-            AverageAndPackScalarField( mf_avg[lev], *costs[lev], dcomp, ngrow );
-            if(lev==0) varnames.push_back("costs");
-            dcomp += 1;
+            if (costs[0] != nullptr and plot_costs)
+            {
+                AverageAndPackScalarField( mf_avg[lev], *costs[lev], dcomp, ngrow );
+                if(lev==0) varnames.push_back("costs");
+                dcomp += 1;
+            }
         }
-
         BL_ASSERT(dcomp == ncomp);
     } // end loop over levels of refinement
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -187,9 +187,11 @@ WarpX::WriteCheckPointFile() const
             pml[lev]->CheckPoint(amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "pml"));
         }
 
-        if (costs[lev]) {
-            VisMF::Write(*costs[lev],
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "costs"));
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+            if (costs[lev]) {
+                VisMF::Write(*costs[lev],
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "costs"));
+            }
         }
     }
 
@@ -382,13 +384,15 @@ WarpX::InitFromCheckpoint ()
             }
         }
 
-        if (costs[lev]) {
-            const auto& cost_mf_name =
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+            if (costs[lev]) {
+                const auto& cost_mf_name =
                 amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "costs");
-            if (VisMF::Exist(cost_mf_name)) {
-                VisMF::Read(*costs[lev], cost_mf_name);
-            } else {
-                costs[lev]->setVal(0.0);
+                if (VisMF::Exist(cost_mf_name)) {
+                    VisMF::Read(*costs[lev], cost_mf_name);
+                } else {
+                    costs[lev]->setVal(0.0);
+                }
             }
         }
     }

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -262,7 +262,7 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
         F  = F_cp[lev].get();
     }
 
-    MultiFab* cost = costs[lev].get();
+    MultiFab* cost = WarpX::getCosts(lev);
     const IntVect& rr = (lev > 0) ? refRatio(lev-1) : IntVect::TheUnitVector();
 
     // xmin is only used by the kernel for cylindrical geometry,

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -83,7 +83,7 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, Real a_dt)
         Bz = Bfield_cp[lev][2].get();
     }
 
-    MultiFab* cost = costs[lev].get();
+    MultiFab* cost = WarpX::getCosts(lev);
     const IntVect& rr = (lev > 0) ? refRatio(lev-1) : IntVect::TheUnitVector();
 
     // xmin is only used by the kernel for cylindrical geometry,

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -12,6 +12,7 @@
 #include "Filter/NCIGodfreyFilter.H"
 #include "Parser/GpuParser.H"
 #include "Utils/WarpXUtil.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
@@ -420,8 +421,16 @@ WarpX::InitLevelData (int lev, Real time)
         rho_cp[lev]->setVal(0.0);
     }
 
-    if (costs[lev]) {
-        costs[lev]->setVal(0.0);
+    if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+        if (costs[lev]) {
+            costs[lev]->setVal(0.0);
+        }
+    } else if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic) {
+        if (costs_heuristic[lev]) {
+            std::fill((*costs_heuristic[lev]).begin(),
+                      (*costs_heuristic[lev]).end(),
+                      0.0);
+        }
     }
 }
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -7,6 +7,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include <WarpX.H>
+#include <WarpXAlgorithmSelection.H>
 #include <AMReX_BLProfiler.H>
 
 using namespace amrex;
@@ -17,6 +18,18 @@ WarpX::LoadBalance ()
     WARPX_PROFILE_REGION("LoadBalance");
     WARPX_PROFILE("WarpX::LoadBalance()");
 
+    if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
+    {
+        LoadBalanceTimers();
+    } else if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+    {
+        LoadBalanceHeuristic();
+    }
+}
+
+void
+WarpX::LoadBalanceTimers ()
+{
     AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
 
     const int nLevels = finestLevel();
@@ -30,7 +43,36 @@ WarpX::LoadBalance ()
             : DistributionMapping::makeKnapSack(*costs[lev], nmax);
         RemakeLevel(lev, t_new[lev], boxArray(lev), newdm);
     }
+    mypc->Redistribute();
+}
 
+void
+WarpX::LoadBalanceHeuristic ()
+{
+    AMREX_ALWAYS_ASSERT(costs_heuristic[0] != nullptr);
+    WarpX::ComputeCostsHeuristic();
+
+    const int nLevels = finestLevel();
+    for (int lev = 0; lev <= nLevels; ++lev)
+    {
+#ifdef AMREX_USE_MPI
+        // Parallel reduce the costs_heurisitc
+        amrex::Vector<Real>::iterator it = (*costs_heuristic[lev]).begin();
+        amrex::Real* itAddr = &(*it);
+        ParallelAllReduce::Sum(itAddr,
+                               costs_heuristic[lev]->size(),
+                               ParallelContext::CommunicatorSub());
+#endif
+        const amrex::Real nboxes = costs_heuristic[lev]->size();
+        const amrex::Real nprocs = ParallelContext::NProcsSub();
+        const int nmax = static_cast<int>(std::ceil(nboxes/nprocs*load_balance_knapsack_factor));
+
+        const DistributionMapping newdm = (load_balance_with_sfc)
+            ? DistributionMapping::makeSFC(*costs_heuristic[lev], boxArray(lev), false)
+            : DistributionMapping::makeKnapSack(*costs_heuristic[lev], nmax);
+
+        RemakeLevel(lev, t_new[lev], boxArray(lev), newdm);
+    }
     mypc->Redistribute();
 }
 
@@ -47,7 +89,6 @@ WarpX::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMa
 #endif // WARPX_DO_ELECTROSTATIC
 
         // Fine patch
-
         const auto& period = Geom(lev).periodicity();
         for (int idim=0; idim < 3; ++idim)
         {
@@ -98,7 +139,6 @@ WarpX::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMa
         }
 
         // Aux patch
-
         if (lev == 0 && Bfield_aux[0][0]->ixType() == Bfield_fp[0][0]->ixType())
         {
             for (int idim = 0; idim < 3; ++idim) {
@@ -223,15 +263,57 @@ WarpX::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMa
             }
         }
 
-        if (costs[lev] != nullptr) {
-            costs[lev].reset(new MultiFab(costs[lev]->boxArray(), dm, 1, 0));
-            costs[lev]->setVal(0.0);
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
+        {
+            if (costs[lev] != nullptr)
+            {
+                costs[lev].reset(new MultiFab(costs[lev]->boxArray(), dm, 1, 0));
+                costs[lev]->setVal(0.0);
+            }
+        } else if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+        {
+            if (costs_heuristic[lev] != nullptr)
+            {
+                costs_heuristic[lev].reset(new amrex::Vector<Real>);
+                const int nboxes = Efield_fp[lev][0].get()->size();
+                costs_heuristic[lev]->resize(nboxes, 0.0); // Initializes to 0.0?
+            }
         }
 
         SetDistributionMap(lev, dm);
-    }
-    else
+
+    } else
     {
         amrex::Abort("RemakeLevel: to be implemented");
     }
 }
+
+void
+WarpX::ComputeCostsHeuristic ()
+{
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        auto nSpecies = mypc.nSpecies();
+
+        // Species loop
+        for (int i_s = 0; i_s < nSpecies; ++i_s)
+        {
+            auto & myspc = mypc.GetParticleContainer(i_s);
+
+            // Particle loop
+            for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
+            {
+                (*costs_heuristic[lev])[pti.index()] += costs_heuristic_particles_wt*pti.numParticles();
+            }
+        }
+
+        //Cell loop
+        MultiFab* Ex = Efield_fp[lev][0].get();
+        for (MFIter mfi(*Ex, false); mfi.isValid(); ++mfi)
+        {
+            const Box& gbx = mfi.growntilebox();
+            (*costs_heuristic[lev])[mfi.index()] += costs_heuristic_cells_wt*gbx.numPts();
+        }
+    } // for (int lev ...)
+} // WarpX::ComputeCostsHeuristic

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -154,9 +154,7 @@ void PhysicalParticleContainer::InitData()
     // Init ionization module here instead of in the PhysicalParticleContainer
     // constructor because dt is required
     if (do_field_ionization) {InitIonizationModule();}
-
     AddParticles(0); // Note - add on level 0
-
     Redistribute();  // We then redistribute
 }
 
@@ -1128,6 +1126,7 @@ PhysicalParticleContainer::Evolve (int lev,
     BL_ASSERT(OnSameGrids(lev,jx));
 
     MultiFab* cost = WarpX::getCosts(lev);
+
     const iMultiFab* current_masks = WarpX::CurrentBufferMasks(lev);
     const iMultiFab* gather_masks = WarpX::GatherBufferMasks(lev);
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -47,6 +47,16 @@ struct GatheringAlgo {
     };
 };
 
+/** Strategy to compute weights for use in load balance.
+ */
+struct LoadBalanceCostsUpdateAlgo {
+    enum {
+        Timers = 0,   //!< load balance according to in-code timer-based weights (i.e., with  `costs`)
+        Heuristic = 1 /**< load balance according to weights computed from number of cells
+                             and number of particles per box (i.e., with `costs_heuristic`)*/
+    };
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -52,6 +52,12 @@ const std::map<std::string, int> gathering_algo_to_int = {
     {"default",             GatheringAlgo::EnergyConserving }
 };
 
+const std::map<std::string, int> load_balance_costs_update_algo_to_int = {
+    {"timers",    LoadBalanceCostsUpdateAlgo::Timers },
+    {"heuristic", LoadBalanceCostsUpdateAlgo::Heuristic },
+    {"default",   LoadBalanceCostsUpdateAlgo::Timers }
+};
+
 
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
@@ -74,13 +80,15 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
         algo_to_int = charge_deposition_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "field_gathering")) {
         algo_to_int = gathering_algo_to_int;
+    } else if (0 == std::strcmp(pp_search_key, "load_balance_costs_update")) {
+        algo_to_int = load_balance_costs_update_algo_to_int;
     } else {
         std::string pp_search_string = pp_search_key;
         amrex::Abort("Unknown algorithm type: " + pp_search_string);
     }
 
     // Check if the user-input is a valid key for the dictionary
-    if (algo_to_int.count(algo) == 0){
+    if (algo_to_int.count(algo) == 0) {
         // Not a valid key ; print error message
         std::string pp_search_string = pp_search_key;
         std::string error_message = "Invalid string for algo." + pp_search_string

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -18,6 +18,8 @@
 #include "Filter/BilinearFilter.H"
 #include "Filter/NCIGodfreyFilter.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
+#include "Utils/WarpXUtil.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #ifdef WARPX_USE_PSATD
@@ -131,6 +133,7 @@ public:
     static long field_gathering_algo;
     static long particle_pusher_algo;
     static int maxwell_fdtd_solver_id;
+    static long load_balance_costs_update_algo;
 
     // div E cleaning
     static int do_dive_cleaning;
@@ -199,8 +202,24 @@ public:
     std::vector<bool> getPMLdirections() const;
 
     static amrex::MultiFab* getCosts (int lev) {
-        if (m_instance) {
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+            if (m_instance) {
             return m_instance->costs[lev].get();
+        } else {
+            return nullptr;
+            }
+        } else {
+            return nullptr;
+        }
+    }
+
+    static amrex::Vector<amrex::Real>* getCostsHeuristic (int lev) {
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic) {
+            if (m_instance) {
+                return m_instance->costs_heuristic[lev].get();
+            } else {
+                return nullptr;
+            }
         } else {
             return nullptr;
         }
@@ -266,6 +285,12 @@ public:
     void Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real dt);
 
     static amrex::Real quantum_xi_c2;
+
+    /** \brief perform load balance; compute and communicate new `amrex::DistributionMapping`
+     */
+    void LoadBalance ();
+    void LoadBalanceTimers ();
+    void LoadBalanceHeuristic ();
 
 #ifdef WARPX_DIM_RZ
     void ApplyInverseVolumeScalingToCurrentDensity(amrex::MultiFab* Jx,
@@ -425,6 +450,10 @@ public:
          amrex::IntVect y_nodal_flag, amrex::IntVect z_nodal_flag,
          const int lev);
 
+    /** \brief add particle and cell contributions to multifabs in `costs_heuristic`
+     */
+    void ComputeCostsHeuristic ();
+
 protected:
 
     /**
@@ -567,8 +596,6 @@ private:
     void ExchangeWithPmlE (int lev);
     void ExchangeWithPmlF (int lev);
 
-    void LoadBalance ();
-
     void BuildBufferMasks ();
     void BuildBufferMasksInBox ( const amrex::Box tbx, amrex::IArrayBox &buffer_mask,
                                  const amrex::IArrayBox &guard_mask, const int ng );
@@ -655,10 +682,27 @@ private:
     int n_buffer = 4;
     amrex::Real const_dt = 0.5e-11;
 
+    // Load balancing
+    /** Interval to perform load balance; `load_balance_int=5`, e.g., will load
+     * balance during steps 5, 10, 15, etc. */
     int load_balance_int = -1;
+    /** Collection of multifabs to keep track of weights, based on in-code timers,
+     * for use in load balancing routines. */
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > costs;
+    /** Collection of multifabs to keep track of weights, based on number of cells
+     * and number of particles per box; for use in load balancing routines. */
+    amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > > costs_heuristic;
+    /** Load balance with 'space filling curve' strategy. */
     int load_balance_with_sfc = 0;
+    /** Controls the maximum number of boxes that can be assigned to a rank during
+     * load balance via the 'knapsack' strategy; e.g., if there are 4 boxes per rank,
+     * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
+     * be assigned to a rank to 8. */
     amrex::Real load_balance_knapsack_factor = 1.24;
+    /** Weight factor for cells in updating `costs_heuristic`. */
+    amrex::Real costs_heuristic_cells_wt = 0.1;
+    /** Weight factor for particles in updating `costs_heuristic`. */
+    amrex::Real costs_heuristic_particles_wt = 0.9;
 
     // Override sync every ? steps
     int override_sync_int = 1;
@@ -766,7 +810,7 @@ private:
     amrex::Vector<std::unique_ptr<amrex::LayoutData<FFTData> > > dataptr_fp_fft;
     amrex::Vector<std::unique_ptr<amrex::LayoutData<FFTData> > > dataptr_cp_fft;
 
-  // Domain decomposition containing the valid part of the dual grids (i.e. without FFT guard cells)
+    // Domain decomposition containing the valid part of the dual grids (i.e. without FFT guard cells)
     amrex::Vector<amrex::BoxArray> ba_valid_fp_fft;
     amrex::Vector<amrex::BoxArray> ba_valid_cp_fft;
 
@@ -796,6 +840,5 @@ private:
     std::string insitu_config;
     int insitu_pin_mesh;
 };
-
 
 #endif

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -205,8 +205,8 @@ public:
         if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
             if (m_instance) {
             return m_instance->costs[lev].get();
-        } else {
-            return nullptr;
+            } else {
+                return nullptr;
             }
         } else {
             return nullptr;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -67,6 +67,7 @@ long WarpX::charge_deposition_algo;
 long WarpX::field_gathering_algo;
 long WarpX::particle_pusher_algo;
 int WarpX::maxwell_fdtd_solver_id;
+long WarpX::load_balance_costs_update_algo;
 int WarpX::do_dive_cleaning = 0;
 
 long WarpX::n_rz_azimuthal_modes = 1;
@@ -247,7 +248,14 @@ WarpX::WarpX ()
     gather_masks.resize(nlevs_max);
 #endif // WARPX_DO_ELECTROSTATIC
 
-    costs.resize(nlevs_max);
+    switch (WarpX::load_balance_costs_update_algo)
+    {
+        case LoadBalanceCostsUpdateAlgo::Timers: costs.resize(nlevs_max);
+            break;
+        case LoadBalanceCostsUpdateAlgo::Heuristic: costs_heuristic.resize(nlevs_max);
+            break;
+        default: amrex::Abort("unknown load balance type");
+    }
 
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD
@@ -660,6 +668,9 @@ WarpX::ReadParameters ()
             // Use same shape factors in all directions, for gathering
             l_lower_order_in_v = false;
         }
+        load_balance_costs_update_algo = GetAlgorithmInteger(pp, "load_balance_costs_update");
+        pp.query("costs_heuristic_cells_wt", costs_heuristic_cells_wt);
+        pp.query("costs_heuristic_particles_wt", costs_heuristic_particles_wt);
     }
 
 #ifdef WARPX_USE_PSATD
@@ -780,7 +791,12 @@ WarpX::ClearLevel (int lev)
     F_cp  [lev].reset();
     rho_cp[lev].reset();
 
-    costs[lev].reset();
+    if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+        costs[lev].reset();
+    } else if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic) {
+        costs_heuristic[lev].reset();
+    }
+
 
 #ifdef WARPX_USE_PSATD_HYBRID
     for (int i = 0; i < 3; ++i) {
@@ -1057,7 +1073,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     }
 
     if (load_balance_int > 0) {
-        costs[lev].reset(new MultiFab(ba, dm, 1, 0));
+        if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
+            costs[lev].reset(new MultiFab(ba, dm, 1, 0));
+        } else if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic) {
+            costs_heuristic[lev].reset(new amrex::Vector<Real>);
+            const int nboxes = Efield_fp[lev][0].get()->size();
+            costs_heuristic[lev]->resize(nboxes);
+        }
     }
 }
 


### PR DESCRIPTION
This pull request adds the option to load balance according to an heuristic cost based on the number of particles and number of cells on each box, which is computed only at each load balance iteration (resolves issue #713 ).   The option can be enabled in the input file by setting `algo.load_balance_costs_update = heuristic` (the default option is `algo.load_balance_costs_update = timers`).  When the heuristic cost update is enabled, particle and cell weights can be set also in the input file, e.g. `algo.costs_heuristic_cells_wt = 0.1` and `algo.costs_heuristic_particles_wt = 0.9`.