### PR TITLE
Style changes

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -38,7 +38,7 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
                                const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
-    
+
     // Whether ion_lev is a null pointer (do_ionization=0) or a real pointer
     // (do_ionization=1)
     const bool do_ionization = ion_lev;

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -26,16 +26,16 @@
  * /param q            : species charge.
  */
 template <int depos_order>
-void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
-                              const amrex::ParticleReal * const wp,
-                              const int * const ion_lev,
-                              amrex::FArrayBox& rho_fab,
-                              const long np_to_depose,
-                              const std::array<amrex::Real,3>& dx,
-                              const std::array<amrex::Real, 3> xyzmin,
-                              const amrex::Dim3 lo,
-                              const amrex::Real q,
-                              const long n_rz_azimuthal_modes)
+void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
+                               const amrex::ParticleReal * const wp,
+                               const int * const ion_lev,
+                               amrex::FArrayBox& rho_fab,
+                               const long np_to_depose,
+                               const std::array<amrex::Real,3>& dx,
+                               const std::array<amrex::Real, 3> xyzmin,
+                               const amrex::Dim3 lo,
+                               const amrex::Real q,
+                               const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
     

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -37,51 +37,53 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
                               const amrex::Real q,
                               const long n_rz_azimuthal_modes)
 {
+    using namespace amrex;
+    
     // Whether ion_lev is a null pointer (do_ionization=0) or a real pointer
     // (do_ionization=1)
     const bool do_ionization = ion_lev;
-    const amrex::Real dxi = 1.0/dx[0];
-    const amrex::Real dzi = 1.0/dx[2];
+    const Real dxi = 1.0/dx[0];
+    const Real dzi = 1.0/dx[2];
 #if (AMREX_SPACEDIM == 2)
-    const amrex::Real invvol = dxi*dzi;
+    const Real invvol = dxi*dzi;
 #elif (defined WARPX_DIM_3D)
-    const amrex::Real dyi = 1.0/dx[1];
-    const amrex::Real invvol = dxi*dyi*dzi;
+    const Real dyi = 1.0/dx[1];
+    const Real invvol = dxi*dyi*dzi;
 #endif
 
-    const amrex::Real xmin = xyzmin[0];
+    const Real xmin = xyzmin[0];
 #if (defined WARPX_DIM_3D)
-    const amrex::Real ymin = xyzmin[1];
+    const Real ymin = xyzmin[1];
 #endif
-    const amrex::Real zmin = xyzmin[2];
+    const Real zmin = xyzmin[2];
 
-    amrex::Array4<amrex::Real> const& rho_arr = rho_fab.array();
-    amrex::IntVect const rho_type = rho_fab.box().type();
+    Array4<Real> const& rho_arr = rho_fab.array();
+    IntVect const rho_type = rho_fab.box().type();
 
     constexpr int zdir = (AMREX_SPACEDIM - 1);
-    constexpr int NODE = amrex::IndexType::NODE;
-    constexpr int CELL = amrex::IndexType::CELL;
+    constexpr int NODE = IndexType::NODE;
+    constexpr int CELL = IndexType::CELL;
 
     // Loop over particles and deposit into rho_fab
-    amrex::ParallelFor(
+    ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
             // --- Get particle quantities
-            amrex::Real wq = q*wp[ip]*invvol;
+            Real wq = q*wp[ip]*invvol;
             if (do_ionization){
                 wq *= ion_lev[ip];
             }
 
-            amrex::ParticleReal xp, yp, zp;
+            ParticleReal xp, yp, zp;
             GetPosition(ip, xp, yp, zp);
 
             // --- Compute shape factors
             // x direction
             // Get particle position in grid coordinates
 #if (defined WARPX_DIM_RZ)
-            const amrex::Real rp = std::sqrt(xp*xp + yp*yp);
-            amrex::Real costheta;
-            amrex::Real sintheta;
+            const Real rp = std::sqrt(xp*xp + yp*yp);
+            Real costheta;
+            Real sintheta;
             if (rp > 0.) {
                 costheta = xp/rp;
                 sintheta = yp/rp;
@@ -90,14 +92,14 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
                 sintheta = 0.;
             }
             const Complex xy0 = Complex{costheta, sintheta};
-            const amrex::Real x = (rp - xmin)*dxi;
+            const Real x = (rp - xmin)*dxi;
 #else
-            const amrex::Real x = (xp - xmin)*dxi;
+            const Real x = (xp - xmin)*dxi;
 #endif
 
             // Compute shape factor along x
             // i: leftmost grid point that the particle touches
-            amrex::Real sx[depos_order + 1];
+            Real sx[depos_order + 1];
             int i;
             if (rho_type[0] == NODE) {
                 i = compute_shape_factor<depos_order>(sx, x);
@@ -107,8 +109,8 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
 
 #if (defined WARPX_DIM_3D)
             // y direction
-            const amrex::Real y = (yp - ymin)*dyi;
-            amrex::Real sy[depos_order + 1];
+            const Real y = (yp - ymin)*dyi;
+            Real sy[depos_order + 1];
             int j;
             if (rho_type[1] == NODE) {
                 j = compute_shape_factor<depos_order>(sy, y);
@@ -117,8 +119,8 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
             }
 #endif
             // z direction
-            const amrex::Real z = (zp - zmin)*dzi;
-            amrex::Real sz[depos_order + 1];
+            const Real z = (zp - zmin)*dzi;
+            Real sz[depos_order + 1];
             int k;
             if (rho_type[zdir] == NODE) {
                 k = compute_shape_factor<depos_order>(sz, z);
@@ -130,14 +132,14 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
             for (int iz=0; iz<=depos_order; iz++){
                 for (int ix=0; ix<=depos_order; ix++){
-                    amrex::Gpu::Atomic::Add(
+                    Gpu::Atomic::Add(
                         &rho_arr(lo.x+i+ix, lo.y+k+iz, 0, 0),
                         sx[ix]*sz[iz]*wq);
 #if (defined WARPX_DIM_RZ)
                     Complex xy = xy0; // Throughout the following loop, xy takes the value e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
-                        amrex::Gpu::Atomic::Add( &rho_arr(lo.x+i+ix, lo.y+k+iz, 0, 2*imode-1), sx[ix]*sz[iz]*wq*xy.real());
-                        amrex::Gpu::Atomic::Add( &rho_arr(lo.x+i+ix, lo.y+k+iz, 0, 2*imode  ), sx[ix]*sz[iz]*wq*xy.imag());
+                        Gpu::Atomic::Add( &rho_arr(lo.x+i+ix, lo.y+k+iz, 0, 2*imode-1), sx[ix]*sz[iz]*wq*xy.real());
+                        Gpu::Atomic::Add( &rho_arr(lo.x+i+ix, lo.y+k+iz, 0, 2*imode  ), sx[ix]*sz[iz]*wq*xy.imag());
                         xy = xy*xy0;
                     }
 #endif
@@ -147,7 +149,7 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
             for (int iz=0; iz<=depos_order; iz++){
                 for (int iy=0; iy<=depos_order; iy++){
                     for (int ix=0; ix<=depos_order; ix++){
-                        amrex::Gpu::Atomic::Add(
+                        Gpu::Atomic::Add(
                             &rho_arr(lo.x+i+ix, lo.y+j+iy, lo.z+k+iz),
                             sx[ix]*sy[iy]*sz[iz]*wq);
                     }

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -51,70 +51,72 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                         const amrex::Real q,
                         const long n_rz_azimuthal_modes)
 {
+    using namespace amrex;
+
     // Whether ion_lev is a null pointer (do_ionization=0) or a real pointer
     // (do_ionization=1)
     const bool do_ionization = ion_lev;
-    const amrex::Real dxi = 1.0/dx[0];
-    const amrex::Real dzi = 1.0/dx[2];
+    const Real dxi = 1.0/dx[0];
+    const Real dzi = 1.0/dx[2];
 #if !(defined WARPX_DIM_RZ)
-    const amrex::Real dts2dx = 0.5*dt*dxi;
+    const Real dts2dx = 0.5*dt*dxi;
 #endif
-    const amrex::Real dts2dz = 0.5*dt*dzi;
+    const Real dts2dz = 0.5*dt*dzi;
 #if (AMREX_SPACEDIM == 2)
-    const amrex::Real invvol = dxi*dzi;
+    const Real invvol = dxi*dzi;
 #elif (defined WARPX_DIM_3D)
-    const amrex::Real dyi = 1.0/dx[1];
-    const amrex::Real dts2dy = 0.5*dt*dyi;
-    const amrex::Real invvol = dxi*dyi*dzi;
+    const Real dyi = 1.0/dx[1];
+    const Real dts2dy = 0.5*dt*dyi;
+    const Real invvol = dxi*dyi*dzi;
 #endif
 
-    const amrex::Real xmin = xyzmin[0];
+    const Real xmin = xyzmin[0];
 #if (defined WARPX_DIM_3D)
-    const amrex::Real ymin = xyzmin[1];
+    const Real ymin = xyzmin[1];
 #endif
-    const amrex::Real zmin = xyzmin[2];
+    const Real zmin = xyzmin[2];
 
-    const amrex::Real clightsq = 1.0/PhysConst::c/PhysConst::c;
+    const Real clightsq = 1.0/PhysConst::c/PhysConst::c;
 
-    amrex::Array4<amrex::Real> const& jx_arr = jx_fab.array();
-    amrex::Array4<amrex::Real> const& jy_arr = jy_fab.array();
-    amrex::Array4<amrex::Real> const& jz_arr = jz_fab.array();
-    amrex::IntVect const jx_type = jx_fab.box().type();
-    amrex::IntVect const jy_type = jy_fab.box().type();
-    amrex::IntVect const jz_type = jz_fab.box().type();
+    Array4<Real> const& jx_arr = jx_fab.array();
+    Array4<Real> const& jy_arr = jy_fab.array();
+    Array4<Real> const& jz_arr = jz_fab.array();
+    IntVect const jx_type = jx_fab.box().type();
+    IntVect const jy_type = jy_fab.box().type();
+    IntVect const jz_type = jz_fab.box().type();
 
     constexpr int zdir = (AMREX_SPACEDIM - 1);
-    constexpr int NODE = amrex::IndexType::NODE;
-    constexpr int CELL = amrex::IndexType::CELL;
+    constexpr int NODE = IndexType::NODE;
+    constexpr int CELL = IndexType::CELL;
 
     // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::ParallelFor(
+    ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
             // --- Get particle quantities
-            const amrex::Real gaminv = 1.0/std::sqrt(1.0 + uxp[ip]*uxp[ip]*clightsq
+            const Real gaminv = 1.0/std::sqrt(1.0 + uxp[ip]*uxp[ip]*clightsq
                                                          + uyp[ip]*uyp[ip]*clightsq
                                                          + uzp[ip]*uzp[ip]*clightsq);
-            amrex::Real wq  = q*wp[ip];
+            Real wq  = q*wp[ip];
             if (do_ionization){
                 wq *= ion_lev[ip];
             }
 
-            amrex::ParticleReal xp, yp, zp;
+            ParticleReal xp, yp, zp;
             GetPosition(ip, xp, yp, zp);
 
-            const amrex::Real vx  = uxp[ip]*gaminv;
-            const amrex::Real vy  = uyp[ip]*gaminv;
-            const amrex::Real vz  = uzp[ip]*gaminv;
+            const Real vx  = uxp[ip]*gaminv;
+            const Real vy  = uyp[ip]*gaminv;
+            const Real vz  = uzp[ip]*gaminv;
             // wqx, wqy wqz are particle current in each direction
 #if (defined WARPX_DIM_RZ)
             // In RZ, wqx is actually wqr, and wqy is wqtheta
             // Convert to cylinderical at the mid point
-            const amrex::Real xpmid = xp - 0.5*dt*vx;
-            const amrex::Real ypmid = yp - 0.5*dt*vy;
-            const amrex::Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
-            amrex::Real costheta;
-            amrex::Real sintheta;
+            const Real xpmid = xp - 0.5*dt*vx;
+            const Real ypmid = yp - 0.5*dt*vy;
+            const Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
+            Real costheta;
+            Real sintheta;
             if (rpmid > 0.) {
                 costheta = xpmid/rpmid;
                 sintheta = ypmid/rpmid;
@@ -123,28 +125,28 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                 sintheta = 0.;
             }
             const Complex xy0 = Complex{costheta, sintheta};
-            const amrex::Real wqx = wq*invvol*(+vx*costheta + vy*sintheta);
-            const amrex::Real wqy = wq*invvol*(-vx*sintheta + vy*costheta);
+            const Real wqx = wq*invvol*(+vx*costheta + vy*sintheta);
+            const Real wqy = wq*invvol*(-vx*sintheta + vy*costheta);
 #else
-            const amrex::Real wqx = wq*invvol*vx;
-            const amrex::Real wqy = wq*invvol*vy;
+            const Real wqx = wq*invvol*vx;
+            const Real wqy = wq*invvol*vy;
 #endif
-            const amrex::Real wqz = wq*invvol*vz;
+            const Real wqz = wq*invvol*vz;
 
             // --- Compute shape factors
             // x direction
             // Get particle position after 1/2 push back in position
 #if (defined WARPX_DIM_RZ)
-            const amrex::Real xmid = (rpmid - xmin)*dxi;
+            const Real xmid = (rpmid - xmin)*dxi;
 #else
-            const amrex::Real xmid = (xp - xmin)*dxi - dts2dx*vx;
+            const Real xmid = (xp - xmin)*dxi - dts2dx*vx;
 #endif
             // j_j[xyz] leftmost grid point in x that the particle touches for the centering of each current
             // sx_j[xyz] shape factor along x for the centering of each current
             // There are only two possible centerings, node or cell centered, so at most only two shape factor
             // arrays will be needed.
-            amrex::Real sx_node[depos_order + 1];
-            amrex::Real sx_cell[depos_order + 1];
+            Real sx_node[depos_order + 1];
+            Real sx_cell[depos_order + 1];
             int j_node;
             int j_cell;
             if (jx_type[0] == NODE || jy_type[0] == NODE || jz_type[0] == NODE) {
@@ -153,18 +155,18 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             if (jx_type[0] == CELL || jy_type[0] == CELL || jz_type[0] == CELL) {
                 j_cell = compute_shape_factor<depos_order>(sx_cell, xmid - 0.5);
             }
-            const amrex::Real (&sx_jx)[depos_order + 1] = ((jx_type[0] == NODE) ? sx_node : sx_cell);
-            const amrex::Real (&sx_jy)[depos_order + 1] = ((jy_type[0] == NODE) ? sx_node : sx_cell);
-            const amrex::Real (&sx_jz)[depos_order + 1] = ((jz_type[0] == NODE) ? sx_node : sx_cell);
+            const Real (&sx_jx)[depos_order + 1] = ((jx_type[0] == NODE) ? sx_node : sx_cell);
+            const Real (&sx_jy)[depos_order + 1] = ((jy_type[0] == NODE) ? sx_node : sx_cell);
+            const Real (&sx_jz)[depos_order + 1] = ((jz_type[0] == NODE) ? sx_node : sx_cell);
             int const j_jx = ((jx_type[0] == NODE) ? j_node : j_cell);
             int const j_jy = ((jy_type[0] == NODE) ? j_node : j_cell);
             int const j_jz = ((jz_type[0] == NODE) ? j_node : j_cell);
 
 #if (defined WARPX_DIM_3D)
             // y direction
-            const amrex::Real ymid = (yp - ymin)*dyi - dts2dy*vy;
-            amrex::Real sy_node[depos_order + 1];
-            amrex::Real sy_cell[depos_order + 1];
+            const Real ymid = (yp - ymin)*dyi - dts2dy*vy;
+            Real sy_node[depos_order + 1];
+            Real sy_cell[depos_order + 1];
             int k_node;
             int k_cell;
             if (jx_type[1] == NODE || jy_type[1] == NODE || jz_type[1] == NODE) {
@@ -173,18 +175,18 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             if (jx_type[1] == CELL || jy_type[1] == CELL || jz_type[1] == CELL) {
                 k_cell = compute_shape_factor<depos_order>(sy_cell, ymid - 0.5);
             }
-            const amrex::Real (&sy_jx)[depos_order + 1] = ((jx_type[1] == NODE) ? sy_node : sy_cell);
-            const amrex::Real (&sy_jy)[depos_order + 1] = ((jy_type[1] == NODE) ? sy_node : sy_cell);
-            const amrex::Real (&sy_jz)[depos_order + 1] = ((jz_type[1] == NODE) ? sy_node : sy_cell);
+            const Real (&sy_jx)[depos_order + 1] = ((jx_type[1] == NODE) ? sy_node : sy_cell);
+            const Real (&sy_jy)[depos_order + 1] = ((jy_type[1] == NODE) ? sy_node : sy_cell);
+            const Real (&sy_jz)[depos_order + 1] = ((jz_type[1] == NODE) ? sy_node : sy_cell);
             int const k_jx = ((jx_type[1] == NODE) ? k_node : k_cell);
             int const k_jy = ((jy_type[1] == NODE) ? k_node : k_cell);
             int const k_jz = ((jz_type[1] == NODE) ? k_node : k_cell);
 #endif
 
             // z direction
-            const amrex::Real zmid = (zp - zmin)*dzi - dts2dz*vz;
-            amrex::Real sz_node[depos_order + 1];
-            amrex::Real sz_cell[depos_order + 1];
+            const Real zmid = (zp - zmin)*dzi - dts2dz*vz;
+            Real sz_node[depos_order + 1];
+            Real sz_cell[depos_order + 1];
             int l_node;
             int l_cell;
             if (jx_type[zdir] == NODE || jy_type[zdir] == NODE || jz_type[zdir] == NODE) {
@@ -193,9 +195,9 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             if (jx_type[zdir] == CELL || jy_type[zdir] == CELL || jz_type[zdir] == CELL) {
                 l_cell = compute_shape_factor<depos_order>(sz_cell, zmid - 0.5);
             }
-            const amrex::Real (&sz_jx)[depos_order + 1] = ((jx_type[zdir] == NODE) ? sz_node : sz_cell);
-            const amrex::Real (&sz_jy)[depos_order + 1] = ((jy_type[zdir] == NODE) ? sz_node : sz_cell);
-            const amrex::Real (&sz_jz)[depos_order + 1] = ((jz_type[zdir] == NODE) ? sz_node : sz_cell);
+            const Real (&sz_jx)[depos_order + 1] = ((jx_type[zdir] == NODE) ? sz_node : sz_cell);
+            const Real (&sz_jy)[depos_order + 1] = ((jy_type[zdir] == NODE) ? sz_node : sz_cell);
+            const Real (&sz_jz)[depos_order + 1] = ((jz_type[zdir] == NODE) ? sz_node : sz_cell);
             int const l_jx = ((jx_type[zdir] == NODE) ? l_node : l_cell);
             int const l_jy = ((jy_type[zdir] == NODE) ? l_node : l_cell);
             int const l_jz = ((jz_type[zdir] == NODE) ? l_node : l_cell);
@@ -204,25 +206,25 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
             for (int iz=0; iz<=depos_order; iz++){
                 for (int ix=0; ix<=depos_order; ix++){
-                    amrex::Gpu::Atomic::Add(
+                    Gpu::Atomic::Add(
                         &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 0),
                         sx_jx[ix]*sz_jx[iz]*wqx);
-                    amrex::Gpu::Atomic::Add(
+                    Gpu::Atomic::Add(
                         &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 0),
                         sx_jy[ix]*sz_jy[iz]*wqy);
-                    amrex::Gpu::Atomic::Add(
+                    Gpu::Atomic::Add(
                         &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
                         sx_jz[ix]*sz_jz[iz]*wqz);
 #if (defined WARPX_DIM_RZ)
                     Complex xy = xy0; // Note that xy is equal to e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 on the weighting comes from the normalization of the modes
-                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode-1), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.real());
-                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode  ), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.imag());
-                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode-1), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.real());
-                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode  ), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.imag());
-                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode-1), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.real());
-                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode  ), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.imag());
+                        Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode-1), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.real());
+                        Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode  ), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.imag());
+                        Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode-1), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.real());
+                        Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode  ), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.imag());
+                        Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode-1), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.real());
+                        Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode  ), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.imag());
                         xy = xy*xy0;
                     }
 #endif
