### PR TITLE
GitHub Action: Check Tests on OSX

### DIFF
--- a/.github/workflows/source/hasEOLwhiteSpace
+++ b/.github/workflows/source/hasEOLwhiteSpace
@@ -26,6 +26,8 @@ for i in $(find . \
                 -not -path "./.idea/*"         \
                 -not -path "*wp_parse*"        \
                 -not -path "./tmp_build_dir/*" \
+                -not -path "./Docs/build/*"    \
+                -not -path "./Docs/doxy*"      \
                 -type f | \
            grep -E "${pattern}")
 do

--- a/.github/workflows/source/hasEOLwhiteSpace
+++ b/.github/workflows/source/hasEOLwhiteSpace
@@ -12,6 +12,8 @@
 # note: .md files can contain EOL white spaces for syntax reasons
 #       (newline without starting a new paragraph)
 
+set -eu -o pipefail
+
 ok=0
 files=()
 
@@ -25,8 +27,8 @@ for i in $(find . \
                 -type f | \
            grep -P "${pattern}")
 do
-  grep -q "[[:blank:]]\+$" $i
-  if [ $? -eq 0 ]
+  fileHasEOLws=$(grep -q "[[:blank:]]\+$" $i || echo "-FILE CLEAN-")
+  if [ "$fileHasEOLws" != "-FILE CLEAN-" ]
   then
     files+=($i)
     echo "$i contains EOL white spaces!"

--- a/.github/workflows/source/hasEOLwhiteSpace
+++ b/.github/workflows/source/hasEOLwhiteSpace
@@ -22,12 +22,14 @@ pattern="\.c$|\.cpp$|\.F90$|\.h$|\.H$|\.ini$|\.py$|"\
 "CMakeLists\.txt|inputs"
 
 for i in $(find . \
-                -not -path "./.git/*"  \
-                -not -path "./.idea/*" \
+                -not -path "./.git/*"          \
+                -not -path "./.idea/*"         \
+                -not -path "*wp_parse*"        \
+                -not -path "./tmp_build_dir/*" \
                 -type f | \
-           grep -P "${pattern}")
+           grep -E "${pattern}")
 do
-  fileHasEOLws=$(grep -q "[[:blank:]]\+$" $i || echo "-FILE CLEAN-")
+  fileHasEOLws=$(grep -e "[[:blank:]]\+$" $i || echo "-FILE CLEAN-")
   if [ "$fileHasEOLws" != "-FILE CLEAN-" ]
   then
     files+=($i)

--- a/.github/workflows/source/hasNonASCII
+++ b/.github/workflows/source/hasNonASCII
@@ -20,18 +20,26 @@ pattern="\.c$|\.cpp$|\.F90$|\.h$|\.H$|\.ini$|\.py$|"\
 "\.sh$|\.tex$|\.txt$|\.xml$|\.yml$|"\
 "CMakeLists\.txt|inputs"
 
+GNU_GREP=$(echo "a" | grep -P "a" >/dev/null 2>&1 && { echo 1; } || { echo 0; })
+
 for i in $(find . \
-                -not -path "./.git/*"   \
-                -not -path "./.idea/*"  \
-                -not -path "*wp_parse*" \
+                -not -path "./.git/*"          \
+                -not -path "./.idea/*"         \
+                -not -path "*wp_parse*"        \
+                -not -path "./tmp_build_dir/*" \
                 -type f | \
-           grep -P "${pattern}")
+           grep -E "${pattern}")
 do
   # non-ASCII test regex via jerrymouse at stackoverflow under CC-By-SA 3.0:
   #   http://stackoverflow.com/questions/3001177/how-do-i-grep-for-all-non-ascii-characters-in-unix/9395552#9395552
-  result=$(grep --color='always' -P -n "[\x80-\xFF]" $i || echo "-FILE CLEAN-";)
+  if [ ${GNU_GREP} -eq 1 ]; then
+    result=$(grep --color='always' -n -P "[\x80-\xF7]" $i || echo "")
+  else
+    # all OSX have perl
+    result=$(perl -ne 'print "$. $_" if m/[\x80-\xF7]/' $i)
+  fi
 
-  if [ "$result" != "-FILE CLEAN-" ]
+  if [ "$result" != "" ]
   then
     echo "$i contains non-ASCII characters!"
     echo "$result"

--- a/.github/workflows/source/hasNonASCII
+++ b/.github/workflows/source/hasNonASCII
@@ -27,6 +27,7 @@ for i in $(find . \
                 -not -path "./.idea/*"         \
                 -not -path "*wp_parse*"        \
                 -not -path "./tmp_build_dir/*" \
+                -not -path "./Docs/*"          \
                 -type f | \
            grep -E "${pattern}")
 do

--- a/.github/workflows/source/hasNonASCII
+++ b/.github/workflows/source/hasNonASCII
@@ -12,6 +12,8 @@
 # @result 0 if no files are found, else 1
 #
 
