### PR TITLE
[mini PR] At Initialization, step = -1 for diagnostics

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -65,7 +65,7 @@ WarpX::InitData ()
 
     if (restart_chkfile.empty())
     {
-        multi_diags->FilterComputePackFlush( 0, true );
+        multi_diags->FilterComputePackFlush( -1, true );
 
         // Write reduced diagnostics before the first iteration.
         if (reduced_diags->m_plot_rd != 0)


### PR DESCRIPTION
At initialization, the step interval should be -1 for "FilterComputePackFlush(int step, bool force_flush)" function, similar to what is done for reduced diagnostics
reduced_diags->ComputeDiags(-1)
reduced_diags->WriteToFile(-1).

This ensures that for BackTransformedDiagnostics, we dont perform computation twice, namely at initialization and again at
 step == 0 when the PIC loop begins.

