### PR TITLE
Respect AMREX_MPI_THREAD_MULTIPLE when calling MPI Init.

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -21,12 +21,18 @@ int main(int argc, char* argv[])
     using namespace amrex;
 
 #if defined(AMREX_USE_MPI)
-#   if defined(_OPENMP) && defined(WARPX_USE_PSATD)
-    int provided;
-    MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
-    AMREX_ALWAYS_ASSERT(provided >= MPI_THREAD_FUNNELED);
+#   ifdef AMREX_MPI_THREAD_MULTIPLE
+    int provided = -1;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    AMREX_ALWAYS_ASSERT(provided >= MPI_THREAD_MULTIPLE);
 #   else
-    MPI_Init(&argc, &argv);
+#      if defined(_OPENMP) && defined(WARPX_USE_PSATD)
+       int provided = -1;
+       MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
+       AMREX_ALWAYS_ASSERT(provided >= MPI_THREAD_FUNNELED);
+#      else
+       MPI_Init(&argc, &argv);
+#      endif
 #   endif
 #endif
 


### PR DESCRIPTION
This will allow us to use `amrex.async_out` with > 64 MPI ranks. 

Here are some performance results on Summit with and without `amrex.use_async=1`. Without:

```
TinyProfiler total time across processes [min...avg...max]: 105.8 ... 105.8 ... 105.8

-------------------------------------------------------------------------------------------
Name                                        NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------
WriteBinaryParticleData()                      101      14.76      26.16      43.12  40.74%
VisMF::Write(FabArray)                         101      22.86      29.64      38.79  36.65%
FillBoundary_finish()                        18411      2.371      14.09      33.57  31.72%
ParticleContainer::WriteParticles()            101   0.004241      5.065      14.61  13.80%
```

with:

```
TinyProfiler total time across processes [min...avg...max]: 58.19 ... 58.26 ... 58.29

-------------------------------------------------------------------------------------------
Name                                        NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------
FillBoundary_finish()                        18411      5.479      15.47      27.62  47.39%
FabArray::ParallelCopy()                      6000      8.602      13.82       19.9  34.14%
WarpX::Evolve()                                  1     0.1746     0.6085      9.697  16.64%
FillBoundary_nowait()                        18411      4.375      6.211      8.088  13.88%
PPC::CurrentDeposition                         955          0      2.674      7.079  12.14%
WriteBinaryParticleDataAsync                   101       4.57      5.125      5.931  10.18%
```

The inputs I used:

```
#################################
####### GENERAL PARAMETERS ######
#################################
max_step = 1000
amr.n_cell =  256  256  1536
amr.max_grid_size = 128   # maximum size of each AMReX box, used to decompose the domain
amr.blocking_factor = 32 # minimum size of each AMReX box, used to decompose the domain
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -30.e-6   -30.e-6   -56.e-6    # physical domain
geometry.prob_hi     =  30.e-6    30.e-6    12.e-6
amr.max_level = 0 # Maximum level in hierarchy (1 might be unstable, >1 is not supported)
# warpx.fine_tag_lo = -5.e-6   -5.e-6   -50.e-6
# warpx.fine_tag_hi =  5.e-6    5.e-6   -30.e-6

#################################
############ NUMERICS ###########
#################################
interpolation.nox = 3 # Particle interpolation order. Must be the same in x, y, and z
interpolation.noy = 3
interpolation.noz = 3
warpx.verbose = 1
warpx.do_dive_cleaning = 0
warpx.use_filter = 1
warpx.cfl = 1. # if 1., the time step is set to its CFL limit
warpx.do_pml = 0 # use Perfectly Matched Layer as boundary condition
warpx.do_moving_window = 1
warpx.moving_window_dir = z # Only z is supported for the moment
warpx.moving_window_v = 1.0 # units of speed of light
#################################
############ PLASMA #############
#################################
particles.nspecies = 1 # number of species
particles.species_names = electrons

electrons.charge = -q_e
electrons.mass = m_e
electrons.injection_style = "NUniformPerCell"
electrons.num_particles_per_cell_each_dim = 1 1 1
electrons.xmin = -20.e-6
electrons.xmax =  20.e-6
electrons.ymin = -20.e-6
electrons.ymax =  20.e-6
electrons.zmin =  10.e-6
electrons.profile = constant
electrons.density = 2.e23  # number of electrons per m^3
electrons.momentum_distribution_type = "constant"
electrons.do_continuous_injection = 1

#################################
############ LASER  #############
#################################
lasers.nlasers      = 1
lasers.names        = laser1
laser1.profile      = Gaussian
laser1.position     = 0. 0. 9.e-6        # This point is on the laser plane
laser1.direction    = 0. 0. 1.           # The plane normal direction
laser1.polarization = 0. 1. 0.           # The main polarization vector
laser1.e_max        = 16.e12             # Maximum amplitude of the laser field (in V/m)
laser1.profile_waist = 5.e-6             # The waist of the laser (in m)
laser1.profile_duration = 15.e-15        # The duration of the laser (in s)
laser1.profile_t_peak = 30.e-15          # Time at which the laser reaches its peak (in s)
laser1.profile_focal_distance = 100.e-6  # Focal distance from the antenna (in m)
laser1.wavelength = 0.8e-6               # The wavelength of the laser (in m)

# Diagnostics
diagnostics.diags_names = diag1
diag1.period = 10
diag1.diag_type = Full

amrex.async_out=1
```

and the batch script:

```
#!/bin/bash
#BSUB -P APH114
#BSUB -W 0:10
#BSUB -nnodes 4
#BSUB -J WarpX
#BSUB -o WarpXo.%J
#BSUB -e WarpXe.%J
module load gcc
module load cuda
module list
set -x
omp=1
export OMP_NUM_THREADS=${omp}
EXE="./main3d.gnu.TPROF.MTMPI.CUDA.ex"
jsrun -n 24 -a 1 -g 1 -c 7 --bind=packed:${omp} ${EXE} inputs_3d > output.txt
```