### PR TITLE
Input: Remove n<something> options

### DIFF
--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -21,7 +21,6 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
 warpx.serialize_ics = 1
-particles.nspecies = 1
 particles.species_names = beam
 particles.rigid_injected_species = beam
 beam.charge = -q_e

--- a/Examples/Modules/RigidInjection/inputs_2d_LabFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_LabFrame
@@ -13,7 +13,6 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
 warpx.serialize_ics = 1
-particles.nspecies = 1
 particles.species_names = beam
 particles.rigid_injected_species = beam
 beam.charge = -q_e

--- a/Examples/Modules/boosted_diags/inputs_3d_slice
+++ b/Examples/Modules/boosted_diags/inputs_3d_slice
@@ -34,7 +34,6 @@ warpx.num_snapshots_lab = 4
 warpx.dz_snapshots_lab = 0.001
 warpx.back_transformed_diag_fields= Ex Ey Ez By rho
 
-particles.nspecies = 3
 particles.species_names = electrons ions beam
 particles.use_fdtd_nci_corr = 1
 
@@ -89,7 +88,6 @@ beam.ux_th = .2
 beam.uy_th = .2
 beam.uz_th = 20.
 
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. -0.1e-6 # This point is on the laser plane

--- a/Examples/Modules/dive_cleaning/inputs_3d
+++ b/Examples/Modules/dive_cleaning/inputs_3d
@@ -11,7 +11,6 @@ geometry.prob_hi     =  50.e-6    50.e-6   50.e-6
 warpx.do_dive_cleaning = 1
 warpx.do_pml = 1
 
-particles.nspecies = 1
 particles.species_names = beam
 beam.charge = -q_e
 beam.mass = 1.e30

--- a/Examples/Modules/ionization/inputs_2d_bf_rt
+++ b/Examples/Modules/ionization/inputs_2d_bf_rt
@@ -17,7 +17,6 @@ warpx.moving_window_v = 1.0
 warpx.gamma_boost = 2.
 warpx.boost_direction = z
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 ions.mass = 2.3428415e-26
@@ -46,7 +45,6 @@ electrons.density = 2.
 electrons.momentum_distribution_type = constant
 electrons.do_continuous_injection=1
 
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. -1.e-6

--- a/Examples/Modules/ionization/inputs_2d_rt
+++ b/Examples/Modules/ionization/inputs_2d_rt
@@ -12,7 +12,6 @@ algo.maxwell_solver = ckc
 warpx.do_pml = 1
 warpx.cfl = .999
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 ions.mass = 2.3428415e-26
@@ -39,7 +38,6 @@ electrons.profile = constant
 electrons.density = 2.
 electrons.momentum_distribution_type = constant
 
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 3.e-6

--- a/Examples/Modules/laser_injection/inputs_2d_rt
+++ b/Examples/Modules/laser_injection/inputs_2d_rt
@@ -29,7 +29,6 @@ algo.current_deposition = esirkepov
 warpx.cfl = 1.0
 
 # Laser
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 9.e-6  0.  0.  # This point is on the laser plane
@@ -53,6 +52,3 @@ warpx.do_pml = 0
 warpx.do_moving_window = 1
 warpx.moving_window_dir = x
 warpx.moving_window_v = 1.0 # in units of the speed of light
-
-# Remove species
-particles.nspecies = 0

--- a/Examples/Modules/laser_injection/inputs_3d_rt
+++ b/Examples/Modules/laser_injection/inputs_3d_rt
@@ -29,7 +29,6 @@ warpx.do_pml = 0
 warpx.cfl = 1.0
 
 # Laser
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 9.e-6 # This point is on the laser plane
@@ -52,6 +51,3 @@ diag1.fields_to_plot = jx jy jz Ex Ey Ez Bx Bz
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
-
-# Remove species
-particles.nspecies = 0

