### PR TITLE
RZ PSATD: rho diags must be cell-centered

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -586,7 +586,9 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     const auto& ba = m_gdb->ParticleBoxArray(lev);
     const auto& dm = m_gdb->DistributionMap(lev);
     BoxArray nba = ba;
+#if (!defined WARPX_DIM_RZ) || (!defined WARPX_USE_PSATD)
     nba.surroundingNodes();
+#endif
 
     const int ng = WarpX::nox;
 


### PR DESCRIPTION
The MultiFab used to allocate `rho` in `WarpXParticleContainer::GetChargeDensity` was created always nodal. However, with the PSATD solver in RZ geometry the `rho` field should be cell-centered.