### PR TITLE
PML: Remove unneeded ExchangeF

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -268,8 +268,6 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
 
     if (do_pml && pml[lev]->ok())
     {
-        if (F) pml[lev]->ExchangeF(patch_type, F, do_pml_in_domain);
-
         const auto& pml_B = (patch_type == PatchType::fine) ? pml[lev]->GetB_fp() : pml[lev]->GetB_cp();
         const auto& pml_E = (patch_type == PatchType::fine) ? pml[lev]->GetE_fp() : pml[lev]->GetE_cp();
         const auto& pml_j = (patch_type == PatchType::fine) ? pml[lev]->Getj_fp() : pml[lev]->Getj_cp();


### PR DESCRIPTION
There is call to `ExchangeF` that is not needed in `EvolveE`, since the exchange of `F` is performed anyway by `FillBoundaryF` in the `Evolve` function. 

In order to check that this call is indeed not needed, I ran the following script, which was adapted from the one developed by @MaxThevenet [here](https://github.com/ECP-WarpX/WarpX/tree/master/Regression/TestFillBoundary):

[compare_exchange_f.sh.txt](https://github.com/ECP-WarpX/WarpX/files/4613287/compare_exchange_f.sh.txt)
[inputs.2d.txt](https://github.com/ECP-WarpX/WarpX/files/4613289/inputs.2d.txt)

This script runs a simple 2d script with the `master` branch (which contains the call to `ExchangeF`) and the current PR (which does not contain it), and compares the results to machine precision using `fcompare`. It does so for a number of configuration (e.g. with/without subcycling, PML, nci filter, etc.). All configurations agreed to machine precision.