### PR TITLE
Load Particles: external_file MPI Support

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -309,7 +309,10 @@ Particle initialization
       It requires the additional arguments:
       ``<species_name>.injection_file`` (`string`) openPMD file name and
       ``<species_name>.q_tot`` (`double`) optional (default is ``q_tot=0`` and no re-scaling is done, ``weight=q_p``) when specified it is used to re-scale the weight of externally loaded ``N`` physical particles, each of charge ``q_p``, to inject macroparticles of ``weight=<species_name>.q_tot/q_p/N``.
-      The external file should include the species ``openPMD::Record`` s labeled ``mass`` and ``charge`` (`double` scalars) and also the ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
+      ``<species_name>.charge`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
+      ``<species_name>.mass`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
+      The external file must include the species ``openPMD::Record``s labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
+      If the external file also contains ``openPMD::Records``s for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see ``<species_name>.mass``, ```<species_name>.charge`` or ```<species_name>.species_type``).
       The ``external_file`` option is currently implemented for 2D and 3D geometries, with record components ``x``, ``z`` and ``y`` for 3D.
       For more information on the `openPMD format <https://github.com/openPMD>`__ and how to build WarpX with it, please visit :doc:`../building/openpmd`.
 

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -21,6 +21,10 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Utility.H>
 
+#ifdef WARPX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+#endif
+
 #include <array>
 
 ///
@@ -71,8 +75,11 @@ public:
     long npart;
     int do_symmetrize = 0;
 
-    bool external_file = false;
-    std::string str_injection_file;
+    bool external_file = false; //! initialize from an openPMD file
+#ifdef WARPX_USE_OPENPMD
+    //! openPMD::Series to load from in external_file injection
+    std::unique_ptr<openPMD::Series> m_openpmd_input_series;
+#endif
 
     bool radially_weighted = true;
 

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -14,9 +14,12 @@
 #include "WarpX.H"
 
 #include <AMReX.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Print.H>
 
-#include <sstream>
 #include <functional>
+#include <sstream>
+#include <string>
 
 
 using namespace amrex;
@@ -105,9 +108,15 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         mass = species::get_mass( physical_species );
     }
 
+    std::string s_inj_style;
+    pp.query("injection_style", s_inj_style);
+
     // parse charge and mass
     std::string charge_s;
+    std::string mass_s;
     bool charge_is_specified = pp.query("charge", charge_s);
