### PR TITLE
Lower tolerance of Langmuir_multi_single_precision

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -391,7 +391,7 @@ runtime_params = warpx.do_dynamic_scheduling=0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.0e-3
+tolerance = 1.0e-4
 
 [Langmuir_multi_nodal]
 buildDir = .


### PR DESCRIPTION
The benchmark of this test needs to be reset. Hopefully, this tolerance will be enough once it is reset.