### PR TITLE
Includes: Only From `Source/`

### DIFF
--- a/Source/BoundaryConditions/Make.package
+++ b/Source/BoundaryConditions/Make.package
@@ -1,4 +1,3 @@
 CEXE_sources += PML.cpp WarpXEvolvePML.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/BoundaryConditions
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/BoundaryConditions

--- a/Source/Diagnostics/ComputeDiagFunctors/Make.package
+++ b/Source/Diagnostics/ComputeDiagFunctors/Make.package
@@ -4,5 +4,4 @@ CEXE_sources += PartPerGridFunctor.cpp
 CEXE_sources += DivBFunctor.cpp
 CEXE_sources += DivEFunctor.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/ComputeDiagFunctors
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/ComputeDiagFunctors

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -10,14 +10,15 @@
 #include "Utils/Average.H"
 #include "Utils/WarpXUtil.H"
 
+#ifdef WARPX_USE_PSATD
+#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
+#endif
+
 #include <AMReX_FillPatchUtil_F.H>
 #include <AMReX_Interpolater.H>
 
 #ifdef WARPX_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
-#endif
-#ifdef WARPX_USE_PSATD
-#include <SpectralSolver.H>
+#   include <openPMD/openPMD.hpp>
 #endif
 
 using namespace amrex;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -1,6 +1,6 @@
 #include "FlushFormatPlotfile.H"
 #include "WarpX.H"
-#include "Interpolate.H"
+#include "Utils/Interpolate.H"
 
 #include <AMReX_buildInfo.H>
 

--- a/Source/Diagnostics/FlushFormats/Make.package
+++ b/Source/Diagnostics/FlushFormats/Make.package
@@ -1,4 +1,3 @@
 CEXE_sources += FlushFormatPlotfile.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/FlushFormats
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/FlushFormats

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -15,5 +15,4 @@ include $(WARPX_HOME)/Source/Diagnostics/ReducedDiags/Make.package
 include $(WARPX_HOME)/Source/Diagnostics/ComputeDiagFunctors/Make.package
 include $(WARPX_HOME)/Source/Diagnostics/FlushFormats/Make.package
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -6,5 +6,4 @@ CEXE_sources += BeamRelevant.cpp
 CEXE_sources += LoadBalanceCosts.cpp
 CEXE_sources += ParticleHistogram.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags

--- a/Source/Evolve/Make.package
+++ b/Source/Evolve/Make.package
@@ -1,4 +1,3 @@
 CEXE_sources += WarpXEvolve.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Evolve
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Evolve

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "WarpXAlgorithmSelection.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #ifdef WARPX_DIM_RZ
 #   include "FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
@@ -14,7 +14,7 @@
 #   include "FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
 #   include "FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
 #endif
-#include "WarpXConst.H"
+#include "Utils/WarpXConst.H"
 #include "WarpX.H"
 #include <AMReX_Gpu.H>
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "WarpXAlgorithmSelection.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #ifdef WARPX_DIM_RZ
 #   include "FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
@@ -14,7 +14,7 @@
 #   include "FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
 #   include "FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
 #endif
-#include "WarpXConst.H"
+#include "Utils/WarpXConst.H"
 #include "WarpX.H"
 #include <AMReX_Gpu.H>
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/Make.package
+++ b/Source/FieldSolver/FiniteDifferenceSolver/Make.package
@@ -4,5 +4,4 @@ CEXE_sources += EvolveE.cpp
 CEXE_sources += EvolveF.cpp
 CEXE_sources += ComputeDivE.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FieldSolver/FiniteDifferenceSolver
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FieldSolver/FiniteDifferenceSolver

--- a/Source/FieldSolver/Make.package
+++ b/Source/FieldSolver/Make.package
@@ -9,5 +9,4 @@ ifeq ($(USE_PSATD),TRUE)
 endif
 include $(WARPX_HOME)/Source/FieldSolver/FiniteDifferenceSolver/Make.package
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FieldSolver
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FieldSolver

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/Make.package
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/Make.package
@@ -1,5 +1,4 @@
 CEXE_sources += PicsarHybridSpectralSolver.cpp
 F90EXE_sources += picsar_hybrid_spectral.F90
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FieldSolver/PicsarHybridSpectralSolver
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FieldSolver/PicsarHybridSpectralSolver

