### PR TITLE
Fix: read_raw_data Tool for Reduced

### DIFF
--- a/Tools/read_raw_data.py
+++ b/Tools/read_raw_data.py
@@ -320,7 +320,10 @@ def read_reduced_diags(filename, delimiter=' '):
     field_column =  [s[s.find("[")+1:s.find("]")] for s in unformatted_header]
     # Load data and re-format to a dictionary
     data = np.loadtxt( filename, delimiter=delimiter )
-    data_dict = {key: data[:,i] for i, key in enumerate(field_names)}
+    if data.ndim == 1:
+        data_dict = {key: np.atleast_1d(data[i]) for i, key in enumerate(field_names)}
+    else:
+        data_dict = {key: data[:,i] for i, key in enumerate(field_names)}
     # Put header data into a dictionary
     metadata_dict = {}
     metadata_dict['units'] = {key: field_units[i] for i, key in enumerate(field_names)}


### PR DESCRIPTION
The read_raw_data python scripts were not consistently returning arrays.
This fixes it, making sure that both a reduced diagnostics that has only been run for one step (e.g. in a test case) as well as for arbitrary many steps returns a dict of arrays.

Seen with BeamRelevant reduced diagnostics. (Follow-up PR will test this functionality in CI.)