### PR TITLE
Remove "include fftw" statements

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -14,9 +14,6 @@
 
 #include <string>
 
-#ifdef WARPX_USE_PSATD
-#   include <fftw3.h>
-
 // Declare type for spectral fields
 using SpectralField = amrex::FabArray< amrex::BaseFab <Complex> >;
 
@@ -90,5 +87,4 @@ class SpectralFieldData
 #endif
 };
 
-#endif // WARPX_USE_PSATD
 #endif // WARPX_SPECTRAL_FIELD_DATA_H_


### PR DESCRIPTION
- On CPU, these statements are not necessary because they are include with `include "WarpX_ComplexforFFT.H"`
- On GPU, these statements cause compilation to fail if `fftw` is not installed (not that FFTW is not actually needed on GPU because we use `cufft`)