+    bool mass_is_specified = pp.query("mass", mass_s);
+
     if (charge_is_specified){
         std::transform(charge_s.begin(),
                        charge_s.end(),
@@ -116,20 +125,15 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         charge = parseChargeString(pp, charge_s);
     }
     if ( charge_is_specified && species_is_specified ){
-        Print()<<"WARNING: Both <species>.charge and <species>.species_type specified\n";
-        Print()<<"         The charge in <species>.mass overwrite the one from <species>.species_type\n";
+        Print() << "WARNING: Both '" << species_name << ".charge' and "
+                << species_name << ".species_type' are specified\n'"
+                << species_name << ".charge' will take precedence.\n";
     }
-    if (!charge_is_specified && !species_is_specified){
-        //No need for charge/species definition if external file is used
-        std::string s_inj_style;
-        pp.query("injection_style", s_inj_style);
-        if (s_inj_style != "external_file") {
-            amrex::Abort("Need to specify at least one of species_type or charge");
-        }
+    if (!charge_is_specified && !species_is_specified && s_inj_style != "external_file"){
+        // external file will throw own assertions below if charge cannot be found
+        amrex::Abort("Need to specify at least one of species_type or charge");
     }
 
-    std::string mass_s;
-    bool mass_is_specified = pp.query("mass", mass_s);
     if (mass_is_specified){
         std::transform(mass_s.begin(),
                        mass_s.end(),
@@ -138,16 +142,13 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         mass = parseMassString(pp, mass_s);
     }
     if ( mass_is_specified && species_is_specified ){
-        Print()<<"WARNING: Both <species>.mass and <species>species_type specified\n";
-        Print()<<"         The mass in <species>.mass overwrite the one from <species>.species_type\n";
+        Print() << "WARNING: Both '" << species_name << ".mass' and "
+                << species_name << ".species_type' are specified\n'"
+                << species_name << ".mass' will take precedence.\n";
     }
-    if (!mass_is_specified && !species_is_specified){
-        //No need for mass/species definition if external file is used
-        std::string s_inj_style;
-        pp.query("injection_style", s_inj_style);
-        if (s_inj_style != "external_file") {
-            amrex::Abort("Need to specify at least one of species_type or mass");
-        }
+    if (!mass_is_specified && !species_is_specified && s_inj_style != "external_file"){
+        // external file will throw own assertions below if mass cannot be found
+        amrex::Abort("Need to specify at least one of species_type or mass");
     }
 
     // parse injection style
@@ -233,14 +234,89 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         amrex::Abort("The option of reading particle data from an external "
                      "file has not been implemented nor tested in RZ geometry");
 #endif
-#ifdef WARPX_USE_OPENPMD
-        external_file = true;
-        pp.get("injection_file", str_injection_file);
-        pp.query("q_tot", q_tot);
-#else
+        pp.query("q_tot", q_tot); // optional
+#ifndef WARPX_USE_OPENPMD
         amrex::Abort("WarpX has to be compiled with USE_OPENPMD=TRUE to be able"
                      " to read the external openPMD file with species data");
 #endif
+        external_file = true;
+        std::string str_injection_file;
+        pp.get("injection_file", str_injection_file);
+
+#ifdef WARPX_USE_OPENPMD
+        if (ParallelDescriptor::IOProcessor()) {
+            m_openpmd_input_series = std::make_unique<openPMD::Series>(
+                str_injection_file, openPMD::AccessType::READ_ONLY);
+
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                m_openpmd_input_series->iterations.size() == 1u,
+                "External file should contain only 1 iteration\n");
+            openPMD::Iteration it = m_openpmd_input_series->iterations.begin()->second;
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                it.particles.size() == 1u,
+                "External file should contain only 1 species\n");
+            std::string const ps_name = it.particles.begin()->first;
+            openPMD::ParticleSpecies ps = it.particles.begin()->second;
+
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                ps.contains("charge") || charge_is_specified || species_is_specified,
+                std::string("'") + ps_name +
+                ".injection_file' does not contain a 'charge' species record. "
+                "Please specify '" + ps_name + ".charge' or "
+                "'" + ps_name + ".species_type' in your input file!\n");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                ps.contains("mass") || mass_is_specified || species_is_specified,
+                std::string("'") + ps_name +
+                ".injection_file' does not contain a 'mass' species record. "
+                "Please specify '" + ps_name + ".mass' or "
+                "'" + ps_name + ".species_type' in your input file!\n");
+
+            if (charge_is_specified) {
+                Print() << "WARNING: Both '" << ps_name << ".charge' and '"
+                        << ps_name << ".injection_file' specify a charge.\n'"
+                        << ps_name << ".charge' will take precedence.\n";
+            }
+            else if (species_is_specified) {
+                Print() << "WARNING: Both '" << ps_name << ".species_type' and '"
+                        << ps_name << ".injection_file' specify a charge.\n'"
+                        << ps_name << ".species_type' will take precedence.\n";
+            }
+            else {
+                // TODO: Add ASSERT_WITH_MESSAGE to test if charge is a constant record
+                ParticleReal const p_q = ps["charge"][openPMD::RecordComponent::SCALAR].loadChunk<ParticleReal>().get()[0];
+                double const charge_unit = ps["charge"][openPMD::RecordComponent::SCALAR].unitSI();
+                charge = p_q * charge_unit;
+            }
+            if (mass_is_specified) {
+                Print() << "WARNING: Both '" << ps_name << ".mass' and '"
+                        << ps_name << ".injection_file' specify a mass.\n'"
+                        << ps_name << ".mass' will take precedence.\n";
+            }
+            else if (species_is_specified) {
+                Print() << "WARNING: Both '" << ps_name << ".species_type' and '"
+                        << ps_name << ".injection_file' specify a mass.\n'"
+                        << ps_name << ".species_type' will take precedence.\n";
+            }
+            else {
+                // TODO: Add ASSERT_WITH_MESSAGE to test if mass is a constant record
+                ParticleReal const p_m = ps["mass"][openPMD::RecordComponent::SCALAR].loadChunk<ParticleReal>().get()[0];
+                double const mass_unit = ps["mass"][openPMD::RecordComponent::SCALAR].unitSI();
+                mass = p_m * mass_unit;
+            }
+        } // IOProcessor
+
+        // Broadcast charge and mass to non-IO processors
+        if (!charge_is_specified && !species_is_specified)
+            ParallelDescriptor::Bcast(&charge, 1,
+                ParallelDescriptor::IOProcessorNumber());
+        if (!mass_is_specified && !species_is_specified)
+            ParallelDescriptor::Bcast(&mass, 1,
+                ParallelDescriptor::IOProcessorNumber());
+#else
+        Abort("Plasma injection via external_file requires openPMD support: "
+                     "Add USE_OPENPMD=TRUE when compiling WarpX.\n");
+#endif  // WARPX_USE_OPENPMD
+
     } else {
         StringParseAbortMessage("Injection style", part_pos_s);
     }

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -207,10 +207,9 @@ public:
 
     /** Load a particle beam from an external file
      *
-     * @param[in] s_f path to an external file in openPMD markup
      * @param[in] q_tot total charge of the particle species to be initialized
      */
