### PR TITLE
Added optional user defined number of guard cells to use with PSATD solver

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -940,6 +940,11 @@ Numerics and algorithms
 * ``psatd.nox``, ``psatd.noy``, ``pstad.noz`` (`integer`) optional (default `16` for all)
     The order of accuracy of the spatial derivatives, when using the code compiled with a PSATD solver.
 
+* ``nx_guard_psatd``, ``ny_guard_psatd``, ``nz_guard_psatd`` (`integer`) optional
+    The number of guard cells to use with PSATD solver.
+    If not set by users, these values are calculated automatically and determined *empirically* and
+    would be equal the order of the solver for nodal grid, and half the order of the solver for staggered.
+
 * ``psatd.hybrid_mpi_decomposition`` (`0` or `1`; default: 0)
     Whether to use a different MPI decomposition for the particle-grid operations
     (deposition and gather) and for the PSATD solver. If `1`, the FFT will

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -940,7 +940,7 @@ Numerics and algorithms
 * ``psatd.nox``, ``psatd.noy``, ``pstad.noz`` (`integer`) optional (default `16` for all)
     The order of accuracy of the spatial derivatives, when using the code compiled with a PSATD solver.
 
-* ``nx_guard_psatd``, ``ny_guard_psatd``, ``nz_guard_psatd`` (`integer`) optional
+* ``psatd.nx_guard`, ``psatd.ny_guard``, ``psatd.nz_guard`` (`integer`) optional
     The number of guard cells to use with PSATD solver.
     If not set by users, these values are calculated automatically and determined *empirically* and
     would be equal the order of the solver for nodal grid, and half the order of the solver for staggered.

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -26,7 +26,7 @@ guardCellManager::Init(
     const int maxwell_fdtd_solver_id,
     const int max_level,
     const amrex::Array<amrex::Real,3> v_galilean,
-    const bool exchange_all_guard_cells)
+    const bool safe_guard_cells)
 {
     // When using subcycling, the particles on the fine level perform two pushes
     // before being redistributed ; therefore, we need one extra guard cell
@@ -108,10 +108,10 @@ guardCellManager::Init(
         int ngFFt_y = do_nodal ? noy_fft : noy_fft/2.;
         int ngFFt_z = do_nodal ? noz_fft : noz_fft/2.;
 
-        ParmParse pp;
-        pp.query("nx_guard_psatd", ngFFt_x);
-        pp.query("ny_guard_psatd", ngFFt_y);
-        pp.query("nz_guard_psatd", ngFFt_z);
+        ParmParse pp("psatd");
+        pp.query("nx_guard", ngFFt_x);
+        pp.query("ny_guard", ngFFt_y);
+        pp.query("nz_guard", ngFFt_z);
 
         IntVect ngFFT = IntVect(AMREX_D_DECL(ngFFt_x, ngFFt_y, ngFFt_z));
 
@@ -144,7 +144,7 @@ guardCellManager::Init(
     ng_FieldSolverF = IntVect(AMREX_D_DECL(1,1,1));
 #endif
 
-    if (exchange_all_guard_cells){
+    if (safe_guard_cells){
         // Run in safe mode: exchange all allocated guard cells at each
         // call of FillBoundary
         ng_FieldSolver = ng_alloc_EB;

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "GuardCellManager.H"
-#include "NCIGodfreyFilter.H"
+#include "Filter/NCIGodfreyFilter.H"
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>
 
@@ -103,7 +103,6 @@ guardCellManager::Init(
         // the stencil of the FFT solver. Here, this number (`ngFFT`)
         // is determined *empirically* to be the order of the solver
         // for nodal, and half the order of the solver for staggered.
-        //IntVect ngFFT;
 
         int ngFFt_x = do_nodal ? nox_fft : nox_fft/2.;
         int ngFFt_y = do_nodal ? noy_fft : noy_fft/2.;
@@ -115,7 +114,6 @@ guardCellManager::Init(
         pp.query("nz_guard_psatd", ngFFt_z);
 
         IntVect ngFFT = IntVect(AMREX_D_DECL(ngFFt_x, ngFFt_y, ngFFt_z));
-        amrex::Print() <<"ngFFT = "<< ngFFT << "------\n"; //oshapoval
 
         for (int i_dim=0; i_dim<AMREX_SPACEDIM; i_dim++ ){
             int ng_required = ngFFT[i_dim];


### PR DESCRIPTION
Added option to have user defined number of guard cells to use with PSATD solver.
If not set by users, these values are calculated automatically and determined *empirically* and
would be equal the order of the solver for nodal grid, and half the order of the solver for staggered grid.