### PR TITLE
Most fun PR ever: print error and tolerance before ASSERT in CI

### DIFF
--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
@@ -39,10 +39,14 @@ theta0 = np.arcsin(0.1)
 
 # Theoretical beam width after propagation if rigid ON
 wth = np.sqrt( w0**2 + (z-z0)**2*theta0**2 )
-error = np.abs((w-wth)/wth)
+error_rel = np.abs((w-wth)/wth)
+tolerance_rel = 0.03
 
 # Print error and assert small error
 print("Beam position: " + str(z))
 print("Beam width   : " + str(w))
-print("error: " + str(error))
-assert( error < 0.03 )
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
@@ -68,9 +68,14 @@ if ( error_no_rigid < 0.05):
 
 # Theoretical beam width after propagation if rigid ON
 wth = np.sqrt( w0**2 + (z-z0)**2*theta0**2 )
-error = np.abs((w-wth)/wth)
+error_rel = np.abs((w-wth)/wth)
+tolerance_rel = 0.05
+
 # Print error and assert small error
 print("Beam position: " + str(z))
 print("Beam width   : " + str(w))
-print("error: " + str(error))
-assert( error < 0.05 )
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
+++ b/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
@@ -36,8 +36,10 @@ Fs = allrd['Ez']
 print("Fs.shape", Fs.shape)
 Fs_1D = np.squeeze(Fs[Fs.shape[0]//2,1,:])
 
-error = np.max(np.abs(Fs_1D - F_1D)) / np.max(np.abs(F_1D))
+error_rel = np.max(np.abs(Fs_1D - F_1D)) / np.max(np.abs(F_1D))
+tolerance_rel = 1E-15
 
-# Print error and assert small error
-print("relative error: " + str(error))
-assert( error < 1E-15 )
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Modules/ionization/analysis_ionization.py
+++ b/Examples/Modules/ionization/analysis_ionization.py
@@ -80,4 +80,10 @@ if do_plot:
     plt.ylabel("x (m)")
     plt.savefig("image_ionization.pdf", bbox_inches='tight')
 
-assert ((N5_fraction > 0.30) and (N5_fraction < 0.34))
+error_rel = abs(N5_fraction-0.32) / 0.32
+tolerance_rel = 0.07
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
@@ -15,7 +15,7 @@ import sys
 # do actually have an exponentially distributed optical depth
 
 # Tolerance
-toloerance_rel = 1e-2
+tolerance_rel = 1e-2
 
 def check():
     filename = sys.argv[1]

--- a/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
@@ -15,7 +15,7 @@ import sys
 # do actually have an exponentially distributed optical depth
 
 # Tolerance
-tol = 1e-2
+toloerance_rel = 1e-2
 
 def check():
     filename = sys.argv[1]
@@ -25,10 +25,18 @@ def check():
     res_tau = all_data["photons", 'particle_optical_depth_BW']
 
     loc, scale = st.expon.fit(res_tau)
-
+    
     # loc should be very close to 0, scale should be very close to 1
-    assert(np.abs(loc - 0) < tol)
-    assert(np.abs(scale - 1) < tol)
+
+    error_rel = np.abs(loc - 0)
+    print("error_rel for location: " + str(error_rel))
+    print("tolerance_rel: " + str(tolerance_rel))
+    assert( error_rel < tolerance_rel )
+
+    error_rel = np.abs(scale - 1)
+    print("error_rel for scale: " + str(error_rel))
+    print("tolerance_rel: " + str(tolerance_rel))
+    assert( error_rel < tolerance_rel )
 
 def main():
     check()

--- a/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_2d_tau_init.py
@@ -25,7 +25,7 @@ def check():
     res_tau = all_data["photons", 'particle_optical_depth_BW']
 
     loc, scale = st.expon.fit(res_tau)
-    
+
     # loc should be very close to 0, scale should be very close to 1
 
     error_rel = np.abs(loc - 0)
@@ -43,4 +43,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_3d_optical_depth_evolution.py
@@ -111,6 +111,7 @@ def check():
         exp_scale = 1.0
         loc_discrepancy = np.abs(opt_depth_loc-exp_loc)
         scale_discrepancy = np.abs(opt_depth_scale-exp_scale)
+        print("tolerance_rel: " + str(tol))
         print("species " + name)
         print("exp distrib loc tol = " + str(tol))
         print("exp distrib loc discrepancy = " + str(loc_discrepancy))

--- a/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
@@ -16,7 +16,7 @@ import sys
 # do actually have an exponentially distributed optical depth
 
 # Tolerance
-tol = 1e-2
+tolerance_rel = 1e-2
 print("tolerance_rel: " + str(tol))
 
 def check():

--- a/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
@@ -17,6 +17,7 @@ import sys
 
 # Tolerance
 tol = 1e-2
+print("tolerance_rel: " + str(tol))
 
 def check():
     filename = sys.argv[1]
@@ -30,10 +31,21 @@ def check():
     loc_pos, scale_pos = st.expon.fit(res_pos_tau)
 
     # loc should be very close to 0, scale should be very close to 1
-    assert(np.abs(loc_ele - 0) < tol)
-    assert(np.abs(loc_pos - 0) < tol)
-    assert(np.abs(scale_ele - 1) < tol)
-    assert(np.abs(scale_pos - 1) < tol)
+    error_rel = np.abs(loc_ele - 0)
+    print("error_rel loc_ele: " + str(error_rel))
+    assert( error_rel < tolerance_rel )
+
+    error_rel = np.abs(loc_pos - 0)
+    print("error_rel loc_pos: " + str(error_rel))
+    assert( error_rel < tolerance_rel )
+
+    error_rel = np.abs(scale_ele - 1)
+    print("error_rel scale_ele: " + str(error_rel))
+    assert( error_rel < tolerance_rel )
+
+    error_rel = np.abs(scale_pos - 1)
+    print("error_rel scale_pos: " + str(error_rel))
+    assert( error_rel < tolerance_rel )
 
 def main():
     check()

--- a/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis_2d_tau_init.py
@@ -17,7 +17,7 @@ import sys
 
 # Tolerance
 tolerance_rel = 1e-2
-print("tolerance_rel: " + str(tol))
+print("tolerance_rel: " + str(tolerance_rel))
 
 def check():
     filename = sys.argv[1]

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -90,7 +90,9 @@ plt.savefig('Comparison.png')
 def check(E, E_th, label):
     print( 'Relative error in %s: %.3f'%(
             label, abs(E-E_th).max()/E_th.max()))
-    assert np.allclose( E, E_th, atol=0.1*E_th.max() )
+    tolerance_rel = 0.1
+    print("tolerance_rel: " + str(tolerance_rel))
+    assert np.allclose( E, E_th, atol=tolerance_rel*E_th.max() )
 
 check( Ex_array, Ex_th, 'Ex' )
 check( Ey_array, Ey_th, 'Ey' )

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -72,17 +72,22 @@ ds = yt.load(fn)
 
 # Check that the particle selective output worked:
 species = 'electrons'
+print('ds.field_list', field_list)
 for field in ['particle_weight',
               'particle_momentum_x']:
+    print('assert that this is in ds.field_list', (species, field))
     assert (species, field) in ds.field_list
 for field in ['particle_momentum_y',
               'particle_momentum_z']:
+    print('assert that this is NOT in ds.field_list', (species, field))
     assert (species, field) not in ds.field_list
 species = 'positrons'
 for field in ['particle_Ey']:
+    print('assert that this is in ds.field_list', (species, field))
     assert (species, field) in ds.field_list
 for field in ['particle_momentum_y',
               'particle_momentum_z']:
+    print('assert that this is NOT in ds.field_list', (species, field))
     assert (species, field) not in ds.field_list
 
 t0 = ds.current_time.to_ndarray().mean()
@@ -90,14 +95,14 @@ data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                                     dims=ds.domain_dimensions)
 
 # Check the validity of the fields
-overall_max_error = 0
+error_rel = 0
 for field in ['Ex', 'Ey', 'Ez']:
     E_sim = data[field].to_ndarray()
 
     E_th = get_theoretical_field(field, t0)
     max_error = abs(E_sim-E_th).max()/abs(E_th).max()
     print('%s: Max error: %.2e' %(field,max_error))
-    overall_max_error = max( overall_max_error, max_error )
+    error_rel = max( error_rel, max_error )
 
 # Plot the last field from the loop (Ez at iteration 40)
 plt.subplot2grid( (1,2), (0,0) )
@@ -111,5 +116,9 @@ plt.title('Ez, last iteration\n(theory)')
 plt.tight_layout()
 plt.savefig('langmuir_multi_analysis.png')
 
-# Automatically check the validity
-assert overall_max_error < 0.15
+tolerance_rel = 0.15
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -72,7 +72,7 @@ ds = yt.load(fn)
 
 # Check that the particle selective output worked:
 species = 'electrons'
-print('ds.field_list', field_list)
+print('ds.field_list', ds.field_list)
 for field in ['particle_weight',
               'particle_momentum_x']:
     print('assert that this is in ds.field_list', (species, field))

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -69,13 +69,13 @@ data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                                     dims=ds.domain_dimensions)
 
 # Check the validity of the fields
