### PR TITLE
Remove The_Managed_Arena

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -306,7 +306,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
         ParserFilter const parser_filter(particle_diags[i].m_do_parser_filter,
-                                         particle_diags[i].m_particle_filter_parser.get());
+                                         getParser(particle_diags[i].m_particle_filter_parser));
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
         // real_names contains a list of all particle attributes.

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -135,7 +135,7 @@ void ParticleHistogram::ComputeDiags (int step)
     using PType = typename WarpXParticleContainer::SuperParticleType;
 
     // get parser
-    ParserWrapper<m_nvars> *fun_partparser = m_parser.get();
+    HostDeviceParser<m_nvars> fun_partparser = getParser(m_parser);
 
     // declare local variables
     Real const bin_min  = m_bin_min;
@@ -156,7 +156,7 @@ void ParticleHistogram::ComputeDiags (int step)
             auto const ux = p.rdata(PIdx::ux)/PhysConst::c;
             auto const uy = p.rdata(PIdx::uy)/PhysConst::c;
             auto const uz = p.rdata(PIdx::uz)/PhysConst::c;
-            auto const f = (*fun_partparser)(t,x,y,z,ux,uy,uz);
+            auto const f = fun_partparser(t,x,y,z,ux,uy,uz);
             auto const f1 = bin_min + bin_size*i;
             auto const f2 = bin_min + bin_size*(i+1);
             if ( f > f1 && f < f2 ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -33,7 +33,7 @@ public:
       *  with user-defined functions(x,y,z).
       */
      void InitializeMacroMultiFabUsingParser (amrex::MultiFab *macro_mf,
-                                  ParserWrapper<3> *macro_parser, int lev);
+                                  HostDeviceParser<3> const& macro_parser, int lev);
      /** Gpu Vector with index type of the conductivity multifab */
      amrex::GpuArray<int, 3> sigma_IndexType;
      /** Gpu Vector with index type of the permittivity multifab */

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -106,7 +106,7 @@ MacroscopicProperties::InitData ()
 
     } else if (m_sigma_s == "parse_sigma_function") {
 
-        InitializeMacroMultiFabUsingParser(m_sigma_mf.get(), m_sigma_parser.get(), lev);
+        InitializeMacroMultiFabUsingParser(m_sigma_mf.get(), getParser(m_sigma_parser), lev);
     }
     // Initialize epsilon
     if (m_epsilon_s == "constant") {
@@ -115,7 +115,7 @@ MacroscopicProperties::InitData ()
 
     } else if (m_epsilon_s == "parse_epsilon_function") {
 
-        InitializeMacroMultiFabUsingParser(m_eps_mf.get(), m_epsilon_parser.get(), lev);
+        InitializeMacroMultiFabUsingParser(m_eps_mf.get(), getParser(m_epsilon_parser), lev);
 
     }
     // Initialize mu
@@ -125,7 +125,7 @@ MacroscopicProperties::InitData ()
 
     } else if (m_mu_s == "parse_mu_function") {
 
-        InitializeMacroMultiFabUsingParser(m_mu_mf.get(), m_mu_parser.get(), lev);
+        InitializeMacroMultiFabUsingParser(m_mu_mf.get(), getParser(m_mu_parser), lev);
 
     }
 
@@ -161,7 +161,7 @@ MacroscopicProperties::InitData ()
 
 void
 MacroscopicProperties::InitializeMacroMultiFabUsingParser (
-                       MultiFab *macro_mf, ParserWrapper<3> *macro_parser,
+                       MultiFab *macro_mf, HostDeviceParser<3> const& macro_parser,
                        int lev)
 {
     auto& warpx = WarpX::GetInstance();
@@ -187,7 +187,7 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
                 Real z = k * dx_lev[2] + real_box.lo(2) + fac_z;
 
                 // initialize the macroparameter
-                macro_fab(i,j,k) = (*macro_parser)(x,y,z);
+                macro_fab(i,j,k) = macro_parser(x,y,z);
         });
 
     }

--- a/Source/Initialization/CustomDensityProb.H
+++ b/Source/Initialization/CustomDensityProb.H
@@ -19,15 +19,13 @@
 struct InjectorDensityCustom
 {
     InjectorDensityCustom (std::string const& species_name)
-        : p(nullptr)
     {
-        // Read parameters for custom density profile from file, and
-        // store them in managed memory.
+        // Read parameters for custom density profile from file
         amrex::ParmParse pp(species_name);
         std::vector<amrex::Real> v;
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
+                                         "Too many parameters for InjectorDensityCustom");
         pp.getarr("custom_profile_params", v);
-        p = static_cast<amrex::Real*>
-            (amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real)*v.size()));
         for (int i = 0; i < static_cast<int>(v.size()); ++i) {
             p[i] = v[i];
         }
@@ -43,13 +41,11 @@ struct InjectorDensityCustom
     }
 
     // Note that we are not allowed to have non-trivial destructor.
-    // So we rely on clear() to free memory.
-    void clear () {
-        amrex::The_Managed_Arena()->free(p);
-    }
+    // So we rely on clear() to free memory if needed.
+    void clear () {}
 
 private:
-    amrex::Real* p;
+    amrex::GpuArray<amrex::Real,6> p;
 };
 
 #endif

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -108,7 +108,7 @@ struct InjectorDensityPredefined
 private:
     enum struct Profile { null, parabolic_channel };
     Profile profile;
-    amrex::Real* p;
+    amrex::GpuArray<amrex::Real,6> p;
 };
 
 // Base struct for density injector.
@@ -119,12 +119,8 @@ private:
 // - InjectorDensityCustom    : to generate density from custom profile;
 // - InjectorDensityPredefined: to generate density from predefined profile;
 // The choice is made at runtime, depending in the constructor called.
-// This mimics virtual functions, except the struct is stored in managed memory
-// and member functions are made __host__ __device__ to run on CPU and GPU.
-// This struct inherits from amrex::Gpu::Managed to provide new and delete
-// operators in managed memory when running on GPU. Nothing special on CPU.
+// This mimics virtual functions.
 struct InjectorDensity