--- a/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
+++ b/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
@@ -26,14 +26,8 @@ warpx.use_filter = 0
 algo.maxwell_solver = ckc
 
 #################################
-############ PLASMA #############
-#################################
-particles.nspecies = 0
-
-#################################
 ############# LASER #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = txye_laser
 txye_laser.position     = 0. 0. 0. # This point is on the laser plane
 txye_laser.direction    = 1. 0. 1.     # The plane normal direction

--- a/Examples/Modules/nci_corrector/inputs_2d
+++ b/Examples/Modules/nci_corrector/inputs_2d
@@ -32,7 +32,6 @@ warpx.serialize_ics = 1
 warpx.cfl = 1.0
 warpx.do_subcycling = 1
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 particles.use_fdtd_nci_corr = 1
 

--- a/Examples/Modules/qed/breit_wheeler/inputs_2d_tau_init
+++ b/Examples/Modules/qed/breit_wheeler/inputs_2d_tau_init
@@ -31,7 +31,6 @@ warpx.serialize_ics = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 3 # number of species
 particles.species_names = photons ele_bw pos_bw
 particles.photon_species = photons
 #################################

--- a/Examples/Modules/qed/breit_wheeler/inputs_3d_optical_depth_evolution
+++ b/Examples/Modules/qed/breit_wheeler/inputs_3d_optical_depth_evolution
@@ -31,7 +31,6 @@ warpx.serialize_ics = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 6 # number of species
 particles.species_names = p1 p2 p3 p4 ele_bw pos_bw
 particles.photon_species = p1 p2 p3 p4
 #################################

--- a/Examples/Modules/qed/quantum_synchrotron/inputs_2d_tau_init
+++ b/Examples/Modules/qed/quantum_synchrotron/inputs_2d_tau_init
@@ -32,7 +32,6 @@ warpx.serialize_ics = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 3 # number of species
 particles.species_names = electrons positrons qs_phot
 particles.photon_species = qs_phot
 #################################

--- a/Examples/Modules/qed/schwinger/inputs_3d_schwinger
+++ b/Examples/Modules/qed/schwinger/inputs_3d_schwinger
@@ -38,7 +38,6 @@ warpx.E_external_grid = 0. 0. 0.
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2 # number of species
 particles.species_names =  ele_schwinger pos_schwinger
 
 ele_schwinger.species_type = "electron"

--- a/Examples/Modules/relativistic_space_charge_initialization/inputs_3d
+++ b/Examples/Modules/relativistic_space_charge_initialization/inputs_3d
@@ -9,7 +9,6 @@ geometry.prob_lo     = -50.e-6   -50.e-6    -50.e-6
 geometry.prob_hi     =  50.e-6    50.e-6     50.e-6
 
 warpx.cfl = 1.e-5
-particles.nspecies = 1
 particles.species_names = beam
 beam.charge = -q_e
 beam.mass = m_e

--- a/Examples/Modules/space_charge_initialization/inputs_3d
+++ b/Examples/Modules/space_charge_initialization/inputs_3d
@@ -9,7 +9,6 @@ geometry.prob_lo     = -50.e-6   -50.e-6    -50.e-6
 geometry.prob_hi     =  50.e-6    50.e-6     50.e-6
 
 warpx.cfl = 1.e-3
-particles.nspecies = 1
 particles.species_names = beam
 beam.charge = -q_e
 beam.mass = m_e

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d
@@ -31,7 +31,6 @@ warpx.moving_window_v = 1.0 # units of speed of light
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2 # number of species
 particles.species_names = electrons beam
 
 electrons.species_type = electron
@@ -66,7 +65,6 @@ beam.uz_th = 50.
 #################################
 ############ PLASMA #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 9.e-6        # This point is on the laser plane

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d_boost
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d_boost
@@ -47,7 +47,6 @@ warpx.dt_snapshots_lab = 1.6678204759907604e-12
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 3
 particles.species_names = electrons ions beam
 particles.use_fdtd_nci_corr = 1
 particles.rigid_injected_species = beam
