### PR TITLE
openPMD: Binary Suffix

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -146,6 +146,7 @@ ifeq ($(USE_OPENPMD), TRUE)
        libraries += -lopenPMD
    endif
    DEFINES += -DWARPX_USE_OPENPMD
+   USERSuffix := $(USERSuffix).OPMD
 endif
 
 


### PR DESCRIPTION
Add the binary suffix `.OPMD` to WarpX binaries.