### PR TITLE
macOS CI: brew update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ jobs:
         path: 'warpx_directory/WarpX'
     - name: install dependencies
       run: |
+        brew update
         brew install cmake
         brew install fftw
         brew install libomp


### PR DESCRIPTION
Homebrew needs a `brew update` to detect new packages:
https://formulae.brew.sh/formula/hdf5-mpi