### PR TITLE
Yt release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,8 @@ before_install:
 
 install:
     - python -m pip install --upgrade pip
-    - python -m pip install --upgrade cmake cython matplotlib mpi4py numpy scipy
+    - python -m pip install --upgrade cmake cython matplotlib mpi4py numpy scipy yt
     - export CEI_CMAKE="/home/travis/.local/bin/cmake"
-    - python -m conda install -c conda-forge yt
     - sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY && sudo chmod a+x /usr/local/bin/cmake-easyinstall
     - if [ "${WARPX_CI_OPENPMD}" != "FALSE" ]; then
         sudo cmake-easyinstall git+https://github.com/openPMD/openPMD-api.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - python -m pip install --upgrade pip
     - python -m pip install --upgrade cmake cython matplotlib mpi4py numpy scipy
     - export CEI_CMAKE="/home/travis/.local/bin/cmake"
-    - python -m pip install --upgrade git+https://github.com/yt-project/yt.git
+    - python -m conda install -c conda-forge yt
     - sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY && sudo chmod a+x /usr/local/bin/cmake-easyinstall
     - if [ "${WARPX_CI_OPENPMD}" != "FALSE" ]; then
         sudo cmake-easyinstall git+https://github.com/openPMD/openPMD-api.git

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -25,18 +25,4 @@ Then, ``cd`` into the directory ``WarpX`` and use the following set of commands 
 
 See :doc:`../running_cpp/platforms` for more information on how to run WarpX on Summit.
 
-See :doc:`../visualization/yt` for more information on how to visualize the simulation results. In order to build yt **and** a Python environment, you can download the yt installation script as explained in section "All-in-One Installation Script" of the `yt installation web page <https://yt-project.org/doc/installing.html>`__, and run
-
-.. code-block:: sh
-
-    module purge
-    module load gcc
-
-Then modify the few first lines of the installation script ``install_script.sh`` to have
-
-::
-
-   INST_YT_SOURCE=1
-   INST_SCIPY=1
-
-and follow the instructions from the yt website.
+See :doc:`../visualization/yt` for more information on how to visualize the simulation results.

--- a/Docs/source/visualization/yt.rst
+++ b/Docs/source/visualization/yt.rst
@@ -13,9 +13,9 @@ From the terminal, install the latest version of yt:
 ::
 
     pip install cython
-    pip install git+https://github.com/yt-project/yt.git
+    conda install -c conda-forge yt
 
-Alternatively, yt can be installed via their installation script, see `yt installation web page <https://yt-project.org/doc/installing.html>`__, which can be particularly useful to setup a post-processing workflow on supercomputers (see instructions in :doc:`../building/summit` to install yt on Summit).
+Alternatively, yt can be installed via their installation script, see `yt installation web page <https://yt-project.org/doc/installing.html>`__.
 
 Visualizing the data
 --------------------

--- a/Docs/source/visualization/yt.rst
+++ b/Docs/source/visualization/yt.rst
@@ -13,7 +13,7 @@ From the terminal, install the latest version of yt:
 ::
 
     pip install cython
-    conda install -c conda-forge yt
+    python -m pip install --upgrade yt
 
 Alternatively, yt can be installed via their installation script, see `yt installation web page <https://yt-project.org/doc/installing.html>`__.
 


### PR DESCRIPTION
With the new yt release, we can install yt from the Conda-forge wheel and we don't have to install yt from source anymore :tada:. Hence this PR makes the following changes:
- Do not document yt installation from yt `installation_script.sh`, as this is not required anymore.
- Use the conda-forge wheel in `.travis.yml`, which will hopefully accelerate CI (currently yt takes > 2min to install).

