### PR TITLE
Clean up profiling labels

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -116,7 +116,7 @@ MultiParticleContainer::WriteHeader (std::ostream& os) const
 void
 PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
 {
-    WARPX_PROFILE("PPC::ConvertUnits()");
+    WARPX_PROFILE("PhysicalParticleContainer::ConvertUnits()");
 
     // Compute conversion factor
     auto factor = 1_rt;

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -242,7 +242,7 @@ WarpX::InitFromCheckpoint ()
 std::unique_ptr<MultiFab>
 WarpX::GetCellCenteredData() {
 
-    WARPX_PROFILE("WarpX::GetCellCenteredData");
+    WARPX_PROFILE("WarpX::GetCellCenteredData()");
 
     const int ng =  1;
     const int nc = 10;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -224,7 +224,7 @@ PsatdAlgorithm::CurrentCorrection (SpectralFieldData& field_data,
                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current,
                                    const std::unique_ptr<amrex::MultiFab>& rho) {
     // Profiling
-    WARPX_PROFILE( "PsatdAlgorithm::CurrentCorrection" );
+    WARPX_PROFILE("PsatdAlgorithm::CurrentCorrection()");
 
     using Idx = SpectralFieldIndex;
 
@@ -301,7 +301,7 @@ void
 PsatdAlgorithm::VayDeposition (SpectralFieldData& field_data,
                                std::array<std::unique_ptr<amrex::MultiFab>,3>& current) {
     // Profiling
-    WARPX_PROFILE("PsatdAlgorithm::VayDeposition");
+    WARPX_PROFILE("PsatdAlgorithm::VayDeposition()");
 
     using Idx = SpectralFieldIndex;
 

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -27,7 +27,7 @@ using namespace amrex;
 void
 Filter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, int scomp, int dcomp, int ncomp)
 {
-    WARPX_PROFILE("BilinearFilter::ApplyStencil(MultiFab)");
+    WARPX_PROFILE("Filter::ApplyStencil(MultiFab)");
     ncomp = std::min(ncomp, srcmf.nComp());
 
     for (MFIter mfi(dstmf); mfi.isValid(); ++mfi)
@@ -70,7 +70,7 @@ void
 Filter::ApplyStencil (FArrayBox& dstfab, const FArrayBox& srcfab,
                       const Box& tbx, int scomp, int dcomp, int ncomp)
 {
-    WARPX_PROFILE("BilinearFilter::ApplyStencil(FArrayBox)");
+    WARPX_PROFILE("Filter::ApplyStencil(FArrayBox)");
     ncomp = std::min(ncomp, srcfab.nComp());
     const auto& src = srcfab.array();
     const auto& dst = dstfab.array();
@@ -156,7 +156,7 @@ void Filter::DoFilter (const Box& tbx,
 void
 Filter::ApplyStencil (amrex::MultiFab& dstmf, const amrex::MultiFab& srcmf, int scomp, int dcomp, int ncomp)
 {
-    WARPX_PROFILE("BilinearFilter::ApplyStencil()");
+    WARPX_PROFILE("Filter::ApplyStencil(MultiFab)");
     ncomp = std::min(ncomp, srcmf.nComp());
 #ifdef _OPENMP
 #pragma omp parallel
@@ -192,7 +192,7 @@ void
 Filter::ApplyStencil (amrex::FArrayBox& dstfab, const amrex::FArrayBox& srcfab,
                       const amrex::Box& tbx, int scomp, int dcomp, int ncomp)
 {
-    WARPX_PROFILE("BilinearFilter::ApplyStencil(FArrayBox)");
+    WARPX_PROFILE("Filter::ApplyStencil(FArrayBox)");
     ncomp = std::min(ncomp, srcfab.nComp());
     FArrayBox tmpfab;
     const Box& gbx = amrex::grow(tbx,stencil_length_each_dir-1);

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -392,11 +392,8 @@ LaserParticleContainer::Evolve (int lev,
                                 const MultiFab*, const MultiFab*, const MultiFab*,
                                 Real t, Real dt, DtType /*a_dt_type*/)
 {
-    WARPX_PROFILE("Laser::Evolve()");
-    WARPX_PROFILE_VAR_NS("Laser::Evolve::Copy", blp_copy);
-    WARPX_PROFILE_VAR_NS("Laser::ParticlePush", blp_pp);
-    WARPX_PROFILE_VAR_NS("Laser::CurrentDepo", blp_cd);
-    WARPX_PROFILE_VAR_NS("Laser::Evolve::Accumulate", blp_accumulate);
+    WARPX_PROFILE("LaserParticleContainer::Evolve()");
+    WARPX_PROFILE_VAR_NS("LaserParticleContainer::Evolve::ParticlePush", blp_pp);
 
     Real t_lab = t;
     if (WarpX::gamma_boost > 1) {

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -57,7 +57,7 @@ WarpX::ExchangeWithPmlF (int lev)
 void
 WarpX::UpdateAuxilaryData ()
 {
-    WARPX_PROFILE("UpdateAuxilaryData()");
+    WARPX_PROFILE("WarpX::UpdateAuxilaryData()");
 
     if (Bfield_aux[0][0]->ixType() == Bfield_fp[0][0]->ixType()) {
         UpdateAuxilaryDataSameType();
@@ -673,7 +673,7 @@ WarpX::FillBoundaryAux (int lev, IntVect ng)
 void
 WarpX::SyncCurrent ()
 {
-    WARPX_PROFILE("SyncCurrent()");
+    WARPX_PROFILE("WarpX::SyncCurrent()");
 
     // Restrict fine patch current onto the coarse patch, before
     // summing the guard cells of the fine patch
@@ -708,7 +708,7 @@ WarpX::SyncCurrent ()
 void
 WarpX::SyncRho ()
 {
-    WARPX_PROFILE("SyncRho()");
+    WARPX_PROFILE("WarpX::SyncRho()");
 
     if (!rho_fp[0]) return;
     const int ncomp = rho_fp[0]->nComp();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -442,7 +442,7 @@ MultiParticleContainer
                    Vector<WarpXParticleContainer::DiagnosticParticleData>& parts) const
 {
 
-    WARPX_PROFILE("MultiParticleContainer::GetLabFrameData");
+    WARPX_PROFILE("MultiParticleContainer::GetLabFrameData()");
 
     // Loop over particle species
     for (int i = 0; i < nspecies_back_transformed_diagnostics; ++i){
@@ -619,7 +619,7 @@ MultiParticleContainer::doFieldIonization (int lev,
                                            const MultiFab& By,
                                            const MultiFab& Bz)
 {
-    WARPX_PROFILE("MPC::doFieldIonization");
+    WARPX_PROFILE("MultiParticleContainer::doFieldIonization()");
 
     // Loop over all species.
     // Ionized particles in pc_source create particles in pc_product
@@ -664,7 +664,7 @@ MultiParticleContainer::doFieldIonization (int lev,
 void
 MultiParticleContainer::doCoulombCollisions ()
 {
-    WARPX_PROFILE("MPC::doCoulombCollisions");
+    WARPX_PROFILE("MultiParticleContainer::doCoulombCollisions()");
 
     for( auto const& collision : allcollisions )
     {
@@ -697,7 +697,7 @@ MultiParticleContainer::doCoulombCollisions ()
 
 void MultiParticleContainer::doResampling (const int timestep)
 {
-    WARPX_PROFILE("MPC::doResampling");
+    WARPX_PROFILE("MultiParticleContainer::doResampling()");
 
     for (auto& pc : allcontainers)
     {
@@ -1018,7 +1018,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 void
 MultiParticleContainer::doQEDSchwinger ()
 {
-    WARPX_PROFILE("MPC::doQEDSchwinger");
+    WARPX_PROFILE("MultiParticleContainer::doQEDSchwinger()");
 
     if (!m_do_qed_schwinger) {return;}
 
@@ -1128,7 +1128,7 @@ void MultiParticleContainer::doQedEvents (int lev,
                                           const MultiFab& By,
                                           const MultiFab& Bz)
 {
-    WARPX_PROFILE("MPC::doQedEvents");
+    WARPX_PROFILE("MultiParticleContainer::doQedEvents()");
 
     doQedBreitWheeler(lev, Ex, Ey, Ez, Bx, By, Bz);
     doQedQuantumSync(lev, Ex, Ey, Ez, Bx, By, Bz);
@@ -1142,7 +1142,7 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
                                                 const MultiFab& By,
                                                 const MultiFab& Bz)
 {
-    WARPX_PROFILE("MPC::doQedBreitWheeler");
+    WARPX_PROFILE("MultiParticleContainer::doQedBreitWheeler()");
 
     // Loop over all species.
     // Photons undergoing Breit Wheeler process create electrons
@@ -1209,7 +1209,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
                                                const MultiFab& By,
                                                const MultiFab& Bz)
 {
-    WARPX_PROFILE("MPC::doQedEvents::doQedQuantumSync");
+    WARPX_PROFILE("MultiParticleContainer::doQedQuantumSync()");
 
     // Loop over all species.
     // Electrons or positrons undergoing Quantum photon emission process

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -524,7 +524,7 @@ PhysicalParticleContainer::AddParticles (int lev)
 void
 PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 {
-    WARPX_PROFILE("PhysicalParticleContainer::AddPlasma");
+    WARPX_PROFILE("PhysicalParticleContainer::AddPlasma()");
 
     // If no part_realbox is provided, initialize particles in the whole domain
     const Geometry& geom = Geom(lev);
@@ -933,8 +933,8 @@ PhysicalParticleContainer::Evolve (int lev,
                                    Real /*t*/, Real dt, DtType a_dt_type)
 {
 
-    WARPX_PROFILE("PPC::Evolve()");
-    WARPX_PROFILE_VAR_NS("PPC::GatherAndPush", blp_fg);
+    WARPX_PROFILE("PhysicalParticleContainer::Evolve()");
+    WARPX_PROFILE_VAR_NS("PhysicalParticleContainer::Evolve::GatherAndPush", blp_fg);
 
     BL_ASSERT(OnSameGrids(lev,jx));
 
@@ -1410,7 +1410,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                                   const MultiFab& Ex, const MultiFab& Ey, const MultiFab& Ez,
                                   const MultiFab& Bx, const MultiFab& By, const MultiFab& Bz)
 {
-    WARPX_PROFILE("PhysicalParticleContainer::PushP");
+    WARPX_PROFILE("PhysicalParticleContainer::PushP()");
 
     if (do_not_push) return;
 
@@ -1544,7 +1544,7 @@ PhysicalParticleContainer::GetParticleSlice (
     const Real t_lab, const Real dt,
     DiagnosticParticles& diagnostic_particles)
 {
-    WARPX_PROFILE("PhysicalParticleContainer::GetParticleSlice");
+    WARPX_PROFILE("PhysicalParticleContainer::GetParticleSlice()");
 
     // Assume that the boost in the positive z direction.
 #if (AMREX_SPACEDIM == 2)
@@ -1985,7 +1985,7 @@ PhysicalParticleContainer::getIonizationFunc (const WarpXParIter& pti,
                                               const amrex::FArrayBox& By,
                                               const amrex::FArrayBox& Bz)
 {
-    WARPX_PROFILE("PPC::getIonizationFunc");
+    WARPX_PROFILE("PhysicalParticleContainer::getIonizationFunc()");
 
     return IonizationFilterFunc(pti, lev, ngE, Ex, Ey, Ez, Bx, By, Bz,
                                 v_galilean,
@@ -2045,14 +2045,14 @@ set_quantum_sync_engine_ptr (std::shared_ptr<QuantumSynchrotronEngine> ptr)
 PhotonEmissionFilterFunc
 PhysicalParticleContainer::getPhotonEmissionFilterFunc ()
 {
-    WARPX_PROFILE("PPC::getPhotonEmissionFunc");
+    WARPX_PROFILE("PhysicalParticleContainer::getPhotonEmissionFunc()");
     return PhotonEmissionFilterFunc{particle_runtime_comps["optical_depth_QSR"]};
 }
 
 PairGenerationFilterFunc
 PhysicalParticleContainer::getPairGenerationFilterFunc ()
 {
-    WARPX_PROFILE("PPC::getPairGenerationFunc");
+    WARPX_PROFILE("PhysicalParticleContainer::getPairGenerationFunc()");
     return PairGenerationFilterFunc{particle_runtime_comps["optical_depth_BW"]};
 }
 

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -48,7 +48,7 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     iMultiFab const* gather_masks,
     RealVector& uxp, RealVector& uyp, RealVector& uzp, RealVector& wp)
 {
-    WARPX_PROFILE("PPC::Evolve::partition");
+    WARPX_PROFILE("PhysicalParticleContainer::PartitionParticlesInBuffers");
 
     // Initialize temporary arrays
     Gpu::DeviceVector<int> inexflag;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -238,9 +238,8 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
     const std::array<Real,3>& dx = WarpX::CellSize(std::max(depos_lev,0));
     Real q = this->charge;
 
-    WARPX_PROFILE_VAR_NS("PPC::Evolve::Accumulate", blp_accumulate);
-    WARPX_PROFILE_VAR_NS("PPC::CurrentDeposition", blp_deposit);
-
+    WARPX_PROFILE_VAR_NS("WarpXParticleContainer::DepositCurrent::CurrentDeposition", blp_deposit);
+    WARPX_PROFILE_VAR_NS("WarpXParticleContainer::DepositCurrent::Accumulate", blp_accumulate);
 
     // Get tile box where current is deposited.
     // The tile box is different when depositing in the buffers (depos_lev<lev)
@@ -431,8 +430,8 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector& wp,
     const std::array<Real,3>& dx = WarpX::CellSize(std::max(depos_lev,0));
     const Real q = this->charge;
 
-    WARPX_PROFILE_VAR_NS("PPC::ChargeDeposition", blp_ppc_chd);
-    WARPX_PROFILE_VAR_NS("PPC::Evolve::Accumulate", blp_accumulate);
+    WARPX_PROFILE_VAR_NS("WarpXParticleContainer::DepositCharge::ChargeDeposition", blp_ppc_chd);
+    WARPX_PROFILE_VAR_NS("WarpXParticleContainer::DepositCharge::Accumulate", blp_accumulate);
 
     // Get tile box where charge is deposited.
     // The tile box is different when depositing in the buffers (depos_lev<lev)
@@ -788,7 +787,7 @@ WarpXParticleContainer::PushX (amrex::Real dt)
 void
 WarpXParticleContainer::PushX (int lev, amrex::Real dt)
 {
-    WARPX_PROFILE("WPC::PushX()");
+    WARPX_PROFILE("WarpXParticleContainer::PushX()");
 
     if (do_not_push) return;
 

--- a/Source/Utils/CoarsenIO.cpp
+++ b/Source/Utils/CoarsenIO.cpp
@@ -78,7 +78,7 @@ CoarsenIO::Coarsen ( MultiFab& mf_dst,
                      const int ngrow,
                      const IntVect crse_ratio )
 {
-    BL_PROFILE( "CoarsenIO::Coarsen" );
+    BL_PROFILE("CoarsenIO::Coarsen()");
 
     // Convert BoxArray of source MultiFab to staggering of destination MultiFab and coarsen it
     BoxArray ba_tmp = amrex::convert( mf_src.boxArray(), mf_dst.ixType().toIntVect() );

--- a/Source/Utils/CoarsenMR.cpp
+++ b/Source/Utils/CoarsenMR.cpp
@@ -66,7 +66,7 @@ CoarsenMR::Coarsen ( MultiFab& mf_dst,
                      const MultiFab& mf_src,
                      const IntVect crse_ratio )
 {
-    BL_PROFILE( "CoarsenMR::Coarsen" );
+    BL_PROFILE("CoarsenMR::Coarsen()");
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.ixType() == mf_dst.ixType(),
         "source MultiFab and destination MultiFab have different IndexType" );

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -127,7 +127,7 @@ void ConvertLabParamsToBoost()
  * zmin and zmax.
  */
 void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax){
-    WARPX_PROFILE("WarpX::NullifyMF()");
+    WARPX_PROFILE("WarpXUtil::NullifyMF()");
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif


### PR DESCRIPTION
While profiling some PSATD tests in order to address the time-out issues on Travis, I noticed that the naming conventions adopted for some of the profiling labels were a bit inconsistent throughout the code. In this PR I tried to clean it up a bit in order to make the profiling labels less prone to confusion when performing profiling tasks.