### PR TITLE
fixing bug to include Bx in CellCenterFunctor for diags

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -100,6 +100,7 @@ Diagnostics::InitData ()
                 all_field_functors[lev][comp] = new CellCenterFunctor(warpx.get_pointer_Efield_aux(lev, 1), lev, m_crse_ratio);
             } else if ( varnames[comp] == "Ez" ){
                 all_field_functors[lev][comp] = new CellCenterFunctor(warpx.get_pointer_Efield_aux(lev, 2), lev, m_crse_ratio);
+            } else if ( varnames[comp] == "Bx" ){
                 all_field_functors[lev][comp] = new CellCenterFunctor(warpx.get_pointer_Bfield_aux(lev, 0), lev, m_crse_ratio);
             } else if ( varnames[comp] == "By" ){
                 all_field_functors[lev][comp] = new CellCenterFunctor(warpx.get_pointer_Bfield_aux(lev, 1), lev, m_crse_ratio);


### PR DESCRIPTION
PR#856 introduced an error where an existing `else if` statement for Bx was deleted! 
This lead to segfault when Bx was added, and also, an incorrect Ez value from the newly refactored diagnostics. 

This PR re-introduces that `else if` statement to correctly initialize Ez, and also include 'Bx'.

Thank you @MaxThevenet for identifying the issue through tests.