### PR TITLE
AMReX Change in BaseFab

### DIFF
--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -620,7 +620,7 @@ WarpX::AverageAndPackFields ( Vector<std::string>& varnames,
 #pragma omp parallel
 #endif
                 for (MFIter mfi(mf_avg[lev]); mfi.isValid(); ++mfi) {
-                    (mf_avg[lev])[mfi].setVal(static_cast<Real>(npart_in_grid[mfi.index()]));
+                    (mf_avg[lev])[mfi].setVal<RunOn::Host>(static_cast<Real>(npart_in_grid[mfi.index()]));
                 }
                 dcomp++;
             } else if (fieldname == "part_per_proc"){
@@ -926,7 +926,7 @@ getInterpolatedScalar(
 
             // Add temporary array to the returned structure
             const Box& bx = (*interpolated_F)[mfi].box();
-            (*interpolated_F)[mfi].plus(ffab, bx, bx, 0, 0, 1);
+            (*interpolated_F)[mfi].plus<RunOn::Host>(ffab, bx, bx, 0, 0, 1);
         }
     }
     return interpolated_F;
@@ -1027,7 +1027,7 @@ getInterpolatedVector(
             // Add temporary array to the returned structure
             for (int i = 0; i < 3; ++i) {
                 const Box& bx = (*interpolated_F[i])[mfi].box();
-                (*interpolated_F[i])[mfi].plus(ffab[i], bx, bx, 0, 0, 1);
+                (*interpolated_F[i])[mfi].plus<RunOn::Host>(ffab[i], bx, bx, 0, 0, 1);
             }
         }
     }


### PR DESCRIPTION
Because of AMReX change, we now have to explicitly specify where BaseFab functions should run when compiling for GPU.  This pull-request does not change the behavior of the code.

This pull-request should not be merged until the AMReX change is merged on March 16.
