### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -206,7 +206,7 @@ void LoadBalanceCosts::WriteToFile (int step) const
             int ind_rank = i - m_nDataFields + 2; // index for the rank corresponding to current box
 
             // m_data --> rank --> hostname
-            ofs << m_sep << m_data_string[m_data[ind_rank]];
+            ofs << m_sep << m_data_string[(long unsigned int)(m_data[ind_rank])];
         }
     }
     // end loop over data size

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -206,7 +206,7 @@ void LoadBalanceCosts::WriteToFile (int step) const
             int ind_rank = i - m_nDataFields + 2; // index for the rank corresponding to current box
 
             // m_data --> rank --> hostname
-            ofs << m_sep << m_data_string[(long unsigned int)(m_data[ind_rank])];
+            ofs << m_sep << m_data_string[static_cast<long unsigned int>(m_data[ind_rank])];
         }
     }
     // end loop over data size


### PR DESCRIPTION
This PR fixes an implicit conversion warning from `Real` to `long unsigned int` in the load balance reduced diagnostics (fixes issue  #1238).  The conversion is done to use the rank, stored as a real, as an index, and so the conversion should be safe for any realistic number of ranks.  The warning is removed with an explicit conversion.