### PR TITLE
[WIP] Improve Accuracy for Single Precision: Pushers

### DIFF
--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -19,15 +19,17 @@ void UpdateMomentumBoris(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
-    const amrex::Real econst = 0.5*q*dt/m;
+    const amrex::Real econst = 0.5*q/m*dt;
 
     // First half-push for E
     ux += econst*Ex;
     uy += econst*Ey;
     uz += econst*Ez;
     // Compute temporary gamma factor
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    const amrex::Real uxc = ux / PhysConst::c;
+    const amrex::Real uyc = uy / PhysConst::c;
+    const amrex::Real uzc = uz / PhysConst::c;
+    const amrex::Real inv_gamma = 1./std::sqrt(1. + uxc*uxc + uyc*uyc + uzc*uzc);
     // Magnetic rotation
     // - Compute temporary variables
     const amrex::Real tx = econst*inv_gamma*Bx;

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -26,7 +26,7 @@ void UpdateMomentumHigueraCary(
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     // Constants
-    const amrex::Real qmt = 0.5*q*dt/m;
+    const amrex::Real qmt = 0.5*q/m*dt;
     constexpr amrex::Real invclight = 1./PhysConst::c;
     constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
     // Compute u_minus
@@ -34,7 +34,10 @@ void UpdateMomentumHigueraCary(
     const amrex::Real umy = uy + qmt*Ey;
     const amrex::Real umz = uz + qmt*Ez;
     // Compute gamma squared of u_minus
-    amrex::Real gamma = 1. + (umx*umx + umy*umy + umz*umz)*invclightsq;
+    const amrex::Real umxc = umx / PhysConst::c;
+    const amrex::Real umyc = umy / PhysConst::c;
+    const amrex::Real umzc = umz / PhysConst::c;
+    amrex::Real gamma = 1. + umxc*umxc + umyc*umyc + umzc*umzc;
     // Compute beta and betam squared
     const amrex::Real betax = qmt*Bx;
     const amrex::Real betay = qmt*By;

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -24,12 +24,14 @@ void UpdateMomentumVay(
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
     // Constants
-    const amrex::Real econst = q*dt/m;
-    const amrex::Real bconst = 0.5*q*dt/m;
+    const amrex::Real econst = q/m*dt;
+    const amrex::Real bconst = 0.5*q/m*dt;
     constexpr amrex::Real invclight = 1./PhysConst::c;
-    constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
     // Compute initial gamma
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*invclightsq);
+    const amrex::Real uxc = ux / PhysConst::c;
+    const amrex::Real uyc = uy / PhysConst::c;
+    const amrex::Real uzc = uz / PhysConst::c;
+    const amrex::Real inv_gamma = 1./std::sqrt(1. + uxc*uxc + uyc*uyc + uzc*uzc);
     // Get tau
     const amrex::Real taux = bconst*Bx;
     const amrex::Real tauy = bconst*By;
@@ -39,7 +41,10 @@ void UpdateMomentumVay(
     const amrex::Real uxpr = ux + econst*Ex + (uy*tauz-uz*tauy)*inv_gamma;
     const amrex::Real uypr = uy + econst*Ey + (uz*taux-ux*tauz)*inv_gamma;
     const amrex::Real uzpr = uz + econst*Ez + (ux*tauy-uy*taux)*inv_gamma;
-    const amrex::Real gprsq = (1. + (uxpr*uxpr + uypr*uypr + uzpr*uzpr)*invclightsq);
+    const amrex::Real uxprc = uxpr / PhysConst::c;
+    const amrex::Real uyprc = uypr / PhysConst::c;
+    const amrex::Real uzprc = uzpr / PhysConst::c;
+    const amrex::Real gprsq = (1. + uxprc*uxprc + uyprc*uyprc + uzprc*uzprc);
     // Get u*
     const amrex::Real ust = (uxpr*taux + uypr*tauy + uzpr*tauz)*invclight;
     // Get new gamma

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -21,11 +21,11 @@ void UpdatePosition(amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::Parti
                     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
                     const amrex::Real dt )
 {
-
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-
     // Compute inverse Lorentz factor
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    const amrex::Real uxc = ux / PhysConst::c;
+    const amrex::Real uyc = uy / PhysConst::c;
+    const amrex::Real uzc = uz / PhysConst::c;
+    const amrex::Real inv_gamma = 1./std::sqrt(1. + uxc*uxc + uyc*uyc + uzc*uzc);
     // Update positions over one time step
     x += ux * inv_gamma * dt;
 #if (AMREX_SPACEDIM == 3) || (defined WARPX_DIM_RZ) // RZ pushes particles in 3D


### PR DESCRIPTION
To improve accuracy of single precision (SP) runs, some operations in pushers are reordered.

The test in `../Examples/Tests/particle_pusher/inputs_3d` is used, in which a single particle is under a force-free field:  an initial velocity `vy` corresponding to `Lorentz factor = 20` is used, `Bz` is fixed at 1 T, `Ex = -Vy*Bz`, thus the particle should not move in `x`, but due to errors in the pusher, it will move in `x` in the long run, and the `x` value at time step 10000 is compared to zero.

```
Possible errors:
Boris:     2321.3958529
Vay:       0.00010467
HC:        0.00011403
tolerance: 0.001
Possible running time: ~ 4.0 s
```

The input file used in attached below.
[inputs_3d.txt](https://github.com/ECP-WarpX/WarpX/files/4670994/inputs_3d.txt)

For Boris pusher:
Without reordering, double precision (DP) produces `x = -2.32139585289579e+03`.
With reordering as shown in this PR, DP produces `x = -2.32139585069922e+03`.
They are similar, so the reordering is correct, and `|x|` with reordering is smaller than that without reordering, so reordering should help improve the accuracy.
Without reordering, SP produces `x = 0.00000000000000e+00`.
With reordering, SP produces `x = -6.25000048828125e+03`.
So, reordering does make a difference, although SP without reordering produces exactly zero for some unknown reason.
It is believed that the reordering will produce more reasonable results.

For Vay pusher:
Without reordering, double precision (DP) produces `x = -1.04665828497268e-04`.
With reordering as shown in this PR, DP produces `x = -1.01690296596670e-04`.
Again,`|x|` with reordering is smaller than that without reordering, so reordering should help improve the accuracy.
Without reordering, SP produces `x = 0.00000000000000e+00`.
With reordering, SP produces `x = -6.24937402343750e+03`.
Again, the weird zero is the same as the previous `boris` test for some unknown reason.
And the magnitude of `x` of reordering SP is the same as the previous `boris` test, which indicates that the huge error of SP may not be in the pusher, but in somewhere else in the code that these runs use.

For HC pusher:
Without reordering, double precision (DP) produces `x = -1.14030939526990e-04`.
With reordering as shown in this PR, DP produces `x = -1.09888498438652e-04`.
Without reordering, SP produces `x = 0.00000000000000e+00`.
With reordering, SP produces `x = -6.25000048828125e+03`.
Conclusions are the same as before.