### PR TITLE
PSATD: current correction works only with global FFTs

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1073,10 +1073,19 @@ Numerics and algorithms
     See `this section of the FFTW documentation <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`__
     for more information.
 
-* ``psatd.do_current_correction`` (`0` or `1`; default: `0`)
-    If true, the current correction defined by equation (19) of
-    `(Vay et al, JCP 243, 2013) <https://doi.org/10.1016/j.jcp.2013.03.010>`_ is applied.
-    Only used when compiled and running with the PSATD solver.
+* ``psatd.current_correction`` (`0` or `1`; default: `0`)
+    If true, the current correction `(Vay et al, JCP 243, 2013) <https://doi.org/10.1016/j.jcp.2013.03.010>`_
+
+    .. math::
+       \widetilde{\boldsymbol{J}}^{\,n+1/2}_{\mathrm{correct}} = \widetilde{\boldsymbol{J}}^{\,n+1/2}
+       -\bigg[\boldsymbol{k}\cdot\widetilde{\boldsymbol{J}}^{\,n+1/2}
+       -i\frac{\widetilde{\rho}^{n+1}-\widetilde{\rho}^{n}}{\Delta t}\bigg]
+       \frac{\boldsymbol{k}}{k^2}
+
+    is applied. This option guarantees charge conservation only when used in combination
+    with ``psatd.periodic_single_box_fft=1``, that is, only for periodic single-box
+    simulations with global FFTs without guard cells. The implementation for domain
+    decomposition with local FFTs over guard cells is planned but not yet completed.
 
 * ``pstad.v_galilean`` (`3 floats`, in units of the speed of light; default `0. 0. 0.`)
     Defines the galilean velocity.

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -29,7 +29,7 @@ import checksumAPI
 # this will be the name of the plot file
 fn = sys.argv[1]
 
-# Parse test name and check if current correction (psatd.do_current_correction=1) is applied
+# Parse test name and check if current correction (psatd.current_correction=1) is applied
 current_correction = True if re.search( 'current_correction', fn ) else False
 
 # Parameters (these parameters must match the parameters in `inputs.multi.rt`)
@@ -127,7 +127,7 @@ print("tolerance_rel: " + str(tolerance_rel))
 assert( error_rel < tolerance_rel )
 
 # Check relative L-infinity spatial norm of rho/epsilon_0 - div(E) when
-# current correction (psatd.do_current_correction=1) is applied
+# current correction (psatd.current_correction=1) is applied
 if current_correction:
     rho  = data['rho' ].to_ndarray()
     divE = data['divE'].to_ndarray()

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -29,7 +29,7 @@ import checksumAPI
 # this will be the name of the plot file
 fn = sys.argv[1]
 
-# Parse test name and check if current correction (psatd.do_current_correction=1) is applied
+# Parse test name and check if current correction (psatd.current_correction=1) is applied
 current_correction = True if re.search( 'current_correction', fn ) else False
 
 # Parameters (these parameters must match the parameters in `inputs.multi.rt`)
@@ -103,7 +103,7 @@ print("tolerance_rel: " + str(tolerance_rel))
 assert( error_rel < tolerance_rel )
 
 # Check relative L-infinity spatial norm of rho/epsilon_0 - div(E) when
-# current correction (psatd.do_current_correction=1) is applied
+# current correction (psatd.current_correction=1) is applied
 if current_correction:
     rho  = data['rho' ].to_ndarray()
     divE = data['divE'].to_ndarray()

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -453,7 +453,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
         if self.method == 'PSATD':
             self.periodic_single_box_fft = kw.pop('warpx_periodic_single_box_fft', None)
             self.fftw_plan_measure = kw.pop('warpx_fftw_plan_measure', None)
-            self.do_current_correction = kw.pop('warpx_do_current_correction', None)
+            self.current_correction = kw.pop('warpx_current_correction', None)
 
     def initialize_inputs(self):
 
@@ -466,7 +466,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
         if self.method == 'PSATD':
             pywarpx.psatd.periodic_single_box_fft = self.periodic_single_box_fft
             pywarpx.psatd.fftw_plan_measure = self.fftw_plan_measure
