### PR TITLE
Option to have absorbing BC for particles, regarless of field BC

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -277,6 +277,9 @@ Particle initialization
 * ``particles.use_fdtd_nci_corr`` (`0` or `1`) optional (default `0`)
     Whether to activate the FDTD Numerical Cherenkov Instability corrector.
 
+* ``particles.absorbing_bc`` (`0` or `1`) optional (default `0`)
+    Whether to use absorbing boundary conditions for particles, regardless of the boundary conditions for the fields.
+
 * ``particles.rigid_injected_species`` (`strings`, separated by spaces)
     List of species injected using the rigid injection method. The rigid injection
     method is useful when injecting a relativistic particle beam, in boosted-frame

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -180,6 +180,8 @@ WarpX::Evolve (int numsteps)
 
         int num_moved = MoveWindow(move_j);
 
+        mypc->ApplyBoundaryConditions();
+
         // Electrostatic solver: particles can move by an arbitrary number of cells
         if( do_electrostatic )
         {

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -160,6 +160,10 @@ public:
 
     void RedistributeLocal (const int num_ghost);
 
+    /** Apply BC. For now, just discard particles outside the domain, regardless
+     *  of the whole simulation BC. */
+    void ApplyBoundaryConditions ();
+
     amrex::Vector<long> NumberOfParticlesInGrid(int lev) const;
 
     void Increment (amrex::MultiFab& mf, int lev);
@@ -278,6 +282,9 @@ protected:
     std::vector<PCTypes> species_types;
 
     Resampling m_resampler;
+
+    /** Whether to absorb particles exiting the domain */
+    bool m_absorbing_bc = false;
 
     template<typename ...Args>
     amrex::MFItInfo getMFItInfo (const WarpXParticleContainer& pc_src,

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -250,6 +250,8 @@ MultiParticleContainer::ReadParameters ()
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 
+        pp.query("absorbing_bc", m_absorbing_bc);
+
         ParmParse ppl("lasers");
         ppl.queryarr("names", lasers_names);
 
@@ -382,6 +384,14 @@ MultiParticleContainer::RedistributeLocal (const int num_ghost)
 {
     for (auto& pc : allcontainers) {
         pc->Redistribute(0, 0, 0, num_ghost);
+    }
+}
+
+void
+MultiParticleContainer::ApplyBoundaryConditions ()
+{
+    for (auto& pc : allcontainers) {
+        pc->ApplyBoundaryConditions(m_absorbing_bc);
     }
 }
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -263,6 +263,13 @@ public:
 
     static void BackwardCompatibility ();
 
+    /** \brief Apply BC. For now, just discard particles outside the domain, regardless
+     *  of the whole simulation BC.
+     *
+     * \param[in] do_absorbing_bc whether to absorb particles exiting the domain
+     */
+    void ApplyBoundaryConditions (bool do_absorbing_bc);
+
     bool do_splitting = false;
     bool initialize_self_fields = false;
     amrex::Real self_fields_required_precision = 1.e-11;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -884,11 +884,11 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 void
 WarpXParticleContainer::ApplyBoundaryConditions (bool do_absorbing_bc){
     WARPX_PROFILE("WarpXParticleContainer::ApplyBoundaryConditions()");
-    for (int lev = 0; lev <= finestLevel(); ++lev) {
+    for (int lev = 0; lev <= finestLevel(); ++lev)
+    {
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             auto GetPosition = GetParticlePosition(pti);
-            // Loop over the particles and update their position
             const Real xmin = Geom(lev).ProbLo(0);
             const Real xmax = Geom(lev).ProbHi(0);
 #ifdef WARPX_DIM_3D
@@ -901,6 +901,7 @@ WarpXParticleContainer::ApplyBoundaryConditions (bool do_absorbing_bc){
             ParticleTileType& ptile = ParticlesAt(lev, pti);
             ParticleType * const pp = ptile.GetArrayOfStructs()().data();
 
+            // Loop over particles and apply BC to each particle
             amrex::ParallelFor(
                 pti.numParticles(),
                 [=] AMREX_GPU_DEVICE (long i) {

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -880,3 +880,44 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
         // to lower level.
     }
 }
+
+void
+WarpXParticleContainer::ApplyBoundaryConditions (bool do_absorbing_bc){
+    WARPX_PROFILE("WarpXParticleContainer::ApplyBoundaryConditions()");
+    for (int lev = 0; lev <= finestLevel(); ++lev) {
+        for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
+        {
+            auto GetPosition = GetParticlePosition(pti);
+            // Loop over the particles and update their position
+            const Real xmin = Geom(lev).ProbLo(0);
+            const Real xmax = Geom(lev).ProbHi(0);
+#ifdef WARPX_DIM_3D
+            const Real ymin = Geom(lev).ProbLo(1);
+            const Real ymax = Geom(lev).ProbHi(1);
+#endif
+            const Real zmin = Geom(lev).ProbLo(AMREX_SPACEDIM-1);
+            const Real zmax = Geom(lev).ProbHi(AMREX_SPACEDIM-1);
+
+            ParticleTileType& ptile = ParticlesAt(lev, pti);
+            ParticleType * const pp = ptile.GetArrayOfStructs()().data();
+
+            amrex::ParallelFor(
+                pti.numParticles(),
+                [=] AMREX_GPU_DEVICE (long i) {
+                    ParticleType& p = pp[i];
+                    ParticleReal x, y, z;
+                    GetPosition(i, x, y, z);
+#ifdef WARPX_DIM_3D
+                    if (x < xmin || x > xmax || y < ymin || y > ymax || z < zmin || z > zmax){
+                        if (do_absorbing_bc) p.id() = -1;
+                    }
+#else
+                    if (x < xmin || x > xmax || z < zmin || z > zmax){
+                        if (do_absorbing_bc) p.id() = -1;
+                    }
+#endif
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
Ideally, we could set field and particle BC independently. This is currently not possible, and BC are mostly handled in AMReX. This PR is a first towards more independent BC for particles: right before the call to `MultiParticleContainer::Redistribute`, we call `MultiParticleContiner::ApplyBoundaryConditions`, which either does nothing or applies absorbing boundary conditions for particles (discards particles, i.e., set their `id` to -1).

To use absorbing BC for particles, run the simulation with
```
particles.absorbing_bc = 1
```

In the future, we could have something smarter, e.g.,
```
particles.boundary_conditions = absorbing absorbing periodic
```