### PR TITLE
Include guard cells for init fields

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -404,9 +404,9 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
     for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
        // Box index-space includes the staggering of the multifabs
-       const Box& tbx = mfi.tilebox( x_nodal_flag );
-       const Box& tby = mfi.tilebox( y_nodal_flag );
-       const Box& tbz = mfi.tilebox( z_nodal_flag );
+       amrex::Box tbx = mfi.tilebox( x_nodal_flag );
+       amrex::Box tby = mfi.tilebox( y_nodal_flag );
+       amrex::Box tbz = mfi.tilebox( z_nodal_flag );
        if (init_guard_cells) {
            // Box index-space includes staggering and guard cells of multifabs
            tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -393,7 +393,7 @@ void
 WarpX::InitializeExternalFieldsOnGridUsingParser (
        MultiFab *mfx, MultiFab *mfy, MultiFab *mfz,
        ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-       ParserWrapper<3> *zfield_parser, const int lev, bool init_guard_cells)
+       ParserWrapper<3> *zfield_parser, const int lev)
 {
 
     const auto dx_lev = geom[lev].CellSizeArray();
@@ -403,16 +403,9 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
     amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
     for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-       // Box index-space includes the staggering of the multifabs
-       amrex::Box tbx = mfi.tilebox( x_nodal_flag );
-       amrex::Box tby = mfi.tilebox( y_nodal_flag );
-       amrex::Box tbz = mfi.tilebox( z_nodal_flag );
-       if (init_guard_cells) {
-           // Box index-space includes staggering and guard cells of multifabs
-           tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
-           tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
-           tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
-       }
+       const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
+       const amrex::Box& tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
+       const amrex::Box& tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
 
        auto const& mfxfab = mfx->array(mfi);
        auto const& mfyfab = mfy->array(mfi);

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -393,7 +393,7 @@ void
 WarpX::InitializeExternalFieldsOnGridUsingParser (
        MultiFab *mfx, MultiFab *mfy, MultiFab *mfz,
        ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-       ParserWrapper<3> *zfield_parser, const int lev)
+       ParserWrapper<3> *zfield_parser, const int lev, bool init_guard_cells)
 {
 
     const auto dx_lev = geom[lev].CellSizeArray();
@@ -403,9 +403,16 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
     amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
     for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-       const Box& tbx = mfi.growntilebox(x_nodal_flag);
-       const Box& tby = mfi.growntilebox(y_nodal_flag);
-       const Box& tbz = mfi.growntilebox(z_nodal_flag);
+       // Box index-space includes the staggering of the multifabs
+       const Box& tbx = mfi.tilebox( x_nodal_flag );
+       const Box& tby = mfi.tilebox( y_nodal_flag );
+       const Box& tbz = mfi.tilebox( z_nodal_flag );
+       if (init_guard_cells) {
+           // Box index-space includes staggering and guard cells of multifabs
+           tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
+           tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
+           tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
+       }
 
        auto const& mfxfab = mfx->array(mfi);
        auto const& mfyfab = mfy->array(mfi);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -493,7 +493,7 @@ public:
     void InitializeExternalFieldsOnGridUsingParser (
          amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
          ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-         ParserWrapper<3> *zfield_parser, const int lev, init_guard_cells = true);
+         ParserWrapper<3> *zfield_parser, const int lev, bool init_guard_cells = true);
 
     /** \brief adds particle and cell contributions in cells to compute heuristic
      * cost in each box on each level, and records in `costs`

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -476,13 +476,24 @@ public:
      * This function initializes the E and B fields on each level
      * using the parser and the user-defined function for the external fields.
      * The subroutine will parse the x_/y_z_external_grid_function and
-     * then, the B or E multifab is initialized based on the (x,y,z) position
-     * on the staggered yee-grid or cell-centered grid.
+     * then, the field multifab is initialized based on the (x,y,z) position
+     * on the staggered yee-grid or cell-centered grid, in the interior cells
+     * and guard cells.
+     *
+     * \param[in] mfx, x-component of the field to be initialized
+     * \param[in] mfy, y-component of the field to be initialized
+     * \param[in] mfz, z-component of the field to be initialized
+     * \param[in] xfield_parser, parser function to initialize x-field
+     * \param[in] yfield_parser, parser function to initialize y-field
+     * \param[in] zfield_parser, parser function to initialize z-field
+     * \param[in] lev, level of the Multifabs that is initialized
+     * \param[in] init_guard_cells, boolean flag to initialize guard cells
+     *            (default value for init_guard_cells is true)
      */
     void InitializeExternalFieldsOnGridUsingParser (
          amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
          ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-         ParserWrapper<3> *zfield_parser, const int lev);
+         ParserWrapper<3> *zfield_parser, const int lev, init_guard_cells = true);
 
     /** \brief adds particle and cell contributions in cells to compute heuristic
      * cost in each box on each level, and records in `costs`

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -487,13 +487,11 @@ public:
      * \param[in] yfield_parser, parser function to initialize y-field
      * \param[in] zfield_parser, parser function to initialize z-field
      * \param[in] lev, level of the Multifabs that is initialized
-     * \param[in] init_guard_cells, boolean flag to initialize guard cells
-     *            (default value for init_guard_cells is true)
      */
     void InitializeExternalFieldsOnGridUsingParser (
          amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
          ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-         ParserWrapper<3> *zfield_parser, const int lev, bool init_guard_cells = true);
+         ParserWrapper<3> *zfield_parser, const int lev);
 
     /** \brief adds particle and cell contributions in cells to compute heuristic
      * cost in each box on each level, and records in `costs`


### PR DESCRIPTION
Currently, when we initialize E and B fields using a constant value with the amrex::setVal function, i.e., `mf.setVal( constant_val )`, it initializes the interior cells and guard cells with the constant value.
But, when we use the parser to  initialize the E-B fields, the current implementation only included the interior cells and not the guard cells. 

In this PR, the Box used to loop over the cells is grown to include that nodal_staggering and guard cells of the respective multifabs.

Depends on https://github.com/AMReX-Codes/amrex/pull/1059