### PR TITLE
Install Docs: Spack Env Update

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -1,3 +1,5 @@
+.. _building-cori:
+
 Building WarpX for Cori (NERSC)
 ===============================
 
@@ -90,36 +92,39 @@ Finally, navigate to the base of the WarpX repository and compile in GPU mode:
     make -j 16 USE_GPU=TRUE
 
 
+.. _building-cori-openPMD:
+
 Building WarpX with openPMD support
 -----------------------------------
 
 First, load the appropriate modules:
 
-::
+.. code-block:: bash
 
-    module swap craype-haswell craype-mic-knl
-    module swap PrgEnv-intel PrgEnv-gnu
-    module load cmake/3.14.4
-    module load cray-hdf5-parallel
-    module load adios/1.13.1
-    export CRAYPE_LINK_TYPE=dynamic
+   module swap craype-haswell craype-mic-knl
+   module swap PrgEnv-intel PrgEnv-gnu
+   module load cmake/3.14.4
+   module load cray-hdf5-parallel
+   module load adios/1.13.1
+   export CRAYPE_LINK_TYPE=dynamic
 
-Then, in the `warpx_directory`, download and build the openPMD API:
+Then, in the ``warpx_directory``, download and build openPMD-api:
 
-::
+.. code-block:: bash
 
-    git clone https://github.com/openPMD/openPMD-api.git
-    mkdir openPMD-api-build
-    cd openPMD-api-build
-    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
-    cmake --build . --target install
+   git clone https://github.com/openPMD/openPMD-api.git
+   mkdir openPMD-api-build
+   cd openPMD-api-build
+   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
+   cmake --build . --target install
 
 Finally, compile WarpX:
 
-::
+.. code-block:: bash
 
-    cd ../WarpX
-    export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib64/pkgconfig:$PKG_CONFIG_PATH
-    make -j 16 COMP=gcc USE_OPENPMD=TRUE
+   cd ../WarpX
+   export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib64/pkgconfig:$PKG_CONFIG_PATH
+   export CMAKE_PREFIX_PATH=$PWD/../openPMD-install:$CMAKE_PREFIX_PATH
+   make -j 16 COMP=gcc USE_OPENPMD=TRUE
 
 In order to run WarpX, load the same modules again.

--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -19,16 +19,20 @@ In order to install spack, you can simply do:
 .. code-block:: bash
 
    git clone https://github.com/spack/spack.git
-   export SPACK_ROOT=/path/to/spack  # note: adjust this path
+   export SPACK_ROOT=$PWD/spack
    . $SPACK_ROOT/share/spack/setup-env.sh
 
-(You may want to add the last 2 lines to your ``.bashrc`` file.)
+You may want to auto-activate spack when you open a new terminal by adding this to your ``$HOME/.bashrc`` file:
+
+.. code-block:: bash
+
+   echo -e "# activate spack package manager\n. ${SPACK_ROOT}/share/spack/setup-env.sh" >> $HOME/.bashrc
 
 
 WarpX Development Environment with Spack
 ----------------------------------------
 
-Create an activate a Spack environment with all software needed to build WarpX
+Create and activate a Spack environment with all software needed to build WarpX
 
 .. code-block:: bash
 

--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -16,74 +16,90 @@ library from source.
 
 In order to install spack, you can simply do:
 
-::
+.. code-block:: bash
 
-  git clone https://github.com/spack/spack.git
-  export SPACK_ROOT=/path/to/spack
-  . $SPACK_ROOT/share/spack/setup-env.sh
+   git clone https://github.com/spack/spack.git
+   export SPACK_ROOT=/path/to/spack  # note: adjust this path
+   . $SPACK_ROOT/share/spack/setup-env.sh
 
 (You may want to add the last 2 lines to your ``.bashrc`` file.)
 
 
-Building openPMD support, by installing openPMD-api directly from spack
------------------------------------------------------------------------
+WarpX Development Environment with Spack
+----------------------------------------
 
-First, install the openPMD-api library:
+Create an activate a Spack environment with all software needed to build WarpX
 
-::
+.. code-block:: bash
 
-    spack install openpmd-api -python
+   spack env create warpx-dev    # you do this once
+   spack env activate warpx-dev
+   spack add gmake
+   spack add mpi
+   spack add openpmd-api
+   spack add pkg-config
+   spack install
 
-Then, ``cd`` into the ``WarpX`` folder, and type:
+This will download and compile all dependencies.
 
-::
+Whenever you need this development environment in the future, just repeat the quick ``spack env activate warpx-dev`` step.
+For example, we can now compile WarpX by ``cd``-ing into the ``WarpX`` folder and typing:
 
