### PR TITLE
Fix some compilation warnings

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -56,8 +56,8 @@ namespace amrex {
     public:
         FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
             : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta) {}
-        virtual SigmaBox* create (const Box& box, int ncomps,
-                                  const FabInfo& info, int box_index) const final
+        virtual SigmaBox* create (const Box& box, int /*ncomps*/,
+                                  const FabInfo& /*info*/, int /*box_index*/) const final
             { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta); }
         virtual void destroy (SigmaBox* fab) const final {
             delete fab;

--- a/Source/BoundaryConditions/PML_current.H
+++ b/Source/BoundaryConditions/PML_current.H
@@ -8,6 +8,7 @@
 #ifndef PML_CURRENT_H_
 #define PML_CURRENT_H_
 
+#include <AMReX.H>
 #include <AMReX_FArrayBox.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -33,6 +34,10 @@ void push_ex_pml_current (int j, int k, int l,
     Ex(j,k,l,1) = Ex(j,k,l,1) - mu_c2_dt  * alpha_xz * jx(j,k,l);
 #else
     Ex(j,k,l,1) = Ex(j,k,l,1) - mu_c2_dt  * jx(j,k,l);
+    amrex::ignore_unused(sigjy);
+    amrex::ignore_unused(sigjz);
+    amrex::ignore_unused(ylo);
+    amrex::ignore_unused(zlo);
 #endif
 }
 
@@ -60,6 +65,10 @@ void push_ey_pml_current (int j, int k, int l,
 #else
     Ey(j,k,l,0) = Ey(j,k,l,0) - 0.5 * mu_c2_dt  * jy(j,k,l);
     Ey(j,k,l,1) = Ey(j,k,l,1) - 0.5 * mu_c2_dt  * jy(j,k,l);
+    amrex::ignore_unused(sigjx);
+    amrex::ignore_unused(sigjz);
+    amrex::ignore_unused(xlo);
+    amrex::ignore_unused(zlo);
 #endif
 }
 
