### PR TITLE
[mini-PR] Fix energy calculation for photons in reduced diagnostics

### DIFF
--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -7,7 +7,7 @@
 # License: BSD-3-Clause-LBNL
 
 # This script tests the reduced diagnostics.
-# The setup is a uniform plasma with electrons and protons.
+# The setup is a uniform plasma with electrons, protons and photons.
 # Particle energy and field energy will be outputed
 # using the reduced diagnostics.
 # And they will be compared with the data in the plotfiles.
@@ -44,6 +44,13 @@ py = ad['protons','particle_momentum_y'].to_ndarray()
 pz = ad['protons','particle_momentum_z'].to_ndarray()
 w  = ad['protons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt((px**2+py**2+pz**2)*scc.c**2+scc.m_p**2*scc.c**4)-scc.m_p*scc.c**2)*w )
+
+# photon
+px = ad['photons','particle_momentum_x'].to_ndarray()
+py = ad['photons','particle_momentum_y'].to_ndarray()
+pz = ad['photons','particle_momentum_z'].to_ndarray()
+w  = ad['photons','particle_weight'].to_ndarray()
+EPyt = EPyt + np.sum( (np.sqrt(px**2+py**2+pz**2)*scc.c)*w )
 
 ad = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
 Ex = ad['Ex'].to_ndarray()

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -36,8 +36,9 @@ warpx.cfl = 0.99999
 amr.plot_int = 200
 
 # Particles
-particles.nspecies = 2
-particles.species_names = electrons protons
+particles.nspecies = 3
+particles.species_names = electrons protons photons
+particles.photon_species = photons
 
 electrons.charge = -q_e
 electrons.mass = m_e
@@ -60,6 +61,16 @@ protons.momentum_distribution_type = gaussian
 protons.ux_th = 0.
 protons.uy_th = 0.
 protons.uz_th = 0.
+
+photons.species_type = "photon"
+photons.injection_style = "NUniformPerCell"
+photons.num_particles_per_cell_each_dim = 1 1 1
+photons.profile = constant
+photons.density = 1.e14   # number of protons per m^3
+photons.momentum_distribution_type = gaussian
+photons.ux_th = 0.2
+photons.uy_th = 0.2
+photons.uz_th = 0.2
 
 #################################
 ###### REDUCED DIAGS ############

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -130,11 +130,11 @@ void ParticleEnergy::ComputeDiags (int step)
             Etot = ReduceSum( myspc,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                auto w  = p.rdata(PIdx::w);
-                auto ux = p.rdata(PIdx::ux);
-                auto uy = p.rdata(PIdx::uy);
-                auto uz = p.rdata(PIdx::uz);
-                auto us = (ux*ux + uy*uy + uz*uz);
+                const auto w  = p.rdata(PIdx::w);
+                const auto ux = p.rdata(PIdx::ux);
+                const auto uy = p.rdata(PIdx::uy);
+                const auto uz = p.rdata(PIdx::uz);
+                const auto us = ux*ux + uy*uy + uz*uz;
                 return ( std::sqrt(us*c2 + c2*c2) - c2 ) * m * w;
             });
         }

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -119,11 +119,11 @@ void ParticleEnergy::ComputeDiags (int step)
             Etot = ReduceSum( myspc,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                auto w  = p.rdata(PIdx::w);
-                auto ux = p.rdata(PIdx::ux);
-                auto uy = p.rdata(PIdx::uy);
-                auto uz = p.rdata(PIdx::uz);
-                auto us = (ux*ux + uy*uy + uz*uz);
+                const auto w  = p.rdata(PIdx::w);
+                const auto ux = p.rdata(PIdx::ux);
+                const auto uy = p.rdata(PIdx::uy);
+                const auto uz = p.rdata(PIdx::uz);
+                const auto us = ux*ux + uy*uy + uz*uz;
                 return std::sqrt(us) * me_c * w;
             });
         } else {

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -114,8 +114,8 @@ void ParticleEnergy::ComputeDiags (int step)
         if(myspc.AmIA<PhysicalSpecies::photon>()){
             //Photons have m = 0, but ux,uy and uz are calculated assuming
             //a mass equal to the electron mass. Therefore, photons need a special
-            //tretment to calculate the total energy.
-            const auto me2 = PhysConst::m_e * PhysConst::m_e;
+            //treatment to calculate the total energy.
+            constexpr auto me_c = PhysConst::m_e * PhysConst::c;
             Etot = ReduceSum( myspc,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
@@ -123,8 +123,8 @@ void ParticleEnergy::ComputeDiags (int step)
                 auto ux = p.rdata(PIdx::ux);
                 auto uy = p.rdata(PIdx::uy);
                 auto uz = p.rdata(PIdx::uz);
-                auto us = (ux*ux + uy*uy + uz*uz)*me2;
-                return std::sqrt(us*c2*me2) * w;
+                auto us = (ux*ux + uy*uy + uz*uz);
+                return std::sqrt(us) * me_c * w;
             });
         } else {
             Etot = ReduceSum( myspc,

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -110,16 +110,34 @@ void ParticleEnergy::ComputeDiags (int step)
         // Use amex::ReduceSum to compute the sum of energies of all particles
         // held by the current MPI rank, for this species. This involves a loop over all
         // boxes held by this MPI rank.
-        auto Etot = ReduceSum( myspc,
-        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
-        {
-            auto w  = p.rdata(PIdx::w);
-            auto ux = p.rdata(PIdx::ux);
-            auto uy = p.rdata(PIdx::uy);
-            auto uz = p.rdata(PIdx::uz);
-            auto us = (ux*ux + uy*uy + uz*uz);
-            return ( std::sqrt(us*c2 + c2*c2) - c2 ) * m * w;
-        });
+        Real Etot = 0.0_rt;
+        if(myspc.AmIA<PhysicalSpecies::photon>()){
+            //Photons have m = 0, but ux,uy and uz are calculated assuming
+            //a mass equal to the electron mass. Therefore, photons need a special
+            //tretment to calculate the total energy.
+            const auto me2 = PhysConst::m_e * PhysConst::m_e;
+            Etot = ReduceSum( myspc,
+            [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+            {
+                auto w  = p.rdata(PIdx::w);
+                auto ux = p.rdata(PIdx::ux);
+                auto uy = p.rdata(PIdx::uy);
+                auto uz = p.rdata(PIdx::uz);
+                auto us = (ux*ux + uy*uy + uz*uz)*me2;
+                return std::sqrt(us*c2*me2) * w;
+            });
+        } else {
+            Etot = ReduceSum( myspc,
+            [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+            {
+                auto w  = p.rdata(PIdx::w);
+                auto ux = p.rdata(PIdx::ux);
+                auto uy = p.rdata(PIdx::uy);
+                auto uz = p.rdata(PIdx::uz);
+                auto us = (ux*ux + uy*uy + uz*uz);
+                return ( std::sqrt(us*c2 + c2*c2) - c2 ) * m * w;
+            });
+        }
 
         // Same thing for the particles weights.
         auto Wtot = ReduceSum( myspc,


### PR DESCRIPTION
Photon particles have `m=0`, but `ux, uy, uz` in the code are calculated assuming a mass equal to the electron mass. This was not taken into account when calculating particle energy in reduced diagnostics. This PR should fix the bug.

I've also added photon particles to the reduced diagnostics test.