### PR TITLE
Make Build System: No Public Includes

### DIFF
--- a/Source/BoundaryConditions/Make.package
+++ b/Source/BoundaryConditions/Make.package
@@ -1,5 +1,4 @@
 CEXE_sources += PML.cpp WarpXEvolvePML.cpp
-CEXE_headers += PML.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/BoundaryConditions
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/BoundaryConditions

--- a/Source/Diagnostics/ComputeDiagFunctors/Make.package
+++ b/Source/Diagnostics/ComputeDiagFunctors/Make.package
@@ -1,18 +1,7 @@
-CEXE_headers += ComputeDiagFunctor.H
-
-CEXE_headers += CellCenterFunctor.H
 CEXE_sources += CellCenterFunctor.cpp
-
-CEXE_headers += PartPerCellFunctor.H
 CEXE_sources += PartPerCellFunctor.cpp
-
-CEXE_headers += PartPerGridFunctor.H
 CEXE_sources += PartPerGridFunctor.cpp
-
-CEXE_headers += DivBFunctor.H
 CEXE_sources += DivBFunctor.cpp
-
-CEXE_headers += DivEFunctor.H
 CEXE_sources += DivEFunctor.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/ComputeDiagFunctors

--- a/Source/Diagnostics/FlushFormats/Make.package
+++ b/Source/Diagnostics/FlushFormats/Make.package
@@ -1,6 +1,3 @@
-CEXE_headers += FlushFormat.H
-
-CEXE_headers += FlushFormatPlotfile.H
 CEXE_sources += FlushFormatPlotfile.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/FlushFormats

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -1,17 +1,11 @@
 CEXE_sources += MultiDiagnostics.cpp
 CEXE_sources += Diagnostics.cpp
 CEXE_sources += FullDiagnostics.cpp
-CEXE_headers += Diagnostics.H
-CEXE_headers += FullDiagnostics.H
-CEXE_headers += MultiDiagnostics.H
 CEXE_sources += WarpXIO.cpp
 CEXE_sources += BackTransformedDiagnostic.cpp
 CEXE_sources += ParticleIO.cpp
 CEXE_sources += FieldIO.cpp
 CEXE_sources += SliceDiagnostic.cpp
-CEXE_headers += FieldIO.H
-CEXE_headers += BackTransformedDiagnostic.H
-CEXE_headers += SliceDiagnostic.H
 
 ifeq ($(USE_OPENPMD), TRUE)
   CEXE_sources += WarpXOpenPMD.cpp

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -1,22 +1,9 @@
-CEXE_headers += MultiReducedDiags.H
 CEXE_sources += MultiReducedDiags.cpp
-
-CEXE_headers += ReducedDiags.H
 CEXE_sources += ReducedDiags.cpp
-
-CEXE_headers += ParticleEnergy.H
 CEXE_sources += ParticleEnergy.cpp
-
-CEXE_headers += FieldEnergy.H
 CEXE_sources += FieldEnergy.cpp
-
-CEXE_headers += BeamRelevant.H
 CEXE_sources += BeamRelevant.cpp
-
-CEXE_headers += LoadBalanceCosts.H
 CEXE_sources += LoadBalanceCosts.cpp
-
-CEXE_headers += ParticleHistogram.H
 CEXE_sources += ParticleHistogram.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags

--- a/Source/Evolve/Make.package
+++ b/Source/Evolve/Make.package
@@ -1,4 +1,3 @@
-CEXE_headers += WarpXDtType.H
 CEXE_sources += WarpXEvolve.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Evolve

--- a/Source/FieldSolver/FiniteDifferenceSolver/Make.package
+++ b/Source/FieldSolver/FiniteDifferenceSolver/Make.package
@@ -1,4 +1,3 @@
-CEXE_headers += FiniteDifferenceSolver.H
 CEXE_sources += FiniteDifferenceSolver.cpp
 CEXE_sources += EvolveB.cpp
 CEXE_sources += EvolveE.cpp

--- a/Source/FieldSolver/Make.package
+++ b/Source/FieldSolver/Make.package
@@ -1,4 +1,3 @@
-CEXE_headers += WarpX_FDTD.H
 CEXE_sources += WarpXPushFieldsEM.cpp
 CEXE_sources += ElectrostaticSolver.cpp
 CEXE_sources += WarpX_QED_Field_Pushers.cpp

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/Make.package
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/Make.package
@@ -1,4 +1,3 @@
-CEXE_headers += PicsarHybridFFTData.H
 CEXE_sources += PicsarHybridSpectralSolver.cpp
 F90EXE_sources += picsar_hybrid_spectral.F90
 

--- a/Source/FieldSolver/SpectralSolver/Make.package
+++ b/Source/FieldSolver/SpectralSolver/Make.package
@@ -1,8 +1,5 @@
-CEXE_headers += SpectralSolver.H
 CEXE_sources += SpectralSolver.cpp
-CEXE_headers += SpectralFieldData.H
 CEXE_sources += SpectralFieldData.cpp
-CEXE_headers += SpectralKSpace.H
 CEXE_sources += SpectralKSpace.cpp
 
 include $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package