@@ -108,7 +107,6 @@ beam.focused = false
 #################################
 ############# LASER #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. -0.1e-6 # This point is on the laser plane

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d_rz
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d_rz
@@ -31,7 +31,6 @@ warpx.moving_window_v = 1.0 # units of speed of light
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2 # number of species
 particles.species_names = electrons beam
 
 electrons.charge = -q_e
@@ -68,7 +67,6 @@ beam.uz_th = 50.
 #################################
 ############ PLASMA #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 9.e-6        # This point is on the laser plane

--- a/Examples/Physics_applications/laser_acceleration/inputs_3d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_3d
@@ -31,7 +31,6 @@ warpx.moving_window_v = 1.0 # units of speed of light
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 1 # number of species
 particles.species_names = electrons
 
 electrons.charge = -q_e
@@ -51,7 +50,6 @@ electrons.do_continuous_injection = 1
 #################################
 ############ LASER  #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 9.e-6        # This point is on the laser plane

--- a/Examples/Physics_applications/plasma_acceleration/inputs_2d
+++ b/Examples/Physics_applications/plasma_acceleration/inputs_2d
@@ -31,7 +31,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 3
 particles.species_names = plasma_e beam driver
 
 driver.charge = -q_e

--- a/Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
+++ b/Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
@@ -42,7 +42,6 @@ warpx.dt_snapshots_lab = 3.335640951981521e-11
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 4
 particles.species_names = driver plasma_e plasma_p beam
 particles.use_fdtd_nci_corr = 1
 particles.rigid_injected_species = driver beam

--- a/Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
+++ b/Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
@@ -42,7 +42,6 @@ warpx.dt_snapshots_lab = 3.335640951981521e-11
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 5
 particles.species_names = driver plasma_e plasma_p beam driverback
 particles.use_fdtd_nci_corr = 1
 particles.rigid_injected_species = driver beam

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -33,7 +33,6 @@ warpx.use_filter = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e
@@ -63,7 +62,6 @@ ions.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>=zp)*(z<=zp2)*2.*
 #################################
 ############# LASER #############
 #################################
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.position     = 0. 0. 5.e-6 # This point is on the laser plane
 laser1.direction    = 0. 0. 1.     # The plane normal direction

--- a/Examples/Physics_applications/uniform_plasma/inputs_2d
+++ b/Examples/Physics_applications/uniform_plasma/inputs_2d
@@ -21,7 +21,6 @@ warpx.cfl = 1.0
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.charge = -q_e

--- a/Examples/Physics_applications/uniform_plasma/inputs_3d
+++ b/Examples/Physics_applications/uniform_plasma/inputs_3d
@@ -21,7 +21,6 @@ warpx.cfl = 1.0
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.species_type = electron

--- a/Examples/Tests/ElectrostaticSphere/inputs_3d
+++ b/Examples/Tests/ElectrostaticSphere/inputs_3d
@@ -11,7 +11,6 @@ warpx.do_pml = 0
 warpx.const_dt = 1e-6
 warpx.do_electrostatic = 1
 
-particles.nspecies = 1
 particles.species_names = electron
 
 algo.field_gathering = momentum-conserving

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rt
@@ -42,7 +42,6 @@ my_constants.k = 314159.2653589793
 # k is calculated so as to have 2 periods within the 40e-6 wide box.
 
 # Particles
-particles.nspecies = 2
 particles.species_names = electrons positrons
 
 electrons.charge = -q_e

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -47,7 +47,6 @@ my_constants.w0 = 5.e-6
 # k0 is calculated so as to have 2 periods within the 40e-6 wide box.
 
 # Particles
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e

--- a/Examples/Tests/Langmuir/inputs_3d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -43,7 +43,6 @@ my_constants.k       = 314159.2653589793
 # k is calculated so as to have 2 periods within the 40e-6 wide box.
 
 # Particles
