### PR TITLE
openPMD-api 0.12.0: Iteration::close()

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -46,6 +46,9 @@ FlushFormatOpenPMD::WriteToFile (
 
     // particles: all (reside only on locally finest level)
     m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags);
+
+    // signal that no further updates will be written to this iteration
+    m_OpenPMDPlotWriter->CloseStep();
 }
 
 FlushFormatOpenPMD::~FlushFormatOpenPMD (){

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -89,16 +89,22 @@ public:
    * @param filetype file backend, e.g. "bp" or "h5"
    * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
    */
-  WarpXOpenPMDPlot(bool oneFilePerTS, std::string filetype, std::vector<bool> fieldPMLdirections);
+  WarpXOpenPMDPlot (bool oneFilePerTS, std::string filetype, std::vector<bool> fieldPMLdirections);
 
-  ~WarpXOpenPMDPlot();
+  ~WarpXOpenPMDPlot ();
 
   /** Set Iteration Step for the series
    *
    * @note If an iteration has been written, then it will give a warning
    *
    */
-  void SetStep(int ts, const std::string& filePrefix);
+  void SetStep (int ts, const std::string& filePrefix);
+
+  /** Close the step
+   *
+   * Signal that no further updates will be written for the step.
+   */
+  void CloseStep ();
 
   void WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags);
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -235,7 +235,7 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 }
 
 
-void WarpXOpenPMDPlot::SetStep(int ts, const std::string& filePrefix)
+void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
 
@@ -252,8 +252,14 @@ void WarpXOpenPMDPlot::SetStep(int ts, const std::string& filePrefix)
 
 }
 
+void WarpXOpenPMDPlot::CloseStep ()
+{
+    if (m_Series)
+        m_Series->iterations[m_CurrentStep].close();
+}
+
 void
-WarpXOpenPMDPlot::Init(openPMD::Access access, const std::string& filePrefix)
+WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix)
 {
     // either for the next ts file,
     // or init a single file for all ts


### PR DESCRIPTION
We ca now signal to the I/O backend that no further information will be written to a step.

Close #645