### PR TITLE
Use Long for the pid type in ParticleCreation

### DIFF
--- a/Source/Particles/ParticleCreation/SmartUtils.H
+++ b/Source/Particles/ParticleCreation/SmartUtils.H
@@ -39,7 +39,7 @@ SmartCopyTag getSmartCopyTag (const NameMap& src, const NameMap& dst) noexcept;
 template <typename PTile>
 void setNewParticleIDs (PTile& ptile, int old_size, int num_added)
 {
-    int pid;
+    amrex::Long pid;
 #ifdef _OPENMP
 #pragma omp critical (ionization_nextid)
 #endif


### PR DESCRIPTION
This could affect runs with ionization, QED, etc where we use more than max int particles.