### PR TITLE
Bug fix in Div E computation for RZ PSATD

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -20,11 +20,16 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const int /*i_
     // output Multifab, mf_dst, the guard-cell data is not needed especially considering
     // the operations performend in the CoarsenAndInterpolate function.
     constexpr int ng = 1;
+#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
+    // For RZ spectral, all quantities are cell centered.
+    amrex::IntVect typ = amrex::IntVect::TheCellVector();
+#else
     // For staggered and nodal calculations, divE is computed on the nodes.
     // The temporary divE MultiFab is generated to comply with the location of divE.
-    const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev),
-                                amrex::IntVect::TheUnitVector());
-    amrex::MultiFab divE(ba, warpx.DistributionMap(m_lev), 2*warpx.n_rz_azimuthal_modes-1, ng);
+    amrex::IntVect typ = amrex::IntVect::TheNodeVector();
+#endif
+    const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev),typ);
+    amrex::MultiFab divE(ba, warpx.DistributionMap(m_lev), 2*warpx.n_rz_azimuthal_modes-1, ng );
     warpx.ComputeDivE(divE, m_lev);
 
 #ifdef WARPX_DIM_RZ

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -22,13 +22,13 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const int /*i_
     constexpr int ng = 1;
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     // For RZ spectral, all quantities are cell centered.
-    amrex::IntVect typ = amrex::IntVect::TheCellVector();
+    amrex::IntVect cell_type = amrex::IntVect::TheCellVector();
 #else
     // For staggered and nodal calculations, divE is computed on the nodes.
     // The temporary divE MultiFab is generated to comply with the location of divE.
-    amrex::IntVect typ = amrex::IntVect::TheNodeVector();
+    amrex::IntVect cell_type = amrex::IntVect::TheNodeVector();
 #endif
-    const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev),typ);
+    const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev), cell_type);
     amrex::MultiFab divE(ba, warpx.DistributionMap(m_lev), 2*warpx.n_rz_azimuthal_modes-1, ng );
     warpx.ComputeDivE(divE, m_lev);
 


### PR DESCRIPTION
**These code changes were extracted from #1216. Many thanks to @EZoni and @dpgrote for spotting and fixing this bug.**

In the RZ PSATD mode, all the fields are computed on the cell centers. However, div(E) was still computed on the nodes, which lead to a discrepancy. This PR fixes the issue.