### PR TITLE
Diagnostics: Implicit Int Conversion Warning

### DIFF
--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -49,8 +49,9 @@ void LoadBalanceCosts::ComputeDiags (int step)
     m_nBoxesMax = std::max(m_nBoxesMax, nBoxes);
 
     // resize and clear data array
-    m_data.resize(m_nDataFields*nBoxes, 0.0);
-    m_data.assign(m_nDataFields*nBoxes, 0.0);
+    const size_t m_dataSize = m_nDataFields*nBoxes;
+    m_data.resize(m_dataSize, 0.0);
+    m_data.assign(m_dataSize, 0.0);
 
     // read in WarpX costs_heuristic to local copy
     amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > > costs_heuristic;

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -49,9 +49,9 @@ void LoadBalanceCosts::ComputeDiags (int step)
     m_nBoxesMax = std::max(m_nBoxesMax, nBoxes);
 
     // resize and clear data array
-    const size_t m_dataSize = m_nDataFields*nBoxes;
-    m_data.resize(m_dataSize, 0.0);
-    m_data.assign(m_dataSize, 0.0);
+    const size_t dataSize = m_nDataFields*nBoxes;
+    m_data.resize(dataSize, 0.0);
+    m_data.assign(dataSize, 0.0);
 
     // read in WarpX costs_heuristic to local copy
     amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > > costs_heuristic;


### PR DESCRIPTION
This is identical to PR #840 (closed) but with the same commit history as the master branch.

PR #790 introduced two overflow alerts:

> 2 for Multiplication result converted to larger type

This small PR fixes the potential overflow issues.