### PR TITLE
Dpcpp

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -19,7 +19,7 @@
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 
-#include <cmath>
+#include <AMReX_Math.H>
 #include <limits>
 
 
@@ -531,7 +531,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
             // Apply the inverse volume scaling
             // Since Jr is never node centered in r, no need for distinction
             // between on axis and off-axis factors
-            const amrex::Real r = std::abs(rminr + (i - irmin)*dr);
+            const amrex::Real r = amrex::Math::abs(rminr + (i - irmin)*dr);
             Jr_arr(i,j,0,0) /= (2.*MathConst::pi*r);
 
             for (int imode=1 ; imode < nmodes ; imode++) {
@@ -562,7 +562,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
 
             // Apply the inverse volume scaling
             // Jt is forced to zero on axis.
-            const amrex::Real r = std::abs(rmint + (i - irmin)*dr);
+            const amrex::Real r = amrex::Math::abs(rmint + (i - irmin)*dr);
             if (r == 0.) {
                 Jt_arr(i,j,0,0) = 0.;
             } else {
@@ -600,7 +600,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
             }
 
             // Apply the inverse volume scaling
-            const amrex::Real r = std::abs(rminz + (i - irmin)*dr);
+            const amrex::Real r = amrex::Math::abs(rminz + (i - irmin)*dr);
             if (r == 0.) {
                 // Verboncoeur JCP 164, 421-427 (2001) : corrected volume on axis
                 Jz_arr(i,j,0,0) /= (MathConst::pi*dr/3.);
@@ -685,7 +685,7 @@ WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
             }
 
             // Apply the inverse volume scaling
-            const amrex::Real r = std::abs(rminr + (i - irmin)*dr);
+            const amrex::Real r = amrex::Math::abs(rminr + (i - irmin)*dr);
             if (r == 0.) {
                 // Verboncoeur JCP 164, 421-427 (2001) : corrected volume on axis
                 Rho_arr(i,j,0,icomp) /= (MathConst::pi*dr/3.);

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -15,7 +15,7 @@
 
 using namespace amrex;
 
-#ifdef AMREX_USE_CUDA
+#ifdef AMREX_USE_GPU
 
 /* \brief Apply stencil on MultiFab (GPU version, 2D/3D).
  * \param dstmf Destination MultiFab

--- a/Source/Parser/GpuParser.H
+++ b/Source/Parser/GpuParser.H
@@ -35,7 +35,7 @@ public:
     {
 #ifdef AMREX_USE_GPU
         amrex::GpuArray<amrex::Real,N> l_var{var...};
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if AMREX_DEVICE_COMPILE
 // WarpX compiled for GPU, function compiled for __device__
         return wp_ast_eval(m_gpu_parser.ast, l_var.data());
 #else

--- a/Source/Parser/wp_parser_c.h
+++ b/Source/Parser/wp_parser_c.h
@@ -5,6 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
+#include <cassert>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +26,10 @@ AMREX_GPU_HOST_DEVICE
 inline amrex_real
 wp_ast_eval (struct wp_node* node, amrex_real const* x)
 {
+#if defined(__SYCL_DEVICE_ONLY__)
+    assert(0); // Recursive funciton is not support in DPC++
+    return 0.;
+#else
     amrex_real result;
 
     switch (node->type)
@@ -181,6 +186,7 @@ wp_ast_eval (struct wp_node* node, amrex_real const* x)
     }
 
     return result;
+#endif
 }
 
 inline

--- a/Source/Particles/Collision/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/UpdateMomentumPerezElastic.H
@@ -243,8 +243,10 @@ void UpdateMomentumPerezElastic (
         u1x  = p1fx / m1;
         u1y  = p1fy / m1;
         u1z  = p1fz / m1;
+#ifndef AMREX_USE_DPCPP
         AMREX_ASSERT(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z));
         AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
+#endif
     }
     r = amrex::Random();
     if ( w1 > r*amrex::max(w1, w2) )
@@ -252,8 +254,10 @@ void UpdateMomentumPerezElastic (
         u2x  = p2fx / m2;
         u2y  = p2fy / m2;
         u2z  = p2fz / m2;
+#ifndef AMREX_USE_DPCPP
         AMREX_ASSERT(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z));
         AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
+#endif
     }
 
 }

--- a/Source/Particles/Collision/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/UpdateMomentumPerezElastic.H
@@ -9,6 +9,7 @@
 
 #include "Utils/WarpXConst.H"
 #include <AMReX_Random.H>
+#include <AMReX_Math.H>
 
 #include <cmath>  // isnan() isinf()
 #include <limits> // numeric_limits<float>::min()
@@ -35,9 +36,9 @@ void UpdateMomentumPerezElastic (
 {
 
     // If g = u1 - u2 = 0, do not collide.
-    if ( std::abs(u1x-u2x) < std::numeric_limits<T_R>::min() &&
-         std::abs(u1y-u2y) < std::numeric_limits<T_R>::min() &&
-         std::abs(u1z-u2z) < std::numeric_limits<T_R>::min() )
+    if ( amrex::Math::abs(u1x-u2x) < std::numeric_limits<T_R>::min() &&
+         amrex::Math::abs(u1y-u2y) < std::numeric_limits<T_R>::min() &&
+         amrex::Math::abs(u1z-u2z) < std::numeric_limits<T_R>::min() )
     { return; }
 
     T_R constexpr inv_c2 = T_R(1.0) / ( PhysConst::c * PhysConst::c );
@@ -96,7 +97,7 @@ void UpdateMomentumPerezElastic (
     else
     {
         // Compute b0
-        T_R const b0 = std::abs(q1*q2) * inv_c2 /
+        T_R const b0 = amrex::Math::abs(q1*q2) * inv_c2 /
                (T_R(4.0)*MathConst::pi*PhysConst::ep0) * gc/mass_g *
                ( m1*g1s*m2*g2s/(p1sm*p1sm*inv_c2) + T_R(1.0) );
 

--- a/Source/Utils/CoarsenIO.H
+++ b/Source/Utils/CoarsenIO.H
@@ -2,6 +2,7 @@
 #define WARPX_COARSEN_IO_H_
 
 #include "WarpX.H"
+#include <AMReX_Math.H>
 
 namespace CoarsenIO{
 
@@ -43,7 +44,7 @@ namespace CoarsenIO{
 
         // Compute number of points
         for ( int l = 0; l < 3; ++l ) {
-            if ( cr[l] == 1 ) np[l] = 1+abs(sf[l]-sc[l]); // no coarsening
+            if ( cr[l] == 1 ) np[l] = 1+amrex::Math::abs(sf[l]-sc[l]); // no coarsening
             else              np[l] = 2-sf[l];
         }
 

--- a/Source/Utils/CoarsenMR.H
+++ b/Source/Utils/CoarsenMR.H
@@ -2,6 +2,7 @@
 #define WARPX_COARSEN_MR_H_
 
 #include "WarpX.H"
+#include <AMReX_Math.H>
 
 namespace CoarsenMR{
 
@@ -97,11 +98,11 @@ namespace CoarsenMR{
                     jj = jmin+jref;
                     kk = kmin+kref;
                     wx = (1.0_rt/static_cast<Real>(numx))*(1-sfx)*(1-scx) // if cell-centered
-                         +((abs(crx-abs(ii-i*crx)))/static_cast<Real>(crx*crx))*sfx*scx; // if nodal
+                         +((amrex::Math::abs(crx-amrex::Math::abs(ii-i*crx)))/static_cast<Real>(crx*crx))*sfx*scx; // if nodal
                     wy = (1.0_rt/static_cast<Real>(numy))*(1-sfy)*(1-scy) // if cell-centered
-                         +((abs(cry-abs(jj-j*cry)))/static_cast<Real>(cry*cry))*sfy*scy; // if nodal
+                         +((amrex::Math::abs(cry-amrex::Math::abs(jj-j*cry)))/static_cast<Real>(cry*cry))*sfy*scy; // if nodal
                     wz = (1.0_rt/static_cast<Real>(numz))*(1-sfz)*(1-scz) // if cell-centered
-                         +((abs(crz-abs(kk-k*crz)))/static_cast<Real>(crz*crz))*sfz*scz; // if nodal
+                         +((amrex::Math::abs(crz-amrex::Math::abs(kk-k*crz)))/static_cast<Real>(crz*crz))*sfz*scz; // if nodal
                     c += wx*wy*wz*arr_src_safe(ii,jj,kk,comp);
                 }
             }


### PR DESCRIPTION
Make some changes for DPC++, because (1) it does not support recursive device function, (2) some math functions are missing in std namespace in device functions.  WarpX tests without using parser and random number generator can run on Intel Gen9 GPU now.  The changes should not affect non-DPC++ build.
