### PR TITLE
Single Precision: Regression Tolerance

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -260,6 +260,7 @@ numprocs = 2
 useOMP = 1
 numthreads = 2
 compileTest = 0
+tolerance = 1.0e-4
 doVis = 0
 compareParticles = 1
 particleTypes = electrons
@@ -367,6 +368,7 @@ numprocs = 4
 useOMP = 1
 numthreads = 2
 compileTest = 0
+tolerance = 1.0e-4
 doVis = 0
 compareParticles = 1
 runtime_params = warpx.do_dynamic_scheduling=0


### PR DESCRIPTION
For single precision, roughly 4 significant digits are comparable for our floating point precision tolerance.

See:
- https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2020-03-04/Langmuir_2d_single_precision.html
- https://ccse.lbl.gov/pub/RegressionTesting/WarpX/2020-03-04/Langmuir_multi_single_precision.html
  (in the latter, I am not sure why the magnetic field is only to 2.5e-3 tolerance precise. Is it maybe supposed to be zero?)