### PR TITLE
[tiny] Fix bug concerning a misprint in preprocessor directive

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1870,7 +1870,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
 
-#ifdef WARPX_WED
+#ifdef WARPX_QED
     if (local_has_quantum_sync) {
         const ParticleReal px = m * ux[ip];
         const ParticleReal py = m * uy[ip];


### PR DESCRIPTION
`WARPX_QED` was inadvertently written as `WARPX_WED` in `PhysicalParticleContainer.cpp`. This PR corrects the bug.

I am working on a PR to add tests which would have spotted this bug.