### PR TITLE
Travis CI: Wait Longer for Make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
 
     # Run the script that prepares the test environment and runs the tests
     - export OMP_NUM_THREADS=1
-    - ./run_test.sh
+    - travis_wait 50 ./run_test.sh

--- a/run_test.sh
+++ b/run_test.sh
@@ -69,8 +69,8 @@ cp -r Checksum ../../regression_testing/
 cd ../../regression_testing/
 # run only tests specified in variable tests_arg (single test or multiple tests)
 if [[ ! -z "${tests_arg}" ]]; then
-python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} "${tests_run}"
+  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} "${tests_run}"
 # run all tests (variables tests_arg and tests_run are empty)
 else
-python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}
+  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}
 fi


### PR DESCRIPTION
It looks like "make" run from our python test scripts does sometimes take longer than 10 minutes and does not produce output on stdout during that time (probably because we hide it).

This adds a 20min grace time for this (default: 10min) before ending the job with a timeout.

Generally, tests on Travis are close to the 50min mark of total job time, this patch does not change this :)

Ref.: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received