-    void AddPlasmaFromFile (const std::string s_f, amrex::Real q_tot);
+    void AddPlasmaFromFile (amrex::ParticleReal q_tot);
 
     void CheckAndAddParticle (
         amrex::Real x, amrex::Real y, amrex::Real z,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -313,9 +313,6 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot)
         double const momentum_unit_x = ps["momentum"]["x"].unitSI();
         std::shared_ptr<ParticleReal> ptr_uz = ps["momentum"]["z"].loadChunk<ParticleReal>();
         double const momentum_unit_z = ps["momentum"]["z"].unitSI();
-#   ifndef WARPX_DIM_XZ
-        Abort("AddPlasmaFromFile is only implemented for 2D and 3D\n");
-#   endif
 #   ifdef WARPX_DIM_3D
         std::shared_ptr<ParticleReal> ptr_y = ps["position"]["y"].loadChunk<ParticleReal>();
         double const position_unit_y = ps["position"]["y"].unitSI();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -28,6 +28,13 @@
 #include "Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H"
 #include "Particles/Pusher/UpdateMomentumHigueraCary.H"
 
+#include <AMReX_Print.H>
+
+#ifdef WARPX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+#endif
+
+#include <cmath>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -273,8 +280,7 @@ PhysicalParticleContainer::AddGaussianBeam (
 }
 
 void
