### PR TITLE
Cori: ADIOS2

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -105,8 +105,7 @@ First, load the appropriate modules:
    module swap PrgEnv-intel PrgEnv-gnu
    module load cmake/3.14.4
    module load cray-hdf5-parallel
-   module load adios/1.13.1
-   export CRAYPE_LINK_TYPE=dynamic
+   module load adios2/2.5.0
 
 Then, in the ``warpx_directory``, download and build openPMD-api:
 


### PR DESCRIPTION
- ADIOS2 2.5.0 is available on Cori
- ADIOS1 is no longer needed
- Dynamic library support is now the default