### PR TITLE
Ascent in situ integration: add support for particles

### DIFF
--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -50,60 +50,65 @@ performed.
 
 Visualization/Analysis Pipeline Configuration
 ---------------------------------------------
-Ascent uses the file :code:`ascent_actions.json` to configure analysis and
-visualization pipelines. For example, the following :code:`ascent_actions.json`
+Ascent uses the file :code:`ascent_actions.yaml` to configure analysis and
+visualization pipelines. 
+
+For example, the following :code:`ascent_actions.yaml`
 file extracts an isosurface of the field Ex for 15 levels and saves the
 resulting images to :code:`levels_<nnnn>.png`. `Ascent Actions
 <https://ascent.readthedocs.io/en/latest/Actions/index.html>`_ provides an
 overview over all available analysis and visualization actions.
 
 .. code-block:: json
+- 
+  action: "add_pipelines"
+  pipelines:
+    p1:
+      f1:
+        type: "contour"
+        params:
+           field: "Ex"
+           levels: 15
+- 
+  action: "add_scenes"
+  scenes: 
+    scene1: 
+      image_prefix: "levels_%04d"
+      plots: 
+        plot1: 
+          type: "pseudocolor"
+          pipeline: "p1"
+          field: "Ex"
 
-  [
-    {
-      "action": "add_pipelines",
-      "pipelines":
-      {
-        "p1":
-        {
-          "f1":
-          {
-            "type" : "contour",
-            "params" :
-            {
-              "field" : "Ex",
-              "levels": 15
-            }
-          }
-        }
-      }
-    },
-    {
-      "action": "add_scenes",
-      "scenes":
-      {
-        "s1":
-        {
-          "image_prefix": "levels_%04d",
-          "plots":
-          {
-          "p1":
-            {
-              "type": "pseudocolor",
-              "pipeline": "p1",
-              "field": "Ex"
-            }
-          }
-        }
-      }
-    },
+Here is another example that renders isosurfaces and particles: 
 
-    {
-      "action": "execute"
-    },
-
-    {
-      "action": "reset"
-    }
-  ]
-
+.. code-block:: json
+- 
+  action: "add_pipelines"
+  pipelines:
+    p1:
+      f1:
+        type: "contour"
+        params:
+           field: "Bx"
+           levels: 3
+- 
+  action: "add_scenes"
+  scenes: 
+    scene1: 
+      plots: 
+        plot1: 
+          type: "pseudocolor"
+          pipeline: "p1"
+          field: "Bx"
+        plot2: 
+          type: "pseudocolor"
+          field: "particle_electrons_Bx"
+          points: 
+            radius: 0.0000005
+      renders: 
+        r1: 
+          camera: 
+            azimuth: 100
+            elevation: 10
+          image_prefix: "out_render_3d_%06d"

--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -45,13 +45,14 @@ The supported parameters are described in the following table.
 +-------------------------+------------------------------------------------------+---------+
 
 A typical use case is setting :code:`insitu.int` to a value of one or greater and
-:code:`insitu.start` to the first time step where in situ analyswhere in situ analysis should be
+:code:`insitu.start` to the first time step where in situ analysis should be
 performed.
 
 Visualization/Analysis Pipeline Configuration
 ---------------------------------------------
 Ascent uses the file :code:`ascent_actions.yaml` to configure analysis and
-visualization pipelines.
+visualization pipelines. Ascent looks for the :code:`ascent_actions.yaml` file
+in the current working directory.
 
 For example, the following :code:`ascent_actions.yaml`
 file extracts an isosurface of the field Ex for 15 levels and saves the
@@ -80,7 +81,8 @@ overview over all available analysis and visualization actions.
           pipeline: "p1"
           field: "Ex"
 
-Here is another example that renders isosurfaces and particles:
+Here is another :code:`ascent_actions.yaml` example that renders isosurfaces
+and particles:
 
 .. code-block:: json
 -
@@ -112,3 +114,84 @@ Here is another example that renders isosurfaces and particles:
             azimuth: 100
             elevation: 10
           image_prefix: "out_render_3d_%06d"