-particles.nspecies = 2
 particles.species_names = electrons positrons
 
 electrons.charge = -q_e

--- a/Examples/Tests/Langmuir/inputs_3d_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_rt
@@ -34,7 +34,6 @@ interpolation.noz = 1
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.charge = -q_e

--- a/Examples/Tests/Larmor/inputs_2d_mr
+++ b/Examples/Tests/Larmor/inputs_2d_mr
@@ -39,7 +39,6 @@ warpx.verbose = 1
 warpx.cfl = 1.0
 
 # particles
-particles.nspecies = 2
 particles.species_names = electron positron
 
 electron.charge = -q_e

--- a/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
+++ b/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
@@ -22,8 +22,6 @@ warpx.cfl = 1.
 warpx.do_pml = 0
 warpx.use_hybrid_QED = 1
 
-particles.nspecies = 0
-
 #################################
 ############ FIELDS #############
 #################################

--- a/Examples/Tests/PML/inputs_2d
+++ b/Examples/Tests/PML/inputs_2d
@@ -24,14 +24,12 @@ warpx.verbose = 1
 
 warpx.cfl = 1.0
 warpx.do_pml = 1
-particles.nspecies = 0
 
 warpx.do_moving_window = 0
 # warpx.moving_window_dir = z
 # warpx.moving_window_v = 1.0 # in units of the speed of light
 
 # Laser
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.profile      = Gaussian
 laser1.position     = 0. 0. 0.e-6 # This point is on the laser plane

--- a/Examples/Tests/SingleParticle/inputs_2d
+++ b/Examples/Tests/SingleParticle/inputs_2d
@@ -12,7 +12,6 @@ algo.charge_deposition = standard
 algo.field_gathering = energy-conserving
 warpx.cfl = 1.0
 
-particles.nspecies = 1
 particles.species_names = electron
 electron.charge = -q_e
 electron.mass = m_e

--- a/Examples/Tests/averaged_galilean/inputs_avg_2d
+++ b/Examples/Tests/averaged_galilean/inputs_avg_2d
@@ -35,7 +35,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 warpx.do_nodal = 1

--- a/Examples/Tests/averaged_galilean/inputs_avg_3d
+++ b/Examples/Tests/averaged_galilean/inputs_avg_3d
@@ -33,7 +33,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 warpx.do_nodal = 1

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -22,7 +22,6 @@ warpx.cfl = 1.0
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electron ion
 
 electron.charge = -q_e
@@ -53,7 +52,6 @@ ion.do_not_deposit = 1
 #################################
 ############ COLLISION ##########
 #################################
-collisions.ncollisions = 3
 collisions.collision_names = collision1 collision2 collision3
 collision1.species = electron ion
 collision2.species = electron electron

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -22,7 +22,6 @@ warpx.cfl = 1.0
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electron ion
 
 electron.charge = -q_e
@@ -53,7 +52,6 @@ ion.do_not_deposit = 1
 #################################
 ############ COLLISION ##########
 #################################
-collisions.ncollisions = 3
 collisions.collision_names = collision1 collision2 collision3
 collision1.species = electron ion
 collision2.species = electron electron

--- a/Examples/Tests/galilean/inputs_2d
+++ b/Examples/Tests/galilean/inputs_2d
@@ -31,7 +31,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 warpx.do_nodal = 1

--- a/Examples/Tests/galilean/inputs_3d
+++ b/Examples/Tests/galilean/inputs_3d
@@ -32,7 +32,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 warpx.do_nodal = 1

--- a/Examples/Tests/initial_distribution/inputs
+++ b/Examples/Tests/initial_distribution/inputs
@@ -21,7 +21,6 @@ warpx.cfl     = 1.e-8
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies      = 4
 particles.species_names = gaussian maxwell_boltzmann maxwell_juttner beam
 
 gaussian.charge                     = -q_e