-overall_max_error = 0
+error_rel = 0
 for field in ['Ex', 'Ez']:
     E_sim = data[field].to_ndarray()[:,:,0]
     E_th = get_theoretical_field(field, t0)
     max_error = abs(E_sim-E_th).max()/abs(E_th).max()
     print('%s: Max error: %.2e' %(field,max_error))
-    overall_max_error = max( overall_max_error, max_error )
+    error_rel = max( error_rel, max_error )
 
 # Plot the last field from the loop (Ez at iteration 40)
 plt.subplot2grid( (1,2), (0,0) )
@@ -89,5 +89,9 @@ plt.title('Ez, last iteration\n(theory)')
 plt.tight_layout()
 plt.savefig('langmuir_multi_2d_analysis.png')
 
-# Automatically check the validity
-assert overall_max_error < 0.04
+tolerance_rel = 0.04
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -97,5 +97,10 @@ plt.title('Ez, last iteration\n(theory)')
 plt.tight_layout()
 plt.savefig('langmuir_multi_rz_analysis.png')
 
-# Automatically check the validity
-assert overall_max_error < 0.04
+error_rel = overal_max_error
+tolerance_rel = 0.04
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -97,7 +97,7 @@ plt.title('Ez, last iteration\n(theory)')
 plt.tight_layout()
 plt.savefig('langmuir_multi_rz_analysis.png')
 
