### PR TITLE
Do PSATD+RZ in the RZ_NO_MPI travis instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
         cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF;
       fi
-    - if [ "${WARPX_CI_PSATD:-FALSE}" == "TRUE" ]; then
+    - if [ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" ]; then
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git
           -DBLAS_LIBRARY=generic -DUSE_OPENMP=OFF -DBLASPP_BUILD_TESTS=OFF;
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -104,6 +104,8 @@ if ci_psatd:
     test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], True)
     # Remove PSATD single-precision, which is done in ci_single_precision
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT'], False)
+    # Remove PSATD RZ, which is done in ci_rz_or_nompi
+    test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
 
 if ci_python_main:
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], True)
@@ -116,7 +118,6 @@ if ci_rz_or_nompi:
     block1 = select_tests(test_blocks, ['USE_RZ=TRUE'], True)
     block2 = select_tests(test_blocks, ['useMPI = 0'], True)
     test_blocks = block1 + block2
-    test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], False)
 
 if ci_qed:
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], True)


### PR DESCRIPTION
The automated tests for PSATD+RZ were done in the Travis CI instance that performs the PSATD tests in general (as I suggested in a previous PR review). However, it seems that this instance now exceeds the maximum time allowed on Travis. Therefore, this current moves that test to the RZ_NO_MPI travis instance (which performs the RZ tests and the no-MPI tests) in the hope that this will fit within the time limit.