@@ -1,12 +1,6 @@
-CEXE_headers += SpectralBaseAlgorithm.H
 CEXE_sources += SpectralBaseAlgorithm.cpp
-CEXE_headers += PsatdAlgorithm.H
 CEXE_sources += PsatdAlgorithm.cpp
-
-CEXE_headers += GalileanAlgorithm.H
 CEXE_sources += GalileanAlgorithm.cpp
-
-CEXE_headers += PMLPsatdAlgorithm.H
 CEXE_sources += PMLPsatdAlgorithm.cpp
 
 

--- a/Source/Filter/Make.package
+++ b/Source/Filter/Make.package
@@ -1,9 +1,6 @@
-CEXE_headers += Filter.H
 CEXE_sources += Filter.cpp
 CEXE_sources += BilinearFilter.cpp
-CEXE_headers += BilinearFilter.H
 CEXE_sources += NCIGodfreyFilter.cpp
-CEXE_headers += NCIGodfreyFilter.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Filter
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Filter

--- a/Source/FortranInterface/Make.package
+++ b/Source/FortranInterface/Make.package
@@ -1,4 +1,2 @@
-CEXE_headers   += WarpX_f.H
-
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FortranInterface
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FortranInterface

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -1,18 +1,7 @@
 CEXE_sources += WarpXInitData.cpp
-
 CEXE_sources += PlasmaInjector.cpp
-CEXE_headers += PlasmaInjector.H
-
-CEXE_headers += InjectorPosition.H
-
-CEXE_headers += InjectorDensity.H
 CEXE_sources += InjectorDensity.cpp
-
-CEXE_headers += InjectorMomentum.H
 CEXE_sources += InjectorMomentum.cpp
-
-CEXE_headers += CustomDensityProb.H
-CEXE_headers += CustomMomentumProb.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Initialization
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Initialization

--- a/Source/Laser/Make.package
+++ b/Source/Laser/Make.package
@@ -1,7 +1,4 @@
-CEXE_headers += LaserParticleContainer.H
 CEXE_sources += LaserParticleContainer.cpp
-CEXE_headers += LaserProfiles.H
-CEXE_headers += LaserAntennaParams.H
 
 include $(WARPX_HOME)/Source/Laser/LaserProfilesImpl/Make.package
 

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -194,7 +194,6 @@ endif
 
 # job_info support
 CEXE_sources += AMReX_buildInfo.cpp
-CEXE_headers += $(AMREX_HOME)/Tools/C_scripts/AMReX_buildInfo.H
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Tools/C_scripts
 
 ifeq ($(USE_PYTHON_MAIN),TRUE)

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -3,7 +3,6 @@ ifneq ($(USE_PYTHON_MAIN),TRUE)
 endif
 
 CEXE_sources += WarpX.cpp
-CEXE_headers += WarpX.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source

--- a/Source/Parallelization/Make.package
+++ b/Source/Parallelization/Make.package
@@ -1,10 +1,6 @@
 CEXE_sources += WarpXComm.cpp
 CEXE_sources += WarpXRegrid.cpp
 CEXE_sources += GuardCellManager.cpp
-CEXE_headers += WarpXSumGuardCells.H
-CEXE_headers += WarpXComm_K.H
-CEXE_headers += GuardCellManager.H
-CEXE_headers += WarpXComm.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Parallelization
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parallelization

--- a/Source/Parser/Make.package
+++ b/Source/Parser/Make.package
@@ -1,10 +1,5 @@
-
 cEXE_sources += wp_parser_y.c wp_parser.tab.c wp_parser.lex.c wp_parser_c.c
-cEXE_headers += wp_parser_y.h wp_parser.tab.h wp_parser.lex.h wp_parser_c.h
 CEXE_sources += WarpXParser.cpp
-CEXE_headers += WarpXParser.H
-CEXE_headers += GpuParser.H
-CEXE_headers += WarpXParserWrapper.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Parser
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parser

--- a/Source/Particles/Collision/Make.package
+++ b/Source/Particles/Collision/Make.package
@@ -1,9 +1,3 @@
-CEXE_headers += CollisionType.H
-CEXE_headers += ElasticCollisionPerez.H
-CEXE_headers += ShuffleFisherYates.H
-CEXE_headers += UpdateMomentumPerezElastic.H
-CEXE_headers += ComputeTemperature.H
-
 CEXE_sources += CollisionType.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Collision

--- a/Source/Particles/Deposition/Make.package
+++ b/Source/Particles/Deposition/Make.package
@@ -1,4 +1,2 @@
-CEXE_headers += CurrentDeposition.H
-CEXE_headers += ChargeDeposition.H
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Deposition
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Deposition

--- a/Source/Particles/ElementaryProcess/Make.package
+++ b/Source/Particles/ElementaryProcess/Make.package
@@ -1,8 +1,4 @@
-CEXE_headers += Ionization.H
-
 ifeq ($(QED),TRUE)
-    CEXE_headers += QEDPairGeneration.H
-    CEXE_headers += QEDPhotonEmission.H
     include $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/Make.package
     INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/
     VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/

