### PR TITLE
Change default warpx.sort_bin_size to a better-performing value.

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -94,7 +94,7 @@ bool WarpX::refine_plasma     = false;
 int WarpX::num_mirrors = 0;
 
 IntervalsParser WarpX::sort_intervals;
-amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(4,4,4));
+amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(1,1,1));
 
 bool WarpX::do_back_transformed_diagnostics = false;
 std::string WarpX::lab_data_directory = "lab_frame_data";


### PR DESCRIPTION
The `SortParticlesByBin()` method in AMReX was recently changed. This new value gives better results on two benchmarks I tried. The first was a 1 V100 uniform plasma run with 8 particles per cell, the second was our standard KPP run on 320 Summit nodes. In both cases, the new value leads to a 10-20% improvement in the overall runtime.