### PR TITLE
Includes: Clean Up

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -6,19 +6,20 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <array>
-
 #ifndef WARPX_PML_H_
 #define WARPX_PML_H_
 
-#include "WarpXProfilerWrapper.H"
+#include "Utils/WarpXProfilerWrapper.H"
+
+#ifdef WARPX_USE_PSATD
+#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
+#endif
 
 #include <AMReX_MultiFab.H>
 #include <AMReX_Geometry.H>
 
-#ifdef WARPX_USE_PSATD
-#include <SpectralSolver.H>
-#endif
+#include <array>
+
 
 struct Sigma : amrex::Gpu::ManagedVector<amrex::Real>
 {

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -6,18 +6,19 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <PML.H>
-#include <WarpX.H>
-#include <WarpXConst.H>
+#include "PML.H"
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_VisMF.H>
 
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
+
 #include <algorithm>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 using namespace amrex;
 

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -5,21 +5,22 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "WarpX_PML_kernels.H"
+#ifdef WARPX_USE_PY
+#   include "Python/WarpX_py.H"
+#endif
+
+#include "PML_current.H"
+
+#ifdef BL_USE_SENSEI_INSITU
+#   include <AMReX_AmrMeshInSituBridge.H>
+#endif
+
 #include <cmath>
 #include <limits>
 
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpX_PML_kernels.H>
-#ifdef WARPX_USE_PY
-#include <WarpX_py.H>
-#endif
-
-#ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
-#endif
-
-#include <PML_current.H>
 
 using namespace amrex;
 

--- a/Source/Diagnostics/BackTransformedDiagnostic.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic.H
@@ -8,16 +8,17 @@
 #ifndef WARPX_BackTransformedDiagnostic_H_
 #define WARPX_BackTransformedDiagnostic_H_
 
-#include <vector>
-#include <map>
+#include "Particles/MultiParticleContainer.H"
+#include "Utils/WarpXConst.H"
 
-#include <AMReX_VisMF.H>
-#include <AMReX_PlotFileUtil.H>
-#include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
-#include "MultiParticleContainer.H"
-#include "WarpXConst.H"
+#include <map>
+#include <vector>
+
 
 /** \brief
  * The capability for back-transformed lab-frame data is implemented to generate
@@ -39,7 +40,6 @@
  * instead of re-generating the backtransformed slice data at z_lab for a given
  * t_lab for each diagnostic.
  */
-
 class LabFrameDiag {
     public:
     std::string m_file_name;

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -6,15 +6,16 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "FieldIO.H"
+#include "WarpX.H"
 
-#include <WarpX.H>
-#include <FieldIO.H>
+#include <AMReX_FillPatchUtil_F.H>
+#include <AMReX_Interpolater.H>
+
 #ifdef WARPX_USE_OPENPMD
 #   include <openPMD/openPMD.hpp>
 #endif
 
-#include <AMReX_FillPatchUtil_F.H>
-#include <AMReX_Interpolater.H>
 
 using namespace amrex;
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -6,8 +6,8 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <MultiParticleContainer.H>
-#include <WarpX.H>
+#include "Particles/MultiParticleContainer.H"
+#include "WarpX.H"
 
 using namespace amrex;
 

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -4,15 +4,17 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-
 #include "BeamRelevant.H"
 #include "WarpX.H"
-#include "WarpXConst.H"
-#include "AMReX_REAL.H"
-#include "AMReX_ParticleReduce.H"
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_REAL.H>
+#include <AMReX_ParticleReduce.H>
+
 #include <iostream>
 #include <cmath>
 #include <limits>
+
 
 using namespace amrex;
 

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -7,11 +7,14 @@
 
 #include "FieldEnergy.H"
 #include "WarpX.H"
-#include "WarpXConst.H"
-#include "AMReX_REAL.H"
-#include "AMReX_ParticleReduce.H"
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_REAL.H>
+#include <AMReX_ParticleReduce.H>
+
 #include <iostream>
 #include <cmath>
+
 
 using namespace amrex;
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -7,12 +7,15 @@
 
 #include "ParticleEnergy.H"
 #include "WarpX.H"
-#include "WarpXConst.H"
-#include "AMReX_REAL.H"
-#include "AMReX_ParticleReduce.H"
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_REAL.H>
+#include <AMReX_ParticleReduce.H>
+
 #include <iostream>
 #include <cmath>
 #include <limits>
+
 
 using namespace amrex;
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -7,28 +7,26 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "WarpX.H"
+#include "FieldIO.H"
+#include "SliceDiagnostic.H"
+
+#ifdef WARPX_USE_OPENPMD
+#   include "Diagnostics/WarpXOpenPMD.H"
+#endif
+
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_FillPatchUtil_F.H>
-
-#include <WarpX.H>
-#include <FieldIO.H>
-
-#include "AMReX_buildInfo.H"
+#include <AMReX_buildInfo.H>
 
 #ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
+#   include <AMReX_AmrMeshInSituBridge.H>
 #endif
-
-#include "SliceDiagnostic.H"
 
 #ifdef AMREX_USE_ASCENT
-#include <ascent.hpp>
-#include <AMReX_Conduit_Blueprint.H>
-#endif
-
-#ifdef WARPX_USE_OPENPMD
-#   include "WarpXOpenPMD.H"
+#   include <ascent.hpp>
+#   include <AMReX_Conduit_Blueprint.H>
 #endif
 
 

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -8,14 +8,16 @@
 #ifndef WARPX_OPEN_PMD_H_
 #define WARPX_OPEN_PMD_H_
 
-#include "WarpXParticleContainer.H"
-#include "MultiParticleContainer.H" // PIdx
+#include "Particles/WarpXParticleContainer.H"
+#include "Particles/MultiParticleContainer.H" // PIdx
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
 
-#include <openPMD/openPMD.hpp>
+#ifdef WARPX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+#endif
 
 #include <memory>
 #include <string>
@@ -72,6 +74,7 @@ private:
 };
 
 
+#ifdef WARPX_USE_OPENPMD
 //
 //
 /** Writer logic for openPMD particles and fields */
@@ -181,6 +184,6 @@ private:
   // meta data
   std::vector< bool > m_fieldPMLdirections; //! @see WarpX::getPMLdirections()
 };
-
+#endif // WARPX_USE_OPENPMD
 
 #endif // WARPX_OPEN_PMD_H

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "WarpXOpenPMD.H"
-#include "WarpXAlgorithmSelection.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "FieldIO.H"  // for getReversedVec
 
 #include <algorithm>
@@ -18,6 +18,7 @@
 #include <utility>
 #include <iostream>
 
+
 namespace detail
 {
 
@@ -29,6 +30,7 @@ namespace detail
     };
     static_assert(sizeof(int) * 2u <= sizeof(uint64_t), "int size might cause collisions in global IDs");
 