-error_rel = overal_max_error
+error_rel = overall_max_error
 tolerance_rel = 0.04
 
 print("error_rel    : " + str(error_rel))

--- a/Examples/Tests/PML/analysis_pml_ckc.py
+++ b/Examples/Tests/PML/analysis_pml_ckc.py
@@ -41,5 +41,10 @@ Reflectivity_theory = 1.8015e-06
 print("Reflectivity: %s" %Reflectivity)
 print("Reflectivity_theory: %s" %Reflectivity_theory)
 
-assert( Reflectivity < 105./100 * Reflectivity_theory )
+error_rel = abs(Reflectivity-Reflectivity_theory) / Reflectivity_theory
+tolerance_rel = 5./100
 
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -40,10 +40,13 @@ energy_end = energyE + energyB
 Reflectivity = energy_end/energy_start
 Reflectivity_theory = 1.3806831258153887e-06
 
-print("Reflectivity: %s" %Reflectivity)
-print("Reflectivity_theory: %s" %Reflectivity_theory)
+error_rel = abs(Reflectivity-Reflectivity_theory) / Reflectivity_theory
+tolerance_rel = 5./100
 
-assert( abs(Reflectivity-Reflectivity_theory) < 5./100 * Reflectivity_theory )
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )
 
 # Check relative L-infinity spatial norm of rho/epsilon_0 - div(E)
 Linf_norm = np.amax( np.abs( rho/scc.epsilon_0 - divE ) ) / np.amax( np.abs( rho/scc.epsilon_0 ) )

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -41,5 +41,10 @@ Reflectivity_theory = 5.683000058954201e-07
 print("Reflectivity: %s" %Reflectivity)
 print("Reflectivity_theory: %s" %Reflectivity_theory)
 
