### PR TITLE
Small fixes to Python to better handle particle weights

### DIFF
--- a/Python/pywarpx/PGroup.py
+++ b/Python/pywarpx/PGroup.py
@@ -28,7 +28,7 @@ class PGroup(object):
 
         self.sm = np.zeros(self.ns) # Species mass [kg]
         self.sq = np.zeros(self.ns) # Species charge [C]
-        self.sw = np.zeros(self.ns) # Species weight, (real particles per simulation particles)
+        self.sw = np.ones(self.ns) # Species weight, (real particles per simulation particles)
 
         self.sid = np.arange(self.ns, dtype=int) # Global species index for each species
         self.ndts = np.ones(self.ns, dtype=int) # Stride for time step advance for each species
@@ -110,11 +110,12 @@ class PGroup(object):
         return _libwarpx.get_particle_uz(self.ispecie, self.level)[self.igroup]
     uzp = property(getuzp)
 
-    def getpid(self):
-        id = _libwarpx.get_particle_id(self.ispecie, self.level)[self.igroup]
-        pid = np.array([id]).T
-        return pid
-    pid = property(getpid)
+    def getw(self):
+        return _libwarpx.get_particle_weight(self.ispecie, self.level)[self.igroup]
+
+    def getpid(self, id):
+        pid = _libwarpx.get_particle_arrays(self.ispecie, id, self.level)[self.igroup]
+        return np.array([pid]).T
 
     def getgaminv(self):
         uxp = self.getuxp()

--- a/Python/pywarpx/WarpInterface.py
+++ b/Python/pywarpx/WarpInterface.py
@@ -8,6 +8,8 @@ import warp
 from . import fields
 from pywarpx import PGroup
 
+# The particle weight is always the first pid
+warp.top.wpid = 1
 
 def warp_species(warp_type, picmi_species, level=0):
     """Returns a Warp species that has a reference to the WarpX particles.


### PR DESCRIPTION
With these fixes, the particle weights can be accessed via the Warp species interface, using the getw method.