### PR TITLE
Only tag particles for splitting when we change levels if splitting is on.

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -861,6 +861,8 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
                                            const ParticleLocData& pld,
                                            const int lev)
 {
+    if (not do_splitting) return;
+
     // Tag particle if goes to higher level.
     // It will be split later in the loop
     if (pld.m_lev == lev+1


### PR DESCRIPTION
This destroys information about the particle ids so we should only do it when necessary. 