### PR TITLE
Disable ParticleIO for slices

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1403,10 +1403,12 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Root for output file names. Supports sub-directories.
 
 * ``<diag_name>.diag_lo`` (list `float`, 1 per dimension) optional (default `-infinity -infinity -infinity`)
-    Lower corner of the output fields (if smaller than ``warpx.dom_lo``, then set to ``warpx.dom_lo``).
+    Lower corner of the output fields (if smaller than ``warpx.dom_lo``, then set to ``warpx.dom_lo``). Currently, when the ``diag_lo`` is different from ``warpx.dom_lo``, particle output is disabled.
 
 * ``<diag_name>.diag_hi`` (list `float`, 1 per dimension) optional (default `+infinity +infinity +infinity`)
-    Higher corner of the output fields (if larger than ``warpx.dom_hi``, then set to ``warpx.dom_hi``).
+    Higher corner of the output fields (if larger than ``warpx.dom_hi``, then set to ``warpx.dom_hi``). Currently, when the ``diag_hi`` is different from ``warpx.dom_hi``, particle output i
+s disabled.
+
 
 * ``<diag_name>.species`` (list of `string`, default all physical species in the simulation)
     Which species dumped in this diagnostics.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -145,6 +145,8 @@ Diagnostics::InitData ()
         for (int i = 0; i < m_all_species.size(); ++i) {
             m_all_species[i].m_do_geom_filter = true;
         }
+        // Disabling particle-io for reduced domain diagnostics by reducing
+        // the particle-diag vector to zero.
         // This is a temporary fix until particle_buffer is supported in diagnostics.
         m_all_species.clear();
         amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -74,13 +74,6 @@ Diagnostics::BaseReadParameters ()
             m_hi[idim] = warpx.Geom(0).ProbHi(idim);
        }
     }
-    if (lo_specified || hi_specified) {
-        // set geometry filter for particle-diags to true when the diagnostic domain-extent
-        // is specified by the user
-        for (int i = 0; i < m_all_species.size(); ++i) {
-            m_all_species[i].m_do_geom_filter = true;
-        }
-    }
     // For a moving window simulation, the user-defined m_lo and m_hi must be converted.
     if (warpx.do_moving_window) {
 #if (AMREX_SPACEDIM == 3)
@@ -144,6 +137,18 @@ Diagnostics::InitData ()
     // When particle buffers, m_particle_buffers are included, they will be initialized here
     InitializeParticleBuffer();
 
+    amrex::ParmParse pp(m_diag_name);
+    amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
+    if ( pp.queryarr("diag_lo", dummy_val) || pp.queryarr("diag_hi", dummy_val) ) {
+        // set geometry filter for particle-diags to true when the diagnostic domain-extent
+        // is specified by the user
+        for (int i = 0; i < m_all_species.size(); ++i) {
+            m_all_species[i].m_do_geom_filter = true;
+        }
+        // This is a temporary fix until particle_buffer is supported in diagnostics.
+        m_all_species.clear();
+        amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+    }
 }
 
 


### PR DESCRIPTION
In this PR
1. do_geom_filter is set to true after the ParticleDiag, m_all_species, is initialized.
2. When diag_lo and diag_hi are specified, ParticleIO is disabled with a warning message.

This feature will be supported when particle_buffers are included. See Issue #1166 