### PR TITLE
Add input parameter to control Galerkin-scheme gather

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1061,7 +1061,7 @@ Numerics and algorithms
     Whether to use a Galerkin scheme when gathering fields to particles.
     When set to `1`, the interpolation order for each field component is reduced by one along the direction of that component.
     For example, `E_z` is gathered using ``interpolation.nox``, ``interpolation.noy``, and ``interpolation.noz - 1``.
-    Defaults to `1` unless ``warpx.do_nodal = 1`` and ``algo.field_gathering = energy-conserving``.
+    Defaults to `1` unless ``warpx.do_nodal = 1`` and/or ``algo.field_gathering = energy-conserving``.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1058,10 +1058,10 @@ Numerics and algorithms
     Note that in the current implementation in WarpX these 3 numbers must be equal.
 
 * ``interpolation.galerkin_scheme`` (`0` or `1`)
-    Whether to use a galerkin scheme when gathering fields to particles.
+    Whether to use a Galerkin scheme when gathering fields to particles.
     When set to `1`, the interpolation order for each field component is reduced by one along the direction of that component.
-    For example, `E_z` is gathered using `interpolation.nox`, `interpolation.noy`, and `interpolation.noz - 1`.
-    Defaults to `1` unless `warpx.do_nodal = 1` and `algo.field_gathering = energy-conserving`.
+    For example, `E_z` is gathered using ``interpolation.nox``, ``interpolation.noy``, and ``interpolation.noz - 1``.
+    Defaults to `1` unless ``warpx.do_nodal = 1`` and ``algo.field_gathering = energy-conserving``.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1061,7 +1061,7 @@ Numerics and algorithms
     Whether to use a Galerkin scheme when gathering fields to particles.
     When set to `1`, the interpolation order for each field component is reduced by one along the direction of that component.
     For example, `E_z` is gathered using ``interpolation.nox``, ``interpolation.noy``, and ``interpolation.noz - 1``.
-    Defaults to `1` unless ``warpx.do_nodal = 1`` and/or ``algo.field_gathering = energy-conserving``.
+    Defaults to `1` unless ``warpx.do_nodal = 1`` and/or ``algo.field_gathering = momentum-conserving``.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1057,6 +1057,12 @@ Numerics and algorithms
 
     Note that in the current implementation in WarpX these 3 numbers must be equal.
 
+* ``interpolation.galerkin_scheme`` (`0` or `1`)
+    Whether to use a galerkin scheme when gathering fields to particles.
+    When set to `1`, the interpolation order for each field component is reduced by one along the direction of that component.
+    For example, `E_z` is gathered using `interpolation.nox`, `interpolation.noy`, and `interpolation.noz - 1`.
+    Defaults to `1` unless `warpx.do_nodal = 1` and `algo.field_gathering = energy-conserving`.
+
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)
     Whether to use modified Maxwell equations that progressively eliminate
     the error in :math:`div(E)-\rho`. This can be useful when using a current

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1059,8 +1059,9 @@ Numerics and algorithms
 
 * ``interpolation.galerkin_scheme`` (`0` or `1`)
     Whether to use a Galerkin scheme when gathering fields to particles.
-    When set to `1`, the interpolation order for each field component is reduced by one along the direction of that component.
+    When set to `1`, the interpolation orders used for field-gathering are reduced for certain field components along certain directions.
     For example, `E_z` is gathered using ``interpolation.nox``, ``interpolation.noy``, and ``interpolation.noz - 1``.
+    See equations 21-23 of (`Godfrey and Vay, 2013 <https://doi.org/10.1016/j.jcp.2013.04.006>`_) and associated references for details.
     Defaults to `1` unless ``warpx.do_nodal = 1`` and/or ``algo.field_gathering = momentum-conserving``.
 
 * ``warpx.do_dive_cleaning`` (`0` or `1` ; default: 0)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -187,7 +187,7 @@ WarpX::InitNCICorrector ()
 
             // Initialize Godfrey filters
             // Same filter for fields Ex, Ey and Bz
-            const bool nodal_gather = (galerkin_interpolation == 0);
+            const bool nodal_gather = !galerkin_interpolation;
             nci_godfrey_filter_exeybz[lev].reset( new NCIGodfreyFilter(godfrey_coeff_set::Ex_Ey_Bz, cdtodz, nodal_gather) );
             // Same filter for fields Bx, By and Ez
             nci_godfrey_filter_bxbyez[lev].reset( new NCIGodfreyFilter(godfrey_coeff_set::Bx_By_Ez, cdtodz, nodal_gather) );

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -187,7 +187,7 @@ WarpX::InitNCICorrector ()
 
             // Initialize Godfrey filters
             // Same filter for fields Ex, Ey and Bz
