### PR TITLE
Add note on realclean on GPU systems

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -25,16 +25,15 @@ Then, ``cd`` into the directory ``WarpX`` and use the following set of commands 
 
 See :doc:`../running_cpp/platforms` for more information on how to run WarpX on Summit.
 
-.. note:
-   
+.. note::
    If you want to recompile the code, please add the GPU option to realclean:
-   
+
    ::
 
-   module load gcc
-   module load cuda
-   make realclean USE_GPU=TRUE
-   make -j 4 USE_GPU=TRUE
+      module load gcc
+      module load cuda
+      make realclean USE_GPU=TRUE
+      make -j 4 USE_GPU=TRUE
 
 See :doc:`../visualization/yt` for more information on how to visualize the simulation results. In order to build yt **and** a Python environment, you can download the yt installation script as explained in section "All-in-One Installation Script" of the `yt installation web page <https://yt-project.org/doc/installing.html>`__, and run
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -25,6 +25,17 @@ Then, ``cd`` into the directory ``WarpX`` and use the following set of commands 
 
 See :doc:`../running_cpp/platforms` for more information on how to run WarpX on Summit.
 
+.. note:
+   
+   If you want to recompile the code, please add the GPU option to realclean:
+   
+   ::
+
+   module load gcc
+   module load cuda
+   make realclean USE_GPU=TRUE
+   make -j 4 USE_GPU=TRUE
+
 See :doc:`../visualization/yt` for more information on how to visualize the simulation results. In order to build yt **and** a Python environment, you can download the yt installation script as explained in section "All-in-One Installation Script" of the `yt installation web page <https://yt-project.org/doc/installing.html>`__, and run
 
 .. code-block:: sh


### PR DESCRIPTION
Hi,
This small PR is just to let the users know that to clean the makefile for GPUs requires the use of the extra flag `USE_GPU=TRUE`. Otherwise the code can fail to compile.
Changed 1 file:
- Docs/source/building/summit.rst (to include the note)

Cheers,
Diana