### PR TITLE
CI: Fix Brew Install

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,12 +12,14 @@ jobs:
         path: 'warpx_directory/WarpX'
     - name: install dependencies
       run: |
+        set +e
         brew update
         brew install cmake
         brew install fftw
         brew install libomp
         brew install open-mpi
         brew install pkg-config
+        set -e
         brew tap openpmd/openpmd
         brew install openpmd-api
     - name: build WarpX


### PR DESCRIPTION
Brew is weeeird. "Already installed (all good)" is not a reason to return a non-zero exit code. Urgh.