### PR TITLE
[mini] Add comments about resample virtual method

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -701,6 +701,7 @@ void MultiParticleContainer::doResampling (const int timestep)
 
     for (auto& pc : allcontainers)
     {
+        // do_resampling can only be true for PhysicalParticleContainers
         if (!pc->do_resampling){ continue; }
 
         pc->resample(m_resampler, timestep);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -330,7 +330,10 @@ public:
     amrex::Array<amrex::Real,3> get_v_galilean () {return v_galilean;}
 
     /**
-     * \brief Virtual method to resample the species. Overriden by PhysicalParticleContainer.
+     * \brief Virtual method to resample the species. Overriden by PhysicalParticleContainer only.
+     * Empty body is here because making the method purely virtual would mean that we need to
+     * override the method for every derived class. Note that in practice this function is never
+     * called because resample() is only called for PhysicalParticleContainers.
      */
     virtual void resample (const Resampling& /*resampler*/, const int /*timestep*/) {}
 


### PR DESCRIPTION
This adds a couple of comments explaining why we have an empty body for `WarpXParticleContainer::resample` and don't make this method purely virtual.