### PR TITLE
update due to change in amrex

### DIFF
--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -200,8 +200,8 @@ class copyAndReorder
 {
     public:
         copyAndReorder(
-            amrex::Gpu::ManagedDeviceVector<T> const& src,
-            amrex::Gpu::ManagedDeviceVector<T>& dst,
+            amrex::Gpu::DeviceVector<T> const& src,
+            amrex::Gpu::DeviceVector<T>& dst,
             amrex::Gpu::DeviceVector<long> const& indices ) {
             // Extract simple structure that can be used directly on the GPU
             m_src_ptr = src.dataPtr();


### PR DESCRIPTION
These should be just "DeviceVector" now, due to a change in amrex.