-            const bool nodal_gather = (l_lower_order_in_v == 0);
+            const bool nodal_gather = (galerkin_interpolation == 0);
             nci_godfrey_filter_exeybz[lev].reset( new NCIGodfreyFilter(godfrey_coeff_set::Ex_Ey_Bz, cdtodz, nodal_gather) );
             // Same filter for fields Bx, By and Ez
             nci_godfrey_filter_bxbyez[lev].reset( new NCIGodfreyFilter(godfrey_coeff_set::Bx_By_Ez, cdtodz, nodal_gather) );

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -45,7 +45,7 @@ struct IonizationFilterFunc
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_l_lower_order_in_v;
+    int m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 
@@ -93,7 +93,7 @@ struct IonizationFilterFunc
                            m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                            m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                            m_dx_arr, m_xyzmin_arr, m_lo, m_n_rz_azimuthal_modes,
-                           m_nox, m_l_lower_order_in_v);
+                           m_nox, m_galerkin_interpolation);
 
             // Compute electric field amplitude in the particle's frame of
             // reference (particularly important when in boosted frame).

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -45,7 +45,7 @@ struct IonizationFilterFunc
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_galerkin_interpolation;
+    bool m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/Ionization.cpp
+++ b/Source/Particles/ElementaryProcess/Ionization.cpp
@@ -64,7 +64,7 @@ IonizationFilterFunc::IonizationFilterFunc (const WarpXParIter& a_pti, int lev, 
     const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, galilean_shift, lev);
     m_xyzmin_arr = {xyzmin[0], xyzmin[1], xyzmin[2]};
 
-    m_l_lower_order_in_v = WarpX::l_lower_order_in_v;
+    m_galerkin_interpolation = WarpX::galerkin_interpolation;
     m_nox = WarpX::nox;
     m_n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -195,7 +195,7 @@ private:
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_galerkin_interpolation;
+    bool m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -128,7 +128,7 @@ public:
                        m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                        m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                        m_dx_arr, m_xyzmin_arr, m_lo, m_n_rz_azimuthal_modes,
-                       m_nox, m_l_lower_order_in_v);
+                       m_nox, m_galerkin_interpolation);
 
         const auto px = ux*me;
         const auto py = uy*me;
@@ -195,7 +195,7 @@ private:
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_l_lower_order_in_v;
+    int m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
@@ -54,7 +54,7 @@ PairGenerationTransformFunc (BreitWheelerGeneratePairs const generate_functor,
     const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, galilean_shift, lev);
     m_xyzmin_arr = {xyzmin[0], xyzmin[1], xyzmin[2]};
 
-    m_l_lower_order_in_v = WarpX::l_lower_order_in_v;
+    m_galerkin_interpolation = WarpX::galerkin_interpolation;
     m_nox = WarpX::nox;
     m_n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -198,7 +198,7 @@ private:
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_galerkin_interpolation;
+    bool m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -134,7 +134,7 @@ public:
                        m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                        m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                        m_dx_arr, m_xyzmin_arr, m_lo, m_n_rz_azimuthal_modes,
-                       m_nox, m_l_lower_order_in_v);
+                       m_nox, m_galerkin_interpolation);
 
         // Particle momentum is stored as gamma * velocity.
         // Convert to m * gamma * velocity before applying the emission functor.
@@ -198,7 +198,7 @@ private:
     amrex::GpuArray<amrex::Real, 3> m_dx_arr;
     amrex::GpuArray<amrex::Real, 3> m_xyzmin_arr;
 
-    int m_l_lower_order_in_v;
+    int m_galerkin_interpolation;
     int m_nox;
     int m_n_rz_azimuthal_modes;
 

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.cpp
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.cpp
@@ -58,7 +58,7 @@ PhotonEmissionTransformFunc (QuantumSynchrotronGetOpticalDepth opt_depth_functor
     const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, galilean_shift, lev);
     m_xyzmin_arr = {xyzmin[0], xyzmin[1], xyzmin[2]};
 
