### PR TITLE
CI: DPC++ Re-Enable

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -80,10 +80,10 @@ jobs:
         cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=single
         make -j 2
 
-  # broken in beta08
+  # [!] very slow runtime work-around for beta08
   #   https://github.com/intel/llvm/issues/2187
+  #   https://github.com/AMReX-Codes/amrex/pull/1243
   build_dpcc:
-    if: false
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With a work-around in place for DPC++ Beta8, we can re-enable this test. This work-around will slow-down the runtime potentially a lot, but we have a better work-around for the upcoming release that already landed upstream (e.g. `-mlong-double-64`) and/or the original issue might just get fixed at all by Intel.

Refs.:
- https://github.com/intel/llvm/issues/2187
- https://github.com/AMReX-Codes/amrex/pull/1243
- https://github.com/intel/llvm/pull/2295