--- a/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
+++ b/Source/FieldSolver/PicsarHybridSpectralSolver/PicsarHybridSpectralSolver.cpp
@@ -7,7 +7,7 @@
  */
 #include "PicsarHybridFFTData.H"
 #include "WarpX.H"
-#include "WarpX_f.H"
+#include "FortranInterface/WarpX_f.H"
 #include <AMReX_iMultiFab.H>
 
 

--- a/Source/FieldSolver/SpectralSolver/Make.package
+++ b/Source/FieldSolver/SpectralSolver/Make.package
@@ -4,5 +4,4 @@ CEXE_sources += SpectralKSpace.cpp
 
 include $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FieldSolver/SpectralSolver
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FieldSolver/SpectralSolver

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/Make.package
@@ -3,6 +3,4 @@ CEXE_sources += PsatdAlgorithm.cpp
 CEXE_sources += GalileanAlgorithm.cpp
 CEXE_sources += PMLPsatdAlgorithm.cpp
 
-
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/SpectralAlgorithms
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FieldSolver/SpectralSolver/SpectralAlgorithms

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.cpp
@@ -4,7 +4,7 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <SpectralBaseAlgorithm.H>
+#include "SpectralBaseAlgorithm.H"
 #include <cmath>
 
 using namespace amrex;

--- a/Source/Filter/Make.package
+++ b/Source/Filter/Make.package
@@ -2,5 +2,4 @@ CEXE_sources += Filter.cpp
 CEXE_sources += BilinearFilter.cpp
 CEXE_sources += NCIGodfreyFilter.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Filter
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Filter

--- a/Source/FortranInterface/Make.package
+++ b/Source/FortranInterface/Make.package
@@ -1,2 +1,1 @@
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/FortranInterface
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/FortranInterface

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -3,5 +3,4 @@ CEXE_sources += PlasmaInjector.cpp
 CEXE_sources += InjectorDensity.cpp
 CEXE_sources += InjectorMomentum.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Initialization
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Initialization

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -9,7 +9,7 @@
 #ifndef PLASMA_INJECTOR_H_
 #define PLASMA_INJECTOR_H_
 
-#include "SpeciesPhysicalProperties.H"
+#include "Particles/SpeciesPhysicalProperties.H"
 #include "InjectorPosition.H"
 #include "InjectorDensity.H"
 #include "InjectorMomentum.H"

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -8,7 +8,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "PlasmaInjector.H"
-#include "SpeciesPhysicalProperties.H"
+#include "Particles/SpeciesPhysicalProperties.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"

--- a/Source/Laser/LaserProfilesImpl/Make.package
+++ b/Source/Laser/LaserProfilesImpl/Make.package
@@ -3,5 +3,4 @@ CEXE_sources += LaserProfileHarris.cpp
 CEXE_sources += LaserProfileFieldFunction.cpp
 CEXE_sources += LaserProfileFromTXYEFile.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Laser/LaserProfilesImpl
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Laser/LaserProfilesImpl

--- a/Source/Laser/Make.package
+++ b/Source/Laser/Make.package
@@ -2,5 +2,4 @@ CEXE_sources += LaserParticleContainer.cpp
 
 include $(WARPX_HOME)/Source/Laser/LaserProfilesImpl/Make.package
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Laser
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Laser

--- a/Source/Parallelization/Make.package
+++ b/Source/Parallelization/Make.package
@@ -2,5 +2,4 @@ CEXE_sources += WarpXComm.cpp
 CEXE_sources += WarpXRegrid.cpp
 CEXE_sources += GuardCellManager.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Parallelization
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parallelization

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -6,8 +6,9 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include <WarpX.H>
-#include <WarpXAlgorithmSelection.H>
+#include "WarpX.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+
 #include <AMReX_BLProfiler.H>
 
 using namespace amrex;

--- a/Source/Parser/Make.package
+++ b/Source/Parser/Make.package
@@ -1,6 +1,5 @@
 cEXE_sources += wp_parser_y.c wp_parser.tab.c wp_parser.lex.c wp_parser_c.c
 CEXE_sources += WarpXParser.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Parser
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parser
 

--- a/Source/Particles/Collision/Make.package
+++ b/Source/Particles/Collision/Make.package
@@ -1,4 +1,3 @@
 CEXE_sources += CollisionType.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Collision
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Collision

--- a/Source/Particles/Deposition/Make.package
+++ b/Source/Particles/Deposition/Make.package
@@ -1,2 +1,1 @@
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Deposition
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Deposition

