### PR TITLE
Load balance efficiency threshold

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -492,7 +492,7 @@ public:
      * to correct number of boxes and boxes per level
      */
     void ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > >& costs);
-    
+
     /** \brief Computes the average cost per MPI rank given a distribution mapping
      * and vector of cost for each FAB.
      * @param[in] dm distribution mapping (mapping from FAB to MPI processes)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -492,6 +492,18 @@ public:
      * to correct number of boxes and boxes per level
      */
     void ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > >& costs);
+    
+    /** \brief Computes the average cost per MPI rank given a distribution mapping
+     * and vector of cost for each FAB.
+     * @param[in] dm distribution mapping (mapping from FAB to MPI processes)
+     * @param[in] cost vector which gives mapping from FAB index space to the
+     * respective FAB's cost
+     * @param[out] efficiency average cost per MPI process computed from the
+     * given distribution mapping and and cost
+     */
+    void ComputeDistributionMappingEfficiency (const amrex::DistributionMapping& dm,
+                                               const amrex::Vector<amrex::Real>& cost,
+                                               amrex::Real& efficiency);
 
 protected:
 
@@ -708,6 +720,12 @@ private:
      * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
      * be assigned to a rank to 8. */
     amrex::Real load_balance_knapsack_factor = 1.24;
+    /** Threshold value that controls whether to adopt the proposed distribution
+     * mapping during load balancing.  The new distribution mapping is adopted
+     * if the ratio of proposed distribution mapping efficiency to current
+     * distribution mapping efficiency is larger than the threshold; 'efficiency'
+     * here means the average cost per MPI rank.  */
+    amrex::Real load_balance_efficiency_ratio_threshold = 0;
     /** Weight factor for cells in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is an empty (i.e. no particles) domain

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -663,6 +663,7 @@ WarpX::ReadParameters ()
         pp.query("load_balance_int", load_balance_int);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
+        pp.query("load_balance_efficiency_ratio_threshold", load_balance_efficiency_ratio_threshold);
 
         pp.query("do_dynamic_scheduling", do_dynamic_scheduling);
 


### PR DESCRIPTION
This PR adds control over whether to remake a level during a load balance, depending an a threshold value for the ratio of proposed to current load balance efficiency.  The value can be controlled in the input by setting an optional parameter `warpx.load_balance_efficiency_ratio_threshold` in the input.  The default threshold value is 0, which maintains the current behavior of the code.  

The attached videos show a test problem with (i.e. `warpx.load_balance_efficiency_ratio_threshold > 0`) and without (`warpx.load_balance_efficiency_ratio_threshold = 0`) the load balance efficiency safeguard; using the safeguard can inhibit unneeded reshuffles of the distribution mapping.
[EfficiencySafeguard.zip](https://github.com/ECP-WarpX/WarpX/files/4423830/EfficiencySafeguard.zip)

'Input Parameters' documentation to be added in a separate PR.
