### PR TITLE
Fixing compiler warnings

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.cpp
@@ -30,7 +30,6 @@ AvgGalileanAlgorithm::AvgGalileanAlgorithm(const SpectralKSpace& spectral_kspace
     Psi2_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
     Psi3_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
 
-
     X1_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
     X2_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
     X3_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
@@ -91,9 +90,10 @@ void AvgGalileanAlgorithm::InitializeSpectralCoefficients(
         Array4<Complex> CRhonew = Rhonew_coef[mfi].array();
         Array4<Complex> Jcoef   = Jcoef_coef[mfi].array();
         // Extract reals (for portability on GPU)
-
         Real vx = v_galilean[0];
+#if (AMREX_SPACEDIM==3)
         Real vy = v_galilean[1];
+#endif
         Real vz = v_galilean[2];
 
         // Loop over indices within one box
@@ -250,11 +250,6 @@ AvgGalileanAlgorithm::pushSpectralFields(SpectralFieldData& f) const{
         Array4<const Complex> Psi1_arr = Psi1_coef[mfi].array();
         Array4<const Complex> Psi2_arr = Psi2_coef[mfi].array();
         Array4<const Complex> Psi3_arr = Psi3_coef[mfi].array();
-        Array4<const Real> C1_arr = C1_coef[mfi].array();
-        Array4<const Real> S1_arr = S1_coef[mfi].array();
-        Array4<const Real> C3_arr = C3_coef[mfi].array();
-        Array4<const Real> S3_arr = S3_coef[mfi].array();
-
 
         Array4<const Complex> A1_arr = A1_coef[mfi].array();
         Array4<const Complex> A2_arr = A2_coef[mfi].array();
@@ -305,18 +300,12 @@ AvgGalileanAlgorithm::pushSpectralFields(SpectralFieldData& f) const{
             constexpr Real ky = 0;
             const Real kz = modified_kz_arr[j];
 #endif
-            constexpr Real c = PhysConst::c;
             constexpr Real c2 = PhysConst::c*PhysConst::c;
             constexpr Real inv_ep0 = 1._rt/PhysConst::ep0;
             constexpr Complex I = Complex{0,1};
 
             const Real C = C_arr(i,j,k);
             const Real S_ck = S_ck_arr(i,j,k);
-
-            const Real C1 = C1_arr(i,j,k);
-            const Real C3 = C3_arr(i,j,k);
-            const Real S1 = S1_arr(i,j,k);
-            const Real S3 = S3_arr(i,j,k);
 
             const Complex X1 = X1_arr(i,j,k);
             const Complex X2 = X2_arr(i,j,k);

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -102,9 +102,9 @@ guardCellManager::Init(
     // is determined *empirically* to be the order of the solver
     // for nodal, and half the order of the solver for staggered.
 
-    int ngFFt_x = do_nodal ? nox_fft : nox_fft/2.;
-    int ngFFt_y = do_nodal ? noy_fft : noy_fft/2.;
-    int ngFFt_z = do_nodal ? noz_fft : noz_fft/2.;
+    int ngFFt_x = do_nodal ? nox_fft : nox_fft/2;
+    int ngFFt_y = do_nodal ? noy_fft : noy_fft/2;
+    int ngFFt_z = do_nodal ? noz_fft : noz_fft/2;
 
     ParmParse pp("psatd");
     pp.query("nx_guard", ngFFt_x);


### PR DESCRIPTION
This PR fixes compiler warnings:

- Removed unused variables in `AvgGalileanAlgorithm::pushSpectralFields()` and made 'vy=v_galilean[1]' declaration conditional on 3D case in `AvgGalileanAlgorithm::InitializeSpectralCoefficients()`;

-  Avoid unnecessary conversion from 'double' to 'int' in `guardCellManager::Init()`.