### PR TITLE
Travis: Work-Around yt/matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 install:
     - python -m pip install --upgrade pip
-    - python -m pip install --upgrade cmake matplotlib mpi4py numpy scipy yt
+    - python -m pip install --upgrade cmake matplotlib==3.2.2 mpi4py numpy scipy yt
     - export CEI_CMAKE="/home/travis/.local/bin/cmake"
     - sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY && sudo chmod a+x /usr/local/bin/cmake-easyinstall
     - if [ "${WARPX_CI_OPENPMD}" != "FALSE" ]; then


### PR DESCRIPTION
Matplotlib 3.3.0 removed a private member module which yt relies on. We downgrade matplotlib to keep going.

https://github.com/yt-project/yt/issues/2752