### PR TITLE
[mini] remove cython from CI pip install list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 install:
     - python -m pip install --upgrade pip
-    - python -m pip install --upgrade cmake cython matplotlib mpi4py numpy scipy yt
+    - python -m pip install --upgrade cmake matplotlib mpi4py numpy scipy yt
     - export CEI_CMAKE="/home/travis/.local/bin/cmake"
     - sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY && sudo chmod a+x /usr/local/bin/cmake-easyinstall
     - if [ "${WARPX_CI_OPENPMD}" != "FALSE" ]; then


### PR DESCRIPTION
Cython shouldn't be needed anymore, as mentioned by @ax3l in PR https://github.com/ECP-WarpX/WarpX/pull/910.