### PR TITLE
Add support for infinite-order PSATD

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1052,6 +1052,7 @@ Numerics and algorithms
 
 * ``psatd.nox``, ``psatd.noy``, ``pstad.noz`` (`integer`) optional (default `16` for all)
     The order of accuracy of the spatial derivatives, when using the code compiled with a PSATD solver.
+    If ``psatd.periodic_single_box_fft`` is used, these can be set to ``inf`` for infinite-order PSATD.
 
 * ``psatd.nx_guard`, ``psatd.ny_guard``, ``psatd.nz_guard`` (`integer`) optional
     The number of guard cells to use with PSATD solver.

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -180,7 +180,6 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
 
     if (n_order == -1) { // Infinite-order case
         for ( MFIter mfi(spectralspace_ba, dm); mfi.isValid(); ++mfi ){
-            Real delta_x = dx[i_dim];
             const ManagedVector<Real>& k = k_vec[i_dim][mfi];
             ManagedVector<Real>& modified_k = modified_k_comp[mfi];
 

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -249,37 +249,37 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
  * `nodal` indicates whether this finite-difference approximation is
  * taken on a nodal grid or a staggered grid.
  */
- Vector<Real>
- getFonbergStencilCoefficients( const int n_order, const bool nodal )
- {
-     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
-                                       "n_order should be even.");
-     const int m = n_order/2;
-     Vector<Real> coefs;
-     coefs.resize( m+1 );
+Vector<Real>
+getFonbergStencilCoefficients( const int n_order, const bool nodal )
+{
+   AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
+                                     "n_order should be even.");
+   const int m = n_order/2;
+   Vector<Real> coefs;
+   coefs.resize( m+1 );
 
-     // Note: there are closed-form formula for these coefficients,
-     // but they result in an overflow when evaluated numerically.
-     // One way to avoid the overflow is to calculate the coefficients
-     // by recurrence.
+   // Note: there are closed-form formula for these coefficients,
+   // but they result in an overflow when evaluated numerically.
+   // One way to avoid the overflow is to calculate the coefficients
+   // by recurrence.
 
-     // Coefficients for nodal (a.k.a. centered) finite-difference
-     if (nodal == true) {
-         coefs[0] = -2.; // First coefficient
-         for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
-             coefs[n] = - (m+1-n)*1./(m+n)*coefs[n-1];
-         }
-     }
-     // Coefficients for staggered finite-difference
-     else {
-         Real prod = 1.;
-         for (int k=1; k<m+1; k++){
-             prod *= (m+k)*1./(4*k);
-         }
-         coefs[0] = 4*m*prod*prod; // First coefficient
-         for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
-             coefs[n] = - ((2*n-3)*(m+1-n))*1./((2*n-1)*(m-1+n))*coefs[n-1];
-         }
-     }
-     return coefs;
- }
+   // Coefficients for nodal (a.k.a. centered) finite-difference
+   if (nodal == true) {
+       coefs[0] = -2.; // First coefficient
+       for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
+           coefs[n] = - (m+1-n)*1./(m+n)*coefs[n-1];
+       }
+   }
+   // Coefficients for staggered finite-difference
+   else {
+       Real prod = 1.;
+       for (int k=1; k<m+1; k++){
+           prod *= (m+k)*1./(4*k);
+       }
+       coefs[0] = 4*m*prod*prod; // First coefficient
+       for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
+           coefs[n] = - ((2*n-3)*(m+1-n))*1./((2*n-1)*(m-1+n))*coefs[n-1];
+       }
+   }
+   return coefs;
+}

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -10,7 +10,6 @@
 
 #include <cmath>
 
-
 using namespace amrex;
 using namespace Gpu;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -169,9 +169,6 @@ SpectralKSpace::getSpectralShiftFactor( const DistributionMapping& dm,
  * \param nodal Whether the stencil is to be applied to a nodal or
                 staggered set of fields
  */
-
-
-
 KVectorComponent
 SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
                                        const int i_dim,

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -252,26 +252,26 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
 Vector<Real>
 getFonbergStencilCoefficients( const int n_order, const bool nodal )
 {
-   AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
                                      "n_order should be even.");
-   const int m = n_order/2;
-   Vector<Real> coefs;
-   coefs.resize( m+1 );
+    const int m = n_order/2;
+    Vector<Real> coefs;
+    coefs.resize( m+1 );
 
-   // Note: there are closed-form formula for these coefficients,
-   // but they result in an overflow when evaluated numerically.
-   // One way to avoid the overflow is to calculate the coefficients
-   // by recurrence.
+    // Note: there are closed-form formula for these coefficients,
+    // but they result in an overflow when evaluated numerically.
+    // One way to avoid the overflow is to calculate the coefficients
+    // by recurrence.
 
-   // Coefficients for nodal (a.k.a. centered) finite-difference
-   if (nodal == true) {
+    // Coefficients for nodal (a.k.a. centered) finite-difference
+    if (nodal == true) {
        coefs[0] = -2.; // First coefficient
        for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
            coefs[n] = - (m+1-n)*1./(m+n)*coefs[n-1];
        }
-   }
-   // Coefficients for staggered finite-difference
-   else {
+    }
+    // Coefficients for staggered finite-difference
+    else {
        Real prod = 1.;
        for (int k=1; k<m+1; k++){
            prod *= (m+k)*1./(4*k);
@@ -280,6 +280,6 @@ getFonbergStencilCoefficients( const int n_order, const bool nodal )
        for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
            coefs[n] = - ((2*n-3)*(m+1-n))*1./((2*n-1)*(m-1+n))*coefs[n-1];
        }
-   }
-   return coefs;
+    }
+    return coefs;
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -178,7 +178,7 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
     // Initialize an empty ManagedVector in each box
     KVectorComponent modified_k_comp(spectralspace_ba, dm);
 
-    if(n_order == -1){ // Infinite-order case
+    if (n_order == -1) { // Infinite-order case
         for ( MFIter mfi(spectralspace_ba, dm); mfi.isValid(); ++mfi ){
             Real delta_x = dx[i_dim];
             const ManagedVector<Real>& k = k_vec[i_dim][mfi];

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 
+
 using namespace amrex;
 using namespace Gpu;
 
@@ -169,6 +170,9 @@ SpectralKSpace::getSpectralShiftFactor( const DistributionMapping& dm,
  * \param nodal Whether the stencil is to be applied to a nodal or
                 staggered set of fields
  */
+
+
+
 KVectorComponent
 SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
                                        const int i_dim,
@@ -178,48 +182,65 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
     // Initialize an empty ManagedVector in each box
     KVectorComponent modified_k_comp(spectralspace_ba, dm);
 
-    // Compute real-space stencil coefficients
-    Vector<Real> stencil_coef = getFonbergStencilCoefficients(n_order, nodal);
+    if(n_order == -1){ // Infinite-order case
+        for ( MFIter mfi(spectralspace_ba, dm); mfi.isValid(); ++mfi ){
+            Real delta_x = dx[i_dim];
+            const ManagedVector<Real>& k = k_vec[i_dim][mfi];
+            ManagedVector<Real>& modified_k = modified_k_comp[mfi];
 
-    // Loop over boxes and allocate the corresponding ManagedVector
-    // for each box owned by the local MPI proc
-    for ( MFIter mfi(spectralspace_ba, dm); mfi.isValid(); ++mfi ){
-        Real delta_x = dx[i_dim];
-        const ManagedVector<Real>& k = k_vec[i_dim][mfi];
-        ManagedVector<Real>& modified_k = modified_k_comp[mfi];
+            // Allocate modified_k to the same size as k
+            modified_k.resize( k.size() );
 
-        // Allocate modified_k to the same size as k
-        modified_k.resize( k.size() );
-
-        // Fill the modified k vector
-        for (int i=0; i<k.size(); i++ ){
-            modified_k[i] = 0;
-            for (int n=1; n<stencil_coef.size(); n++){
-                if (nodal){
-                    modified_k[i] += stencil_coef[n]* \
-                        std::sin( k[i]*n*delta_x )/( n*delta_x );
-                } else {
-                    modified_k[i] += stencil_coef[n]* \
-                        std::sin( k[i]*(n-0.5)*delta_x )/( (n-0.5)*delta_x );
-                }
+            // Fill the modified k vector
+            for (int i=0; i<k.size(); i++ ){
+                modified_k[i] = k[i]; // infinite-order case.
             }
         }
+    } else {
 
-        // By construction, at finite order and for a nodal grid,
-        // the *modified* k corresponding to the Nyquist frequency
-        // (i.e. highest *real* k) is 0. However, the above calculation
-        // based on stencil coefficients does not give 0 to machine precision.
-        // Therefore, we need to enforce the fact that the modified k be 0 here.
-        if (nodal){
-            if (i_dim == 0){
-                // Because of the real-to-complex FFTs, the first axis (idim=0)
-                // contains only the positive k, and the Nyquist frequency is
-                // the last element of the array.
-                modified_k[k.size()-1] = 0.0_rt;
-            } else {
-                // The other axes contains both positive and negative k ;
-                // the Nyquist frequency is in the middle of the array.
-                modified_k[k.size()/2] = 0.0_rt;
+        // Compute real-space stencil coefficients
+        Vector<Real> stencil_coef = getFonbergStencilCoefficients(n_order, nodal);
+
+        // Loop over boxes and allocate the corresponding ManagedVector
+        // for each box owned by the local MPI proc
+        for ( MFIter mfi(spectralspace_ba, dm); mfi.isValid(); ++mfi ){
+            Real delta_x = dx[i_dim];
+            const ManagedVector<Real>& k = k_vec[i_dim][mfi];
+            ManagedVector<Real>& modified_k = modified_k_comp[mfi];
+
+            // Allocate modified_k to the same size as k
+            modified_k.resize( k.size() );
+
+            // Fill the modified k vector
+            for (int i=0; i<k.size(); i++ ){
+                modified_k[i] = 0;
+                for (int n=1; n<stencil_coef.size(); n++){
+                    if (nodal){
+                        modified_k[i] += stencil_coef[n]* \
+                            std::sin( k[i]*n*delta_x )/( n*delta_x );
+                    } else {
+                        modified_k[i] += stencil_coef[n]* \
+                            std::sin( k[i]*(n-0.5)*delta_x )/( (n-0.5)*delta_x );
+                    }
+                }
+            }
+
+            // By construction, at finite order and for a nodal grid,
+            // the *modified* k corresponding to the Nyquist frequency
+            // (i.e. highest *real* k) is 0. However, the above calculation
+            // based on stencil coefficients does not give 0 to machine precision.
+            // Therefore, we need to enforce the fact that the modified k be 0 here.
+            if (nodal){
+                if (i_dim == 0){
+                    // Because of the real-to-complex FFTs, the first axis (idim=0)
+                    // contains only the positive k, and the Nyquist frequency is
+                    // the last element of the array.
+                    modified_k[k.size()-1] = 0.0_rt;
+              }   else {
+                    // The other axes contains both positive and negative k ;
+                    // the Nyquist frequency is in the middle of the array.
+                    modified_k[k.size()/2] = 0.0_rt;
+              }
             }
         }
     }
@@ -233,37 +254,37 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
  * `nodal` indicates whether this finite-difference approximation is
  * taken on a nodal grid or a staggered grid.
  */
-Vector<Real>
-getFonbergStencilCoefficients( const int n_order, const bool nodal )
-{
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
-                                      "n_order should be even.");
-    const int m = n_order/2;
-    Vector<Real> coefs;
-    coefs.resize( m+1 );
+ Vector<Real>
+ getFonbergStencilCoefficients( const int n_order, const bool nodal )
+ {
+     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_order%2 == 0,
+                                       "n_order should be even.");
+     const int m = n_order/2;
+     Vector<Real> coefs;
+     coefs.resize( m+1 );
 
-    // Note: there are closed-form formula for these coefficients,
-    // but they result in an overflow when evaluated numerically.
-    // One way to avoid the overflow is to calculate the coefficients
-    // by recurrence.
+     // Note: there are closed-form formula for these coefficients,
+     // but they result in an overflow when evaluated numerically.
+     // One way to avoid the overflow is to calculate the coefficients
+     // by recurrence.
 
-    // Coefficients for nodal (a.k.a. centered) finite-difference
-    if (nodal == true) {
-        coefs[0] = -2.; // First coefficient
-        for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
-            coefs[n] = - (m+1-n)*1./(m+n)*coefs[n-1];
-        }
-    }
-    // Coefficients for staggered finite-difference
-    else {
-        Real prod = 1.;
-        for (int k=1; k<m+1; k++){
-            prod *= (m+k)*1./(4*k);
-        }
-        coefs[0] = 4*m*prod*prod; // First coefficient
-        for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
-            coefs[n] = - ((2*n-3)*(m+1-n))*1./((2*n-1)*(m-1+n))*coefs[n-1];
-        }
-    }
-    return coefs;
-}
+     // Coefficients for nodal (a.k.a. centered) finite-difference
+     if (nodal == true) {
+         coefs[0] = -2.; // First coefficient
+         for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
+             coefs[n] = - (m+1-n)*1./(m+n)*coefs[n-1];
+         }
+     }
+     // Coefficients for staggered finite-difference
+     else {
+         Real prod = 1.;
+         for (int k=1; k<m+1; k++){
+             prod *= (m+k)*1./(4*k);
+         }
+         coefs[0] = 4*m*prod*prod; // First coefficient
+         for (int n=1; n<m+1; n++){ // Get the other coefficients by recurrence
+             coefs[n] = - ((2*n-3)*(m+1-n))*1./((2*n-1)*(m-1+n))*coefs[n-1];
+         }
+     }
+     return coefs;
+ }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -644,6 +644,8 @@ WarpX::ReadParameters ()
         pp.query("current_correction", current_correction);
         pp.query("update_with_rho", update_with_rho);
         pp.query("v_galilean", v_galilean);
+        pp.query("do_time_averaging", fft_do_time_averaging);
+        
       // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) v_galilean[i] *= PhysConst::c;
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -644,7 +644,7 @@ WarpX::ReadParameters ()
         pp.query("current_correction", current_correction);
         pp.query("update_with_rho", update_with_rho);
         pp.query("v_galilean", v_galilean);
-        pp.query("do_time_averaging", fft_do_time_averaging); 
+        pp.query("do_time_averaging", fft_do_time_averaging);
 
       // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) v_galilean[i] *= PhysConst::c;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -636,9 +636,9 @@ WarpX::ReadParameters ()
 
 
         if (!fft_periodic_single_box) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
         }
 
         pp.query("current_correction", current_correction);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -635,7 +635,7 @@ WarpX::ReadParameters ()
         }
 
 
-        if(!fft_periodic_single_box){
+        if (!fft_periodic_single_box) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -610,13 +610,40 @@ WarpX::ReadParameters ()
         ParmParse pp("psatd");
         pp.query("periodic_single_box_fft", fft_periodic_single_box);
         pp.query("fftw_plan_measure", fftw_plan_measure);
-        pp.query("nox", nox_fft);
-        pp.query("noy", noy_fft);
-        pp.query("noz", noz_fft);
+        std::string nox_str;
+        std::string noy_str;
+        std::string noz_str;
+
+        pp.query("nox", nox_str);
+        pp.query("noy", noy_str);
+        pp.query("noz", noz_str);
+
+        if(nox_str == "inf"){
+            nox_fft = -1;
+        } else{
+            pp.query("nox", nox_fft);
+        }
+        if(noy_str == "inf"){
+            noy_fft = -1;
+        } else{
+            pp.query("noy", noy_fft);
+        }
+        if(noz_str == "inf"){
+            noz_fft = -1;
+        } else{
+            pp.query("noz", noz_fft);
+        }
+
+
+        if(!fft_periodic_single_box){
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless periodic_single_box_fft is used");
+        }
+
         pp.query("current_correction", current_correction);
         pp.query("update_with_rho", update_with_rho);
         pp.query("v_galilean", v_galilean);
-        pp.query("do_time_averaging", fft_do_time_averaging);
       // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) v_galilean[i] *= PhysConst::c;
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -644,8 +644,8 @@ WarpX::ReadParameters ()
         pp.query("current_correction", current_correction);
         pp.query("update_with_rho", update_with_rho);
         pp.query("v_galilean", v_galilean);
-        pp.query("do_time_averaging", fft_do_time_averaging);
-        
+        pp.query("do_time_averaging", fft_do_time_averaging); 
+
       // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) v_galilean[i] *= PhysConst::c;
     }


### PR DESCRIPTION
When `periodic_single_box_fft = 1`, the user can set PSATD order to `inf`. For example, `psatd.nox = inf` does infinite-order PSATD along the x-direction.  If infinite PSATD order is requested without `periodic_single_box_fft`, an exception is thrown.