### PR TITLE
Domain decomposition by user

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -147,6 +147,12 @@ Setting up the field mesh
 Distribution across MPI ranks and parallelization
 -------------------------------------------------
 
+* ``warpx.numprocs`` (`2 ints` for 2D, `3 ints` for 3D) optional (default `none`)
+    This optional parameter can be used to control the domain decomposition on the
+    coarsest level. The domain will be chopped into the exact number of pieces in each
+    dimension as specified by this parameter. If it's not specified, the domain
+    decomposition will be determined by the parameters that will be discussed below.  If
+    specified, the product of the numbers must be equal to the number of MPI processes.
 
 * ``amr.max_grid_size`` (`integer`) optional (default `128`)
     Maximum allowable size of each **subdomain**

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -26,6 +26,40 @@
 using namespace amrex;
 
 void
+WarpX::PostProcessBaseGrids (BoxArray& ba0) const
+{
+    if (numprocs != 0) {
+        const Box& dom = Geom(0).Domain();
+        const IntVect& domlo = dom.smallEnd();
+        const IntVect& domlen = dom.size();
+        const IntVect sz = domlen / numprocs;
+        const IntVect extra = domlen - sz*numprocs;
+        BoxList bl;
+#if (AMREX_SPACEDIM == 3)
+        for (int k = 0; k < numprocs[2]; ++k) {
+            int klo = (k < extra[2]) ? k*(sz[2]+1) : (k*sz[2]+extra[2]);
+            int khi = (k < extra[2]) ? klo+(sz[2]+1)-1 : klo+sz[2]-1;
+            klo += domlo[2];
+            khi += domlo[2];
+#endif
+            for (int j = 0; j < numprocs[1]; ++j) {
+                int jlo = (j < extra[1]) ? j*(sz[1]+1) : (j*sz[1]+extra[1]);
+                int jhi = (j < extra[1]) ? jlo+(sz[1]+1)-1 : jlo+sz[1]-1;
+                jlo += domlo[1];
+                jhi += domlo[1];
+                for (int i = 0; i < numprocs[0]; ++i) {
+                    int ilo = (i < extra[0]) ? i*(sz[0]+1) : (i*sz[0]+extra[0]);
+                    int ihi = (i < extra[0]) ? ilo+(sz[0]+1)-1 : ilo+sz[0]-1;
+                    ilo += domlo[0];
+                    ihi += domlo[0];
+                    bl.push_back(Box(IntVect(AMREX_D_DECL(ilo,jlo,klo)),
+                                     IntVect(AMREX_D_DECL(ihi,jhi,khi))));
+        AMREX_D_TERM(},},})
+        ba0 = BoxArray(std::move(bl));
+    }
+}
+
+void
 WarpX::InitData ()
 {
     WARPX_PROFILE("WarpX::InitData()");

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -37,6 +37,9 @@ WarpX::PostProcessBaseGrids (BoxArray& ba0) const
         BoxList bl;
 #if (AMREX_SPACEDIM == 3)
         for (int k = 0; k < numprocs[2]; ++k) {
+            // The first extra[2] blocks get one extra cell with a total of
+            // sz[2]+1.  The rest get sz[2] cells.  The docomposition in y
+            // and x directions are similar.
             int klo = (k < extra[2]) ? k*(sz[2]+1) : (k*sz[2]+extra[2]);
             int khi = (k < extra[2]) ? klo+(sz[2]+1)-1 : klo+sz[2]-1;
             klo += domlo[2];

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -552,7 +552,8 @@ protected:
     //! Tagging cells for refinement
     virtual void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int /*ngrow*/) final;
 
-    //! Use this function to override the Level 0 grids made by AMReX
+    //! Use this function to override the Level 0 grids made by AMReX.
+    //! This function is called in amrex::AmrCore::InitFromScratch.
     virtual void PostProcessBaseGrids (amrex::BoxArray& ba0) const final;
 
     //! Make a new level from scratch using provided BoxArray and

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -552,6 +552,9 @@ protected:
     //! Tagging cells for refinement
     virtual void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int /*ngrow*/) final;
 
+    //! Use this function to override the Level 0 grids made by AMReX
+    virtual void PostProcessBaseGrids (amrex::BoxArray& ba0) const final;
+
     //! Make a new level from scratch using provided BoxArray and
     //! DistributionMapping.  Only used during initialization.  Called
     //! by AmrCoreInitFromScratch.
@@ -831,6 +834,9 @@ private:
     int nox_fft = 16;
     int noy_fft = 16;
     int noz_fft = 16;
+
+    // Domain decomposition on Level 0
+    amrex::IntVect numprocs{0};
 
 #ifdef WARPX_USE_PSATD
 private:

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -329,6 +329,22 @@ WarpX::ReadParameters ()
     {
         ParmParse pp("warpx");
 
+        std::vector<int> numprocs_in;
+        pp.queryarr("numprocs", numprocs_in);
+        if (not numprocs_in.empty()) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+                (numprocs_in.size() == AMREX_SPACEDIM,
+                 "warpx.numprocs, if specified, must have AMREX_SPACEDIM numbers");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+                (ParallelDescriptor::NProcs() == AMREX_D_TERM(numprocs_in[0],
+                                                             *numprocs_in[1],
+                                                             *numprocs_in[2]),
+                 "warpx.numprocs, if specified, its product must be equal to the number of processes");
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                numprocs[idim] = numprocs_in[idim];
+            }
+        }
+
         // set random seed
         std::string random_seed = "default";
         pp.query("random_seed", random_seed);


### PR DESCRIPTION
A new optional runtime parameter, warpx.numprocs, is added.  The parameter, an array with
the size of the space dimension, can be used by the user to decompose the domain on the
coarsest level.  If specified, the size of the array must be the number of the space
dimension, and the product of the numbers must be equal to the number of MPI processes.