### PR TITLE
Fix Race condition in GetParticleSlice for BTD

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1720,6 +1720,10 @@ PhysicalParticleContainer::GetParticleSlice (
 
     for (int lev = 0; lev < nlevs; ++lev) {
 
+        // temporary arrays to store copy_flag and copy_index
+        // for particles that cross the z-slice
+        amrex::Gpu::ManagedDeviceVector<int> FlagForPartCopy;
+        amrex::Gpu::ManagedDeviceVector<int> IndexForPartCopy;
         const Real* dx  = Geom(lev).CellSize();
         const Real* plo = Geom(lev).ProbLo();
 
@@ -1768,10 +1772,8 @@ PhysicalParticleContainer::GetParticleSlice (
                 Real uzfrm = -WarpX::gamma_boost*WarpX::beta_boost*PhysConst::c;
                 Real inv_c2 = 1.0/PhysConst::c/PhysConst::c;
 
-                // temporary arrays to store copy_flag and copy_index
-                // for particles that cross the z-slice
-                amrex::Gpu::ManagedDeviceVector<int> FlagForPartCopy(np);
-                amrex::Gpu::ManagedDeviceVector<int> IndexForPartCopy(np);
+                FlagForPartCopy.resize(np);
+                IndexForPartCopy.resize(np);
 
                 int* const AMREX_RESTRICT Flag = FlagForPartCopy.dataPtr();
                 int* const AMREX_RESTRICT IndexLocation = IndexForPartCopy.dataPtr();


### PR DESCRIPTION
This PR fixes a race condition in GetParticleSlice called for BTD, and  fixes the out-of-box problems mentioned in Issue #1095

Below is the input file used to reproduce the error and test the fix. Compared to the input file attached in #1095 , `v_galilean = 0. 0. 0.` for the test cases performed in this PR.
[inputs_2d_boostedFrame.txt](https://github.com/ECP-WarpX/WarpX/files/4802467/inputs_2d_boostedFrame.txt)

For a 2D PSATD simulation on the development branch, the back-transformed position was out of the box and the velocities were not gaussian in the first snapshot as shown below.
![Screenshot from 2020-06-18 21-51-35](https://user-images.githubusercontent.com/41089244/85097937-f79de480-b1ad-11ea-853a-9b65071c1cdb.png)

After fixing this, the 2D PSATD GPU simulation results in the following lab-frame position and velocity
![Screenshot from 2020-06-18 21-51-51](https://user-images.githubusercontent.com/41089244/85097982-143a1c80-b1ae-11ea-8dc3-ea5d27bdfbfc.png)

I also got the same results for the following tests using the same input file (attached above in the PR)

- FDTD 2D simulation on the GPU
- FDTD 2D simulation on the CPU
- PSATD 2D simulation on the CPU.