--- a/Examples/Tests/initial_plasma_profile/inputs
+++ b/Examples/Tests/initial_plasma_profile/inputs
@@ -22,7 +22,6 @@ warpx.use_filter = 0
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.charge = -q_e

--- a/Examples/Tests/laser_on_fine/inputs_2d
+++ b/Examples/Tests/laser_on_fine/inputs_2d
@@ -37,7 +37,6 @@ algo.field_gathering = energy-conserving
 
 # CFL
 warpx.cfl = 1.0
-particles.nspecies = 0
 
 # interpolation
 interpolation.nox = 1
@@ -48,7 +47,6 @@ interpolation.noz = 1
 warpx.do_moving_window = 0
 
 # Laser
-lasers.nlasers      = 1
 lasers.names        = laser1
 laser1.prob_lo      = -12.e-6  -5.e-6
 laser1.prob_hi      =  12.e-6   5.e-6

--- a/Examples/Tests/particle_pusher/inputs_3d
+++ b/Examples/Tests/particle_pusher/inputs_3d
@@ -25,7 +25,6 @@ algo.particle_pusher = "higuera"
 warpx.cfl = 1.0
 
 # particles
-particles.nspecies = 1
 particles.species_names = positron
 positron.charge = 1.0
 positron.mass = 1.0

--- a/Examples/Tests/particles_in_PML/inputs_2d
+++ b/Examples/Tests/particles_in_PML/inputs_2d
@@ -29,7 +29,6 @@ warpx.cfl = 1.0
 warpx.use_filter = 1
 
 # Particle species
-particles.nspecies = 2
 particles.species_names = electron proton
 
 electron.charge = -q_e

--- a/Examples/Tests/particles_in_PML/inputs_3d
+++ b/Examples/Tests/particles_in_PML/inputs_3d
@@ -29,7 +29,6 @@ warpx.cfl = 1.0
 warpx.use_filter = 1
 
 # Particle species
-particles.nspecies = 2
 particles.species_names = electron proton
 
 electron.charge = -q_e

--- a/Examples/Tests/photon_pusher/analysis_photon_pusher.py
+++ b/Examples/Tests/photon_pusher/analysis_photon_pusher.py
@@ -128,7 +128,6 @@ def generate():
         f.write("algo.field_gathering = energy-conserving\n")
         f.write("warpx.cfl = 1.0\n")
 
-        f.write("\nparticles.nspecies = {}\n".format(len(spec_names)))
         f.write("particles.species_names = {}\n".format(' '.join(spec_names)))
         f.write("particles.photon_species = {}\n".format(' '.join(spec_names)))
 

--- a/Examples/Tests/photon_pusher/inputs_3d
+++ b/Examples/Tests/photon_pusher/inputs_3d
@@ -16,7 +16,6 @@ algo.charge_deposition = standard
 algo.field_gathering = energy-conserving
 warpx.cfl = 1.0
 
-particles.nspecies = 16
 particles.species_names = p_xp_1 p_xn_1 p_yp_1 p_yn_1 p_zp_1 p_zn_1 p_dp_1 p_dn_1 p_xp_10 p_xn_10 p_yp_10 p_yn_10 p_zp_10 p_zn_10 p_dp_10 p_dn_10
 particles.photon_species = p_xp_1 p_xn_1 p_yp_1 p_yn_1 p_zp_1 p_zn_1 p_dp_1 p_dn_1 p_xp_10 p_xn_10 p_yp_10 p_yn_10 p_zp_10 p_zn_10 p_dp_10 p_dn_10
 

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -172,7 +172,6 @@ def generate():
         f.write("warpx.cfl = 1.0\n")
         f.write("warpx.serialize_ics = 1\n")
 
-        f.write("\nparticles.nspecies = {}\n".format(len(cases)))
         f.write("particles.species_names = ")
         for cc in cases:
             f.write(" {}".format(cc.name))

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
@@ -17,7 +17,6 @@ algo.field_gathering = energy-conserving
 warpx.cfl = 1.0
 warpx.serialize_ics = 1
 
