### PR TITLE
Fix: new AMReX AoS Syntax

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -469,7 +469,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
                     [](amrex::ParticleReal const *p){ delete[] p; }
                 );
                 for (auto i=0; i<numParticleOnTile; i++) {
-                     curr.get()[i] = aos[i].m_rdata.pos[currDim];
+                     curr.get()[i] = aos[i].pos(currDim);
                 }
                 std::string const positionComponent = positionComponents[currDim];
                 currSpecies["position"][positionComponent].storeChunk(curr, {offset}, {numParticleOnTile64});
@@ -582,7 +582,7 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
           );
 
           for( auto kk=0; kk<numParticleOnTile; kk++ )
-               d.get()[kk] = aos[kk].m_rdata.arr[AMREX_SPACEDIM+idx];
+               d.get()[kk] = aos[kk].rdata(idx);
 
           currRecordComp.storeChunk(d,
                {offset}, {numParticleOnTile64});


### PR DESCRIPTION
Update the AMReX Particle syntax to access AoS data with the new, non-type-pruning getters. This fixes a build error with openPMD (new API for low-level memory access in AMReX).

Ref.: https://github.com/AMReX-Codes/amrex/pull/1337