### PR TITLE
Refactor AMReX IDs to Global ID

### DIFF
--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -15,6 +15,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParmParse.H>
 
+#include <cstdint>
 #include <string>
 
 
@@ -46,6 +47,30 @@ namespace WarpXUtilIO{
  * return true if it succeeds, false otherwise
  */
 bool WriteBinaryDataOnFile(std::string filename, const amrex::Vector<char>& data);
+
+/** A helper function to derive a globally unique particle ID
+ *
+ * @param[in] id  AMReX particle ID (on local cpu/rank), AoS .id
+ * @param[in] cpu AMReX particle CPU (rank) at creation of the particle, AoS .cpu
+ * @return global particle ID that is unique and permanent in the whole simulation
+ */
+constexpr uint64_t
+localIDtoGlobal(int const id, int const cpu)
+{
+    static_assert(sizeof(int) * 2u <= sizeof(uint64_t),
+                  "int size might cause collisions in global IDs");
+    // implementation:
+    //   - we cast both 32-bit (or smaller) ints to a 64bit unsigned int
+    //   - this will leave half of the "upper range" bits in the 64bit unsigned int zeroed out
+    //     because the corresponding (extended) value range was not part of the value range in
+    //     the int representation
+    //   - we bit-shift the cpu into the upper half of zero bits in the 64 bit unsigned int
+    //     (imagine this step as "adding a per-cpu/rank offset to the local integers")
+    //   - then we add this offset
+    //     note: the add is expressed as bitwise OR (|) since this saves us from writing
+    //           brackets for operator precedence between + and <<
+    return uint64_t(id) | uint64_t(cpu) << 32u;
+}
 }
 
 namespace WarpXUtilAlgo{


### PR DESCRIPTION
This PR exposes the AMReX AoS `.id` and `.cpu` to global particle ID conversion for general usage in WarpX. The generated particle ID is unique per particle in the sim and we want to use it for particle filter operations as well.

Also replaces the old implementation with a well-defined bitshift. The old implementation used C-style union type punning, via access of the inactive union member, which is technically undefined behavior (UB) in C++ (and is known to crash on some platforms, e.g. MSVC). Although some popular compilers implemented this C feature as an extension, it is never good to rely on a specific interpretation of UB on a certain platform.

Some more background: https://www.youtube.com/watch?v=_qzMpk-22cc