### PR TITLE
Fix error with IntervalsParser and whitespaces

### DIFF
--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -55,9 +55,9 @@ FullDiagnostics::ReadParameters ()
         m_format == "checkpoint" || m_format == "ascent" ||
         m_format == "sensei",
         "<diag>.format must be plotfile or openpmd or checkpoint or ascent or sensei");
-    std::string period_string = "0";
-    pp.query("period", period_string);
-    m_intervals = IntervalsParser(period_string);
+    std::vector<std::string> period_string_vec = {"0"};
+    pp.queryarr("period", period_string_vec);
+    m_intervals = IntervalsParser(period_string_vec);
     bool raw_specified = pp.query("plot_raw_fields", m_plot_raw_fields);
     raw_specified += pp.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
 

--- a/Source/Particles/Resampling/ResamplingTrigger.cpp
+++ b/Source/Particles/Resampling/ResamplingTrigger.cpp
@@ -11,9 +11,9 @@ ResamplingTrigger::ResamplingTrigger ()
 {
     amrex::ParmParse pprt("resampling_trigger");
 
-    std::string resampling_trigger_int_string = "0";
-    pprt.query("intervals", resampling_trigger_int_string);
-    m_resampling_intervals = IntervalsParser(resampling_trigger_int_string);
+    std::vector<std::string> resampling_trigger_int_string_vec = {"0"};
+    pprt.queryarr("intervals", resampling_trigger_int_string_vec);
+    m_resampling_intervals = IntervalsParser(resampling_trigger_int_string_vec);
 
     pprt.query("max_avg_ppc", m_max_avg_ppc);
 }

--- a/Source/Utils/IntervalsParser.H
+++ b/Source/Utils/IntervalsParser.H
@@ -90,10 +90,11 @@ public:
     /**
     * \brief Constructor of the IntervalsParser class.
     *
-    * @param[in] instr an input string of the form "x,y,z,...". This will call the constructor of
-    * SliceParser using x, y and z as input arguments.
+    * @param[in] instr_vec an input vector string, which when concatenated is of the form
+    * "x,y,z,...". This will call the constructor of SliceParser using x, y and z as input
+    * arguments.
     */
-    IntervalsParser (const std::string& instr);
+    IntervalsParser (const std::vector<std::string>& instr_vec);
 
     /**
     * \brief A method that returns true if the input integer is contained in any of the slices

--- a/Source/Utils/IntervalsParser.cpp
+++ b/Source/Utils/IntervalsParser.cpp
@@ -58,9 +58,12 @@ int SliceParser::getStart () const {return m_start;}
 
 int SliceParser::getStop () const {return m_stop;}
 
-IntervalsParser::IntervalsParser (const std::string& instr)
+IntervalsParser::IntervalsParser (const std::vector<std::string>& instr_vec)
 {
-    auto insplit = WarpXUtilStr::split<std::vector<std::string>>(instr, m_separator);
+    std::string inconcatenated;
+    for (const auto instr_element : instr_vec) inconcatenated +=instr_element;
+
+    auto insplit = WarpXUtilStr::split<std::vector<std::string>>(inconcatenated, m_separator);
 
     for(int i=0; i<static_cast<int>(insplit.size()); i++)
     {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -369,9 +369,9 @@ WarpX::ReadParameters ()
         pp.query("do_subcycling", do_subcycling);
         pp.query("use_hybrid_QED", use_hybrid_QED);
         pp.query("safe_guard_cells", safe_guard_cells);
-        std::string override_sync_int_string = "1";
-        pp.query("override_sync_int", override_sync_int_string);
-        override_sync_intervals = IntervalsParser(override_sync_int_string);
+        std::vector<std::string> override_sync_int_string_vec = {"1"};
+        pp.queryarr("override_sync_int", override_sync_int_string_vec);
+        override_sync_intervals = IntervalsParser(override_sync_int_string_vec);
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycling != 1 || max_level <= 1,
                                          "Subcycling method 1 only works for 2 levels.");
@@ -488,12 +488,12 @@ WarpX::ReadParameters ()
         pp.query("n_field_gather_buffer", n_field_gather_buffer);
         pp.query("n_current_deposition_buffer", n_current_deposition_buffer);
 #ifdef AMREX_USE_GPU
-        std::string sort_int_string = "4";
+        std::vector<std::string>sort_int_string_vec = {"4"};
 #else
-        std::string sort_int_string = "-1";
+        std::vector<std::string> sort_int_string_vec = {"-1"};
 #endif
-        pp.query("sort_int", sort_int_string);
-        sort_intervals = IntervalsParser(sort_int_string);
+        pp.queryarr("sort_int", sort_int_string_vec);
+        sort_intervals = IntervalsParser(sort_int_string_vec);
 
         Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
         bool sort_bin_size_is_specified = pp.queryarr("sort_bin_size", vect_sort_bin_size);
@@ -568,9 +568,9 @@ WarpX::ReadParameters ()
             fine_tag_hi = RealVect{hi};
         }
 
-        std::string load_balance_int_string = "0";
-        pp.query("load_balance_int", load_balance_int_string);
-        load_balance_intervals = IntervalsParser(load_balance_int_string);
+        std::vector<std::string> load_balance_int_string_vec = {"0"};
+        pp.queryarr("load_balance_int", load_balance_int_string_vec);
+        load_balance_intervals = IntervalsParser(load_balance_int_string_vec);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
         pp.query("load_balance_efficiency_ratio_threshold", load_balance_efficiency_ratio_threshold);


### PR DESCRIPTION
In the documentation of the intervals parser, we state that whitespaces are ignored and even give examples of syntaxes where whitespaces are used. If the input intervals are given between quotes, this works fine. For instance, 
`something_int = "100, 1250:1270"` works as expected.

However, if there are no quotes, we currently disregard whatever is after the first whitespace. This can result in an invalid syntax error. For example:
`something_int = 100, 1250:1270` is currently the same as `something_int = 100,`, which is invalid.
This can also result in a simulation that runs but with the wrong intervals. For instance
`something_int = 100 ,1250:1270` is currently the same as `something_int = 100`, which is pretty bad.

A simple solution to fix this is to read the input file parameter as a vector of strings rather than as a string using `ParmParse::queryarr` instead of `ParmParse::query`. Then, we can concatenate the vector of strings in the constructor of the `IntervalsParser` object and proceed as before.

For the future, it might be worth testing the intervals parser in one of the CI tests, which will be easy to do once the syntax is used for reduced diagnostics.