### PR TITLE
Default: abort_on_out_of_gpu_memory = 1

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -45,7 +45,7 @@ Overall simulation parameters
     printed to standard output. Currently only works if the Lorentz boost and
     the moving window are along the z direction.
 
-* ``warpx.verbose`` (``0`` or ``1``; default is ``0`` for false)
+* ``warpx.verbose`` (``0`` or ``1``; default is ``1`` for true)
     Controls how much information is printed to the terminal, when running WarpX.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
@@ -72,7 +72,7 @@ Overall simulation parameters
 * ``amrex.abort_on_out_of_gpu_memory``  (``0`` or ``1``; default is ``1`` for true)
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
     This will cause severe performance drops.
-    Note that even with this set to ``1`` we will not catch all out-of-memory events yet when operating close to maximum device memory.
+    Note that even with this set to ``1`` WarpX will not catch all out-of-memory events yet when operating close to maximum device memory.
     `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`_.
 
 .. _running-cpp-parameters-box:

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -45,7 +45,7 @@ Overall simulation parameters
     printed to standard output. Currently only works if the Lorentz boost and
     the moving window are along the z direction.
 
-* ``warpx.verbose`` (`0` or `1`)
+* ``warpx.verbose`` (``0`` or ``1``; default is ``0`` for false)
     Controls how much information is printed to the terminal, when running WarpX.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
@@ -61,13 +61,19 @@ Overall simulation parameters
     one should not expect to obtain the same random numbers,
     even if a fixed ``warpx.random_seed`` is provided.
 
-* ``warpx.do_electrostatic`` (`0` or `1`; default is `0`)
+* ``warpx.do_electrostatic`` (``0`` or ``1``; default is ``0`` for false)
     Run WarpX in electrostatic mode. Instead of updating the fields
     at each iteration with the full Maxwell equations, the fields are
     instead recomputed at each iteration from the (relativistic) Poisson
     equation. There is no limitation on the timestep in this case, but
     electromagnetic effects (e.g. propagation of radiation, lasers, etc.)
     are not captured.
+
+* ``amrex.abort_on_out_of_gpu_memory``  (``0`` or ``1``; default is ``1`` for true)
+    When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
+    This will cause severe performance drops.
+    Note that even with this set to ``1`` we will not catch all out-of-memory events yet when operating close to maximum device memory.
+    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`_.
 
 .. _running-cpp-parameters-box:
 

--- a/Source/Initialization/CMakeLists.txt
+++ b/Source/Initialization/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(WarpX
   PRIVATE
+    WarpXAMReXInit.cpp
     InjectorDensity.cpp
     InjectorMomentum.cpp
     PlasmaInjector.cpp

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -1,3 +1,4 @@
+CEXE_sources += WarpXAMReXInit.cpp
 CEXE_sources += WarpXInitData.cpp
 CEXE_sources += PlasmaInjector.cpp
 CEXE_sources += InjectorDensity.cpp

--- a/Source/Initialization/WarpXAMReXInit.H
+++ b/Source/Initialization/WarpXAMReXInit.H
@@ -1,0 +1,23 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_AMREX_INIT_H_
+#define WARPX_AMREX_INIT_H_
+
+#include <AMReX.H>
+
+/** Call amrex::Initialize
+ *
+ * This function calls amrex::Initialize and overwrites AMReX' defaults.
+ *
+ * @param[in] argc number of arguments from main()
+ * @param[in] argv argument strings from main()
+ * @returns pointer to an AMReX* object, forwarded from amrex::Initialize
+ */
+amrex::AMReX*
+warpx_amrex_init(int& argc, char**& argv);
+
+#endif

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -1,0 +1,44 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "Initialization/WarpXAMReXInit.H"
+
+#include <AMReX_ParmParse.H>
+
+
+namespace {
+    /** Overwrite defaults in AMReX Inputs
+     *
+     * This overwrites defaults in amrex::ParamParse for inputs.
+     */
+    void
+    overwrite_amrex_parser_defaults()
+    {
+        amrex::ParmParse pp("amrex");
+
+        // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
+        bool abort_on_out_of_gpu_memory = true; // default: false
+        pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        pp.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+    }
+}
+
+amrex::AMReX*
+warpx_amrex_init(int& argc, char**& argv)
+{
+    // note: AMReX defines a placeholder/"mock-up" for MPI_COMM_WORLD in serial builds
+    bool const build_parm_parse = true; // default
+    MPI_Comm const mpi_comm = MPI_COMM_WORLD; // default
+
+    return amrex::Initialize(
+        argc,
+        argv,
+        build_parm_parse,
+        mpi_comm,
+        overwrite_amrex_parser_defaults
+    );
+}

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -21,7 +21,7 @@ namespace {
         amrex::ParmParse pp("amrex");
 
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
-        bool abort_on_out_of_gpu_memory = true; // default: false
+        bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
         pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
         pp.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
     }
@@ -31,8 +31,8 @@ amrex::AMReX*
 warpx_amrex_init(int& argc, char**& argv)
 {
     // note: AMReX defines a placeholder/"mock-up" for MPI_COMM_WORLD in serial builds
-    bool const build_parm_parse = true; // default
-    MPI_Comm const mpi_comm = MPI_COMM_WORLD; // default
+    bool const build_parm_parse = true; // AMReX' default
+    MPI_Comm const mpi_comm = MPI_COMM_WORLD; // AMReX' default
 
     return amrex::Initialize(
         argc,

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -7,15 +7,13 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "WarpX.H"
+#include "Initialization/WarpXAMReXInit.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
 #include <AMReX.H>
-#include <AMReX_ParmParse.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
-
-#include <iostream>
 
 
 int main(int argc, char* argv[])
@@ -32,7 +30,7 @@ int main(int argc, char* argv[])
 #   endif
 #endif
 
-    amrex::Initialize(argc,argv);
+    warpx_amrex_init(argc, argv);
 
     // in Debug mode, we need a larger stack limit than usual bc of the parser.
 #if defined(AMREX_USE_CUDA) && defined(AMREX_DEBUG)


### PR DESCRIPTION
Change the default input parameter from AMReX `amrex.abort_on_out_of_gpu_memory` from false (`0`) to true (`1`).

We set this by default to avoid that users experience super-slow GPU runs when exceeding GPU memory *from initial configuration alone*. If users want to oversubscribe GPUs (with respectively severe performance drop) they should explicitly set this option.

In my opinion, this is only an intermediate solution since what we actually want on out-of-GPU memory events:
- finish current simulation step and cause a load balance or
- trigger a checkpoint and shut down cleanly
  - then the user can manually restart with more resources

We want to address the opposite case, user under-utilizes a GPU, with a warning for now.

Also, we could instead of aborting (this PR) or getting slow (old behavior) just throw a warning: https://github.com/AMReX-Codes/amrex/issues/1125

Ref.:
- https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters