### PR TITLE
[WIP] Diagnostics: Directory Cleanup, 6 Digits

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1406,8 +1406,10 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     (This is done by averaging the field over 1 or 2 points along each direction, depending on the staggering).
     ``plot_coarsening_ratio`` should be an integer divisor of ``blocking_factor``, defined in the :ref:`parallelization <parallelization_warpx>` section.
 
-* ``<diag_name>.file_prefix`` (`string`) optional (default `diags/plotfiles/plt`)
-    Root for output file names. Supports sub-directories.
+* ``<diag_name>.file_prefix`` (`string`) optional (default ``<diag_name>/``)
+    Directory root for output files relative to ``diags/``.
+    Supports sub-directories.
+    Actual file names in the herein set directory are determined by the ``<diag_name>.format``: ``openpmd_<N>.bp|h5|json`` for ``openpmd``, ``plt<N>`` for ``plotfile``
 
 * ``<diag_name>.diag_lo`` (list `float`, 1 per dimension) optional (default `-infinity -infinity -infinity`)
     Lower corner of the output fields (if smaller than ``warpx.dom_lo``, then set to ``warpx.dom_lo``). Currently, when the ``diag_lo`` is different from ``warpx.dom_lo``, particle output is disabled.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1406,9 +1406,9 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     (This is done by averaging the field over 1 or 2 points along each direction, depending on the staggering).
     ``plot_coarsening_ratio`` should be an integer divisor of ``blocking_factor``, defined in the :ref:`parallelization <parallelization_warpx>` section.
 
-* ``<diag_name>.file_prefix`` (`string`) optional (default ``<diag_name>/``)
-    Directory root for output files relative to ``diags/``.
-    Supports sub-directories.
+* ``<diag_name>.file_prefix`` (`string`) optional (default directory: ``diags/<diag_name>``)
+    Directory root for output files.
+    Supports arbitrary paths and sub-directories. [Wit the current logic, we need more details and examples here!]
     Actual file names in the herein set directory are determined by the ``<diag_name>.format``: ``openpmd_<N>.bp|h5|json`` for ``openpmd``, ``plt<N>`` for ``plotfile``
 
 * ``<diag_name>.diag_lo`` (list `float`, 1 per dimension) optional (default `-infinity -infinity -infinity`)

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -24,7 +24,7 @@ FlushFormatPlotfile::WriteToFile (
 {
     WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();
-    const std::string& filename = amrex::Concatenate(prefix, iteration[0]);
+    const std::string filename = prefix + amrex::Concatenate("/plt", iteration[0], 6);
     amrex::Print() << "  Writing plotfile " << filename << "\n";
 
     Vector<std::string> rfs;


### PR DESCRIPTION
This reorders the naming of diagnostics to be a bit more readable.

Before #1149 full diagnostics wrote by default as:
```bash
$ ls Bin/diags/
diag1bp/<N>.bp
diag1h5/<N>.h5
...
diag100000
diag100100
     <N>
     ...
```

Now it proposes
```bash
$ ls Bin/diags/
diag1/openpmd_<N>.bp  # already via #1149
diag1/openpmd_<N>.h5  # already via #1149
diag1/plt<N>  # this PR
```

note: `diag1` is the default name of for `<diag>.file_prefix` if a diagnostics is called `diag1`. This can be overwritten by the user with different names or other deeper directories, if needed.

note: we don't go for `plt_<N>` since some post-processing tooling hardcode a `plt<N>` logic ([VisIt](https://github.com/visit-dav/visit/blob/c933592fbf730cffdd809da23741811c84f3efd2/src/databases/Boxlib3D/avtBoxlibFileFormat.C), to some extend picViewer, potentially yt). Keeping it that way should lead to less breakage.

This is also a bit easier for some tooling (i.e. yt and openPMD-viewer that expect full consistent dirs atm.) and keeps things nicely together.

Also bumps the zero-padding to use consistently 6 digits for iterations in output files (<1M iterations), since sims (ions) with >100k steps are not uncommon.

- [ ] adjust regression configs: `Regression/WarpX-*.ini`
- [ ] adjust test scripts
- [ ] adjust docs?