### PR TITLE
[Tiny-PR] Added blocking factor in picmi

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -331,6 +331,7 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
         pywarpx.amr.max_grid_size = self.max_grid_size
+        pywarpx.amr.blocking_factor = self.blocking_factor
 
         assert self.lower_bound[0] >= 0., Exception('Lower radial boundary must be >= 0.')
         assert self.bc_rmin != 'periodic' and self.bc_rmax != 'periodic', Exception('Radial boundaries can not be periodic')
@@ -373,6 +374,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
         pywarpx.amr.max_grid_size = self.max_grid_size
+        pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry
         pywarpx.geometry.coord_sys = 0  # Cartesian
@@ -411,7 +413,6 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
         pywarpx.amr.max_grid_size = self.max_grid_size
-
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry


### PR DESCRIPTION
Hi all,
This small PR allows us to use `picmi` to generate a WarpX input containing the ``amr.blocking_factor`` entry also in the RZ and 2D geometries.

The changes were done to ``Python/pywarpx/picmi.py`` file and tested with the script below:
[script_picmi.txt](https://github.com/ECP-WarpX/WarpX/files/4396210/script_picmi.txt)

Cheers,
Diana