-    m_l_lower_order_in_v = WarpX::l_lower_order_in_v;
+    m_galerkin_interpolation = WarpX::galerkin_interpolation;
     m_nox = WarpX::nox;
     m_n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -449,7 +449,7 @@ void doGatherShapeN(const GetParticlePosition& getPosition,
  * \param lo                        : Index lower bounds of domain.
  * \param n_rz_azimuthal_modes      : Number of azimuthal modes when using RZ geometry
  * \param nox                       : order of the particle shape function
- * \param l_lower_order_in_v        : whether to use lower order in v
+ * \param galerkin_interpolation        : whether to use lower order in v
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void doGatherShapeN (const amrex::ParticleReal xp,
@@ -478,9 +478,9 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                      const amrex::Dim3& lo,
                      const long n_rz_azimuthal_modes,
                      const int nox,
-                     const int l_lower_order_in_v)
+                     const int galerkin_interpolation)
 {
-    if (l_lower_order_in_v) {
+    if (galerkin_interpolation) {
         if (nox == 1) {
             doGatherShapeN<1,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -478,7 +478,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                      const amrex::Dim3& lo,
                      const long n_rz_azimuthal_modes,
                      const int nox,
-                     const int galerkin_interpolation)
+                     const bool galerkin_interpolation)
 {
     if (galerkin_interpolation) {
         if (nox == 1) {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -248,7 +248,7 @@ MultiParticleContainer::ReadParameters ()
         }
 
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
-        pp.query("l_lower_order_in_v", WarpX::l_lower_order_in_v);
+        pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 
         ParmParse ppl("lasers");
         ppl.queryarr("names", lasers_names);

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -134,7 +134,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 
     const Dim3 lo = lbound(box);
 
-    int galerkin_interpolation = WarpX::galerkin_interpolation;
+    bool galerkin_interpolation = WarpX::galerkin_interpolation;
     int nox = WarpX::nox;
     int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -134,7 +134,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 
     const Dim3 lo = lbound(box);
 
-    int l_lower_order_in_v = WarpX::l_lower_order_in_v;
+    int galerkin_interpolation = WarpX::galerkin_interpolation;
     int nox = WarpX::nox;
     int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
@@ -176,7 +176,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
                                ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes,
-                               nox, l_lower_order_in_v);
+                               nox, galerkin_interpolation);
             }
 
 #ifdef WARPX_QED

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1436,7 +1436,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
 
             const Dim3 lo = lbound(box);
 
-            int galerkin_interpolation = WarpX::galerkin_interpolation;
+            bool galerkin_interpolation = WarpX::galerkin_interpolation;
             int nox = WarpX::nox;
             int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
@@ -1797,7 +1797,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
     const Dim3 lo = lbound(box);
 
-    int galerkin_interpolation = WarpX::galerkin_interpolation;
+    bool galerkin_interpolation = WarpX::galerkin_interpolation;
     int nox = WarpX::nox;
     int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1436,7 +1436,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
 
             const Dim3 lo = lbound(box);
 
-            int l_lower_order_in_v = WarpX::l_lower_order_in_v;
+            int galerkin_interpolation = WarpX::galerkin_interpolation;
             int nox = WarpX::nox;
             int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
@@ -1493,7 +1493,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                                    ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                    ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                    dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes,
-                                   nox, l_lower_order_in_v);
+                                   nox, galerkin_interpolation);
                 }
 
                 if (do_crr) {
@@ -1797,7 +1797,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
     const Dim3 lo = lbound(box);
 
-    int l_lower_order_in_v = WarpX::l_lower_order_in_v;
+    int galerkin_interpolation = WarpX::galerkin_interpolation;
     int nox = WarpX::nox;
     int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
@@ -1872,7 +1872,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
                            ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                            ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                            dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes,
-                           nox, l_lower_order_in_v);
+                           nox, galerkin_interpolation);
         }
 
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -419,7 +419,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
 
             const Dim3 lo = lbound(box);
 
-            int galerkin_interpolation = WarpX::galerkin_interpolation;
+            bool galerkin_interpolation = WarpX::galerkin_interpolation;
             int nox = WarpX::nox;
             int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -419,7 +419,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
 
             const Dim3 lo = lbound(box);
 
-            int l_lower_order_in_v = WarpX::l_lower_order_in_v;
+            int galerkin_interpolation = WarpX::galerkin_interpolation;
             int nox = WarpX::nox;
             int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
@@ -481,7 +481,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                                ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes,
-                               nox, l_lower_order_in_v);
+                               nox, galerkin_interpolation);
 
                 if (do_crr) {
                     amrex::Real qp = q;

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -98,9 +98,9 @@ extern "C"
         return WarpX::use_fdtd_nci_corr;
     }
 