+
+
+Finally, here is a more complex :code:`ascent_actions.yaml` example that
+creates the same images as the prior example, but adds a trigger that
+creates a Cinema Database at cycle 300:
+
+.. code-block:: json
+-
+  action: "add_triggers"
+  triggers:
+    t1:
+      params:
+        condition: "cycle() == 300"
+        actions_file: "trigger.yaml"
+-
+  action: "add_pipelines"
+  pipelines:
+    p1:
+      f1:
+        type: "contour"
+        params:
+           field: "jy"
+           iso_values: [ 1000000000000.0, -1000000000000.0]
+-
+  action: "add_scenes"
+  scenes:
+    scene1:
+      plots:
+        plot1:
+          type: "pseudocolor"
+          pipeline: "p1"
+          field: "jy"
+        plot2:
+          type: "pseudocolor"
+          field: "particle_electrons_w"
+          points:
+            radius: 0.0000002
+      renders:
+        r1:
+          camera:
+            azimuth: 100
+            elevation: 10
+          image_prefix: "out_render_jy_part_w_3d_%06d"
+
+
+When the trigger condition is meet, `cycle() == 300`, the actions in
+:code:`trigger.yaml` are also executed:
+
+.. code-block:: json
+-
+  action: "add_pipelines"
+  pipelines:
+    p1:
+      f1:
+        type: "contour"
+        params:
+           field: "jy"
+           iso_values: [ 1000000000000.0, -1000000000000.0]
+-
+  action: "add_scenes"
+  scenes:
+    scene1:
+      plots:
+        plot1:
+          type: "pseudocolor"
+          pipeline: "p1"
+          field: "jy"
+        plot2:
+          type: "pseudocolor"
+          field: "particle_electrons_w"
+          points:
+            radius: 0.0000001
+      renders:
+        r1:
+          type: "cinema"
+          phi: 10
+          theta: 10
+          db_name: "cinema_out"
+
+You can view the Cinema Database result by opening
+:code:`cinema_databases/cinema_out/index.html`.

--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -51,7 +51,7 @@ performed.
 Visualization/Analysis Pipeline Configuration
 ---------------------------------------------
 Ascent uses the file :code:`ascent_actions.yaml` to configure analysis and
-visualization pipelines. 
+visualization pipelines.
 
 For example, the following :code:`ascent_actions.yaml`
 file extracts an isosurface of the field Ex for 15 levels and saves the
