### PR TITLE
Replace amrex namespace with amrex:: prefix in DiagFunctors

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
@@ -1,8 +1,6 @@
 #include "CellCenterFunctor.H"
 #include "Utils/CoarsenIO.H"
 
-using namespace amrex;
-
 CellCenterFunctor::CellCenterFunctor(amrex::MultiFab const * mf_src, int lev,
                                      amrex::IntVect crse_ratio,
                                      bool convertRZmodes2cartesian, int ncomp)
@@ -21,12 +19,12 @@ CellCenterFunctor::operator()(amrex::MultiFab& mf_dst, int dcomp) const
             nComp()==1,
             "The RZ averaging over modes must write into 1 single component");
         auto& warpx = WarpX::GetInstance();
-        MultiFab mf_dst_stag(m_mf_src->boxArray(), warpx.DistributionMap(m_lev), 1, m_mf_src->nGrowVect());
+        amrex::MultiFab mf_dst_stag(m_mf_src->boxArray(), warpx.DistributionMap(m_lev), 1, m_mf_src->nGrowVect());
         // Mode 0
-        MultiFab::Copy(mf_dst_stag, *m_mf_src, 0, 0, 1, m_mf_src->nGrowVect());
+        amrex::MultiFab::Copy(mf_dst_stag, *m_mf_src, 0, 0, 1, m_mf_src->nGrowVect());
         for (int ic=1 ; ic < m_mf_src->nComp() ; ic += 2) {
             // All modes > 0
-            MultiFab::Add(mf_dst_stag, *m_mf_src, ic, 0, 1, m_mf_src->nGrowVect());
+            amrex::MultiFab::Add(mf_dst_stag, *m_mf_src, ic, 0, 1, m_mf_src->nGrowVect());
         }
         CoarsenIO::Coarsen( mf_dst, mf_dst_stag, dcomp, 0, nComp(), 0,  m_crse_ratio);
     } else {

--- a/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.cpp
@@ -1,8 +1,6 @@
 #include "DivBFunctor.H"
 #include "Utils/CoarsenIO.H"
 
-using namespace amrex;
-
 DivBFunctor::DivBFunctor(const std::array<const amrex::MultiFab* const, 3> arr_mf_src, const int lev, const amrex::IntVect crse_ratio, const int ncomp)
     : ComputeDiagFunctor(ncomp, crse_ratio), m_arr_mf_src(arr_mf_src), m_lev(lev)
 {}
@@ -17,7 +15,7 @@ DivBFunctor::operator()(amrex::MultiFab& mf_dst, int dcomp) const
     constexpr int ng = 1;
     // A cell-centered divB multifab spanning the entire domain is generated
     // and divB is computed on the cell-center, with ng=1.
-    MultiFab divB( warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng );
+    amrex::MultiFab divB( warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng );
     warpx.ComputeDivB(divB, 0, m_arr_mf_src, WarpX::CellSize(m_lev) );
     // Coarsen and Interpolate from divB to coarsened/reduced_domain mf_dst
     CoarsenIO::Coarsen( mf_dst, divB, dcomp, 0, nComp(), 0, m_crse_ratio);

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -1,8 +1,6 @@
 #include "DivEFunctor.H"
 #include "Utils/CoarsenIO.H"
 
-using namespace amrex;
-
 DivEFunctor::DivEFunctor(const std::array<const amrex::MultiFab* const, 3> arr_mf_src, const int lev,
                          const amrex::IntVect crse_ratio,
                          bool convertRZmodes2cartesian, const int ncomp)
@@ -20,8 +18,9 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp) const
     constexpr int ng = 1;
     // For staggered and nodal calculations, divE is computed on the nodes.
     // The temporary divE MultiFab is generated to comply with the location of divE.
-    const BoxArray& ba = amrex::convert(warpx.boxArray(m_lev),IntVect::TheUnitVector());
-    MultiFab divE(ba, warpx.DistributionMap(m_lev), 2*warpx.n_rz_azimuthal_modes-1, ng );
+    const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev),
+                                amrex::IntVect::TheUnitVector());
+    amrex::MultiFab divE(ba, warpx.DistributionMap(m_lev), 2*warpx.n_rz_azimuthal_modes-1, ng);
     warpx.ComputeDivE(divE, m_lev);
 
 #ifdef WARPX_DIM_RZ
