### PR TITLE
openPMD-api: 0.11.0+

### DIFF
--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -9,7 +9,7 @@ therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library 0.10.3a or newer <https://openpmd-api.readthedocs.io/en/0.10.3-alpha/>`__
+`openPMD-api library 0.11.0a or newer <https://openpmd-api.readthedocs.io/en/0.11.0-alpha/>`__
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -196,12 +196,7 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType)
     uint32_t const openPMD_ED_PIC = 1u;
     m_Series->setOpenPMDextension( openPMD_ED_PIC );
     // meta info
-#if (OPENPMDAPI_VERSION_MAJOR>=0) && (OPENPMDAPI_VERSION_MINOR>=11)
     m_Series->setSoftware( "WarpX", WarpX::Version() );
-#else
-    m_Series->setSoftware( "WarpX" );
-    m_Series->setSoftwareVersion( WarpX::Version() );
-#endif
 }
 
 

--- a/Source/Diagnostics/requirements.txt
+++ b/Source/Diagnostics/requirements.txt
@@ -5,4 +5,4 @@
 # License: BSD-3-Clause-LBNL
 
 # keep this entry for GitHub's dependency graph
-openPMD-api>=0.10.3
+openPMD-api>=0.11.0

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -130,7 +130,7 @@ endif
 
 ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
-   ifeq (0, $(shell pkg-config "openPMD >= 0.10.3"; echo $$?))
+   ifeq (0, $(shell pkg-config "openPMD >= 0.11.0"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
        libraries += $(shell pkg-config --libs-only-l openPMD)


### PR DESCRIPTION
Upgrade the dependency of openPMD-api to 0.11.0 or newer.
This version has all defaults for independent I/O with HDF5, ADIOS1 (and as before in ADIOS2) in place.

Changelog: https://openpmd-api.readthedocs.io/en/0.11.0-alpha/install/changelog.html
Upgrade Guide: https://openpmd-api.readthedocs.io/en/0.11.0-alpha/install/upgrade.html