-    : public amrex::Gpu::Managed
 {
     // This constructor stores a InjectorDensityConstant in union object.
     InjectorDensity (InjectorDensityConstant* t, amrex::Real a_rho)
@@ -157,7 +153,7 @@ struct InjectorDensity
     void operator= (InjectorDensity const&) = delete;
     void operator= (InjectorDensity &&) = delete;
 
-    ~InjectorDensity ();
+    void clear ();
 
     // call getDensity from the object stored in the union
     // (the union is called Object, and the instance is called object).
@@ -212,6 +208,17 @@ private:
         InjectorDensityPredefined predefined;
     };
     Object object;
+};
+
+// In order for InjectorDensity to be trivially copyable, its destructor
+// must be trivial.  So we have to rely on a custom deleter for unique_ptr.
+struct InjectorDensityDeleter {
+    void operator () (InjectorDensity* p) const {
+        if (p) {
+            p->clear();
+            delete p;
+        }
+    }
 };
 
 #endif

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -11,7 +11,7 @@
 
 using namespace amrex;
 
-InjectorDensity::~InjectorDensity ()
+void InjectorDensity::clear ()
 {
     switch (type)
     {
@@ -42,11 +42,10 @@ InjectorDensityPredefined::InjectorDensityPredefined (
     ParmParse pp(a_species_name);
 
     std::vector<amrex::Real> v;
-    // Read parameters for the predefined plasma profile,
-    // and store them in managed memory
+    // Read parameters for the predefined plasma profile.
     pp.getarr("predefined_profile_params", v);
-    p = static_cast<amrex::Real*>
-        (amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real)*v.size()));
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
+                                     "Too many parameters for InjectorDensityPredefined");
     for (int i = 0; i < static_cast<int>(v.size()); ++i) {
         p[i] = v[i];
     }
@@ -64,8 +63,7 @@ InjectorDensityPredefined::InjectorDensityPredefined (
 }
 
 // Note that we are not allowed to have non-trivial destructor.
-// So we rely on clear() to free memory.
+// So we rely on clear() to free memory if needed.
 void InjectorDensityPredefined::clear ()
 {
-    amrex::The_Managed_Arena()->free(p);
 }

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -293,12 +293,8 @@ struct InjectorMomentumParser
 // - InjectorMomentumRadialExpansion: to generate radial expansion;
 // - InjectorMomentumParser         : to generate momentum from parser;
 // The choice is made at runtime, depending in the constructor called.
-// This mimics virtual functions, except the struct is stored in managed memory
-// and member functions are made __host__ __device__ to run on CPU and GPU.
-// This struct inherits from amrex::Gpu::Managed to provide new and delete
-// operators in managed memory when running on GPU. Nothing special on CPU.
+// This mimics virtual functions.
 struct InjectorMomentum
-    : public amrex::Gpu::Managed
 {
     // This constructor stores a InjectorMomentumConstant in union object.
     InjectorMomentum (InjectorMomentumConstant* t,
@@ -358,7 +354,7 @@ struct InjectorMomentum
     void operator= (InjectorMomentum const&) = delete;
     void operator= (InjectorMomentum &&) = delete;
 
-    ~InjectorMomentum ();
+    void clear ();
 
     // call getMomentum from the object stored in the union
     // (the union is called Object, and the instance is called object).
@@ -490,6 +486,17 @@ private:
         InjectorMomentumParser   parser;
     };
     Object object;
+};
+
+// In order for InjectorMomentum to be trivially copyable, its destructor
+// must be trivial.  So we have to rely on a custom deleter for unique_ptr.
+struct InjectorMomentumDeleter {
+    void operator () (InjectorMomentum* p) const {
+        if (p) {
+            p->clear();
+            delete p;
+        }
+    }
 };
 
 #endif

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -11,7 +11,7 @@
 
 using namespace amrex;
 