-    spack load -r openpmd-api
-    make -j 4 USE_OPENPMD=TRUE
+.. code-block:: bash
+
+   spack env activate warpx-dev
+   make -j 4 USE_OPENPMD=TRUE
 
 You will also need to load the same spack environment when running WarpX, for instance:
 
-::
+.. code-block:: bash
 
-    spack load -r openpmd-api
+   spack env activate warpx-dev
+   mpirun -np 4 ./warpx.exe inputs
 
-    mpirun -np 4 ./warpx.exe inputs
+You can check which Spack environments exist and if one is still active with
 
-Building openPMD support, by installing openPMD-api from source
----------------------------------------------------------------
+.. code-block:: bash
 
-First, install the openPMD-api library, and load it in your environment:
+   spack env list  # already created environments
+   spack env st    # is an environment active?
 
-::
 
-    spack install hdf5
-    spack install adios2
-    spack load -r hdf5
-    spack load -r adios2
+Installing openPMD-api from source
+----------------------------------
 
-Then, in the `warpx_directory`, download and build the openPMD API:
+You can also build openPMD-api from source, e.g. to build against the module environment of a supercomputer cluster.
 
-::
+First, load the according modules of the cluster to support the openPMD-api dependencies.
+You can find the `required and optional dependencies here <https://github.com/openPMD/openPMD-api#dependencies_`.
 
-    git clone https://github.com/openPMD/openPMD-api.git
-    mkdir openPMD-api-build
-    cd openPMD-api-build
-    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
-    cmake --build . --target install
+You usually just need a C++ compiler, CMake, and one or more file backend libraries, such as HDF5 and/or ADIOS2.
+See for example `our installation guidelines for Cori :ref`<building-cori-openPMD>`.
+
+Then, in the ``$HOME/warpx_directory/``, download and build openPMD-api:
+
+.. code-block:: bash
+
+   git clone https://github.com/openPMD/openPMD-api.git
+   mkdir openPMD-api-build
+   cd openPMD-api-build
+   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=$HOME/warpx_directory/openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
+   cmake --build . --target install
 
 Finally, compile WarpX:
 
-::
+.. code-block:: bash
 
-    cd ../WarpX
-    export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib/pkgconfig:$PKG_CONFIG_PATH
-    make -j 4 USE_OPENPMD=TRUE
+   cd ../WarpX
+   export PKG_CONFIG_PATH=$HOME/warpx_directory/openPMD-install/lib/pkgconfig:$PKG_CONFIG_PATH
+   export CMAKE_PREFIX_PATH=$HOME/warpx_directory/openPMD-install:$CMAKE_PREFIX_PATH
 
-You will also need to load the same spack environment when running WarpX, for instance:
+   make -j 4 USE_OPENPMD=TRUE
 
-::
+When running WarpX, we will recall where you installed openPMD-api via RPATHs, so you just need to load the same module environment as used for building (same MPI, HDF5, ADIOS2, for instance).
 
-    spack load -r hdf5
-    spack load -r adios2
+.. code-block:: bash
 
-    mpirun -np 4 ./warpx.exe inputs
+   # module load ...  (compiler, MPI, HDF5, ADIOS2, ...)
+
+   mpirun -np 4 ./warpx.exe inputs

--- a/Docs/source/building/python.rst
+++ b/Docs/source/building/python.rst
@@ -1,27 +1,27 @@
 Installing WarpX as a Python package
 ------------------------------------
 
+WarpX' Python bindings depend on ``numpy``, ``mpi4py``, and ``picmistandard``.
+
 Type
 
-::
+.. code-block:: bash
 
-    make -j 4 USE_PYTHON_MAIN=TRUE
+   make -j 4 USE_PYTHON_MAIN=TRUE
 
-or edit the GNUmakefile and set `USE_PYTHON_MAIN=TRUE`, and type
+or edit the ``GNUmakefile`` and set ``USE_PYTHON_MAIN=TRUE``, and type
 
-::
+.. code-block:: bash
 
-    make -j 4
+   make -j 4
 
-This will compile the code, and install the Python bindings as a package (named
-``pywarpx``) in your standard Python installation (i.e. in your
-``site-packages`` directory). The note on compiler options from the previous
-section also holds when compiling the Python package.
+This will compile the code, and install the Python bindings as a package (named ``pywarpx``) in your standard Python installation (i.e. in your ``site-packages`` directory).
+The note on compiler options from the previous section also holds when compiling the Python package.
 
 In case you do not have write permissions to the default Python installation (e.g. typical on computer clusters), use the following command instead:
 
-::
+.. code-block:: bash
 
    make -j 4 PYINSTALLOPTIONS=--user
 
-In this case, you can also set the variable `PYTHONUSERBASE` to set the folder where `pywarpx` will be installed.
+In this case, you can also set the variable ``PYTHONUSERBASE`` to set the folder where ``pywarpx`` will be installed.

--- a/Docs/source/building/spack.rst
+++ b/Docs/source/building/spack.rst
@@ -15,6 +15,8 @@ From the `Spack web page <https://spack.io>`_: "Spack is a package management to
 
 Spack is available from `github <https://github.com/spack/spack>`_.
 Spack only needs to be cloned and can be used right away - there are no installation steps.
