### PR TITLE
[WIP] ADIOS2: 2.6.0+

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -105,7 +105,7 @@ First, load the appropriate modules:
    module swap PrgEnv-intel PrgEnv-gnu
    module load cmake/3.14.4
    module load cray-hdf5-parallel
-   module load adios2/2.5.0
+   module load adios2/2.6.0
 
 Then, in the ``warpx_directory``, download and build openPMD-api:
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -55,7 +55,7 @@ We use the following modules and environments on the system.
    # optional: for openPMD support
    module load cmake
    module load hdf5/1.10.4
-   module load adios2/2.5.0
+   module load adios2/2.6.0
    export PKG_CONFIG_PATH=$HOME/sw/openPMD-api-install/lib64/pkgconfig:$PKG_CONFIG_PATH
    export CMAKE_PREFIX_PATH=$HOME/sw/openPMD-api-install:$CMAKE_PREFIX_PATH
 


### PR DESCRIPTION
Update docs and system support to require ADIOS 2.6.0+.

Follow-up to #1302 (Thanks to @NeilZaim for noticing!)

- [ ] Summit/OLCF ticket: `430508` (temporarily self-provided via #1369)
- [ ] Cori/NERSC ticket: `INC0159976`