### PR TITLE
Include private members of classes in Doxygen documentation

### DIFF
--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -441,7 +441,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -178,7 +178,7 @@ LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
  * The up-to-date antenna position is stored in updated_position.
  */
 void
-LaserParticleContainer::UpdateContinuousInjectionPosition(Real dt)
+LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
 {
     int dir = WarpX::moving_window_dir;
     if (do_continuous_injection and (WarpX::gamma_boost > 1)){
@@ -624,14 +624,14 @@ LaserParticleContainer::calculate_laser_plane_coordinates (const WarpXParIter& p
  * \param dt: time step.
  */
 void
-LaserParticleContainer::update_laser_particle(WarpXParIter& pti,
-                                              const int np,
-                                              ParticleReal * AMREX_RESTRICT const puxp,
-                                              ParticleReal * AMREX_RESTRICT const puyp,
-                                              ParticleReal * AMREX_RESTRICT const puzp,
-                                              ParticleReal const * AMREX_RESTRICT const pwp,
-                                              Real const * AMREX_RESTRICT const amplitude,
-                                              const Real dt)
+LaserParticleContainer::update_laser_particle (WarpXParIter& pti,
+                                               const int np,
+                                               ParticleReal * AMREX_RESTRICT const puxp,
+                                               ParticleReal * AMREX_RESTRICT const puyp,
+                                               ParticleReal * AMREX_RESTRICT const puzp,
+                                               ParticleReal const * AMREX_RESTRICT const pwp,
+                                               Real const * AMREX_RESTRICT const amplitude,
+                                               const Real dt)
 {
     const auto GetPosition = GetParticlePosition(pti);
     auto       SetPosition = SetParticlePosition(pti);


### PR DESCRIPTION
With this mini-PR private members of classes will show up in the WarpX Doxygen documentation. Previously we had `EXTRACT_PRIVATE=NO` in `Docs/Doxyfile`, thus hiding some important functions (such as `EvolveEM` in the main class `WarpX`).