### PR TITLE
[mini] Add Warning/Assert for segfault in laser injection

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -83,6 +83,8 @@ jobs:
   # [!] very slow runtime work-around for beta08
   #   https://github.com/intel/llvm/issues/2187
   #   https://github.com/AMReX-Codes/amrex/pull/1243
+  # quick-fix for beta09: activate beta08 compiler
+  # bug report: 04801443 on https://supporttickets.intel.com
   build_dpcc:
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-latest
@@ -104,6 +106,7 @@ jobs:
         sudo apt-get install -y intel-oneapi-dpcpp-compiler intel-oneapi-mkl
         set +e
         source /opt/intel/oneapi/setvars.sh
+        source /opt/intel/oneapi/compiler/2021.1-beta08/env/vars.sh
         set -e
         git clone https://github.com/openPMD/openPMD-api.git
         mkdir openPMD-api/build
@@ -116,6 +119,7 @@ jobs:
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
+        source /opt/intel/oneapi/compiler/2021.1-beta08/env/vars.sh
         set -e
         export CXX=$(which dpcpp)
         export CC=$(which clang)

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -63,6 +63,11 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     m_up_laser_profile = laser_profiles_dictionary.at(laser_type_s)();
     //__________
 
+#ifdef WARPX_DIM_XZ
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nvec[1] == amrex::Real(0),
+        "Laser propagation direction must be 0 along y in 2D");
+#endif
+
     // Plane normal
     Real s = 1.0_rt / std::sqrt(nvec[0]*nvec[0] + nvec[1]*nvec[1] + nvec[2]*nvec[2]);
     nvec = { nvec[0]*s, nvec[1]*s, nvec[2]*s };
@@ -569,6 +574,14 @@ LaserParticleContainer::ComputeWeightMobility (Real Sx, Real Sy)
     // the amplitude of the field) are given in the lab-frame.
     // Therefore, the mobility needs to be modified by a factor WarpX::gamma_boost.
     mobility = mobility/WarpX::gamma_boost;
+
+    // If mobility is too high (caused by a small wavelength compared to the grid size),
+    // calculated antenna particle velocities may exceed c, which can cause a segfault.
+    constexpr Real warning_tol = 0.1_rt;
+    if (wavelength < std::min(Sx,Sy)*warning_tol){
+        amrex::Warning("WARNING: laser wavelength seems to be much smaller than the grid size."
+                       " This may cause a segmentation fault");
+    }
 }
 
 void


### PR DESCRIPTION
I've encountered a segfault that can occur with laser injection. It occurs if the antenna mobility is too high and the calculated velocities for the particles exceed c. This can happen if the laser wavelength is much smaller than the grid size or if the laser propagation direction has a significant y-component in 2D. Both cases are not really meaningful physically but I assume it's better to have a warning/error message than a raw segfault.

So this PR adds an assert which ensures that the laser propagation direction is 0 along y in 2D (I don't think a propagation along y really makes sense and that the implementation of the antenna is designed to do that) and a warning if the laser wavelength becomes too small compared to the antenna spacing.