+set -eu -o pipefail
+
 ok=0
 
 pattern="\.c$|\.cpp$|\.F90$|\.h$|\.H$|\.ini$|\.py$|"\
@@ -27,9 +29,9 @@ for i in $(find . \
 do
   # non-ASCII test regex via jerrymouse at stackoverflow under CC-By-SA 3.0:
   #   http://stackoverflow.com/questions/3001177/how-do-i-grep-for-all-non-ascii-characters-in-unix/9395552#9395552
-  result=$(grep --color='always' -P -n "[\x80-\xFF]" $i)
+  result=$(grep --color='always' -P -n "[\x80-\xFF]" $i || echo "-FILE CLEAN-";)
 
-  if [ $? -eq 0 ]
+  if [ "$result" != "-FILE CLEAN-" ]
   then
     echo "$i contains non-ASCII characters!"
     echo "$result"

--- a/.github/workflows/source/hasTabs
+++ b/.github/workflows/source/hasTabs
@@ -9,6 +9,8 @@
 # @result 0 if no files are found, else 1
 #
 
+set -eu -o pipefail
+
 ok=0
 files=()
 
@@ -23,8 +25,8 @@ for i in $(find . \
                 -type f | \
            grep -P "${pattern}")
 do
-  grep -q -P "\t" $i
-  if [ $? -eq 0 ]
+  fileHasTabs=$(grep -q -P "\t" $i || echo "-FILE CLEAN-")
+  if [ "$fileHasTabs" != "-FILE CLEAN-" ]
   then
     files+=($i)
     echo "$i contains TABs instead of spaces!"

--- a/.github/workflows/source/hasTabs
+++ b/.github/workflows/source/hasTabs
@@ -23,6 +23,8 @@ for i in $(find . \
                 -not -path "./.idea/*"         \
                 -not -path "*wp_parse*"        \
                 -not -path "./tmp_build_dir/*" \
+                -not -path "./Docs/build/*"    \
+                -not -path "./Docs/doxy*"      \
                 -type f | \
            grep -E "${pattern}")
 do

--- a/.github/workflows/source/hasTabs
+++ b/.github/workflows/source/hasTabs
@@ -19,13 +19,14 @@ pattern="\.c$|\.cpp$|\.F90$|\.h$|\.H$|\.ini$|\.md$|\.py$|"\
 "CMakeLists\.txt|inputs"
 
 for i in $(find . \
-                -not -path "./.git/*"   \
-                -not -path "./.idea/*"  \
-                -not -path "*wp_parse*" \
+                -not -path "./.git/*"          \
+                -not -path "./.idea/*"         \
+                -not -path "*wp_parse*"        \
+                -not -path "./tmp_build_dir/*" \
                 -type f | \
-           grep -P "${pattern}")
+           grep -E "${pattern}")
 do
-  fileHasTabs=$(grep -q -P "\t" $i || echo "-FILE CLEAN-")
+  fileHasTabs=$(grep -q -E "$(printf '\t')" $i || echo "-FILE CLEAN-")
   if [ "$fileHasTabs" != "-FILE CLEAN-" ]
   then
     files+=($i)

--- a/.github/workflows/source/inputsNotTested
+++ b/.github/workflows/source/inputsNotTested
@@ -2,6 +2,8 @@
 
 # Search input files in Examples/ and verify if all input files are tested
 
+set -eu -o pipefail
+
 ok=0
 
 for file in $(find Examples -type f)

--- a/.github/workflows/source/test_travis_matrix.sh
+++ b/.github/workflows/source/test_travis_matrix.sh
@@ -1,6 +1,6 @@
-#! /usr/bin/env sh
+#!/usr/bin/env bash
 
-set -e
+set -eu -o pipefail
 
 cp .github/workflows/source/travis_matrix.py Regression/
 cd Regression/

--- a/.github/workflows/source/travis_matrix.py
+++ b/.github/workflows/source/travis_matrix.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Concatenation of tests in each of the 6 elements in Travis matrix
 f = open('./travis_matrix_elements.txt') ; matrix_elements = f.readlines() ; f.close()

--- a/.github/workflows/source/wrongFileNameInExamples
+++ b/.github/workflows/source/wrongFileNameInExamples
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-
+#
 # Search inside Examples/ and check that file names start with
 # inputs
 # PICMI_inputs
 # analysis
 # README
+
+set -eu -o pipefail
 
 ok=0
 files=()


### PR DESCRIPTION
The produced *output commands* of our style checks is already Linux *and* OSX compatible.

This PR adds that we can also *execute* the test scripts themselves on OSX, e.g. for local testing.

- [x] `hasTabs`: now also OSX executable
- [x] `hasEOLwhiteSpace`: now also OSX executable
- [x] `hasNonASCII`: now also OSX executable (all OSX have perl installed)

Re: #845