### PR TITLE
Summit: no `-n` in jsrun

### DIFF
--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -19,5 +19,4 @@ module load cuda
 omp=1
 export OMP_NUM_THREADS=${omp}
 
-num_nodes=$(( $(printf '%s\n' ${LSB_HOSTS} | sort -u | wc -l) - 1 ))
-jsrun -n ${num_nodes} -a 6 -g 6 -c 6 --bind=packed:${omp} <path/to/executable> <input file> > output.txt
+jsrun -a 6 -g 6 -c 6 --bind=packed:${omp} <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-# Copyright 2019 Maxence Thevenet
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
 #
 # This file is part of WarpX.
 #
 # License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
 
 #BSUB -P <allocation ID>
 #BSUB -W 00:10
 #BSUB -nnodes 2
+#BSUB -alloc_flags smt4
 #BSUB -J WarpX
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
@@ -16,7 +21,5 @@
 module load gcc
 module load cuda
 
-omp=1
-export OMP_NUM_THREADS=${omp}
-
-jsrun -a 6 -g 6 -c 6 --bind=packed:${omp} <path/to/executable> <input file> > output.txt
+export OMP_NUM_THREADS=1
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
The calculation of `-n` does not seem to work anymore. Luckily, the parameter seems to be automatically taken by some LFS setting in the job.