### PR TITLE
[mini] Fix error when using multiple reduced diags with different frequencies

### DIFF
--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -101,7 +101,7 @@ void MultiReducedDiags::WriteToFile (int step)
     {
 
         // Judge if the diags should be done
-        if ( (step+1) % m_multi_rd[i_rd]->m_freq != 0 ) { return; }
+        if ( (step+1) % m_multi_rd[i_rd]->m_freq != 0 ) { continue; }
 
         // call the write to file function
         m_multi_rd[i_rd]->WriteToFile(step);


### PR DESCRIPTION
This mini PR simply replaces a `return` statement by a `continue` statement.

Using `return` here causes the wrong behavior when we have multiple `ReducedDiags` with different output frequencies. (typically if at a given timestep we want to output `ReducedDiag2` but not `ReducedDiag1` the function will return when the test on `ReducedDiag1` is false and `ReducedDiag2` is never output)