### PR TITLE
GNUmake Build: Enable Warnings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,9 @@ OPENBC_HOME ?= ../openbc_poisson
 DEBUG = FALSE
 #DEBUG	= TRUE
 
+WARN_ALL = TRUE
+#WARN_ERROR=TRUE
+
 #DIM     = 2
 DIM = 3
 


### PR DESCRIPTION
Unconditionally enable compiler warnings for all builds. This will help us to increasing awareness on them to fix them, which will help us on the mid-term to catch bugs that diagnostics can catch early on. Only increases code stability and portability.

Refs.:
- https://github.com/AMReX-Codes/amrex/pull/1176
- https://github.com/AMReX-Codes/amrex/pull/1198