-            pywarpx.psatd.do_current_correction = self.do_current_correction
+            pywarpx.psatd.current_correction = self.current_correction
 
             if self.stencil_order is not None:
                 pywarpx.psatd.nox = self.stencil_order[0]

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_psatd_current_correction_nodal.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_psatd_current_correction_nodal.json
@@ -2,31 +2,31 @@
   "electrons": {
     "particle_cpu": 0.0,
     "particle_id": 2229305344.0,
-    "particle_momentum_x": 5.658193607299875e-20,
+    "particle_momentum_x": 5.666933339402305e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 5.658193607299919e-20,
+    "particle_momentum_z": 5.66693333940231e-20,
     "particle_position_x": 0.65536,
     "particle_position_y": 0.65536,
     "particle_weight": 3200000000000000.5
   },
   "lev=0": {
-    "Ex": 3797003259305.1904,
+    "Ex": 3754823063509.187,
     "Ey": 0.0,
-    "Ez": 3797003259305.2344,
-    "divE": 2.383282496736726e+18,
-    "jx": 1.0086760816184212e+16,
+    "Ez": 3754823063509.1787,
+    "divE": 2.3596320673507973e+18,
+    "jx": 1.0088801837356758e+16,
     "jy": 0.0,
-    "jz": 1.0086760816184312e+16,
+    "jz": 1.008880183735675e+16,
     "part_per_cell": 131072.0,
-    "rho": 21102030.83706584
+    "rho": 20892625.49342951
   },
   "positrons": {
     "particle_cpu": 0.0,
     "particle_id": 6725599232.0,
-    "particle_momentum_x": 5.658193607299875e-20,
+    "particle_momentum_x": 5.666933339402305e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 5.658193607299919e-20,
-    "particle_position_x": 0.65536,
+    "particle_momentum_z": 5.66693333940231e-20,
+    "particle_position_x": 0.6553599999999999,
     "particle_position_y": 0.65536,
     "particle_weight": 3200000000000000.5
   }

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_psatd_current_correction_nodal.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_psatd_current_correction_nodal.json
@@ -1,0 +1,33 @@
+{
+  "electrons": {
+    "particle_cpu": 0.0,
+    "particle_id": 37409652736.0,
+    "particle_momentum_x": 9.427560635869364e-20,
+    "particle_position_x": 2.6214400000000015,
+    "particle_position_y": 2.621440000000001,
+    "particle_position_z": 2.6214399999999998,
+    "particle_weight": 128000000000.00002
+  },
+  "lev=0": {
+    "Bx": 17.49996248979552,
+    "By": 17.499962489807935,
+    "Bz": 17.499962489796665,
+    "Ex": 85654801346583.62,
+    "Ey": 85654801346583.34,
+    "Ez": 85654801346583.31,
+    "divE": 8.073511509609898e+19,
+    "jx": 5.898369391324192e+16,
+    "jy": 5.898369391324414e+16,
+    "jz": 5.898369391324419e+16,
+    "part_per_cell": 524288.0,
+    "rho": 714843872.1488855
+  },
+  "positrons": {
+    "particle_cpu": 0.0,
+    "particle_id": 112722575360.0,
+    "particle_momentum_z": 9.427560635869377e-20,
+    "particle_position_x": 2.6214400000000015,
+    "particle_position_y": 2.621440000000001,
+    "particle_position_z": 2.6214399999999998
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -381,7 +381,26 @@ tolerance = 5.e-11
 [Langmuir_multi_psatd_current_correction]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.do_current_correction=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE
+runtime_params = algo.current_deposition=esirkepov psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+tolerance = 5.e-11
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_current_correction_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
+runtime_params = algo.current_deposition=direct psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.do_nodal=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -514,7 +533,25 @@ tolerance = 1.e-14
 [Langmuir_multi_2d_psatd_current_correction]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = amr.max_grid_size=128 psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.do_current_correction=1 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot =Ex Ey Ez jx jy jz part_per_cell rho divE
+runtime_params = amr.max_grid_size=128 algo.current_deposition=esirkepov psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot =Ex Ey Ez jx jy jz part_per_cell rho divE
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+[Langmuir_multi_2d_psatd_current_correction_nodal]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+runtime_params = amr.max_grid_size=128 algo.current_deposition=direct psatd.fftw_plan_measure=0 psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.do_nodal=1 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot =Ex Ey Ez jx jy jz part_per_cell rho divE
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -136,10 +136,11 @@ public:
     static int em_solver_medium;
     static int macroscopic_solver_algo;
 
-    // Static public variable to switch on current correction in Fourier space
-    // (equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010): can be set
-    // true by the user as an input parameter
+#ifdef WARPX_USE_PSATD
+    // If true (overwritten by the user in the input file), the current correction
+    // defined in equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010 is applied
     bool current_correction = false;
+#endif
 
     // div E cleaning
     static int do_dive_cleaning;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -139,7 +139,7 @@ public:
     // Static public variable to switch on current correction in Fourier space
     // (equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010): can be set
     // true by the user as an input parameter
-    bool do_current_correction = false;
+    bool current_correction = false;
 
     // div E cleaning
     static int do_dive_cleaning;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -605,7 +605,7 @@ WarpX::ReadParameters ()
         pp.query("nox", nox_fft);
         pp.query("noy", noy_fft);
         pp.query("noz", noz_fft);
-        pp.query("do_current_correction", do_current_correction);
+        pp.query("current_correction", current_correction);
         pp.query("v_galilean", v_galilean);
       // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) v_galilean[i] *= PhysConst::c;


### PR DESCRIPTION
**Goal**

This PR cleans up the implementation of the current correction for the PSATD solver, as a preliminary step for an upcoming PR, which will address the implementation of the corresponding correction for Galilean PSATD.

**Main changes**

1. Input parameter `psatd.do_current_correction` renamed as `psatd.current_correction`
(the `do_` prefix in the old paramater was redundant and needlessly longer; moreover, this option is currently used by only very few users, thus renaming does not disrupt existing workflows);
2. WarpX runs are now aborted when both `psatd.current_correction=1` and `psatd.periodic_single_box_fft=0`: so far, the current implementation guarantees charge conservation only with global FFTs without guard cells;
3. Two tests added, identical to the previous ones but on nodal grids (`warpx.do_nodal=1`) and with direct current deposition;
4. Previous 2D test on staggered grid uses now Esirkepov deposition, as its corresponding 3D test: both deposition schemes are, therefore, equally tested in both 2D and 3D;
5. Relevant checksum benchmarks added/updated;
6. Online documentation improved with more details.
