### PR TITLE
CKC: Use Enum instead consequently

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -8,8 +8,9 @@
  */
 #include "BoundaryConditions/PML.H"
 #include "BoundaryConditions/PMLComponent.H"
-#include "WarpX.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "WarpX.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_VisMF.H>
@@ -471,7 +472,7 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     IntVect nge = IntVect(AMREX_D_DECL(2, 2, 2));
     IntVect ngb = IntVect(AMREX_D_DECL(2, 2, 2));
     int ngf_int = (do_moving_window) ? 2 : 0;
-    if (WarpX::maxwell_solver_id == 1) ngf_int = std::max( ngf_int, 1 );
+    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
     IntVect ngf = IntVect(AMREX_D_DECL(ngf_int, ngf_int, ngf_int));
 #ifdef WARPX_USE_PSATD
     // Increase the number of guard cells, in order to fit the extent

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -6,6 +6,8 @@
  */
 #include "GuardCellManager.H"
 #include "Filter/NCIGodfreyFilter.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX.H>
@@ -91,7 +93,7 @@ guardCellManager::Init(
     // after pushing particle.
     int ng_alloc_F_int = (do_moving_window) ? 2 : 0;
     // CKC solver requires one additional guard cell
-    if (maxwell_solver_id == 1) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
+    if (maxwell_solver_id == MaxwellSolverAlgo::CKC) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
     ng_alloc_F = IntVect(AMREX_D_DECL(ng_alloc_F_int, ng_alloc_F_int, ng_alloc_F_int));
 
 #ifdef WARPX_USE_PSATD


### PR DESCRIPTION
Use the enums `MaxwellSolverAlgo` consequently for value of `WarpX::maxwell_solver_id`.