### PR TITLE
Assign the external E and B inside the field gather kernel

### DIFF
--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -362,8 +362,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
  * \brief Field gather for particles
  *
  * /param getPosition          : A functor for returning the particle position.
- * /param getEField            : A functor for assigning the external E field.
- * /param getBField            : A functor for assigning the external B field.
+ * /param getExternalEField    : A functor for assigning the external E field.
+ * /param getExternalBField    : A functor for assigning the external B field.
  * \param Exp, Eyp, Ezp        : Pointer to array of electric field on particles.
  * \param Bxp, Byp, Bzp        : Pointer to array of magnetic field on particles.
  * \param exfab eyfab ezfab    : Array4 of the electric field, either full array or tile.
@@ -376,7 +376,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
  */
 template <int depos_order, int lower_in_v>
 void doGatherShapeN(const GetParticlePosition& getPosition,
-                    const GetEField& getEField, const GetBField& getBField,
+                    const GetExternalEField& getExternalE, const GetExternalBField& getExternalB,
                     amrex::ParticleReal * const Exp, amrex::ParticleReal * const Eyp,
                     amrex::ParticleReal * const Ezp, amrex::ParticleReal * const Bxp,
                     amrex::ParticleReal * const Byp, amrex::ParticleReal * const Bzp,
@@ -418,8 +418,8 @@ void doGatherShapeN(const GetParticlePosition& getPosition,
 
             amrex::ParticleReal xp, yp, zp;
             getPosition(ip, xp, yp, zp);
-            getEField(ip, Exp[ip], Eyp[ip], Ezp[ip]);
-            getBField(ip, Bxp[ip], Byp[ip], Bzp[ip]);
+            getExternalE(ip, Exp[ip], Eyp[ip], Ezp[ip]);
+            getExternalB(ip, Bxp[ip], Byp[ip], Bzp[ip]);
 
             doGatherShapeN<depos_order, lower_in_v>(
                 xp, yp, zp, Exp[ip], Eyp[ip], Ezp[ip], Bxp[ip], Byp[ip], Bzp[ip],

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -197,15 +197,15 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     // order can differ for each component of each field
     // when lower_in_v is set to 1
 #if (AMREX_SPACEDIM == 2)
-    // Gather field on particle Eyp[i] from field on grid ey_arr
+    // Gather field on particle Eyp from field on grid ey_arr
     for (int iz=0; iz<=depos_order; iz++){
         for (int ix=0; ix<=depos_order; ix++){
             Eyp += sx_ey[ix]*sz_ey[iz]*
                 ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 0);
         }
     }
-    // Gather field on particle Exp[i] from field on grid ex_arr
-    // Gather field on particle Bzp[i] from field on grid bz_arr
+    // Gather field on particle Exp from field on grid ex_arr
+    // Gather field on particle Bzp from field on grid bz_arr
     for (int iz=0; iz<=depos_order; iz++){
         for (int ix=0; ix<=depos_order-lower_in_v; ix++){
             Exp += sx_ex[ix]*sz_ex[iz]*
@@ -214,8 +214,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                 bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 0);
         }
     }
-    // Gather field on particle Ezp[i] from field on grid ez_arr
-    // Gather field on particle Bxp[i] from field on grid bx_arr
+    // Gather field on particle Ezp from field on grid ez_arr
+    // Gather field on particle Bxp from field on grid bx_arr
     for (int iz=0; iz<=depos_order-lower_in_v; iz++){
         for (int ix=0; ix<=depos_order; ix++){
             Ezp += sx_ez[ix]*sz_ez[iz]*
@@ -224,7 +224,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                 bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 0);
         }
     }
