### PR TITLE
[mini] Fix typo for pml_ncell in parameters doc

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1105,7 +1105,7 @@ Boundary conditions
     and around the refinement patches. See the section :doc:`../../theory/PML`
     for more details.
 
-* ``warpx.pml_ncells`` (`int`; default: 10)
+* ``warpx.pml_ncell`` (`int`; default: 10)
     The depth of the PML, in number of cells.
 
 * ``warpx.pml_delta`` (`int`; default: 10)


### PR DESCRIPTION
This input parameters is listed as `warpx.pml_ncells` in the parameters doc but is actually `warpx.pml_ncell` in the code. This mini-PR just removes the extra `s` from the parameters doc.