### PR TITLE
Docs: Ascent & Python Summit Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,13 +152,6 @@ set_target_properties(WarpX PROPERTIES
 # link dependencies
 target_link_libraries(WarpX PUBLIC WarpX::thirdparty::AMReX)
 
-if(WarpX_ASCENT)
-    # work-around until ascent's CMake Config scripts are properly placed
-    #   https://github.com/Alpine-DAV/ascent/pull/540
-    target_include_directories(WarpX SYSTEM PUBLIC ${Ascent_DIR}/../../include)
-    target_include_directories(WarpX SYSTEM PUBLIC ${Ascent_DIR}/../../include/ascent)
-endif()
-
 if(WarpX_PSATD)
     if(ENABLE_CUDA)
         # CUDA_ADD_CUFFT_TO_TARGET(WarpX)

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -21,6 +21,17 @@ If you are new to this system, please see the following resources:
 Installation
 ------------
 
+Use the following commands to download the WarpX source code and switch to the correct branch:
+
+.. code-block:: bash
+
+   mkdir ~/src
+   cd ~/src
+
+   git clone https://github.com/ECP-WarpX/WarpX.git warpx
+   git clone --branch QED https://github.com/ECP-WarpX/picsar.git
+   git clone --branch development https://github.com/AMReX-Codes/amrex.git
+
 We use the following modules and environments on the system.
 
 .. code-block:: bash
@@ -49,16 +60,21 @@ We use the following modules and environments on the system.
    export CMAKE_PREFIX_PATH=$HOME/sw/openPMD-api-install:$CMAKE_PREFIX_PATH
 
    # optional: Ascent in situ support
-   #   note: you cannot yet use openPMD with parallel HDF5 and
-   #         Ascent (with serial HDF5) at the same time
+   #   note: build WarpX with CMake
    export Alpine=/gpfs/alpine/world-shared/csc340/software/ascent/0.5.3-pre/summit/cuda/gnu
    export Ascent_DIR=$Alpine/ascent-install
    export Conduit_DIR=$Alpine/conduit-install
-   #   work-around for ill-placed AscentConfig.cmake
-   export Ascent_DIR=$Ascent_DIR/lib/cmake
 
-   # optional: for Ascent support (work-in-progress)
-   export ASCENT_DIR=/gpfs/alpine/world-shared/csc340/software/ascent/0.5.3-pre/summit/cuda/gnu/ascent-install/
+   # optional: for Python bindings or libEnsemble
+   module load python/3.7.0
+
+   # optional: for libEnsemble
+   module load openblas/0.3.9-omp
+   module load netlib-lapack/3.8.0
+   if [ -d "$HOME/sw/venvs/warpx-libE" ]
+   then
+     source $HOME/sw/venvs/warpx-libE/bin/activate
+   fi
 
    # optional: just an additional text editor
    module load nano
@@ -82,17 +98,6 @@ We recommend to store the above lines in a file, such as ``$HOME/warpx.profile``
 
    source $HOME/warpx.profile
 
-Use the following commands to download the WarpX source code and switch to the correct branch:
-
-.. code-block:: bash
-
-   mkdir ~/src
-   cd ~/src
-
-   git clone https://github.com/ECP-WarpX/WarpX.git warpx
-   git clone --branch QED https://github.com/ECP-WarpX/picsar.git
-   git clone --branch development https://github.com/AMReX-Codes/amrex.git
-
 Optionally, download and build openPMD-api for I/O:
 
 .. code-block:: bash
@@ -102,6 +107,22 @@ Optionally, download and build openPMD-api for I/O:
    cd openPMD-api-build
    cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/openPMD-api-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
    cmake --build . --target install --parallel 16
+
+Optionally, download and install :ref:`libEnsemble <libensemble>` for dynamic ensemble optimizations:
+
+.. code-block:: bash
+
+   export BLAS=$OLCF_OPENBLAS_ROOT/lib/libopenblas.so
+   export LAPACK=$OLCF_NETLIB_LAPACK_ROOT/lib64/liblapack.so
+   python3 -m pip install --user --upgrade pip
+   python3 -m pip install --user virtualenv
+   python3 -m venv $HOME/sw/venvs/warpx-libE
+   source $HOME/sw/venvs/warpx-libE/bin/activate
+   python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade cython
+   python3 -m pip install --upgrade numpy
+   python3 -m pip install --upgrade scipy
+   python3 -m pip install --upgrade -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
 Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -88,6 +88,7 @@ We use the following modules and environments on the system.
    # compiler environment hints
    export CC=$(which gcc)
    export CXX=$(which g++)
+   export FC=$(which gfortran)
    export CUDACXX=$(which nvcc)
    export CUDAHOSTCXX=$(which g++)
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -123,6 +123,7 @@ Optionally, download and install :ref:`libEnsemble <libensemble>` for dynamic en
    python3 -m pip install --upgrade cython
    python3 -m pip install --upgrade numpy
    python3 -m pip install --upgrade scipy
+   python3 -m pip install --upgrade mpi4py --no-binary mpi4py
    python3 -m pip install --upgrade -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
 Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:

--- a/Docs/source/libensemble/libensemble.rst
+++ b/Docs/source/libensemble/libensemble.rst
@@ -133,6 +133,12 @@ This is adapted to a 4-core machine, as it will use:
 Run on Summit at OLCF
 ^^^^^^^^^^^^^^^^^^^^^
 
+- ``cp -r $HOME/warpx/Tools/LibEnsemble/* sim_directory``
+- modify ``run_libensemble_on_warpx.py`` to have ``machine = 'summit'``
+- modify ``all_machine_specs.py`` to put the right path to the WarpX executable
+- modify ``summit_submit_mproc.sh`` to set ``LIBE_PLOTS`` to ``false`` and set the project ID
+- ``bsub summit_submit_mproc.sh``:
+
 .. code-block:: sh
 
     bsub summit_submit_mproc.sh

--- a/Docs/source/libensemble/libensemble.rst
+++ b/Docs/source/libensemble/libensemble.rst
@@ -49,7 +49,7 @@ You can either install all packages via `conda` (recommended),
 
    conda install -c conda-forge libensemble matplotlib numpy scipy yt
 
-or try to install the same dependencies via `pip` (pick one *or* the other):
+or try to install the same dependencies via `pip` (pick one *or* the other; note our :ref:`installation details on Summit <building-summit>`):
 
 .. literalinclude:: ../../../Tools/LibEnsemble/requirements.txt
 

--- a/Docs/source/libensemble/libensemble.rst
+++ b/Docs/source/libensemble/libensemble.rst
@@ -1,3 +1,5 @@
+.. _libensemble:
+
 Run LibEnsemble on WarpX
 ========================
 

--- a/Tools/LibEnsemble/requirements.txt
+++ b/Tools/LibEnsemble/requirements.txt
@@ -5,3 +5,4 @@ pytest
 libensemble
 yt
 nlopt
+


### PR DESCRIPTION
Updates the instructions on how to use Python with WarpX, e.g. for libEnsemble runs on Summit or when building the python bindings.

Also simplifies Ascent build after https://github.com/Alpine-DAV/ascent/pull/540 was merged (CMake on Summit: `cmake .. -DWarpX_ASCENT=ON -DWarpX_COMPUTE=CUDA`)