### PR TITLE
For PICMI, expect length 2 args for 2D solver

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -486,10 +486,13 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 
             if self.stencil_order is not None:
                 pywarpx.psatd.nox = self.stencil_order[0]
-                pywarpx.psatd.noy = self.stencil_order[1]
-                pywarpx.psatd.noz = self.stencil_order[2]
+                if self.grid.number_of_dimensions == 3:
+                    pywarpx.psatd.noy = self.stencil_order[1]
+                pywarpx.psatd.noz = self.stencil_order[-1]
 
             if self.galilean_velocity is not None:
+                if self.grid.number_of_dimensions == 2:
+                    self.galilean_velocity = [self.galilean_velocity[0], 0., self.galilean_velocity[1]]
                 pywarpx.psatd.v_galilean = np.array(self.galilean_velocity)/constants.c
 
         else:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -479,8 +479,9 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
             pywarpx.psatd.do_time_averaging = self.psatd_do_time_averaging
             if self.grid.guard_cells is not None:
                 pywarpx.psatd.nx_guard = self.grid.guard_cells[0]
-                pywarpx.psatd.ny_guard = self.grid.guard_cells[1]
-                pywarpx.psatd.nz_guard = self.grid.guard_cells[2]
+                if self.grid.number_of_dimensions == 3:
+                    pywarpx.psatd.ny_guard = self.grid.guard_cells[1]
+                pywarpx.psatd.nz_guard = self.grid.guard_cells[-1]
 
             if self.stencil_order is not None:
                 pywarpx.psatd.nox = self.stencil_order[0]


### PR DESCRIPTION
This changes the user API when using picmi for 2D (Cartesian and RZ). Several arguments, guard_cells, stencil_order, and galilean_velocity, are changed to expect length 2 lists, the values for x or r, and z. This change is needed to strictly follow the picmi standard. No example input files are affected.