### PR TITLE
openPMD: Fix no-MPI build

### DIFF
--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -142,11 +142,17 @@ WriteOpenPMDFields( const std::string& filename,
 
   // Create new file and store the time/iteration info
   auto series = [filename](){
-      if( ParallelDescriptor::NProcs() > 1 )
+      if( ParallelDescriptor::NProcs() > 1 ) {
+#if defined(AMREX_USE_MPI)
           return openPMD::Series( filename,
                                   openPMD::AccessType::CREATE,
                                   ParallelDescriptor::Communicator() );
-      else
+#else
+          amrex::Abort("openPMD-api not built with MPI support!");
+          return openPMD::Series( filename,
+                                  openPMD::AccessType::CREATE );
+#endif
+      } else
           return openPMD::Series( filename,
                                   openPMD::AccessType::CREATE );
   }();

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -162,12 +162,16 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType, const std::string& filePr
 
     if( amrex::ParallelDescriptor::NProcs() > 1 )
     {
+#if defined(AMREX_USE_MPI)
         m_Series = std::make_unique<openPMD::Series>(
             filename, accessType,
             amrex::ParallelDescriptor::Communicator()
         );
         m_MPISize = amrex::ParallelDescriptor::NProcs();
         m_MPIRank = amrex::ParallelDescriptor::MyProc();
+#else
+        amrex::Abort("openPMD-api not built with MPI support!");
+#endif
     }
     else
     {


### PR DESCRIPTION
Fix builds in purely no-MPI mode with openPMD-api by hiding the MPI overloaded constructor.

Note: openPMD-api must be build without MPI for now, too.