### PR TITLE
We also need to specify the plt and chk file names for the GPU tests.

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -38,6 +38,10 @@ reportActiveTestsOnly = 1
 # Add "GO UP" link at the top of the web page?
 goUpLink = 1
 
+# string queried to change plotfiles and checkpoint files
+plot_file_name = diag1.file_prefix
+check_file_name = none
+
 # email
 sendEmailWhenFail = 1
 emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, mthevenet@lbl.gov, oshapoval@lbl.gov, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, axelhuebl@lbl.gov, ezoni@lbl.gov


### PR DESCRIPTION
The GPU tests failed last night for this reason: 

    https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/