### PR TITLE
Instrument WriteToFile and use it in automated perf tests

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -22,6 +22,7 @@ FlushFormatPlotfile::WriteToFile (
     const std::string prefix, bool plot_raw_fields,
     bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
 {
+    WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();
     const std::string& filename = amrex::Concatenate(prefix, iteration[0]);
     amrex::Print() << "  Writing plotfile " << filename << "\n";

--- a/Tools/PerformanceTests/functions_perftest.py
+++ b/Tools/PerformanceTests/functions_perftest.py
@@ -191,7 +191,7 @@ def extract_dataframe(filename, n_steps):
     line_match_looptime = re.search('\nWarpX::Evolve().*', search_area)
     time_wo_initialization = float(line_match_looptime.group(0).split()[3])
     # New, might break something
-    line_match_WritePlotFile = re.search('\nWarpX::WritePlotFile().*', search_area)
+    line_match_WritePlotFile = re.search('\nFlushFormatPlotfile::WriteToFile().*', search_area)
     if line_match_WritePlotFile is not None:
          time_WritePlotFile = float(line_match_WritePlotFile.group(0).split()[3])
     else:


### PR DESCRIPTION
`FlushFormatOpenPMD::WriteToFile()` was already instrumented, this PR proposes to do the same for `FlushFormatPlotfile::WriteToFile()`. Then, the output is read in the automated performance tests, and it is 1 step to fix a current issue: on https://ecp-warpx.github.io/perf_logs/ the data for test number 6 (IO) is missing.