### PR TITLE
openPMD: Reconstruct RZ Particles

### DIFF
--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -45,6 +45,7 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
 #ifdef WARPX_DIM_RZ
     // Always write out theta, whether or not it's requested,
     // to be consistent with always writing out r and z.
+    // TODO: openPMD does a reconstruction to Cartesian, so we can now skip force-writing this
     plot_flags[ParticleStringNames::to_index.at("theta")] = 1;
 #endif
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -399,15 +399,11 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
            }
 
            //   reconstruct x and y from polar coordinates r, theta
-           amrex::ParticleReal const* theta = nullptr;
-           for (auto idx=0; idx<m_NumSoARealAttributes; idx++) {
-               auto ii = m_NumAoSRealAttributes + idx;
-               if (real_comp_names[ii] == "theta") {
-                   auto const& soa = pti.GetStructOfArrays();
-                   theta = soa.GetRealData(idx).data();
-               }
-           }
-           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(theta != nullptr, "openPMD: theta not found.");
+           auto const& soa = pti.GetStructOfArrays();
+           amrex::ParticleReal const* theta = soa.GetRealData(PIdx::theta).dataPtr();
+           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(theta != nullptr, "openPMD: invalid theta pointer.");
+           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(int(soa.GetRealData(PIdx::theta).size()) == numParticleOnTile,
+                                            "openPMD: theta and tile size do not match");
            {
                std::shared_ptr< amrex::ParticleReal > x(
                        new amrex::ParticleReal[numParticleOnTile],


### PR DESCRIPTION
This reconstructs particle positions to Cartesian before dumping them into openPMD files.

Related to #353

- [x] rebase after #1224
- [ ] "un-force" writing the theta component with openPMD

Pretty openPMD-viewer images for `Examples/Physics_applications/laser_acceleration/inputs_2d_rz`:

![theta](https://user-images.githubusercontent.com/1353258/88880666-3e85ed80-d1e2-11ea-9f39-e7bd63a3f6db.png)
![(PNG Image, 600 × 500 pixels)](https://user-images.githubusercontent.com/1353258/88880668-3f1e8400-d1e2-11ea-957f-5b050df1b16e.png)
