### PR TITLE
Improve documentation to compile with openPMD support on Summit

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -66,6 +66,8 @@ Then, in the ``warpx_directory``, download and build openPMD-api:
    git clone https://github.com/openPMD/openPMD-api.git
    mkdir openPMD-api-build
    cd openPMD-api-build
+   export CXX=$(which g++)
+   export CC=$(which gcc)
    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
    cmake --build . --target install --parallel 16
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -59,6 +59,11 @@ First, load the appropriate modules:
     module load hdf5/1.10.4
     module load adios2/2.5.0
 
+    export CC=$(which gcc)
+    export CXX=$(which g++)
+    export CUDACXX=$(which nvcc)
+    export CUDAHOSTCXX=$(which g++)
+
 Then, in the ``warpx_directory``, download and build openPMD-api:
 
 .. code-block:: bash
@@ -66,8 +71,6 @@ Then, in the ``warpx_directory``, download and build openPMD-api:
    git clone https://github.com/openPMD/openPMD-api.git
    mkdir openPMD-api-build
    cd openPMD-api-build
-   export CXX=$(which g++)
-   export CC=$(which gcc)
    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
    cmake --build . --target install --parallel 16
 


### PR DESCRIPTION
@NeilZaim  noticed that following exactly the instructions in the manual to compile WarpX with openPMD support results in an error.

This is due to the fact that an old version of `gcc` is used to compile openPMD-api instead of the newer version loaded with `module load gcc`.

It is enough to do 
```
export CXX=$(which g++)
export CC=$(which gcc)
```
to fix the issue.

This PR adds these two lines to the manual.