### PR TITLE
Prevent the use of Esirkepov with the nodal algorithm

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -309,6 +309,9 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
     const std::array<Real, 3>& xyzmin = WarpX::LowerCorner(tilebox, galilean_shift, depos_lev);
 
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov) {
+        if (WarpX::do_nodal==1) {
+          amrex::Abort("The Esirkepov algorithm cannot be used with a nodal grid.");
+        }
         if ( (v_galilean[0]!=0) or (v_galilean[1]!=0) or (v_galilean[2]!=0)){
             amrex::Abort("The Esirkepov algorithm cannot be used with the Galilean algorithm.");
         }


### PR DESCRIPTION
The Esirkepov algorithm explicitly assumes a staggered grid. Therefore, it should not be used with the `do_nodal` option.