-    // Gather field on particle Byp[i] from field on grid by_arr
+    // Gather field on particle Byp from field on grid by_arr
     for (int iz=0; iz<=depos_order-lower_in_v; iz++){
         for (int ix=0; ix<=depos_order-lower_in_v; ix++){
             Byp += sx_by[ix]*sz_by[iz]*
@@ -248,7 +248,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
 
     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
 
-        // Gather field on particle Eyp[i] from field on grid ey_arr
+        // Gather field on particle Eyp from field on grid ey_arr
         for (int iz=0; iz<=depos_order; iz++){
             for (int ix=0; ix<=depos_order; ix++){
                 const amrex::Real dEy = (+ ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode-1)*xy.real()
@@ -256,8 +256,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                 Eyp += sx_ey[ix]*sz_ey[iz]*dEy;
             }
         }
-        // Gather field on particle Exp[i] from field on grid ex_arr
-        // Gather field on particle Bzp[i] from field on grid bz_arr
+        // Gather field on particle Exp from field on grid ex_arr
+        // Gather field on particle Bzp from field on grid bz_arr
         for (int iz=0; iz<=depos_order; iz++){
             for (int ix=0; ix<=depos_order-lower_in_v; ix++){
                 const amrex::Real dEx = (+ ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode-1)*xy.real()
@@ -268,8 +268,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                 Bzp += sx_bz[ix]*sz_bz[iz]*dBz;
             }
         }
-        // Gather field on particle Ezp[i] from field on grid ez_arr
-        // Gather field on particle Bxp[i] from field on grid bx_arr
+        // Gather field on particle Ezp from field on grid ez_arr
+        // Gather field on particle Bxp from field on grid bx_arr
         for (int iz=0; iz<=depos_order-lower_in_v; iz++){
             for (int ix=0; ix<=depos_order; ix++){
                 const amrex::Real dEz = (+ ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode-1)*xy.real()
@@ -280,7 +280,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                 Bxp += sx_bx[ix]*sz_bx[iz]*dBx;
             }
         }
-        // Gather field on particle Byp[i] from field on grid by_arr
+        // Gather field on particle Byp from field on grid by_arr
         for (int iz=0; iz<=depos_order-lower_in_v; iz++){
             for (int ix=0; ix<=depos_order-lower_in_v; ix++){
                 const amrex::Real dBy = (+ by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode-1)*xy.real()
@@ -301,7 +301,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
 #endif
 
 #else // (AMREX_SPACEDIM == 3)
-    // Gather field on particle Exp[i] from field on grid ex_arr
+    // Gather field on particle Exp from field on grid ex_arr
     for (int iz=0; iz<=depos_order; iz++){
         for (int iy=0; iy<=depos_order; iy++){
             for (int ix=0; ix<=depos_order-lower_in_v; ix++){
@@ -310,7 +310,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
             }
         }
     }
-    // Gather field on particle Eyp[i] from field on grid ey_arr
+    // Gather field on particle Eyp from field on grid ey_arr
     for (int iz=0; iz<=depos_order; iz++){
         for (int iy=0; iy<=depos_order-lower_in_v; iy++){
             for (int ix=0; ix<=depos_order; ix++){
@@ -319,7 +319,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
             }
         }
     }
-    // Gather field on particle Ezp[i] from field on grid ez_arr
+    // Gather field on particle Ezp from field on grid ez_arr
     for (int iz=0; iz<=depos_order-lower_in_v; iz++){
         for (int iy=0; iy<=depos_order; iy++){
             for (int ix=0; ix<=depos_order; ix++){
@@ -328,7 +328,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
             }
         }
     }
-    // Gather field on particle Bzp[i] from field on grid bz_arr
+    // Gather field on particle Bzp from field on grid bz_arr
     for (int iz=0; iz<=depos_order; iz++){
         for (int iy=0; iy<=depos_order-lower_in_v; iy++){
             for (int ix=0; ix<=depos_order-lower_in_v; ix++){
@@ -337,7 +337,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
             }
         }
     }
-    // Gather field on particle Byp[i] from field on grid by_arr
+    // Gather field on particle Byp from field on grid by_arr
     for (int iz=0; iz<=depos_order-lower_in_v; iz++){
         for (int iy=0; iy<=depos_order; iy++){
             for (int ix=0; ix<=depos_order-lower_in_v; ix++){
@@ -346,7 +346,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
             }
         }
     }
-    // Gather field on particle Bxp[i] from field on grid bx_arr
+    // Gather field on particle Bxp from field on grid bx_arr
     for (int iz=0; iz<=depos_order-lower_in_v; iz++){
         for (int iy=0; iy<=depos_order-lower_in_v; iy++){
             for (int ix=0; ix<=depos_order; ix++){

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -424,7 +424,7 @@ void doGatherShapeN(const GetParticlePosition& getPosition,
 
             amrex::ParticleReal Bxp, Byp, Bzp;
             getBField(ip, Bxp, Byp, Bzp);
-            
+
             doGatherShapeN<depos_order, lower_in_v>(
                 xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -418,15 +418,11 @@ void doGatherShapeN(const GetParticlePosition& getPosition,
 
             amrex::ParticleReal xp, yp, zp;
             getPosition(ip, xp, yp, zp);
-
-            amrex::ParticleReal Exp, Eyp, Ezp;
-            getEField(ip, Exp, Eyp, Ezp);
-
-            amrex::ParticleReal Bxp, Byp, Bzp;
-            getBField(ip, Bxp, Byp, Bzp);
+            getEField(ip, Exp[ip], Eyp[ip], Ezp[ip]);
+            getBField(ip, Bxp[ip], Byp[ip], Bzp[ip]);
 
             doGatherShapeN<depos_order, lower_in_v>(
-                xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                xp, yp, zp, Exp[ip], Eyp[ip], Ezp[ip], Bxp[ip], Byp[ip], Bzp[ip],
                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -9,6 +9,7 @@
 #define FIELDGATHER_H_
 
 #include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/Gather/GetExternalFields.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpX_Complex.H"
 
@@ -360,7 +361,9 @@ void doGatherShapeN (const amrex::ParticleReal xp,
 /**
  * \brief Field gather for particles
  *
- * /param GetPosition          : A functor for returning the particle position.
+ * /param getPosition          : A functor for returning the particle position.
+ * /param getEField            : A functor for assigning the external E field.
+ * /param getBField            : A functor for assigning the external B field.
  * \param Exp, Eyp, Ezp        : Pointer to array of electric field on particles.
  * \param Bxp, Byp, Bzp        : Pointer to array of magnetic field on particles.
  * \param exfab eyfab ezfab    : Array4 of the electric field, either full array or tile.
@@ -372,7 +375,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
  * \param n_rz_azimuthal_modes : Number of azimuthal modes when using RZ geometry
  */
 template <int depos_order, int lower_in_v>
-void doGatherShapeN(const GetParticlePosition& GetPosition,
+void doGatherShapeN(const GetParticlePosition& getPosition,
+                    const GetEField& getEField, const GetBField& getBField,
                     amrex::ParticleReal * const Exp, amrex::ParticleReal * const Eyp,
                     amrex::ParticleReal * const Ezp, amrex::ParticleReal * const Bxp,
                     amrex::ParticleReal * const Byp, amrex::ParticleReal * const Bzp,
@@ -413,10 +417,16 @@ void doGatherShapeN(const GetParticlePosition& GetPosition,
         [=] AMREX_GPU_DEVICE (long ip) {
 
             amrex::ParticleReal xp, yp, zp;
-            GetPosition(ip, xp, yp, zp);
+            getPosition(ip, xp, yp, zp);
 
+            amrex::ParticleReal Exp, Eyp, Ezp;
+            getEField(ip, Exp, Eyp, Ezp);
+
+            amrex::ParticleReal Bxp, Byp, Bzp;
+            getBField(ip, Bxp, Byp, Bzp);
+            
             doGatherShapeN<depos_order, lower_in_v>(
-                xp, yp, zp, Exp[ip], Eyp[ip], Ezp[ip], Bxp[ip], Byp[ip], Bzp[ip],
+                xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -12,7 +12,7 @@ enum ExternalFieldInitType { Constant, Parser };
 /** \brief Base class for functors that assign external
  *         field values (E or B) to particles.
 */
-struct GetField
+struct GetExternalField
 {
     ExternalFieldInitType m_type;
 
@@ -58,9 +58,9 @@ struct GetField
 /** \brief Functor that can be used to assign the external
  *         E field to a particle inside a ParallelFor kernel
 */
-struct GetEField : GetField
+struct GetExternalEField : GetExternalField
 {
-    GetEField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
+    GetExternalEField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
     {
         auto& warpx = WarpX::GetInstance();
         auto& mypc = warpx.GetPartContainer();
@@ -86,9 +86,9 @@ struct GetEField : GetField
 /** \brief Functor that can be used to assign the external
  *         B field to a particle inside a ParallelFor kernel
 */
-struct GetBField : GetField
+struct GetExternalBField : GetExternalField
 {
-    GetBField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
+    GetExternalBField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
     {
         auto& warpx = WarpX::GetInstance();
         auto& mypc = warpx.GetPartContainer();

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -1,0 +1,148 @@
+#ifndef WARPX_PARTICLES_GATHER_GETEXTERNALFIELDS_H_
+#define WARPX_PARTICLES_GATHER_GETEXTERNALFIELDS_H_
+
+#include "Particles/WarpXParticleContainer.H"
+
+#include <AMReX_REAL.H>
+
+#include <limits>
+
+enum ExternalFieldInitType { Constant, Parser };
+
+/** \brief Functor that can be used to assign the external 
+ *         E field to a particle inside a ParallelFor kernel
+*/
+struct GetEField
+{
+    ExternalFieldInitType m_type;
+
+    amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
+
+    ParserWrapper<4>* m_xfield_partparser = nullptr;
+    ParserWrapper<4>* m_yfield_partparser = nullptr;
+    ParserWrapper<4>* m_zfield_partparser = nullptr;
+    GetParticlePosition m_get_position;
+    amrex::Real m_time;
+
+    GetEField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
+    {        
+        auto& warpx = WarpX::GetInstance();
+        auto& mypc = warpx.GetPartContainer();
+        if (mypc.m_E_ext_particle_s=="constant" || mypc.m_E_ext_particle_s=="default")
+        {
+            m_type = Constant;
+            m_field_value[0] = mypc.m_E_external_particle[0];
+            m_field_value[1] = mypc.m_E_external_particle[1];
+            m_field_value[2] = mypc.m_E_external_particle[2];
+        }
+        else if (mypc.m_E_ext_particle_s=="parse_e_ext_particle_function")
+        {
+            m_type = Parser;
+            m_time = warpx.gett_new(a_pti.GetLevel());
+            m_get_position = GetParticlePosition(a_pti, a_offset);
+            m_xfield_partparser = mypc.m_Ex_particle_parser.get();
+            m_yfield_partparser = mypc.m_Ey_particle_parser.get();
+            m_zfield_partparser = mypc.m_Ez_particle_parser.get();            
+        }
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator () (long i,
+                      amrex::ParticleReal& Exp,
+                      amrex::ParticleReal& Eyp,
+                      amrex::ParticleReal& Ezp) const noexcept
+    {
+        if (m_type == Constant)
+        {
+            Exp = m_field_value[0];
+            Eyp = m_field_value[1];
+            Ezp = m_field_value[2];
+        }
+        else if (m_type == Parser)
+        {
+            AMREX_ASSERT(m_xfield_partparser != nullptr);
+            AMREX_ASSERT(m_yfield_partparser != nullptr);
+            AMREX_ASSERT(m_zfield_partparser != nullptr);
+            
+            amrex::ParticleReal x, y, z;
+            m_get_position(i, x, y, z);
+            Exp = (*m_xfield_partparser)(x, y, z, m_time);
+            Eyp = (*m_yfield_partparser)(x, y, z, m_time);
+            Ezp = (*m_zfield_partparser)(x, y, z, m_time);
+        }
+        else
+        {
+            amrex::Abort("ExternalFieldInitType not known!!! \n");
+        }
+    }
+};
+
+/** \brief Functor that can be used to assign the external 
+ *         B field to a particle inside a ParallelFor kernel
+*/
+struct GetBField
+{
+    ExternalFieldInitType m_type;
+
+    amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
+
+    ParserWrapper<4>* m_xfield_partparser = nullptr;
+    ParserWrapper<4>* m_yfield_partparser = nullptr;
+    ParserWrapper<4>* m_zfield_partparser = nullptr;
+    GetParticlePosition m_get_position;
+    amrex::Real m_time;
+    
+    GetBField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
+    {        
+        auto& warpx = WarpX::GetInstance();
+        auto& mypc = warpx.GetPartContainer();
+        if (mypc.m_B_ext_particle_s=="constant" || mypc.m_B_ext_particle_s=="default")
+        {
+            m_type = Constant;
+            m_field_value[0] = mypc.m_B_external_particle[0];
+            m_field_value[1] = mypc.m_B_external_particle[1];
+            m_field_value[2] = mypc.m_B_external_particle[2];
+        }
+        else if (mypc.m_B_ext_particle_s=="parse_e_ext_particle_function")
+        {
+            m_type = Parser;
+            m_time = warpx.gett_new(a_pti.GetLevel());
+            m_get_position = GetParticlePosition(a_pti, a_offset);
+            m_xfield_partparser = mypc.m_Bx_particle_parser.get();
+            m_yfield_partparser = mypc.m_By_particle_parser.get();
+            m_zfield_partparser = mypc.m_Bz_particle_parser.get();            
+        }
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator () (long i,
+                      amrex::ParticleReal& Bxp,
+                      amrex::ParticleReal& Byp,
+                      amrex::ParticleReal& Bzp) const noexcept
+    {
+        if (m_type == Constant)
+        {
+            Bxp = m_field_value[0];
+            Byp = m_field_value[1];
+            Bzp = m_field_value[2];
+        }
+        else if (m_type == Parser)
+        {
+            AMREX_ASSERT(m_xfield_partparser != nullptr);
+            AMREX_ASSERT(m_yfield_partparser != nullptr);
+            AMREX_ASSERT(m_zfield_partparser != nullptr);
+            
+            amrex::ParticleReal x, y, z;
+            m_get_position(i, x, y, z);
+            Bxp = (*m_xfield_partparser)(x, y, z, m_time);
+            Byp = (*m_yfield_partparser)(x, y, z, m_time);
+            Bzp = (*m_zfield_partparser)(x, y, z, m_time);
+        }
+        else
+        {
+            amrex::Abort("ExternalFieldInitType not known!!! \n");
+        }
+    }
+};
+
+#endif

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -9,21 +9,57 @@
 
 enum ExternalFieldInitType { Constant, Parser };
 
-/** \brief Functor that can be used to assign the external
- *         E field to a particle inside a ParallelFor kernel
+/** \brief Base class for functors that assign external
+ *         field values (E or B) to particles.
 */
-struct GetEField
+struct GetField
 {
     ExternalFieldInitType m_type;
-
+    
     amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
-
+    
     ParserWrapper<4>* m_xfield_partparser = nullptr;
     ParserWrapper<4>* m_yfield_partparser = nullptr;
     ParserWrapper<4>* m_zfield_partparser = nullptr;
     GetParticlePosition m_get_position;
     amrex::Real m_time;
+    
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator () (long i,
+                      amrex::ParticleReal& field_x,
+                      amrex::ParticleReal& field_y,
+                      amrex::ParticleReal& field_z) const noexcept
+    {
+        if (m_type == Constant)
+        {
+            field_x = m_field_value[0];
+            field_y = m_field_value[1];
+            field_z = m_field_value[2];
+        }
+        else if (m_type == Parser)
+        {
+            AMREX_ASSERT(m_xfield_partparser != nullptr);
+            AMREX_ASSERT(m_yfield_partparser != nullptr);
+            AMREX_ASSERT(m_zfield_partparser != nullptr);
 
+            amrex::ParticleReal x, y, z;
+            m_get_position(i, x, y, z);
+            field_x = (*m_xfield_partparser)(x, y, z, m_time);
+            field_y = (*m_yfield_partparser)(x, y, z, m_time);
+            field_z = (*m_zfield_partparser)(x, y, z, m_time);
+        }
+        else
+        {
+            amrex::Abort("ExternalFieldInitType not known!!! \n");
+        }
+    }
+};
+
+/** \brief Functor that can be used to assign the external
+ *         E field to a particle inside a ParallelFor kernel
+*/
+struct GetEField : GetField
+{
     GetEField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
     {
         auto& warpx = WarpX::GetInstance();
@@ -45,53 +81,13 @@ struct GetEField
             m_zfield_partparser = mypc.m_Ez_particle_parser.get();
         }
     }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator () (long i,
-                      amrex::ParticleReal& Exp,
-                      amrex::ParticleReal& Eyp,
-                      amrex::ParticleReal& Ezp) const noexcept
-    {
-        if (m_type == Constant)
-        {
-            Exp = m_field_value[0];
-            Eyp = m_field_value[1];
-            Ezp = m_field_value[2];
-        }
-        else if (m_type == Parser)
-        {
-            AMREX_ASSERT(m_xfield_partparser != nullptr);
-            AMREX_ASSERT(m_yfield_partparser != nullptr);
-            AMREX_ASSERT(m_zfield_partparser != nullptr);
-
-            amrex::ParticleReal x, y, z;
-            m_get_position(i, x, y, z);
-            Exp = (*m_xfield_partparser)(x, y, z, m_time);
-            Eyp = (*m_yfield_partparser)(x, y, z, m_time);
-            Ezp = (*m_zfield_partparser)(x, y, z, m_time);
-        }
-        else
-        {
-            amrex::Abort("ExternalFieldInitType not known!!! \n");
-        }
-    }
 };
 
 /** \brief Functor that can be used to assign the external
  *         B field to a particle inside a ParallelFor kernel
 */
-struct GetBField
+struct GetBField : GetField
 {
-    ExternalFieldInitType m_type;
-
-    amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
-
-    ParserWrapper<4>* m_xfield_partparser = nullptr;
-    ParserWrapper<4>* m_yfield_partparser = nullptr;
-    ParserWrapper<4>* m_zfield_partparser = nullptr;
-    GetParticlePosition m_get_position;
-    amrex::Real m_time;
-
     GetBField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
     {
         auto& warpx = WarpX::GetInstance();
@@ -111,36 +107,6 @@ struct GetBField
             m_xfield_partparser = mypc.m_Bx_particle_parser.get();
             m_yfield_partparser = mypc.m_By_particle_parser.get();
             m_zfield_partparser = mypc.m_Bz_particle_parser.get();
-        }
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator () (long i,
-                      amrex::ParticleReal& Bxp,
-                      amrex::ParticleReal& Byp,
-                      amrex::ParticleReal& Bzp) const noexcept
-    {
-        if (m_type == Constant)
-        {
-            Bxp = m_field_value[0];
-            Byp = m_field_value[1];
-            Bzp = m_field_value[2];
-        }
-        else if (m_type == Parser)
-        {
-            AMREX_ASSERT(m_xfield_partparser != nullptr);
-            AMREX_ASSERT(m_yfield_partparser != nullptr);
-            AMREX_ASSERT(m_zfield_partparser != nullptr);
-
-            amrex::ParticleReal x, y, z;
-            m_get_position(i, x, y, z);
-            Bxp = (*m_xfield_partparser)(x, y, z, m_time);
-            Byp = (*m_yfield_partparser)(x, y, z, m_time);
-            Bzp = (*m_zfield_partparser)(x, y, z, m_time);
-        }
-        else
-        {
-            amrex::Abort("ExternalFieldInitType not known!!! \n");
         }
     }
 };

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -9,7 +9,7 @@
 
 enum ExternalFieldInitType { Constant, Parser };
 
-/** \brief Functor that can be used to assign the external 
+/** \brief Functor that can be used to assign the external
  *         E field to a particle inside a ParallelFor kernel
 */
 struct GetEField
@@ -25,7 +25,7 @@ struct GetEField
     amrex::Real m_time;
 
     GetEField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
-    {        
+    {
         auto& warpx = WarpX::GetInstance();
         auto& mypc = warpx.GetPartContainer();
         if (mypc.m_E_ext_particle_s=="constant" || mypc.m_E_ext_particle_s=="default")
@@ -42,7 +42,7 @@ struct GetEField
             m_get_position = GetParticlePosition(a_pti, a_offset);
             m_xfield_partparser = mypc.m_Ex_particle_parser.get();
             m_yfield_partparser = mypc.m_Ey_particle_parser.get();
-            m_zfield_partparser = mypc.m_Ez_particle_parser.get();            
+            m_zfield_partparser = mypc.m_Ez_particle_parser.get();
         }
     }
 
@@ -63,7 +63,7 @@ struct GetEField
             AMREX_ASSERT(m_xfield_partparser != nullptr);
             AMREX_ASSERT(m_yfield_partparser != nullptr);
             AMREX_ASSERT(m_zfield_partparser != nullptr);
-            
+
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);
             Exp = (*m_xfield_partparser)(x, y, z, m_time);
@@ -77,7 +77,7 @@ struct GetEField
     }
 };
 
-/** \brief Functor that can be used to assign the external 
+/** \brief Functor that can be used to assign the external
  *         B field to a particle inside a ParallelFor kernel
 */
 struct GetBField
@@ -91,9 +91,9 @@ struct GetBField
     ParserWrapper<4>* m_zfield_partparser = nullptr;
     GetParticlePosition m_get_position;
     amrex::Real m_time;
-    
+
     GetBField (const WarpXParIter& a_pti, int a_offset = 0) noexcept
-    {        
+    {
         auto& warpx = WarpX::GetInstance();
         auto& mypc = warpx.GetPartContainer();
         if (mypc.m_B_ext_particle_s=="constant" || mypc.m_B_ext_particle_s=="default")
@@ -110,7 +110,7 @@ struct GetBField
             m_get_position = GetParticlePosition(a_pti, a_offset);
             m_xfield_partparser = mypc.m_Bx_particle_parser.get();
             m_yfield_partparser = mypc.m_By_particle_parser.get();
-            m_zfield_partparser = mypc.m_Bz_particle_parser.get();            
+            m_zfield_partparser = mypc.m_Bz_particle_parser.get();
         }
     }
 
@@ -131,7 +131,7 @@ struct GetBField
             AMREX_ASSERT(m_xfield_partparser != nullptr);
             AMREX_ASSERT(m_yfield_partparser != nullptr);
             AMREX_ASSERT(m_zfield_partparser != nullptr);
-            
+
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);
             Bxp = (*m_xfield_partparser)(x, y, z, m_time);

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -15,15 +15,15 @@ enum ExternalFieldInitType { Constant, Parser };
 struct GetField
 {
     ExternalFieldInitType m_type;
-    
+
     amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
-    
+
     ParserWrapper<4>* m_xfield_partparser = nullptr;
     ParserWrapper<4>* m_yfield_partparser = nullptr;
     ParserWrapper<4>* m_zfield_partparser = nullptr;
     GetParticlePosition m_get_position;
     amrex::Real m_time;
-    
+
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator () (long i,
                       amrex::ParticleReal& field_x,

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -59,23 +59,6 @@ public:
 
     void InitIonizationModule ();
 
-    /**
-     * \brief Apply external E and B fields on the particles. The E and B
-     * fields could be defined as a constant or using a parser for reading
-     * in a mathematical expression. The default value for the E- and B-fields
-     * is (0.0,0.0,0.0).
-     *
-     * \param[in,out] Exp-Bzp pointer to fields on particles modified based
-     *                  on external E and B
-     * \param[in] xp,yp,zp arrays of particle positions required to compute
-     *                  mathematical expression for the external fields
-     *                  using parser.
-     */
-    void AssignExternalFieldOnParticles ( WarpXParIter& pti,
-                                          RealVector& Exp, RealVector& Eyp,
-                                          RealVector& Ezp, RealVector& Bxp,
-                                          RealVector& Byp, RealVector& Bzp, int lev);
-
     virtual void FieldGather (int lev,
                               const amrex::MultiFab& Ex,
                               const amrex::MultiFab& Ey,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2050,8 +2050,9 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
     box.grow(ngE);
 
     const auto getPosition = GetParticlePosition(pti, offset);
-    const auto getEField = GetEField(pti, offset);
-    const auto getBField = GetBField(pti, offset);
+
+    const auto getExternalE = GetExternalEField(pti, offset);
+    const auto getExternalB = GetExternalBField(pti, offset);
 
     // Lower corner of tile box physical domain (take into account Galilean shift)
     Real cur_time = WarpX::GetInstance().gett_new(lev);
@@ -2066,7 +2067,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
     // different versions of template function doGatherShapeN
     if (WarpX::l_lower_order_in_v){
         if        (WarpX::nox == 1){
-            doGatherShapeN<1,1>(getPosition, getEField, getBField,
+            doGatherShapeN<1,1>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,
@@ -2074,7 +2075,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
                                 np_to_gather, dx,
                                 xyzmin, lo, WarpX::n_rz_azimuthal_modes);
         } else if (WarpX::nox == 2){
-            doGatherShapeN<2,1>(getPosition, getEField, getBField,
+            doGatherShapeN<2,1>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,
@@ -2082,7 +2083,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
                                 np_to_gather, dx,
                                 xyzmin, lo, WarpX::n_rz_azimuthal_modes);
         } else if (WarpX::nox == 3){
-            doGatherShapeN<3,1>(getPosition, getEField, getBField,
+            doGatherShapeN<3,1>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,
@@ -2092,7 +2093,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
         }
     } else {
         if        (WarpX::nox == 1){
-            doGatherShapeN<1,0>(getPosition, getEField, getBField,
+            doGatherShapeN<1,0>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,
@@ -2100,7 +2101,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
                                 np_to_gather, dx,
                                 xyzmin, lo, WarpX::n_rz_azimuthal_modes);
         } else if (WarpX::nox == 2){
-            doGatherShapeN<2,0>(getPosition, getEField, getBField,
+            doGatherShapeN<2,0>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,
@@ -2108,7 +2109,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
                                 np_to_gather, dx,
                                 xyzmin, lo, WarpX::n_rz_azimuthal_modes);
         } else if (WarpX::nox == 3){
-            doGatherShapeN<3,0>(getPosition, getEField, getBField,
+            doGatherShapeN<3,0>(getPosition, getExternalE, getExternalB,
                                 Exp.dataPtr() + offset, Eyp.dataPtr() + offset,
                                 Ezp.dataPtr() + offset, Bxp.dataPtr() + offset,
                                 Byp.dataPtr() + offset, Bzp.dataPtr() + offset,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2049,7 +2049,7 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
     // Add guard cells to the box.
     box.grow(ngE);
 
-    const auto getPosition = GetParticlePosition(pti, offset);    
+    const auto getPosition = GetParticlePosition(pti, offset);
     const auto getEField = GetEField(pti, offset);
     const auto getBField = GetBField(pti, offset);
 

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -32,6 +32,9 @@ struct GetParticlePosition
 #elif (AMREX_SPACEDIM == 2)
     static constexpr RType m_snan = std::numeric_limits<RType>::quiet_NaN();
 #endif
+
+    GetParticlePosition () = default;
+
     GetParticlePosition (const WarpXParIter& a_pti, int a_offset = 0) noexcept
     {
         const auto& aos = a_pti.GetArrayOfStructs();


### PR DESCRIPTION
This fuses the "assign the external E+B field" and "field gather" kernels. 

This is a step along the way to removing the persistent E+B particle components. 