-particles.nspecies = 5
 particles.species_names =  ele_para0 ele_perp0 ele_perp1 ele_perp2 pos_perp2
 
 ele_para0.species_type = "electron"

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -33,7 +33,6 @@ interpolation.noz = 1
 warpx.cfl = 0.99999
 
 # Particles
-particles.nspecies = 3
 particles.species_names = electrons protons photons
 particles.photon_species = photons
 

--- a/Examples/Tests/reduced_diags/inputs_loadbalancecosts
+++ b/Examples/Tests/reduced_diags/inputs_loadbalancecosts
@@ -37,7 +37,6 @@ interpolation.noz = 1
 warpx.cfl = 0.99999
 
 # Particles
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.charge = -q_e

--- a/Examples/Tests/subcycling/inputs_2d
+++ b/Examples/Tests/subcycling/inputs_2d
@@ -33,7 +33,6 @@ algo.maxwell_solver = "ckc"
 
 # CFL
 warpx.cfl = .9999
-particles.nspecies = 4
 particles.species_names = driver beam plasma_e plasma_p
 particles.deposit_on_main_grid = plasma_e plasma_p
 

--- a/Python/pywarpx/Lasers.py
+++ b/Python/pywarpx/Lasers.py
@@ -6,12 +6,11 @@
 
 from .Bucket import Bucket
 
-lasers = Bucket('lasers', nlasers=0, names=[])
+lasers = Bucket('lasers', names=[])
 lasers_list = []
 
 def newlaser(name):
     result = Bucket(name)
     lasers_list.append(result)
-    lasers.nlasers += 1
     lasers.names.append(name)
     return result

--- a/Python/pywarpx/Particles.py
+++ b/Python/pywarpx/Particles.py
@@ -6,7 +6,7 @@
 
 from .Bucket import Bucket
 
-particles = Bucket('particles', nspecies=0, species_names=[])
+particles = Bucket('particles', species_names=[])
 particles_list = []
 
 electrons = Bucket('electrons')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -65,8 +65,7 @@ class Species(picmistandard.PICMI_Species):
                     self.mass = element.mass*periodictable.constants.atomic_mass_constant
 
     def initialize_inputs(self, layout, initialize_self_fields=False):
-        self.species_number = pywarpx.particles.nspecies
-        pywarpx.particles.nspecies += 1
+        self.species_number = len(pywarpx.particles.species_names)
 
         if self.name is None:
             self.name = 'species{}'.format(self.species_number)
@@ -502,7 +501,7 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
 
 class GaussianLaser(picmistandard.PICMI_GaussianLaser):
     def initialize_inputs(self):
-        self.laser_number = pywarpx.lasers.nlasers + 1
+        self.laser_number = len(pywarpx.lasers.names) + 1
         if self.name is None:
             self.name = 'laser{}'.format(self.laser_number)
 
@@ -521,7 +520,7 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
 
 class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
     def initialize_inputs(self):
-        self.laser_number = pywarpx.lasers.nlasers + 1
+        self.laser_number = len(pywarpx.lasers.names) + 1
         if self.name is None:
             self.name = 'laser{}'.format(self.laser_number)
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -160,7 +160,7 @@ public:
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
-    int nSpecies() const {return nspecies;}
+    int nSpecies() const {return species_names.size();}
 
     int nSpeciesBackTransformedDiagnostics() const {return nspecies_back_transformed_diagnostics;}
     int mapSpeciesBackTransformedDiagnostics(int i) const {return map_species_back_transformed_diagnostics[i];}
@@ -380,11 +380,6 @@ private:
     // MultiParticleContainer for 0<i<nspecies_back_transformed_diagnostics
     std::vector<int> map_species_back_transformed_diagnostics;
     int do_back_transformed_diagnostics = 0;
