### PR TITLE
Breathe: <4.15.0

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -8,4 +8,4 @@ sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx>=2.0
 pygments
-breathe
+breathe<4.15.0


### PR DESCRIPTION
RTD does not yet provide Sphinx 3 but the Breathe extension in version 4.15.0+ requires Sphinx 3.

Ref.: https://github.com/michaeljones/breathe/issues/495