### PR TITLE
Fix compile ⚠️warnings⚠️ for DIM=RZ

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -137,7 +137,7 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
         // Loop over the cells and update the fields
         amrex::ParallelFor(tdive,
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + i*dr; // r on a nodal grid (F is nodal in r)
                 if (r != 0) { // Off-axis, regular equations
                     divE(i, j, 0, 0) =

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -154,7 +154,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
         // Loop over the cells and update the fields
         amrex::ParallelFor(tbr, tbt, tbz,
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + i*dr; // r on nodal point (Br is nodal in r)
                 if (r != 0) { // Off-axis, regular Maxwell equations
                     Br(i, j, 0, 0) += dt * T_Algo::UpwardDz(Et, coefs_z, n_coefs_z, i, j, 0, 0); // Mode m=0
@@ -187,7 +187,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
                 }
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Bt(i, j, 0, 0) += dt*(
                     T_Algo::UpwardDr(Ez, coefs_r, n_coefs_r, i, j, 0, 0)
                     - T_Algo::UpwardDz(Er, coefs_z, n_coefs_z, i, j, 0, 0)); // Mode m=0
@@ -201,7 +201,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
                 }
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + (i + 0.5)*dr; // r on a cell-centered grid (Bz is cell-centered in r)
                 Bz(i, j, 0, 0) += dt*( - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_r, n_coefs_r, i, j, 0, 0));
                 for (int m=1 ; m<nmodes ; m++) { // Higher-order modes

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
@@ -16,6 +16,7 @@
 #endif
 #include "BoundaryConditions/PMLComponent.H"
 #include <AMReX_Gpu.H>
+#include <AMReX.H>
 
 using namespace amrex;
 
@@ -30,6 +31,7 @@ void FiniteDifferenceSolver::EvolveBPML (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Bfield, Efield, dt);
     amrex::Abort("PML are not implemented in cylindrical geometry.");
 #else
     if (m_do_nodal) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -202,7 +202,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         // Loop over the cells and update the fields
         amrex::ParallelFor(ter, tet, tez,
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + (i + 0.5)*dr; // r on cell-centered point (Er is cell-centered in r)
                 Er(i, j, 0, 0) +=  c2 * dt*(
                     - T_Algo::DownwardDz(Bt, coefs_z, n_coefs_z, i, j, 0, 0)
@@ -219,7 +219,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
                 }
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
                 if (r != 0) { // Off-axis, regular Maxwell equations
                     Et(i, j, 0, 0) += c2 * dt*(
@@ -260,7 +260,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
                 }
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + i*dr; // r on a nodal grid (Ez is nodal in r)
                 if (r != 0) { // Off-axis, regular Maxwell equations
                     Ez(i, j, 0, 0) += c2 * dt*(
@@ -302,14 +302,14 @@ void FiniteDifferenceSolver::EvolveECylindrical (
             // Loop over the cells and update the fields
             amrex::ParallelFor(ter, tet, tez,
 
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                     Er(i, j, 0, 0) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 0);
                     for (int m=1; m<nmodes; m++) { // Higher-order modes
                         Er(i, j, 0, 2*m-1) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 2*m-1); // Real part
                         Er(i, j, 0, 2*m  ) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 2*m  ); // Imaginary part
                     }
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                     // Mode m=0: no update
                     Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
                     if (r != 0){ // Off-axis, regular Maxwell equations
@@ -327,7 +327,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
                         }
                     }
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                     Ez(i, j, 0, 0) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, 0, 0);
                     for (int m=1; m<nmodes; m++) { // Higher-order modes
                         Ez(i, j, 0, 2*m-1) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, 0, 2*m-1); // Real part

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -19,6 +19,7 @@
 #include "BoundaryConditions/PMLComponent.H"
 #include "Utils/WarpXConst.H"
 #include <AMReX_Gpu.H>
+#include <AMReX.H>
 
 using namespace amrex;
 
@@ -36,6 +37,7 @@ void FiniteDifferenceSolver::EvolveEPML (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Efield, Bfield, Jfield, Ffield, sigba, dt, pml_has_particles);
     amrex::Abort("PML are not implemented in cylindrical geometry.");
 #else
     if (m_do_nodal) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -162,7 +162,7 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
         // Loop over the cells and update the fields
         amrex::ParallelFor(tf,
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + i*dr; // r on a nodal grid (F is nodal in r)
                 if (r != 0) { // Off-axis, regular equations
                     F(i, j, 0, 0) += dt * (

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
@@ -16,6 +16,7 @@
 #endif
 #include "BoundaryConditions/PMLComponent.H"
 #include <AMReX_Gpu.H>
+#include <AMReX.H>
 
 using namespace amrex;
 
@@ -30,6 +31,7 @@ void FiniteDifferenceSolver::EvolveFPML (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Ffield, Efield, dt);
     amrex::Abort("PML are not implemented in cylindrical geometry.");
 #else
     if (m_do_nodal) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -13,6 +13,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Array4.H>
 #include <AMReX_Gpu.H>
+#include <AMReX.H>
 
 #include <array>
 #include <cmath>
@@ -76,6 +77,8 @@ struct CylindricalYeeAlgorithm {
         int const i, int const j, int const k, int const comp ) {
 
         using namespace amrex;
+        ignore_unused(n_coefs_r);
+
         Real const inv_dr = coefs_r[0];
         return 1._rt/r * inv_dr*( (r+0.5_rt*dr)*F(i+1,j,k,comp) - (r-0.5_rt*dr)*F(i,j,k,comp) );
     };
@@ -92,6 +95,8 @@ struct CylindricalYeeAlgorithm {
         int const i, int const j, int const k, int const comp ) {
 
         using namespace amrex;
+        ignore_unused(n_coefs_r);
+
         Real const inv_dr = coefs_r[0];
         return 1._rt/r * inv_dr*( (r+0.5_rt*dr)*F(i,j,k,comp) - (r-0.5_rt*dr)*F(i-1,j,k,comp) );
     };
@@ -105,6 +110,8 @@ struct CylindricalYeeAlgorithm {
         int const i, int const j, int const k, int const comp ) {
 
         using namespace amrex;
+        ignore_unused(n_coefs_r);
+
         Real const inv_dr = coefs_r[0];
         return inv_dr*( F(i+1,j,k,comp) - F(i,j,k,comp) );
     };
@@ -118,6 +125,8 @@ struct CylindricalYeeAlgorithm {
         int const i, int const j, int const k, int const comp ) {
 
         using namespace amrex;
+        ignore_unused(n_coefs_r);
+
         Real const inv_dr = coefs_r[0];
         return inv_dr*( F(i,j,k,comp) - F(i-1,j,k,comp) );
     };
@@ -130,6 +139,8 @@ struct CylindricalYeeAlgorithm {
         amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const comp ) {
 
+        amrex::ignore_unused(n_coefs_z);
+
         amrex::Real const inv_dz = coefs_z[0];
         return inv_dz*( F(i,j+1,k,comp) - F(i,j,k,comp) );
     };
@@ -141,6 +152,8 @@ struct CylindricalYeeAlgorithm {
         amrex::Array4<amrex::Real> const& F,
         amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const comp ) {
+
+        amrex::ignore_unused(n_coefs_z);
 
         amrex::Real const inv_dz = coefs_z[0];
         return inv_dz*( F(i,j,k,comp) - F(i,j-1,k,comp) );

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -9,8 +9,10 @@
 #endif
 #include "Utils/WarpXConst.H"
 #include "Utils/CoarsenIO.H"
-#include <AMReX_Gpu.H>
 #include <WarpX.H>
+#include <AMReX.H>
+#include <AMReX_Gpu.H>
+
 
 using namespace amrex;
 
@@ -23,6 +25,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveE (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Efield, Bfield, Jfield, dt, macroscopic_properties);
     amrex::Abort("currently macro E-push does not work for RZ");
 #else
     if (m_do_nodal) {

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -391,7 +391,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         // Rescale current in r-z mode since the inverse volume factor was not
         // included in the current deposition.
         amrex::ParallelFor(tbr, tbt, tbz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
@@ -420,7 +420,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                 Jr_arr(i,j,0,2*imode) /= (2.*MathConst::pi*r);
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
@@ -458,7 +458,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
                 }
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
@@ -543,7 +543,7 @@ WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
         // Note that the loop is also over ncomps, which takes care of the RZ modes,
         // as well as the old and new rho.
         amrex::ParallelFor(tb, Rho->nComp(),
-        [=] AMREX_GPU_DEVICE (int i, int j, int k, int icomp)
+        [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int icomp)
         {
             // Wrap the charge density deposited in the guard cells around
             // to the cells above the axis.

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -102,7 +102,7 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
             // Compute shape factor along x
             // i: leftmost grid point that the particle touches
             amrex::Real sx[depos_order + 1];
-            int i;
+            int i = 0;
             Compute_shape_factor< depos_order > const compute_shape_factor;
             if (rho_type[0] == NODE) {
                 i = compute_shape_factor(sx, x);
@@ -114,7 +114,7 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
             // y direction
             const amrex::Real y = (yp - ymin)*dyi;
             amrex::Real sy[depos_order + 1];
-            int j;
+            int j = 0;
             if (rho_type[1] == NODE) {
                 j = compute_shape_factor(sy, y);
             } else if (rho_type[1] == CELL) {
@@ -124,7 +124,7 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
             // z direction
             const amrex::Real z = (zp - zmin)*dzi;
             amrex::Real sz[depos_order + 1];
-            int k;
+            int k = 0;
             if (rho_type[zdir] == NODE) {
                 k = compute_shape_factor(sz, z);
             } else if (rho_type[zdir] == CELL) {

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -630,6 +630,9 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
                             const long n_rz_azimuthal_modes)
 {
 #if (defined WARPX_DIM_RZ)
+    amrex::ignore_unused(GetPosition,
+        wp, uxp, uyp, uzp, ion_lev, jx_fab, jy_fab, jz_fab,
+        np_to_depose, dt, dx, xyzmin, lo, q, n_rz_azimuthal_modes);
     amrex::Abort("Vay deposition not implemented in RZ geometry");
 #endif
 


### PR DESCRIPTION
This small PR fixes essentially all the warnings when compiling WarpX with DIM=RZ