### PR TITLE
Initialize fields in guard cells when using external grid function

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -475,9 +475,9 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
     const RealBox& real_box = geom[lev].ProbDomain();
     for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-       const Box& tbx = mfi.tilebox(x_nodal_flag);
-       const Box& tby = mfi.tilebox(y_nodal_flag);
-       const Box& tbz = mfi.tilebox(z_nodal_flag);
+       const Box& tbx = convert(mfi.growntilebox(),x_nodal_flag);
+       const Box& tby = convert(mfi.growntilebox(),y_nodal_flag);
+       const Box& tbz = convert(mfi.growntilebox(),z_nodal_flag);
 
        auto const& mfxfab = mfx->array(mfi);
        auto const& mfyfab = mfy->array(mfi);


### PR DESCRIPTION
I stumbled upon a (probably) rare bug. When using an external field via the following line in the input file, `warpx.E_ext_grid_init_style = parse_E_ext_grid_function`, the fields are not initialized in the guard cells in `WarpXInitData.cpp`.

Now, if the code is compiled in debug mode and if there are no specified boundary conditions (i.e. `geometry.is_periodic = 0     0` and  `warpx.do_pml = 0`) the fields will actually be NaNs in the guard cells, which can cause the code to crash when particles are present (even more so when using PSATD since in this case the NaNs quickly propagate in the non guard cells). This can also occur with periodic boundary conditions if the number of guard cells exceeds the total number of non guard cells in one direction (this is essentially triggered with PSATD and very small simulations).

Although this issue is probably quite rare, I guess it should be fixed. What worked for me, and is proposed in this PR, is simply to replace `mfi.tilebox()` by `mfi.growntilebox()` in the function `WarpX::InitializeExternalFieldsOnGridUsingParser` so that the fields are also initialized in the guard cells.

Do you think that's a viable solution?  