@@ -232,13 +234,13 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             for (int iz=0; iz<=depos_order; iz++){
                 for (int iy=0; iy<=depos_order; iy++){
                     for (int ix=0; ix<=depos_order; ix++){
-                        amrex::Gpu::Atomic::Add(
+                        Gpu::Atomic::Add(
                             &jx_arr(lo.x+j_jx+ix, lo.y+k_jx+iy, lo.z+l_jx+iz),
                             sx_jx[ix]*sy_jx[iy]*sz_jx[iz]*wqx);
-                        amrex::Gpu::Atomic::Add(
+                        Gpu::Atomic::Add(
                             &jy_arr(lo.x+j_jy+ix, lo.y+k_jy+iy, lo.z+l_jy+iz),
                             sx_jy[ix]*sy_jy[iy]*sz_jy[iz]*wqy);
-                        amrex::Gpu::Atomic::Add(
+                        Gpu::Atomic::Add(
                             &jz_arr(lo.x+j_jz+ix, lo.y+k_jz+iy, lo.z+l_jz+iz),
                             sx_jz[ix]*sy_jz[iy]*sz_jz[iz]*wqz);
                     }
@@ -366,7 +368,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 costheta_new = 1.;
                 sintheta_new = 0.;
             }
-            amrex::Real costheta_mid, sintheta_mid;
+            Real costheta_mid, sintheta_mid;
             if (rp_mid > 0._rt) {
                 costheta_mid = xp_mid/rp_mid;
                 sintheta_mid = yp_mid/rp_mid;
@@ -374,7 +376,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 costheta_mid = 1.;
                 sintheta_mid = 0.;
             }
-            amrex::Real costheta_old, sintheta_old;
+            Real costheta_old, sintheta_old;
             if (rp_old > 0._rt) {
                 costheta_old = xp_old/rp_old;
                 sintheta_old = yp_old/rp_old;
@@ -446,31 +448,31 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int j=djl; j<=depos_order+2-dju; j++) {
-                    amrex::Real sdxi = 0.;
+                    Real sdxi = 0.;
                     for (int i=dil; i<=depos_order+1-diu; i++) {
                         sdxi += wqx*(sx_old[i] - sx_new[i])*((sy_new[j] + 0.5*(sy_old[j] - sy_new[j]))*sz_new[k] +
                                                              (0.5*sy_new[j] + 1./3.*(sy_old[j] - sy_new[j]))*(sz_old[k] - sz_new[k]));
-                        amrex::Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
+                        Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
                     }
                 }
             }
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sdyj = 0.;
+                    Real sdyj = 0.;
                     for (int j=djl; j<=depos_order+1-dju; j++) {
                         sdyj += wqy*(sy_old[j] - sy_new[j])*((sz_new[k] + 0.5*(sz_old[k] - sz_new[k]))*sx_new[i] +
                                                              (0.5*sz_new[k] + 1./3.*(sz_old[k] - sz_new[k]))*(sx_old[i] - sx_new[i]));
-                        amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
+                        Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
                     }
                 }
             }
             for (int j=djl; j<=depos_order+2-dju; j++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sdzk = 0.;
+                    Real sdzk = 0.;
                     for (int k=dkl; k<=depos_order+1-dku; k++) {
                         sdzk += wqz*(sz_old[k] - sz_new[k])*((sx_new[i] + 0.5*(sx_old[i] - sx_new[i]))*sy_new[j] +
                                                              (0.5*sx_new[i] + 1./3.*(sx_old[i] - sx_new[i]))*(sy_old[j] - sy_new[j]));
-                        amrex::Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
+                        Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
                     }
                 }
             }