+Do not miss out on `the official Spack tutorial <https://spack-tutorial.readthedocs.io/>`_ if you are new to Spack.
+
 The spack command, ``spack/bin/spack``, can be used directly or ``spack/bin`` can be added to your ``PATH`` environment variable.
 
 WarpX is built with the single command

--- a/Docs/source/building/spack.rst
+++ b/Docs/source/building/spack.rst
@@ -1,40 +1,49 @@
 Building WarpX with Spack
 ===============================
 
-WarpX can be installed using Spack. From the Spack web page: "Spack is a package management tool designed to support multiple
-versions and configurations of software on a wide variety of platforms and environments."
+WarpX can be installed using Spack.
+From the `Spack web page <https://spack.io>`_: "Spack is a package management tool designed to support multiple versions and configurations of software on a wide variety of platforms and environments."
 
-Spack is available from `github <https://github.com/spack/spack>`__. Spack only needs to be cloned and can be used right away - there are no installation
-steps. The spack command, "spack/bin/spack", can be used directly or "spack/bin" can be added to your execute path.
+.. note::
+
+   Quick-start hint for macOS users:
+   Before getting started with Spack, please check what you manually installed in ``/usr/local``.
+   If you find entries in ``bin/``, ``lib/`` et al. that look like you manually installed MPI, HDF5 or other software at some point, then remove those files first.
+
+   If you find software such as MPI in the same directories that are shown as symbolic links then it is likely you `brew installed <https://brew.sh>`_ software before.
+   Run `brew unlink ... <https://docs.brew.sh/Tips-N%27-Tricks#quickly-remove-something-from-usrlocal>`_ on such packages first to avoid software incompatibilities.
+
+Spack is available from `github <https://github.com/spack/spack>`_.
+Spack only needs to be cloned and can be used right away - there are no installation steps.
+The spack command, ``spack/bin/spack``, can be used directly or ``spack/bin`` can be added to your ``PATH`` environment variable.
 
 WarpX is built with the single command
 
-::
+.. code-block:: bash
 
-    spack install warpx
+   spack install warpx
 
-This will build the 3-D version of WarpX using the master branch.
+This will build the 3-D version of WarpX using the ``master`` branch.
 At the very end of the output from build sequence, Spack tells you where the WarpX executable has been placed.
-Alternatively, the "spack load" command can be configured so that "spack load warpx" will put the executable in your execute path.
+Alternatively, ``spack load -r warpx`` can be called, which will put the executable in your ``PATH`` environment variable.
 
-Other variants of WarpX can be installed, for example
+WarpX can be built in several variants, see
 
-::
+.. code-block:: bash
 
-    spack install warpx dims=2
+   spack info warpx
 
-will build the 2-D version.
+for all available options.
 
-::
+For example
 
-    spack install warpx debug=True
+.. code-block:: bash
 
-will build with debugging turned on.
+   spack install warpx dims=2 +debug
 
-::
+will build the 2-D version and also turns debugging on.
 
-    spack install warpx %intel
+See ``spack help --spec`` for all syntax details.
+Also, please consult the `basic usage section <https://spack.readthedocs.io/en/latest/basic_usage.html>`_ of the Spack package manager for an extended introduction to Spack.
 
-will build using the intel compiler (instead of gcc).
-
-The Python verson of WarpX is not yet available with Spack.
+The Python version of WarpX is not yet available with Spack.

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -1,6 +1,6 @@
 .. _building-summit:
 
-Building WarpX for Summit (OLCF)
+Building WarpX on Summit (OLCF)
 ================================
 
 For the `Summit cluster

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -1,3 +1,5 @@
+.. _building-summit:
+
 Building WarpX for Summit (OLCF)
 ================================
 


### PR DESCRIPTION
Update the installation docs, modernize Spack instructions for environments, list common macOS "cleanup" hint, document Python dependencies for `pywarpx`.

Spack development workflow tested on my local Ubuntu 18.04 machine and from-source build tested on Cori with the documented modules.