### PR TITLE
Add checkpoint capability to new diags

### DIFF
--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -2,10 +2,6 @@
 #define WARPX_DIAGNOSTICS_H_
 
 #include "FlushFormats/FlushFormat.H"
-#include "FlushFormats/FlushFormatPlotfile.H"
-#ifdef WARPX_USE_OPENPMD
-#   include "FlushFormats/FlushFormatOpenPMD.H"
-#endif
 #include "ComputeDiagFunctors/ComputeDiagFunctor.H"
 #include "ParticleDiag/ParticleDiag.H"
 #include <AMReX_Vector.H>

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -89,7 +89,7 @@ Diagnostics::ReadParameters ()
            m_crse_ratio[idim] = cr_ratio[idim];
        }
     }
-    
+
     bool species_specified = pp.queryarr("species", m_species_names);
 
     if (m_format == "checkpoint"){

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -4,6 +4,11 @@
 #include "ComputeDiagFunctors/PartPerGridFunctor.H"
 #include "ComputeDiagFunctors/DivBFunctor.H"
 #include "ComputeDiagFunctors/DivEFunctor.H"
+#include "FlushFormats/FlushFormatPlotfile.H"
+#include "FlushFormats/FlushFormatCheckpoint.H"
+#ifdef WARPX_USE_OPENPMD
+#   include "FlushFormats/FlushFormatOpenPMD.H"
+#endif
 #include "WarpX.H"
 #include "Utils/Average.H"
 #include "Utils/WarpXUtil.H"
@@ -118,6 +123,8 @@ Diagnostics::InitData ()
     // Construct Flush class.
     if        (m_format == "plotfile"){
         m_flush_format = new FlushFormatPlotfile;
+    } else if (m_format == "checkpoint"){
+        m_flush_format = new FlushFormatCheckpoint;
     } else if (m_format == "openpmd"){
 #ifdef WARPX_USE_OPENPMD
         m_flush_format = new FlushFormatOpenPMD(m_diag_name);

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -1,0 +1,23 @@
+#ifndef WARPX_FLUSHFORMATCHECKPOINT_H_
+#define WARPX_FLUSHFORMATCHECKPOINT_H_
+
+#include "FlushFormatPlotfile.H"
+
+class FlushFormatCheckpoint : public FlushFormatPlotfile
+{
+    /** Flush fields and particles to plotfile */
+    virtual void WriteToFile (
+        const amrex::Vector<std::string> varnames,
+        const amrex::Vector<const amrex::MultiFab*> mf,
+        amrex::Vector<amrex::Geometry>& geom,
+        const amrex::Vector<int> iteration, const double time,
+        const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
+        bool plot_raw_fields,
+        bool plot_raw_fields_guards,
+        bool plot_raw_rho, bool plot_raw_F) const override final;
+
+    void CheckpointParticles(const std::string& dir,
+                             const amrex::Vector<ParticleDiag>& particle_diags) const;
+};
+
+#endif // WARPX_FLUSHFORMATCHECKPOINT_H_

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -3,7 +3,7 @@
 
 #include "FlushFormatPlotfile.H"
 
-class FlushFormatCheckpoint : public FlushFormatPlotfile
+class FlushFormatCheckpoint final : public FlushFormatPlotfile
 {
     /** Flush fields and particles to plotfile */
     virtual void WriteToFile (

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -1,0 +1,116 @@
+#include "FlushFormatCheckpoint.H"
+#include "WarpX.H"
+#include "Utils/WarpXProfilerWrapper.H"
+
+//#include <AMReX_MultiFabUtil.H>
+//#include <AMReX_PlotFileUtil.H>
+//#include <AMReX_FillPatchUtil_F.H>
+#include <AMReX_buildInfo.H>
+
+using namespace amrex;
+
+namespace
+{
+    const std::string level_prefix {"Level_"};
+}
+
+void
+FlushFormatCheckpoint::WriteToFile (
+        const amrex::Vector<std::string> varnames,
+        const amrex::Vector<const amrex::MultiFab*> mf,
+        amrex::Vector<amrex::Geometry>& geom,
+        const amrex::Vector<int> iteration, const double time,
+        const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
+        bool plot_raw_fields,
+        bool plot_raw_fields_guards,
+        bool plot_raw_rho, bool plot_raw_F) const
+{
+    WARPX_PROFILE("FlushFormatCheckpoint::WriteToFile()");
+
+    auto & warpx = WarpX::GetInstance();
+
+    VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
+    VisMF::SetHeaderVersion(amrex::VisMF::Header::NoFabHeader_v1);
+
+    const std::string& checkpointname = amrex::Concatenate(prefix,iteration[0]);
+
+    amrex::Print() << "  Writing checkpoint " << checkpointname << "\n";
+
+    // const int nlevels = finestLevel()+1;
+    amrex::PreBuildDirectorHierarchy(checkpointname, level_prefix, nlev, true);
+
+    WriteWarpXHeader(checkpointname, particle_diags);
+
+    WriteJobInfo(checkpointname);
+
+    for (int lev = 0; lev < nlev; ++lev)
+    {
+        VisMF::Write(warpx.getEfield_fp(lev, 0),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ex_fp"));
+        VisMF::Write(warpx.getEfield_fp(lev, 1),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ey_fp"));
+        VisMF::Write(warpx.getEfield_fp(lev, 2),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ez_fp"));
+        VisMF::Write(warpx.getBfield_fp(lev, 0),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Bx_fp"));
+        VisMF::Write(warpx.getBfield_fp(lev, 1),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "By_fp"));
+        VisMF::Write(warpx.getBfield_fp(lev, 2),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Bz_fp"));
+        if (warpx.getis_synchronized()) {
+            // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
+            VisMF::Write(warpx.getcurrent_fp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jx_fp"));
+            VisMF::Write(warpx.getcurrent_fp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jy_fp"));
+            VisMF::Write(warpx.getcurrent_fp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jz_fp"));
+        }
+
+        if (lev > 0)
+        {
+            VisMF::Write(warpx.getEfield_cp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ex_cp"));
+            VisMF::Write(warpx.getEfield_cp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ey_cp"));
+            VisMF::Write(warpx.getEfield_cp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Ez_cp"));
+            VisMF::Write(warpx.getBfield_cp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Bx_cp"));
+            VisMF::Write(warpx.getBfield_cp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "By_cp"));
+            VisMF::Write(warpx.getBfield_cp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "Bz_cp"));
+            if (warpx.getis_synchronized()) {
+                // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
+                VisMF::Write(warpx.getcurrent_cp(lev, 0),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jx_cp"));
+                VisMF::Write(warpx.getcurrent_cp(lev, 1),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jy_cp"));
+                VisMF::Write(warpx.getcurrent_cp(lev, 2),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "jz_cp"));
+            }
+        }
+
+        if (warpx.DoPML() && warpx.GetPML(lev)) {
+            warpx.GetPML(lev)->CheckPoint(
+                amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "pml"));
+        }
+    }
+
+    CheckpointParticles(checkpointname, particle_diags);
+
+    VisMF::SetHeaderVersion(current_version);
+
+}
+
+void
+FlushFormatCheckpoint::CheckpointParticles(
+    const std::string& dir,
+    const amrex::Vector<ParticleDiag>& particle_diags) const
+{
+    for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
+        particle_diags[i].getParticleContainer()->Checkpoint(
+            dir, particle_diags[i].getSpeciesName());
+    }
+}

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -2,9 +2,6 @@
 #include "WarpX.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
-//#include <AMReX_MultiFabUtil.H>
-//#include <AMReX_PlotFileUtil.H>
-//#include <AMReX_FillPatchUtil_F.H>
 #include <AMReX_buildInfo.H>
 
 using namespace amrex;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -21,7 +21,7 @@ public:
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override final;
+        bool plot_raw_rho, bool plot_raw_F) const override;
 
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;

--- a/Source/Diagnostics/FlushFormats/Make.package
+++ b/Source/Diagnostics/FlushFormats/Make.package
@@ -1,4 +1,5 @@
 CEXE_sources += FlushFormatPlotfile.cpp
+CEXE_sources += FlushFormatCheckpoint.cpp
 ifeq ($(USE_OPENPMD), TRUE)
     CEXE_sources += FlushFormatOpenPMD.cpp
 endif

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -235,7 +235,7 @@ public:
     const amrex::MultiFab& getBfield_fp  (int lev, int direction) {return *Bfield_fp[lev][direction];}
     const amrex::MultiFab& getrho_fp (int lev) {return *rho_fp[lev];}
     const amrex::MultiFab& getF_fp (int lev) {return *F_fp[lev];}
-    const bool DoPML () const {return do_pml;};
+    bool DoPML () const {return do_pml;};
 
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */
     std::vector<bool> getPMLdirections() const;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -235,6 +235,7 @@ public:
     const amrex::MultiFab& getBfield_fp  (int lev, int direction) {return *Bfield_fp[lev][direction];}
     const amrex::MultiFab& getrho_fp (int lev) {return *rho_fp[lev];}
     const amrex::MultiFab& getF_fp (int lev) {return *F_fp[lev];}
+    const bool DoPML () const {return do_pml;};
 
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */
     std::vector<bool> getPMLdirections() const;


### PR DESCRIPTION
While deleting old diags, a number of functions cannot be removed because they are used for checkpoint-restart. This PR doesn't touch the restart capability, but moves the checkpoint capability to the new diags, so that these functions can safely be deleted.

When
```
<diag_name>.diags_type = Full
```
a new flush format "checkpoint" is available
```
<diag_name>.format = checkpoint
```
that will write a checkpoint file. This could be further abstracted so that the user enters
```
<diag_name>.diags_type = checkpoint
```
instead, but I think this minor change will be more relevant once we start working on the back-transformed diagnostics, because then we will clarify what belongs to which `diag_type`.