### PR TITLE
Remove unused methods from WarpXParticleContainer.

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -262,10 +262,6 @@ public:
 
     static void BackwardCompatibility ();
 
-    static int NextID () { return ParticleType::NextID(); }
-
-    void setNextID(int next_id) { ParticleType::NextID(next_id); }
-
     bool do_splitting = false;
     bool initialize_self_fields = false;
     amrex::Real self_fields_required_precision = 1.e-11;


### PR DESCRIPTION
These container-level next_id functions are not used anywhere and also not really needed.