@@ -86,6 +95,10 @@ void push_ez_pml_current (int j, int k, int l,
     Ez(j,k,l,1) = Ez(j,k,l,1) - mu_c2_dt  * alpha_zy * jz(j,k,l);
 #else
     Ez(j,k,l,0) = Ez(j,k,l,0) - mu_c2_dt  * jz(j,k,l);
+    amrex::ignore_unused(sigjx);
+    amrex::ignore_unused(sigjy);
+    amrex::ignore_unused(xlo);
+    amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -101,6 +114,8 @@ void damp_jx_pml (int j, int k, int l,
     jx(j,k,l) = jx(j,k,l) * sigsjx[j-xlo] * sigjy[k-ylo] * sigjz[l-zlo];
 #else
     jx(j,k,l) = jx(j,k,l) * sigsjx[j-xlo] * sigjz[k-zlo];
+    amrex::ignore_unused(xlo);
+    amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -116,6 +131,8 @@ void damp_jy_pml (int j, int k, int l,
     jy(j,k,l) = jy(j,k,l) * sigjx[j-xlo] * sigsjy[k-ylo] * sigjz[l-zlo];
 #else
     jy(j,k,l) = jy(j,k,l) * sigjx[j-xlo] * sigjz[k-zlo];
+    amrex::ignore_unused(sigsjy);
+    amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -131,6 +148,8 @@ void damp_jz_pml (int j, int k, int l,
     jz(j,k,l) = jz(j,k,l) * sigjx[j-xlo] * sigjy[k-ylo] * sigsjz[l-zlo];
 #else
     jz(j,k,l) = jz(j,k,l) * sigjx[j-xlo] * sigsjz[k-zlo];
+    amrex::ignore_unused(sigjy);
+    amrex::ignore_unused(ylo);
 #endif
 }
 

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -8,6 +8,7 @@
 #ifndef WARPX_PML_KERNELS_H_
 #define WARPX_PML_KERNELS_H_
 
+#include <AMReX.H>
 #include <AMReX_FArrayBox.H>
 
 using namespace amrex;
@@ -24,6 +25,8 @@ void warpx_damp_pml_ex (int i, int j, int k, Array4<Real> const& Ex,
     Ex(i,j,k,1) *= sigma_fac_z[k-zlo];
 #else
     Ex(i,j,k,1) *= sigma_fac_z[j-zlo];
+    amrex::ignore_unused(sigma_fac_y);
+    amrex::ignore_unused(ylo);
 #endif
     Ex(i,j,k,2) *= sigma_star_fac_x[i-xlo];
 }
@@ -40,6 +43,8 @@ void warpx_damp_pml_ey (int i, int j, int k, Array4<Real> const& Ey,
     Ey(i,j,k,2) *= sigma_star_fac_y[j-ylo];
 #else
     Ey(i,j,k,0) *= sigma_fac_z[j-zlo];
+    amrex::ignore_unused(sigma_star_fac_y);
+    amrex::ignore_unused(ylo);
 #endif
     Ey(i,j,k,1) *= sigma_fac_x[i-xlo];
 }
@@ -57,6 +62,8 @@ void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
     Ez(i,j,k,2) *= sigma_star_fac_z[k-zlo];
 #else
     Ez(i,j,k,2) *= sigma_star_fac_z[j-zlo];
+    amrex::ignore_unused(sigma_fac_y);
+    amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -72,6 +79,8 @@ void warpx_damp_pml_bx (int i, int j, int k, Array4<Real> const& Bx,
    Bx(i,j,k,1) *= sigma_star_fac_z[k-zlo];
 #else
    Bx(i,j,k,1) *= sigma_star_fac_z[j-zlo];
+   amrex::ignore_unused(sigma_star_fac_y);
+   amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -98,6 +107,9 @@ void warpx_damp_pml_bz (int i, int j, int k, Array4<Real> const& Bz,
    Bz(i,j,k,0) *= sigma_star_fac_x[i-xlo];
 #if (AMREX_SPACEDIM == 3)
    Bz(i,j,k,1) *= sigma_star_fac_y[j-ylo];
+#else
+   amrex::ignore_unused(sigma_star_fac_y);
+   amrex::ignore_unused(ylo);
 #endif
 }
 
@@ -114,6 +126,8 @@ void warpx_damp_pml_F (int i, int j, int k, Array4<Real> const& F_fab,
    F_fab(i,j,k,2) *= sigma_fac_z[k-zlo];
 #else
    F_fab(i,j,k,2) *= sigma_fac_z[j-zlo];
+   amrex::ignore_unused(sigma_fac_y);
+   amrex::ignore_unused(ylo);
 #endif
 }
 

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -16,7 +16,7 @@ private:
     /** Flush m_mf_output and particles to file. */
     // Currently this is an empty function. When OpenPMD/Plotfile is supported
     // this function can be moved to the base class Diagnostics.
-    void Flush (int i_buffer) override {}
+    void Flush (int /*i_buffer*/) override {}
     /** whether to write output files at this time step
      *  The data is flushed when the buffer is full and/or
      *   when the simulation ends or when forced.

--- a/Source/Diagnostics/BackTransformedDiagnostic.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic.H
@@ -87,8 +87,8 @@ class LabFrameDiag {
     /// For the reduced diagnostic, the data is selectively copied if the
     /// extent of the z_lab multifab intersects with the user-defined sub-domain
     /// for the reduced diagnostic (i.e., a 1D, 2D, or 3D region of the domain).
-    virtual void AddDataToBuffer(amrex::MultiFab& tmp_slice_ptr, int i_lab,
-                 amrex::Gpu::ManagedDeviceVector<int> map_actual_fields_to_dump){}
+    virtual void AddDataToBuffer(amrex::MultiFab& /*tmp_slice_ptr*/, int /*i_lab*/,
+                 amrex::Gpu::ManagedDeviceVector<int> /*map_actual_fields_to_dump*/){}
 
     /// Back-transformed lab-frame particles is copied from
     /// tmp_particle_buffer to particles_buffer.
@@ -97,8 +97,8 @@ class LabFrameDiag {
     /// copied if their position in within the user-defined
     /// sub-domain +/- 1 cell size width for the reduced slice diagnostic.
     virtual void AddPartDataToParticleBuffer(
-                 amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> tmp_particle_buffer,
-                 int nSpeciesBoostedFrame) {}
+                 amrex::Vector<WarpXParticleContainer::DiagnosticParticleData> /*tmp_particle_buffer*/,
+                 int /*nSpeciesBoostedFrame*/) {}
 };
 
 /** \brief

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -14,6 +14,7 @@
 #ifdef WARPX_USE_OPENPMD
 #    include "FlushFormats/FlushFormatOpenPMD.H"
 #endif
+#include <AMReX.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
 using namespace amrex::literals;
@@ -96,7 +97,7 @@ FullDiagnostics::FlushRaw () {}
 
 
 bool
-FullDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
+FullDiagnostics::DoDump (int step, int /*i_buffer*/, bool force_flush)
 {
     if (m_already_done) return false;
     if ( force_flush || (m_intervals.contains(step+1)) ){
@@ -214,6 +215,8 @@ FullDiagnostics::AddRZModesToDiags (int lev)
         ncomp_from_src += m_all_field_functors[lev][i]->nComp();
     }
     AMREX_ALWAYS_ASSERT( ncomp_from_src == m_varnames.size() );
+#else
+    amrex::ignore_unused(lev);
 #endif
 }
 
@@ -227,6 +230,9 @@ FullDiagnostics::AddRZModesToOutputNames (const std::string& field, int ncomp){
         m_varnames.push_back( field + "_" + std::to_string(ic) + "_real" );
         m_varnames.push_back( field + "_" + std::to_string(ic) + "_imag" );
     }
+#else
+    amrex::ignore_unused(field);
+    amrex::ignore_unused(ncomp);
 #endif
 }
 

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -13,6 +13,8 @@
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpX_Complex.H"
 
