### PR TITLE
Charge in BeamRelevant Redu. Diagnostic

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1317,6 +1317,8 @@ Diagnostics and output
         :math:`\epsilon_z = \dfrac{1}{mc} \sqrt{\delta_z^2 \delta_{pz}^2 -
         \Big\langle (z-\langle z \rangle) (p_z-\langle p_z \rangle) \Big\rangle^2}`.
 
+        [18]: The charge of the beam (C).
+
         For 2D-XZ,
         :math:`\langle y \rangle`,
         :math:`\delta_y`, and

--- a/Examples/Tests/initial_distribution/analysis_distribution.py
+++ b/Examples/Tests/initial_distribution/analysis_distribution.py
@@ -16,7 +16,7 @@
 import numpy as np
 import scipy.constants as scc
 import scipy.special as scs
-from read_raw_data import read_reduced_diags_histogram
+from read_raw_data import read_reduced_diags_histogram, read_reduced_diags
 
 # print tolerance
 tolerance = 0.01
@@ -93,6 +93,8 @@ assert(f3_error < tolerance)
 bin_value, h4x = read_reduced_diags_histogram("h4x.txt")[2:]
 h4y = read_reduced_diags_histogram("h4y.txt")[3]
 h4z = read_reduced_diags_histogram("h4z.txt")[3]
+_, bmmntr = read_reduced_diags("bmmntr.txt")
+charge = bmmntr['charge'][0]
 
 # parameters of theory
 x_rms = 0.25
@@ -107,9 +109,11 @@ f_xy = npart*db * np.exp(-0.5*(bin_value/x_rms)**2)/(x_rms*np.sqrt(2.0*scc.pi)) 
 f_z = npart*db * np.exp(-0.5*(bin_value/x_rms)**2)/(x_rms*np.sqrt(2.0*scc.pi))
 f_z[ np.absolute(bin_value) > z_cut * x_rms ] = 0.
 f_peak = np.amax(f_z)
+q_tot_cut = q_tot * scs.erf(z_cut/np.sqrt(2.))
 
 # compute error
 f4_error = np.sum(np.abs(f_xy-h4x)+np.abs(f_xy-h4y)+np.abs(f_z-h4z))/bin_value.size / f_peak
+charge_error = np.abs((q_tot_cut - charge) / q_tot)
 
 do_plot = False
 if do_plot:
@@ -126,5 +130,7 @@ if do_plot:
     plt.savefig('toto.pdf', bbox_inches='tight')
 
 print('Gaussian position distribution difference:', f4_error)
-
 assert(f4_error < tolerance)
+
+print('Relative beam charge difference:', charge_error)
+assert(charge_error < tolerance)

--- a/Examples/Tests/initial_distribution/inputs
+++ b/Examples/Tests/initial_distribution/inputs
@@ -85,7 +85,7 @@ beam.focused                    = false
 # 2 for maxwell-boltzmann
 # 3 for maxwell-juttner
 # 4 for beam
-warpx.reduced_diags_names              = h1x h1y h1z h2x h2y h2z h3 h4x h4y h4z
+warpx.reduced_diags_names              = h1x h1y h1z h2x h2y h2z h3 h4x h4y h4z bmmntr
 
 h1x.type                                 = ParticleHistogram
 h1x.frequency                            = 1
@@ -176,3 +176,9 @@ h4z.bin_number                           = 50
 h4z.bin_min                              = -1.0
 h4z.bin_max                              = +1.0
 h4z.histogram_function(t,x,y,z,ux,uy,uz) = "z"
+
+# our little beam monitor
+bmmntr.type                              = BeamRelevant
+bmmntr.frequency                         = 1
+bmmntr.path                              = "./"
+bmmntr.species                           = beam


### PR DESCRIPTION
Adds the beam parameter "charge" to our reduced diagnostics, type "BeamRelevant".

Will be useful for libEnsemble studies :)

## To Do

- [x] rebase on top of bug fix in #879

## Follow-Up

- potentially needs multiplication with ionization state `ion_lev` for ion beams?