### PR TITLE
[tiny] doxygen info to header

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -174,6 +174,16 @@ public:
     // Inject particles in Box 'part_box'
     virtual void AddParticles (int lev);
 
+    /**
+     * Create new macroparticles for this species, with a fixed
+     * number of particles per cell (in the cells of `part_realbox`).
+     * The new particles are only created inside the intersection of `part_realbox`
+     * with the local grid for the current proc.
+     * @param[in] lev the index of the refinement level
+     * @param[in] part_realbox the box in which new particles should be created
+     * (this box should correspond to an integer number of cells in each direction,
+     * but its boundaries need not be aligned with the actual cells of the simulation)
+    */
     void AddPlasma (int lev, amrex::RealBox part_realbox = amrex::RealBox());
 
     void MapParticletoBoostedFrame (amrex::Real& x, amrex::Real& y, amrex::Real& z, std::array<amrex::Real, 3>& u);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -464,16 +464,6 @@ PhysicalParticleContainer::AddParticles (int lev)
     }
 }
 
-/**
- * Create new macroparticles for this species, with a fixed
- * number of particles per cell (in the cells of `part_realbox`).
- * The new particles are only created inside the intersection of `part_realbox`
- * with the local grid for the current proc.
- * @param lev the index of the refinement level
- * @param part_realbox the box in which new particles should be created
- * (this box should correspond to an integer number of cells in each direction,
- * but its boundaries need not be aligned with the actual cells of the simulation)
- */
 void
 PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 {


### PR DESCRIPTION
This tiny PR moves the doxygen information on:

* **Source/Particles/PhysicalParticleContainer.cpp**

to the header file for consistency.