### PR TITLE
Use PICSAR new development branch

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -17,10 +17,10 @@ extraction:
       - unzip development.zip
       - mv amrex-development third-party/amrex
       - rm development.zip
-      - wget https://github.com/ECP-WarpX/picsar/archive/master.zip
-      - unzip master.zip
-      - mv picsar-master third-party/picsar
-      - rm master.zip
+      - wget https://github.com/ECP-WarpX/picsar/archive/development.zip
+      - unzip development.zip
+      - mv picsar-development third-party/picsar
+      - rm development.zip
     configure:
       command:
       - echo "Yeah"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,7 +33,7 @@ Then, you can execute:
    # These 4 first lines are the same as for a standard WarpX install
    mkdir warpx_directory
    cd warpx_directory
-   git clone --branch master https://github.com/ECP-WarpX/picsar.git
+   git clone --branch development https://github.com/ECP-WarpX/picsar.git
    git clone --branch development https://github.com/AMReX-Codes/amrex.git
 
    # Clone your fork on your local computer. You can get this address on your fork's Github page.

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -56,7 +56,7 @@ branch = development
 
 [extra-PICSAR]
 dir = /home/regtester/git/picsar/
-branch = master
+branch = development
 
 # individual problems follow
 

--- a/Tools/PerformanceTests/run_alltests.py
+++ b/Tools/PerformanceTests/run_alltests.py
@@ -346,4 +346,4 @@ if args.mode == 'read':
     if args.commit == True:
         os.system('git add ' + log_dir + log_file + ';'\
                   'git commit -m "performance tests";'\
-                  'git push -u origin master')
+                  'git push -u origin development')

--- a/Tools/PerformanceTests/run_alltests_1node.py
+++ b/Tools/PerformanceTests/run_alltests_1node.py
@@ -298,7 +298,7 @@ if args.mode == 'read':
     if do_commit == True:
         os.system('git add ' + log_dir + log_file + ';'\
                   'git commit -m "performance tests";'\
-                  'git push -u origin master')
+                  'git push -u origin development')
 
     # Plot file
     import numpy as np

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -44,7 +44,7 @@ if(WarpX_QED)
     set(WarpX_picsar_repo "https://github.com/ECP-WarpX/picsar.git"
         CACHE STRING
         "Repository URI to pull and build PICSAR from if(WarpX_picsar_internal)")
-    set(WarpX_picsar_branch "master"
+    set(WarpX_picsar_branch "development"
         CACHE STRING
         "Repository branch for WarpX_picsar_repo if(WarpX_picsar_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -52,7 +52,7 @@ git clone --branch development https://github.com/AMReX-Codes/amrex.git
 if [ "${WARPX_CI_QED}" = "TRUE" ]; then
     git clone --branch QED https://github.com/ECP-WarpX/picsar.git
 else
-    git clone --branch master https://github.com/ECP-WarpX/picsar.git
+    git clone --branch development https://github.com/ECP-WarpX/picsar.git
 fi
 
 # Clone the AMReX regression test utility


### PR DESCRIPTION
I've created a new default branch named `development` for picsar. Before deleting the `master` branch of picsar, we need to make sure that warpx uses the `development` branch and that everything works fine.

Note that for the files `run_alltests_1node.py` and `run_alltests.py` I don't think the change in this PR is related to picsar. I'm not sure if we forgot to update these files when changing the default WarpX branch to `development` or if these test scripts are outdated (the changed lines date from 3 years ago). Is it ok to change master to development here?