### PR TITLE
openPMD: Generalize Mesh Position

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -6,6 +6,7 @@
  */
 #include "WarpXOpenPMD.H"
 #include "FieldIO.H"  // for getReversedVec
+#include "Utils/RelativeCellPosition.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXUtil.H"
 
@@ -792,9 +793,10 @@ WarpXOpenPMDPlot::WriteOpenPMDFields( //const std::string& filename,
     // Create a new mesh record component, and store the associated metadata
     auto mesh_comp = mesh[comp_name];
     mesh_comp.resetDataset( dataset );
-    // Cell-centered data: position is at 0.5 of a cell size.
-    // TODO: honor nodal/cell centered data per component; reverse order to axisLabel order
-    mesh_comp.setPosition( std::vector<double>{AMREX_D_DECL(0.5, 0.5, 0.5)} );
+
+    auto relative_cell_pos = utils::getRelativeCellPosition( mf );       // AMReX Fortran index order
+    std::reverse( relative_cell_pos.begin(), relative_cell_pos.end() );  // now in C order
+    mesh_comp.setPosition( relative_cell_pos );
 
     // Loop through the multifab, and store each box as a chunk,
     // in the openPMD file.

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(WarpX
     CoarsenMR.cpp
     Interpolate.cpp
     IntervalsParser.cpp
+    RelativeCellPosition.cpp
     WarpXAlgorithmSelection.cpp
     WarpXMovingWindow.cpp
     WarpXTagging.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -6,5 +6,6 @@ CEXE_sources += CoarsenIO.cpp
 CEXE_sources += CoarsenMR.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += IntervalsParser.cpp
+CEXE_sources += RelativeCellPosition.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Utils

--- a/Source/Utils/RelativeCellPosition.H
+++ b/Source/Utils/RelativeCellPosition.H
@@ -1,0 +1,31 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_RELATIVE_CELL_POSITION_H_
+#define WARPX_RELATIVE_CELL_POSITION_H_
+
+#include "WarpX.H"
+
+#include <AMReX_MultiFab.H>
+
+#include <vector>
+
+
+namespace utils
+{
+    /** Get the Relative Cell Position of Values in an MultiFab
+     *
+     * Translate the IndexType of a given MultiFab into a position relative to
+     * the lower corner of a cell.
+     *
+     * @param[in] mf the amrex::MultiFab to get relative cell positions for
+     * @return relative position to the lower corner, scaled to cell size [0.0:1.0)
+     */
+    std::vector< double >
+    getRelativeCellPosition (amrex::MultiFab const& mf);
+}
+
+#endif // WARPX_RELATIVE_CELL_POSITION_H_

--- a/Source/Utils/RelativeCellPosition.cpp
+++ b/Source/Utils/RelativeCellPosition.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "RelativeCellPosition.H"
+
+#include <AMReX_IndexType.H>
+
+
+std::vector< double >
+utils::getRelativeCellPosition(amrex::MultiFab const& mf)
+{
+    amrex::IndexType const idx_type = mf.ixType();
+
+    std::vector< double > relative_position(AMREX_SPACEDIM, 0.0);
+
+    // amrex::CellIndex::CELL means: 0.5 from lower corner for that index/direction
+    // amrex::CellIndex::NODE means: at corner for that index/direction
+    // WarpX::do_nodal means: all indices/directions on CellIndex::NODE
+    for (int d = 0; d < AMREX_SPACEDIM; d++)
+    {
+        if (idx_type.cellCentered(d))
+            relative_position.at(d) = 0.5;
+    }
+
+    return relative_position;
+}


### PR DESCRIPTION
This adds a small utility that returns the relative in-cell position of values on each cell depending on an `amrex::MultiFab`'s `Box`'s `IndexType`.

This does not change the output of openPMD yet, since we spatially and temporally center fields before output, but makes the routines more general overall for future use.