+#ifdef WARPX_USE_OPENPMD
     /** Unclutter a real_names to openPMD record
      *
      * @param fullName name as in real_names variable
@@ -88,8 +90,10 @@ namespace detail
         };
         else return {};
     }
+#endif // WARPX_USE_OPENPMD
 }
 
+#ifdef WARPX_USE_OPENPMD
 WarpXOpenPMDPlot::WarpXOpenPMDPlot(bool oneFilePerTS,
     std::string openPMDFileType, std::vector<bool> fieldPMLdirections)
   :m_Series(nullptr),
@@ -684,7 +688,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
   // Flush data to disk after looping over all components
   m_Series->flush();
 }
-
+#endif // WARPX_USE_OPENPMD
 
 
 

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -1,29 +1,29 @@
 /* Copyright 2019-2020 Andrew Myers, Ann Almgren, Aurore Blelly
- * Axel Huebl, Burlen Loring, David Grote
- * Glenn Richardson, Jean-Luc Vay, Luca Fedeli
- * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
- * Weiqun Zhang, Yinjian Zhao
+ *                     Axel Huebl, Burlen Loring, David Grote
+ *                     Glenn Richardson, Jean-Luc Vay, Luca Fedeli
+ *                     Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ *                     Weiqun Zhang, Yinjian Zhao
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <cmath>
-#include <limits>
-
-#include <WarpX.H>
-#include <WarpX_QED_K.H>
-#include <WarpX_QED_Field_Pushers.cpp>
-#include <WarpXConst.H>
-#include <WarpXUtil.H>
-#include <WarpXAlgorithmSelection.H>
+#include "WarpX.H"
+#include "FieldSolver/WarpX_QED_K.H"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #ifdef WARPX_USE_PY
-#include <WarpX_py.H>
+#   include "Python/WarpX_py.H"
 #endif
 
 #ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
+#   include <AMReX_AmrMeshInSituBridge.H>
 #endif
+
+#include <cmath>
+#include <limits>
+
 
 using namespace amrex;
 

--- a/Source/Evolve/WarpXEvolveES.cpp
+++ b/Source/Evolve/WarpXEvolveES.cpp
@@ -6,14 +6,16 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <WarpX_f.H>
+#include "WarpX.H"
+#include "FortranInterface/WarpX_f.H"
+
 
 namespace
 {
     const std::string level_prefix {"Level_"};
 }
 
+#ifdef WARPX_DO_ELECTROSTATIC
 using namespace amrex;
 
 void
@@ -213,3 +215,4 @@ void WarpX::getLevelMasks(Vector<std::unique_ptr<FabArray<BaseFab<int> > > >& ma
         }
     }
 }
+#endif // WARPX_DO_ELECTROSTATIC

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "WarpXAlgorithmSelection.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #ifdef WARPX_DIM_RZ
 #   include "FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "WarpXAlgorithmSelection.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #ifdef WARPX_DIM_RZ
 #    include "FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
 #else

--- a/Source/FieldSolver/Make.package
+++ b/Source/FieldSolver/Make.package
@@ -2,6 +2,7 @@ CEXE_headers += WarpX_K.H
 CEXE_headers += WarpX_FDTD.H
 CEXE_sources += WarpXPushFieldsEM.cpp
 CEXE_sources += ElectrostaticSolver.cpp
+CEXE_sources += WarpX_QED_Field_Pushers.cpp
 ifeq ($(USE_PSATD),TRUE)
   include $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/Make.package
   ifeq ($(USE_PSATD_PICSAR),TRUE)

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridFFTData.H
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridFFTData.H
@@ -7,6 +7,10 @@
 #ifndef WARPX_PICSAR_HYBRID_FFTDATA_H_
 #define WARPX_PICSAR_HYBRID_FFTDATA_H_
 
+#ifdef WARPX_USE_PSATD
+#   include <fftw3.h>
+
+
 // FFTData is a stuct containing a 22 pointers to auxiliary arrays
 // 1-11: padded arrays in real space (required by FFTW); 12-22: arrays in spectral space
 struct FFTData
@@ -35,4 +39,5 @@ struct FFTData
     void operator= (FFTData&&) = delete;
 };
 
+#endif // WARPX_USE_PSATD
 #endif // WARPX_PICSAR_HYBRID_FFTDATA_H_

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
@@ -5,9 +5,12 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-
-#include <WarpX.H>
+#include "PicsarHybridFFTData.H"
+#include "WarpX.H"
 #include <AMReX_iMultiFab.H>
+
+
+#ifdef WARPX_USE_PSATD
 
 using namespace amrex;
 
@@ -451,3 +454,5 @@ WarpX::PushPSATD_hybridFFT (int lev, amrex::Real /* dt */)
         amrex::Abort("WarpX::PushPSATD: TODO");
     }
 }
+
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.H
@@ -1,8 +1,9 @@
 #ifndef WARPX_GALILEAN_ALGORITHM_H_
 #define WARPX_GALILEAN_ALGORITHM_H_
 
-#include <SpectralBaseAlgorithm.H>
+#include "SpectralBaseAlgorithm.H"
 
+#if WARPX_USE_PSATD
 /* \brief Class that updates the field in spectral space
  * and stores the coefficients of the corresponding update equation.
  */
@@ -29,5 +30,5 @@ class GalileanAlgorithm : public SpectralBaseAlgorithm
         SpectralRealCoefficients C_coef, S_ck_coef;
         SpectralComplexCoefficients Theta2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 };
-
+#endif // WARPX_USE_PSATD
 #endif // WARPX_GALILEAN_ALGORITHM_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.cpp
@@ -1,6 +1,10 @@
-#include <GalileanAlgorithm.H>
-#include <WarpXConst.H>
+#include "GalileanAlgorithm.H"
+#include "Utils/WarpXConst.H"
+
 #include <cmath>
+
+
+#if WARPX_USE_PSATD
 
 using namespace amrex;
 
@@ -237,3 +241,4 @@ void GalileanAlgorithm::InitializeSpectralCoefficients(const SpectralKSpace& spe
         });
     }
 }
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
@@ -7,7 +7,9 @@
 #ifndef WARPX_PML_PSATD_ALGORITHM_H_
 #define WARPX_PML_PSATD_ALGORITHM_H_
 
-#include <SpectralBaseAlgorithm.H>
+#include "SpectralBaseAlgorithm.H"
+
+#if WARPX_USE_PSATD
 
 /* \brief Class that updates the field in spectral space
  * and stores the coefficients of the corresponding update equation.
@@ -37,4 +39,5 @@ class PMLPsatdAlgorithm : public SpectralBaseAlgorithm
 
 };
 
+#endif // WARPX_USE_PSATD
 #endif // WARPX_PML_PSATD_ALGORITHM_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.cpp
@@ -4,9 +4,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <PMLPsatdAlgorithm.H>
-#include <WarpXConst.H>
+#include "PMLPsatdAlgorithm.H"
+#include "Utils/WarpXConst.H"
+
 #include <cmath>
+
+
+#if WARPX_USE_PSATD
 
 using namespace amrex;
 
@@ -150,3 +154,4 @@ void PMLPsatdAlgorithm::InitializeSpectralCoefficients (
         });
     }
 };
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -8,7 +8,10 @@
 #ifndef WARPX_PSATD_ALGORITHM_H_
 #define WARPX_PSATD_ALGORITHM_H_
 
-#include <SpectralBaseAlgorithm.H>
+#include "SpectralBaseAlgorithm.H"
+
+
+#if WARPX_USE_PSATD
 
 /**
  * \brief Class that updates the field in spectral space
@@ -37,4 +40,5 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralRealCoefficients C_coef, S_ck_coef, X1_coef, X2_coef, X3_coef;
 };
 
+#endif // WARPX_USE_PSATD
 #endif // WARPX_PSATD_ALGORITHM_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -4,10 +4,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <PsatdAlgorithm.H>
-#include <WarpXConst.H>
+#include "PsatdAlgorithm.H"
+#include "Utils/WarpXConst.H"
+
 #include <cmath>
 
+
+#if WARPX_USE_PSATD
 using namespace amrex;
 
 /* \brief Initialize coefficients for the update equation */
