### PR TITLE
specify _rt in the particle pushers

### DIFF
--- a/Source/Particles/Pusher/UpdateMomentumBoris.H
+++ b/Source/Particles/Pusher/UpdateMomentumBoris.H
@@ -19,21 +19,23 @@ void UpdateMomentumBoris(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
-    const amrex::Real econst = 0.5*q*dt/m;
+    using namespace amrex::literals;
+
+    const amrex::Real econst = 0.5_rt*q*dt/m;
 
     // First half-push for E
     ux += econst*Ex;
     uy += econst*Ey;
     uz += econst*Ez;
     // Compute temporary gamma factor
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
+    const amrex::Real inv_gamma = 1._rt/std::sqrt(1._rt + (ux*ux + uy*uy + uz*uz)*inv_c2);
     // Magnetic rotation
     // - Compute temporary variables
     const amrex::Real tx = econst*inv_gamma*Bx;
     const amrex::Real ty = econst*inv_gamma*By;
     const amrex::Real tz = econst*inv_gamma*Bz;
-    const amrex::Real tsqi = 2./(1. + tx*tx + ty*ty + tz*tz);
+    const amrex::Real tsqi = 2._rt/(1._rt + tx*tx + ty*ty + tz*tz);
     const amrex::Real sx = tx*tsqi;
     const amrex::Real sy = ty*tsqi;
     const amrex::Real sz = tz*tsqi;

--- a/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
+++ b/Source/Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H
@@ -25,13 +25,15 @@ void UpdateMomentumBorisWithRadiationReaction(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex::literals;
+
     //RR algorithm needs to store old value of the normalized momentum
     const amrex::Real ux_old = ux;
     const amrex::Real uy_old = uy;
     const amrex::Real uz_old = uz;
 
     //Useful constant
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+    constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
 
     //Call to regular Boris pusher
     UpdateMomentumBoris(
@@ -41,14 +43,14 @@ void UpdateMomentumBorisWithRadiationReaction(
         q, m, dt );
 
     //Estimation of the normalized momentum at intermediate (integer) time
-    const amrex::Real ux_n = (ux+ux_old)*0.5;
-    const amrex::Real uy_n = (uy+uy_old)*0.5;
-    const amrex::Real uz_n = (uz+uz_old)*0.5;
+    const amrex::Real ux_n = (ux+ux_old)*0.5_rt;
+    const amrex::Real uy_n = (uy+uy_old)*0.5_rt;
+    const amrex::Real uz_n = (uz+uz_old)*0.5_rt;
 
     // Compute Lorentz factor (and inverse) at intermediate (integer) time
-    const amrex::Real gamma_n = std::sqrt( 1. +
+    const amrex::Real gamma_n = std::sqrt( 1._rt +
         (ux_n*ux_n + uy_n*uy_n + uz_n*uz_n)*inv_c2);
-    const amrex::Real inv_gamma_n = 1.0/gamma_n;
+    const amrex::Real inv_gamma_n = 1.0_rt/gamma_n;
 
     //Estimation of the velocity at intermediate (integer) time
     const amrex::Real vx_n = ux_n*inv_gamma_n;
@@ -70,8 +72,8 @@ void UpdateMomentumBorisWithRadiationReaction(
     const amrex::Real coeff = gamma_n*gamma_n*(fl_q2-bdotE2);
 
     //Radiation reaction constant
-    const amrex::Real RRcoeff = 2.0*PhysConst::r_e*q*q/
-        (3.0*m*m*PhysConst::c*PhysConst::c);
+    const amrex::Real RRcoeff = 2.0_rt*PhysConst::r_e*q*q/
+        (3.0_rt*m*m*PhysConst::c*PhysConst::c);
 
     //Compute the components of the RR force
     const amrex::Real frx =

--- a/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
+++ b/Source/Particles/Pusher/UpdateMomentumHigueraCary.H
@@ -25,16 +25,18 @@ void UpdateMomentumHigueraCary(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex::literals;
+
     // Constants
-    const amrex::Real qmt = 0.5*q*dt/m;
-    constexpr amrex::Real invclight = 1./PhysConst::c;
-    constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
+    const amrex::Real qmt = 0.5_rt*q*dt/m;
+    constexpr amrex::Real invclight = 1._rt/PhysConst::c;
+    constexpr amrex::Real invclightsq = 1._rt/(PhysConst::c*PhysConst::c);
     // Compute u_minus
     const amrex::Real umx = ux + qmt*Ex;
     const amrex::Real umy = uy + qmt*Ey;
     const amrex::Real umz = uz + qmt*Ez;
     // Compute gamma squared of u_minus
-    amrex::Real gamma = 1. + (umx*umx + umy*umy + umz*umz)*invclightsq;
+    amrex::Real gamma = 1._rt + (umx*umx + umy*umy + umz*umz)*invclightsq;
     // Compute beta and betam squared
     const amrex::Real betax = qmt*Bx;
     const amrex::Real betay = qmt*By;
@@ -45,13 +47,13 @@ void UpdateMomentumHigueraCary(
     // Get u*
     const amrex::Real ust = (umx*betax + umy*betay + umz*betaz)*invclight;
     // Get new gamma inversed
-    gamma = 1./std::sqrt(0.5*(sigma + std::sqrt(sigma*sigma + 4.*(betam + ust*ust)) ));
+    gamma = 1._rt/std::sqrt(0.5_rt*(sigma + std::sqrt(sigma*sigma + 4._rt*(betam + ust*ust)) ));
     // Compute t
     const amrex::Real tx = gamma*betax;
     const amrex::Real ty = gamma*betay;
     const amrex::Real tz = gamma*betaz;
     // Compute s
-    const amrex::Real s = 1./(1.+(tx*tx + ty*ty + tz*tz));
+    const amrex::Real s = 1._rt/(1._rt+(tx*tx + ty*ty + tz*tz));
     // Compute um dot t
     const amrex::Real umt = umx*tx + umy*ty + umz*tz;
     // Compute u_plus

--- a/Source/Particles/Pusher/UpdateMomentumVay.H
+++ b/Source/Particles/Pusher/UpdateMomentumVay.H
@@ -23,13 +23,15 @@ void UpdateMomentumVay(
     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
     const amrex::Real q, const amrex::Real m, const amrex::Real dt )
 {
+    using namespace amrex::literals;
+
     // Constants
     const amrex::Real econst = q*dt/m;
-    const amrex::Real bconst = 0.5*q*dt/m;
-    constexpr amrex::Real invclight = 1./PhysConst::c;
-    constexpr amrex::Real invclightsq = 1./(PhysConst::c*PhysConst::c);
+    const amrex::Real bconst = 0.5_rt*q*dt/m;
+    constexpr amrex::Real invclight = 1._rt/PhysConst::c;
+    constexpr amrex::Real invclightsq = 1._rt/(PhysConst::c*PhysConst::c);
     // Compute initial gamma
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*invclightsq);
+    const amrex::Real inv_gamma = 1._rt/std::sqrt(1._rt + (ux*ux + uy*uy + uz*uz)*invclightsq);
     // Get tau
     const amrex::Real taux = bconst*Bx;
     const amrex::Real tauy = bconst*By;
@@ -39,18 +41,18 @@ void UpdateMomentumVay(
     const amrex::Real uxpr = ux + econst*Ex + (uy*tauz-uz*tauy)*inv_gamma;
     const amrex::Real uypr = uy + econst*Ey + (uz*taux-ux*tauz)*inv_gamma;
     const amrex::Real uzpr = uz + econst*Ez + (ux*tauy-uy*taux)*inv_gamma;
-    const amrex::Real gprsq = (1. + (uxpr*uxpr + uypr*uypr + uzpr*uzpr)*invclightsq);
+    const amrex::Real gprsq = (1._rt + (uxpr*uxpr + uypr*uypr + uzpr*uzpr)*invclightsq);
     // Get u*
     const amrex::Real ust = (uxpr*taux + uypr*tauy + uzpr*tauz)*invclight;
     // Get new gamma
     const amrex::Real sigma = gprsq-tausq;
-    const amrex::Real gisq = 2./(sigma + std::sqrt(sigma*sigma + 4.*(tausq + ust*ust)) );
+    const amrex::Real gisq = 2._rt/(sigma + std::sqrt(sigma*sigma + 4._rt*(tausq + ust*ust)) );
     // Get t, s
     const amrex::Real bg = bconst*std::sqrt(gisq);
     const amrex::Real tx = bg*Bx;
     const amrex::Real ty = bg*By;
     const amrex::Real tz = bg*Bz;
-    const amrex::Real s = 1./(1.+tausq*gisq);
+    const amrex::Real s = 1._rt/(1._rt+tausq*gisq);
     // Get t.u'
     const amrex::Real tu = tx*uxpr + ty*uypr + tz*uzpr;
     // Get new U

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -21,11 +21,12 @@ void UpdatePosition(amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::Parti
                     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
                     const amrex::Real dt )
 {
-
-    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+    using namespace amrex::literals;
+    
+    constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
 
     // Compute inverse Lorentz factor
-    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    const amrex::Real inv_gamma = 1._rt/std::sqrt(1._rt + (ux*ux + uy*uy + uz*uz)*inv_c2);
     // Update positions over one time step
     x += ux * inv_gamma * dt;
 #if (AMREX_SPACEDIM == 3) || (defined WARPX_DIM_RZ) // RZ pushes particles in 3D

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -22,7 +22,7 @@ void UpdatePosition(amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::Parti
                     const amrex::Real dt )
 {
     using namespace amrex::literals;
-    
+
     constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
 
     // Compute inverse Lorentz factor


### PR DESCRIPTION
I was doing some profiling with nsight and I noticed we were still doing some double-precision arithmetic here with `PRECISION=FLOAT` and `USE_SINGLE_PRECISION_PARTICLES=TRUE`. 