### PR TITLE
Fix link to Contributing Guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ To contact the developers, feel free to open an issue on this repo, or visit our
 
 ## Contributing
 
-Our workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
+Our workflow is described in [contributing section](CONTRIBUTING.rst).

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ To contact the developers, feel free to open an issue on this repo, or visit our
 
 ## Contributing
 
-Our workflow is described in [contributing section](CONTRIBUTING.rst).
+Our workflow is described in [CONTRIBUTING.rst](CONTRIBUTING.rst).


### PR DESCRIPTION
Fixes the link to our contributing guide (now a `.rst` file) in `README.md`.

Follow-up to #888 