### PR TITLE
Fix bug for PSATD momentum-conserving runs

### DIFF
--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -93,7 +93,7 @@ plt.title('Ez, last iteration\n(theory)')
 plt.tight_layout()
 plt.savefig('langmuir_multi_2d_analysis.png')
 
-tolerance_rel = 0.04
+tolerance_rel = 0.05
 
 print("error_rel    : " + str(error_rel))
 print("tolerance_rel: " + str(tolerance_rel))

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -398,6 +398,25 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
 
+[Langmuir_multi_psatd_momentum_conserving]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+runtime_params = psatd.fftw_plan_measure=0 algo.field_gathering=momentum-conserving
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+tolerance = 5.e-11
+
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -459,6 +478,25 @@ tolerance = 1.e-14
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = psatd.fftw_plan_measure=0 diag1.electrons.variables=w ux uy uz Ex Ey Ez diag1.positrons.variables=w ux uy uz Ex Ey Ez diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+tolerance = 1.e-14
+
+[Langmuir_multi_2d_psatd_momentum_conserving]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+runtime_params = algo.field_gathering=momentum-conserving psatd.fftw_plan_measure=0 diag1.electrons.variables=w ux uy uz Ex Ey Ez diag1.positrons.variables=w ux uy uz Ex Ey Ez diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -233,10 +233,10 @@ SpectralFieldData::ForwardTransform( const MultiFab& mf,
                 realspace_bx = mf[mfi].box(); // Keep guard cells
             }
             realspace_bx.enclosedCells(); // Discard last point in nodal direction
-            AMREX_ALWAYS_ASSERT( realspace_bx == tmpRealField[mfi].box() );
+            AMREX_ALWAYS_ASSERT( realspace_bx.contains(tmpRealField[mfi].box()) );
             Array4<const Real> mf_arr = mf[mfi].array();
             Array4<Real> tmp_arr = tmpRealField[mfi].array();
-            ParallelFor( realspace_bx,
+            ParallelFor( tmpRealField[mfi].box(),
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 tmp_arr(i,j,k) = mf_arr(i,j,k,i_comp);
             });


### PR DESCRIPTION
When performing Fourier transforms, the code copies the main MultiFab data (`E_fp`, `B_fp`, etc.) to a temporary MultiFab. When doing this, it checks that the sizes of these MultiFab match exactly.

However, the temporary MultiFab has `ngE` guard cells, while for `momentum-conserving`, `E_fp` has `ngE+1` guard cells (because `ngextra` is `1`, see [this code](https://github.com/ECP-WarpX/WarpX/blob/master/Source/WarpX.cpp#L890)). Therefore, the boxes don't match exactly.

Therefore, this PR relaxes the test, so that the boxes don't have to match exactly ; instead the box of `E_fp`, `B_fp` need to *contain* the box of the temporary MultiFab (which has already `ngE` guard cells, which is enough to contain the stencil of the PSATD solver with reasonable accuracy)

I have also added automated tests for the PSATD solver with momentum-conserving gather in 2D and 3D.

**Many thanks to @danielbelkin and @EZoni for reporting and investigating this issue.**