-InjectorMomentum::~InjectorMomentum ()
+void InjectorMomentum::clear ()
 {
     switch (type)
     {

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -66,12 +66,8 @@ private:
 // - InjectorPositionRandom : to generate random distribution;
 // - InjectorPositionRegular: to generate regular distribution.
 // The choice is made at runtime, depending in the constructor called.
-// This mimics virtual functions, except the struct is stored in managed memory
-// and member functions are made __host__ __device__ to run on CPU and GPU.
-// This struct inherits from amrex::Gpu::Managed to provide new and delete
-// operators in managed memory when running on GPU. Nothing special on CPU.
+// This mimics virtual functions.
 struct InjectorPosition
-    : public amrex::Gpu::Managed
 {
     // This constructor stores a InjectorPositionRandom in union object.
     InjectorPosition (InjectorPositionRandom* t,

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -41,6 +41,8 @@ public:
 
     PlasmaInjector (int ispecies, const std::string& name);
 
+    ~PlasmaInjector ();
+
     // bool: whether the point (x, y, z) is inside the plasma region
     bool insideBounds (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept;
 
@@ -58,7 +60,7 @@ public:
     amrex::Real getMass () {return mass;}
     PhysicalSpecies getPhysicalSpecies() const {return physical_species;}
 
-    bool doInjection () const noexcept { return inj_pos != NULL;}
+    bool doInjection () const noexcept { return h_inj_pos != nullptr;}
 
     bool add_single_particle = false;
     amrex::Vector<amrex::ParticleReal> single_particle_pos;
@@ -114,9 +116,14 @@ protected:
     int species_id;
     std::string species_name;
 
-    std::unique_ptr<InjectorPosition> inj_pos;
-    std::unique_ptr<InjectorDensity > inj_rho;
-    std::unique_ptr<InjectorMomentum> inj_mom;
+    std::unique_ptr<InjectorPosition> h_inj_pos;
+    InjectorPosition* d_inj_pos = nullptr;
+
+    std::unique_ptr<InjectorDensity,InjectorDensityDeleter> h_inj_rho;
+    InjectorDensity* d_inj_rho = nullptr;
+
+    std::unique_ptr<InjectorMomentum,InjectorMomentumDeleter> h_inj_mom;
+    InjectorMomentum* d_inj_mom = nullptr;
 
     void parseDensity (amrex::ParmParse& pp);
     void parseMomentum (amrex::ParmParse& pp);

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -76,6 +76,13 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 {
     ParmParse pp(species_name);
 
+    static_assert(std::is_trivially_copyable<InjectorPosition>::value,
+                  "InjectorPosition must be trivially copyable");
+    static_assert(std::is_trivially_copyable<InjectorDensity>::value,
+                  "InjectorDensity must be trivially copyable");
+    static_assert(std::is_trivially_copyable<InjectorMomentum>::value,
+                  "InjectorMomentum must be trivially copyable");
+
     pp.query("radially_weighted", radially_weighted);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(radially_weighted, "ERROR: Only radially_weighted=true is supported");
 
@@ -223,8 +230,8 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             "(Please visit PR#765 for more information.)");
 #endif
         // Construct InjectorPosition with InjectorPositionRandom.
-        inj_pos.reset(new InjectorPosition((InjectorPositionRandom*)nullptr,
-                                           xmin, xmax, ymin, ymax, zmin, zmax));
+        h_inj_pos.reset(new InjectorPosition((InjectorPositionRandom*)nullptr,
+                                             xmin, xmax, ymin, ymax, zmin, zmax));
         parseDensity(pp);
         parseMomentum(pp);
     } else if (part_pos_s == "nuniformpercell") {
@@ -243,11 +250,11 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             "n_rz_azimuthal_modes (Please visit PR#765 for more information.)");
 #endif
         // Construct InjectorPosition from InjectorPositionRegular.
-        inj_pos.reset(new InjectorPosition((InjectorPositionRegular*)nullptr,
-                                           xmin, xmax, ymin, ymax, zmin, zmax,
-                                           Dim3{num_particles_per_cell_each_dim[0],
-                                                num_particles_per_cell_each_dim[1],
-                                                num_particles_per_cell_each_dim[2]}));
+        h_inj_pos.reset(new InjectorPosition((InjectorPositionRegular*)nullptr,
+                                             xmin, xmax, ymin, ymax, zmin, zmax,
+                                             Dim3{num_particles_per_cell_each_dim[0],
+                                                  num_particles_per_cell_each_dim[1],
+                                                  num_particles_per_cell_each_dim[2]}));
         num_particles_per_cell = num_particles_per_cell_each_dim[0] *
                                  num_particles_per_cell_each_dim[1] *
                                  num_particles_per_cell_each_dim[2];
@@ -342,6 +349,53 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     } else {
         StringParseAbortMessage("Injection style", part_pos_s);
     }
+
+    if (h_inj_pos) {
+#ifdef AMREX_USE_GPU
+        d_inj_pos = static_cast<InjectorPosition*>
+            (amrex::The_Arena()->alloc(sizeof(InjectorPosition)));
+        amrex::Gpu::htod_memcpy_async(d_inj_pos, h_inj_pos.get(), sizeof(InjectorPosition));
+#else
+        d_inj_pos = h_inj_pos.get();
+#endif
+    }
+
+    if (h_inj_rho) {
+#ifdef AMREX_USE_GPU
+        d_inj_rho = static_cast<InjectorDensity*>
+            (amrex::The_Arena()->alloc(sizeof(InjectorDensity)));
+        amrex::Gpu::htod_memcpy_async(d_inj_rho, h_inj_rho.get(), sizeof(InjectorDensity));
+#else
+        d_inj_rho = h_inj_rho.get();
+#endif
+    }
+
+    if (h_inj_mom) {
+#ifdef AMREX_USE_GPU
+        d_inj_mom = static_cast<InjectorMomentum*>
+            (amrex::The_Arena()->alloc(sizeof(InjectorMomentum)));
+        amrex::Gpu::htod_memcpy_async(d_inj_mom, h_inj_mom.get(), sizeof(InjectorMomentum));
+#else
+        d_inj_mom = h_inj_mom.get();
+#endif
+    }
+
+    amrex::Gpu::synchronize();
+}
+
+PlasmaInjector::~PlasmaInjector ()
+{
+#ifdef AMREX_USE_GPU
+    if (d_inj_pos) {
+        amrex::The_Arena()->free(d_inj_pos);
+    }
+    if (d_inj_rho) {
+        amrex::The_Arena()->free(d_inj_rho);
+    }
+    if (d_inj_mom) {
+        amrex::The_Arena()->free(d_inj_mom);
+    }
+#endif
 }
 
 // Depending on injection type at runtime, initialize inj_rho
@@ -357,18 +411,18 @@ void PlasmaInjector::parseDensity (ParmParse& pp)
     if (rho_prof_s == "constant") {
         pp.get("density", density);
         // Construct InjectorDensity with InjectorDensityConstant.
-        inj_rho.reset(new InjectorDensity((InjectorDensityConstant*)nullptr, density));
+        h_inj_rho.reset(new InjectorDensity((InjectorDensityConstant*)nullptr, density));
     } else if (rho_prof_s == "custom") {
         // Construct InjectorDensity with InjectorDensityCustom.
-        inj_rho.reset(new InjectorDensity((InjectorDensityCustom*)nullptr, species_name));
+        h_inj_rho.reset(new InjectorDensity((InjectorDensityCustom*)nullptr, species_name));
     } else if (rho_prof_s == "predefined") {
         // Construct InjectorDensity with InjectorDensityPredefined.
-        inj_rho.reset(new InjectorDensity((InjectorDensityPredefined*)nullptr,species_name));
+        h_inj_rho.reset(new InjectorDensity((InjectorDensityPredefined*)nullptr,species_name));
     } else if (rho_prof_s == "parse_density_function") {
         Store_parserString(pp, "density_function(x,y,z)", str_density_function);
         // Construct InjectorDensity with InjectorDensityParser.
-        inj_rho.reset(new InjectorDensity((InjectorDensityParser*)nullptr,
-                                          makeParser(str_density_function,{"x","y","z"})));
+        h_inj_rho.reset(new InjectorDensity((InjectorDensityParser*)nullptr,
+                                            makeParser(str_density_function,{"x","y","z"})));
     } else {
         //No need for profile definition if external file is used
         std::string s_inj_style;
@@ -399,10 +453,10 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
         pp.query("uy", uy);
         pp.query("uz", uz);
         // Construct InjectorMomentum with InjectorMomentumConstant.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumConstant*)nullptr, ux,uy, uz));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumConstant*)nullptr, ux,uy, uz));
     } else if (mom_dist_s == "custom") {
         // Construct InjectorMomentum with InjectorMomentumCustom.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumCustom*)nullptr, species_name));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumCustom*)nullptr, species_name));
     } else if (mom_dist_s == "gaussian") {
         Real ux_m = 0.;
         Real uy_m = 0.;
@@ -417,8 +471,8 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
         pp.query("uy_th", uy_th);
         pp.query("uz_th", uz_th);
         // Construct InjectorMomentum with InjectorMomentumGaussian.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumGaussian*)nullptr,
-                                           ux_m, uy_m, uz_m, ux_th, uy_th, uz_th));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumGaussian*)nullptr,
+                                             ux_m, uy_m, uz_m, ux_th, uy_th, uz_th));
     } else if (mom_dist_s == "maxwell_boltzmann"){
         Real beta = 0.;
         Real theta = 10.;
@@ -449,7 +503,7 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
             amrex::Abort(direction.c_str());
         }
         // Construct InjectorMomentum with InjectorMomentumBoltzmann.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumBoltzmann*)nullptr, theta, beta, dir));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumBoltzmann*)nullptr, theta, beta, dir));
     } else if (mom_dist_s == "maxwell_juttner"){
         Real beta = 0.;
         Real theta = 10.;
@@ -480,13 +534,13 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
             amrex::Abort(direction.c_str());
         }
         // Construct InjectorMomentum with InjectorMomentumJuttner.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumJuttner*)nullptr, theta, beta, dir));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumJuttner*)nullptr, theta, beta, dir));
     } else if (mom_dist_s == "radial_expansion") {
         Real u_over_r = 0.;
         pp.query("u_over_r", u_over_r);
         // Construct InjectorMomentum with InjectorMomentumRadialExpansion.
-        inj_mom.reset(new InjectorMomentum
-                      ((InjectorMomentumRadialExpansion*)nullptr, u_over_r));
+        h_inj_mom.reset(new InjectorMomentum
+                        ((InjectorMomentumRadialExpansion*)nullptr, u_over_r));
     } else if (mom_dist_s == "parse_momentum_function") {
         Store_parserString(pp, "momentum_function_ux(x,y,z)",
                                                str_momentum_function_ux);
@@ -495,10 +549,10 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
         Store_parserString(pp, "momentum_function_uz(x,y,z)",
                                                str_momentum_function_uz);
         // Construct InjectorMomentum with InjectorMomentumParser.
-        inj_mom.reset(new InjectorMomentum((InjectorMomentumParser*)nullptr,
-                                           makeParser(str_momentum_function_ux,{"x","y","z"}),
-                                           makeParser(str_momentum_function_uy,{"x","y","z"}),
-                                           makeParser(str_momentum_function_uz,{"x","y","z"})));
+        h_inj_mom.reset(new InjectorMomentum((InjectorMomentumParser*)nullptr,
+                                             makeParser(str_momentum_function_ux,{"x","y","z"}),
+                                             makeParser(str_momentum_function_uy,{"x","y","z"}),
+                                             makeParser(str_momentum_function_uz,{"x","y","z"})));
     } else {
         //No need for momentum definition if external file is used
         std::string s_inj_style;
@@ -511,7 +565,7 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
 
 XDim3 PlasmaInjector::getMomentum (Real x, Real y, Real z) const noexcept
 {
-    return inj_mom->getMomentum(x, y, z); // gamma*beta
+    return h_inj_mom->getMomentum(x, y, z); // gamma*beta
 }
 
 bool PlasmaInjector::insideBounds (Real x, Real y, Real z) const noexcept
@@ -532,17 +586,17 @@ bool PlasmaInjector::overlapsWith (const amrex::XDim3& lo,
 InjectorPosition*
 PlasmaInjector::getInjectorPosition ()
 {
-    return inj_pos.get();
+    return d_inj_pos;
 }
 
 InjectorDensity*
 PlasmaInjector::getInjectorDensity ()
 {
-    return inj_rho.get();
+    return d_inj_rho;
 }
 
 InjectorMomentum*
 PlasmaInjector::getInjectorMomentum ()
 {
-    return inj_mom.get();
+    return d_inj_mom;
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -356,25 +356,25 @@ WarpX::InitLevelData (int lev, Real /*time*/)
        InitializeExternalFieldsOnGridUsingParser(Bfield_fp[lev][0].get(),
                                                  Bfield_fp[lev][1].get(),
                                                  Bfield_fp[lev][2].get(),
-                                                 Bxfield_parser.get(),
-                                                 Byfield_parser.get(),
-                                                 Bzfield_parser.get(),
+                                                 getParser(Bxfield_parser),
+                                                 getParser(Byfield_parser),
+                                                 getParser(Bzfield_parser),
                                                  lev);
        if (lev > 0) {
           InitializeExternalFieldsOnGridUsingParser(Bfield_aux[lev][0].get(),
                                                     Bfield_aux[lev][1].get(),
                                                     Bfield_aux[lev][2].get(),
-                                                    Bxfield_parser.get(),
-                                                    Byfield_parser.get(),
-                                                    Bzfield_parser.get(),
+                                                    getParser(Bxfield_parser),
+                                                    getParser(Byfield_parser),
+                                                    getParser(Bzfield_parser),
                                                     lev);
 
           InitializeExternalFieldsOnGridUsingParser(Bfield_cp[lev][0].get(),
                                                     Bfield_cp[lev][1].get(),
                                                     Bfield_cp[lev][2].get(),
-                                                    Bxfield_parser.get(),
-                                                    Byfield_parser.get(),
-                                                    Bzfield_parser.get(),
+                                                    getParser(Bxfield_parser),
+                                                    getParser(Byfield_parser),
+                                                    getParser(Bzfield_parser),
                                                     lev);
        }
     }
@@ -405,25 +405,25 @@ WarpX::InitLevelData (int lev, Real /*time*/)
        InitializeExternalFieldsOnGridUsingParser(Efield_fp[lev][0].get(),
                                                  Efield_fp[lev][1].get(),
                                                  Efield_fp[lev][2].get(),
-                                                 Exfield_parser.get(),
-                                                 Eyfield_parser.get(),
-                                                 Ezfield_parser.get(),
+                                                 getParser(Exfield_parser),
+                                                 getParser(Eyfield_parser),
+                                                 getParser(Ezfield_parser),
                                                  lev);
        if (lev > 0) {
           InitializeExternalFieldsOnGridUsingParser(Efield_aux[lev][0].get(),
                                                     Efield_aux[lev][1].get(),
                                                     Efield_aux[lev][2].get(),
-                                                    Exfield_parser.get(),
-                                                    Eyfield_parser.get(),
-                                                    Ezfield_parser.get(),
+                                                    getParser(Exfield_parser),
+                                                    getParser(Eyfield_parser),
+                                                    getParser(Ezfield_parser),
                                                     lev);
 
           InitializeExternalFieldsOnGridUsingParser(Efield_cp[lev][0].get(),
                                                     Efield_cp[lev][1].get(),
                                                     Efield_cp[lev][2].get(),
-                                                    Exfield_parser.get(),
-                                                    Eyfield_parser.get(),
-                                                    Ezfield_parser.get(),
+                                                    getParser(Exfield_parser),
+                                                    getParser(Eyfield_parser),
+                                                    getParser(Ezfield_parser),
                                                     lev);
        }
     }
@@ -454,8 +454,8 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 void
 WarpX::InitializeExternalFieldsOnGridUsingParser (
        MultiFab *mfx, MultiFab *mfy, MultiFab *mfz,
-       ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-       ParserWrapper<3> *zfield_parser, const int lev)
+       HostDeviceParser<3> const& xfield_parser, HostDeviceParser<3> const& yfield_parser,
+       HostDeviceParser<3> const& zfield_parser, const int lev)
 {
 
     const auto dx_lev = geom[lev].CellSizeArray();
@@ -490,7 +490,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the x-component of the field.
-                mfxfab(i,j,k) = (*xfield_parser)(x,y,z);
+                mfxfab(i,j,k) = xfield_parser(x,y,z);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
@@ -506,7 +506,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the y-component of the field.
-                mfyfab(i,j,k)  = (*yfield_parser)(x,y,z);
+                mfyfab(i,j,k)  = yfield_parser(x,y,z);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
@@ -522,7 +522,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the z-component of the field.
-                mfzfab(i,j,k) = (*zfield_parser)(x,y,z);
+                mfzfab(i,j,k) = zfield_parser(x,y,z);
             }
         );
     }

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -46,9 +46,9 @@ WarpXLaserProfiles::FieldFunctionLaserProfile::fill_amplitude (
     const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
     Real t, Real * AMREX_RESTRICT const amplitude) const
 {
-    auto parser = m_gpu_parser.get();
+    auto parser = getParser(m_gpu_parser);
     amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
     {
-        amplitude[i] = (*parser)(Xp[i], Yp[i], t);
+        amplitude[i] = parser(Xp[i], Yp[i], t);
     });
 }

