### PR TITLE
Fix: new AMReX AoS syntax (RZ)

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -434,7 +434,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
                       [](amrex::ParticleReal const *p) { delete[] p; }
               );
               for (auto i = 0; i < numParticleOnTile; i++)
-                  z.get()[i] = aos[i].m_rdata.pos[1];  // {0: "r", 1: "z"}
+                  z.get()[i] = aos[i].pos(1);  // {0: "r", 1: "z"}
               std::string const positionComponent = "z";
               currSpecies["position"]["z"].storeChunk(z, {offset}, {numParticleOnTile64});
            }
@@ -455,7 +455,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
                        [](amrex::ParticleReal const *p){ delete[] p; }
                );
                for (auto i=0; i<numParticleOnTile; i++) {
-                   auto const r = aos[i].m_rdata.pos[0];  // {0: "r", 1: "z"}
+                   auto const r = aos[i].pos(0);  // {0: "r", 1: "z"}
                    x.get()[i] = r * std::cos(theta[i]);
                    y.get()[i] = r * std::sin(theta[i]);
                }


### PR DESCRIPTION
Old syntax left over in RZ code (following up [AMReX-Codes/amrex#1337](https://github.com/AMReX-Codes/amrex/pull/1337) and #1324).