### PR TITLE
Comment/Remove Unused Parameters

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -364,14 +364,14 @@ MultiSigmaBox::ComputePMLFactorsE (const Real* dx, Real dt)
     }
 }
 
-PML::PML (const BoxArray& grid_ba, const DistributionMapping& grid_dm,
+PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
           const Geometry* geom, const Geometry* cgeom,
           int ncell, int delta, int ref_ratio,
 #ifdef WARPX_USE_PSATD
           Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
 #endif
           int do_dive_cleaning, int do_moving_window,
-          int pml_has_particles, int do_pml_in_domain,
+          int /*pml_has_particles*/, int do_pml_in_domain,
           const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
     : m_geom(geom),
       m_cgeom(cgeom)

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -471,7 +471,7 @@ bool compare_tlab_uptr(const std::unique_ptr<LabFrameDiag>&a,
 namespace
 {
 void
-LorentzTransformZ(MultiFab& data, Real gamma_boost, Real beta_boost, int ncomp)
+LorentzTransformZ(MultiFab& data, Real gamma_boost, Real beta_boost)
 {
     // Loop over tiles/boxes and in-place convert each slice from boosted
     // frame to back-transformed lab frame.
@@ -683,7 +683,7 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
     AMREX_ALWAYS_ASSERT(m_max_box_size_ >= m_num_buffer_);
 }
 
-void BackTransformedDiagnostic::Flush(const Geometry& geom)
+void BackTransformedDiagnostic::Flush(const Geometry& /*geom*/)
 {
     WARPX_PROFILE("BackTransformedDiagnostic::Flush");
 
@@ -846,7 +846,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                                              start_comp, ncomp,
                                              interpolate);
                // Back-transform data to the lab-frame
-               LorentzTransformZ(*slice, m_gamma_boost_, m_beta_boost_, ncomp);
+               LorentzTransformZ(*slice, m_gamma_boost_, m_beta_boost_);
              }
              // Create a 2D box for the slice in the boosted frame
              Real dx = geom.CellSize(m_boost_direction_);

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -262,6 +262,9 @@ AverageAndPackVectorField( MultiFab& mf_avg,
                            const DistributionMapping& dm,
                            const int dcomp, const int ngrow )
 {
+#ifndef WARPX_DIM_RZ
+    (void)dm;
+#endif
     // The object below is temporary, and is needed because
     // `average_edge_to_cellcenter` requires fields to be passed as Vector
     Vector<const MultiFab*> srcmf(AMREX_SPACEDIM);
@@ -884,7 +887,7 @@ std::unique_ptr<MultiFab>
 getInterpolatedScalar(
     const MultiFab& F_cp, const MultiFab& F_fp,
     const DistributionMapping& dm, const int r_ratio,
-    const Real* dx, const int ngrow )
+    const Real* /*dx*/, const int ngrow )
 {
     // Prepare the structure that will contain the returned fields
     std::unique_ptr<MultiFab> interpolated_F;

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -383,7 +383,7 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
 void
 InterpolateSliceValues(MultiFab& smf, IntVect interp_lo, RealBox slice_realbox,
                        Vector<Geometry> geom, int ncomp, int nghost,
-                       IntVect slice_lo, IntVect slice_hi, IntVect SliceType,
+                       IntVect slice_lo, IntVect /*slice_hi*/, IntVect SliceType,
                        const RealBox real_box)
 {
     for (MFIter mfi(smf); mfi.isValid(); ++mfi)
@@ -408,7 +408,7 @@ void
 InterpolateLo(const Box& bx, FArrayBox &fabox, IntVect slice_lo,
              Vector<Geometry> geom, int idir, IntVect IndType,
              RealBox slice_realbox, int srccomp, int ncomp,
-             int nghost, const RealBox real_box )
+             int /*nghost*/, const RealBox real_box )
 {
     auto fabarr = fabox.array();
     const auto lo = amrex::lbound(bx);

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -510,7 +510,7 @@ WarpX::UpdateInSitu () const
 
 void
 WarpX::prepareFields(
-        int const step,
+        int const /*step*/,
         Vector<std::string>& varnames,
         Vector<MultiFab>& mf_avg,
         Vector<const MultiFab*>& output_mf,

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -249,7 +249,7 @@ WarpX::PostRestart ()
 
 
 void
-WarpX::InitLevelData (int lev, Real time)
+WarpX::InitLevelData (int lev, Real /*time*/)
 {
 
     ParmParse pp("warpx");

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -378,7 +378,7 @@ LaserParticleContainer::Evolve (int lev,
                                 MultiFab* rho, MultiFab* crho,
                                 const MultiFab*, const MultiFab*, const MultiFab*,
                                 const MultiFab*, const MultiFab*, const MultiFab*,
-                                Real t, Real dt, DtType a_dt_type)
+                                Real t, Real dt, DtType /*a_dt_type*/)
 {
     WARPX_PROFILE("Laser::Evolve()");
     WARPX_PROFILE_VAR_NS("Laser::Evolve::Copy", blp_copy);

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -15,7 +15,7 @@ void
 FieldFunctionLaserProfile::init (
     const amrex::ParmParse& ppl,
     const amrex::ParmParse& ppc,
-    CommonLaserParameters params)
+    CommonLaserParameters /*params*/)
 {
     // Parse the properties of the parse_field_function profile
     ppl.get("field_function(X,Y,t)", m_params.field_function);

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -27,6 +27,12 @@ guardCellManager::Init(
     const amrex::Array<amrex::Real,3> v_galilean,
     const bool safe_guard_cells)
 {
+#ifndef WARPX_USE_PSATD
+    (void)do_fft_mpi_dec;
+    (void)nox_fft;
+    (void)noy_fft;
+    (void)noz_fft;
+#endif
     // When using subcycling, the particles on the fine level perform two pushes
     // before being redistributed ; therefore, we need one extra guard cell
     // (the particles may move by 2*c*dt)

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -35,7 +35,7 @@ WarpX::LoadBalance ()
 }
 
 void
-WarpX::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
+WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const DistributionMapping& dm)
 {
     if (ba == boxArray(lev))
     {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -487,8 +487,8 @@ MultiParticleContainer::PostRestart ()
 
 void
 MultiParticleContainer
-::GetLabFrameData (const std::string& snapshot_name,
-                   const int i_lab, const int direction,
+::GetLabFrameData (const std::string& /*snapshot_name*/,
+                   const int /*i_lab*/, const int direction,
                    const Real z_old, const Real z_new,
                    const Real t_boost, const Real t_lab, const Real dt,
                    Vector<WarpXParticleContainer::DiagnosticParticleData>& parts) const

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -56,7 +56,7 @@ void PhotonParticleContainer::InitData()
 }
 
 void
-PhotonParticleContainer::PushPX(WarpXParIter& pti, Real dt, DtType a_dt_type)
+PhotonParticleContainer::PushPX(WarpXParIter& pti, Real dt, DtType /*a_dt_type*/)
 {
 
     // This wraps the momentum and position advance so that inheritors can modify the call.
@@ -101,7 +101,7 @@ PhotonParticleContainer::Evolve (int lev,
                                  MultiFab* rho, MultiFab* crho,
                                  const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
                                  const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                 Real t, Real dt, DtType a_dt_type)
+                                 Real t, Real dt, DtType /*a_dt_type*/)
 {
     // This does gather, push and depose.
     // Push and depose have been re-written for photon,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1109,7 +1109,7 @@ PhysicalParticleContainer::Evolve (int lev,
                                    MultiFab* rho, MultiFab* crho,
                                    const MultiFab* cEx, const MultiFab* cEy, const MultiFab* cEz,
                                    const MultiFab* cBx, const MultiFab* cBy, const MultiFab* cBz,
-                                   Real t, Real dt, DtType a_dt_type)
+                                   Real /*t*/, Real dt, DtType a_dt_type)
 {
     WARPX_PROFILE("PPC::Evolve()");
     WARPX_PROFILE_VAR_NS("PPC::Evolve::Copy", blp_copy);
@@ -2177,7 +2177,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
                                         amrex::FArrayBox const * bxfab,
                                         amrex::FArrayBox const * byfab,
                                         amrex::FArrayBox const * bzfab,
-                                        const int ngE, const int e_is_nodal,
+                                        const int ngE, const int /*e_is_nodal*/,
                                         const long offset,
                                         const long np_to_gather,
                                         int lev,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -96,12 +96,12 @@ WarpXParticleContainer::AllocData ()
 }
 
 void
-WarpXParticleContainer::AddNParticles (int lev,
+WarpXParticleContainer::AddNParticles (int /*lev*/,
                                        int n, const ParticleReal* x, const ParticleReal* y, const ParticleReal* z,
                                        const ParticleReal* vx, const ParticleReal* vy, const ParticleReal* vz,
                                        int nattr, const ParticleReal* attr, int uniqueparticles, int id)
 {
-    BL_ASSERT(nattr == 1);
+    BL_ASSERT(nattr == 1); //! @fixme nattr is unused below: false sense of safety
     const ParticleReal* weight = attr;
 
     int ibegin, iend;
@@ -492,6 +492,9 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
                                         bool local, bool reset,
                                         bool do_rz_volume_scaling)
 {
+#ifdef WARPX_DIM_RZ
+    (void)do_rz_volume_scaling;
+#endif
     // Loop over the refinement levels
     int const finest_level = rho.size() - 1;
     for (int lev = 0; lev <= finest_level; ++lev) {

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -14,7 +14,7 @@
 using namespace amrex;
 
 void
-WarpX::ErrorEst (int lev, TagBoxArray& tags, Real time, int /*ngrow*/)
+WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
 {
     const Real* problo = Geom(lev).ProbLo();
     const Real* dx = Geom(lev).CellSize();


### PR DESCRIPTION
Use the `clang-tidy` pass `misc-unused-parameters` to remove unused parameter warnings.

https://clang.llvm.org/extra/clang-tidy/checks/misc-unused-parameters.html)

Executed via
```bash
cmake .. "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-7);-checks=-*,misc-unused-parameters;-fix"
make
```

- [ ] We should evaluate if some of the commented params can also generally be changed in the defined function/method signatures.

Committed as generic user so git does not credit the many lines to me:
```bash
GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="warpx@lbl.gov"  \
  git commit
```