### PR TITLE
Docs: Spack Env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Python/pywarpx/libwarpx*.so
 d/
 f/
 o/
+build/
 tmp_build_dir/
 test_dir
 test_dir/
@@ -33,6 +34,14 @@ Python/pywarpx.egg-info/
 Docs/doxyhtml/
 Docs/doxyxml/
 Docs/source/_static/
+
+####################
+# Package Managers #
+####################
+# anonymous Spack environments
+# https://spack.readthedocs.io/en/latest/environments.html#anonymous-environments
+.spack-env/
+spack.lock
 
 #######
 # IDE #

--- a/Docs/spack.yaml
+++ b/Docs/spack.yaml
@@ -1,0 +1,26 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html#anonymous-environments
+#
+# Inside WarpX' Docs/ directory:
+#   spack env activate -d .
+#   spack install  # only needed the first time
+#   make clean
+#   make html
+#
+spack:
+  specs:
+  # note: the spec "doxygen+graphviz" causes an environment issue for me
+  - doxygen
+  - graphviz
+  - python
+  - py-sphinx
+  - py-breathe
+  - py-recommonmark
+  - py-pygments
+  - py-sphinx-rtd-theme


### PR DESCRIPTION
Adding a simple spack environment to install all dependencies to build the documentation locally. This is just an alternative to the already provided (pip) `requirements.txt` file (prequisite: have doxygen installed).

Activating and installing this environment will provide *all* dependencies (incl. Doxygen) that are needed to build the whole documentation locally. Spack manual link:
  https//spack.readthedocs.io/en/latest/environments.html#anonymous-environments

Inside WarpX' `Docs/` directory:
```bash
   spack env activate -d .
   spack install            # only needed the first time
```

Related to #1330