+#include <AMReX.H>
+
 /**
  * \brief Field gather for a single particle
  *
@@ -57,6 +59,14 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                      const long n_rz_azimuthal_modes)
 {
     using namespace amrex;
+
+#if defined(WARPX_DIM_XZ)
+    amrex::ignore_unused(yp);
+#endif
+
+#ifndef WARPX_DIM_RZ
+    amrex::ignore_unused(n_rz_azimuthal_modes);
+#endif
 
     const amrex::Real dxi = 1.0/dx[0];
     const amrex::Real dzi = 1.0/dx[2];

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -381,7 +381,7 @@ private:
     std::vector<int> map_species_back_transformed_diagnostics;
     int do_back_transformed_diagnostics = 0;
 
-    void MFItInfoCheckTiling(const WarpXParticleContainer& pc_src) const noexcept
+    void MFItInfoCheckTiling(const WarpXParticleContainer& /*pc_src*/) const noexcept
     {
         return;
     }

--- a/Source/Particles/ParticleCreation/SmartCreate.H
+++ b/Source/Particles/ParticleCreation/SmartCreate.H
@@ -32,7 +32,7 @@ struct SmartCreate
 {
     const InitializationPolicy* m_policy_real;
     const InitializationPolicy* m_policy_int;
-    const int m_weight_index;
+    const int m_weight_index = 0;
 
     template <typename PartData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -10,6 +10,7 @@
 
 #include "Particles/WarpXParticleContainer.H"
 
+#include <AMReX.H>
 #include <AMReX_REAL.H>
 
 #include <limits>

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -561,8 +561,8 @@ protected:
     //! Make a new level using provided BoxArray and
     //! DistributionMapping and fill with interpolated coarse level
     //! data.  Called by AmrCore::regrid.
-    virtual void MakeNewLevelFromCoarse (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                         const amrex::DistributionMapping& dm) final
+    virtual void MakeNewLevelFromCoarse (int /*lev*/, amrex::Real /*time*/, const amrex::BoxArray& /*ba*/,
+                                         const amrex::DistributionMapping& /*dm*/) final
         { amrex::Abort("MakeNewLevelFromCoarse: To be implemented"); }
 
     //! Remake an existing level using provided BoxArray and


### PR DESCRIPTION
This PR should get rid of some more compilation warnings (mainly unused variables, one case of uninitialized member variable )