### PR TITLE
Small Fix of a Bug

### DIFF
--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -61,6 +61,6 @@ collision2.CoulombLog = 15.9
 collision3.CoulombLog = 15.9
 
 # Diagnostics
-diagnostics.diags_names = diag1
-diag1.period = 10
-diag1.diag_type = Full
+diagnostics.diags_names = diag
+diag.period = 10
+diag.diag_type = Full

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -61,6 +61,6 @@ collision2.CoulombLog = 15.9
 collision3.CoulombLog = 15.9
 
 # Diagnostics
-diagnostics.diags_names = diag1
-diag1.period = 10
-diag1.diag_type = Full
+diagnostics.diags_names = diag
+diag.period = 10
+diag.diag_type = Full


### PR DESCRIPTION
When testing a collision example, I found the test cannot pass due to the naming of the `diag` folder. Simply changing `diag1` to `diga` can fix the problem.