### PR TITLE
[tiny] Explained print when NaN in LibEnsemble

### DIFF
--- a/Tools/LibEnsemble/warpx_simf.py
+++ b/Tools/LibEnsemble/warpx_simf.py
@@ -90,7 +90,7 @@ def run_warpx(H, persis_info, sim_specs, libE_info):
 
     # Excluding results - NAN - from runs where beam was lost
     if (warpx_out[0] != warpx_out[0]):
-        print(task.workdir, ' output led to NAN values')
+        print(task.workdir, ' output led to NaN values (beam was lost or run did not finish)')
 
     # Pass the sim output values to LibEnsemble.
     # When optimization is ON, 'f' is then passed to the generating function

--- a/Tools/LibEnsemble/warpx_simf.py
+++ b/Tools/LibEnsemble/warpx_simf.py
@@ -88,7 +88,7 @@ def run_warpx(H, persis_info, sim_specs, libE_info):
     # Get output from a run and delete output files
     warpx_out = read_sim_output(task.workdir)
 
-    # Excluding results - NAN - from runs where beam was lost
+    # Excluding results - NaN - from runs where beam was lost
     if (warpx_out[0] != warpx_out[0]):
         print(task.workdir, ' output led to NaN values (beam was lost or run did not finish)')
 


### PR DESCRIPTION
This tiny PR follows PR #1157 's suggestion from @ax3l to explain the occurrence of NaNs as output of each run when using LibEnsemble example with wider range of parameters (in which case some of the runs might not finish in the allocated time and others might completely defocus the beam).