### PR TITLE
Raise the stack limit when running with cuda

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -34,6 +34,11 @@ int main(int argc, char* argv[])
 
     amrex::Initialize(argc,argv);
 
+    // we need a larger stack limit that usual bc of the parser.
+#if defined(AMREX_USE_GPU) && defined(AMREX_USE_CUDA)
+    AMREX_CUDA_SAFE_CALL(cudaDeviceSetLimit(cudaLimitStackSize, 20*1024));
+#endif
+
     ConvertLabParamsToBoost();
 
     CheckGriddingForRZSpectral();

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -34,8 +34,8 @@ int main(int argc, char* argv[])
 
     amrex::Initialize(argc,argv);
 
-    // we need a larger stack limit that usual bc of the parser.
-#if defined(AMREX_USE_GPU) && defined(AMREX_USE_CUDA)
+    // in Debug mode, we need a larger stack limit than usual bc of the parser.
+#if defined(AMREX_USE_CUDA) && defined(AMREX_DEBUG)
     AMREX_CUDA_SAFE_CALL(cudaDeviceSetLimit(cudaLimitStackSize, 20*1024));
 #endif
 


### PR DESCRIPTION
The `GetExternalEField` and `GetExternalBField` functors use a lot of stack memory, I think because of the use of recursive functions in the parser. This PR proposes that we raise the limit, which fixes #1153. 

In the future, we made to explore alternative approaches to recursive functions - for one thing, DPC++ doesn't support them.