-    int warpx_l_lower_order_in_v()
+    int warpx_galerkin_interpolation()
     {
-        return WarpX::l_lower_order_in_v;
+        return WarpX::galerkin_interpolation;
     }
 
     int warpx_nComps()

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -29,7 +29,7 @@ extern "C" {
 
     bool warpx_use_fdtd_nci_corr();
 
-    int warpx_l_lower_order_in_v();
+    int warpx_galerkin_interpolation();
 
     int warpx_nComps();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -162,7 +162,7 @@ public:
     static long ncomps;
 
     static bool use_fdtd_nci_corr;
-    static int  galerkin_interpolation;
+    static bool galerkin_interpolation;
 
     static bool use_filter;
     static bool use_kspace_filter;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -162,7 +162,7 @@ public:
     static long ncomps;
 
     static bool use_fdtd_nci_corr;
-    static int  l_lower_order_in_v;
+    static int  galerkin_interpolation;
 
     static bool use_filter;
     static bool use_kspace_filter;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -82,7 +82,7 @@ long WarpX::noy = 1;
 long WarpX::noz = 1;
 
 bool WarpX::use_fdtd_nci_corr = false;
-int  WarpX::galerkin_interpolation = true;
+bool WarpX::galerkin_interpolation = true;
 
 bool WarpX::use_filter        = false;
 bool WarpX::use_kspace_filter       = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -606,7 +606,7 @@ WarpX::ReadParameters ()
         pp.query("noy", noy);
         pp.query("noz", noz);
 
-        pp.query("galerkin_scheme",galerkin_interpolation)
+        pp.query("galerkin_scheme",galerkin_interpolation);
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
             "warpx.nox, noy and noz must be equal");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -82,7 +82,7 @@ long WarpX::noy = 1;
 long WarpX::noz = 1;
 
 bool WarpX::use_fdtd_nci_corr = false;
-int  WarpX::l_lower_order_in_v = true;
+int  WarpX::galerkin_interpolation = true;
 
 bool WarpX::use_filter        = false;
 bool WarpX::use_kspace_filter       = false;
@@ -563,7 +563,7 @@ WarpX::ReadParameters ()
 
         pp.query("do_nodal", do_nodal);
         // Use same shape factors in all directions, for gathering
-        if (do_nodal) l_lower_order_in_v = false;
+        if (do_nodal) galerkin_interpolation = false;
 
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
         pp.query("n_rz_azimuthal_modes", n_rz_azimuthal_modes);
@@ -576,7 +576,7 @@ WarpX::ReadParameters ()
         // Force do_nodal=true (that is, not staggered) and
         // use same shape factors in all directions, for gathering
         do_nodal = true;
-        l_lower_order_in_v = false;
+        galerkin_interpolation = false;
 #endif
     }
 
@@ -600,7 +600,7 @@ WarpX::ReadParameters ()
         field_gathering_algo = GetAlgorithmInteger(pp, "field_gathering");
         if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
             // Use same shape factors in all directions, for gathering
-            l_lower_order_in_v = false;
+            galerkin_interpolation = false;
         }
         load_balance_costs_update_algo = GetAlgorithmInteger(pp, "load_balance_costs_update");
         em_solver_medium = GetAlgorithmInteger(pp, "em_solver_medium");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -581,17 +581,6 @@ WarpX::ReadParameters ()
     }
 
     {
-        ParmParse pp("interpolation");
-        pp.query("nox", nox);
-        pp.query("noy", noy);
-        pp.query("noz", noz);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
-            "warpx.nox, noy and noz must be equal");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox >= 1, "warpx.nox must >= 1");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox <= 3, "warpx.nox must <= 3");
-    }
-
-    {
         ParmParse pp("algo");
         current_deposition_algo = GetAlgorithmInteger(pp, "current_deposition");
         charge_deposition_algo = GetAlgorithmInteger(pp, "charge_deposition");
@@ -609,6 +598,19 @@ WarpX::ReadParameters ()
         }
         pp.query("costs_heuristic_cells_wt", costs_heuristic_cells_wt);
         pp.query("costs_heuristic_particles_wt", costs_heuristic_particles_wt);
+    }
+
+    {
+        ParmParse pp("interpolation");
+        pp.query("nox", nox);
+        pp.query("noy", noy);
+        pp.query("noz", noz);
+
+        pp.query("galerkin_scheme",galerkin_interpolation)
+
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
+            "warpx.nox, noy and noz must be equal");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox >= 1, "warpx.nox must >= 1");
     }
 
 #ifdef WARPX_USE_PSATD


### PR DESCRIPTION
Right now, WarpX uses a Galerkin scheme to gather the fields. The stability of certain alternative staggerings can be improved dramatically by instead using the same interpolation order in every direction for every field component. This PR exposes the variable `galerkin_interpolation` (previously named `l_lower_order_in_v`) to the user via an input parameter `interpolation.galerkin_scheme`. 