@@ -176,3 +179,4 @@ void PsatdAlgorithm::InitializeSpectralCoefficients(const SpectralKSpace& spectr
         });
      }
 }
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
@@ -7,8 +7,11 @@
 #ifndef WARPX_SPECTRAL_BASE_ALGORITHM_H_
 #define WARPX_SPECTRAL_BASE_ALGORITHM_H_
 
-#include <SpectralKSpace.H>
-#include <SpectralFieldData.H>
+#include "FieldSolver/SpectralSolver/SpectralKSpace.H"
+#include "FieldSolver/SpectralSolver/SpectralFieldData.H"
+
+
+#if WARPX_USE_PSATD
 
 /* \brief Class that updates the field in spectral space
  * and stores the coefficients of the corresponding update equation.
@@ -57,4 +60,5 @@ class SpectralBaseAlgorithm
 #endif
 };
 
+#endif // WARPX_USE_PSATD
 #endif // WARPX_SPECTRAL_BASE_ALGORITHM_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -8,11 +8,14 @@
 #ifndef WARPX_SPECTRAL_FIELD_DATA_H_
 #define WARPX_SPECTRAL_FIELD_DATA_H_
 
-#include <WarpX_ComplexForFFT.H>
-#include <SpectralKSpace.H>
+#include "WarpX_ComplexForFFT.H"
+#include "SpectralKSpace.H"
 #include <AMReX_MultiFab.H>
 
 #include <string>
+
+#ifdef WARPX_USE_PSATD
+#   include <fftw3.h>
 
 // Declare type for spectral fields
 using SpectralField = amrex::FabArray< amrex::BaseFab <Complex> >;
@@ -85,4 +88,5 @@ class SpectralFieldData
 #endif
 };
 
+#endif // WARPX_USE_PSATD
 #endif // WARPX_SPECTRAL_FIELD_DATA_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -5,9 +5,12 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <SpectralFieldData.H>
+#include "SpectralFieldData.H"
 
 #include <map>
+
+
+#if WARPX_USE_PSATD
 
 using namespace amrex;
 
@@ -351,3 +354,4 @@ SpectralFieldData::cufftErrorToString (const cufftResult& err)
     }
 }
 #endif
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -8,9 +8,11 @@
 #ifndef WARPX_SPECTRAL_K_SPACE_H_
 #define WARPX_SPECTRAL_K_SPACE_H_
 
-#include <WarpX_ComplexForFFT.H>
+#include "WarpX_ComplexForFFT.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_LayoutData.H>
+
 
 // `KVectorComponent` and `SpectralShiftFactor` hold one 1D array
 // ("ManagedVector") for each box ("LayoutData"). The arrays are

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -5,9 +5,11 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpXConst.H>
-#include <SpectralKSpace.H>
+#include "Utils/WarpXConst.H"
+#include "SpectralKSpace.H"
+
 #include <cmath>
+
 
 using namespace amrex;
 using namespace Gpu;

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -7,9 +7,11 @@
 #ifndef WARPX_SPECTRAL_SOLVER_H_
 #define WARPX_SPECTRAL_SOLVER_H_
 
-#include <SpectralBaseAlgorithm.H>
-#include <SpectralFieldData.H>
+#include "SpectralAlgorithms/SpectralBaseAlgorithm.H"
+#include "SpectralFieldData.H"
 
+
+#ifdef WARPX_USE_PSATD
 /**
  * \brief Top-level class for the electromagnetic spectral solver
  *
@@ -64,5 +66,5 @@ class SpectralSolver
         // SpectralBaseAlgorithm is a base class ; this pointer is meant
         // to point an instance of a *sub-class* defining a specific algorithm
 };
-
+#endif // WARPX_USE_PSATD
 #endif // WARPX_SPECTRAL_SOLVER_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -4,13 +4,16 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <SpectralKSpace.H>
-#include <SpectralSolver.H>
-#include <PsatdAlgorithm.H>
-#include <GalileanAlgorithm.H>
-#include <PMLPsatdAlgorithm.H>
+#include "SpectralKSpace.H"
+#include "SpectralSolver.H"
+#include "SpectralAlgorithms/PsatdAlgorithm.H"
+#include "SpectralAlgorithms/GalileanAlgorithm.H"
+#include "SpectralAlgorithms/PMLPsatdAlgorithm.H"
 #include "WarpX.H"
-#include "WarpXProfilerWrapper.H"
+#include "Utils/WarpXProfilerWrapper.H"
+
+
+#if WARPX_USE_PSATD
 
 /* \brief Initialize the spectral Maxwell solver
  *
@@ -91,3 +94,4 @@ SpectralSolver::pushSpectralFields(){
     // initialized in the constructor of `SpectralSolver`
     algorithm->pushSpectralFields( field_data );
 }
+#endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/WarpX_ComplexForFFT.H
+++ b/Source/FieldSolver/SpectralSolver/WarpX_ComplexForFFT.H
@@ -7,7 +7,8 @@
 #ifndef WARPX_COMPLEXFORFFT_H_
 #define WARPX_COMPLEXFORFFT_H_
 
-#include <WarpX_Complex.H>
+#include "Utils/WarpX_Complex.H"
+
 
 // Check the complex type on GPU/CPU
 #ifdef AMREX_USE_GPU
@@ -17,10 +18,11 @@ static_assert( sizeof(Complex) == sizeof(cuDoubleComplex),
     "The complex types in WarpX and cuFFT do not match.");
 
 #else
-
-#include <fftw3.h>
+#   ifdef WARPX_USE_PSATD
+#       include <fftw3.h>
 static_assert( sizeof(Complex) == sizeof(fftw_complex),
     "The complex types in WarpX and FFTW do not match.");
+#   endif // WARPX_USE_PSATD
 
 #endif
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -6,24 +6,23 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "WarpX_K.H"
+#include "BoundaryConditions/WarpX_PML_kernels.H"
+#include "BoundaryConditions/PML_current.H"
+#include "WarpX_FDTD.H"
+#ifdef WARPX_USE_PY
+#   include "Python/WarpX_py.H"
+#endif
+
+#ifdef BL_USE_SENSEI_INSITU
+#   include <AMReX_AmrMeshInSituBridge.H>
+#endif
 
 #include <cmath>
 #include <limits>
 
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpX_K.H>
-#include <WarpX_PML_kernels.H>
-#include <WarpX_FDTD.H>
-#ifdef WARPX_USE_PY
-#include <WarpX_py.H>
-#endif
-
-#include <PML_current.H>
-
-#ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
-#endif
 
 using namespace amrex;
 

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -4,25 +4,24 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "WarpX_K.H"
+#include "WarpX_QED_K.H"
+#include "BoundaryConditions/WarpX_PML_kernels.H"
+#include "BoundaryConditions/PML_current.H"
+#include "WarpX_FDTD.H"
+#ifdef WARPX_USE_PY
+#   include "Python/WarpX_py.H"
+#endif
+
+#ifdef BL_USE_SENSEI_INSITU
+#   include <AMReX_AmrMeshInSituBridge.H>
+#endif
+
 #include <cmath>
 #include <limits>
 
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpX_K.H>
-#include <WarpX_PML_kernels.H>
-#include <WarpX_FDTD.H>
-#ifdef WARPX_USE_PY
-#include <WarpX_py.H>
-#endif
-
-#include <WarpX_QED_K.H>
-
-#include <PML_current.H>
-
-#ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
-#endif
 
 using namespace amrex;
 

--- a/Source/FieldSolver/WarpX_QED_K.H
+++ b/Source/FieldSolver/WarpX_QED_K.H
@@ -7,9 +7,11 @@
 #ifndef WarpX_QED_K_h
 #define WarpX_QED_K_h
 
+#include "Utils/WarpXConst.H"
 #include <AMReX_FArrayBox.H>
-#include <WarpXConst.H>
+
 #include <cmath>
+
 
 using namespace amrex;
 
@@ -33,7 +35,7 @@ void calc_M(Real arr [], Real ex, Real ey, Real ez, Real bx, Real by, Real bz, R
     arr[0] = -2._rt*xi_c2*( 2._rt*bx*(ee-bb_c2) - 7._rt*ex*eb );
     arr[1] = -2._rt*xi_c2*( 2._rt*by*(ee-bb_c2) - 7._rt*ey*eb );
     arr[2] = -2._rt*xi_c2*( 2._rt*bz*(ee-bb_c2) - 7._rt*ez*eb );
-};
+}
 
 
 /**

--- a/Source/Filter/BilinearFilter.H
+++ b/Source/Filter/BilinearFilter.H
@@ -5,10 +5,11 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <Filter.H>
-
 #ifndef WARPX_BILIN_FILTER_H_
 #define WARPX_BILIN_FILTER_H_
+
+#include "Filter.H"
+
 
 class BilinearFilter : public Filter
 {

--- a/Source/Filter/BilinearFilter.cpp
+++ b/Source/Filter/BilinearFilter.cpp
@@ -5,12 +5,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <BilinearFilter.H>
+#include "BilinearFilter.H"
+#include "WarpX.H"
 
 #ifdef _OPENMP
-#include <omp.h>
+#   include <omp.h>
 #endif
+
 
 using namespace amrex;
 

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -5,12 +5,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <Filter.H>
+#include "Filter.H"
+#include "WarpX.H"
 
 #ifdef _OPENMP
-#include <omp.h>
+#   include <omp.h>
 #endif
+
 
 using namespace amrex;
 

--- a/Source/Filter/NCIGodfreyFilter.H
+++ b/Source/Filter/NCIGodfreyFilter.H
@@ -4,10 +4,11 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <Filter.H>
-
 #ifndef WARPX_GODFREY_FILTER_H_
 #define WARPX_GODFREY_FILTER_H_
+
+#include "Filter.H"
+
 
 enum class godfrey_coeff_set { Ex_Ey_Bz=0, Bx_By_Ez=1 };
 

--- a/Source/Filter/NCIGodfreyFilter.cpp
+++ b/Source/Filter/NCIGodfreyFilter.cpp
@@ -4,13 +4,14 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <NCIGodfreyFilter.H>
-#include <NCIGodfreyTables.H>
+#include "NCIGodfreyFilter.H"
+#include "Utils/NCIGodfreyTables.H"
+#include "WarpX.H"
 
 #ifdef _OPENMP
-#include <omp.h>
+#   include <omp.h>
 #endif
+
 
 using namespace amrex;
 

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -8,9 +8,9 @@
 #ifndef INJECTOR_DENSITY_H_
 #define INJECTOR_DENSITY_H_
 
-#include <GpuParser.H>
-#include <CustomDensityProb.H>
-#include <WarpXConst.H>
+#include "Parser/GpuParser.H"
+#include "CustomDensityProb.H"
+#include "Utils/WarpXConst.H"
 
 #include <AMReX_Gpu.H>
 #include <AMReX_Dim3.H>

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -5,8 +5,9 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <InjectorDensity.H>
-#include <PlasmaInjector.H>
+#include "InjectorDensity.H"
+#include "PlasmaInjector.H"
+
 
 using namespace amrex;
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -8,8 +8,8 @@
 #ifndef INJECTOR_MOMENTUM_H_
 #define INJECTOR_MOMENTUM_H_
 
-#include <CustomMomentumProb.H>
-#include <GpuParser.H>
+#include "CustomMomentumProb.H"
+#include "Parser/GpuParser.H"
 
 #include <AMReX_Gpu.H>
 #include <AMReX_Dim3.H>

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -5,8 +5,9 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <InjectorMomentum.H>
-#include <PlasmaInjector.H>
+#include "InjectorMomentum.H"
+#include "PlasmaInjector.H"
+
 
 using namespace amrex;
 

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -9,12 +9,12 @@
 #ifndef PLASMA_INJECTOR_H_
 #define PLASMA_INJECTOR_H_
 
-#include <InjectorPosition.H>
-#include <InjectorDensity.H>
-#include <InjectorMomentum.H>
+#include "InjectorPosition.H"
+#include "InjectorDensity.H"
+#include "InjectorMomentum.H"
 
-#include <WarpXConst.H>
-#include <WarpXParser.H>
+#include "Utils/WarpXConst.H"
+#include "Parser/WarpXParser.H"
 
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -9,14 +9,15 @@
  */
 #include "PlasmaInjector.H"
 
