### PR TITLE
Overwrite AMReX Defaults: Python

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.H
+++ b/Source/Initialization/WarpXAMReXInit.H
@@ -12,12 +12,21 @@
 /** Call amrex::Initialize
  *
  * This function calls amrex::Initialize and overwrites AMReX' defaults.
+ * Note: AMReX defines a placeholder/"mock-up" for MPI_Comm and
+ * MPI_COMM_WORLD in serial builds
  *
  * @param[in] argc number of arguments from main()
  * @param[in] argv argument strings from main()
+ * @param[in] build_parm_parse build the input file parser (AMReX' default: true)
+ * @param[in] mpi_comm the MPI communicator to use (AMReX' default: MPI_COMM_WORLD)
  * @returns pointer to an AMReX* object, forwarded from amrex::Initialize
  */
 amrex::AMReX*
-warpx_amrex_init(int& argc, char**& argv);
+warpx_amrex_init(
+    int& argc,
+    char**& argv,
+    bool const build_parm_parse = true,
+    MPI_Comm const mpi_comm = MPI_COMM_WORLD
+);
 
 #endif

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -28,12 +28,8 @@ namespace {
 }
 
 amrex::AMReX*
-warpx_amrex_init(int& argc, char**& argv)
+warpx_amrex_init(int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
 {
-    // note: AMReX defines a placeholder/"mock-up" for MPI_COMM_WORLD in serial builds
-    bool const build_parm_parse = true; // AMReX' default
-    MPI_Comm const mpi_comm = MPI_COMM_WORLD; // AMReX' default
-
     return amrex::Initialize(
         argc,
         argv,

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -7,6 +7,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "WarpXWrappers.h"
+#include "Initialization/WarpXAMReXInit.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "WarpX.H"
 #include "Utils/WarpXUtil.H"
@@ -114,13 +115,13 @@ extern "C"
 
     void amrex_init (int argc, char* argv[])
     {
-        amrex::Initialize(argc,argv);
+        warpx_amrex_init(argc, argv);
     }
 
 #ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
-        amrex::Initialize(argc,argv,true,mpicomm);
+        warpx_amrex_init(argc, argv, true, mpicomm);
     }
 #endif
 


### PR DESCRIPTION
Forgot to also overwrite the initialization defines for Python with my last PR ##1164.

Thanks to @dpgrote for spotting this!