--- a/Source/Particles/ElementaryProcess/Make.package
+++ b/Source/Particles/ElementaryProcess/Make.package
@@ -1,8 +1,6 @@
 ifeq ($(QED),TRUE)
     include $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/Make.package
-    INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/
     VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/ElementaryProcess/QEDInternals/
 endif
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/ElementaryProcess/
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/ElementaryProcess/

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -11,7 +11,7 @@
 #include "Utils/WarpXConst.H"
 #include "Particles/WarpXParticleContainer.H"
 
-#include <BreitWheelerEngineWrapper.H>
+#include "QEDInternals/BreitWheelerEngineWrapper.H"
 
 /** @file
  *

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -11,7 +11,7 @@
 #include "Utils/WarpXConst.H"
 #include "Particles/WarpXParticleContainer.H"
 
-#include <QuantumSyncEngineWrapper.H>
+#include "QEDInternals/QuantumSyncEngineWrapper.H"
 
 /** @file
  *

--- a/Source/Particles/Gather/Make.package
+++ b/Source/Particles/Gather/Make.package
@@ -1,2 +1,1 @@
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Gather
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Gather

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -12,5 +12,4 @@ include $(WARPX_HOME)/Source/Particles/ParticleCreation/Make.package
 include $(WARPX_HOME)/Source/Particles/ElementaryProcess/Make.package
 include $(WARPX_HOME)/Source/Particles/Collision/Make.package
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles

--- a/Source/Particles/ParticleCreation/Make.package
+++ b/Source/Particles/ParticleCreation/Make.package
@@ -1,4 +1,3 @@
 CEXE_sources += SmartUtils.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/ParticleCreation/
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/ParticleCreation/

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -15,16 +15,16 @@
 #include "Filter/NCIGodfreyFilter.H"
 #include "Particles/ElementaryProcess/Ionization.H"
 
-#include <AMReX_IArrayBox.H>
-
 #ifdef WARPX_QED
-    #include <QuantumSyncEngineWrapper.H>
-    #include <BreitWheelerEngineWrapper.H>
-    #include <QedChiFunctions.H>
+    #include "Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H"
+    #include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
+    #include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 
-    #include <Particles/ElementaryProcess/QEDPairGeneration.H>
-    #include <Particles/ElementaryProcess/QEDPhotonEmission.H>
+    #include "Particles/ElementaryProcess/QEDPairGeneration.H"
+    #include "Particles/ElementaryProcess/QEDPhotonEmission.H"
 #endif
+
+#include <AMReX_IArrayBox.H>
 
 #include <map>
 

--- a/Source/Particles/Pusher/Make.package
+++ b/Source/Particles/Pusher/Make.package
@@ -1,2 +1,1 @@
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Pusher
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Pusher

--- a/Source/Particles/Sorting/Make.package
+++ b/Source/Particles/Sorting/Make.package
@@ -1,3 +1,2 @@
 CEXE_sources += Partition.cpp
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Particles/Sorting
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Sorting

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -14,15 +14,16 @@
 #include "SpeciesPhysicalProperties.H"
 #include "Evolve/WarpXDtType.H"
 
+#ifdef WARPX_QED
+    #include "ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H"
+    #include "ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
+#endif
+
 #include <AMReX_Particles.H>
 #include <AMReX_AmrCore.H>
 
-#ifdef WARPX_QED
-    #include <QuantumSyncEngineWrapper.H>
-    #include <BreitWheelerEngineWrapper.H>
-#endif
-
 #include <memory>
+
 
 enum struct ConvertDirection{WarpX_to_SI, SI_to_WarpX};
 

--- a/Source/Python/Make.package
+++ b/Source/Python/Make.package
@@ -1,5 +1,4 @@
 CEXE_sources += WarpXWrappers.cpp
 CEXE_sources += WarpX_py.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Python
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Python

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -5,5 +5,4 @@ CEXE_sources += WarpXAlgorithmSelection.cpp
 CEXE_sources += Average.cpp
 CEXE_sources += Interpolate.cpp
 
-INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Utils
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Utils


### PR DESCRIPTION
Avoid adding all directories to include paths:

- automatically structure includes more clearly, e.g. a util include with a short name is clearly seen as such
- should have some small positive impact on compile time, since the compiler has to search less directories for an include file

See #743