### PR TITLE
`amrex::Math::sqrt` -> `std::math`.  `amrex::Math::sqrt` was a temporary

### DIFF
--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -80,7 +80,7 @@ struct InjectorDensityPredefined
             double n0        = p[5];
             double n;
             double kp = PhysConst::q_e/PhysConst::c
-                *amrex::Math::sqrt( n0/(PhysConst::m_e*PhysConst::ep0) );
+                *std::sqrt( n0/(PhysConst::m_e*PhysConst::ep0) );
 
             // Longitudinal profile, normalized to 1
             if        ((z-z_start)>=0               and


### PR DESCRIPTION
workaround for HIP.  It has been removed now.