### PR TITLE
Fix compilation of AvgGalilean for GPU

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.H
@@ -19,7 +19,12 @@ class AvgGalileanAlgorithm : public SpectralBaseAlgorithm
         virtual void pushSpectralFields (SpectralFieldData& f) const override final;
         virtual int getRequiredNumberOfFields () const override final {
              return SpectralAvgFieldIndex::n_fields;
-    }
+        };
+        void InitializeSpectralCoefficients(
+           const SpectralKSpace& spectral_kspace,
+           const amrex::DistributionMapping& dm,
+           const amrex::Array<amrex::Real, 3>& v_galilean,
+           const amrex::Real dt);
 
     private:
         SpectralRealCoefficients C_coef, S_ck_coef, C1_coef, C3_coef, S1_coef,S3_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.cpp
@@ -11,7 +11,7 @@ AvgGalileanAlgorithm::AvgGalileanAlgorithm(const SpectralKSpace& spectral_kspace
                          const int norder_z, const bool nodal,
                          const amrex::Array<amrex::Real,3>& v_galilean,
                          const Real dt)
-     // Initialize members of base classinde
+     // Initialize members of base class
      : SpectralBaseAlgorithm( spectral_kspace, dm,
                               norder_x, norder_y, norder_z, nodal )
 {
@@ -44,6 +44,17 @@ AvgGalileanAlgorithm::AvgGalileanAlgorithm(const SpectralKSpace& spectral_kspace
     Rhonew_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
     Jcoef_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
 
+    InitializeSpectralCoefficients(spectral_kspace, dm, v_galilean, dt);
+
+}
+
+void AvgGalileanAlgorithm::InitializeSpectralCoefficients(
+         const SpectralKSpace& spectral_kspace,
+         const amrex::DistributionMapping& dm,
+         const Array<Real, 3>& v_galilean,
+         const amrex::Real dt)
+{
+    const BoxArray& ba = spectral_kspace.spectralspace_ba;
     // Fill them with the right values:
     // Loop over boxes and allocate the corresponding coefficients
     // for each box owned by the local MPI proc


### PR DESCRIPTION
The implementation of `AvgGalilean` was declaring a lambda function inside the constructor of the class ; this raises an error with cuda compilers.

This fixes this by declaring this lambda function in a separate function (similar to what it is done for regular galilean)