@@ -478,17 +480,17 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 #elif (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
 
             for (int k=dkl; k<=depos_order+2-dku; k++) {
-                amrex::Real sdxi = 0.;
+                Real sdxi = 0.;
                 for (int i=dil; i<=depos_order+1-diu; i++) {
                     sdxi += wqx*(sx_old[i] - sx_new[i])*(sz_new[k] + 0.5*(sz_old[k] - sz_new[k]));
-                    amrex::Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdxi);
+                    Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdxi);
 #if (defined WARPX_DIM_RZ)
                     Complex xy_mid = xy_mid0; // Throughout the following loop, xy_mid takes the value e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         const Complex djr_cmplx = 2._rt *sdxi*xy_mid;
-                        amrex::Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djr_cmplx.real());
-                        amrex::Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djr_cmplx.imag());
+                        Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djr_cmplx.real());
+                        Gpu::Atomic::Add( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djr_cmplx.imag());
                         xy_mid = xy_mid*xy_mid0;
                     }
 #endif
@@ -498,7 +500,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 for (int i=dil; i<=depos_order+2-diu; i++) {
                     Real const sdyj = wq*vy*invvol*((sz_new[k] + 0.5_rt * (sz_old[k] - sz_new[k]))*sx_new[i] +
                                                            (0.5_rt * sz_new[k] + 1._rt / 3._rt *(sz_old[k] - sz_new[k]))*(sx_old[i] - sx_new[i]));
-                    amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdyj);
+                    Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdyj);
 #if (defined WARPX_DIM_RZ)
                     Complex xy_new = xy_new0;
                     Complex xy_mid = xy_mid0;