--- a/Source/Parser/GpuParser.H
+++ b/Source/Parser/GpuParser.H
@@ -16,14 +16,20 @@
 
 // When compiled for CPU, wrap WarpXParser and enable threading.
 // When compiled for GPU, store one copy of the parser in
-// CUDA managed memory for __device__ code, and one copy of the parser
-// in CUDA managed memory for __host__ code. This way, the parser can be
+// device memory for __device__ code, and one copy of the parser
+// in host memory for __host__ code. This way, the parser can be
 // efficiently called from both host and device.
 template <int N>
 class GpuParser
 {
 public:
     GpuParser (WarpXParser const& wp);
+
+    GpuParser (GpuParser<N> const&) = delete;
+    GpuParser (GpuParser<N> &&) = delete;
+    void operator= (GpuParser<N> const&) = delete;
+    void operator= (GpuParser<N> &&) = delete;
+
     void clear ();
 
     template <typename... Ts>
@@ -37,7 +43,7 @@ public:
         amrex::GpuArray<amrex::Real,N> l_var{var...};
 #if AMREX_DEVICE_COMPILE
 // WarpX compiled for GPU, function compiled for __device__
-        return wp_ast_eval<0>(m_gpu_parser.ast, l_var.data());
+        return wp_ast_eval<0>(m_gpu_parser_ast, l_var.data());
 #else
 // WarpX compiled for GPU, function compiled for __host__
         return wp_ast_eval<0>(m_cpu_parser->ast, nullptr);
@@ -55,12 +61,13 @@ public:
 #endif
     }
 
