### PR TITLE
Move ascent to new diagnostics

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1150,7 +1150,9 @@ This should be changed in the future.
     * ``checkpoint`` for a checkpoint file, only wirks with ``<diag_name>.diag_type = Full``.
 
     * ``openpmd`` for OpenPMD format `openPMD <https://www.openPMD.org>`_.
-      ``openpmd`` requires to build WarpX with ``USE_OPENPMD=TRUE`` (see :ref:`instructions <building-openpmd>`).
+      Requires to build WarpX with ``USE_OPENPMD=TRUE`` (see :ref:`instructions <building-openpmd>`).
+
+    * ``ascent`` for in-situ visualization using Ascent.
 
     example: ``diag1.format = openpmd``.
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -6,6 +6,7 @@
 #include "ComputeDiagFunctors/DivEFunctor.H"
 #include "FlushFormats/FlushFormatPlotfile.H"
 #include "FlushFormats/FlushFormatCheckpoint.H"
+#include "FlushFormats/FlushFormatAscent.H"
 #ifdef WARPX_USE_OPENPMD
 #   include "FlushFormats/FlushFormatOpenPMD.H"
 #endif
@@ -38,8 +39,8 @@ Diagnostics::ReadParameters ()
     m_intervals = IntervalsParser(period_string);
     pp.query("format", m_format);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        m_format == "plotfile" || m_format == "openpmd" || m_format == "checkpoint",
-        "<diag>.format must be plotfile or openpmd or checkpoint");
+        m_format == "plotfile" || m_format == "openpmd" || m_format == "checkpoint" || m_format == "ascent",
+        "<diag>.format must be plotfile or openpmd or checkpoint or ascent");
     bool raw_specified = pp.query("plot_raw_fields", m_plot_raw_fields);
     raw_specified += pp.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
     bool varnames_specified = pp.queryarr("fields_to_plot", m_varnames);
@@ -145,6 +146,8 @@ Diagnostics::InitData ()
         m_flush_format = new FlushFormatPlotfile;
     } else if (m_format == "checkpoint"){
         m_flush_format = new FlushFormatCheckpoint;
+    } else if (m_format == "ascent"){
+        m_flush_format = new FlushFormatAscent;
     } else if (m_format == "openpmd"){
 #ifdef WARPX_USE_OPENPMD
         m_flush_format = new FlushFormatOpenPMD(m_diag_name);

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -4,6 +4,12 @@
 #include "FlushFormat.H"
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 
+
+#ifdef AMREX_USE_ASCENT
+#   include <ascent.hpp>
+#   include <AMReX_Conduit_Blueprint.H>
+#endif
+
 /**
  * \brief This class aims at dumping performing in-situ diagnostics with ASCENT.
  * In particular, function WriteToFile takes fields and particles as input arguments,

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -1,0 +1,34 @@
+#ifndef WARPX_FLUSHFORMATASCENT_H_
+#define WARPX_FLUSHFORMATASCENT_H_
+
+#include "FlushFormat.H"
+#include "Diagnostics/ParticleDiag/ParticleDiag.H"
+
+/**
+ * \brief This class aims at dumping performing in-situ diagnostics with ASCENT.
+ * In particular, function WriteToFile takes fields and particles as input arguments,
+ * and calls amrex functions to do the in-situ visualization.
+ */
+class FlushFormatAscent : public FlushFormat
+{
+public:
+    /** Do in-situ visualization for field and particle data */
+    virtual void WriteToFile (
+        const amrex::Vector<std::string> varnames,
+        const amrex::Vector<const amrex::MultiFab*> mf,
+        amrex::Vector<amrex::Geometry>& geom,
+        const amrex::Vector<int> iteration, const double time,
+        const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
+        bool plot_raw_fields,
+        bool plot_raw_fields_guards,
+        bool plot_raw_rho, bool plot_raw_F) const override;
+
+    /** \brief Do in-situ visualization for particle data.
+     * \param[in] particle_diags Each element of this vector handles output of 1 species.
+     */
+    void WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags) const;
+
+    ~FlushFormatAscent() {};
+};
+
+#endif // WARPX_FLUSHFORMATASCENT_H_

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -25,8 +25,11 @@ public:
 
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
+     * Only compile if AMREX_USE_ASCENT because we need to pass a conduit class
      */