@@ -507,10 +509,10 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         // The minus sign comes from the different convention with respect to Davidson et al.
-                        const Complex djt_cmplx = -2._rt * I*(i_new-1 + i + xmin*dxi)*wq*invdtdx/(amrex::Real)imode*
+                        const Complex djt_cmplx = -2._rt * I*(i_new-1 + i + xmin*dxi)*wq*invdtdx/(Real)imode*
                                                   (sx_new[i]*sz_new[k]*(xy_new - xy_mid) + sx_old[i]*sz_old[k]*(xy_mid - xy_old));
-                        amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djt_cmplx.real());
-                        amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djt_cmplx.imag());
+                        Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djt_cmplx.real());
+                        Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djt_cmplx.imag());
                         xy_new = xy_new*xy_new0;
                         xy_mid = xy_mid*xy_mid0;
                         xy_old = xy_old*xy_old0;
@@ -522,14 +524,14 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 Real sdzk = 0.;
                 for (int k=dkl; k<=depos_order+1-dku; k++) {
                     sdzk += wqz*(sz_old[k] - sz_new[k])*(sx_new[i] + 0.5_rt * (sx_old[i] - sx_new[i]));
-                    amrex::Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdzk);
+                    Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdzk);
 #if (defined WARPX_DIM_RZ)
                     Complex xy_mid = xy_mid0; // Throughout the following loop, xy_mid takes the value e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         const Complex djz_cmplx = 2._rt * sdzk * xy_mid;
-                        amrex::Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djz_cmplx.real());
-                        amrex::Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djz_cmplx.imag());
+                        Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djz_cmplx.real());
+                        Gpu::Atomic::Add( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djz_cmplx.imag());
                         xy_mid = xy_mid*xy_mid0;
                     }
 #endif

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -35,21 +35,21 @@
  * /param q            : species charge.
  */
 template <int depos_order>
