### PR TITLE
Correct misprint in documentation

### DIFF
--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -42,7 +42,7 @@ Field solver
 
 The field solver is performed in ``WarpX::EvolveE`` for the electric field and ``WarpX::EvolveB`` for the magnetic field, called from ``WarpX::OneStep_nosub`` in ``WarpX::EvolveEM``. This section describes the FDTD field push. It is implemented in ``Source/FieldSolver/FiniteDifferenceSolver/``.
 
-As all cell-wise operation, the field push is done as follows (this is split in multiple functions in the actual implementation to aboid code duplication)
+As all cell-wise operation, the field push is done as follows (this is split in multiple functions in the actual implementation to avoid code duplication)
 :
 
 .. code-block:: cpp


### PR DESCRIPTION
This extremely small PR corrects a minor misprint in the documentation