@@ -31,12 +30,12 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp) const
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             nComp()==1,
             "The RZ averaging over modes must write into 1 single component");
-        MultiFab mf_dst_stag(divE.boxArray(), warpx.DistributionMap(m_lev), 1, divE.nGrowVect());
+        amrex::MultiFab mf_dst_stag(divE.boxArray(), warpx.DistributionMap(m_lev), 1, divE.nGrowVect());
         // Mode 0
-        MultiFab::Copy(mf_dst_stag, divE, 0, 0, 1, divE.nGrowVect());
+        amrex::MultiFab::Copy(mf_dst_stag, divE, 0, 0, 1, divE.nGrowVect());
         for (int ic=1 ; ic < divE.nComp() ; ic += 2) {
             // Real part of all modes > 0
-            MultiFab::Add(mf_dst_stag, divE, ic, 0, 1, divE.nGrowVect());
+            amrex::MultiFab::Add(mf_dst_stag, divE, ic, 0, 1, divE.nGrowVect());
         }
         CoarsenIO::Coarsen( mf_dst, mf_dst_stag, dcomp, 0, nComp(), 0,  m_crse_ratio);
     } else {

--- a/Source/Diagnostics/ComputeDiagFunctors/PartPerCellFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/PartPerCellFunctor.cpp
@@ -2,7 +2,7 @@
 #include "WarpX.H"
 #include "Utils/CoarsenIO.H"
 
-using namespace amrex;
+using namespace amrex::literals;
 
 PartPerCellFunctor::PartPerCellFunctor(const amrex::MultiFab* mf_src, const int lev, amrex::IntVect crse_ratio, const int ncomp)
     : ComputeDiagFunctor(ncomp, crse_ratio), m_lev(lev)
@@ -22,7 +22,7 @@ PartPerCellFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp) const
     // the operations performend in the CoarsenAndInterpolate function.
     constexpr int ng = 1;
     // Temporary cell-centered, single-component MultiFab for storing particles per cell.
-    MultiFab ppc_mf(warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng);
+    amrex::MultiFab ppc_mf(warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng);
     // Set value to 0, and increment the value in each cell with ppc.
     ppc_mf.setVal(0._rt);
     // Compute ppc which includes a summation over all species.

--- a/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.cpp
@@ -1,8 +1,6 @@
 #include "PartPerGridFunctor.H"
 #include "Utils/CoarsenIO.H"
 
-using namespace amrex;
-
 PartPerGridFunctor::PartPerGridFunctor(const amrex::MultiFab * const mf_src, const int lev, const amrex::IntVect crse_ratio, const int ncomp)
     : ComputeDiagFunctor(ncomp, crse_ratio), m_lev(lev)
 {
@@ -16,19 +14,19 @@ void
 PartPerGridFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp) const
 {
     auto& warpx = WarpX::GetInstance();
-    const Vector<long>& npart_in_grid = warpx.GetPartContainer().NumberOfParticlesInGrid(m_lev);
+    const amrex::Vector<long>& npart_in_grid = warpx.GetPartContainer().NumberOfParticlesInGrid(m_lev);
     // Guard cell is set to 1 for generality. However, for a cell-centered
     // output Multifab, mf_dst, the guard-cell data is not needed especially considering
     // the operations performend in the CoarsenAndInterpolate function.
     constexpr int ng = 1;
     // Temporary MultiFab containing number of particles per grid.
     // (stored as constant for all cells in each grid)
-    MultiFab ppg_mf(warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng);
+    amrex::MultiFab ppg_mf(warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng);
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(ppg_mf); mfi.isValid(); ++mfi) {
-        ppg_mf[mfi].setVal<RunOn::Host>(static_cast<Real>(npart_in_grid[mfi.index()]));
+    for (amrex::MFIter mfi(ppg_mf); mfi.isValid(); ++mfi) {
+        ppg_mf[mfi].setVal<amrex::RunOn::Host>(static_cast<amrex::Real>(npart_in_grid[mfi.index()]));
     }
 
     // Coarsen and interpolate from ppg_mf to the output diagnostic MultiFab, mf_dst.


### PR DESCRIPTION
In this PR, "using namespace amrex" is removed from the .cpp files in diagnostic functions : Source/Diagnostics/ComputeDiagFunctors/*.cpp
Instead, all the amrex functionality is accessed using the scope operator (::)