### PR TITLE
Fail gracefully when laser amplitude is zero

### DIFF
--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -138,6 +138,13 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     }
 
     //Init laser profile
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(e_max > 0.,
+        "Laser amplitude (e_max) must be positive.");
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(wavelength > 0.,
+        "Laser wavelength must be positive.");
+
     CommonLaserParameters common_params;
     common_params.wavelength = wavelength;
     common_params.e_max = e_max;

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -23,6 +23,9 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     //Copy common params
     m_common_params = params;
 
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(params.e_max > 0,
+        "Laser amplitude (e_max) must be positive");
+
     // Parse the properties of the Gaussian profile
     ppl.get("profile_waist", m_params.waist);
     ppl.get("profile_duration", m_params.duration);

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -23,9 +23,6 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     //Copy common params
     m_common_params = params;
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(params.e_max > 0,
-        "Laser amplitude (e_max) must be positive");
-
     // Parse the properties of the Gaussian profile
     ppl.get("profile_waist", m_params.waist);
     ppl.get("profile_duration", m_params.duration);


### PR DESCRIPTION
Put an AMREX_ALWAYS_ASSERT_WITH_MESSAGE in LaserProfileGaussia.cpp. The code previously segfaulted when given a laser with e_max = 0.