-void doDepositionShapeN(const GetParticlePosition& GetPosition,
-                        const amrex::ParticleReal * const wp,
-                        const amrex::ParticleReal * const uxp,
-                        const amrex::ParticleReal * const uyp,
-                        const amrex::ParticleReal * const uzp,
-                        const int * const ion_lev,
-                        amrex::FArrayBox& jx_fab,
-                        amrex::FArrayBox& jy_fab,
-                        amrex::FArrayBox& jz_fab,
-                        const long np_to_depose, const amrex::Real dt,
-                        const std::array<amrex::Real,3>& dx,
-                        const std::array<amrex::Real,3>& xyzmin,
-                        const amrex::Dim3 lo,
-                        const amrex::Real q,
-                        const long n_rz_azimuthal_modes)
+void doDepositionShapeN (const GetParticlePosition& GetPosition,
+                         const amrex::ParticleReal * const wp,
+                         const amrex::ParticleReal * const uxp,
+                         const amrex::ParticleReal * const uyp,
+                         const amrex::ParticleReal * const uzp,
+                         const int * const ion_lev,
+                         amrex::FArrayBox& jx_fab,
+                         amrex::FArrayBox& jy_fab,
+                         amrex::FArrayBox& jz_fab,
+                         const long np_to_depose, const amrex::Real dt,
+                         const std::array<amrex::Real,3>& dx,
+                         const std::array<amrex::Real,3>& xyzmin,
+                         const amrex::Dim3 lo,
+                         const amrex::Real q,
+                         const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
 

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -12,7 +12,6 @@
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpX_Complex.H"
 
-
 /**
  * \brief Field gather for particles handled by thread thread_num
  * /param GetPosition : A functor for returning the particle position.
@@ -29,21 +28,21 @@
  * \param n_rz_azimuthal_modes: Number of azimuthal modes when using RZ geometry
  */
 template <int depos_order, int lower_in_v>
-void doGatherShapeN(const GetParticlePosition& GetPosition,
-                    amrex::ParticleReal * const Exp, amrex::ParticleReal * const Eyp,
-                    amrex::ParticleReal * const Ezp, amrex::ParticleReal * const Bxp,
-                    amrex::ParticleReal * const Byp, amrex::ParticleReal * const Bzp,
-                    amrex::FArrayBox const * const exfab,
-                    amrex::FArrayBox const * const eyfab,
-                    amrex::FArrayBox const * const ezfab,
-                    amrex::FArrayBox const * const bxfab,
-                    amrex::FArrayBox const * const byfab,
-                    amrex::FArrayBox const * const bzfab,
-                    const long np_to_gather,
-                    const std::array<amrex::Real, 3>& dx,
-                    const std::array<amrex::Real, 3> xyzmin,
-                    const amrex::Dim3 lo,
-                    const long n_rz_azimuthal_modes)
+void doGatherShapeN (const GetParticlePosition& GetPosition,
+                     amrex::ParticleReal * const Exp, amrex::ParticleReal * const Eyp,
+                     amrex::ParticleReal * const Ezp, amrex::ParticleReal * const Bxp,
+                     amrex::ParticleReal * const Byp, amrex::ParticleReal * const Bzp,
+                     amrex::FArrayBox const * const exfab,
+                     amrex::FArrayBox const * const eyfab,
+                     amrex::FArrayBox const * const ezfab,
+                     amrex::FArrayBox const * const bxfab,
+                     amrex::FArrayBox const * const byfab,
+                     amrex::FArrayBox const * const bzfab,
+                     const long np_to_gather,
+                     const std::array<amrex::Real, 3>& dx,
+                     const std::array<amrex::Real, 3> xyzmin,
+                     const amrex::Dim3 lo,
+                     const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
     

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -45,7 +45,7 @@ void doGatherShapeN (const GetParticlePosition& GetPosition,
                      const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
-    
+
     const Real dxi = 1.0/dx[0];
     const Real dzi = 1.0/dx[2];
 #if (AMREX_SPACEDIM == 3)

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -45,63 +45,65 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
                     const amrex::Dim3 lo,
                     const long n_rz_azimuthal_modes)
 {
-    const amrex::Real dxi = 1.0/dx[0];
-    const amrex::Real dzi = 1.0/dx[2];
+    using namespace amrex;
+    
+    const Real dxi = 1.0/dx[0];
+    const Real dzi = 1.0/dx[2];
 #if (AMREX_SPACEDIM == 3)
-    const amrex::Real dyi = 1.0/dx[1];
+    const Real dyi = 1.0/dx[1];
 #endif
 
-    const amrex::Real xmin = xyzmin[0];
+    const Real xmin = xyzmin[0];
 #if (AMREX_SPACEDIM == 3)
-    const amrex::Real ymin = xyzmin[1];
+    const Real ymin = xyzmin[1];
 #endif
-    const amrex::Real zmin = xyzmin[2];
+    const Real zmin = xyzmin[2];
 
-    amrex::Array4<const amrex::Real> const& ex_arr = exfab->array();
-    amrex::Array4<const amrex::Real> const& ey_arr = eyfab->array();
-    amrex::Array4<const amrex::Real> const& ez_arr = ezfab->array();
-    amrex::Array4<const amrex::Real> const& bx_arr = bxfab->array();
-    amrex::Array4<const amrex::Real> const& by_arr = byfab->array();
-    amrex::Array4<const amrex::Real> const& bz_arr = bzfab->array();
+    Array4<const Real> const& ex_arr = exfab->array();
+    Array4<const Real> const& ey_arr = eyfab->array();
+    Array4<const Real> const& ez_arr = ezfab->array();
+    Array4<const Real> const& bx_arr = bxfab->array();
+    Array4<const Real> const& by_arr = byfab->array();
+    Array4<const Real> const& bz_arr = bzfab->array();
 
-    amrex::IntVect const ex_type = exfab->box().type();
-    amrex::IntVect const ey_type = eyfab->box().type();
-    amrex::IntVect const ez_type = ezfab->box().type();
-    amrex::IntVect const bx_type = bxfab->box().type();
-    amrex::IntVect const by_type = byfab->box().type();
-    amrex::IntVect const bz_type = bzfab->box().type();
+    IntVect const ex_type = exfab->box().type();
+    IntVect const ey_type = eyfab->box().type();
+    IntVect const ez_type = ezfab->box().type();
+    IntVect const bx_type = bxfab->box().type();
+    IntVect const by_type = byfab->box().type();
+    IntVect const bz_type = bzfab->box().type();
 
     constexpr int zdir = (AMREX_SPACEDIM - 1);
-    constexpr int NODE = amrex::IndexType::NODE;
-    constexpr int CELL = amrex::IndexType::CELL;
+    constexpr int NODE = IndexType::NODE;
+    constexpr int CELL = IndexType::CELL;
 
     // Loop over particles and gather fields from
     // {e,b}{x,y,z}_arr to {E,B}{xyz}p.
-    amrex::ParallelFor(
+    ParallelFor(
         np_to_gather,
         [=] AMREX_GPU_DEVICE (long ip) {
 
-            amrex::ParticleReal xp, yp, zp;
+            ParticleReal xp, yp, zp;
             GetPosition(ip, xp, yp, zp);
 
             // --- Compute shape factors
             // x direction
             // Get particle position
 #ifdef WARPX_DIM_RZ
-            const amrex::Real rp = std::sqrt(xp*xp + yp*yp);
-            const amrex::Real x = (rp - xmin)*dxi;
+            const Real rp = std::sqrt(xp*xp + yp*yp);
+            const Real x = (rp - xmin)*dxi;
 #else
-            const amrex::Real x = (xp-xmin)*dxi;
+            const Real x = (xp-xmin)*dxi;
 #endif
 
             // j_[eb][xyz] leftmost grid point in x that the particle touches for the centering of each current
             // sx_[eb][xyz] shape factor along x for the centering of each current
             // There are only two possible centerings, node or cell centered, so at most only two shape factor
             // arrays will be needed.
-            amrex::Real sx_node[depos_order + 1];
-            amrex::Real sx_cell[depos_order + 1];
-            amrex::Real sx_node_v[depos_order + 1 - lower_in_v];
-            amrex::Real sx_cell_v[depos_order + 1 - lower_in_v];
+            Real sx_node[depos_order + 1];
+            Real sx_cell[depos_order + 1];
+            Real sx_node_v[depos_order + 1 - lower_in_v];
+            Real sx_cell_v[depos_order + 1 - lower_in_v];
             int j_node;
             int j_cell;
             int j_node_v;
@@ -118,12 +120,12 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
             if ((ex_type[0] == CELL) || (by_type[0] == CELL) || (bz_type[0] == CELL)) {
                 j_cell_v = compute_shape_factor<depos_order-lower_in_v>(sx_cell_v, x - 0.5);
             }
-            const amrex::Real (&sx_ex)[depos_order + 1 - lower_in_v] = ((ex_type[0] == NODE) ? sx_node_v : sx_cell_v);
-            const amrex::Real (&sx_ey)[depos_order + 1             ] = ((ey_type[0] == NODE) ? sx_node   : sx_cell  );
-            const amrex::Real (&sx_ez)[depos_order + 1             ] = ((ez_type[0] == NODE) ? sx_node   : sx_cell  );
-            const amrex::Real (&sx_bx)[depos_order + 1             ] = ((bx_type[0] == NODE) ? sx_node   : sx_cell  );
-            const amrex::Real (&sx_by)[depos_order + 1 - lower_in_v] = ((by_type[0] == NODE) ? sx_node_v : sx_cell_v);
-            const amrex::Real (&sx_bz)[depos_order + 1 - lower_in_v] = ((bz_type[0] == NODE) ? sx_node_v : sx_cell_v);
+            const Real (&sx_ex)[depos_order + 1 - lower_in_v] = ((ex_type[0] == NODE) ? sx_node_v : sx_cell_v);
+            const Real (&sx_ey)[depos_order + 1             ] = ((ey_type[0] == NODE) ? sx_node   : sx_cell  );
+            const Real (&sx_ez)[depos_order + 1             ] = ((ez_type[0] == NODE) ? sx_node   : sx_cell  );
+            const Real (&sx_bx)[depos_order + 1             ] = ((bx_type[0] == NODE) ? sx_node   : sx_cell  );
+            const Real (&sx_by)[depos_order + 1 - lower_in_v] = ((by_type[0] == NODE) ? sx_node_v : sx_cell_v);
+            const Real (&sx_bz)[depos_order + 1 - lower_in_v] = ((bz_type[0] == NODE) ? sx_node_v : sx_cell_v);
             int const j_ex = ((ex_type[0] == NODE) ? j_node_v : j_cell_v);
             int const j_ey = ((ey_type[0] == NODE) ? j_node   : j_cell  );
             int const j_ez = ((ez_type[0] == NODE) ? j_node   : j_cell  );
@@ -133,11 +135,11 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
 
 #if (AMREX_SPACEDIM == 3)
             // y direction
-            const amrex::Real y = (yp-ymin)*dyi;
-            amrex::Real sy_node[depos_order + 1];
-            amrex::Real sy_cell[depos_order + 1];
-            amrex::Real sy_node_v[depos_order + 1 - lower_in_v];
-            amrex::Real sy_cell_v[depos_order + 1 - lower_in_v];
+            const Real y = (yp-ymin)*dyi;
+            Real sy_node[depos_order + 1];
+            Real sy_cell[depos_order + 1];
+            Real sy_node_v[depos_order + 1 - lower_in_v];
+            Real sy_cell_v[depos_order + 1 - lower_in_v];
             int k_node;
             int k_cell;
             int k_node_v;
@@ -154,12 +156,12 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
             if ((ey_type[1] == CELL) || (bx_type[1] == CELL) || (bz_type[1] == CELL)) {
                 k_cell_v = compute_shape_factor<depos_order-lower_in_v>(sy_cell_v, y - 0.5);
             }
-            const amrex::Real (&sy_ex)[depos_order + 1             ] = ((ex_type[1] == NODE) ? sy_node   : sy_cell  );
-            const amrex::Real (&sy_ey)[depos_order + 1 - lower_in_v] = ((ey_type[1] == NODE) ? sy_node_v : sy_cell_v);
-            const amrex::Real (&sy_ez)[depos_order + 1             ] = ((ez_type[1] == NODE) ? sy_node   : sy_cell  );
-            const amrex::Real (&sy_bx)[depos_order + 1 - lower_in_v] = ((bx_type[1] == NODE) ? sy_node_v : sy_cell_v);
-            const amrex::Real (&sy_by)[depos_order + 1             ] = ((by_type[1] == NODE) ? sy_node   : sy_cell  );
-            const amrex::Real (&sy_bz)[depos_order + 1 - lower_in_v] = ((bz_type[1] == NODE) ? sy_node_v : sy_cell_v);
+            const Real (&sy_ex)[depos_order + 1             ] = ((ex_type[1] == NODE) ? sy_node   : sy_cell  );
+            const Real (&sy_ey)[depos_order + 1 - lower_in_v] = ((ey_type[1] == NODE) ? sy_node_v : sy_cell_v);
+            const Real (&sy_ez)[depos_order + 1             ] = ((ez_type[1] == NODE) ? sy_node   : sy_cell  );
+            const Real (&sy_bx)[depos_order + 1 - lower_in_v] = ((bx_type[1] == NODE) ? sy_node_v : sy_cell_v);
+            const Real (&sy_by)[depos_order + 1             ] = ((by_type[1] == NODE) ? sy_node   : sy_cell  );
+            const Real (&sy_bz)[depos_order + 1 - lower_in_v] = ((bz_type[1] == NODE) ? sy_node_v : sy_cell_v);
             int const k_ex = ((ex_type[1] == NODE) ? k_node   : k_cell  );
             int const k_ey = ((ey_type[1] == NODE) ? k_node_v : k_cell_v);
             int const k_ez = ((ez_type[1] == NODE) ? k_node   : k_cell  );
@@ -169,11 +171,11 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
 
 #endif
             // z direction
-            const amrex::Real z = (zp-zmin)*dzi;
-            amrex::Real sz_node[depos_order + 1];
-            amrex::Real sz_cell[depos_order + 1];
-            amrex::Real sz_node_v[depos_order + 1 - lower_in_v];
-            amrex::Real sz_cell_v[depos_order + 1 - lower_in_v];
+            const Real z = (zp-zmin)*dzi;
+            Real sz_node[depos_order + 1];
+            Real sz_cell[depos_order + 1];
+            Real sz_node_v[depos_order + 1 - lower_in_v];
+            Real sz_cell_v[depos_order + 1 - lower_in_v];
             int l_node;
             int l_cell;
             int l_node_v;
@@ -190,12 +192,12 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
             if ((ez_type[zdir] == CELL) || (bx_type[zdir] == CELL) || (by_type[zdir] == CELL)) {
                 l_cell_v = compute_shape_factor<depos_order-lower_in_v>(sz_cell_v, z - 0.5);
             }
-            const amrex::Real (&sz_ex)[depos_order + 1             ] = ((ex_type[zdir] == NODE) ? sz_node   : sz_cell  );
-            const amrex::Real (&sz_ey)[depos_order + 1             ] = ((ey_type[zdir] == NODE) ? sz_node   : sz_cell  );
-            const amrex::Real (&sz_ez)[depos_order + 1 - lower_in_v] = ((ez_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-            const amrex::Real (&sz_bx)[depos_order + 1 - lower_in_v] = ((bx_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-            const amrex::Real (&sz_by)[depos_order + 1 - lower_in_v] = ((by_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-            const amrex::Real (&sz_bz)[depos_order + 1             ] = ((bz_type[zdir] == NODE) ? sz_node   : sz_cell  );
+            const Real (&sz_ex)[depos_order + 1             ] = ((ex_type[zdir] == NODE) ? sz_node   : sz_cell  );
+            const Real (&sz_ey)[depos_order + 1             ] = ((ey_type[zdir] == NODE) ? sz_node   : sz_cell  );
+            const Real (&sz_ez)[depos_order + 1 - lower_in_v] = ((ez_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
+            const Real (&sz_bx)[depos_order + 1 - lower_in_v] = ((bx_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
+            const Real (&sz_by)[depos_order + 1 - lower_in_v] = ((by_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
+            const Real (&sz_bz)[depos_order + 1             ] = ((bz_type[zdir] == NODE) ? sz_node   : sz_cell  );
             int const l_ex = ((ex_type[zdir] == NODE) ? l_node   : l_cell  );
             int const l_ey = ((ey_type[zdir] == NODE) ? l_node   : l_cell  );
             int const l_ez = ((ez_type[zdir] == NODE) ? l_node_v : l_cell_v);
@@ -246,8 +248,8 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
 
 #ifdef WARPX_DIM_RZ
 
-            amrex::Real costheta;
-            amrex::Real sintheta;
+            Real costheta;
+            Real sintheta;
             if (rp > 0.) {
                 costheta = xp/rp;
                 sintheta = yp/rp;
@@ -263,7 +265,7 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
                 // Gather field on particle Eyp[i] from field on grid ey_arr
                 for (int iz=0; iz<=depos_order; iz++){
                     for (int ix=0; ix<=depos_order; ix++){
-                        const amrex::Real dEy = (+ ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode-1)*xy.real()
+                        const Real dEy = (+ ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode-1)*xy.real()
                                                  - ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode)*xy.imag());
                         Eyp[ip] += sx_ey[ix]*sz_ey[iz]*dEy;
                     }
@@ -272,10 +274,10 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
                 // Gather field on particle Bzp[i] from field on grid bz_arr
                 for (int iz=0; iz<=depos_order; iz++){
                     for (int ix=0; ix<=depos_order-lower_in_v; ix++){
-                        const amrex::Real dEx = (+ ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode-1)*xy.real()
+                        const Real dEx = (+ ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode-1)*xy.real()
                                                  - ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode)*xy.imag());
                         Exp[ip] += sx_ex[ix]*sz_ex[iz]*dEx;
-                        const amrex::Real dBz = (+ bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 2*imode-1)*xy.real()
+                        const Real dBz = (+ bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 2*imode-1)*xy.real()
                                                  - bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 2*imode)*xy.imag());
                         Bzp[ip] += sx_bz[ix]*sz_bz[iz]*dBz;
                     }
@@ -284,10 +286,10 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
                 // Gather field on particle Bxp[i] from field on grid bx_arr
                 for (int iz=0; iz<=depos_order-lower_in_v; iz++){
                     for (int ix=0; ix<=depos_order; ix++){
-                        const amrex::Real dEz = (+ ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode-1)*xy.real()
+                        const Real dEz = (+ ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode-1)*xy.real()
                                                  - ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode)*xy.imag());
                         Ezp[ip] += sx_ez[ix]*sz_ez[iz]*dEz;
-                        const amrex::Real dBx = (+ bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 2*imode-1)*xy.real()
+                        const Real dBx = (+ bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 2*imode-1)*xy.real()
                                                  - bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 2*imode)*xy.imag());
                         Bxp[ip] += sx_bx[ix]*sz_bx[iz]*dBx;
                     }
@@ -295,7 +297,7 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
                 // Gather field on particle Byp[i] from field on grid by_arr
                 for (int iz=0; iz<=depos_order-lower_in_v; iz++){
                     for (int ix=0; ix<=depos_order-lower_in_v; ix++){
-                        const amrex::Real dBy = (+ by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode-1)*xy.real()
+                        const Real dBy = (+ by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode-1)*xy.real()
                                                  - by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode)*xy.imag());
                         Byp[ip] += sx_by[ix]*sz_by[iz]*dBy;
                     }
@@ -304,10 +306,10 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
             }
 
             // Convert Exp and Eyp (which are actually Er and Etheta) to Ex and Ey
-            const amrex::Real Exp_save = Exp[ip];
+            const Real Exp_save = Exp[ip];
             Exp[ip] = costheta*Exp[ip] - sintheta*Eyp[ip];
             Eyp[ip] = costheta*Eyp[ip] + sintheta*Exp_save;
-            const amrex::Real Bxp_save = Bxp[ip];
+            const Real Bxp_save = Bxp[ip];
             Bxp[ip] = costheta*Bxp[ip] - sintheta*Byp[ip];
             Byp[ip] = costheta*Byp[ip] + sintheta*Bxp_save;
 #endif

--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -20,7 +20,7 @@ void UpdateMomentumBoris (
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     const Real econst = 0.5*q*dt/m;
 
     // First half-push for E

--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -19,27 +19,29 @@ void UpdateMomentumBoris(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
-    const amrex::Real econst = 0.5*q*dt/m;
+    using namespace amrex;
+    
+    const Real econst = 0.5*q*dt/m;
 
     // First half-push for E
     ux += econst*Ex;
     uy += econst*Ey;
     uz += econst*Ez;
     // Compute temporary gamma factor
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    constexpr Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+    const Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
     // Magnetic rotation
     // - Compute temporary variables
-    const amrex::Real tx = econst*inv_gamma*Bx;
-    const amrex::Real ty = econst*inv_gamma*By;
-    const amrex::Real tz = econst*inv_gamma*Bz;
-    const amrex::Real tsqi = 2./(1. + tx*tx + ty*ty + tz*tz);
-    const amrex::Real sx = tx*tsqi;
-    const amrex::Real sy = ty*tsqi;
-    const amrex::Real sz = tz*tsqi;
-    const amrex::Real ux_p = ux + uy*tz - uz*ty;
-    const amrex::Real uy_p = uy + uz*tx - ux*tz;
-    const amrex::Real uz_p = uz + ux*ty - uy*tx;
+    const Real tx = econst*inv_gamma*Bx;
+    const Real ty = econst*inv_gamma*By;
+    const Real tz = econst*inv_gamma*Bz;
+    const Real tsqi = 2./(1. + tx*tx + ty*ty + tz*tz);
+    const Real sx = tx*tsqi;
+    const Real sy = ty*tsqi;
+    const Real sz = tz*tsqi;
+    const Real ux_p = ux + uy*tz - uz*ty;
+    const Real uy_p = uy + uz*tx - ux*tz;
+    const Real uz_p = uz + ux*ty - uy*tx;
     // - Update momentum
     ux += uy_p*sz - uz_p*sy;
     uy += uz_p*sx - ux_p*sz;

--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -13,7 +13,7 @@
 /** \brief Push the particle's positions over one timestep,
  *    given the value of its momenta `ux`, `uy`, `uz` */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdateMomentumBoris(
+void UpdateMomentumBoris (
     amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
     const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -19,7 +19,7 @@
  * https://doi.org/10.1088/1367-2630/12/12/123005
  */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdateMomentumBorisWithRadiationReaction(
+void UpdateMomentumBorisWithRadiationReaction (
     amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
     const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -25,13 +25,15 @@ void UpdateMomentumBorisWithRadiationReaction(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex;
+    
     //RR algorithm needs to store old value of the normalized momentum
-    const amrex::Real ux_old = ux;
-    const amrex::Real uy_old = uy;
-    const amrex::Real uz_old = uz;
+    const Real ux_old = ux;
+    const Real uy_old = uy;
+    const Real uz_old = uz;
 
     //Useful constant
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+    constexpr Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
     //Call to regular Boris pusher
     UpdateMomentumBoris(
@@ -41,44 +43,44 @@ void UpdateMomentumBorisWithRadiationReaction(
         q, m, dt );
 
     //Estimation of the normalized momentum at intermediate (integer) time
-    const amrex::Real ux_n = (ux+ux_old)*0.5;
-    const amrex::Real uy_n = (uy+uy_old)*0.5;
-    const amrex::Real uz_n = (uz+uz_old)*0.5;
+    const Real ux_n = (ux+ux_old)*0.5;
+    const Real uy_n = (uy+uy_old)*0.5;
+    const Real uz_n = (uz+uz_old)*0.5;
 
     // Compute Lorentz factor (and inverse) at intermediate (integer) time
-    const amrex::Real gamma_n = std::sqrt( 1. +
+    const Real gamma_n = std::sqrt( 1. +
         (ux_n*ux_n + uy_n*uy_n + uz_n*uz_n)*inv_c2);
-    const amrex::Real inv_gamma_n = 1.0/gamma_n;
+    const Real inv_gamma_n = 1.0/gamma_n;
 
     //Estimation of the velocity at intermediate (integer) time
-    const amrex::Real vx_n = ux_n*inv_gamma_n;
-    const amrex::Real vy_n = uy_n*inv_gamma_n;
-    const amrex::Real vz_n = uz_n*inv_gamma_n;
-    const amrex::Real bx_n = vx_n/PhysConst::c;
-    const amrex::Real by_n = vy_n/PhysConst::c;
-    const amrex::Real bz_n = vz_n/PhysConst::c;
+    const Real vx_n = ux_n*inv_gamma_n;
+    const Real vy_n = uy_n*inv_gamma_n;
+    const Real vz_n = uz_n*inv_gamma_n;
+    const Real bx_n = vx_n/PhysConst::c;
+    const Real by_n = vy_n/PhysConst::c;
+    const Real bz_n = vz_n/PhysConst::c;
 
     //Lorentz force over charge
-    const amrex::Real flx_q = (Ex + vy_n*Bz - vz_n*By);
-    const amrex::Real fly_q = (Ey + vz_n*Bx - vx_n*Bz);
-    const amrex::Real flz_q = (Ez + vx_n*By - vy_n*Bx);
-    const amrex::Real fl_q2 = flx_q*flx_q + fly_q*fly_q + flz_q*flz_q;
+    const Real flx_q = (Ex + vy_n*Bz - vz_n*By);
+    const Real fly_q = (Ey + vz_n*Bx - vx_n*Bz);
+    const Real flz_q = (Ez + vx_n*By - vy_n*Bx);
+    const Real fl_q2 = flx_q*flx_q + fly_q*fly_q + flz_q*flz_q;
 
     //Calculation of auxiliary quantities
-    const amrex::Real bdotE = (bx_n*Ex + by_n*Ey + bz_n*Ez);
-    const amrex::Real bdotE2 = bdotE*bdotE;
-    const amrex::Real coeff = gamma_n*gamma_n*(fl_q2-bdotE2);
+    const Real bdotE = (bx_n*Ex + by_n*Ey + bz_n*Ez);
+    const Real bdotE2 = bdotE*bdotE;
+    const Real coeff = gamma_n*gamma_n*(fl_q2-bdotE2);
 
     //Radiation reaction constant
-    const amrex::Real RRcoeff = 2.0*PhysConst::r_e*q*q/
+    const Real RRcoeff = 2.0*PhysConst::r_e*q*q/
         (3.0*m*m*PhysConst::c*PhysConst::c);
 
     //Compute the components of the RR force
-    const amrex::Real frx =
+    const Real frx =
         RRcoeff*(PhysConst::c*(fly_q*Bz - flz_q*By) + bdotE*Ex - coeff*bx_n);
-    const amrex::Real fry =
+    const Real fry =
         RRcoeff*(PhysConst::c*(flz_q*Bx - flx_q*Bz) + bdotE*Ey - coeff*by_n);
-    const amrex::Real frz =
+    const Real frz =
         RRcoeff*(PhysConst::c*(flx_q*By - fly_q*Bx) + bdotE*Ez - coeff*bz_n);
 
     //Update momentum using the RR force

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -26,7 +26,7 @@ void UpdateMomentumBorisWithRadiationReaction (
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     //RR algorithm needs to store old value of the normalized momentum
     const Real ux_old = ux;
     const Real uy_old = uy;

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -19,7 +19,7 @@
  */
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdateMomentumHigueraCary(
+void UpdateMomentumHigueraCary (
     amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
     const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -25,39 +25,41 @@ void UpdateMomentumHigueraCary(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex;
+    
     // Constants
-    const amrex::Real qmt = 0.5*q*dt/m;
-    constexpr amrex::Real invclight = 1./PhysConst::c;
-    constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
+    const Real qmt = 0.5*q*dt/m;
+    constexpr Real invclight = 1./PhysConst::c;
+    constexpr Real invclightsq = 1./(PhysConst::c*PhysConst::c);
     // Compute u_minus
-    const amrex::Real umx = ux + qmt*Ex;
-    const amrex::Real umy = uy + qmt*Ey;
-    const amrex::Real umz = uz + qmt*Ez;
+    const Real umx = ux + qmt*Ex;
+    const Real umy = uy + qmt*Ey;
+    const Real umz = uz + qmt*Ez;
     // Compute gamma squared of u_minus
-    amrex::Real gamma = 1. + (umx*umx + umy*umy + umz*umz)*invclightsq;
+    Real gamma = 1. + (umx*umx + umy*umy + umz*umz)*invclightsq;
     // Compute beta and betam squared
-    const amrex::Real betax = qmt*Bx;
-    const amrex::Real betay = qmt*By;
-    const amrex::Real betaz = qmt*Bz;
-    const amrex::Real betam = betax*betax + betay*betay + betaz*betaz;
+    const Real betax = qmt*Bx;
+    const Real betay = qmt*By;
+    const Real betaz = qmt*Bz;
+    const Real betam = betax*betax + betay*betay + betaz*betaz;
     // Compute sigma
-    const amrex::Real sigma = gamma - betam;
+    const Real sigma = gamma - betam;
     // Get u*
-    const amrex::Real ust = (umx*betax + umy*betay + umz*betaz)*invclight;
+    const Real ust = (umx*betax + umy*betay + umz*betaz)*invclight;
     // Get new gamma inversed
     gamma = 1./std::sqrt(0.5*(sigma + std::sqrt(sigma*sigma + 4.*(betam + ust*ust)) ));
     // Compute t
-    const amrex::Real tx = gamma*betax;
-    const amrex::Real ty = gamma*betay;
-    const amrex::Real tz = gamma*betaz;
+    const Real tx = gamma*betax;
+    const Real ty = gamma*betay;
+    const Real tz = gamma*betaz;
     // Compute s
-    const amrex::Real s = 1./(1.+(tx*tx + ty*ty + tz*tz));
+    const Real s = 1./(1.+(tx*tx + ty*ty + tz*tz));
     // Compute um dot t
-    const amrex::Real umt = umx*tx + umy*ty + umz*tz;
+    const Real umt = umx*tx + umy*ty + umz*tz;
     // Compute u_plus
-    const amrex::Real upx = s*( umx + umt*tx + umy*tz - umz*ty );
-    const amrex::Real upy = s*( umy + umt*ty + umz*tx - umx*tz );
-    const amrex::Real upz = s*( umz + umt*tz + umx*ty - umy*tx );
+    const Real upx = s*( umx + umt*tx + umy*tz - umz*ty );
+    const Real upy = s*( umy + umt*ty + umz*tx - umx*tz );
+    const Real upz = s*( umz + umt*tz + umx*ty - umy*tx );
     // Get new u
     ux = upx + qmt*Ex + upy*tz - upz*ty;
     uy = upy + qmt*Ey + upz*tx - upx*tz;

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -26,7 +26,7 @@ void UpdateMomentumHigueraCary (
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     // Constants
     const Real qmt = 0.5*q*dt/m;
     constexpr Real invclight = 1./PhysConst::c;

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -23,36 +23,38 @@ void UpdateMomentumVay(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex;
+    
     // Constants
-    const amrex::Real econst = q*dt/m;
-    const amrex::Real bconst = 0.5*q*dt/m;
-    constexpr amrex::Real invclight = 1./PhysConst::c;
-    constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
+    const Real econst = q*dt/m;
+    const Real bconst = 0.5*q*dt/m;
+    constexpr Real invclight = 1./PhysConst::c;
+    constexpr Real invclightsq = 1./(PhysConst::c*PhysConst::c);
     // Compute initial gamma
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*invclightsq);
+    const Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*invclightsq);
     // Get tau
-    const amrex::Real taux = bconst*Bx;
-    const amrex::Real tauy = bconst*By;
-    const amrex::Real tauz = bconst*Bz;
-    const amrex::Real tausq = taux*taux+tauy*tauy+tauz*tauz;
+    const Real taux = bconst*Bx;
+    const Real tauy = bconst*By;
+    const Real tauz = bconst*Bz;
+    const Real tausq = taux*taux+tauy*tauy+tauz*tauz;
     // Get U', gamma'^2
-    const amrex::Real uxpr = ux + econst*Ex + (uy*tauz-uz*tauy)*inv_gamma;
-    const amrex::Real uypr = uy + econst*Ey + (uz*taux-ux*tauz)*inv_gamma;
-    const amrex::Real uzpr = uz + econst*Ez + (ux*tauy-uy*taux)*inv_gamma;
-    const amrex::Real gprsq = (1. + (uxpr*uxpr + uypr*uypr + uzpr*uzpr)*invclightsq);
+    const Real uxpr = ux + econst*Ex + (uy*tauz-uz*tauy)*inv_gamma;
+    const Real uypr = uy + econst*Ey + (uz*taux-ux*tauz)*inv_gamma;
+    const Real uzpr = uz + econst*Ez + (ux*tauy-uy*taux)*inv_gamma;
+    const Real gprsq = (1. + (uxpr*uxpr + uypr*uypr + uzpr*uzpr)*invclightsq);
     // Get u*
-    const amrex::Real ust = (uxpr*taux + uypr*tauy + uzpr*tauz)*invclight;
+    const Real ust = (uxpr*taux + uypr*tauy + uzpr*tauz)*invclight;
     // Get new gamma
-    const amrex::Real sigma = gprsq-tausq;
-    const amrex::Real gisq = 2./(sigma + std::sqrt(sigma*sigma + 4.*(tausq + ust*ust)) );
+    const Real sigma = gprsq-tausq;
+    const Real gisq = 2./(sigma + std::sqrt(sigma*sigma + 4.*(tausq + ust*ust)) );
     // Get t, s
-    const amrex::Real bg = bconst*std::sqrt(gisq);
-    const amrex::Real tx = bg*Bx;
-    const amrex::Real ty = bg*By;
-    const amrex::Real tz = bg*Bz;
-    const amrex::Real s = 1./(1.+tausq*gisq);
+    const Real bg = bconst*std::sqrt(gisq);
+    const Real tx = bg*Bx;
+    const Real ty = bg*By;
+    const Real tz = bg*Bz;
+    const Real s = 1./(1.+tausq*gisq);
     // Get t.u'
-    const amrex::Real tu = tx*uxpr + ty*uypr + tz*uzpr;
+    const Real tu = tx*uxpr + ty*uypr + tz*uzpr;
     // Get new U
     ux = s*(uxpr+tx*tu+uypr*tz-uzpr*ty);
     uy = s*(uypr+ty*tu+uzpr*tx-uxpr*tz);

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -17,7 +17,7 @@
 /** \brief Push the particle's positions over one timestep,
  *    given the value of its momenta `ux`, `uy`, `uz` */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdateMomentumVay(
+void UpdateMomentumVay (
     amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
     const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -24,7 +24,7 @@ void UpdateMomentumVay (
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     // Constants
     const Real econst = q*dt/m;
     const Real bconst = 0.5*q*dt/m;

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -21,11 +21,12 @@ void UpdatePosition(amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::Parti
                     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
                     const amrex::Real dt )
 {
-
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+    using namespace amrex;
+    
+    constexpr Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
     // Compute inverse Lorentz factor
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    const Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
     // Update positions over one time step
     x += ux * inv_gamma * dt;
 #if (AMREX_SPACEDIM == 3) || (defined WARPX_DIM_RZ) // RZ pushes particles in 3D

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -17,9 +17,9 @@
 /** \brief Push the particle's positions over one timestep,
  *    given the value of its momenta `ux`, `uy`, `uz` */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdatePosition(amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
-                    const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
-                    const amrex::Real dt )
+void UpdatePosition (amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
+                     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
+                     const amrex::Real dt )
 {
     using namespace amrex;
     

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -22,7 +22,7 @@ void UpdatePosition (amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::Part
                      const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     constexpr Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
     // Compute inverse Lorentz factor

--- a/Source/Particles/Pusher/UpdatePositionPhoton.H
+++ b/Source/Particles/Pusher/UpdatePositionPhoton.H
@@ -24,8 +24,10 @@ void UpdatePositionPhoton(
     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
     const amrex::Real dt )
 {
+    using namespace amrex;
+    
     // Compute speed of light over inverse of momentum modulus
-    const amrex::Real c_over_umod = PhysConst::c/std::sqrt(ux*ux + uy*uy + uz*uz);
+    const Real c_over_umod = PhysConst::c/std::sqrt(ux*ux + uy*uy + uz*uz);
 
     // Update positions over one time step
     x += ux * c_over_umod * dt;

--- a/Source/Particles/Pusher/UpdatePositionPhoton.H
+++ b/Source/Particles/Pusher/UpdatePositionPhoton.H
@@ -19,7 +19,7 @@
  *    given the value of its momenta `ux`, `uy`, `uz`
  */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void UpdatePositionPhoton(
+void UpdatePositionPhoton (
     amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
     const amrex::Real dt )

--- a/Source/Particles/Pusher/UpdatePositionPhoton.H
+++ b/Source/Particles/Pusher/UpdatePositionPhoton.H
@@ -25,7 +25,7 @@ void UpdatePositionPhoton (
     const amrex::Real dt )
 {
     using namespace amrex;
-    
+
     // Compute speed of light over inverse of momentum modulus
     const Real c_over_umod = PhysConst::c/std::sqrt(ux*ux + uy*uy + uz*uz);
 


### PR DESCRIPTION
1. Does "using namespace amrex" in several functions instead of using `amrex::` a lot.
2. Add spaces to function declarations / definitions to make searching easier. 