### PR TITLE
Added some features for support of PSATD with PICMI.

### DIFF
--- a/Python/pywarpx/Psatd.py
+++ b/Python/pywarpx/Psatd.py
@@ -1,0 +1,9 @@
+# Copyright 2016 David Grote
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+from .Bucket import Bucket
+
+psatd = Bucket('psatd')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -16,6 +16,7 @@ from .Lasers import lasers, lasers_list
 from . import Particles
 from .Particles import particles, particles_list
 from .Diagnostics import diagnostics
+from .Psatd import psatd
 
 
 class WarpX(Bucket):
@@ -32,6 +33,7 @@ class WarpX(Bucket):
         argv += algo.attrlist()
         argv += langmuirwave.attrlist()
         argv += interpolation.attrlist()
+        argv += psatd.attrlist()
 
         # --- Search through species_names and add any predefined particle objects in the list.
         particles_list_names = [p.instancename for p in particles_list]

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -98,4 +98,3 @@ class WarpX(Bucket):
                 ff.write('{0}\n'.format(arg))
 
 warpx = WarpX('warpx')
-

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -14,3 +14,4 @@ from .Interpolation import interpolation
 from .Particles import particles, electrons, positrons, protons, newspecies
 from .Lasers import lasers
 from .Diagnostics import diagnostics
+from .Psatd import psatd

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -457,7 +457,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 
         pywarpx.warpx.do_pml = self.do_pml
         pywarpx.warpx.pml_ncell = self.pml_ncell
-        
+
         pywarpx.psatd.v_galilean = self.v_galilean
 
         # --- Same method names are used, though mapped to lower case.
@@ -469,10 +469,10 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 
         if self.source_smoother is not None:
             self.source_smoother.initialize_inputs(self)
-            
+
         if self.l_nodal is not None:
             pywarpx.warpx.do_nodal = self.l_nodal
-            
+
         if self.stencil_order is not None:
             if type(self.stencil_order) is type(0.):
                 pywarpx.psatd.nox = self.stencil_order
@@ -578,7 +578,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         pywarpx.warpx.load_balance_int = self.load_balance_int
         pywarpx.warpx.load_balance_with_sfc = self.load_balance_with_sfc
         pywarpx.particles.use_fdtd_nci_corr = self.use_fdtd_nci_corr
-        
+
         particle_shape = self.particle_shape
         for s in self.species:
             if s.particle_shape is not None:


### PR DESCRIPTION
Added import to psatd in __init__.py.
Added Psatd.py file.
Added Psatd module in WarpX.py.
Added support for v_galilean, l_nodal, nci correction and stencil order in picmi.py. Also fixed boost_direction.

Can be tested with provided scripts (see zip file below) with the following commands:
python3 PICMI_inputs_laser_acceleration.py
mpirun -np 4 ~/warpx/warpx/Bin/main2d.gnu.TPROF.MPI.ex inputs_from_PICMI
python3 mkplots.py --path diags

[test.zip](https://github.com/ECP-WarpX/WarpX/files/4659639/test.zip)
