### PR TITLE
Switch to new overloads of makeKnapSack, makeSFC w/ reduced comms

### DIFF
--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -21,57 +21,83 @@ WarpX::LoadBalance ()
 
     AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
 
+#ifdef AMREX_USE_MPI
     if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
     {
+        // compute the costs on a per-rank basis
         WarpX::ComputeCostsHeuristic(costs);
     }
 
     // By default, do not do a redistribute; this toggles to true if RemakeLevel
     // is called for any level
-    bool doRedistribute = false;
+    int doLoadBalance = 0;
 
     const int nLevels = finestLevel();
     for (int lev = 0; lev <= nLevels; ++lev)
     {
-#ifdef AMREX_USE_MPI
-        // Parallel reduce the costs
-        amrex::Vector<Real>::iterator it = (*costs[lev]).begin();
-        amrex::Real* itAddr = &(*it);
-        ParallelAllReduce::Sum(itAddr, costs[lev]->size(), ParallelContext::CommunicatorSub());
-#endif
-        // To store efficiency (meaning, the  average 'cost' over all ranks, normalized to the
-        // max cost) for current distribution mapping
-        amrex::Real currentEfficiency = 0.0;
-
-        // Compute efficiency for the current distribution mapping
-        const DistributionMapping& currentdm = DistributionMap(lev);
-        if (load_balance_efficiency_ratio_threshold > 0.0)
+        LayoutData<Real> costsLayoutData(boxArray(lev), DistributionMap(lev));
+        for (auto i : costsLayoutData.IndexArray())
         {
-            ComputeDistributionMappingEfficiency(currentdm, *costs[lev],
-                                                 currentEfficiency);
+            costsLayoutData[i] = (*costs[lev])[i];
         }
 
+        // Compute the new distribution mapping
+        DistributionMapping newdm;
         const amrex::Real nboxes = costs[lev]->size();
         const amrex::Real nprocs = ParallelContext::NProcsSub();
         const int nmax = static_cast<int>(std::ceil(nboxes/nprocs*load_balance_knapsack_factor));
-
-        // To store efficiency for proposed distribution mapping
+        // These store efficiency (meaning, the  average 'cost' over all ranks,
+        // normalized to max cost) for current and proposed distribution mappings
+        amrex::Real currentEfficiency = 0.0;
         amrex::Real proposedEfficiency = 0.0;
 
-        const DistributionMapping newdm = (load_balance_with_sfc)
-            ? DistributionMapping::makeSFC(*costs[lev], boxArray(lev), proposedEfficiency, false)
-            : DistributionMapping::makeKnapSack(*costs[lev], proposedEfficiency, nmax);
-
-        if (proposedEfficiency > load_balance_efficiency_ratio_threshold*currentEfficiency)
+        newdm = (load_balance_with_sfc)
+            ? DistributionMapping::makeSFC(costsLayoutData,
+                                           currentEfficiency, proposedEfficiency,
+                                           false,
+                                           ParallelDescriptor::IOProcessorNumber())
+            : DistributionMapping::makeKnapSack(costsLayoutData,
+                                                currentEfficiency, proposedEfficiency,
+                                                nmax,
+                                                false,
+                                                ParallelDescriptor::IOProcessorNumber());
+        // As specified in the above calls to makeSFC and makeKnapSack, the new
+        // distribution mapping is NOT communicated to all ranks; the loadbalanced
+        // dm is up-to-date only on root, and we can decide whether to broadcast
+        if (load_balance_efficiency_ratio_threshold > 0.0
+            & ParallelDescriptor::MyProc() == ParallelDescriptor::IOProcessorNumber())
         {
+            doLoadBalance = (proposedEfficiency > load_balance_efficiency_ratio_threshold*currentEfficiency);
+        }
+
+        ParallelDescriptor::Bcast(&doLoadBalance, 1,
+                                  ParallelDescriptor::IOProcessorNumber());
+
+        if (doLoadBalance)
+        {
+            Vector<int> pmap;
+            if (ParallelDescriptor::MyProc() == ParallelDescriptor::IOProcessorNumber())
+            {
+                pmap = newdm.ProcessorMap();
+            } else
+            {
+                pmap.resize(nboxes);
+            }
+            ParallelDescriptor::Bcast(&pmap[0], pmap.size(), ParallelDescriptor::IOProcessorNumber());
+
+            if (ParallelDescriptor::MyProc() != ParallelDescriptor::IOProcessorNumber())
+            {
+                newdm = DistributionMapping(pmap);
+            }
+
             RemakeLevel(lev, t_new[lev], boxArray(lev), newdm);
-            doRedistribute = true;
         }
     }
