### PR TITLE
Fix IO automated performance test

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -212,6 +212,7 @@ Diagnostics::ComputeAndPack ()
 void
 Diagnostics::FilterComputePackFlush (int step, bool force_flush)
 {
+    WARPX_PROFILE("Diagnostics::FilterComputePackFlush()");
     if ( DoComputeAndPack (step, force_flush) ) {
         ComputeAndPack();
 

--- a/Tools/PerformanceTests/functions_perftest.py
+++ b/Tools/PerformanceTests/functions_perftest.py
@@ -191,7 +191,7 @@ def extract_dataframe(filename, n_steps):
     line_match_looptime = re.search('\nWarpX::Evolve().*', search_area)
     time_wo_initialization = float(line_match_looptime.group(0).split()[3])
     # New, might break something
-    line_match_WritePlotFile = re.search('\nFlushFormatPlotfile::WriteToFile().*', search_area)
+    line_match_WritePlotFile = re.search('\nDiagnostics::FilterComputePackFlush().*', search_area)
     if line_match_WritePlotFile is not None:
          time_WritePlotFile = float(line_match_WritePlotFile.group(0).split()[3])
     else:


### PR DESCRIPTION
The IO automated performance was still broken on Summit. Just tested: this PR does fix the issue https://ecp-warpx.github.io/perf_logs/.