### PR TITLE
Replace ixType().ixType() with ixType().toIntVect() for clarity

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -83,7 +83,7 @@ void FiniteDifferenceSolver::ComputeDivECartesian (
         int const n_coefs_z = m_stencil_coefs_z.size();
 
         // Extract tileboxes for which to loop
-        Box const& tdive = mfi.tilebox(divEfield.ixType().ixType());
+        Box const& tdive = mfi.tilebox(divEfield.ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tdive,
@@ -132,7 +132,7 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
         Real const rmin = m_rmin;
 
         // Extract tileboxes for which to loop
-        Box const& tdive  = mfi.tilebox(divEfield.ixType().ixType());
+        Box const& tdive  = mfi.tilebox(divEfield.ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tdive,

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -85,9 +85,9 @@ void FiniteDifferenceSolver::EvolveBCartesian (
         int const n_coefs_z = m_stencil_coefs_z.size();
 
         // Extract tileboxes for which to loop
-        Box const& tbx  = mfi.tilebox(Bfield[0]->ixType().ixType());
-        Box const& tby  = mfi.tilebox(Bfield[1]->ixType().ixType());
-        Box const& tbz  = mfi.tilebox(Bfield[2]->ixType().ixType());
+        Box const& tbx  = mfi.tilebox(Bfield[0]->ixType().toIntVect());
+        Box const& tby  = mfi.tilebox(Bfield[1]->ixType().toIntVect());
+        Box const& tbz  = mfi.tilebox(Bfield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tbx, tby, tbz,
@@ -147,9 +147,9 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
         Real const rmin = m_rmin;
 
         // Extract tileboxes for which to loop
-        Box const& tbr  = mfi.tilebox(Bfield[0]->ixType().ixType());
-        Box const& tbt  = mfi.tilebox(Bfield[1]->ixType().ixType());
-        Box const& tbz  = mfi.tilebox(Bfield[2]->ixType().ixType());
+        Box const& tbr  = mfi.tilebox(Bfield[0]->ixType().toIntVect());
+        Box const& tbt  = mfi.tilebox(Bfield[1]->ixType().toIntVect());
+        Box const& tbz  = mfi.tilebox(Bfield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tbr, tbt, tbz,

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -96,9 +96,9 @@ void FiniteDifferenceSolver::EvolveECartesian (
         int const n_coefs_z = m_stencil_coefs_z.size();
 
         // Extract tileboxes for which to loop
-        Box const& tex  = mfi.tilebox(Efield[0]->ixType().ixType());
-        Box const& tey  = mfi.tilebox(Efield[1]->ixType().ixType());
-        Box const& tez  = mfi.tilebox(Efield[2]->ixType().ixType());
+        Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
+        Box const& tey  = mfi.tilebox(Efield[1]->ixType().toIntVect());
+        Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tex, tey, tez,
@@ -193,9 +193,9 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         Real const rmin = m_rmin;
 
         // Extract tileboxes for which to loop
-        Box const& ter  = mfi.tilebox(Efield[0]->ixType().ixType());
-        Box const& tet  = mfi.tilebox(Efield[1]->ixType().ixType());
-        Box const& tez  = mfi.tilebox(Efield[2]->ixType().ixType());
+        Box const& ter  = mfi.tilebox(Efield[0]->ixType().toIntVect());
+        Box const& tet  = mfi.tilebox(Efield[1]->ixType().toIntVect());
+        Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         Real const c2 = PhysConst::c * PhysConst::c;
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -90,7 +90,7 @@ void FiniteDifferenceSolver::EvolveFCartesian (
         int const n_coefs_z = m_stencil_coefs_z.size();
 
         // Extract tileboxes for which to loop
-        Box const& tf  = mfi.tilebox(Ffield->ixType().ixType());
+        Box const& tf  = mfi.tilebox(Ffield->ixType().toIntVect());
 
         Real constexpr inv_epsilon0 = 1./PhysConst::ep0;
 
@@ -146,7 +146,7 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
         Real const rmin = m_rmin;
 
         // Extract tileboxes for which to loop
-        Box const& tf  = mfi.tilebox(Ffield->ixType().ixType());
+        Box const& tf  = mfi.tilebox(Ffield->ixType().toIntVect());
 
         Real constexpr inv_epsilon0 = 1./PhysConst::ep0;
         Real constexpr c2 = PhysConst::c * PhysConst::c;

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -468,7 +468,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     const Real dr = dx[0];
 
     constexpr int NODE = amrex::IndexType::NODE;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().ixType()[0] != NODE,
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().toIntVect()[0] != NODE,
         "Jr should never node-centered in r");
 
     Box tilebox;

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -106,17 +106,17 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, Real a_dt)
 
         // Get boxes for E, B, and J
 
-        const Box& tbx = mfi.tilebox(Bx->ixType().ixType());
-        const Box& tby = mfi.tilebox(By->ixType().ixType());
-        const Box& tbz = mfi.tilebox(Bz->ixType().ixType());
+        const Box& tbx = mfi.tilebox(Bx->ixType().toIntVect());
+        const Box& tby = mfi.tilebox(By->ixType().toIntVect());
+        const Box& tbz = mfi.tilebox(Bz->ixType().toIntVect());
 
-        const Box& tex = mfi.tilebox(Ex->ixType().ixType());
-        const Box& tey = mfi.tilebox(Ey->ixType().ixType());
-        const Box& tez = mfi.tilebox(Ez->ixType().ixType());
+        const Box& tex = mfi.tilebox(Ex->ixType().toIntVect());
+        const Box& tey = mfi.tilebox(Ey->ixType().toIntVect());
+        const Box& tez = mfi.tilebox(Ez->ixType().toIntVect());
 
-        const Box& tjx = mfi.tilebox(Jx->ixType().ixType());
-        const Box& tjy = mfi.tilebox(Jy->ixType().ixType());
-        const Box& tjz = mfi.tilebox(Jz->ixType().ixType());
+        const Box& tjx = mfi.tilebox(Jx->ixType().toIntVect());
+        const Box& tjy = mfi.tilebox(Jy->ixType().toIntVect());
+        const Box& tjz = mfi.tilebox(Jz->ixType().toIntVect());
 
         // Get field arrays
         auto const& Bxfab = Bx->array(mfi);

--- a/Source/Utils/Average.cpp
+++ b/Source/Utils/Average.cpp
@@ -19,7 +19,7 @@ Average::ToCellCenter ( MultiFab& mf_out,
         const Box bx = mfi.growntilebox( ngrow );
         Array4<Real> const& mf_out_arr = mf_out.array( mfi );
         Array4<Real const> const& mf_in_arr = mf_in.const_array( mfi );
-        const IntVect stag = mf_in.boxArray().ixType().ixType();
+        const IntVect stag = mf_in.boxArray().ixType().toIntVect();
         ParallelFor( bx, ncomp,
                      [=] AMREX_GPU_DEVICE( int i, int j, int k, int n )
                      {


### PR DESCRIPTION
Call AMReX function `IndexType::toIntVect()` to convert to `IntVect`, instead of `IndexType::IndexType()`. This is just for clarity of the name, it is doing the exact same thing.