### PR TITLE
Increase tolerance for test PlasmaAccelerationBoost3d from 1.e-14 t2.e-14

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -972,7 +972,7 @@ useOMP = 1
 numthreads = 2
 compileTest = 0
 doVis = 0
-tolerance = 1.e-14
+tolerance = 2.e-14
 
 [PlasmaMirror]
 buildDir = .


### PR DESCRIPTION
Battra tests failed last night for a tolerance issue. This is a fix.