### PR TITLE
Stop mailing errors from Battra

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -44,7 +44,7 @@ check_file_name = none
 
 # email
 sendEmailWhenFail = 1
-emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, mthevenet@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, axelhuebl@lbl.gov, ezoni@lbl.gov, yinjianzhao@lbl.gov
+emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, axelhuebl@lbl.gov, ezoni@lbl.gov, yinjianzhao@lbl.gov
 emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more details.
 
 [AMReX]

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -44,7 +44,7 @@ check_file_name = none
 
 # email
 sendEmailWhenFail = 1
-emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, ezoni@lbl.gov, yinjianzhao@lbl.gov
+emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, rjambunathan@lbl.gov, yinjianzhao@lbl.gov
 emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more details.
 
 [AMReX]

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -44,7 +44,7 @@ check_file_name = none
 
 # email
 sendEmailWhenFail = 1
-emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, axelhuebl@lbl.gov, ezoni@lbl.gov, yinjianzhao@lbl.gov
+emailTo = weiqunzhang@lbl.gov, jlvay@lbl.gov, rlehe@lbl.gov, atmyers@lbl.gov, oshapoval@lbl.gov, henri.vincenti@cea.fr, ldianaamorim@lbl.gov, rjambunathan@lbl.gov, ezoni@lbl.gov, yinjianzhao@lbl.gov
 emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more details.
 
 [AMReX]


### PR DESCRIPTION
Currently, this PR only removes my email address from the Battra mailing list. If you want to remove yours too, feel free to add suggestions to this PR.