### PR TITLE
Fix error with Schwinger when multiple tiles are used

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1083,7 +1083,7 @@ MultiParticleContainer::doQEDSchwinger ()
     for (MFIter mfi(Ex, info); mfi.isValid(); ++mfi )
     {
         // Make the box cell centered to avoid creating particles twice on the tile edges
-        const Box& box = enclosedCells(mfi.tilebox());
+        const Box& box = enclosedCells(mfi.nodaltilebox());
 
         const auto& arrEx = Ex[mfi].array();
         const auto& arrEy = Ey[mfi].array();

--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -51,9 +51,6 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
     const auto ncells = box.volume();
     if (ncells == 0) return 0;
 
-    const auto box_sizex = box.length(0);
-    const auto box_sizey = box.length(1);
-
     auto & warpx = WarpX::GetInstance();
     const int level_0 = 0;
     Geometry const & geom = warpx.Geom(level_0);
@@ -173,12 +170,6 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
     // filterCreateTransformFromFAB called below, but let us keep it for safety.
     Elixir tmp_eli = NumPartCreation.elixir();
     auto arrNumPartCreation = NumPartCreation.array();
-
-    const Dim3 lo = lbound(box);
-    const Dim3 hi = ubound(box);
-
-    const auto box_sizex = box.length(0);
-    const auto box_sizey = box.length(1);
 
     const auto ncells = box.volume();
     if (ncells == 0) return 0;


### PR DESCRIPTION
In the `MFIter` loop of `MultiParticleContainer::doQEDSchwinger ()`, we currently use the line `const Box& box = enclosedCells(mfi.tilebox());`. The `enclosedCells` is used so that the nodes at the edge of two boxes/tiles are not counted twice.

This works well without tiling but fails when tiling is activated. This is because boxes obtained with `mfi.tilebox()` already do not overlap at the tile edges. So adding `enclosedCells` in this case will remove cells at the tile edges from the Schwinger calculations, resulting in less pair production than expected. This can be fixed by replacing `mfi.tilebox()` by `mfi.nodaltilebox()`.

I've also removed a few unused lines in `FilterCreateTransformFromFAB.H`