### PR TITLE
Docs: Summit Restructure

### DIFF
--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -51,8 +51,8 @@ options are:
     * ``COMP=gcc`` or ``intel``: Compiler.
     * ``USE_MPI=TRUE`` or ``FALSE``: Whether to compile with MPI support.
     * ``USE_OMP=TRUE`` or ``FALSE``: Whether to compile with OpenMP support.
-    * ``USE_GPU=TRUE`` or ``FALSE``: Wheter to compile for Nvidia GPUs (requires CUDA).
-    * ``USE_OPENPMD=TRUE`` or ``FALSE``: Wheter to support openPMD for I/O (requires openPMD-api).
+    * ``USE_GPU=TRUE`` or ``FALSE``: Whether to compile for Nvidia GPUs (requires CUDA).
+    * ``USE_OPENPMD=TRUE`` or ``FALSE``: Whether to support openPMD for I/O (requires openPMD-api).
 
 For a description of these different options, see the `corresponding page <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html>`__ in the AMReX documentation.
 

--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -51,6 +51,8 @@ options are:
     * ``COMP=gcc`` or ``intel``: Compiler.
     * ``USE_MPI=TRUE`` or ``FALSE``: Whether to compile with MPI support.
     * ``USE_OMP=TRUE`` or ``FALSE``: Whether to compile with OpenMP support.
+    * ``USE_GPU=TRUE`` or ``FALSE``: Wheter to compile for Nvidia GPUs (requires CUDA).
+    * ``USE_OPENPMD=TRUE`` or ``FALSE``: Wheter to support openPMD for I/O (requires openPMD-api).
 
 For a description of these different options, see the `corresponding page <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html>`__ in the AMReX documentation.
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -3,7 +3,7 @@
 Building WarpX on Summit (OLCF)
 ================================
 
-The `Summit cluster <https://www.olcf.ornl.gov/summit/>`_ is located OLCF.
+The `Summit cluster <https://www.olcf.ornl.gov/summit/>`_ is located at OLCF.
 
 If you are new to this system, please see the following resources:
 
@@ -106,4 +106,3 @@ Running
 Please see :ref:`our example job scripts <running-cpp-summit>` on how to run WarpX on Summit.
 
 See :doc:`../visualization/yt` for more information on how to visualize the simulation results.
-

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -3,87 +3,107 @@
 Building WarpX on Summit (OLCF)
 ================================
 
-For the `Summit cluster
-<https://www.olcf.ornl.gov/summit/>`__ at OLCF,
-use the following commands to download the source code, and switch to the
-correct branch:
+The `Summit cluster <https://www.olcf.ornl.gov/summit/>`_ is located OLCF.
 
-::
+If you are new to this system, please see the following resources:
 
-    mkdir warpx_directory
-    cd warpx_directory
+* `Summit user guide <https://docs.olcf.ornl.gov/systems/summit_user_guide.html>`_
+* Batch system: `LSF <https://docs.olcf.ornl.gov/systems/summit_user_guide.html#running-jobs>`_
+* `Production directories <https://docs.olcf.ornl.gov/data/storage_overview.html>`_:
 
-    git clone https://github.com/ECP-WarpX/WarpX.git
-    git clone https://bitbucket.org/berkeleylab/picsar.git
-    git clone --branch development https://github.com/AMReX-Codes/amrex.git
-
-Then, ``cd`` into the directory ``WarpX`` and use the following set of commands to compile:
-
-::
-
-    module load gcc
-    module load cuda
-    make -j 16 COMP=gcc USE_GPU=TRUE
-
-See :doc:`../running_cpp/platforms` for more information on how to run WarpX on Summit.
-
-See :doc:`../visualization/yt` for more information on how to visualize the simulation results.
-
-.. note::
-
-   To compile and run WarpX on Summit CPUs, the cuda module is not necessary.
-
-   But to build with the spectral solver, PSATD, you need to use an MPI-enabled version of FFTW like the `fftw` module (because the `cuFFT` tool is not available when cuda is not loaded).
-
-   ::
-
-      module load gcc
-      module load fftw
-      make -j 16 COMP=gcc USE_PSATD=TRUE
+  * ``$PROJWORK/$proj/``: shared with all members of a project (recommended)
+  * ``$MEMBERWORK/$proj/``: single user (usually smaller quota)
+  * ``$WORLDWORK/$proj/``: shared with all users
+  * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
+    That means you cannot run in your ``$HOME``.
 
 
+Installation
+------------
 
-
-.. _building-summit-openPMD:
-
-Building WarpX with openPMD support
------------------------------------
-
-First, load the appropriate modules:
+We use the following modules and environments on the system.
 
 .. code-block:: bash
 
