### PR TITLE
For RZ, generalized the centering of the inverse volume scaling of J and rho

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -492,6 +492,8 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
     const Real dr = dx[0];
 
+    constexpr int NODE = amrex::IndexType::NODE;
+
     Box tilebox;
 
     for ( MFIter mfi(*Jx, TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -511,11 +513,30 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         // these do not include the guard cells.
         std::array<amrex::Real,3> galilean_shift = {0,0,0};
         const std::array<Real, 3>& xyzmin = WarpX::LowerCorner(tilebox, galilean_shift, lev);
+        const Real rmin  = xyzmin[0] + (tbr.type(0) == NODE ? 0. : 0.5*dx[0]);
+        const Real rminr = xyzmin[0] + (tbr.type(0) == NODE ? 0. : 0.5*dx[0]);
+        const Real rmint = xyzmin[0] + (tbt.type(0) == NODE ? 0. : 0.5*dx[0]);
+        const Real rminz = xyzmin[0] + (tbz.type(0) == NODE ? 0. : 0.5*dx[0]);
         const Dim3 lo = lbound(tilebox);
-        const Real rmin = xyzmin[0];
         const int irmin = lo.x;
+        int const ishift_t = (rmint > rmin ? 1 : 0);
+        int const ishift_z = (rminz > rmin ? 1 : 0);
 
         const long nmodes = n_rz_azimuthal_modes;
+
+        // Grow the tileboxes to include the guard cells, except for the
+        // guard cells at negative radius.
+        if (rmin > 0.) {
+           tbr.growLo(0, ngJ);
+           tbt.growLo(0, ngJ);
+           tbz.growLo(0, ngJ);
+        }
+        tbr.growHi(0, ngJ);
+        tbt.growHi(0, ngJ);
+        tbz.growHi(0, ngJ);
+        tbr.grow(1, ngJ);
+        tbt.grow(1, ngJ);
+        tbz.grow(1, ngJ);
 
         // Rescale current in r-z mode since the inverse volume factor was not
         // included in the current deposition.
@@ -529,9 +550,9 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                 Jr_arr(i,j,0,0) -= Jr_arr(-1-i,j,0,0);
             }
             // Apply the inverse volume scaling
-            // Since Jr is not cell centered in r, no need for distinction
+            // Since Jr is never node centered in r, no need for distinction
             // between on axis and off-axis factors
-            const amrex::Real r = std::abs(rmin + (i - irmin + 0.5)*dr);
+            const amrex::Real r = std::abs(rminr + (i - irmin)*dr);
             Jr_arr(i,j,0,0) /= (2.*MathConst::pi*r);
 
             for (int imode=1 ; imode < nmodes ; imode++) {
@@ -544,7 +565,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                     Jr_arr(i,j,0,2*imode) -= ifact*Jr_arr(-1-i,j,0,2*imode);
                 }
                 // Apply the inverse volume scaling
-                // Since Jr is not cell centered in r, no need for distinction
+                // Since Jr is never node centered in r, no need for distinction
                 // between on axis and off-axis factors
                 Jr_arr(i,j,0,2*imode-1) /= (2.*MathConst::pi*r);
                 Jr_arr(i,j,0,2*imode) /= (2.*MathConst::pi*r);
@@ -554,14 +575,15 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
-            // Jt is located on the boundary
-            if (rmin == 0. && 0 < i && i <= ngJ) {
-                Jt_arr(i,j,0,0) += Jt_arr(-i,j,0,0);
+            // If Jt is node centered, Jt[0] is located on the boundary.
+            // If Jt is cell centered, Jt[0] is at 1/2 dr.
+            if (rmin == 0. && 0 < i && i <= ngJ-ishift_t) {
+                Jt_arr(i,j,0,0) += Jt_arr(-ishift_t-i,j,0,0);
             }
 
             // Apply the inverse volume scaling
             // Jt is forced to zero on axis.
-            const amrex::Real r = std::abs(rmin + (i - irmin)*dr);
+            const amrex::Real r = std::abs(rmint + (i - irmin)*dr);
             if (r == 0.) {
                 Jt_arr(i,j,0,0) = 0.;
             } else {
@@ -572,10 +594,9 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                 const Real ifact = ( (imode%2) == 0 ? +1. : -1.);
                 // Wrap the current density deposited in the guard cells around
                 // to the cells above the axis.
-                // Jt is located on the boundary
-                if (rmin == 0. && 0 < i && i <= ngJ) {
-                    Jt_arr(i,j,0,2*imode-1) += ifact*Jt_arr(-i,j,0,2*imode-1);
-                    Jt_arr(i,j,0,2*imode) += ifact*Jt_arr(-i,j,0,2*imode);
+                if (rmin == 0. && 0 < i && i <= ngJ-ishift_t) {
+                    Jt_arr(i,j,0,2*imode-1) += ifact*Jt_arr(-ishift_t-i,j,0,2*imode-1);
+                    Jt_arr(i,j,0,2*imode) += ifact*Jt_arr(-ishift_t-i,j,0,2*imode);
                 }
 
                 // Apply the inverse volume scaling
@@ -593,13 +614,14 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
-            // Jz is located on the boundary
-            if (rmin == 0. && 0 < i && i <= ngJ) {
-                Jz_arr(i,j,0,0) += Jz_arr(-i,j,0,0);
+            // If Jz is node centered, Jt[0] is located on the boundary.
+            // If Jz is cell centered, Jt[0] is at 1/2 dr.
+            if (rmin == 0. && 0 < i && i <= ngJ-ishift_z) {
+                Jz_arr(i,j,0,0) += Jz_arr(-ishift_z-i,j,0,0);
             }
 
             // Apply the inverse volume scaling
-            const amrex::Real r = std::abs(rmin + (i - irmin)*dr);
+            const amrex::Real r = std::abs(rminz + (i - irmin)*dr);
             if (r == 0.) {
                 // Verboncoeur JCP 164, 421-427 (2001) : corrected volume on axis
                 Jz_arr(i,j,0,0) /= (MathConst::pi*dr/3.);
@@ -611,10 +633,9 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                 const Real ifact = ( (imode%2) == 0 ? +1. : -1.);
                 // Wrap the current density deposited in the guard cells around
                 // to the cells above the axis.
-                // Jz is located on the boundary
-                if (rmin == 0. && 0 < i && i <= ngJ) {
-                    Jz_arr(i,j,0,2*imode-1) += ifact*Jz_arr(-i,j,0,2*imode-1);
-                    Jz_arr(i,j,0,2*imode) += ifact*Jz_arr(-i,j,0,2*imode);
+                if (rmin == 0. && 0 < i && i <= ngJ-ishift_z) {
+                    Jz_arr(i,j,0,2*imode-1) += ifact*Jz_arr(-ishift_z-i,j,0,2*imode-1);
+                    Jz_arr(i,j,0,2*imode) += ifact*Jz_arr(-ishift_z-i,j,0,2*imode);
                 }
 
                 // Apply the inverse volume scaling
@@ -639,6 +660,8 @@ WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
     const Real dr = dx[0];
 
+    constexpr int NODE = amrex::IndexType::NODE;
+
     Box tilebox;
 
     for ( MFIter mfi(*Rho, TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -656,22 +679,34 @@ WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
         const std::array<Real, 3>& xyzmin = WarpX::LowerCorner(tilebox, galilean_shift, lev);
         const Dim3 lo = lbound(tilebox);
         const Real rmin = xyzmin[0];
+        const Real rminr = xyzmin[0] + (tb.type(0) == NODE ? 0. : 0.5*dx[0]);
         const int irmin = lo.x;
+        int ishift = (rminr > rmin ? 1 : 0);
+
+        // Grow the tilebox to include the guard cells, except for the
+        // guard cells at negative radius.
+        if (rmin > 0.) {
+           tb.growLo(0, ngRho);
+        }
+        tb.growHi(0, ngRho);
+        tb.grow(1, ngRho);
 
         // Rescale charge in r-z mode since the inverse volume factor was not
         // included in the charge deposition.
+        // Note that the loop is also over ncomps, which takes care of the RZ modes,
+        // as well as the old and new rho.
         amrex::ParallelFor(tb, Rho->nComp(),
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int icomp)
         {
             // Wrap the charge density deposited in the guard cells around
             // to the cells above the axis.
             // Rho is located on the boundary
-            if (rmin == 0. && 0 < i && i <= ngRho) {
-                Rho_arr(i,j,0,icomp) += Rho_arr(-i,j,0,icomp);
+            if (rmin == 0. && 0 < i && i <= ngRho-ishift) {
+                Rho_arr(i,j,0,icomp) += Rho_arr(-ishift-i,j,0,icomp);
             }
 
             // Apply the inverse volume scaling
-            const amrex::Real r = std::abs(rmin + (i - irmin)*dr);
+            const amrex::Real r = std::abs(rminr + (i - irmin)*dr);
             if (r == 0.) {
                 // Verboncoeur JCP 164, 421-427 (2001) : corrected volume on axis
                 Rho_arr(i,j,0,icomp) /= (MathConst::pi*dr/3.);

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -493,6 +493,8 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     const Real dr = dx[0];
 
     constexpr int NODE = amrex::IndexType::NODE;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().ixType()[0] != NODE,
+        "Jr should never node-centered in r");
 
     Box tilebox;
 


### PR DESCRIPTION
This change allows arbitrary node or cell centering of the current and charge density when applying the inverse volume scale, with the exception that Jr will never be node centered.