### PR TITLE
[mini-PR] Clarifying ionizable particle charge

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -254,6 +254,7 @@ Particle initialization
 * ``<species_name>.charge`` (`float`) optional (default `NaN`)
     The charge of one `physical` particle of this species.
     If ``species_type`` is specified, the charge will be set to the physical value and ``charge`` is optional.
+    When ``<species>.do_field_ionization = 1``, the physical particle charge is equal to ``ionization_initial_level`` x ``charge``, so latter parameter should be equal to q_e (which is defined in WarpX as the elementary charge in coulombs).
 
 * ``<species_name>.mass`` (`float`) optional (default `NaN`)
     The mass of one `physical` particle of this species.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -254,7 +254,7 @@ Particle initialization
 * ``<species_name>.charge`` (`float`) optional (default `NaN`)
     The charge of one `physical` particle of this species.
     If ``species_type`` is specified, the charge will be set to the physical value and ``charge`` is optional.
-    When ``<species>.do_field_ionization = 1``, the physical particle charge is equal to ``ionization_initial_level`` x ``charge``, so latter parameter should be equal to q_e (which is defined in WarpX as the elementary charge in coulombs).
+    When ``<species>.do_field_ionization = 1``, the physical particle charge is equal to ``ionization_initial_level * charge``, so latter parameter should be equal to q_e (which is defined in WarpX as the elementary charge in coulombs).
 
 * ``<species_name>.mass`` (`float`) optional (default `NaN`)
     The mass of one `physical` particle of this species.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -56,6 +56,7 @@ class Species(picmistandard.PICMI_Species):
                     assert self.charge_state <= element.number, Exception('%s charge state not valid'%self.particle_type)
                     try:
                         element = element.ion[self.charge_state]
+                        self.charge = 'q_e'
                     except ValueError:
                         # Note that not all valid charge states are defined in elements,
                         # so this value error can be ignored.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -56,7 +56,6 @@ class Species(picmistandard.PICMI_Species):
                     assert self.charge_state <= element.number, Exception('%s charge state not valid'%self.particle_type)
                     try:
                         element = element.ion[self.charge_state]
-                        self.charge = 'q_e'
                     except ValueError:
                         # Note that not all valid charge states are defined in elements,
                         # so this value error can be ignored.
@@ -92,6 +91,7 @@ class Species(picmistandard.PICMI_Species):
             self.species.physical_element=self.particle_type
             self.species.ionization_product_species = interaction[2].name
             self.species.ionization_initial_level = self.charge_state
+            self.species.charge = 'q_e'
 
 picmistandard.PICMI_MultiSpecies.Species_class = Species
 class MultiSpecies(picmistandard.PICMI_MultiSpecies):


### PR DESCRIPTION
Hi all,

This small PR precises the definition of ``<species>.charge`` for a species that can be tunnel ionized in WarpX.

In it I changed:
* **Docs/source/running_cpp/parameters.rst** - to explain that when ionization is activated for the species, charge is equal to q_e instead of the physical particle charge value.
* **Python/pywarpx/picmi.py** - to correctly generate that species' charge.

Without this PR, when trying to simulate an ion species with ``<species>. ionization_ initial _level`` greater than 1 that can be ionized, the code generates the warning:
https://github.com/ECP-WarpX/WarpX/blob/f8d2179f34816a36a8db3b5ba3bee937a7478a5f/Source/Particles/PhysicalParticleContainer.cpp#L2146-L2150
and overwrites the `picmi` generated input file value for ``<species>.charge``.
In this case, the physical ion charge is equal to ``<species>. ionization_ initial _level``x``<species>.charge``.

Please feel free to change the description and correct these changes.

Thanks,
Diana