--- a/Source/Particles/ElementaryProcess/QEDInternals/Make.package
+++ b/Source/Particles/ElementaryProcess/QEDInternals/Make.package
@@ -1,20 +1,9 @@
-CEXE_headers += QedWrapperCommons.H
-CEXE_headers += QedChiFunctions.H
-CEXE_headers += QedTableParserHelperFunctions.H
-CEXE_headers += BreitWheelerEngineInnards.H
-CEXE_headers += QuantumSyncEngineInnards.H
-CEXE_headers += BreitWheelerEngineWrapper.H
-CEXE_headers += QuantumSyncEngineWrapper.H
-CEXE_headers += BreitWheelerDummyTable.H
-CEXE_headers += QuantumSyncDummyTable.H
 CEXE_sources += BreitWheelerEngineWrapper.cpp
 CEXE_sources += QuantumSyncEngineWrapper.cpp
 
 #Table generation is enabled only if QED_TABLE_GEN is
 #set to true
 ifeq ($(QED_TABLE_GEN),TRUE)
-    CEXE_headers += BreitWheelerEngineTableBuilder.H
-    CEXE_headers += QuantumSyncEngineTableBuilder.H
     CEXE_sources += BreitWheelerEngineTableBuilder.cpp
     CEXE_sources += QuantumSyncEngineTableBuilder.cpp
 endif

--- a/Source/Particles/Gather/Make.package
+++ b/Source/Particles/Gather/Make.package
@@ -1,3 +1,2 @@
-CEXE_headers += FieldGather.H
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Gather
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Gather

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -4,13 +4,6 @@ CEXE_sources += RigidInjectedParticleContainer.cpp
 CEXE_sources += PhysicalParticleContainer.cpp
 CEXE_sources += PhotonParticleContainer.cpp
 
-CEXE_headers += MultiParticleContainer.H
-CEXE_headers += WarpXParticleContainer.H
-CEXE_headers += RigidInjectedParticleContainer.H
-CEXE_headers += PhysicalParticleContainer.H
-CEXE_headers += PhotonParticleContainer.H
-CEXE_headers += ShapeFactors.H
-
 include $(WARPX_HOME)/Source/Particles/Pusher/Make.package
 include $(WARPX_HOME)/Source/Particles/Deposition/Make.package
 include $(WARPX_HOME)/Source/Particles/Gather/Make.package

--- a/Source/Particles/ParticleCreation/Make.package
+++ b/Source/Particles/ParticleCreation/Make.package
@@ -1,8 +1,3 @@
-CEXE_headers += DefaultInitialization.H
-CEXE_headers += FilterCopyTransform.H
-CEXE_headers += SmartUtils.H
-CEXE_headers += SmartCopy.H
-CEXE_headers += SmartCreate.H
 CEXE_sources += SmartUtils.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/ParticleCreation/

--- a/Source/Particles/Pusher/Make.package
+++ b/Source/Particles/Pusher/Make.package
@@ -1,8 +1,2 @@
-CEXE_headers += GetAndSetPosition.H
-CEXE_headers += UpdatePosition.H
-CEXE_headers += UpdateMomentumBoris.H
-CEXE_headers += UpdateMomentumVay.H
-CEXE_headers += UpdateMomentumHigueraCary.H
-CEXE_headers += UpdatePositionPhoton.H
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Pusher
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Pusher

--- a/Source/Particles/Sorting/Make.package
+++ b/Source/Particles/Sorting/Make.package
@@ -1,4 +1,3 @@
-CEXE_headers += SortingUtils.H
 CEXE_sources += Partition.cpp
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Sorting
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Sorting

--- a/Source/Python/Make.package
+++ b/Source/Python/Make.package
@@ -1,7 +1,5 @@
 CEXE_sources += WarpXWrappers.cpp
 CEXE_sources += WarpX_py.cpp
-CEXE_headers += WarpXWrappers.h
-CEXE_headers += WarpX_py.H
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Python
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Python

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -1,18 +1,8 @@
-CEXE_headers += WarpX_Complex.H
 CEXE_sources += WarpXMovingWindow.cpp
 CEXE_sources += WarpXTagging.cpp
 CEXE_sources += WarpXUtil.cpp
-CEXE_headers += WarpXConst.H
-CEXE_headers += WarpXUtil.H
-CEXE_headers += WarpXAlgorithmSelection.H
 CEXE_sources += WarpXAlgorithmSelection.cpp
-CEXE_headers += NCIGodfreyTables.H
-CEXE_headers += WarpX_Complex.H
-CEXE_headers += IonizationEnergiesTable.H
-CEXE_headers += WarpXProfilerWrapper.H
-CEXE_headers += Average.H
 CEXE_sources += Average.cpp
-CEXE_headers += Interpolate.H
 CEXE_sources += Interpolate.cpp
 
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Utils


### PR DESCRIPTION
Remove the listing of all header-files from the Make-build system.

Listing public header files here tells the AMReX Makefile build system to install those in an install step after build. WarpX is currently not building a public library which can be consumed by users for their projects and only an executable.