### PR TITLE
Fix 🩹 (almost) all warnings ⚠️ with default configuration (DIM=3, openMP+MPI, double precision, no advanced solvers, no QED, native output)

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -199,6 +199,7 @@ struct CartesianCKCAlgorithm {
 #if defined WARPX_DIM_3D
         Real const inv_dy = coefs_y[0];
         return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
+        amrex::ignore_unused(n_coefs_y);
 #elif (defined WARPX_DIM_XZ)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
@@ -214,7 +215,7 @@ struct CartesianCKCAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDz (
         amrex::Array4<amrex::Real> const& F,
-        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
@@ -234,7 +235,7 @@ struct CartesianCKCAlgorithm {
                       +  F(i-1,j+1,k+1,ncomp) - F(i-1,j+1,k  ,ncomp)
                       +  F(i+1,j-1,k+1,ncomp) - F(i+1,j-1,k  ,ncomp)
                       +  F(i-1,j-1,k+1,ncomp) - F(i-1,j-1,k  ,ncomp));
-        amrex::ignore_unused(n_coefs_y);
+        amrex::ignore_unused(n_coefs_z);
 #elif (defined WARPX_DIM_XZ)
         return alphaz * (F(i  ,j+1,k  ,ncomp) - F(i  ,j  ,k  ,ncomp))
              + betazx * (F(i+1,j+1,k  ,ncomp) - F(i+1,j  ,k  ,ncomp)

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -176,6 +176,7 @@ struct CartesianCKCAlgorithm {
                       +  F(i-1,j+1,k+1,ncomp) - F(i-1,j  ,k+1,ncomp)
                       +  F(i+1,j+1,k-1,ncomp) - F(i+1,j  ,k-1,ncomp)
                        +  F(i-1,j+1,k-1,ncomp) - F(i-1,j  ,k-1,ncomp));
+        amrex::ignore_unused(n_coefs_y);
 #elif (defined WARPX_DIM_XZ)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
@@ -233,6 +234,7 @@ struct CartesianCKCAlgorithm {
                       +  F(i-1,j+1,k+1,ncomp) - F(i-1,j+1,k  ,ncomp)
                       +  F(i+1,j-1,k+1,ncomp) - F(i+1,j-1,k  ,ncomp)
                       +  F(i-1,j-1,k+1,ncomp) - F(i-1,j-1,k  ,ncomp));
+        amrex::ignore_unused(n_coefs_y);
 #elif (defined WARPX_DIM_XZ)
         return alphaz * (F(i  ,j+1,k  ,ncomp) - F(i  ,j  ,k  ,ncomp))
              + betazx * (F(i+1,j+1,k  ,ncomp) - F(i+1,j  ,k  ,ncomp)

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -90,6 +90,7 @@ struct CartesianYeeAlgorithm {
 #if defined WARPX_DIM_3D
         Real const inv_dy = coefs_y[0];
         return inv_dy*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
+        amrex::ignore_unused(n_coefs_y);
 #elif (defined WARPX_DIM_XZ)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
@@ -112,6 +113,7 @@ struct CartesianYeeAlgorithm {
 #if defined WARPX_DIM_3D
         Real const inv_dy = coefs_y[0];
         return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
+        amrex::ignore_unused(n_coefs_y);
 #elif (defined WARPX_DIM_XZ)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);

--- a/Source/Parser/wp_parser_c.h
+++ b/Source/Parser/wp_parser_c.h
@@ -22,7 +22,7 @@ AMREX_NO_INLINE
 amrex::Real
 wp_ast_eval (struct wp_node* node, amrex::Real const* x)
 {
-    amrex::Real result;
+    amrex::Real result = 0.0;
 
     switch (node->type)
     {
@@ -190,7 +190,7 @@ AMREX_GPU_HOST_DEVICE
 AMREX_NO_INLINE
 #endif
 amrex::Real
-wp_ast_eval (struct wp_node* node, amrex::Real const* x)
+wp_ast_eval (struct wp_node* /*node*/, amrex::Real const* /*x*/)
 {
 #if AMREX_DEVICE_COMPILE
     AMREX_DEVICE_PRINTF("wp_ast_eval: WARPX_PARSER_DEPTH %d not big enough\n",

--- a/Source/Parser/wp_parser_c.h
+++ b/Source/Parser/wp_parser_c.h
@@ -2,11 +2,14 @@
 #define WP_PARSER_C_H_
 
 #include "wp_parser_y.h"
+
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuPrint.H>
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>
+#include <AMReX.H>
+
 #include <cassert>
 #include <set>
 #include <string>
@@ -190,7 +193,7 @@ AMREX_GPU_HOST_DEVICE
 AMREX_NO_INLINE
 #endif
 amrex::Real
-wp_ast_eval (struct wp_node* /*node*/, amrex::Real const* /*x*/)
+wp_ast_eval (struct wp_node* node, amrex::Real const* x)
 {
 #if AMREX_DEVICE_COMPILE
     AMREX_DEVICE_PRINTF("wp_ast_eval: WARPX_PARSER_DEPTH %d not big enough\n",
@@ -199,6 +202,7 @@ wp_ast_eval (struct wp_node* /*node*/, amrex::Real const* /*x*/)
     amrex::AllPrint() << "wp_ast_eval: WARPX_PARSER_DEPTH" << WARPX_PARSER_DEPTH
                       << "not big enough\n";
 #endif
+    amrex::ignore_unused(node, x);
     return 0.;
 }
 

--- a/Source/Parser/wp_parser_y.cpp
+++ b/Source/Parser/wp_parser_y.cpp
@@ -199,7 +199,7 @@ wp_ast_size (struct wp_node* node)
 struct wp_node*
 wp_parser_ast_dup (struct wp_parser* my_parser, struct wp_node* node, int move)
 {
-    void* result;
+    void* result = nullptr;
 
     switch (node->type)
     {

--- a/Source/Parser/wp_parser_y.cpp
+++ b/Source/Parser/wp_parser_y.cpp
@@ -143,7 +143,7 @@ wp_parser_dup (struct wp_parser* source)
 size_t
 wp_ast_size (struct wp_node* node)
 {
-    size_t result;
+    size_t result = 0;
 
     switch (node->type)
     {

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -11,6 +11,8 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 
+#include <AMReX.H>
+
 /* \brief Charge Deposition for thread thread_num
  * /param GetPosition : A functor for returning the particle position.
  * \param wp           : Pointer to array of particle weights.
@@ -160,6 +162,10 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
 #endif
         }
         );
+
+#ifndef WARPX_DIM_RZ
+        amrex::ignore_unused(n_rz_azimuthal_modes);
+#endif
 }
 
 #endif // CHARGEDEPOSITION_H_

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -154,8 +154,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             // Keep these double to avoid bug in single precision
             double sx_node[depos_order + 1];
             double sx_cell[depos_order + 1];
-            int j_node;
-            int j_cell;
+            int j_node = 0;
+            int j_cell = 0;
             Compute_shape_factor< depos_order > const compute_shape_factor;
             if (jx_type[0] == NODE || jy_type[0] == NODE || jz_type[0] == NODE) {
                 j_node = compute_shape_factor(sx_node, xmid);
@@ -184,8 +184,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             const double ymid = (yp - ymin)*dyi - dts2dy*vy;
             double sy_node[depos_order + 1];
             double sy_cell[depos_order + 1];
-            int k_node;
-            int k_cell;
+            int k_node = 0;
+            int k_cell = 0;
             if (jx_type[1] == NODE || jy_type[1] == NODE || jz_type[1] == NODE) {
                 k_node = compute_shape_factor(sy_node, ymid);
             }
@@ -211,8 +211,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             const double zmid = (zp - zmin)*dzi - dts2dz*vz;
             double sz_node[depos_order + 1];
             double sz_cell[depos_order + 1];
-            int l_node;
-            int l_cell;
+            int l_node = 0;
+            int l_cell = 0;
             if (jx_type[zdir] == NODE || jy_type[zdir] == NODE || jz_type[zdir] == NODE) {
                 l_node = compute_shape_factor(sz_node, zmid);
             }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -74,7 +74,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     // collision
     auto const ncollisions = collision_names.size();
     allcollisions.resize(ncollisions);
-    for (int i = 0; i < ncollisions; ++i) {
+    for (int i = 0; i < static_cast<int>(ncollisions); ++i) {
         allcollisions[i].reset
             (new CollisionType(species_names, collision_names[i]));
     }
@@ -544,7 +544,7 @@ MultiParticleContainer::doContinuousInjection () const
 void
 MultiParticleContainer::mapSpeciesProduct ()
 {
-    for (int i=0; i<species_names.size(); i++){
+    for (int i=0; i < static_cast<int>(species_names.size()); i++){
         auto& pc = allcontainers[i];
         // If species pc has ionization on, find species with name
         // pc->ionization_product_name and store its ID into
@@ -589,10 +589,10 @@ MultiParticleContainer::mapSpeciesProduct ()
 int
 MultiParticleContainer::getSpeciesID (std::string product_str) const
 {
-    int i_product;
+    int i_product = 0;
     bool found = 0;
     // Loop over species
-    for (int i=0; i<species_names.size(); i++){
+    for (int i=0; i < static_cast<int>(species_names.size()); i++){
         // If species name matches, store its ID
         // into i_product
         if (species_names[i] == product_str){
@@ -697,7 +697,7 @@ MultiParticleContainer::doCoulombCollisions ()
 
 void MultiParticleContainer::CheckIonizationProductSpecies()
 {
-    for (int i=0; i<species_names.size(); i++){
+    for (int i=0; i < static_cast<int>(species_names.size()); i++){
         if (allcontainers[i]->do_field_ionization){
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != allcontainers[i]->ionization_product,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -24,6 +24,7 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <AMReX_Print.H>
+#include <AMReX.H>
 
 #ifdef WARPX_USE_OPENPMD
 #   include <openPMD/openPMD.hpp>
@@ -441,6 +442,9 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
                   particle_ux.dataPtr(), particle_uy.dataPtr(), particle_uz.dataPtr(),
                   1, particle_w.dataPtr(),1);
 #endif // WARPX_USE_OPENPMD
+
+    ignore_unused(q_tot, z_shift);
+
     return;
 }
 
@@ -1427,7 +1431,6 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             const FArrayBox& bzfab = Bz[pti];
 
             const auto getPosition = GetParticlePosition(pti);
-                  auto setPosition = SetParticlePosition(pti);
 
             const auto getExternalE = GetExternalEField(pti);
             const auto getExternalB = GetExternalBField(pti);

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -27,9 +27,9 @@ struct GetParticlePosition
     using PType = WarpXParticleContainer::ParticleType;
     using RType = amrex::ParticleReal;
 
-    const PType* AMREX_RESTRICT m_structs;
+    const PType* AMREX_RESTRICT m_structs = nullptr;
 #if (defined WARPX_DIM_RZ)
-    const RType* m_theta;
+    const RType* m_theta = nullptr;
 #elif (AMREX_SPACEDIM == 2)
     static constexpr RType m_snan = std::numeric_limits<RType>::quiet_NaN();
 #endif

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -410,7 +410,6 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
             const FArrayBox& bzfab = Bz[pti];
 
             const auto getPosition = GetParticlePosition(pti);
-                  auto setPosition = SetParticlePosition(pti);
 
             const auto getExternalE = GetExternalEField(pti);
             const auto getExternalB = GetExternalBField(pti);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -19,6 +19,7 @@
 #include "Deposition/ChargeDeposition.H"
 
 #include <AMReX_AmrParGDB.H>
+#include <AMReX.H>
 
 #include <limits>
 
@@ -557,6 +558,8 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
         if (do_rz_volume_scaling) {
             WarpX::GetInstance().ApplyInverseVolumeScalingToChargeDensity(rho[lev].get(), lev);
         }
+#else
+        ignore_unused(do_rz_volume_scaling);
 #endif
 
         // Exchange guard cells


### PR DESCRIPTION
This PR should fix almost all the compilation warnings in the default configuration (DIM=3, openMP+MPI, double precision, no advanced solvers, no QED, native output...). Or at least it does that on my system (my compiler is `g++ (Ubuntu 9.3.0-10ubuntu2) 9.3.0` ).

I have just two residual warnings:

### 1
```
[ 89%] Building CXX object CMakeFiles/WarpX.dir/Source/Parser/wp_parser.lex.cpp.o
wp_parser.lex.c:1356:17: warning: ‘void yyunput(int, char*)’ defined but not used [-Wunused-function]
```
I don't know if `yyunput(int, char*)` is there for a reason, even if it is not used. So I didn't do anything.


### 2
```
[ 96%] Building CXX object CMakeFiles/WarpX.dir/Source/Utils/CoarsenIO.cpp.o
/home/luca/Projects/warpx_dir/WarpX/Source/Particles/WarpXParticleContainer.cpp: In member function ‘void WarpXParticleContainer::AddNParticles(int, int, const ParticleReal*, const ParticleReal*, const ParticleReal*, const ParticleReal*, const ParticleReal*, const ParticleReal*, int, const ParticleReal*, int, int)’:
/home/luca/Projects/warpx_dir/WarpX/Source/Particles/WarpXParticleContainer.cpp:102:44: warning: unused parameter ‘nattr’ [-Wunused-parameter]
  102 |                                        int nattr, const ParticleReal* attr, int uniqueparticles, int id)
```
The first line of `AddNParticles` is `BL_ASSERT(nattr == 1); //! @fixme nattr is unused below: false sense of safety` . So I thought that there might be something to fix here and I didn't do anything.