### PR TITLE
replace tau by optical_depth_QSR and optical_depth_BW

### DIFF
--- a/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
@@ -22,7 +22,7 @@ def check():
     data_set = yt.load(filename)
 
     all_data = data_set.all_data()
-    res_tau = all_data["photons", 'particle_tau']
+    res_tau = all_data["photons", 'particle_optical_depth_BW']
 
     loc, scale = st.expon.fit(res_tau)
 

--- a/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
@@ -104,7 +104,7 @@ def check():
     all_data_end = data_set_end.all_data()
 
     tau_end_avg = np.array([
-       np.average(all_data_end[name, 'particle_tau'])
+       np.average(all_data_end[name, 'particle_optical_depth_BW'])
        for name in spec_names])
 
     dNBW_dt_sim = (tau_begin_avg - tau_end_avg)/sim_time

--- a/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
@@ -23,8 +23,8 @@ def check():
     data_set = yt.load(filename)
 
     all_data = data_set.all_data()
-    res_ele_tau = all_data["electrons", 'particle_tau']
-    res_pos_tau = all_data["positrons", 'particle_tau']
+    res_ele_tau = all_data["electrons", 'particle_optical_depth_QSR']
+    res_pos_tau = all_data["positrons", 'particle_optical_depth_QSR']
 
     loc_ele, scale_ele = st.expon.fit(res_ele_tau)
     loc_pos, scale_pos = st.expon.fit(res_pos_tau)

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -120,10 +120,12 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             }
 
 #ifdef WARPX_QED
-            if( pc->has_breit_wheeler() )
+            if( pc->has_breit_wheeler() ) {
                 real_names.push_back("optical_depth_BW");
-            if( pc->has_quantum_sync() )
+            }
+            if( pc->has_quantum_sync() ) {
                 real_names.push_back("optical_depth_QSR");
+            }
 #endif
 
             // Convert momentum to SI

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -120,9 +120,10 @@ MultiParticleContainer::WritePlotFile (const std::string& dir) const
             }
 
 #ifdef WARPX_QED
-                if(pc->m_do_qed){
-                        real_names.push_back("tau");
-                }
+            if( pc->has_breit_wheeler() )
+                real_names.push_back("optical_depth_BW");
+            if( pc->has_quantum_sync() )
+                real_names.push_back("optical_depth_QSR");
 #endif
 
             // Convert momentum to SI

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -124,7 +124,7 @@ void
 PhotonParticleContainer::EvolveOpticalDepth(
     WarpXParIter& pti,amrex::Real dt)
 {
-     if(!has_breit_wheeler())
+    if(!has_breit_wheeler())
         return;
 
     auto& attribs = pti.GetAttribs();
@@ -141,8 +141,8 @@ PhotonParticleContainer::EvolveOpticalDepth(
     BreitWheelerEvolveOpticalDepth evolve_opt =
         m_shr_p_bw_engine->build_evolve_functor();
 
-    amrex::Real* AMREX_RESTRICT p_tau =
-        pti.GetAttribs(particle_comps["tau"]).dataPtr();
+    amrex::Real* AMREX_RESTRICT p_optical_depth_BW =
+        pti.GetAttribs(particle_comps["optical_depth_BW"]).dataPtr();
 
     const auto me = PhysConst::m_e;
 
@@ -157,8 +157,8 @@ PhotonParticleContainer::EvolveOpticalDepth(
                 px, py, pz,
                 Ex[i], Ey[i], Ez[i],
                 Bx[i], By[i], Bz[i],
-                dt, p_tau[i]);
+                dt, p_optical_depth_BW[i]);
         }
-    );
+        );
 }
 #endif

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -85,6 +85,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         pp.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
         if (m_do_qed_quantum_sync)
             AddRealComp("optical_depth_QSR");
+        pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
+        if (m_do_qed_breit_wheeler)
+            AddRealComp("optical_depth_BW");
     }
 
     //TODO: SHOULD CHECK IF SPECIES IS EITHER ELECTRONS OR POSITRONS!!

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -79,14 +79,13 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     //_____________________________
 
 #ifdef WARPX_QED
-    //Add real component if QED is enabled
     pp.query("do_qed", m_do_qed);
-    if(m_do_qed)
-        AddRealComp("tau");
-
-    //IF do_qed is enabled, find out if Quantum Synchrotron process is enabled
-    if(m_do_qed)
+    if(m_do_qed){
+        //If do_qed is enabled, find out if Quantum Synchrotron process is enabled
         pp.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
+        if (m_do_qed_quantum_sync)
+            AddRealComp("optical_depth_QSR");
+    }
 
     //TODO: SHOULD CHECK IF SPECIES IS EITHER ELECTRONS OR POSITRONS!!
 #endif
@@ -533,14 +532,19 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
 #ifdef WARPX_QED
         //Pointer to the optical depth component
-        amrex::Real* p_tau;
+        amrex::Real* p_optical_depth_QSR;
+        amrex::Real* p_optical_depth_BW;
 
-        //If a QED effect is enabled, tau has to be initialized
+        // If a QED effect is enabled, the corresponding optical depth
+        // has to be initialized
         bool loc_has_quantum_sync = has_quantum_sync();
         bool loc_has_breit_wheeler = has_breit_wheeler();
-        if(loc_has_quantum_sync || loc_has_breit_wheeler){
-            p_tau = soa.GetRealData(particle_comps["tau"]).data() + old_size;
-        }
+        if (loc_has_quantum_sync)
+            p_optical_depth_QSR = soa.GetRealData(
+                particle_comps["optical_depth_QSR"]).data() + old_size;
+        if(loc_has_breit_wheeler)
+            p_optical_depth_BW = soa.GetRealData(
+                particle_comps["optical_depth_BW"]).data() + old_size;
 
         //If needed, get the appropriate functors from the engines
         QuantumSynchrotronGetOpticalDepth quantum_sync_get_opt;
@@ -704,11 +708,11 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
 #ifdef WARPX_QED
             if(loc_has_quantum_sync){
-                p_tau[ip] = quantum_sync_get_opt();
+                p_optical_depth_QSR[ip] = quantum_sync_get_opt();
             }
 
             if(loc_has_breit_wheeler){
-                p_tau[ip] = breit_wheeler_get_opt();
+                p_optical_depth_BW[ip] = breit_wheeler_get_opt();
             }
 #endif
 
@@ -1770,8 +1774,8 @@ void PhysicalParticleContainer::EvolveOpticalDepth(
     const ParticleReal* const AMREX_RESTRICT By = attribs[PIdx::By].dataPtr();
     const ParticleReal* const AMREX_RESTRICT Bz = attribs[PIdx::Bz].dataPtr();
 
-    ParticleReal* const AMREX_RESTRICT p_tau =
-        pti.GetAttribs(particle_comps["tau"]).dataPtr();
+    ParticleReal* const AMREX_RESTRICT p_optical_depth_QSR =
+        pti.GetAttribs(particle_comps["optical_depth_QSR"]).dataPtr();
 
     const ParticleReal m = this->mass;
 
@@ -1785,7 +1789,7 @@ void PhysicalParticleContainer::EvolveOpticalDepth(
                     px, py, pz,
                     Ex[i], Ey[i], Ez[i],
                     Bx[i], By[i], Bz[i],
-                    dt, p_tau[i]);
+                    dt, p_optical_depth_QSR[i]);
             }
     );
 


### PR DESCRIPTION
The name `tau` is currently used for optical depth for both BW and QSR, though they mean very different things. Let's use different name then.