### PR TITLE
Increase tolerance for single-precision PSATD test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -486,7 +486,7 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
+tolerance = 5.e-7
 
 [Langmuir_multi_2d_nodal]
 buildDir = .


### PR DESCRIPTION
Tolerance level for `Langmuir_multi_psatd_single_precision` is the same as for double-precision tests, which doesn't make sense and caused reg tests to fail last night. This PR increases it.