### PR TITLE
run_tests.sh: cd locations

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -45,6 +45,7 @@ ln -s ${tmp_dir} test_dir
 
 # Switch to the test directory
 cd test_dir
+echo "cd $PWD"
 
 # Clone PICSAR and AMReX
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
@@ -61,12 +62,14 @@ git clone https://github.com/ECP-WarpX/regression_testing.git
 # Prepare regression tests
 mkdir -p rt-WarpX/WarpX-benchmarks
 cd warpx/Regression
+echo "cd $PWD"
 python prepare_file_travis.py
 cp travis-tests.ini ../../rt-WarpX
 cp -r Checksum ../../regression_testing/
 
 # Run tests
 cd ../../regression_testing/
+echo "cd $PWD"
 # run only tests specified in variable tests_arg (single test or multiple tests)
 if [[ ! -z "${tests_arg}" ]]; then
   python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} "${tests_run}"


### PR DESCRIPTION
Adding the location of switched-to directories to the `run_test.sh` script, making it easier to follow its individual steps when debugging something locally.