### PR TITLE
openPMD: Directory Cleanup, 6 Digits

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -174,12 +174,12 @@ WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
 //
 void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 {
-  filename.append(m_OpenPMDFileType).append("/simData");
+  filename.append("/openpmd");
   //
   // OpenPMD supports timestepped names
   //
   if (m_OneFilePerTS)
-      filename = filename.append("_%07T");
+      filename = filename.append("_%06T");
   filename.append(".").append(m_OpenPMDFileType);
 }
 


### PR DESCRIPTION
This reorders the naming of diagnostics to be a bit more readable.

Currently it was:
```bash
$ ls Bin/diags/
diag1bp/<N>.bp
diag1h5/<N>.h5
...
diag100000
diag100100
     <N>
     ...
```

Now it proposes for openPMD output
```bash
$ ls Bin/diags/
diag1/openpmd_<N>.bp
diag1/openpmd_<N>.h5
```

This is also a bit easier for some tooling (i.e. yt and openPMD-viewer that expect full consistent dirs atm.) and keeps things nicely together.

Also bumps the zero-padding to use consistently 6 digits for iterations in output files (<1M iterations), since sims (ions) with >100k steps are not uncommon.

This does not yet change plot files #1087, since this is still requiring to make the regression testing scripts more flexible (and I did not have time to do this yet).