### PR TITLE
Fix and automatically test USE_PSATD_PICSAR=TRUE

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -411,6 +411,25 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
 
+[Langmuir_multi_psatd_hybrid]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+runtime_params = psatd.fftw_plan_measure=0 psatd.hybrid_mpi_decomposition=1 psatd.ngroups_fft=2
+dim = 3
+addToCompileString = USE_PSATD=TRUE USE_PSATD_PICSAR=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+tolerance = 5.e-11
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
@@ -7,6 +7,7 @@
  */
 #include "PicsarHybridFFTData.H"
 #include "WarpX.H"
+#include "WarpX_f.H"
 #include <AMReX_iMultiFab.H>
 
 


### PR DESCRIPTION
The code for `USE_PSATD_PICSAR=TRUE` was slightly broken. 
This PR fixes it and adds a corresponding test.

This is an important first step towards testing PSATD with distributed FFTs on GPU.