### PR TITLE
[Tiny PR] Ignore python build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ chk*
 ##########
 *.pyc
 __pycache__
+Python/build/
+Python/dist/
+Python/pywarpx.egg-info/
 
 ##########
 # Sphinx #


### PR DESCRIPTION
Hi all,
This tiny PR is just so the build output of compiling WarpX with python is ignored by git.
In it, the build folders were to the file `.gitignore`.
Please feel free to neglect/close this PR if there are reasons for not ignoring these folders.
Thanks,
Diana