### PR TITLE
Moved ShiftGalileanBoundary() call

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -162,6 +162,8 @@ WarpX::Evolve (int numsteps)
 
         cur_time += dt[0];
 
+        ShiftGalileanBoundary();
+
         if (do_back_transformed_diagnostics) {
             std::unique_ptr<MultiFab> cell_centered_data = nullptr;
             if (WarpX::do_back_transformed_fields) {
@@ -173,8 +175,6 @@ WarpX::Evolve (int numsteps)
         bool move_j = is_synchronized;
         // If is_synchronized we need to shift j too so that next step we can evolve E by dt/2.
         // We might need to move j because we are going to make a plotfile.
-
-        ShiftGalileanBoundary();
 
         int num_moved = MoveWindow(move_j);
 


### PR DESCRIPTION
This PR moves the call of ShiftGalileanBoundary() to update the grid points positions before the back transformed diagnostics.