### PR TITLE
No OpenMP for GPU tests on Garuda

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -247,7 +247,7 @@ addToCompileString = USE_GPU=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 1
+useOMP = 0
 numthreads = 1
 compileTest = 0
 doVis = 0


### PR DESCRIPTION
WarpX does not compile with `USE_GPU=TRUE` **and** `USE_OMP=TRUE`, so the GPU tests on Garuda must not use OpenMP.