### PR TITLE
[mini-PR] fix test for QED - Breit Wheeler, optical depth evolution

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -869,8 +869,8 @@ addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 1
-numthreads = 2
+useOMP = 0
+numthreads = 0
 compileTest = 0
 doVis = 0
 compareParticles = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -869,8 +869,8 @@ addToCompileString = QED=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
-numthreads = 0
+useOMP = 1
+numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0


### PR DESCRIPTION
This mini-PR sets  `numthreads = 1` for `qed_breit_wheeler_opt_depth_evolution` to prevent regression tests from failing