### PR TITLE
[Mini]Fix Langmuir_multi_nodal test case

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -377,7 +377,7 @@ tolerance = 5.e-11
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
+runtime_params = psatd.fftw_plan_measure=0 warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -339,7 +339,7 @@ tolerance = 1.0e-4
 [Langmuir_multi_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct
 dim = 3
 addToCompileString =
 restartTest = 0


### PR DESCRIPTION
Current deposition was changed from esirkepov to direct, fixing the crash in the regression test. The crash was being caused by the new check disallowing do_nodal with Esirkepov current deposition.