+    void init_gpu_parser (WarpXParser const& wp); // public for CUDA
 
-private:
+protected:
 
 #ifdef AMREX_USE_GPU
     // Copy of the parser running on __device__
-    struct wp_parser m_gpu_parser;
+    struct wp_node* m_gpu_parser_ast;
     // Copy of the parser running on __host__
     struct wp_parser* m_cpu_parser;
     mutable amrex::GpuArray<amrex::Real,N> m_var;
@@ -80,23 +87,15 @@ GpuParser<N>::GpuParser (WarpXParser const& wp)
 #ifdef AMREX_USE_GPU
 
     struct wp_parser* a_wp = wp.m_parser;
-    // Initialize GPU parser: allocate memory in CUDA managed memory,
-    // copy all data needed on GPU to m_gpu_parser
-    m_gpu_parser.sz_mempool = wp_ast_size(a_wp->ast);
-    m_gpu_parser.p_root = (struct wp_node*)
-        amrex::The_Managed_Arena()->alloc(m_gpu_parser.sz_mempool);
-    m_gpu_parser.p_free = m_gpu_parser.p_root;
-    // 0: don't free the source
-    m_gpu_parser.ast = wp_parser_ast_dup(&m_gpu_parser, a_wp->ast, 0);
-    for (int i = 0; i < N; ++i) {
-        wp_parser_regvar_gpu(&m_gpu_parser, wp.m_varnames[i].c_str(), i);
-    }
 
     // Initialize CPU parser:
     m_cpu_parser = wp_parser_dup(a_wp);
     for (int i = 0; i < N; ++i) {
         wp_parser_regvar(m_cpu_parser, wp.m_varnames[i].c_str(), &m_var[i]);
     }
