### PR TITLE
[mini] Add contact us section to documentation

### DIFF
--- a/Docs/source/contact_us.rst
+++ b/Docs/source/contact_us.rst
@@ -1,7 +1,7 @@
 Contact us
 ==========
 
-If you are starting with WarpX, or if you have a user question, of for any other reason, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
+If you are starting using WarpX, or if you have a user question, or for any other reason, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
 
 The `WarpX GitHub repo <https://github.com/ECP-WarpX/WarpX>`__ is the main communication platform.
 Have a look at the action icons on the top right of the web page: feel free to watch the repo if you want to receive updates, or to star the repo to support the project.

--- a/Docs/source/contact_us.rst
+++ b/Docs/source/contact_us.rst
@@ -1,0 +1,8 @@
+Contact us
+==========
+
+If you are starting with WarpX, or if you have a user question, of for any other reason, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
+
+The `WarpX GitHub repo <https://github.com/ECP-WarpX/WarpX>`__ is the main communication platform.
+Have a look at the action icons on the top right of the web page: feel free to watch the repo if you want to receive updates, or to star the repo to support the project.
+For bug reports, to request new features, or other comments on the code you can also open a new issue.

--- a/Docs/source/contact_us.rst
+++ b/Docs/source/contact_us.rst
@@ -1,7 +1,7 @@
 Contact us
 ==========
 
-If you are starting using WarpX, or if you have a user question, or for any other reason, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
+If you are starting using WarpX, or if you have a user question, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
 
 The `WarpX GitHub repo <https://github.com/ECP-WarpX/WarpX>`__ is the main communication platform.
 Have a look at the action icons on the top right of the web page: feel free to watch the repo if you want to receive updates, or to star the repo to support the project.

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -40,5 +40,6 @@ In order to learn to use the code, please see the sections below:
    developers/developers
    developers/doxygen
    libensemble/libensemble
+   contact_us
    acknowledge_us
    acknowledgements


### PR DESCRIPTION
Add small section in the doc with links to the GitHub repo and the WarpX Gitter chat room. 