-PhysicalParticleContainer::AddPlasmaFromFile(const std::string s_f,
-                                               amrex::Real q_tot)
+PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot)
 {
     // Declare temporary vectors on the CPU
     Gpu::HostVector<ParticleReal> particle_x;
@@ -288,69 +294,73 @@ PhysicalParticleContainer::AddPlasmaFromFile(const std::string s_f,
 #ifdef WARPX_USE_OPENPMD
     //TODO: Make changes for read/write in multiple MPI ranks
     if (ParallelDescriptor::IOProcessor()) {
-        openPMD::Series series = openPMD::Series(s_f,
-                                                 openPMD::AccessType::READ_ONLY);
-        amrex::Print() << "openPMD standard version " << series.openPMD() << "\n";
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(series.iterations.size() == 1u, "External "
-                                         "file should contain only 1 iteration\n");
-        openPMD::Iteration& i = series.iterations[1];
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(i.particles.size() == 1u, "External file "
-                                         "should contain only 1 species\n");
-        std::pair<std::string,openPMD::ParticleSpecies> ps = *i.particles.begin();
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(plasma_injector,
+                                         "AddPlasmaFromFile: plasma injector not initialized.\n");
+        // take ownership of the series and close it when done
+        auto series = std::move(plasma_injector->m_openpmd_input_series);
 
-        //TODO: Add ASSERT_WITH_MESSAGE to test if mass and charge are both const
-        amrex::ParticleReal p_m = ps.second["mass"][openPMD::RecordComponent::SCALAR].loadChunk<amrex::ParticleReal>().get()[0];
-        double const mass_unit = ps.second["mass"][openPMD::RecordComponent::SCALAR].unitSI();
-        amrex::ParticleReal p_q = ps.second["charge"][openPMD::RecordComponent::SCALAR].loadChunk<amrex::ParticleReal>().get()[0];
-        double const charge_unit = ps.second["charge"][openPMD::RecordComponent::SCALAR].unitSI();
-#   if (defined WARPX_DIM_3D) || (defined WARPX_DIM_XZ)
-        auto const npart = ps.second["position"]["x"].getExtent()[0];
-        std::shared_ptr<amrex::ParticleReal> ptr_x = ps.second["position"]["x"].loadChunk<amrex::ParticleReal>();
-        double const position_unit_x = ps.second["position"]["x"].unitSI();
-        std::shared_ptr<amrex::ParticleReal> ptr_z = ps.second["position"]["z"].loadChunk<amrex::ParticleReal>();
-        double const position_unit_z = ps.second["position"]["z"].unitSI();
-        std::shared_ptr<amrex::ParticleReal> ptr_ux = ps.second["momentum"]["x"].loadChunk<amrex::ParticleReal>();
-        double const momentum_unit_x = ps.second["momentum"]["x"].unitSI();
-        std::shared_ptr<amrex::ParticleReal> ptr_uz = ps.second["momentum"]["z"].loadChunk<amrex::ParticleReal>();
-        double const momentum_unit_z = ps.second["momentum"]["z"].unitSI();
-#   else
-        amrex::Abort("AddPlasmaFromFile is only implemented for 2D and 3D\n");
+        // assumption asserts: see PlasmaInjector
+        openPMD::Iteration it = series->iterations.begin()->second;
+        std::string const ps_name = it.particles.begin()->first;
+        openPMD::ParticleSpecies ps = it.particles.begin()->second;
+
+        auto const npart = ps["position"]["x"].getExtent()[0];
+        std::shared_ptr<ParticleReal> ptr_x = ps["position"]["x"].loadChunk<ParticleReal>();
+        double const position_unit_x = ps["position"]["x"].unitSI();
+        std::shared_ptr<ParticleReal> ptr_z = ps["position"]["z"].loadChunk<ParticleReal>();
+        double const position_unit_z = ps["position"]["z"].unitSI();
+        std::shared_ptr<ParticleReal> ptr_ux = ps["momentum"]["x"].loadChunk<ParticleReal>();
+        double const momentum_unit_x = ps["momentum"]["x"].unitSI();
+        std::shared_ptr<ParticleReal> ptr_uz = ps["momentum"]["z"].loadChunk<ParticleReal>();
+        double const momentum_unit_z = ps["momentum"]["z"].unitSI();
+#   ifndef WARPX_DIM_XZ
+        Abort("AddPlasmaFromFile is only implemented for 2D and 3D\n");
 #   endif
-#   if (defined WARPX_DIM_3D)
-        std::shared_ptr<amrex::ParticleReal> ptr_y = ps.second["position"]["y"].loadChunk<amrex::ParticleReal>();
-        double const position_unit_y = ps.second["position"]["y"].unitSI();
-        std::shared_ptr<amrex::ParticleReal> ptr_uy = ps.second["momentum"]["y"].loadChunk<amrex::ParticleReal>();
-        double const momentum_unit_y = ps.second["momentum"]["y"].unitSI();
+#   ifdef WARPX_DIM_3D
+        std::shared_ptr<ParticleReal> ptr_y = ps["position"]["y"].loadChunk<ParticleReal>();
+        double const position_unit_y = ps["position"]["y"].unitSI();
 #   endif
-        series.flush();
-
-        mass=p_m*mass_unit;
-        charge=p_q*charge_unit;
-
-        amrex::Real weight;
-        if (q_tot != 0.0){
-            weight = q_tot/(p_q*amrex::Real(npart));
+        std::shared_ptr<ParticleReal> ptr_uy = nullptr;
+        double momentum_unit_y = 1.0;
+        if (ps["momentum"].contains("y")) {
+            ptr_uy = ps["momentum"]["y"].loadChunk<ParticleReal>();
+             momentum_unit_y = ps["momentum"]["y"].unitSI();
         }
-        else {
-            weight = charge;
+        series->flush();  // shared_ptr data can be read now
+
+        ParticleReal weight = 1.0_prt;  // base standard: no info means "real" particles
+        if (q_tot != 0.0) {
+            weight = std::abs(q_tot) / ( std::abs(charge) * ParticleReal(npart) );
+            if (ps.contains("weighting")) {
+                Print() << "WARNING: Both '" << ps_name << ".q_tot' and '"
+                        << ps_name << ".injection_file' specify a total charge.\n'"
+                        << ps_name << ".q_tot' will take precedence.\n";
+            }
+        }
+        // ED-PIC extension?
+        else if (ps.contains("weighting")) {
+            // TODO: Add ASSERT_WITH_MESSAGE to test if weighting is a constant record
+            // TODO: Add ASSERT_WITH_MESSAGE for macroWeighted value in ED-PIC
+            ParticleReal w = ps["weighting"][openPMD::RecordComponent::SCALAR].loadChunk<ParticleReal>().get()[0];
+            double const w_unit = ps["weighting"][openPMD::RecordComponent::SCALAR].unitSI();
+            weight = w * w_unit;
         }
 
         for (auto i = decltype(npart){0}; i<npart; ++i){
-            amrex::ParticleReal const x = ptr_x.get()[i]*position_unit_x;
-            amrex::ParticleReal const z = ptr_z.get()[i]*position_unit_z;
-#   if (defined WARPX_DIM_XZ)
-            amrex::Real const y = 0.0;
-#   elif (defined WARPX_DIM_3D)
-            amrex::ParticleReal const y = ptr_y.get()[i]*position_unit_y;
+            ParticleReal const x = ptr_x.get()[i]*position_unit_x;
+            ParticleReal const z = ptr_z.get()[i]*position_unit_z;
+#   ifndef WARPX_DIM_3D
+            ParticleReal const y = 0.0_prt;
+#   else
+            ParticleReal const y = ptr_y.get()[i]*position_unit_y;
 #   endif
             if (plasma_injector->insideBounds(x, y, z)) {
-                amrex::ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/PhysConst::m_e;
-                amrex::ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/PhysConst::m_e;
-#   if (defined WARPX_DIM_XZ)
-                amrex::ParticleReal const uy = 0.0;
-#   elif (defined WARPX_DIM_3D)
-                amrex::ParticleReal const uy = ptr_uy.get()[i]*momentum_unit_y/PhysConst::m_e;
-#   endif
+                ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/PhysConst::m_e;
+                ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/PhysConst::m_e;
+                ParticleReal uy = 0.0_prt;
+                if (ps["momentum"].contains("y")) {
+                    uy = ptr_uy.get()[i]*momentum_unit_y/PhysConst::m_e;
+                }
                 CheckAndAddParticle(x, y, z, { ux, uy, uz}, weight,
                 particle_x,  particle_y,  particle_z,
                 particle_ux, particle_uy, particle_uz,
@@ -359,15 +369,15 @@ PhysicalParticleContainer::AddPlasmaFromFile(const std::string s_f,
         }
         auto const np = particle_z.size();
         if (np < npart) {
-            amrex::Print()<<"WARNING: Simulation box doesn't cover all particles\n";
+            Print() << "WARNING: Simulation box doesn't cover all particles\n";
         }
-    } //IO Processor
+    } // IO Processor
     auto const np = particle_z.size();
-    AddNParticles(0,np,
+    AddNParticles(0, np,
                   particle_x.dataPtr(),  particle_y.dataPtr(),  particle_z.dataPtr(),
                   particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
                   1, particle_w.dataPtr(),1);
-#endif //OPENPMD
+#endif // WARPX_USE_OPENPMD
     return;
 }
 
@@ -432,8 +442,7 @@ PhysicalParticleContainer::AddParticles (int lev)
     }
 
     if (plasma_injector->external_file) {
-        AddPlasmaFromFile(plasma_injector->str_injection_file,
-                          plasma_injector->q_tot);
+        AddPlasmaFromFile(plasma_injector->q_tot);
         return;
     }
 


### PR DESCRIPTION
Split and add MPI support for particle loading from an openPMD file.

Changes input file to allow overwriting the charge and mass by user input.
Allows to add "weighting" to files as constant record (ED-PIC extension).

Fixes build errors with openPMD enabled and RZ (but no full read runtime support yet).

## Check List

- [x] deactivated compile (2D, 3D)
- [x] activated compile (2D, 3D)
- [x] runtime test: 3D3V with 4 MPI ranks,  2D3V with 4 MPI ranks, RZ: unclear to me if this worked, but guarded in input checks for now and does not crash

Close #952