### PR TITLE
Add tutorial slides to developers section

### DIFF
--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -183,4 +183,4 @@ primary_domain = 'cpp'
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = 'cpp'
 
-subprocess.call('cd ../; doxygen; mkdir -p source/_static; cp -r doxyhtml source/_static/', shell=True)
+subprocess.call('cd ../; doxygen; mkdir -p source/_static; cp -r doxyhtml source/_static/ ; cp source/developers/material/WarpX_tutorial.pdf source/_static/', shell=True)

--- a/Docs/source/developers/developers.rst
+++ b/Docs/source/developers/developers.rst
@@ -22,3 +22,5 @@ Our Doxygen API documentation in classic formatting `is located here <../_static
    testing
    documentation
    workflow
+
+See also the `WarpX tutorial slides <../_static/WarpX_tutorial.pdf>`_.

--- a/Docs/source/developers/developers.rst
+++ b/Docs/source/developers/developers.rst
@@ -5,6 +5,8 @@ Developers documentation
 
 For general information on how to contribute to WarpX, including our ``git`` workflow and code practices, have a look at our `CONTRIBUTING.md <https://github.com/ECP-WarpX/WarpX/blob/master/CONTRIBUTING.md>`__!
 
+A general overview of the code structure can be found in the `WarpX tutorial presentation <../_static/WarpX_tutorial.pdf>`_. It contains information about the code structure, a step-by-step description of what happens in a simulation (initialization and iterations) as well as topical slides on topics relevant to WarpX development.
+
 Our Doxygen API documentation in classic formatting `is located here <../_static/doxyhtml/index.html>`_.
 
 .. toctree::
@@ -22,5 +24,3 @@ Our Doxygen API documentation in classic formatting `is located here <../_static
    testing
    documentation
    workflow
-
-See also the `WarpX tutorial slides <../_static/WarpX_tutorial.pdf>`_.

--- a/Docs/source/developers/developers.rst
+++ b/Docs/source/developers/developers.rst
@@ -5,7 +5,7 @@ Developers documentation
 
 For general information on how to contribute to WarpX, including our ``git`` workflow and code practices, have a look at our `CONTRIBUTING.md <https://github.com/ECP-WarpX/WarpX/blob/master/CONTRIBUTING.md>`__!
 
-A general overview of the code structure can be found in the `WarpX tutorial presentation <../_static/WarpX_tutorial.pdf>`_. It contains information about the code structure, a step-by-step description of what happens in a simulation (initialization and iterations) as well as topical slides on topics relevant to WarpX development.
+A general overview of the code structure can be found in the `WarpX tutorial presentation <../_static/WarpX_tutorial.pdf>`_. It contains information about the code structure, a step-by-step description of what happens in a simulation (initialization and iterations) as well as slides on topics relevant to WarpX development.
 
 Our Doxygen API documentation in classic formatting `is located here <../_static/doxyhtml/index.html>`_.
 


### PR DESCRIPTION
These slides were presented at a few WarpX tutorial sessions, they can be useful material for any interested developer.

The pdf is located in `Docs/source/developers/material/` and copied to `source/_static/`, just like the Doxygen doc, to be available on RTD.