### PR TITLE
ReducedDiags: Missing virtual Destructor

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.H
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.H
@@ -47,6 +47,10 @@ public:
      *  @param[in] rd_name reduced diags name */
     ReducedDiags(std::string rd_name);
 
+    /** Virtual destructor for polymorphism
+     */
+    virtual ~ReducedDiags() = default;
+
     /// function to compute diags
     virtual void ComputeDiags(int step) = 0;
 


### PR DESCRIPTION
If a base class in C++ is not purely virtual, it needs a virtual destructor. Fixes memory leaks and undefined behavior which causes potential crashes.

Spotted with AppleClang 11.0 in #946:
```
warning: delete called on 'ReducedDiags' that is abstract but
has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
```

Refs.:
- https://www.geeksforgeeks.org/virtual-destructor/
- https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP52-CPP.+Do+not+delete+a+polymorphic+object+without+a+virtual+destructor
- https://stackoverflow.com/questions/270917/why-should-i-declare-a-virtual-destructor-for-an-abstract-class-in-c