### PR TITLE
Fix Util: No Variable-Length Array

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -180,18 +180,13 @@ namespace WarpXUtilIO{
 void Store_parserString(amrex::ParmParse& pp, std::string query_string,
                         std::string& stored_string)
 {
-
-    char cstr[query_string.size()+1];
-    strcpy(cstr, query_string.c_str());
-
     std::vector<std::string> f;
-    pp.getarr(cstr, f);
+    pp.getarr(query_string.c_str(), f);
     stored_string.clear();
     for (auto const& s : f) {
         stored_string += s;
     }
     f.clear();
-
 }
 
 


### PR DESCRIPTION
Defining a [variable-length array (VLA)](https://en.wikipedia.org/wiki/Variable-length_array) is a C99 feature.
It's actually not a feature of C++ :)

### More Background Info

if you declare a C-style array `float x[10];` its size is known at compile time, so the data will be stored on the fixed-size ["stack" memory](https://en.wikipedia.org/wiki/Stack-based_memory_allocation) of a program.

if you put `void foo(int i){ float x[i]; }` the size of x is not know at compile time.
this is called dynamic memory, and requires a new/delete in C++. Declaring a `float x[i];` is not allowed in C++, since it is an array of variable length that cannot live in the "stack" but the dynamic ["heap" memory](https://en.wikipedia.org/wiki/Memory_management#HEAP) of a program.

99% of the time, just use a [std::vector](https://en.cppreference.com/w/cpp/container/vector/vector) instead:
```C++
std::vector< float > x( i );
```