-#include <WarpXConst.H>
-#include <WarpX.H>
-#include <WarpXUtil.H>
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
+#include "WarpX.H"
 
 #include <AMReX.H>
 
 #include <sstream>
 #include <functional>
+
 
 using namespace amrex;
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -7,18 +7,18 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <BilinearFilter.H>
-#include <NCIGodfreyFilter.H>
+#include "WarpX.H"
+#include "Filter/BilinearFilter.H"
+#include "Filter/NCIGodfreyFilter.H"
+#include "Parser/GpuParser.H"
+#include "Utils/WarpXUtil.H"
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
 
 #ifdef BL_USE_SENSEI_INSITU
-#include <AMReX_AmrMeshInSituBridge.H>
+#   include <AMReX_AmrMeshInSituBridge.H>
 #endif
-#include <GpuParser.H>
-#include <WarpXUtil.H>
 
 
 using namespace amrex;

--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -9,11 +9,11 @@
 #ifndef WARPX_LaserParticleContainer_H_
 #define WARPX_LaserParticleContainer_H_
 
-#include <LaserProfiles.H>
+#include "LaserProfiles.H"
 
-#include <WarpXParticleContainer.H>
-#include <WarpXConst.H>
-#include <WarpXParser.H>
+#include "Particles/WarpXParticleContainer.H"
+#include "Utils/WarpXConst.H"
+#include "Parser/WarpXParser.H"
 
 #include <memory>
 #include <limits>

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -6,16 +6,17 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpX_Complex.H"
+#include "Particles/MultiParticleContainer.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
+
 #include <limits>
 #include <cmath>
 #include <algorithm>
 #include <numeric>
 
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpX_Complex.H>
-#include <MultiParticleContainer.H>
-#include <GetAndSetPosition.H>
 
 using namespace amrex;
 using namespace WarpXLaserProfiles;

--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -7,13 +7,12 @@
 #ifndef WARPX_LaserProfiles_H_
 #define WARPX_LaserProfiles_H_
 
+#include "Parser/WarpXParser.H"
+
 #include <AMReX_REAL.H>
-#include <WarpXParser.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Gpu.H>
-
-#include <WarpXParser.H>
 
 #include <map>
 #include <string>
@@ -21,6 +20,7 @@
 #include <functional>
 #include <limits>
 #include <utility>
