### PR TITLE
CI: macOS Single Precision

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,4 +27,4 @@ jobs:
         cd WarpX
         export LDFLAGS="-lomp"
         make -j 2 COMP=llvm USE_OMP=FALSE USE_OPENPMD=TRUE XTRA_CXXFLAGS="-Xpreprocessor -fopenmp"
-
+        make -j 2 COMP=llvm USE_OMP=FALSE USE_OPENPMD=TRUE XTRA_CXXFLAGS="-Xpreprocessor -fopenmp" PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.cpp
@@ -193,9 +193,9 @@ void GalileanAlgorithm::InitializeSpectralCoefficients(const SpectralKSpace& spe
 #endif
 
                 const Real nu = kv/(k_norm*c);
-                const Complex theta = MathFunc::exp( 0.5_rt*I*kv*dt );
-                const Complex theta_star = MathFunc::exp( -0.5_rt*I*kv*dt );
-                const Complex e_theta = MathFunc::exp( I*c*k_norm*dt );
+                const Complex theta = amrex::exp( 0.5_rt*I*kv*dt );
+                const Complex theta_star = amrex::exp( -0.5_rt*I*kv*dt );
+                const Complex e_theta = amrex::exp( I*c*k_norm*dt );
 
                 Theta2(i,j,k) = theta*theta;
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -103,7 +103,7 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
 
     // Amplitude and monochromatic oscillations
     Complex prefactor =
-        m_common_params.e_max * MathFunc::exp( I * oscillation_phase );
+        m_common_params.e_max * amrex::exp( I * oscillation_phase );
 
     // Because diffract_factor is a complex, the code below takes into
     // account the impact of the dimensionality on both the Gouy phase
@@ -111,7 +111,7 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
 #if (AMREX_SPACEDIM == 3)
     prefactor = prefactor / diffract_factor;
 #elif (AMREX_SPACEDIM == 2)
-    prefactor = prefactor / MathFunc::sqrt(diffract_factor);
+    prefactor = prefactor / amrex::sqrt(diffract_factor);
 #endif
 
     // Copy member variables to tmp copies for GPU runs.
@@ -125,16 +125,16 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
         np,
         [=] AMREX_GPU_DEVICE (int i) {
             const Complex stc_exponent = 1._rt / stretch_factor * inv_tau2 *
-                MathFunc::pow((t - tmp_profile_t_peak -
+                amrex::pow((t - tmp_profile_t_peak -
                     tmp_beta*k0*(Xp[i]*std::cos(tmp_theta_stc) + Yp[i]*std::sin(tmp_theta_stc)) -
                     2._rt *I*(Xp[i]*std::cos(tmp_theta_stc) + Yp[i]*std::sin(tmp_theta_stc))
                     *( tmp_zeta - tmp_beta*tmp_profile_focal_distance ) * inv_complex_waist_2),2);
             // stcfactor = everything but complex transverse envelope
-            const Complex stcfactor = prefactor * MathFunc::exp( - stc_exponent );
+            const Complex stcfactor = prefactor * amrex::exp( - stc_exponent );
             // Exp argument for transverse envelope
             const Complex exp_argument = - ( Xp[i]*Xp[i] + Yp[i]*Yp[i] ) * inv_complex_waist_2;
             // stcfactor + transverse envelope
-            amplitude[i] = ( stcfactor * MathFunc::exp( exp_argument ) ).real();
+            amplitude[i] = ( stcfactor * amrex::exp( exp_argument ) ).real();
         }
         );
 }

--- a/Source/Utils/WarpX_Complex.H
+++ b/Source/Utils/WarpX_Complex.H
@@ -14,11 +14,10 @@
 
 #include <complex>
 
-// Define complex type on GPU/CPU
-#ifdef AMREX_USE_GPU
-
+// Defines a complex type on GPU & CPU
 using Complex = amrex::GpuComplex<amrex::Real>;
 
+#ifdef AMREX_USE_GPU
 #    ifdef WARPX_USE_PSATD
 #    include <cufft.h>
 #        ifdef AMREX_USE_FLOAT
@@ -31,8 +30,6 @@ static_assert( sizeof(Complex) == sizeof(cuDoubleComplex),
 #    endif // WARPX_USE_PSATD
 
 #else
-
-using Complex = std::complex<amrex::Real>;
 
 #    ifdef WARPX_USE_PSATD
 #    include <fftw3.h>
@@ -48,39 +45,5 @@ static_assert( sizeof(Complex) == sizeof(fftw_complex),
 #endif // AMREX_USE_GPU
 static_assert(sizeof(Complex) == sizeof(amrex::Real[2]),
               "Unexpected complex type.");
-
-// wrapper around math functions, to run on CPU or accelerator.
-namespace MathFunc
-{
-    // exp function
-    template<typename T>
-    AMREX_GPU_HOST_DEVICE T exp (const T& val){
-#ifdef AMREX_USE_GPU
-        return amrex::exp(val);
-#else
-        return std::exp(val);
-#endif
-    }
-
-    // sqrt function
-    template<typename T>
-    AMREX_GPU_HOST_DEVICE T sqrt (const T& val){
-#ifdef AMREX_USE_GPU
-        return amrex::sqrt(val);
-#else
-        return std::sqrt(val);
-#endif
-    }
-
-    // power function
-    template<typename T1, typename T2>
-    AMREX_GPU_HOST_DEVICE T1 pow (const T1& val, const T2& power){
-#ifdef AMREX_USE_GPU
-        return amrex::pow(val, power);
-#else
-        return std::pow(val, power);
-#endif
-    }
-}
 
 #endif //WARPX_COMPLEX_H_


### PR DESCRIPTION
Add another compile with single precision on AppleClang.

Unifies the usage of `complex` to use AMReX' implementation for host and device. This fixes single precision builds on AppleClang.