### PR TITLE
Revert "Breathe: <4.15.0"

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -8,4 +8,4 @@ sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx>=2.0
 pygments
-breathe<4.15.0
+breathe


### PR DESCRIPTION
Reverts ECP-WarpX/WarpX#901

We already updated to non-default Sphinx 2.0+, so there is no reason to constrain this.