-
-    // runtime parameters
-    int nlasers = 0;
-    int nspecies = 1;   // physical particles only. nspecies+nlasers == allcontainers.size().
-    int ncollisions = 0;
 
     void MFItInfoCheckTiling(const WarpXParticleContainer& pc_src) const noexcept
     {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1257,6 +1257,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
 
 void MultiParticleContainer::CheckQEDProductSpecies()
 {
+    auto const nspecies = species_names.size();
     for (int i=0; i<nspecies; i++){
         const auto& pc = allcontainers[i];
         if (pc->has_breit_wheeler()){

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -33,6 +33,9 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 
     ReadParameters();
 
+    auto const nspecies = species_names.size();
+    auto const nlasers = lasers_names.size();
+
     allcontainers.resize(nspecies + nlasers);
     for (int i = 0; i < nspecies; ++i) {
         if (species_types[i] == PCTypes::Physical) {
@@ -69,6 +72,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     }
 
     // collision
+    auto const ncollisions = collision_names.size();
     allcollisions.resize(ncollisions);
     for (int i = 0; i < ncollisions; ++i) {
         allcollisions[i].reset
@@ -170,16 +174,11 @@ MultiParticleContainer::ReadParameters ()
         }
 
 
-
-
-        pp.query("nspecies", nspecies);
-        AMREX_ALWAYS_ASSERT(nspecies >= 0);
+        // particle species
+        pp.queryarr("species_names", species_names);
+        auto const nspecies = species_names.size();
 
         if (nspecies > 0) {
-            // Get species names
-            pp.getarr("species_names", species_names);
-            AMREX_ALWAYS_ASSERT(species_names.size() == nspecies);
-
             // Get species to deposit on main grid
             m_deposit_on_main_grid.resize(nspecies, false);
             std::vector<std::string> tmp;
@@ -242,14 +241,9 @@ MultiParticleContainer::ReadParameters ()
                 }
             }
 
-            // collision
+            // binary collisions
             ParmParse pc("collisions");
-            pc.query("ncollisions", ncollisions);
-            AMREX_ALWAYS_ASSERT(ncollisions >= 0);
-            if (ncollisions > 0) {
-                pc.getarr("collision_names", collision_names);
-                AMREX_ALWAYS_ASSERT(collision_names.size() == ncollisions);
-            }
+            pc.queryarr("collision_names", collision_names);
 
         }
 
@@ -257,12 +251,7 @@ MultiParticleContainer::ReadParameters ()
         pp.query("l_lower_order_in_v", WarpX::l_lower_order_in_v);
 
         ParmParse ppl("lasers");
-        ppl.query("nlasers", nlasers);
-        AMREX_ALWAYS_ASSERT(nlasers >= 0);
-        if (nlasers > 0) {
-            ppl.getarr("names", lasers_names);
-            AMREX_ALWAYS_ASSERT(lasers_names.size() == nlasers);
-        }
+        ppl.queryarr("names", lasers_names);
 
 #ifdef WARPX_QED
         ParmParse ppw("warpx");
@@ -514,8 +503,7 @@ MultiParticleContainer
 void
 MultiParticleContainer::ContinuousInjection (const RealBox& injection_box) const
 {
-    for (int i=0; i<nspecies+nlasers; i++){
-        auto& pc = allcontainers[i];
+    for (auto& pc : allcontainers){
         if (pc->do_continuous_injection){
             pc->ContinuousInjection(injection_box);
         }
@@ -530,8 +518,7 @@ MultiParticleContainer::ContinuousInjection (const RealBox& injection_box) const
 void
 MultiParticleContainer::UpdateContinuousInjectionPosition (Real dt) const
 {
-    for (int i=0; i<nspecies+nlasers; i++){
-        auto& pc = allcontainers[i];
+    for (auto& pc : allcontainers){
         if (pc->do_continuous_injection){
             pc->UpdateContinuousInjectionPosition(dt);
         }
@@ -542,8 +529,7 @@ int
 MultiParticleContainer::doContinuousInjection () const
 {
     int warpx_do_continuous_injection = 0;
-    for (int i=0; i<nspecies+nlasers; i++){
-        auto& pc = allcontainers[i];
+    for (auto& pc : allcontainers){
         if (pc->do_continuous_injection){
             warpx_do_continuous_injection = 1;
         }
@@ -558,7 +544,7 @@ MultiParticleContainer::doContinuousInjection () const
 void
 MultiParticleContainer::mapSpeciesProduct ()
 {
-    for (int i=0; i<nspecies; i++){
+    for (int i=0; i<species_names.size(); i++){
         auto& pc = allcontainers[i];
         // If species pc has ionization on, find species with name
         // pc->ionization_product_name and store its ID into
@@ -606,7 +592,7 @@ MultiParticleContainer::getSpeciesID (std::string product_str) const
     int i_product;
     bool found = 0;
     // Loop over species
-    for (int i=0; i<nspecies; i++){
+    for (int i=0; i<species_names.size(); i++){
         // If species name matches, store its ID
         // into i_product
         if (species_names[i] == product_str){
@@ -680,10 +666,10 @@ MultiParticleContainer::doCoulombCollisions ()
 {
     WARPX_PROFILE("MPC::doCoulombCollisions");
 
-    for (int i = 0; i < ncollisions; ++i)
+    for( auto const& collision : allcollisions )
     {
-        auto& species1 = allcontainers[ allcollisions[i]->m_species1_index ];
-        auto& species2 = allcontainers[ allcollisions[i]->m_species2_index ];
+        auto& species1 = allcontainers[ collision->m_species1_index ];
+        auto& species2 = allcontainers[ collision->m_species2_index ];
 
         // Enable tiling
         MFItInfo info;
@@ -701,8 +687,8 @@ MultiParticleContainer::doCoulombCollisions ()
 
                 CollisionType::doCoulombCollisionsWithinTile
                     ( lev, mfi, species1, species2,
-                      allcollisions[i]->m_isSameSpecies,
-                      allcollisions[i]->m_CoulombLog );
+                      collision->m_isSameSpecies,
+                      collision->m_CoulombLog );
 
             }
         }
@@ -711,7 +697,7 @@ MultiParticleContainer::doCoulombCollisions ()
 
 void MultiParticleContainer::CheckIonizationProductSpecies()
 {
-    for (int i=0; i<nspecies; i++){
+    for (int i=0; i<species_names.size(); i++){
         if (allcontainers[i]->do_field_ionization){
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != allcontainers[i]->ionization_product,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -734,6 +734,22 @@ WarpX::BackwardCompatibility ()
         amrex::Abort("algo.maxwell_fdtd_solver is not supported anymore. "
                      "Please use the renamed option algo.maxwell_solver");
     }
+
+    ParmParse pparticles("particles");
+    int nspecies;
+    if (pparticles.query("nspecies", nspecies)){
+        amrex::Print()<<"particles.nspecies is ignored. Just use particles.species_names please.\n";
+    }
+    ParmParse pcol("collisions");
+    int ncollisions;
+    if (pcol.query("ncollisions", ncollisions)){
+        amrex::Print()<<"collisions.ncollisions is ignored. Just use particles.collision_names please.\n";
+    }
+    ParmParse plasers("lasers");
+    int nlasers;
+    if (plasers.query("nlasers", nlasers)){
+        amrex::Print()<<"lasers.nlasers is ignored. Just use lasers.names please.\n";
+    }
 }
 
 // This is a virtual function.


### PR DESCRIPTION
The information in
- lasers.nlasers
- particles.nspecies
- collisions.ncollisions

is redundant with their `<...>.names` counter-part and require users to change info at two locations. We just remove this now since we can query the size of names automatically in the parser.

Related to #1213 (B)