### PR TITLE
Require Python 3.6+

### DIFF
--- a/Docs/source/building/python.rst
+++ b/Docs/source/building/python.rst
@@ -3,7 +3,7 @@
 Installing WarpX as a Python package
 ====================================
 
-A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts.
+A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Pythone version 3.6 or newer.
 
 For a full Python installation of WarpX
 ---------------------------------------

--- a/Docs/source/running_python/how_to_run.rst
+++ b/Docs/source/running_python/how_to_run.rst
@@ -13,6 +13,8 @@ In either mode, if using a `virtual environment <https://docs.python.org/3/tutor
 Example input files can be found in the section :doc:`examples`.
 The examples support running in both modes by commenting and uncommenting the appropriate lines.
 
+WarpX requires Python version 3.6 or newer.
+
 
 Using Python input as a preprocessor
 ------------------------------------

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -33,5 +33,5 @@ setup (name = 'pywarpx',
        package_dir = {'pywarpx':'pywarpx'},
        description = """Wrapper of WarpX""",
        package_data = package_data,
-       install_requires=['numpy', 'picmistandard', 'periodictable']
+       install_requires=['numpy', 'picmistandard==0.0.6', 'periodictable']
        )

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -33,5 +33,6 @@ setup (name = 'pywarpx',
        package_dir = {'pywarpx':'pywarpx'},
        description = """Wrapper of WarpX""",
        package_data = package_data,
-       install_requires=['numpy', 'picmistandard==0.0.6', 'periodictable']
+       install_requires=['numpy', 'picmistandard==0.0.6', 'periodictable'],
+       python_requires = '>=3.6'
        )


### PR DESCRIPTION
The version of pimcistandard is specified, currently to 0.06. This allows keeping track of the version of the picmistandard that should be used with each version of WarpX.

It also specifies that Python version >= 3.6 is required.