### PR TITLE
Periodic, single-box FFT

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1000,6 +1000,13 @@ Numerics and algorithms
     If not set by users, these values are calculated automatically and determined *empirically* and
     would be equal the order of the solver for nodal grid, and half the order of the solver for staggered.
 
+* ``psatd.periodic_single_box_fft`` (`0` or `1`; default: 0)
+    If true, this will *not* incorporate the guard cells into the box over which FFTs are performed.
+    This is only valid when WarpX is run with periodic boundaries and a single box.
+    In this case, using `psatd.periodic_single_box_fft` is equivalent to using a global FFT over the whole domain.
+    Therefore, all the approximations that are usually made when using local FFTs with guard cells
+    (for problems with multiple boxes) become exact in the case of the periodic, single-box FFT without guard cells.
+
 * ``psatd.hybrid_mpi_decomposition`` (`0` or `1`; default: 0)
     Whether to use a different MPI decomposition for the particle-grid operations
     (deposition and gather) and for the PSATD solver. If `1`, the FFT will

--- a/Examples/Tests/Langmuir/inputs_3d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -6,7 +6,7 @@ amr.n_cell =   64  64  64
 
 # Maximum allowable size of each subdomain in the problem domain;
 #    this is used to decompose the domain for parallel calculations.
-amr.max_grid_size = 32
+amr.max_grid_size = 64
 
 # Maximum level in hierarchy (for now must be 0, i.e., one level in total)
 amr.max_level = 0

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -55,7 +55,8 @@ class SpectralFieldData
         SpectralFieldData( const amrex::BoxArray& realspace_ba,
                            const SpectralKSpace& k_space,
                            const amrex::DistributionMapping& dm,
-                           const int n_field_required );
+                           const int n_field_required,
+                           const bool periodic_single_box );
         SpectralFieldData() = default; // Default constructor
         SpectralFieldData& operator=(SpectralFieldData&& field_data) = default;
         ~SpectralFieldData();
@@ -89,6 +90,8 @@ class SpectralFieldData
         */
         std::string cufftErrorToString (const cufftResult& err);
 #endif
+
+        bool m_periodic_single_box;
 };
 
 #endif // WARPX_SPECTRAL_FIELD_DATA_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -354,6 +354,7 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
                 // Copy field into temporary array
                 tmp_arr(i,j,k) = spectral_field_value;
             });
+
         }
 
         // Perform Fourier transform from `tmpSpectralField` to `tmpRealField`
@@ -397,11 +398,29 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
             const Box realspace_bx = tmpRealField[mfi].box();
             const Real inv_N = 1./realspace_bx.numPts();
 
-            ParallelFor( mfi.validbox(),
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                // Copy and normalize field
-                mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i,j,k);
-            });
+            if (m_periodic_single_box) {
+                // Enforce periodicity on the nodes, by using modulo in indices
+                // This is because `tmp_arr` is cell-centered while `mf_arr` can be nodal
+                int const nx = realspace_bx.length(0);
+                int const ny = realspace_bx.length(1);
+#if (AMREX_SPACEDIM == 3)
+                int const nz = realspace_bx.length(2);
+#else
+                int const nz = 1;
+#endif
+                ParallelFor( mfi.validbox(),
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // Copy and normalize field
+                    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx,j%ny,k%nz);
+                });
+            } else {
+                ParallelFor( mfi.validbox(),
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // Copy and normalize field
+                    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i,j,k);
+                });
+            }
+
         }
     }
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -34,7 +34,8 @@ class SpectralSolver
                         const int norder_z, const bool nodal,
                         const amrex::Array<amrex::Real,3>& v_galilean,
                         const amrex::RealVect dx, const amrex::Real dt,
