### PR TITLE
[Mini]picmi: use kspace filter automatically for RZ PSATD

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -303,14 +303,13 @@ class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
 
 
 class BinomialSmoother(picmistandard.PICMI_BinomialSmoother):
-    def init(self, kw):
-        self.use_spectral = kw.pop('warpx_kspace_filter', None)
-        self.use_spectral_compensation = kw.pop('warpx_kspace_filter_compensation', None)
 
     def initialize_inputs(self, solver):
-        if self.use_spectral:
+        use_spectral = solver.method == 'PSATD' and isinstance(solver.grid, picmistandard.PICMI_CylindricalGrid)
+        if use_spectral:
             pywarpx.warpx.use_kspace_filter = 1
-            pywarpx.warpx.use_filter_compensation = self.use_spectral_compensation
+            if self.compensation is not None:
+                pywarpx.warpx.use_filter_compensation = self.compensation[0] and self.compensation[1]
         else:
             pywarpx.warpx.use_filter = 1
         if self.n_pass is None:


### PR DESCRIPTION
When using RZ spectral, when the binomial filter is specified, this will automatically set the use_kspace_filter input argument instead of use_filter.