### PR TITLE
Abort code if the user attempts to use PML in RZ

### DIFF
--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -72,7 +72,7 @@ grid = picmi.CylindricalGrid(number_of_cells = [nr, nz],
                              moving_window_zvelocity = 0.,
                              warpx_max_grid_size=64)
 
-solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
+solver = picmi.ElectromagneticSolver(grid=grid, cfl=1., warpx_do_pml=0)
 
 sim = picmi.Simulation(solver = solver,
                        max_steps = 40,

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -26,6 +26,7 @@ warpx.serialize_ics = 1
 warpx.verbose = 1
 
 # Algorithms
+warpx.do_pml = 0
 algo.field_gathering = energy-conserving
 algo.current_deposition = esirkepov
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -557,6 +557,10 @@ WarpX::ReadParameters ()
         pp.query("pml_has_particles", pml_has_particles);
         pp.query("do_pml_j_damping", do_pml_j_damping);
         pp.query("do_pml_in_domain", do_pml_in_domain);
+#ifdef WARPX_DIM_RZ
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( do_pml==0,
+            "PML are not implemented in RZ geometry ; please set `warpx.do_pml=0`");
+#endif
 
         Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,1);
         pp.queryarr("do_pml_Lo", parse_do_pml_Lo);


### PR DESCRIPTION
As mentioned in #904, the PML are currently not implemented in RZ geometry, in WarpX.

However, if a user tries to use the PML in RZ geometry, the code still runs! It turns out that in this case, the Cartesian PML code is being used - which is obviously an unwanted behavior.

In order to avoid this, this PR aborts code execution when the user requests PML in RZ geometry (this could be removed once #904 is addressed and cylindrical PML are implemented).

Some of the test input scripts are also updated as part of this PR, in order to explicitly deactivate PML in RZ cases. ~~The picmi code had no way to deactivate PML up to now, so this capability is also added as part of this PR.~~ Edit: I realized later that there is a way to deactivate the PML in PICMI, using `warpx_do_pml=0` ; thus this what is currently used in this PR.