### PR TITLE
Add default values for particle and cell weights used in heuristic costs update

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -699,9 +699,17 @@ private:
      * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
      * be assigned to a rank to 8. */
     amrex::Real load_balance_knapsack_factor = 1.24;
-    /** Weight factor for cells in updating `costs_heuristic`. */
+    /** Weight factor for cells in updating `costs_heuristic`. 
+     * Default values on GPU are determined from single-GPU tests on Summit.  
+     * The problem setup for these tests is an empty (i.e. no particles) domain 
+     * of size 256 by 256 by 256 cells, from which the average time per iteration
+     * per cell is computed. */
     amrex::Real costs_heuristic_cells_wt = -1;
-    /** Weight factor for particles in updating `costs_heuristic`. */
+    /** Weight factor for particles in updating `costs_heuristic`. 
+     * Default values on GPU are determined from single-GPU tests on Summit.
+     * The problem setup for these tests is a high-ppc (27 particles per cell) 
+     * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate 
+     * time per iteration per particle is computed. */
     amrex::Real costs_heuristic_particles_wt = -1;
 
     // Override sync every ? steps

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -699,16 +699,16 @@ private:
      * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
      * be assigned to a rank to 8. */
     amrex::Real load_balance_knapsack_factor = 1.24;
-    /** Weight factor for cells in updating `costs_heuristic`. 
-     * Default values on GPU are determined from single-GPU tests on Summit.  
-     * The problem setup for these tests is an empty (i.e. no particles) domain 
+    /** Weight factor for cells in updating `costs_heuristic`.
+     * Default values on GPU are determined from single-GPU tests on Summit.
+     * The problem setup for these tests is an empty (i.e. no particles) domain
      * of size 256 by 256 by 256 cells, from which the average time per iteration
      * per cell is computed. */
     amrex::Real costs_heuristic_cells_wt = -1;
-    /** Weight factor for particles in updating `costs_heuristic`. 
+    /** Weight factor for particles in updating `costs_heuristic`.
      * Default values on GPU are determined from single-GPU tests on Summit.
-     * The problem setup for these tests is a high-ppc (27 particles per cell) 
-     * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate 
+     * The problem setup for these tests is a high-ppc (27 particles per cell)
+     * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate
      * time per iteration per particle is computed. */
     amrex::Real costs_heuristic_particles_wt = -1;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -700,9 +700,9 @@ private:
      * be assigned to a rank to 8. */
     amrex::Real load_balance_knapsack_factor = 1.24;
     /** Weight factor for cells in updating `costs_heuristic`. */
-    amrex::Real costs_heuristic_cells_wt = 0.1;
+    amrex::Real costs_heuristic_cells_wt = -1;
     /** Weight factor for particles in updating `costs_heuristic`. */
-    amrex::Real costs_heuristic_particles_wt = 0.9;
+    amrex::Real costs_heuristic_particles_wt = -1;
 
     // Override sync every ? steps
     int override_sync_int = 1;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -304,7 +304,7 @@ WarpX::WarpX ()
         costs_heuristic_particles_wt = 0.9;
     }
 #endif // AMREX_USE_GPU
-    
+
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD
     spectral_solver_fp.resize(nlevs_max);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -296,6 +296,13 @@ WarpX::WarpX ()
         }
 #endif // WARPX_USE_PSATD
     }
+#else // CPU
+    if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
+        && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
+    {
+        costs_heuristic_cells_wt = 0.1;
+        costs_heuristic_particles_wt = 0.9;
+    }
 #endif // AMREX_USE_GPU
     
     // Allocate field solver objects

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -257,6 +257,45 @@ WarpX::WarpX ()
         default: amrex::Abort("unknown load balance type");
     }
 
+    // Set default values for particle and cell weights for costs update
+    if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
+        && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
+    {
+#ifdef WARPX_USE_PSATD
+        switch (WarpX::nox)
+        {
+            case 1:
+                costs_heuristic_cells_wt = 0.575;
+                costs_heuristic_particles_wt = 0.425;
+                break;
+            case 2:
+                costs_heuristic_cells_wt = 0.405;
+                costs_heuristic_particles_wt = 0.595;
+                break;
+            case 3:
+                costs_heuristic_cells_wt = 0.250;
+                costs_heuristic_particles_wt = 0.750;
+                break;
+        }
+#else // FDTD
+        switch (WarpX::nox)
+        {
+            case 1:
+                costs_heuristic_cells_wt = 0.401;
+                costs_heuristic_particles_wt = 0.599;
+                break;
+            case 2:
+                costs_heuristic_cells_wt = 0.268;
+                costs_heuristic_particles_wt = 0.732;
+                break;
+            case 3:
+                costs_heuristic_cells_wt = 0.145;
+                costs_heuristic_particles_wt = 0.855;
+                break;
+        }
+#endif
+    }
+
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD
     spectral_solver_fp.resize(nlevs_max);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -257,7 +257,9 @@ WarpX::WarpX ()
         default: amrex::Abort("unknown load balance type");
     }
 
-    // Set default values for particle and cell weights for costs update
+    // Set default values for particle and cell weights for costs update;
+    // Default values listed here for the case AMREX_USE_GPU are determined
+    // from single-GPU tests on Summit.
 #ifdef AMREX_USE_GPU
     if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
         && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -260,10 +260,10 @@ WarpX::WarpX ()
     // Set default values for particle and cell weights for costs update;
     // Default values listed here for the case AMREX_USE_GPU are determined
     // from single-GPU tests on Summit.
-#ifdef AMREX_USE_GPU
-    if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
+    if (costs_heuristic_cells_wt<0. && costs_heuristic_particles_wt<0.
         && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
     {
+#ifdef AMREX_USE_GPU
 #ifdef WARPX_USE_PSATD
         switch (WarpX::nox)
         {
@@ -297,15 +297,11 @@ WarpX::WarpX ()
                 break;
         }
 #endif // WARPX_USE_PSATD
-    }
 #else // CPU
-    if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
-        && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
-    {
         costs_heuristic_cells_wt = 0.1;
         costs_heuristic_particles_wt = 0.9;
-    }
 #endif // AMREX_USE_GPU
+    }
 
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -258,6 +258,7 @@ WarpX::WarpX ()
     }
 
     // Set default values for particle and cell weights for costs update
+#ifdef AMREX_USE_GPU
     if (costs_heuristic_cells_wt==-1 && costs_heuristic_particles_wt==-1
         && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
     {
@@ -293,9 +294,10 @@ WarpX::WarpX ()
                 costs_heuristic_particles_wt = 0.855;
                 break;
         }
-#endif
+#endif // WARPX_USE_PSATD
     }
-
+#endif // AMREX_USE_GPU
+    
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD
     spectral_solver_fp.resize(nlevs_max);


### PR DESCRIPTION
This pull request adds default values for particle and cell weights used to update costs for heuristic load balance.  The values are determined from measurements of time per iteration per cell and per cell, for choice of field solver (PSATD or FDTD) and particle shape order (1, 2, 3).