@@ -60,7 +60,7 @@ resulting images to :code:`levels_<nnnn>.png`. `Ascent Actions
 overview over all available analysis and visualization actions.
 
 .. code-block:: json
-- 
+-
   action: "add_pipelines"
   pipelines:
     p1:
@@ -69,21 +69,21 @@ overview over all available analysis and visualization actions.
         params:
            field: "Ex"
            levels: 15
-- 
+-
   action: "add_scenes"
-  scenes: 
-    scene1: 
+  scenes:
+    scene1:
       image_prefix: "levels_%04d"
-      plots: 
-        plot1: 
+      plots:
+        plot1:
           type: "pseudocolor"
           pipeline: "p1"
           field: "Ex"
 
-Here is another example that renders isosurfaces and particles: 
+Here is another example that renders isosurfaces and particles:
 
 .. code-block:: json
-- 
+-
   action: "add_pipelines"
   pipelines:
     p1:
@@ -92,23 +92,23 @@ Here is another example that renders isosurfaces and particles:
         params:
            field: "Bx"
            levels: 3
-- 
+-
   action: "add_scenes"
-  scenes: 
-    scene1: 
-      plots: 
-        plot1: 
+  scenes:
+    scene1:
+      plots:
+        plot1:
           type: "pseudocolor"
           pipeline: "p1"
           field: "Bx"
-        plot2: 
+        plot2:
           type: "pseudocolor"
           field: "particle_electrons_Bx"
-          points: 
+          points:
             radius: 0.0000005
-      renders: 
-        r1: 
-          camera: 
+      renders:
+        r1:
+          camera:
             azimuth: 100
             elevation: 10
           image_prefix: "out_render_3d_%06d"

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -10,7 +10,7 @@
 #include "WarpX.H"
 #include "FieldIO.H"
 #include "SliceDiagnostic.H"
-
+:wq
 #ifdef WARPX_USE_OPENPMD
 #   include "Diagnostics/WarpXOpenPMD.H"
 #endif
@@ -471,7 +471,7 @@ WarpX::UpdateInSitu () const
             bp_mesh);
 
     // wrap particle data for each species
-    // we prefix the fields with "particle_{species_name}" b/c we 
+    // we prefix the fields with "particle_{species_name}" b/c we
     // want to to uniquely name all the fields that can be plotted
 
     std::vector<std::string> species_names = mypc->GetSpeciesNames();

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -459,6 +459,7 @@ WarpX::UpdateInSitu () const
 #endif
 
 #ifdef AMREX_USE_ASCENT
+    // wrap mesh data
     conduit::Node bp_mesh;
     MultiLevelToBlueprint(finest_level+1,
             amrex::GetVecOfConstPtrs(mf_avg),
@@ -468,6 +469,61 @@ WarpX::UpdateInSitu () const
             istep,
             refRatio(),
             bp_mesh);
+
+    // wrap particle data for each species
+    // we prefix the fields with "particle_{species_name}" b/c we 
+    // want to to uniquely name all the fields that can be plotted
+
+    std::vector<std::string> species_names = mypc->GetSpeciesNames();
+
+    for (unsigned i = 0, n = species_names.size(); i < n; ++i)
+    {
+
+        Vector<std::string> particle_varnames;
+        Vector<std::string> particle_int_varnames;
+        std::string prefix = "particle_" + species_names[i];
+
+        // Get pc for species
+        auto& pc = mypc->GetParticleContainer(i);
+
+        // get names of real comps
+        std::map<std::string, int> real_comps_map = pc.getParticleComps();
+        std::map<std::string, int>::const_iterator r_itr = real_comps_map.begin();
+
+        // TODO: Looking at other code paths, I am not sure compile time
+        //  QED field is included in getParticleComps()?
+        while (r_itr != real_comps_map.end())
+        {
+            // get next real particle name
+            std::string varname = r_itr->first;
+            particle_varnames.push_back(prefix + "_" + varname);
+            r_itr++;
+        }
+
+        // get names of int comps
+        std::map<std::string, int> int_comps_map = pc.getParticleiComps();
+        std::map<std::string, int>::const_iterator i_itr = int_comps_map.begin();
+
+        while (i_itr != int_comps_map.end())
+        {
+            // get next real particle name
+            std::string varname = i_itr->first;
+            particle_int_varnames.push_back(prefix + "_" + varname);
+            i_itr++;
+        }
+
+        // wrap pc for current species into a blueprint topology
+        amrex::ParticleContainerToBlueprint(pc,
+                                            particle_varnames,
+                                            particle_int_varnames,
+                                            bp_mesh,
+                                            prefix);
+    }
+
+    // // If you want to save blueprint HDF5 files w/o using an Ascent
+    // // extract, you can call the following AMReX helper:
+    // const auto step = istep[0];
+    // WriteBlueprintFiles(bp_mesh,"bp_export",step,"hdf5");
 
     ascent::Ascent ascent;
     conduit::Node opts;

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -10,7 +10,7 @@
 #include "WarpX.H"
 #include "FieldIO.H"
 #include "SliceDiagnostic.H"
-:wq
+
 #ifdef WARPX_USE_OPENPMD
 #   include "Diagnostics/WarpXOpenPMD.H"
 #endif


### PR DESCRIPTION
This PR adds support for wrapping WrapX particle containers so they can be published and rendered in Ascent. 

With this change Ascent can render both particles and the AMReX mesh data. 

I updated the Ascent WarpX docs with an example yaml input that shows how to render both an isosurface of the mesh and a particle field. 

This PR requires AMReX develop that includes this PR https://github.com/AMReX-Codes/amrex/pull/734 (already merged) and a recent version of Ascent. 

~~One outstanding issue: The overall UpdateInSitu code path crashes in WarpX::AverageAndPackFields for my example. (see: https://github.com/ECP-WarpX/WarpX/issues/788)~~ -> #837

I am happy to help track this issue done with more guidance.