-                        const bool pml=false );
+                        const bool pml=false,
+                        const bool periodic_single_box=false );
 
         /**
          * \brief Transform the component `i_comp` of MultiFab `mf`

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -28,6 +28,7 @@
  * \param dx       Cell size along each dimension
  * \param dt       Time step
  * \param pml      Whether the boxes in which the solver is applied are PML boxes
+ * \param periodic_single_box Whether the full simulation domain consists of a single periodic box (i.e. the global domain is not MPI parallelized)
  */
 SpectralSolver::SpectralSolver(
                 const amrex::BoxArray& realspace_ba,
@@ -36,7 +37,7 @@ SpectralSolver::SpectralSolver(
                 const int norder_z, const bool nodal,
                 const amrex::Array<amrex::Real,3>& v_galilean,
                 const amrex::RealVect dx, const amrex::Real dt,
-                const bool pml ) {
+                const bool pml, const bool periodic_single_box ) {
 
     // Initialize all structures using the same distribution mapping dm
 
@@ -64,7 +65,7 @@ SpectralSolver::SpectralSolver(
 
     // - Initialize arrays for fields in spectral space + FFT plans
     field_data = SpectralFieldData( realspace_ba, k_space, dm,
-            algorithm->getRequiredNumberOfFields() );
+            algorithm->getRequiredNumberOfFields(), periodic_single_box );
 
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -802,6 +802,7 @@ private:
 #endif
 
     bool fft_hybrid_mpi_decomposition = false;
+    bool fft_periodic_single_box = false;
     int nox_fft = 16;
     int noy_fft = 16;
     int noz_fft = 16;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -959,12 +959,21 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 #elif (AMREX_SPACEDIM == 2)
         RealVect dx_vect(dx[0], dx[2]);
 #endif
+
+        // Check whether the global domain is periodic and parallelized with a single box
+        bool periodic_single_box = (geom[0].isAllPeriodic() && ba.size()==1 && lev==0);
+
         // Get the cell-centered box, with guard cells
         BoxArray realspace_ba = ba;  // Copy box
-        realspace_ba.enclosedCells().grow(ngE); // cell-centered + guard cells
+        realspace_ba.enclosedCells(); // cell-centered
+        if ( periodic_single_box == false ) {
+            realspace_ba.grow(ngE); // add guard cells
+        }
         // Define spectral solver
+        bool const pml=false;
         spectral_solver_fp[lev].reset( new SpectralSolver( realspace_ba, dm,
-            nox_fft, noy_fft, noz_fft, do_nodal, v_galilean, dx_vect, dt[lev] ) );
+            nox_fft, noy_fft, noz_fft, do_nodal, v_galilean, dx_vect, dt[lev],
+            pml, periodic_single_box ) );
     }
 #endif
     std::array<Real,3> const dx = CellSize(lev);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -716,6 +716,7 @@ WarpX::ReadParameters ()
     {
         ParmParse pp("psatd");
         pp.query("hybrid_mpi_decomposition", fft_hybrid_mpi_decomposition);
+        pp.query("periodic_single_box_fft", fft_periodic_single_box);
         pp.query("ngroups_fft", ngroups_fft);
         pp.query("fftw_plan_measure", fftw_plan_measure);
         pp.query("nox", nox_fft);
@@ -960,20 +961,23 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         RealVect dx_vect(dx[0], dx[2]);
 #endif
 
-        // Check whether the global domain is periodic and parallelized with a single box
-        bool periodic_single_box = (geom[0].isAllPeriodic() && ba.size()==1 && lev==0);
+        // Check whether the option periodic, single box is valid here
+        if (fft_periodic_single_box) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( geom[0].isAllPeriodic() && ba.size()==1 && lev==0,
+            "The option `psatd.periodic_single_box_fft` can only be used for a periodic domain, decomposed in a single box.");
+        }
 
         // Get the cell-centered box, with guard cells
         BoxArray realspace_ba = ba;  // Copy box
         realspace_ba.enclosedCells(); // cell-centered
-        if ( periodic_single_box == false ) {
+        if ( fft_periodic_single_box == false ) {
             realspace_ba.grow(ngE); // add guard cells
         }
         // Define spectral solver
         bool const pml=false;
         spectral_solver_fp[lev].reset( new SpectralSolver( realspace_ba, dm,
             nox_fft, noy_fft, noz_fft, do_nodal, v_galilean, dx_vect, dt[lev],
-            pml, periodic_single_box ) );
+            pml, fft_periodic_single_box ) );
     }
 #endif
     std::array<Real,3> const dx = CellSize(lev);


### PR DESCRIPTION
When using the PSATD solver, the FFT is typically performed over the valid cells *and* guard cells. 
The guard cells are included in order to overcome the fact that the FFT is *periodic* by default: after the FFT is performed, the guard cells (which contain erroneous periodic data) are overwritten with the data from neighboring processors.

However, in the special case where the domain is periodic and decomposed into a single `amrex` box, the default periodic aspect of the FFT is actually valid. Therefore, in this special case, we may perform the FFT only over the valid cells. This special case is useful in theoretical studies, because in this case the stencil is not cut in the guard cells, and instead the FFT is equivalent to a global Fourier transform over the domain. As a consequence, non-local algorithms (such as the global current correction, or the infinite-order PSATD) become valid.

This PR allows to use this special FFT, by setting `psatd.periodic_single_box_fft=1`. In this case, WarpX automatically checks that the box is periodic and decomposed in a single `amrex` box.

**Note:** This PR does not contain an automated test ; however, an automated for this new feature is included in the follow-up PR #675.