### PR TITLE
GitHub Action: Update to v2

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Non-ASCII characters
       run: .github/workflows/source/hasNonASCII
     - name: TABs


### PR DESCRIPTION
Update to latest version of [GitHub checkout action](https://github.com/actions/checkout) for CI.