+
+    // Initialize GPU parser
+    init_gpu_parser(wp);
 
 #else // not defined AMREX_USE_GPU
 
@@ -127,13 +126,43 @@ GpuParser<N>::GpuParser (WarpXParser const& wp)
 #endif // AMREX_USE_GPU
 }
 
+template <int N>
+void GpuParser<N>::init_gpu_parser (WarpXParser const& wp)
+{
+#ifdef AMREX_USE_GPU
+
+    // We create a temporary Parser on CPU for memcpy.  We cannot use
+    // m_cpu_parser for this because the variables in m_cpu_parser are
+    // registered for CPU use.
+    struct wp_parser* cpu_tmp = wp_parser_dup(m_cpu_parser);
+    for (int i = 0; i < N; ++i) {
+        wp_parser_regvar_gpu(cpu_tmp, wp.m_varnames[i].c_str(), i);
+    }
+
+    m_gpu_parser_ast = (struct wp_node*)
+        amrex::The_Arena()->alloc(cpu_tmp->sz_mempool);
+    amrex::Gpu::htod_memcpy_async(m_gpu_parser_ast, cpu_tmp->ast, cpu_tmp->sz_mempool);
+
+    auto dp = m_gpu_parser_ast;
+    char* droot = (char*)dp;
+    char* croot = (char*)(cpu_tmp->ast);
+    amrex::single_task([=] AMREX_GPU_DEVICE () noexcept
+    {
+        wp_ast_update_device_ptr<0>(dp, droot, croot);
+    });
+
+    amrex::Gpu::synchronize();
+
+    wp_parser_delete(cpu_tmp);
+#endif
+}
 
 template <int N>
 void
 GpuParser<N>::clear ()
 {
 #ifdef AMREX_USE_GPU
-    amrex::The_Managed_Arena()->free(m_gpu_parser.ast);
+    amrex::The_Arena()->free(m_gpu_parser_ast);
     wp_parser_delete(m_cpu_parser);
 #else
     for (int tid = 0; tid < nthreads; ++tid)

--- a/Source/Parser/WarpXParserWrapper.H
+++ b/Source/Parser/WarpXParserWrapper.H
@@ -1,4 +1,4 @@
-/* Copyright 2020 Revathi Jambunathan
+/* Copyright 2020 Revathi Jambunathan, Weiqun Zhang
  *
  * This file is part of WarpX.
  *
@@ -12,6 +12,45 @@
 
 #include <AMReX_Gpu.H>
 
+#include <memory>
+
+/**
+ * \brief
+ *  The HostDeviceParser struct is non-owning and is suitable for being
+ *  value captured by device lamba.
+ */
+
+template <int N>
+struct HostDeviceParser
+{
+    template <typename... Ts>
+    AMREX_GPU_HOST_DEVICE
+    std::enable_if_t<sizeof...(Ts) == N
+                     and amrex::Same<amrex::Real,Ts...>::value,
+                     amrex::Real>
+    operator() (Ts... var) const noexcept
+    {
+#ifdef AMREX_USE_GPU
+#if AMREX_DEVICE_COMPILE
+// WarpX compiled for GPU, function compiled for __device__
+        amrex::GpuArray<amrex::Real,N> l_var{var...};
+        return wp_ast_eval<0>(m_gpu_parser_ast, l_var.data());
+#else
+// WarpX compiled for GPU, function compiled for __host__
+        return (*m_gpu_parser)(var...);
+#endif
+#else
+// WarpX compiled for CPU
+        return (*m_gpu_parser)(var...);
+#endif
+    }
+
+#ifdef AMREX_USE_GPU
+    struct wp_node * m_gpu_parser_ast = nullptr;
+#endif
+    GpuParser<N> const* m_gpu_parser = nullptr;
+};
+
 /**
  * \brief
  *  The ParserWrapper struct is constructed to safely use the GpuParser class
@@ -22,7 +61,7 @@
  */
 template <int N>
 struct ParserWrapper
-    : public amrex::Gpu::Managed, public GpuParser<N>
+    : public GpuParser<N>
 {
     using GpuParser<N>::GpuParser;
 
@@ -30,6 +69,28 @@ struct ParserWrapper
     void operator= (ParserWrapper<N> const&) = delete;
 
     ~ParserWrapper() { GpuParser<N>::clear(); }
+
+    void operator() () const = delete; // Hide GpuParser<N>::operator()
+
+    HostDeviceParser<N> getParser () const {
+#ifdef AMREX_USE_GPU
+        return HostDeviceParser<N>{this->m_gpu_parser_ast, static_cast<GpuParser<N> const*>(this)};
+#else
+        return HostDeviceParser<N>{static_cast<GpuParser<N> const*>(this)};
+#endif
+    }
 };
+
+template <int N>
+HostDeviceParser<N> getParser (ParserWrapper<N> const* parser_wrapper)
+{
+    return parser_wrapper ? parser_wrapper->getParser() : HostDeviceParser<N>{};
+}
+
+template <int N>
+HostDeviceParser<N> getParser (std::unique_ptr<ParserWrapper<N> > const& parser_wrapper)
+{
+    return parser_wrapper ? parser_wrapper->getParser() : HostDeviceParser<N>{};
+}
 
 #endif

--- a/Source/Parser/wp_parser_c.h
+++ b/Source/Parser/wp_parser_c.h
@@ -17,6 +17,93 @@
 
 struct wp_parser* wp_c_parser_new (char const* function_body);
 
+#ifdef AMREX_USE_GPU
+
+template <int Depth, std::enable_if_t<(Depth<WARPX_PARSER_DEPTH), int> = 0>
+AMREX_GPU_DEVICE AMREX_NO_INLINE
+void wp_ast_update_device_ptr (struct wp_node* node, char* droot, char* hroot)
+{
+    switch (node->type)
+    {
+    case WP_NUMBER:
+        break;
+    case WP_SYMBOL:
+    {
+        auto p = (struct wp_symbol*)node;
+        p->name = droot + (p->name - hroot);
+        break;
+    }
+    case WP_ADD:
+    case WP_SUB:
+    case WP_MUL:
+    case WP_DIV:
+    {
+        node->l = (wp_node*)(droot + ((char*)node->l - hroot));
+        node->r = (wp_node*)(droot + ((char*)node->r - hroot));
+        wp_ast_update_device_ptr<Depth+1>(node->l, droot, hroot);
+        wp_ast_update_device_ptr<Depth+1>(node->r, droot, hroot);
+        break;
+    }
+    case WP_NEG:
+    {
+        node->l = (wp_node*)(droot + ((char*)node->l - hroot));
+        wp_ast_update_device_ptr<Depth+1>(node->l, droot, hroot);
+        break;
+    }
+    case WP_F1:
+    {
+        auto p = (struct wp_f1*)node;
+        p->l = (wp_node*)(droot + ((char*)p->l - hroot));
+        wp_ast_update_device_ptr<Depth+1>(p->l, droot, hroot);
+        break;
+    }
+    case WP_F2:
+    {
+        auto p = (struct wp_f2*)node;
+        p->l = (wp_node*)(droot + ((char*)p->l - hroot));
+        p->r = (wp_node*)(droot + ((char*)p->r - hroot));
+        wp_ast_update_device_ptr<Depth+1>(p->l, droot, hroot);
+        wp_ast_update_device_ptr<Depth+1>(p->r, droot, hroot);
+        break;
+    }
+    case WP_ADD_VP:
+    case WP_ADD_PP:
+    case WP_SUB_VP:
+    case WP_SUB_PP:
+    case WP_MUL_VP:
+    case WP_MUL_PP:
+    case WP_DIV_VP:
+    case WP_DIV_PP:
+    case WP_NEG_P:
+    {
+        // No need to update node->l and node->r that contain a string for
+        // variable name because we don't need them for device code.
+        break;
+    }
+    default:
+    {
+#if AMREX_DEVICE_COMPILE
+        AMREX_DEVICE_PRINTF("wp_ast_update_device_ptr: unknown node type %d\n",
+                            static_cast<int>(node->type));
+        amrex::Abort();
+#endif
+    }
+    }
+}
+
+template <int Depth, std::enable_if_t<Depth == WARPX_PARSER_DEPTH,int> = 0>
+AMREX_GPU_DEVICE AMREX_NO_INLINE
+void wp_ast_update_device_ptr (struct wp_node*, char*, char*)
+{
+#if AMREX_DEVICE_COMPILE
+    AMREX_DEVICE_PRINTF("wp_ast_update_device_ptr: WARPX_PARSER_DEPTH %d not big enough\n",
+                        WARPX_PARSER_DEPTH);
+    amrex::Abort();
+#endif
+}
+
+#endif
+
 template <int Depth, std::enable_if_t<(Depth<WARPX_PARSER_DEPTH), int> = 0>
 AMREX_GPU_HOST_DEVICE
 #ifdef AMREX_USE_GPU
@@ -177,11 +264,13 @@ wp_ast_eval (struct wp_node* node, amrex::Real const* x)
         break;
     }
     default:
