### PR TITLE
Fix the source of some "unused variable" warnings

### DIFF
--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -52,7 +52,7 @@ struct InjectorMomentumGaussian
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         return amrex::XDim3{amrex::RandomNormal(m_ux_m, m_ux_th),
                             amrex::RandomNormal(m_uy_m, m_uy_th),
@@ -61,7 +61,7 @@ struct InjectorMomentumGaussian
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getBulkMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getBulkMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         return amrex::XDim3{m_ux_m, m_uy_m, m_uz_m};
     }
@@ -85,7 +85,7 @@ struct InjectorMomentumBoltzmann
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         amrex::Real x1, x2, gamma;
         amrex::Real u[3];
@@ -127,7 +127,7 @@ struct InjectorMomentumBoltzmann
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getBulkMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getBulkMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         using namespace amrex;
         Real u[3];
@@ -157,7 +157,7 @@ struct InjectorMomentumJuttner
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         // Sobol method for sampling MJ Speeds,
         // from Zenitani 2015 (Phys. Plasmas 22, 042116).

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -213,7 +213,7 @@ struct InjectorMomentumJuttner
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getBulkMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getBulkMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
     {
         using namespace amrex;
         Real u[3];

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -18,7 +18,7 @@ struct InjectorPositionRandom
 {
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getPositionUnitBox (int i_part, int ref_fac=1) const noexcept
+    getPositionUnitBox (int /*i_part*/, int /*ref_fac=1*/) const noexcept
     {
         return amrex::XDim3{amrex::Random(), amrex::Random(), amrex::Random()};
     }

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -75,32 +75,32 @@ public:
                         DtType a_dt_type) override;
 
     // Do nothing
-    virtual void PushP (int lev,
-                        amrex::Real dt,
-                        const amrex::MultiFab& Ex,
-                        const amrex::MultiFab& Ey,
-                        const amrex::MultiFab& Ez,
-                        const amrex::MultiFab& Bx,
-                        const amrex::MultiFab& By,
-                        const amrex::MultiFab& Bz) override {}
+    virtual void PushP (int /*lev*/,
+                        amrex::Real /*dt*/,
+                        const amrex::MultiFab& /*Ex*/,
+                        const amrex::MultiFab& /*Ey*/,
+                        const amrex::MultiFab& /*Ez*/,
+                        const amrex::MultiFab& /*Bx*/,
+                        const amrex::MultiFab& /*By*/,
+                        const amrex::MultiFab& /*Bz*/) override {}
 
 
     // DepositCurrent should do nothing for photons
-    virtual void DepositCurrent(WarpXParIter& pti,
-                                RealVector& wp,
-                                RealVector& uxp,
-                                RealVector& uyp,
-                                RealVector& uzp,
-                                const int * const ion_lev,
-                                amrex::MultiFab* jx,
-                                amrex::MultiFab* jy,
-                                amrex::MultiFab* jz,
-                                const long offset,
-                                const long np_to_depose,
-                                int thread_num,
-                                int lev,
-                                int depos_lev,
-                                amrex::Real dt) override {}
+    virtual void DepositCurrent(WarpXParIter& /*pti*/,
+                                RealVector& /*wp*/,
+                                RealVector& /*uxp*/,
+                                RealVector& /*uyp*/,
+                                RealVector& /*uzp*/,
+                                const int * const /*ion_lev*/,
+                                amrex::MultiFab* /*jx*/,
+                                amrex::MultiFab* /*jy*/,
+                                amrex::MultiFab* /*jz*/,
+                                const long /*offset*/,
+                                const long /*np_to_depose*/,
+                                int /*thread_num*/,
+                                int /*lev*/,
+                                int /*depos_lev*/,
+                                amrex::Real /*dt*/) override {}
 };
 
 #endif // #ifndef WARPX_PhotonParticleContainer_H_

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -96,14 +96,11 @@ struct SetParticlePosition
     /** \brief Set the position of the particle at index `i + a_offset`
      *         to `x`, `y`, `z` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (const int i,
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_3D)
-        RType x, RType y, RType z
-#else
-        RType x, RType /*y*/, RType z
-#endif
-        ) const noexcept
+    void operator() (const int i, RType x, RType y, RType z) const noexcept
     {
+#if defined(WARPX_DIM_XZ)
+        amrex::ignore_unused(y);
+#endif
 #ifdef WARPX_DIM_RZ
         m_theta[i] = std::atan2(y, x);
         m_structs[i].pos(0) = std::sqrt(x*x + y*y);

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -96,7 +96,13 @@ struct SetParticlePosition
     /** \brief Set the position of the particle at index `i + a_offset`
      *         to `x`, `y`, `z` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (const int i, RType x, RType y, RType z) const noexcept
+    void operator() (const int i,
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_3D)
+        RType x, RType y, RType z
+#else
+        RType x, RType /*y*/, RType z
+#endif
+        ) const noexcept
     {
 #ifdef WARPX_DIM_RZ
         m_theta[i] = std::atan2(y, x);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -168,10 +168,10 @@ public:
 
     virtual void PostRestart () = 0;
 
-    virtual void GetParticleSlice(const int direction,     const amrex::Real z_old,
-                                  const amrex::Real z_new, const amrex::Real t_boost,
-                                  const amrex::Real t_lab, const amrex::Real dt,
-                                  DiagnosticParticles& diagnostic_particles) {}
+    virtual void GetParticleSlice(const int /*direction*/, const amrex::Real /*z_old*/,
+                                  const amrex::Real /*z_new*/, const amrex::Real /*t_boost*/,
+                                  const amrex::Real /*t_lab*/, const amrex::Real /*dt*/,
+                                  DiagnosticParticles& /*diagnostic_particles*/) {}
 
     void AllocData ();
 
@@ -233,9 +233,9 @@ public:
     // PhysicalParticleContainer: implemented.
     // LaserParticleContainer: implemented.
     // RigidInjectedParticleContainer: not implemented.
-    virtual void ContinuousInjection(const amrex::RealBox& injection_box) {}
+    virtual void ContinuousInjection(const amrex::RealBox& /*injection_box*/) {}
     // Update optional sub-class-specific injection location.
-    virtual void UpdateContinuousInjectionPosition(amrex::Real dt) {}
+    virtual void UpdateContinuousInjectionPosition(amrex::Real /*dt*/) {}
 
     ///
     /// This returns the total charge for all the particles in this ParticleContainer.
@@ -256,7 +256,7 @@ public:
 
     virtual void WriteHeader (std::ostream& os) const;
 
-    virtual void ConvertUnits (ConvertDirection convert_dir){}
+    virtual void ConvertUnits (ConvertDirection /*convert_dir*/){}
 
     static void ReadParameters ();
 


### PR DESCRIPTION
In this PR I have commented out some unused variables which caused several warning messages during compilation.
