### PR TITLE
CI Inputs Check: Fix Silent Abort

### DIFF
--- a/.github/workflows/source/inputsNotTested
+++ b/.github/workflows/source/inputsNotTested
@@ -17,7 +17,7 @@ do
         cr=$'$'
         file_cr="$file$cr"
         # Search file name in test list
-        string_match=$(grep -m1 "$file_cr" Regression/WarpX-tests.ini)
+        string_match=$(grep -m1 "$file_cr" Regression/WarpX-tests.ini || echo "")
         # If match is empty, inputs examples is not tested
         if [[ -z $string_match ]]
         then


### PR DESCRIPTION
If a file is missing at all then it is not being tested. This currently did abort and fail the test without a hint to the developer. Now it still fails as it should but it also gives a nice hint.