-    module load gcc
-    module load cuda
-    module load cmake
-    module load hdf5/1.10.4
-    module load adios2/2.5.0
+   # please set your project account
+   export proj=<yourProject>
 
-    export CC=$(which gcc)
-    export CXX=$(which g++)
-    export CUDACXX=$(which nvcc)
-    export CUDAHOSTCXX=$(which g++)
+   # required dependencies
+   module load gcc/6.4.0
+   module load cuda
 
-Then, in the ``warpx_directory``, download and build openPMD-api:
+   # optional: faster re-builds
+   module load ccache
+
+   # optional: for PSATD support
+   module load fftw
+
+   # optional: for QED support
+   module load boost/1.66.0
+
+   # optional: for openPMD support
+   module load cmake
+   module load hdf5/1.10.4
+   module load adios2/2.5.0
+   export PKG_CONFIG_PATH=$HOME/sw/openPMD-api-install/lib64/pkgconfig:$PKG_CONFIG_PATH
+   export CMAKE_PREFIX_PATH=$HOME/sw/openPMD-api-install:$CMAKE_PREFIX_PATH
+
+   # optional: just an additional text editor
+   module load nano
+
+   # optional: an alias to request an interactive node for two hours
+   alias getNode="bsub -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
+
+   # fix system defaults: do not escape $ with a \ on tab completion
+   shopt -s direxpand
+
+   # compiler environment hints
+   export CC=$(which gcc)
+   export CXX=$(which g++)
+   export CUDACXX=$(which nvcc)
+   export CUDAHOSTCXX=$(which g++)
+
+
+We recommend to store the above lines in a file, such as ``$HOME/warpx.profile``, and load it into your shell after a login:
+
+.. code-block:: bash
+
+   source $HOME/warpx.profile
+
+Use the following commands to download the WarpX source code and switch to the correct branch:
+
+.. code-block:: bash
+
+   mkdir ~/src
+   cd ~/src
+
+   git clone https://github.com/ECP-WarpX/WarpX.git warpx
+   git clone --branch QED https://bitbucket.org/berkeleylab/picsar.git
+   git clone --branch development https://github.com/AMReX-Codes/amrex.git
+
+Optionally, download and build openPMD-api for I/O:
 
 .. code-block:: bash
 
    git clone https://github.com/openPMD/openPMD-api.git
    mkdir openPMD-api-build
    cd openPMD-api-build
-   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
+   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/openPMD-api-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
    cmake --build . --target install --parallel 16
 
-.. note:
-
-   On Summit, only compute nodes provide the infiniband hardware that Summit's MPI module expects, ``jsrun`` must be used on Summit instead of ``mpiexec``, and ``$HOME`` directories are read-only when computing.
-   In order to run openPMD-api unit tests, run on a compute node inside ``$PROJWORK``, e.g. via ``bsub -P <addYourProjectID> -W 2:00 -nnodes 1 -Is /bin/bash``, and add ``-DMPIEXEC_EXECUTABLE=$(which jsrun)`` to the CMake options.
-
-Finally, compile WarpX:
+Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
 
 .. code-block:: bash
 
-   cd ../WarpX
-   export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib64/pkgconfig:$PKG_CONFIG_PATH
-   export CMAKE_PREFIX_PATH=$PWD/../openPMD-install:$CMAKE_PREFIX_PATH
    make -j 16 COMP=gcc USE_GPU=TRUE USE_OPENPMD=TRUE
+
+The other :ref:`general compile-time options <building-source>` apply as usual.
+
+
+Running
+-------
+
+Please see :ref:`our example job scripts <running-cpp-summit>` on how to run WarpX on Summit.
+
+See :doc:`../visualization/yt` for more information on how to visualize the simulation results.
+

--- a/Docs/source/running_cpp/platforms.rst
+++ b/Docs/source/running_cpp/platforms.rst
@@ -1,5 +1,9 @@
+.. _running-cpp:
+
 Running on specific platforms
 =============================
+
+.. _running-cpp-cori:
 
 Running on Cori KNL at NERSC
 ----------------------------
@@ -32,6 +36,9 @@ regime), the following set of parameters provided good performance:
   system).
 
 * **2 grids per MPI**, *i.e.*, 16 grids per KNL node.
+
+
+.. _running-cpp-summit:
 
 Running on Summit at OLCF
 -------------------------


### PR DESCRIPTION
Restructures the build instructions for Summit (OLCF).

This loads all software that might be needed to reduce the "if then else" logic a user has to understand during install. Everything is now required or optional, but everything is compatible or simply ignored. Everything can just be copy-pasted and will work. Additional choices only need to be made with compile time flags.

Uses new conventions for downloaded source and manually built software to structure things in a simpler, scalable manner.