### PR TITLE
Make sure single-precision compiles on GPU

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -238,6 +238,25 @@ analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
 analysisOutputImage = langmuir2d_analysis.png
 tolerance = 1e-12
 
+[Langmuir_2d_single_precision]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_rt
+runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.fields_to_plot=Ex jx electrons.plot_vars=w ux Ex
+dim = 2
+addToCompileString = USE_GPU=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
+analysisOutputImage = langmuir2d_analysis.png
+tolerance = 1.0e-4
+
 [Langmuir_2d_nompi]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_rt

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -235,13 +235,13 @@ LaserParticleContainer::InitData (int lev)
                  position[2] + (S_X*(Real(i)+0.5_rt))*u_X[2] + (S_Y*(Real(j)+0.5_rt))*u_Y[2] };
 #else
 #   if (defined WARPX_DIM_RZ)
-        return { position[0] + (S_X*(Real(i)+0.5)),
-                 0.0,
+        return { position[0] + (S_X*(Real(i)+0.5_rt)),
+                 0.0_rt,
                  position[2]};
 #   else
-        return { position[0] + (S_X*(Real(i)+0.5))*u_X[0],
-                 0.0,
-                 position[2] + (S_X*(Real(i)+0.5))*u_X[2] };
+        return { position[0] + (S_X*(Real(i)+0.5_rt))*u_X[0],
+                 0.0_rt,
+                 position[2] + (S_X*(Real(i)+0.5_rt))*u_X[2] };
 #   endif
 #endif
     };
@@ -253,9 +253,9 @@ LaserParticleContainer::InitData (int lev)
                 u_Y[0]*(pos[0]-position[0])+u_Y[1]*(pos[1]-position[1])+u_Y[2]*(pos[2]-position[2])};
 #else
 #   if (defined WARPX_DIM_RZ)
-        return {pos[0]-position[0], 0.0};
+        return {pos[0]-position[0], 0.0_rt};
 #   else
-        return {u_X[0]*(pos[0]-position[0])+u_X[2]*(pos[2]-position[2]), 0.0};
+        return {u_X[0]*(pos[0]-position[0])+u_X[2]*(pos[2]-position[2]), 0.0_rt};
 #   endif
 #endif
     };


### PR DESCRIPTION
This includes a few explicit `_rt` and an automated test on Garuda. Just copy-pasted the Langmuir 2D single-precision test on Battra, and turned OpenMP threading and particle comparison off.