+    {
 #if AMREX_DEVICE_COMPILE
         AMREX_DEVICE_PRINTF("wp_ast_eval: unknown node type %d\n", node->type);
 #else
         amrex::AllPrint() << "wp_ast_eval: unknown node type " << node->type << "\n";
 #endif
+    }
     }
 
     return result;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -82,7 +82,7 @@ struct ParserFilter
     /** constructor
      * \param a_is_active whether the test is active
      */
-    ParserFilter(bool a_is_active, ParserWrapper<7>* a_filter_parser)
+    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser)
         : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
     {
         m_t = WarpX::GetInstance().gett_new(0);
@@ -103,7 +103,7 @@ struct ParserFilter
         amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
         amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
         amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
-        if ( (*m_function_partparser)(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
+        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
     }
 private:
@@ -111,7 +111,7 @@ private:
     const bool m_is_active;
 public:
     /** Parser function with 7 input variables, t,x,y,z,ux,uy,uz */
-    ParserWrapper<7> const * const m_function_partparser;
+    HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
 };

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -19,9 +19,9 @@ struct GetExternalField
 
     amrex::GpuArray<amrex::ParticleReal, 3> m_field_value;
 
-    ParserWrapper<4>* m_xfield_partparser = nullptr;
-    ParserWrapper<4>* m_yfield_partparser = nullptr;
-    ParserWrapper<4>* m_zfield_partparser = nullptr;
+    HostDeviceParser<4> m_xfield_partparser;
+    HostDeviceParser<4> m_yfield_partparser;
+    HostDeviceParser<4> m_zfield_partparser;
     GetParticlePosition m_get_position;
     amrex::Real m_time;
 
@@ -39,15 +39,11 @@ struct GetExternalField
         }
         else if (m_type == Parser)
         {
-            AMREX_ASSERT(m_xfield_partparser != nullptr);
-            AMREX_ASSERT(m_yfield_partparser != nullptr);
-            AMREX_ASSERT(m_zfield_partparser != nullptr);
-
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);
-            field_x += (*m_xfield_partparser)(x, y, z, m_time);
-            field_y += (*m_yfield_partparser)(x, y, z, m_time);
-            field_z += (*m_zfield_partparser)(x, y, z, m_time);
+            field_x += m_xfield_partparser(x, y, z, m_time);
+            field_y += m_yfield_partparser(x, y, z, m_time);
+            field_z += m_zfield_partparser(x, y, z, m_time);
         }
         else
         {

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -17,9 +17,9 @@ GetExternalEField::GetExternalEField (const WarpXParIter& a_pti, int a_offset) n
         m_type = Parser;
         m_time = warpx.gett_new(a_pti.GetLevel());
         m_get_position = GetParticlePosition(a_pti, a_offset);
-        m_xfield_partparser = mypc.m_Ex_particle_parser.get();
-        m_yfield_partparser = mypc.m_Ey_particle_parser.get();
-        m_zfield_partparser = mypc.m_Ez_particle_parser.get();
+        m_xfield_partparser = getParser(mypc.m_Ex_particle_parser);
+        m_yfield_partparser = getParser(mypc.m_Ey_particle_parser);
+        m_zfield_partparser = getParser(mypc.m_Ez_particle_parser);
     }
 }
 