-assert( abs(Reflectivity-Reflectivity_theory) < 5./100 * Reflectivity_theory )
+error_rel = abs(Reflectivity-Reflectivity_theory) / Reflectivity_theory
+tolerance_rel = 5./100
 
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
+++ b/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
@@ -48,6 +48,10 @@ all_data_level_0 = ds.covering_grid(level=0,left_edge=ds.domain_left_edge, dims=
 F_filtered = all_data_level_0['boxlib', 'jx'].v.squeeze()
 
 # Compare theory and PIC for filtered value
-error = np.sum( np.abs(F_filtered - my_F_filtered) ) / np.sum( np.abs(my_F_filtered) )
-print( "error: np.sum( np.abs(F_filtered - my_F_filtered) ) / np.sum( np.abs(my_F_filtered) ) = %s" %error )
-assert( error < 1.e-14 )
+error_rel = np.sum( np.abs(F_filtered - my_F_filtered) ) / np.sum( np.abs(my_F_filtered) )
+tolerance_rel = 1.e-14
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/galilean/analysis.py
+++ b/Examples/Tests/galilean/analysis.py
@@ -26,4 +26,10 @@ energyE_gal_psatd = np.sum(scc.epsilon_0/2*(Ex**2+Ey**2+Ez**2))
 #E field energy precalculated with standard PSATD (v_galilean = (0,0,0))
 energyE_psatd = 270975.396667626 #E field energy calculated with PSATD (v_galilean = (0,0,0))
 
-assert( energyE_gal_psatd < 1e-10 * energyE_psatd )
+error_rel = energyE_gal_psatd / energyE_psatd
+tolerance_rel = 1e-10
+
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
+
+assert( error_rel < tolerance_rel )

--- a/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+++ b/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
@@ -36,9 +36,12 @@ print( "max_Efield = %s" %max_Efield )
 # The field associated with the particle does not have
 # the same amplitude in 2d and 3d
 if ds.dimensionality == 2:
-    assert max_Efield < 0.0003
+    tolerance_abs = 0.0003
 elif ds.dimensionality == 3:
-    assert max_Efield < 10
+    tolerance_abs = 10
 else:
     raise ValueError("Unknown dimensionality")
+
+print("tolerance_abs: " + str(tolerance_abs))
+assert max_Efield < tolerance_abs
 

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -74,7 +74,7 @@ B = p_0 * B_val
 #________________________________________
 
 #Tolerance
-tol = 0.05
+tolerance_rel = 0.05
 #________________________________________
 
 #tau_c
@@ -138,7 +138,13 @@ def check():
         init_gamma = gamma(cc[0].init_mom)
         end_gamma = gamma(cc[1]/m_e/c)
         exp_gamma = exp_res(cc[0], sim_time)
-        assert(np.abs(end_gamma-exp_gamma)/exp_gamma < tol)
+
+        error_rel = np.abs(end_gamma-exp_gamma)/exp_gamma
+        
+        print("error_rel    : " + str(error_rel))
+        print("tolerance_rel: " + str(tolerance_rel))
+        
+        assert( error_rel < tolerance_rel )
 
 def generate():
 

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -140,10 +140,10 @@ def check():
         exp_gamma = exp_res(cc[0], sim_time)
 
         error_rel = np.abs(end_gamma-exp_gamma)/exp_gamma
-        
+
         print("error_rel    : " + str(error_rel))
         print("tolerance_rel: " + str(tolerance_rel))
-        
+
         assert( error_rel < tolerance_rel )
 
 def generate():


### PR DESCRIPTION
When a test fails, it is often useful to see the relative error (on TravisCI, for instance) without having to re-run the test. This PR adds some print statements to the analysis scripts for CI tests. So much fun \o/.