-    if (doRedistribute)
+    if (doLoadBalance)
     {
         mypc->Redistribute();
     }
+#endif
 }
 
 
@@ -309,40 +335,4 @@ WarpX::ResetCosts ()
     {
         costs[lev]->assign((*costs[lev]).size(), 0.0);
     }
-}
-
-void
-WarpX::ComputeDistributionMappingEfficiency (const DistributionMapping& dm,
-                                             const Vector<Real>& cost,
-                                             Real& efficiency)
-{
-    const Real nprocs = ParallelDescriptor::NProcs();
-
-    // Collect costs per fab corresponding to each rank, then collapse into vector
-    // of total cost per proc
-
-    // This will store mapping from (proc) --> ([cost_FAB_1, cost_FAB_2, ... ])
-    // for each proc
-    std::map<int, Vector<Real>> rankToCosts;
-
-    for (int i=0; i<cost.size(); ++i)
-    {
-        rankToCosts[dm[i]].push_back(cost[i]);
-    }
-
-    Real maxCost = -1.0;
-
-    // This will store mapping from (proc) --> (sum of cost) for each proc
-    Vector<Real> rankToCost = {0.0};
-    rankToCost.resize(nprocs);
-    for (int i=0; i<nprocs; ++i) {
-        const Real rwSum = std::accumulate(rankToCosts[i].begin(),
-                                           rankToCosts[i].end(), 0.0);
-        rankToCost[i] = rwSum;
-        maxCost = std::max(maxCost, rwSum);
-    }
-
-    // `efficiency` is mean cost per proc
-    efficiency = (std::accumulate(rankToCost.begin(),
-                  rankToCost.end(), 0.0) / (nprocs*maxCost));
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -495,18 +495,6 @@ public:
      */
     void ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::Vector<amrex::Real> > >& costs);
 
-    /** \brief Computes the average cost per MPI rank given a distribution mapping
-     * and vector of cost for each FAB.
-     * @param[in] dm distribution mapping (mapping from FAB to MPI processes)
-     * @param[in] cost vector which gives mapping from FAB index space to the
-     * respective FAB's cost
-     * @param[out] efficiency average cost per MPI process computed from the
-     * given distribution mapping and and cost
-     */
-    void ComputeDistributionMappingEfficiency (const amrex::DistributionMapping& dm,
-                                               const amrex::Vector<amrex::Real>& cost,
-                                               amrex::Real& efficiency);
-
 protected:
 
     /**


### PR DESCRIPTION
This PR (dependency: https://github.com/AMReX-Codes/amrex/pull/805) switches to new overloads of the `makeSFC` and `makeKnapSack` functions for load balance (this offer a performance improvement due to reduced communications of local 'costs' with the new overloads).  `ComputeDistributionMappingEfficiency` is also moved to AMReX and is removed from `WarpXRegrid`.  

Note: the new overloads take `amrex::LayoutData` as arguments, which is a 'one item per box' storage, and can allow a rank to keep track only of the local boxes' costs, but still with knowledge of their indices in the global array.  For now, we convert from `Vector` to `LayoutData` right before computing the new distribution mapping, but in PR #970 we can switch from `Vector<std::unique_ptr<Vector<Real>>> costs` to `Vector<std::unique_ptr<LayoutData<Real>>> costs` as a further improvement.