### PR TITLE
openPMD-api: 0.12.0+

### DIFF
--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -25,7 +25,7 @@ Optional dependencies include:
 - `OpenMP 3.1+ <https://www.openmp.org>`_: for threaded CPU execution (currently not fully accelerated)
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
 - `Boost 1.66.0+ <https://www.boost.org/>`_: for QED support
-- `openPMD-api 0.11.1+ <https://github.com/openPMD/openPMD-api>`_: we automatically download and compile a copy of openPMD-api for openPMD I/O support
+- `openPMD-api 0.12.0+ <https://github.com/openPMD/openPMD-api>`_: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`_
 - `CCache <https://ccache.dev>`_: to speed up rebuilds (needs 3.7.9+ for CUDA)
@@ -39,11 +39,12 @@ macOS/Linux:
 
    spack env create warpx-dev
    spack env activate warpx-dev
+   spack add adios2
    spack add ccache
    spack add cmake
    spack add fftw
+   spack add hdf5
    spack add mpi
-   spack add openpmd-api
    spack add pkgconfig  # for fftw
    # optional:
    # spack add cuda
@@ -56,13 +57,14 @@ or macOS/Linux:
 .. code-block:: bash
 
    brew update
+   brew install adios2
    brew install ccache
    brew install cmake
    brew install fftw
+   brew install hdf5-mpi
    brew install libomp
    brew install pkg-config  # for fftw
    brew install open-mpi
-   brew install openpmd-api
 
 Now, ``cmake --version`` should be at version 3.14.0 or newer.
 

--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -3,13 +3,13 @@
 Building WarpX with support for openPMD output
 ==============================================
 
-WarpX can dump data in the `openPMD format <https://github.com/openPMD>`__.
+WarpX can dump data in the `openPMD format <https://github.com/openPMD>`_.
 This feature currently requires to have a parallel version of HDF5 installed ;
 therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library 0.11.0a or newer <https://openpmd-api.readthedocs.io/en/0.11.0-alpha/>`__
+`openPMD-api library 0.12.0a or newer <https://openpmd-api.readthedocs.io/en/0.12.0-alpha/>`_
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -110,7 +110,7 @@ public:
 
 
 private:
-  void Init(openPMD::AccessType accessType, const std::string& filePrefix);
+  void Init(openPMD::Access access, const std::string& filePrefix);
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -247,12 +247,12 @@ void WarpXOpenPMDPlot::SetStep(int ts, const std::string& filePrefix)
   }
 
     m_CurrentStep =  ts;
-    Init(openPMD::AccessType::CREATE, filePrefix);
+    Init(openPMD::Access::CREATE, filePrefix);
 
 }
 
 void
-WarpXOpenPMDPlot::Init(openPMD::AccessType accessType, const std::string& filePrefix)
+WarpXOpenPMDPlot::Init(openPMD::Access access, const std::string& filePrefix)
 {
     // either for the next ts file,
     // or init a single file for all ts
@@ -267,7 +267,7 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType, const std::string& filePr
     {
 #if defined(AMREX_USE_MPI)
         m_Series = std::make_unique<openPMD::Series>(
-            filename, accessType,
+            filename, access,
             amrex::ParallelDescriptor::Communicator()
         );
         m_MPISize = amrex::ParallelDescriptor::NProcs();
@@ -278,7 +278,7 @@ WarpXOpenPMDPlot::Init(openPMD::AccessType accessType, const std::string& filePr
     }
     else
     {
-        m_Series = std::make_unique<openPMD::Series>(filename, accessType);
+        m_Series = std::make_unique<openPMD::Series>(filename, access);
         m_MPISize = 1;
         m_MPIRank = 1;
     }

--- a/Source/Diagnostics/requirements.txt
+++ b/Source/Diagnostics/requirements.txt
@@ -5,4 +5,4 @@
 # License: BSD-3-Clause-LBNL
 
 # keep this entry for GitHub's dependency graph
-openPMD-api>=0.11.0
+openPMD-api>=0.12.0

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -268,7 +268,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 #ifdef WARPX_USE_OPENPMD
         if (ParallelDescriptor::IOProcessor()) {
             m_openpmd_input_series = std::make_unique<openPMD::Series>(
-                str_injection_file, openPMD::AccessType::READ_ONLY);
+                str_injection_file, openPMD::Access::READ_ONLY);
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 m_openpmd_input_series->iterations.size() == 1u,

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -136,7 +136,7 @@ endif
 
 ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
-   ifeq (0, $(shell pkg-config "openPMD >= 0.11.0"; echo $$?))
+   ifeq (0, $(shell pkg-config "openPMD >= 0.12.0"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
        libraries += $(shell pkg-config --libs-only-l openPMD)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -4,7 +4,7 @@ function(find_openpmd)
         include(FetchContent)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.11.1-alpha/dev/buildoptions.html
+        # see https://openpmd-api.readthedocs.io/en/0.12.0-alpha/dev/buildoptions.html
         set(openPMD_USE_MPI    ${WarpX_MPI}  CACHE INTERNAL "")
         set(openPMD_USE_PYTHON OFF           CACHE INTERNAL "")
         set(BUILD_CLI_TOOLS    OFF           CACHE INTERNAL "")  # FIXME
@@ -52,7 +52,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.11.1 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.12.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()


### PR DESCRIPTION
Update WarpX to depend on openPMD-api 0.12.0+.
Remove deprecated type usage (`AccessType` -> `Access`).