+
 
 namespace WarpXLaserProfiles {
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -4,15 +4,14 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <LaserProfiles.H>
+#include "Laser/LaserProfiles.H"
+#include "Utils/WarpX_Complex.H"
 
-#include <WarpX_Complex.H>
 
 using namespace amrex;
-using namespace WarpXLaserProfiles;
 
 void
-FieldFunctionLaserProfile::init (
+WarpXLaserProfiles::FieldFunctionLaserProfile::init (
     const amrex::ParmParse& ppl,
     const amrex::ParmParse& ppc,
     CommonLaserParameters params)
@@ -41,7 +40,7 @@ FieldFunctionLaserProfile::init (
 }
 
 void
-FieldFunctionLaserProfile::fill_amplitude (
+WarpXLaserProfiles::FieldFunctionLaserProfile::fill_amplitude (
     const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
     Real t, Real * AMREX_RESTRICT const amplitude) const
 {

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -4,11 +4,10 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <LaserProfiles.H>
-
-#include <WarpX_Complex.H>
-#include <WarpXConst.H>
-#include <WarpXUtil.H>
+#include "Laser/LaserProfiles.H"
+#include "Utils/WarpX_Complex.H"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -19,11 +18,11 @@
 #include <cstdint>
 #include <algorithm>
 
+
 using namespace amrex;
-using namespace WarpXLaserProfiles;
 
 void
-FromTXYEFileLaserProfile::init (
+WarpXLaserProfiles::FromTXYEFileLaserProfile::init (
     const amrex::ParmParse& ppl,
     const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
@@ -66,7 +65,7 @@ FromTXYEFileLaserProfile::init (
 }
 
 void
-FromTXYEFileLaserProfile::update (amrex::Real t)
+WarpXLaserProfiles::FromTXYEFileLaserProfile::update (amrex::Real t)
 {
     if(t >= m_params.t_coords.back())
         return;
@@ -82,7 +81,7 @@ FromTXYEFileLaserProfile::update (amrex::Real t)
 }
 
 void
-FromTXYEFileLaserProfile::fill_amplitude (
+WarpXLaserProfiles::FromTXYEFileLaserProfile::fill_amplitude (
     const int np,
     Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
     Real t, Real * AMREX_RESTRICT const amplitude) const
@@ -114,7 +113,7 @@ FromTXYEFileLaserProfile::fill_amplitude (
 }
 
 void
-FromTXYEFileLaserProfile::parse_txye_file(std::string txye_file_name)
+WarpXLaserProfiles::FromTXYEFileLaserProfile::parse_txye_file(std::string txye_file_name)
 {
     if(ParallelDescriptor::IOProcessor()){
         std::ifstream inp(txye_file_name, std::ios::binary);
@@ -227,7 +226,7 @@ FromTXYEFileLaserProfile::parse_txye_file(std::string txye_file_name)
 }
 
 std::pair<int,int>
-FromTXYEFileLaserProfile::find_left_right_time_indices(amrex::Real t) const
+WarpXLaserProfiles::FromTXYEFileLaserProfile::find_left_right_time_indices(amrex::Real t) const
 {
     int idx_t_right;
     if(m_params.is_grid_uniform){
@@ -246,7 +245,7 @@ FromTXYEFileLaserProfile::find_left_right_time_indices(amrex::Real t) const
 }
 
 void
-FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int t_end)
+WarpXLaserProfiles::FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int t_end)
 {
     amrex::Print() <<
         "Reading [" << t_begin << ", " << t_end <<
@@ -290,7 +289,7 @@ FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int t_end)
 }
 
 void
-FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
+WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
     const int idx_t_left,
     const int np,
     Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
@@ -394,7 +393,7 @@ FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
 }
 
 void
-FromTXYEFileLaserProfile::internal_fill_amplitude_nonuniform(
+WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_nonuniform(
     const int idx_t_left,
     const int np,
     Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -5,18 +5,17 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <LaserProfiles.H>
-
-#include <WarpX_Complex.H>
-#include <WarpXConst.H>
+#include "Laser/LaserProfiles.H"
+#include "Utils/WarpX_Complex.H"
+#include "Utils/WarpXConst.H"
 
 #include <cmath>
 
+
 using namespace amrex;
-using namespace WarpXLaserProfiles;
 
 void
-GaussianLaserProfile::init (
+WarpXLaserProfiles::GaussianLaserProfile::init (
     const amrex::ParmParse& ppl,
     const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
@@ -77,7 +76,7 @@ GaussianLaserProfile::init (
  * \param amplitude: pointer to array of field amplitude.
  */
 void
-GaussianLaserProfile::fill_amplitude (
+WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
     const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
     Real t, Real * AMREX_RESTRICT const amplitude) const
 {

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -4,16 +4,15 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <LaserProfiles.H>
+#include "Laser/LaserProfiles.H"
+#include "Utils/WarpX_Complex.H"
+#include "Utils/WarpXConst.H"
 
-#include <WarpX_Complex.H>
-#include <WarpXConst.H>
 
 using namespace amrex;
-using namespace WarpXLaserProfiles;
 
 void
-HarrisLaserProfile::init (
+WarpXLaserProfiles::HarrisLaserProfile::init (
     const amrex::ParmParse& ppl,
     const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
@@ -39,7 +38,7 @@ HarrisLaserProfile::init (
  * \param amplitude: pointer to array of field amplitude.
  */
 void
-HarrisLaserProfile::fill_amplitude (
+WarpXLaserProfiles::HarrisLaserProfile::fill_amplitude (
     const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
     Real t, Real * AMREX_RESTRICT const amplitude) const
 {

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -5,8 +5,10 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "GuardCellManager.H"
-#include "NCIGodfreyFilter.H"
+#include "Filter/NCIGodfreyFilter.H"
+
 #include <AMReX_Print.H>
+
 
 using namespace amrex;
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -6,12 +6,12 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpXComm.H>
-#include <WarpXComm_K.H>
-#include <WarpX.H>
-#include <WarpXSumGuardCells.H>
-#include <InterpolateCurrentFineToCoarse.H>
-#include <InterpolateDensityFineToCoarse.H>
+#include "WarpXComm.H"
+#include "WarpXComm_K.H"
+#include "WarpX.H"
+#include "WarpXSumGuardCells.H"
+#include "InterpolateCurrentFineToCoarse.H"
+#include "InterpolateDensityFineToCoarse.H"
 
 #include <algorithm>
 #include <cstdlib>

--- a/Source/Parser/GpuParser.H
+++ b/Source/Parser/GpuParser.H
@@ -1,6 +1,5 @@
 /* Copyright 2019-2020 Maxence Thevenet, Revathi Jambunathan, Weiqun Zhang
  *
- *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
@@ -8,10 +7,12 @@
 #ifndef WARPX_GPU_PARSER_H_
 #define WARPX_GPU_PARSER_H_
 
-#include <WarpXParser.H>
+#include "Parser/WarpXParser.H"
+
 #include <AMReX_Gpu.H>
 #include <AMReX_Array.H>
 #include <AMReX_TypeTraits.H>
+
 
 // When compiled for CPU, wrap WarpXParser and enable threading.
 // When compiled for GPU, store one copy of the parser in

--- a/Source/Parser/WarpXParserWrapper.H
+++ b/Source/Parser/WarpXParserWrapper.H
@@ -7,9 +7,11 @@
 #ifndef WARPX_PARSER_WRAPPER_H_
 #define WARPX_PARSER_WRAPPER_H_
 
-#include <WarpXParser.H>
+#include "Parser/WarpXParser.H"
+#include "Parser/GpuParser.H"
+
 #include <AMReX_Gpu.H>
-#include <GpuParser.H>
+
 /**
  * \brief
  *  The ParserWrapper struct is constructed to safely use the GpuParser class

--- a/Source/Particles/Collision/CollisionType.H
+++ b/Source/Particles/Collision/CollisionType.H
@@ -7,7 +7,7 @@
 #ifndef WARPX_PARTICLES_COLLISION_COLLISIONTYPE_H_
 #define WARPX_PARTICLES_COLLISION_COLLISIONTYPE_H_
 
-#include "WarpXParticleContainer.H"
+#include "Particles/WarpXParticleContainer.H"
 #include <AMReX_DenseBins.H>
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>

--- a/Source/Particles/Collision/ComputeTemperature.H
+++ b/Source/Particles/Collision/ComputeTemperature.H
@@ -7,7 +7,8 @@
 #ifndef WARPX_PARTICLES_COLLISION_COMPUTE_TEMPERATURE_H_
 #define WARPX_PARTICLES_COLLISION_COMPUTE_TEMPERATURE_H_
 
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
+
 
 template <typename T_index, typename T_R>
 AMREX_GPU_HOST_DEVICE

--- a/Source/Particles/Collision/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/ElasticCollisionPerez.H
@@ -9,8 +9,10 @@
 
 #include "UpdateMomentumPerezElastic.H"
 #include "ComputeTemperature.H"
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
+
 #include <AMReX_Random.H>
+
 
 /** \brief Prepare information for and call
  *        UpdateMomentumPerezElastic().

--- a/Source/Particles/Collision/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/UpdateMomentumPerezElastic.H
@@ -7,10 +7,12 @@
 #ifndef WARPX_PARTICLES_COLLISION_UPDATE_MOMENTUM_PEREZ_ELASTIC_H_
 #define WARPX_PARTICLES_COLLISION_UPDATE_MOMENTUM_PEREZ_ELASTIC_H_
 
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
 #include <AMReX_Random.H>
+
 #include <cmath>  // isnan() isinf()
 #include <limits> // numeric_limits<float>::min()
+
 
 /* \brief Update particle velocities according to
  *        F. Perez et al., Phys.Plasmas.19.083104 (2012),

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -8,8 +8,9 @@
 #ifndef CHARGEDEPOSITION_H_
 #define CHARGEDEPOSITION_H_
 
-#include "GetAndSetPosition.H"
-#include "ShapeFactors.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/ShapeFactors.H"
+
 
 /* \brief Charge Deposition for thread thread_num
  * /param GetPosition : A functor for returning the particle position.

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -8,9 +8,9 @@
 #ifndef CURRENTDEPOSITION_H_
 #define CURRENTDEPOSITION_H_
 
-#include "GetAndSetPosition.H"
-#include "ShapeFactors.H"
-#include <WarpX_Complex.H>
+#include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/ShapeFactors.H"
+#include "Utils/WarpX_Complex.H"
 
 #include <AMReX_Array4.H>
 #include <AMReX_REAL.H>

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -8,8 +8,8 @@
 #ifndef IONIZATION_H_
 #define IONIZATION_H_
 
-#include "WarpXConst.H"
-#include "WarpXParticleContainer.H"
+#include "Utils/WarpXConst.H"
+#include "Particles/WarpXParticleContainer.H"
 
 struct IonizationFilterFunc
 {

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -8,9 +8,10 @@
 #ifndef FIELDGATHER_H_
 #define FIELDGATHER_H_
 
-#include "GetAndSetPosition.H"
-#include "ShapeFactors.H"
-#include <WarpX_Complex.H>
+#include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/ShapeFactors.H"
+#include "Utils/WarpX_Complex.H"
+
 
 /**
  * \brief Field gather for particles handled by thread thread_num

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -11,23 +11,23 @@
 #ifndef WARPX_ParticleContainer_H_
 #define WARPX_ParticleContainer_H_
 
-#include <WarpXParticleContainer.H>
-#include <PhysicalParticleContainer.H>
-#include <RigidInjectedParticleContainer.H>
-#include <PhotonParticleContainer.H>
-#include <LaserParticleContainer.H>
-#include <WarpXParserWrapper.H>
-#include <SmartCopy.H>
-#include <FilterCopyTransform.H>
+#include "WarpXParticleContainer.H"
+#include "PhysicalParticleContainer.H"
+#include "PhotonParticleContainer.H"
+#include "Laser/LaserParticleContainer.H"
+#include "Parser/WarpXParserWrapper.H"
+#include "Particles/Collision/CollisionType.H"
+#include "Particles/ParticleCreation/SmartCopy.H"
+#include "Particles/ParticleCreation/FilterCopyTransform.H"
+#include "Particles/RigidInjectedParticleContainer.H"
 
-#include <AMReX_Particles.H>
 #ifdef WARPX_QED
-    #include <QedChiFunctions.H>
-    #include <BreitWheelerEngineWrapper.H>
-    #include <QuantumSyncEngineWrapper.H>
+#   include "QED/QedChiFunctions.H"
+#   include "QED/BreitWheelerEngineWrapper.H"
+#   include "QED/QuantumSyncEngineWrapper.H"
 #endif
 
-#include "CollisionType.H"
+#include <AMReX_Particles.H>
 
 #include <memory>
 #include <map>

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -8,18 +8,16 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <MultiParticleContainer.H>
+#include "MultiParticleContainer.H"
+#include "Utils/WarpXUtil.H"
+#include "WarpX.H"
 
 #include <AMReX_Vector.H>
-
-#include <WarpX.H>
-
-//This is now needed for writing a binary file on disk.
-#include <WarpXUtil.H>
 
 #include <limits>
 #include <algorithm>
 #include <string>
+
 
 using namespace amrex;
 

--- a/Source/Particles/ParticleCreation/SmartCopy.H
+++ b/Source/Particles/ParticleCreation/SmartCopy.H
@@ -1,5 +1,5 @@
 /* Copyright 2019-2020 Andrew Myers, Axel Huebl,
- * Maxence Thevenet
+ *                     Maxence Thevenet
  *
  * This file is part of WarpX.
  *
@@ -8,7 +8,7 @@
 #ifndef SMART_COPY_H_
 #define SMART_COPY_H_
 
-#include <DefaultInitialization.H>
+#include "DefaultInitialization.H"
 
 #include <AMReX_GpuContainers.H>
 #include <AMReX_ParallelDescriptor.H>

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -8,7 +8,7 @@
 #ifndef WARPX_PhotonParticleContainer_H_
 #define WARPX_PhotonParticleContainer_H_
 
-#include <PhysicalParticleContainer.H>
+#include "PhysicalParticleContainer.H"
 #include <AMReX_Vector.H>
 
 /**

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -5,22 +5,22 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "PhotonParticleContainer.H"
+#include "Utils/WarpXConst.H"
+#include "WarpX.H"
+
+// Import low-level single-particle kernels
+#include "Particles/Pusher/UpdatePositionPhoton.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
+
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
+
 #include <limits>
 #include <sstream>
 #include <algorithm>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
-#include <PhotonParticleContainer.H>
-#include <WarpX.H>
-#include <WarpXConst.H>
-
-
-// Import low-level single-particle kernels
-#include <UpdatePositionPhoton.H>
-#include <GetAndSetPosition.H>
 
 using namespace amrex;
 

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -10,10 +10,10 @@
 #ifndef WARPX_PhysicalParticleContainer_H_
 #define WARPX_PhysicalParticleContainer_H_
 
-#include <PlasmaInjector.H>
-#include <WarpXParticleContainer.H>
-#include <NCIGodfreyFilter.H>
-#include <Ionization.H>
+#include "Initialization/PlasmaInjector.H"
+#include "WarpXParticleContainer.H"
+#include "Filter/NCIGodfreyFilter.H"
+#include "Particles/ElementaryProcess/Ionization.H"
 
 #include <AMReX_IArrayBox.H>
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -8,28 +8,29 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "PhysicalParticleContainer.H"
+
+#include "MultiParticleContainer.H"
+#include "FortranInterface/WarpX_f.H"
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "Python/WarpXWrappers.h"
+#include "Utils/IonizationEnergiesTable.H"
+#include "Particles/Gather/FieldGather.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
+
+#include "Utils/WarpXAlgorithmSelection.H"
+
+// Import low-level single-particle kernels
+#include "Particles/Pusher/UpdatePosition.H"
+#include "Particles/Pusher/UpdateMomentumBoris.H"
+#include "Particles/Pusher/UpdateMomentumVay.H"
+#include "Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H"
+#include "Particles/Pusher/UpdateMomentumHigueraCary.H"
+
 #include <limits>
 #include <sstream>
 
-#include <PhysicalParticleContainer.H>
-
-#include <MultiParticleContainer.H>
-#include <WarpX_f.H>
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpXWrappers.h>
-#include <IonizationEnergiesTable.H>
-#include <FieldGather.H>
-#include <GetAndSetPosition.H>
-
-#include <WarpXAlgorithmSelection.H>
-
-// Import low-level single-particle kernels
-#include <UpdatePosition.H>
-#include <UpdateMomentumBoris.H>
-#include <UpdateMomentumVay.H>
-#include <UpdateMomentumBorisWithRadiationReaction.H>
-#include <UpdateMomentumHigueraCary.H>
 
 using namespace amrex;
 

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -8,9 +8,12 @@
 #ifndef WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 
-#include <limits>
-#include <WarpXParticleContainer.H>
+#include "Particles/WarpXParticleContainer.H"
+
 #include <AMReX_REAL.H>
+
+#include <limits>
+
 
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -4,12 +4,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_WITHRR_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BORIS_WITHRR_H_
 
+#include "UpdateMomentumBoris.H"
+
 #include <AMReX_REAL.H>
-#include <UpdateMomentumBoris.H>
+
 
 /**
  * Push the particle's positions over one timestep,

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -7,9 +7,11 @@
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_HIGUERACARY_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_HIGUERACARY_H_
 
-#include "WarpXConst.H"
+#include "Utils/WarpXConst.H"
+
 #include <AMReX_FArrayBox.H>
 #include <AMReX_REAL.H>
+
 
 /**
  * \brief Push the particle's positions over one timestep,

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -8,9 +8,11 @@
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_VAY_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_VAY_H_
 
-#include <AMReX_FArrayBox.H>
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
+
 #include <AMReX_REAL.H>
+#include <AMReX_FArrayBox.H>
+
 
 /** \brief Push the particle's positions over one timestep,
  *    given the value of its momenta `ux`, `uy`, `uz` */

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -8,9 +8,11 @@
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 
-#include <AMReX_FArrayBox.H>
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
+
 #include <AMReX_REAL.H>
+#include <AMReX_FArrayBox.H>
+
 
 /** \brief Push the particle's positions over one timestep,
  *    given the value of its momenta `ux`, `uy`, `uz` */

--- a/Source/Particles/Pusher/UpdatePositionPhoton.H
+++ b/Source/Particles/Pusher/UpdatePositionPhoton.H
@@ -8,10 +8,11 @@
 #ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITIONPHOTON_H_
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITIONPHOTON_H_
 
-#include <WarpXConst.H>
+#include "Utils/WarpXConst.H"
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_REAL.H>
+
 
 /**
  * \brief Push the position of a photon particle over one timestep,

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -8,7 +8,7 @@
 #ifndef WARPX_RigidInjectedParticleContainer_H_
 #define WARPX_RigidInjectedParticleContainer_H_
 
-#include <PhysicalParticleContainer.H>
+#include "PhysicalParticleContainer.H"
 #include <AMReX_Vector.H>
 
 /**

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -7,23 +7,24 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
+
+#include "RigidInjectedParticleContainer.H"
+#include "WarpX.H"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "Pusher/UpdateMomentumBoris.H"
+#include "Pusher/UpdateMomentumVay.H"
+#include "Pusher/UpdateMomentumBorisWithRadiationReaction.H"
+#include "Pusher/UpdateMomentumHigueraCary.H"
+#include "Pusher/GetAndSetPosition.H"
+
 #include <limits>
 #include <sstream>
 #include <algorithm>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
-#include <RigidInjectedParticleContainer.H>
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpXAlgorithmSelection.H>
-#include <UpdateMomentumBoris.H>
-#include <UpdateMomentumVay.H>
-#include <UpdateMomentumBorisWithRadiationReaction.H>
-#include <UpdateMomentumHigueraCary.H>
-#include <GetAndSetPosition.H>
 
 using namespace amrex;
 

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -4,10 +4,12 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <SortingUtils.H>
-#include <PhysicalParticleContainer.H>
-#include <WarpX.H>
+#include "SortingUtils.H"
+#include "Particles/PhysicalParticleContainer.H"
+#include "WarpX.H"
+
 #include <AMReX_Particles.H>
+
 
 using namespace amrex;
 

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -8,9 +8,11 @@
 #ifndef WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 #define WARPX_PARTICLES_SORTING_SORTINGUTILS_H_
 
-#include <WarpXParticleContainer.H>
+#include "Particles/WarpXParticleContainer.H"
+
 #include <AMReX_Gpu.H>
 #include <AMReX_Partition.H>
+
 
 /** \brief Fill the elements of the input vector with consecutive integer,
  *        starting from 0

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -10,7 +10,7 @@
 #ifndef WARPX_WarpXParticleContainer_H_
 #define WARPX_WarpXParticleContainer_H_
 
-#include "WarpXDtType.H"
+#include "Evolve/WarpXDtType.H"
 
 #include <AMReX_Particles.H>
 #include <AMReX_AmrCore.H>

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -7,20 +7,21 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "MultiParticleContainer.H"
+#include "WarpXParticleContainer.H"
+#include "WarpX.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "Parallelization/WarpXComm.H"
+// Import low-level single-particle kernels
+#include "Pusher/GetAndSetPosition.H"
+#include "Pusher/UpdatePosition.H"
+#include "Deposition/CurrentDeposition.H"
+#include "Deposition/ChargeDeposition.H"
+
+#include <AMReX_AmrParGDB.H>
+
 #include <limits>
 
-#include <MultiParticleContainer.H>
-#include <WarpXParticleContainer.H>
-#include <AMReX_AmrParGDB.H>
-#include <WarpXComm.H>
-#include <WarpX.H>
-#include <WarpXAlgorithmSelection.H>
-#include <WarpXComm.H>
-// Import low-level single-particle kernels
-#include <GetAndSetPosition.H>
-#include <UpdatePosition.H>
-#include <CurrentDeposition.H>
-#include <ChargeDeposition.H>
 
 using namespace amrex;
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -6,14 +6,15 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpXWrappers.h>
-#include <WarpXParticleContainer.H>
-#include <WarpX.H>
-#include <WarpXUtil.H>
-#include <WarpX_py.H>
+#include "WarpXWrappers.h"
+#include "Particles/WarpXParticleContainer.H"
+#include "WarpX.H"
+#include "Utils/WarpXUtil.H"
+#include "WarpX_py.H"
 
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
+
 
 namespace
 {

--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -8,7 +8,8 @@
 #ifndef WARPX_PY_H_
 #define WARPX_PY_H_
 
-#include <WarpXWrappers.h>
+#include "WarpXWrappers.h"
+
 
 extern "C" {
 

--- a/Source/Python/WarpX_py.cpp
+++ b/Source/Python/WarpX_py.cpp
@@ -5,7 +5,8 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX_py.H>
+#include "WarpX_py.H"
+
 
 extern "C" {
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -6,11 +6,12 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpXAlgorithmSelection.H>
+#include "WarpXAlgorithmSelection.H"
 
-#include <map>
 #include <algorithm>
 #include <cstring>
+#include <map>
+
 
 // Define dictionary with correspondance between user-input strings,
 // and corresponding integer for use inside the code

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -6,10 +6,11 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include "GuardCellManager.H"
-#include <WarpX.H>
-#include <WarpXUtil.H>
-#include <WarpXConst.H>
+#include "Parallelization/GuardCellManager.H"
+#include "WarpX.H"
+#include "Utils/WarpXUtil.H"
+#include "Utils/WarpXConst.H"
+
 
 using namespace amrex;
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -8,13 +8,15 @@
 #ifndef WARPX_UTILS_H_
 #define WARPX_UTILS_H_
 
+#include "Parser/WarpXParser.H"
+
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParmParse.H>
-#include <WarpXParser.H>
 
 #include <string>
+
 
 void ReadBoostedFrameParameters(amrex::Real& gamma_boost, amrex::Real& beta_boost,
                                 amrex::Vector<int>& boost_direction);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -6,13 +6,15 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpXUtil.H>
-#include <WarpXConst.H>
+#include "WarpXUtil.H"
+#include "WarpXConst.H"
+#include "WarpX.H"
+
 #include <AMReX_ParmParse.H>
-#include <WarpX.H>
 
 #include <cmath>
 #include <fstream>
+
 
 using namespace amrex;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1,9 +1,8 @@
 /* Copyright 2016-2020 Andrew Myers, Ann Almgren, Aurore Blelly
- * Axel Huebl, Burlen Loring, David Grote
- * Glenn Richardson, Junmin Gu, Luca Fedeli
- * Mathieu Lobet, Maxence Thevenet, Remi Lehe
- * Revathi Jambunathan, Weiqun Zhang, Yinjian Zhao
- *
+ *                     Axel Huebl, Burlen Loring, David Grote
+ *                     Glenn Richardson, Junmin Gu, Luca Fedeli
+ *                     Mathieu Lobet, Maxence Thevenet, Remi Lehe
+ *                     Revathi Jambunathan, Weiqun Zhang, Yinjian Zhao
  *
  * This file is part of WarpX.
  *
@@ -12,21 +11,28 @@
 #ifndef WARPX_H_
 #define WARPX_H_
 
-#include "WarpXDtType.H"
-#include <MultiParticleContainer.H>
-#include <PML.H>
-#include <BackTransformedDiagnostic.H>
-#include <BilinearFilter.H>
-#include <NCIGodfreyFilter.H>
-#include "MultiReducedDiags.H"
+#include "Evolve/WarpXDtType.H"
+#include "Particles/MultiParticleContainer.H"
+#include "BoundaryConditions/PML.H"
+#include "Diagnostics/BackTransformedDiagnostic.H"
+#include "Filter/BilinearFilter.H"
+#include "Filter/NCIGodfreyFilter.H"
+#include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 
-#include <FiniteDifferenceSolver.H>
+#include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #ifdef WARPX_USE_PSATD
-#   include <SpectralSolver.H>
+#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #endif
 #ifdef WARPX_USE_PSATD_HYBRID
-#   include <PicsarHybridFFTData.H>
+#   include "FieldSolver/PicsarHybridSpectralSolver/PicsarHybridFFTData.H"
 #endif
+
+#include "Parallelization/GuardCellManager.H"
+
+#ifdef WARPX_USE_OPENPMD
+#   include "Diagnostics/WarpXOpenPMD.H"
+#endif
+#include "Parser/WarpXParserWrapper.H"
 
 #include <AMReX_AmrCore.H>
 #include <AMReX_BLProfiler.H>
@@ -37,21 +43,15 @@
 #include <AMReX_LayoutData.H>
 #include <AMReX_Interpolater.H>
 #include <AMReX_FillPatchUtil.H>
-#include <WarpXParserWrapper.H>
-
-#include "GuardCellManager.H"
 
 #ifdef _OPENMP
 #   include <omp.h>
 #endif
 
-#ifdef WARPX_USE_OPENPMD
-#   include <WarpXOpenPMD.H>
-#endif
-
 #include <iostream>
 #include <memory>
 #include <array>
+
 
 #if defined(BL_USE_SENSEI_INSITU)
 namespace amrex {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -9,13 +9,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <WarpXConst.H>
-#include <WarpXWrappers.h>
-#include <WarpXUtil.H>
-#include <WarpXAlgorithmSelection.H>
-#include <WarpX_FDTD.H>
-#include "WarpXProfilerWrapper.H"
+#include "WarpX.H"
+#include "FieldSolver/WarpX_FDTD.H"
+#include "Python/WarpXWrappers.h"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "Utils/WarpXProfilerWrapper.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFabUtil.H>

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,14 +1,14 @@
 /* Copyright 2016-2020 Andrew Myers, Ann Almgren, Axel Huebl
- * David Grote, Jean-Luc Vay, Remi Lehe
- * Revathi Jambunathan, Weiqun Zhang
+ *                     David Grote, Jean-Luc Vay, Remi Lehe
+ *                     Revathi Jambunathan, Weiqun Zhang
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <WarpXUtil.H>
-#include "WarpXProfilerWrapper.H"
+#include "WarpX.H"
+#include "Utils/WarpXUtil.H"
+#include "Utils/WarpXProfilerWrapper.H"
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
@@ -17,18 +17,19 @@
 
 #include <iostream>
 
-using namespace amrex;
 
 int main(int argc, char* argv[])
 {
-#if defined AMREX_USE_MPI
-#if defined(_OPENMP) && defined(WARPX_USE_PSATD)
+    using namespace amrex;
+
+#if defined(AMREX_USE_MPI)
+#   if defined(_OPENMP) && defined(WARPX_USE_PSATD)
     int provided;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
     AMREX_ALWAYS_ASSERT(provided >= MPI_THREAD_FUNNELED);
-#else
+#   else
     MPI_Init(&argc, &argv);
-#endif
+#   endif
 #endif
 
     amrex::Initialize(argc,argv);
@@ -59,7 +60,7 @@ int main(int argc, char* argv[])
     WARPX_PROFILE_VAR_STOP(pmain);
 
     amrex::Finalize();
-#if defined AMREX_USE_MPI
+#if defined(AMREX_USE_MPI)
     MPI_Finalize();
 #endif
 }


### PR DESCRIPTION
- Use `""` for WarpX-local includes
- Order: WarpX `""`, AMReX `<>`, other third party includes `<>`
- Add dir prefixes for WarpX (order, collision avoidance, no prefix used elsewhere)

Add order to includes by including from `Source/` onward and keeping directory prefixes of non-local includes for clarity.

Similar to #331, prepares CMake scripts.