-    void WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags) const;
+#ifdef AMREX_USE_ASCENT
+    void WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags, conduit::Node& a_bp_mesh) const;
+#endif
 
     ~FlushFormatAscent() {};
 };

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -1,0 +1,106 @@
+#include "FlushFormatAscent.H"
+#include "WarpX.H"
+
+#ifdef AMREX_USE_ASCENT
+#   include <ascent.hpp>
+#   include <AMReX_Conduit_Blueprint.H>
+#endif
+
+using namespace amrex;
+
+namespace
+{
+    const std::string level_prefix {"Level_"};
+}
+
+void
+FlushFormatAscent::WriteToFile (
+    const amrex::Vector<std::string> varnames,
+    const amrex::Vector<const amrex::MultiFab*> mf,
+    amrex::Vector<amrex::Geometry>& geom,
+    const amrex::Vector<int> iteration, const double time,
+    const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
+    const std::string prefix, bool plot_raw_fields,
+    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
+{
+#ifdef AMREX_USE_ASCENT
+
+    auto & warpx = WarpX::GetInstance();
+
+    // wrap mesh data
+    conduit::Node bp_mesh;
+    amrex::MultiLevelToBlueprint(
+        nlev, mf, varnames, geom, time, iteration, warpx.refRatio(), bp_mesh);
+
+    WriteParticles(particle_diags);
+
+    // If you want to save blueprint HDF5 files w/o using an Ascent
+    // extract, you can call the following AMReX helper:
+    // const auto step = istep[0];
+    // WriteBlueprintFiles(bp_mesh,"bp_export",step,"hdf5");
+
+    ascent::Ascent ascent;
+    conduit::Node opts;
+    opts["exceptions"] = "catch";
+    opts["mpi_comm"] = MPI_Comm_c2f(ParallelDescriptor::Communicator());
+    ascent.open(opts);
+    ascent.publish(bp_mesh);
+    conduit::Node actions;
+    ascent.execute(actions);
+    ascent.close();
+
+#endif // AMREX_USE_ASCENT
+}
+
+void
+FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags) const
+{
+#ifdef AMREX_USE_ASCENT
+    // wrap particle data for each species
+    // we prefix the fields with "particle_{species_name}" b/c we
+    // want to to uniquely name all the fields that can be plotted
+
+    for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
+        Vector<std::string> particle_varnames;
+        Vector<std::string> particle_int_varnames;
+        std::string prefix = "particle_" + particle_diags[i].getSpeciesName();
+
+        // Get pc for species
+        // auto& pc = mypc->GetParticleContainer(i);
+        WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
+
+        // get names of real comps
+        std::map<std::string, int> real_comps_map = pc->getParticleComps();
+        std::map<std::string, int>::const_iterator r_itr = real_comps_map.begin();
+
+        // TODO: Looking at other code paths, I am not sure compile time
+        //  QED field is included in getParticleComps()?
+        while (r_itr != real_comps_map.end())
+        {
+            // get next real particle name
+            std::string varname = r_itr->first;
+            particle_varnames.push_back(prefix + "_" + varname);
+            r_itr++;
+        }
+
+        // get names of int comps
+        std::map<std::string, int> int_comps_map = pc->getParticleiComps();
+        std::map<std::string, int>::const_iterator i_itr = int_comps_map.begin();
+
+        while (i_itr != int_comps_map.end())
+        {
+            // get next real particle name
+            std::string varname = i_itr->first;
+            particle_int_varnames.push_back(prefix + "_" + varname);
+            i_itr++;
+        }
+
+        // wrap pc for current species into a blueprint topology
+        amrex::ParticleContainerToBlueprint(*pc,
+                                            particle_varnames,
+                                            particle_int_varnames,
+                                            bp_mesh,
+                                            prefix);
+    }
+#endif // AMREX_USE_ASCENT
+}

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -27,7 +27,7 @@ FlushFormatAscent::WriteToFile (
     amrex::MultiLevelToBlueprint(
         nlev, mf, varnames, geom, time, iteration, warpx.refRatio(), bp_mesh);
 
-    WriteParticles(particle_diags);
+    WriteParticles(particle_diags, bp_mesh);
 
     // If you want to save blueprint HDF5 files w/o using an Ascent
     // extract, you can call the following AMReX helper:
@@ -47,10 +47,10 @@ FlushFormatAscent::WriteToFile (
 #endif // AMREX_USE_ASCENT
 }
 
-void
-FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags) const
-{
 #ifdef AMREX_USE_ASCENT
+void
+FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags, conduit::Node& a_bp_mesh) const
+{
     // wrap particle data for each species
     // we prefix the fields with "particle_{species_name}" b/c we
     // want to to uniquely name all the fields that can be plotted
@@ -94,8 +94,8 @@ FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_di
         amrex::ParticleContainerToBlueprint(*pc,
                                             particle_varnames,
                                             particle_int_varnames,
-                                            bp_mesh,
+                                            a_bp_mesh,
                                             prefix);
     }
-#endif // AMREX_USE_ASCENT
 }
+#endif // AMREX_USE_ASCENT

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -1,11 +1,6 @@
 #include "FlushFormatAscent.H"
 #include "WarpX.H"
 
-#ifdef AMREX_USE_ASCENT
-#   include <ascent.hpp>
-#   include <AMReX_Conduit_Blueprint.H>
-#endif
-
 using namespace amrex;
 
 void

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -8,11 +8,6 @@
 
 using namespace amrex;
 
-namespace
-{
-    const std::string level_prefix {"Level_"};
-}
-
 void
 FlushFormatAscent::WriteToFile (
     const amrex::Vector<std::string> varnames,

--- a/Source/Diagnostics/FlushFormats/Make.package
+++ b/Source/Diagnostics/FlushFormats/Make.package
@@ -1,5 +1,6 @@
 CEXE_sources += FlushFormatPlotfile.cpp
 CEXE_sources += FlushFormatCheckpoint.cpp
+CEXE_sources += FlushFormatAscent.cpp
 ifeq ($(USE_OPENPMD), TRUE)
     CEXE_sources += FlushFormatOpenPMD.cpp
 endif


### PR DESCRIPTION
As shown in project https://github.com/ECP-WarpX/WarpX/projects/9, we extracted the implementation of all diagnostics from class WarpX to an external class `Diagnostics`, for more flexibility. The last bits of diagnostics code in WarpX are used for in-situ only, with ASCENT and SENSEI. This PR proposes to transfer the in-situ ASCENT implementation to the new diagnostics. Right after, I'll open a PR doing the same thing for SENSEI, and do some cleaning.

WARNING: there is no automated test for ASCENT bindings, and I have not installed ASCENT locally, so I didn't even check that it compiles. @cyrush since you implemented the ASCENT bindings, could you help me check this is working properly? Thanks!!