### PR TITLE
With RZ, always write out theta

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -130,6 +130,13 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }
         }
+
+#ifdef WARPX_DIM_RZ
+        // Always write out theta, whether or not it's requested,
+        // to be consistent with always writing out r and z.
+        plot_flags[ParticleStringNames::to_index.at("theta")] = 1;
+#endif
+
     }
 
     // Parse galilean velocity


### PR DESCRIPTION
The documentation states that the position is alway written out to the plot files. This makes the code consistent with that when using RZ geometry. If the use specifies the plot_vars option, this change sets the flag for theta to one.