### PR TITLE
Add AlwaysAssert with std::string message

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -559,9 +559,13 @@ MultiParticleContainer::getSpeciesID (std::string product_str)
             i_product = i;
         }
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+
+    WarpXUtilMsg::AlwaysAssert(
         found != 0,
-        "ERROR: could not find product species ID for ionization. Wrong name?");
+        "ERROR: could not find the ID of product species '"
+        + product_str + "'" + ". Wrong name?"
+    );
+
     return i_product;
 }
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -137,7 +137,7 @@ namespace WarpXUtilMsg{
  * @param[in] expression
  * @param[in] msg the string to be printed if expression is == 0 (default value is "ERROR!")
  */
-void AlwaysAssert(int expression, const std::string& msg);
+void AlwaysAssert(bool expression, const std::string& msg);
 
 }
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -132,12 +132,12 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
 
 namespace WarpXUtilMsg{
 
-/** \brief If expression is == 0, this function prints msg and calls amrex::abort()
+/** \brief If is_expression_true is false, this function prints msg and calls amrex::abort()
  *
- * @param[in] expression
- * @param[in] msg the string to be printed if expression is == 0 (default value is "ERROR!")
+ * @param[in] is_expression_true
+ * @param[in] msg the string to be printed if is_expression_true is false (default value is "ERROR!")
  */
-void AlwaysAssert(bool expression, const std::string& msg);
+void AlwaysAssert(bool is_expression_true, const std::string& msg);
 
 }
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -130,4 +130,15 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
 */
 WarpXParser makeParser (std::string const& parse_function, std::vector<std::string> const& varnames);
 
+namespace WarpXUtilMsg{
+
+/** \brief If expression is == 0, this function prints msg and calls amrex::abort()
+ *
+ * @param[in] expression
+ * @param[in] msg the string to be printed if expression is == 0 (default value is "ERROR!")
+ */
+void AlwaysAssert(int expression, const std::string& msg);
+
+}
+
 #endif //WARPX_UTILS_H_

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -216,9 +216,9 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
 
 namespace WarpXUtilMsg{
 
-void AlwaysAssert(bool expression, const std::string& msg = "ERROR!")
+void AlwaysAssert(bool is_expression_true, const std::string& msg = "ERROR!")
 {
-    if(expression != 0) return;
+    if(is_expression_true) return;
 
     amrex::Abort(msg);
 }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -216,7 +216,7 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
 
 namespace WarpXUtilMsg{
 
-void AlwaysAssert(int expression, const std::string& msg = "ERROR!")
+void AlwaysAssert(bool expression, const std::string& msg = "ERROR!")
 {
     if(expression != 0) return;
 
@@ -224,4 +224,3 @@ void AlwaysAssert(int expression, const std::string& msg = "ERROR!")
 }
 
 }
-

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -213,3 +213,15 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
     }
     return parser;
 }
+
+namespace WarpXUtilMsg{
+
+void AlwaysAssert(int expression, const std::string& msg = "ERROR!")
+{
+    if(expression != 0) return;
+
+    amrex::Abort(msg);
+}
+
+}
+


### PR DESCRIPTION
This PR adds an `AlwaysAssert` function to replace `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` when printing an `std::string` composed at runtime is desirable (see this conversation with @atmyers  at https://github.com/AMReX-Codes/amrex/issues/737 ). 

In order to test this new function, I have replaced an `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` in `MultiParticleContainer`. Now the code can print error messages like:
`amrex::Abort::0::ERROR: could not find the ID of product species 'electron'. Wrong name? !!!`

I think that similar error messages could be useful for a user...