### PR TITLE
Call AMReX Bin sort

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -971,6 +971,14 @@ Numerics and algorithms
      value here will make the simulation unphysical, but will allow QED effects to become more apparent.
      Note that this option will only have an effect if the warpx.use_Hybrid_QED flag is also triggered.
 
+ * ``warpx.sort_int`` (`int`) optional (default `-1` on CPU, `4` on GPU)
+     If `<=0`, do not sort particles. If `>0`, sort particles by bin every ``sort_int`` iteration.
+     It is turned on on GPUs for performance reasons (to improve memory locality).
+
+ * ``warpx.sort_bin_size`` (list of `int`) optional (default `4 4 4`)
+     If ``sort_int > 0`` particles are sorted in bins of ``sort_bin_size`` cells.
+     In 2D, only the first two elements are read.
+
 Boundary conditions
 -------------------
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -207,7 +207,7 @@ WarpX::EvolveEM (int numsteps)
         bool to_sort = (sort_int > 0) && ((step+1) % sort_int == 0);
         if (to_sort) {
             amrex::Print() << "re-sorting particles \n";
-            mypc->SortParticlesByCell();
+            mypc->SortParticlesByBin(sort_bin_size);
         }
 
         amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -168,7 +168,7 @@ public:
 
     void WriteHeader (std::ostream& os) const;
 
-    void SortParticlesByCell ();
+    void SortParticlesByBin (amrex::IntVect bin_size);
 
     void Redistribute ();
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -414,10 +414,11 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
 }
 
 void
-MultiParticleContainer::SortParticlesByCell ()
+MultiParticleContainer::SortParticlesByBin (amrex::IntVect bin_size)
 {
+    Print()<<"bin_size "<<bin_size<<'\n';
     for (auto& pc : allcontainers) {
-        pc->SortParticlesByCell();
+        pc->SortParticlesByBin(bin_size);
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -416,7 +416,6 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
 void
 MultiParticleContainer::SortParticlesByBin (amrex::IntVect bin_size)
 {
-    Print()<<"bin_size "<<bin_size<<'\n';
     for (auto& pc : allcontainers) {
         pc->SortParticlesByBin(bin_size);
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -169,6 +169,7 @@ public:
     static bool refine_plasma;
 
     static int sort_int;
+    static amrex::IntVect sort_bin_size;
 
     static int do_subcycling;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -89,7 +89,7 @@ int  WarpX::sort_int = 4;
 #else
 int  WarpX::sort_int = -1;
 #endif
-amrex::IntVect WarpX::sort_bin_size = 4*amrex::IntVect::TheUnitVector();
+amrex::IntVect WarpX::sort_bin_size(4,4,4);
 
 bool WarpX::do_back_transformed_diagnostics = false;
 std::string WarpX::lab_data_directory = "lab_frame_data";
@@ -484,9 +484,11 @@ WarpX::ReadParameters ()
         pp.query("sort_int", sort_int);
 
         Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
-        pp.queryarr("sort_bin_size", vect_sort_bin_size);
-        for (int i=0; i<AMREX_SPACEDIM; i++)
-            sort_bin_size[i] = vect_sort_bin_size[i];
+        bool sort_bin_size_is_specified = pp.queryarr("sort_bin_size", vect_sort_bin_size);
+        if (sort_bin_size_is_specified){
+            for (int i=0; i<AMREX_SPACEDIM; i++)
+                sort_bin_size[i] = vect_sort_bin_size[i];
+        }
 
         double quantum_xi;
         int quantum_xi_is_specified = pp.query("quantum_xi", quantum_xi);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -84,7 +84,12 @@ bool WarpX::refine_plasma     = false;
 
 int WarpX::num_mirrors = 0;
 
+#ifdef AMREX_USE_GPU
+int  WarpX::sort_int = 4;
+#else
 int  WarpX::sort_int = -1;
+#endif
+amrex::IntVect WarpX::sort_bin_size = 4*amrex::IntVect::TheUnitVector();
 
 bool WarpX::do_back_transformed_diagnostics = false;
 std::string WarpX::lab_data_directory = "lab_frame_data";
@@ -477,6 +482,11 @@ WarpX::ReadParameters ()
         pp.query("n_field_gather_buffer", n_field_gather_buffer);
         pp.query("n_current_deposition_buffer", n_current_deposition_buffer);
         pp.query("sort_int", sort_int);
+
+        Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
+        pp.queryarr("sort_bin_size", vect_sort_bin_size);
+        for (int i=0; i<AMREX_SPACEDIM; i++)
+            sort_bin_size[i] = vect_sort_bin_size[i];
 
         double quantum_xi;
         int quantum_xi_is_specified = pp.query("quantum_xi", quantum_xi);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -89,7 +89,7 @@ int  WarpX::sort_int = 4;
 #else
 int  WarpX::sort_int = -1;
 #endif
-amrex::IntVect WarpX::sort_bin_size(4,4,4);
+amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(4,4,4));
 
 bool WarpX::do_back_transformed_diagnostics = false;
 std::string WarpX::lab_data_directory = "lab_frame_data";


### PR DESCRIPTION
@atmyers implemented bin sorting in AMReX. After extensive tests on single-GPU uniform plasma simulations, sorting by 4x4x4 bins every 4 iterations looks pretty optimal, so this is the default behavior on GPU. On CPU, sorting is off by default.