@@ -39,8 +39,8 @@ GetExternalBField::GetExternalBField (const WarpXParIter& a_pti, int a_offset) n
         m_type = Parser;
         m_time = warpx.gett_new(a_pti.GetLevel());
         m_get_position = GetParticlePosition(a_pti, a_offset);
-        m_xfield_partparser = mypc.m_Bx_particle_parser.get();
-        m_yfield_partparser = mypc.m_By_particle_parser.get();
-        m_zfield_partparser = mypc.m_Bz_particle_parser.get();
+        m_xfield_partparser = getParser(mypc.m_Bx_particle_parser);
+        m_yfield_partparser = getParser(mypc.m_By_particle_parser);
+        m_zfield_partparser = getParser(mypc.m_Bz_particle_parser);
     }
 }

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -112,21 +112,21 @@ WarpX::MoveWindow (bool move_j)
         // Shift each component of vector fields (E, B, j)
         for (int dim = 0; dim < 3; ++dim) {
             // Fine grid
-            ParserWrapper<3> *Bfield_parser = nullptr;
-            ParserWrapper<3> *Efield_parser = nullptr;
+            HostDeviceParser<3> Bfield_parser;
+            HostDeviceParser<3> Efield_parser;
             bool use_Bparser = false;
             bool use_Eparser = false;
             if (B_ext_grid_s == "parse_b_ext_grid_function") {
                 use_Bparser = true;
-                if (dim == 0) Bfield_parser = Bxfield_parser.get();
-                if (dim == 1) Bfield_parser = Byfield_parser.get();
-                if (dim == 2) Bfield_parser = Bzfield_parser.get();
+                if (dim == 0) Bfield_parser = getParser(Bxfield_parser);
+                if (dim == 1) Bfield_parser = getParser(Byfield_parser);
+                if (dim == 2) Bfield_parser = getParser(Bzfield_parser);
             }
             if (E_ext_grid_s == "parse_e_ext_grid_function") {
                 use_Eparser = true;
-                if (dim == 0) Efield_parser = Exfield_parser.get();
-                if (dim == 1) Efield_parser = Eyfield_parser.get();
-                if (dim == 2) Efield_parser = Ezfield_parser.get();
+                if (dim == 0) Efield_parser = getParser(Exfield_parser);
+                if (dim == 1) Efield_parser = getParser(Eyfield_parser);
+                if (dim == 2) Efield_parser = getParser(Ezfield_parser);
             }
             shiftMF(*Bfield_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, B_external_grid[dim], use_Bparser, Bfield_parser);
             shiftMF(*Efield_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, E_external_grid[dim], use_Eparser, Efield_parser);
@@ -244,7 +244,7 @@ WarpX::MoveWindow (bool move_j)
 void
 WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
                 IntVect ng_extra, amrex::Real external_field, bool useparser,
-                ParserWrapper<3> *field_parser)
+                HostDeviceParser<3> const& field_parser)
 {
     WARPX_PROFILE("WarpX::shiftMF()");
     const BoxArray& ba = mf.boxArray();
@@ -345,7 +345,7 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
                       Real fac_z = (1.0 - mf_type[2]) * dx[2]*0.5;
                       Real z = k*dx[2] + real_box.lo(2) + fac_z;
 #endif
-                      srcfab(i,j,k,n) = (*field_parser)(x,y,z);
+                      srcfab(i,j,k,n) = field_parser(x,y,z);
                 });
             }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -94,7 +94,7 @@ public:
     static void shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
                          int num_shift, int dir, amrex::IntVect ng_extra,
                          amrex::Real external_field=0.0, bool useparser = false,
-                         ParserWrapper<3> *field_parser=nullptr);
+                         HostDeviceParser<3> const& field_parser={});
 
     static void GotoNextLine (std::istream& is);
 
@@ -510,8 +510,8 @@ public:
      */
     void InitializeExternalFieldsOnGridUsingParser (
          amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
-         ParserWrapper<3> *xfield_parser, ParserWrapper<3> *yfield_parser,
-         ParserWrapper<3> *zfield_parser, const int lev);
+         HostDeviceParser<3> const& xfield_parser, HostDeviceParser<3> const& yfield_parser,
+         HostDeviceParser<3> const& zfield_parser, const int lev);
 
     /** \brief adds particle and cell contributions in cells to compute heuristic
      * cost in each box on each level, and records in `costs`


### PR DESCRIPTION
* Remove the base class of InjectorPoisition, InjectorDensity and
  InjectorMomentum so that they no longer live in managed memory.

* Have both host and device copies of Injector*.

* Modify Parser classes so that they can work without unified memory.  Add
  HostDeviceParser that is non-owning and therefore suitable for being value
  captured by device lambda.