### PR TITLE
Update tolerance of regression tests on garuda

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -209,6 +209,7 @@ numprocs = 2
 useOMP = 0
 numthreads = 2
 compileTest = 0
+tolerance = 1e-15
 doVis = 0
 analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
 
@@ -623,6 +624,7 @@ useOMP = 0
 numthreads = 1
 compileTest = 0
 doVis = 0
+tolerance = 1e-12
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 
@@ -638,6 +640,7 @@ useOMP = 0
 numthreads = 2
 compileTest = 0
 doVis = 0
+tolerance = 1e-10
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 


### PR DESCRIPTION
Some of the regression tests on Garuda currently fail due to machine-precision level differences:
https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/
(e.g. caused recently by #676 )

This PR updates the tolerance accordingly.