### PR TITLE
Avoid i%1 in a lambda, gives compiler segfault

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -405,13 +405,16 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
                 int const ny = realspace_bx.length(1);
 #if (AMREX_SPACEDIM == 3)
                 int const nz = realspace_bx.length(2);
-#else
-                int const nz = 1;
 #endif
                 ParallelFor( mfi.validbox(),
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                     // Copy and normalize field
-                    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx,j%ny,k%nz);
+#if (AMREX_SPACEDIM == 3)
+                    int const kz = k % nz;
+#else
+                    int const kz = k;
+#endif
+                    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, kz);
                 });
             } else {
                 ParallelFor( mfi.validbox(),

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -410,12 +410,11 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
 #endif
                 ParallelFor(
                     mfi.validbox(),
-                    /* nz must be explicitly captured by value when nz = 1 due to a bug
-                       in some versions of GCC (at least 8.1 and 8.2) woth operator %.
-                       All other variables are explicitly captured by value to avoid warning
-                       when using both default and explicit captures (i.e., [=,nz]).
-                    */
-                    [mf_arr,i_comp,inv_N,tmp_arr,nx,ny,nz]
+                    /* GCC 8.1-8.2 work-around (ICE):
+                     *   named capture in nonexcept lambda needed for modulo operands
+                     *   https://godbolt.org/z/ppbAzd
+                     */
+                    [mf_arr, i_comp, inv_N, tmp_arr, nx, ny, nz]
                     AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, k%nz);
                     });

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -405,17 +405,20 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
                 int const ny = realspace_bx.length(1);
 #if (AMREX_SPACEDIM == 3)
                 int const nz = realspace_bx.length(2);
-#endif
-                ParallelFor( mfi.validbox(),
-                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    // Copy and normalize field
-#if (AMREX_SPACEDIM == 3)
-                    int const kz = k % nz;
 #else
-                    int const kz = k; // nz = 1 in 2D
+                int constexpr nz = 1;
 #endif
-                    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, kz);
-                });
+                ParallelFor(
+                    mfi.validbox(),
+                    /* nz must be explicitly captured by value when nz = 1 due to a bug
+                       in some versions of GCC (at least 8.1 and 8.2) woth operator %.
+                       All other variables are explicitly captured by value to avoid warning
+                       when using both default and explicit captures (i.e., [=,nz]).
+                    */
+                    [mf_arr,i_comp,inv_N,tmp_arr,nx,ny,nz]
+                    AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, k%nz);
+                    });
             } else {
                 ParallelFor( mfi.validbox(),
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -412,7 +412,7 @@ SpectralFieldData::BackwardTransform( MultiFab& mf,
 #if (AMREX_SPACEDIM == 3)
                     int const kz = k % nz;
 #else
-                    int const kz = k;
+                    int const kz = k; // nz = 1 in 2D
 #endif
                     mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, kz);
                 });


### PR DESCRIPTION
```c++
// nx and ny are const int >1
const int nz = 1; // in 2D only
ParallelFor( mfi.validbox(),
[=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
    mf_arr(i,j,k,i_comp) = inv_N*tmp_arr(i%nx, j%ny, k%nz);
});
```
gives compilation SEGFAULT
```
./Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp: In lambda function:
./Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp:420:17: internal compiler error: Segmentation fault: 11
                 });
                 ^
libbacktrace could not find executable to open
```
which seems to be due to `k%nz` when `nz = 1`.

This explains why all 2D PSATD tests failed last night on Battra. This PR proposes a fix.