### PR TITLE
[WIP] Add option to match shape factors

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1023,6 +1023,11 @@ Numerics and algorithms
     Note that the implementation in WarpX is more efficient when these 3 numbers are equal,
     and when they are between 1 and 3.
 
+* ``interpolation.match_shape_factors`` (`0` or `1` ; default: `0`)
+    On a staggered grid, default shape factors are different for different field components.
+    When ``match_shape_factors = 1``, shape factors are of the same order for every field component along every direction.
+    If `psatd.do_nodal = 1`, this parameter has no effect.
+
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate
     the error in :math:`div(E)-\rho`. This can be useful when using a current

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1025,7 +1025,7 @@ Numerics and algorithms
 
 * ``interpolation.match_shape_factors`` (`0` or `1` ; default: `0`)
     On a staggered grid, default shape factors are different for different field components.
-    When ``match_shape_factors = 1``, shape factors are of the same order for every field component along every direction.
+    When ``match_shape_factors = 1``, shape factors are the same for every field component.
     If `psatd.do_nodal = 1`, this parameter has no effect.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1026,7 +1026,7 @@ Numerics and algorithms
 * ``interpolation.match_shape_factors`` (`0` or `1` ; default: `0`)
     On a staggered grid, default shape factors are different for different field components.
     When ``match_shape_factors = 1``, shape factors are the same for every field component.
-    If `psatd.do_nodal = 1`, this parameter has no effect.
+    If ``psatd.do_nodal = 1``, this parameter has no effect.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -156,6 +156,7 @@ public:
     static long nox;
     static long noy;
     static long noz;
+    static bool match_shape_factors;
 
     // Number of modes for the RZ multimode version
     static long n_rz_azimuthal_modes;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -329,7 +329,7 @@ WarpX::ReadParameters ()
         pp.query("nox", nox);
         pp.query("noy", noy);
         pp.query("noz", noz);
-        pp.query("match_shape_factors", match_shape_factors)
+        pp.query("match_shape_factors", match_shape_factors);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
             "warpx.nox, noy and noz must be equal");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox >= 1, "warpx.nox must >= 1");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -570,7 +570,7 @@ WarpX::ReadParameters ()
 
         pp.query("do_nodal", do_nodal);
         // Use same shape factors in all directions, for gathering
-        if (do_nodal || match_shape_factors) l_lower_order_in_v = false;
+        if (do_nodal || WarpX::match_shape_factors) l_lower_order_in_v = false;
 
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
         pp.query("n_rz_azimuthal_modes", n_rz_azimuthal_modes);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -80,6 +80,7 @@ long WarpX::ncomps = 1;
 long WarpX::nox = 1;
 long WarpX::noy = 1;
 long WarpX::noz = 1;
+bool WarpX::match_shape_factors = false;
 
 bool WarpX::use_fdtd_nci_corr = false;
 int  WarpX::l_lower_order_in_v = true;
@@ -324,6 +325,17 @@ WarpX::ReadParameters ()
     }
 
     {
+        ParmParse pp("interpolation");
+        pp.query("nox", nox);
+        pp.query("noy", noy);
+        pp.query("noz", noz);
+        pp.query("match_shape_factors", match_shape_factors)
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
+            "warpx.nox, noy and noz must be equal");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox >= 1, "warpx.nox must >= 1");
+    }
+
+    {
         ParmParse pp("warpx");
 
         // set random seed
@@ -558,7 +570,7 @@ WarpX::ReadParameters ()
 
         pp.query("do_nodal", do_nodal);
         // Use same shape factors in all directions, for gathering
-        if (do_nodal) l_lower_order_in_v = false;
+        if (do_nodal || match_shape_factors) l_lower_order_in_v = false;
 
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
         pp.query("n_rz_azimuthal_modes", n_rz_azimuthal_modes);
@@ -573,16 +585,6 @@ WarpX::ReadParameters ()
         do_nodal = true;
         l_lower_order_in_v = false;
 #endif
-    }
-
-    {
-        ParmParse pp("interpolation");
-        pp.query("nox", nox);
-        pp.query("noy", noy);
-        pp.query("noz", noz);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
-            "warpx.nox, noy and noz must be equal");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox >= 1, "warpx.nox must >= 1");
     }
 
     {


### PR DESCRIPTION
Adds an input parameter `interpolation.match_shape_factors` which, when set to `1`, forces shape factors to be the same for all field components. 