### PR TITLE
[Mini] PML ncell check only along active axes

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -574,9 +574,12 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
             //  the PML cells surrounding these patches cannot overlap
             // The check is only needed along the axis where PMLs are being used.
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grid_bx.length(idim) > ncell,
-                                    "Consider using larger amr.blocking_factor with PMLs");
+                if (! geom->isPeriodic(idim)) {
+                    if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
+                        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                            grid_bx.length(idim) > ncell,
+                            "Consider using larger amr.blocking_factor with PMLs");
+                    }
                 }
             }
         }

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -572,8 +572,13 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
         if (do_pml_in_domain == 0) {
             // Make sure that, in the case of several distinct refinement patches,
             //  the PML cells surrounding these patches cannot overlap
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grid_bx.shortside() > ncell,
-                            "Consider using larger amr.blocking_factor");
+            // The check is only needed along the axis where PMLs are being used.
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grid_bx.length(idim) > ncell,
+                                    "Consider using larger amr.blocking_factor with PMLs");
+                }
+            }
         }
 
         Box bx = grid_bx;

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -574,7 +574,7 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
             //  the PML cells surrounding these patches cannot overlap
             // The check is only needed along the axis where PMLs are being used.
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                if (! geom->isPeriodic(idim)) {
+                if (! geom.isPeriodic(idim)) {
                     if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                             grid_bx.length(idim) > ncell,


### PR DESCRIPTION
This allows the dimensions where PMLs are not being used to be made small.

Note, for this to be effective, the user must also set the input quantities warpx.do_pml_Lo and warpx.do_pml_Hi appropriately. Could these be automatically set to false when is_periodic is true?