### PR TITLE
[WIP] CMake: Final Link with CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if(ENABLE_CUDA)
         set_target_properties(WarpX PROPERTIES
             CUDA_EXTENSIONS OFF
             CUDA_STANDARD_REQUIRED ON
+            CUDA_RESOLVE_DEVICE_SYMBOLS ON
         )
     endif()
 endif()


### PR DESCRIPTION
With RDC, adding a specific device link step can separate out CUDA and other linker flags. This should mitigate unknown linker flags when linking Spectrum MPI (`-pthread`) and CUDA nvcc as "linker" on LLNL/Lassen.

cc @bzdjordje 
https://github.com/ECP-WarpX/WarpX/issues/1132#issuecomment-654091290