### PR TITLE
CI: Add macOS AppleClang Build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,30 @@
+name: macOS build
+
+on: [push, pull_request]
+
+jobs:
+  build_gcc9:
+    name: AppleClang [macOS]
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: 'warpx_directory/WarpX'
+    - name: install dependencies
+      run: |
+        brew install cmake
+        brew install fftw
+        brew install libomp
+        brew install open-mpi
+        brew install pkg-config
+        brew tap openpmd/openpmd
+        brew install openpmd-api
+    - name: build WarpX
+      run: |
+        cd warpx_directory
+        git clone --depth 1 https://bitbucket.org/berkeleylab/picsar.git
+        git clone --depth 1 --branch development https://github.com/AMReX-Codes/amrex.git
+        cd WarpX
+        export LDFLAGS="-lomp"
+        make -j 2 COMP=llvm USE_OMP=FALSE USE_OPENPMD=TRUE XTRA_CXXFLAGS="-Xpreprocessor -fopenmp"
+


### PR DESCRIPTION
Ensure that our macOS developers can kick-start WarpX on macOS.

This just builds the default compile flags with openPMD I/O enabled so far, to make sure the essentials compile with AppleClang.

This will be prettier after #759 , but let's push ahead now.