### PR TITLE
DiagnosticsToAccountForMovingWindowRestart

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -166,6 +166,14 @@ Diagnostics::InitBaseData ()
     nmax_lev = warpx.maxLevel() + 1;
     m_all_field_functors.resize( nmax_lev );
 
+    // For restart, move the m_lo and m_hi of the diag consistent with the 
+    // current moving_window location
+    if (warpx.do_moving_window) {
+        int moving_dir = warpx.moving_window_dir;
+        int shift_num_base = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
+        m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+        m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+    }
     // Construct Flush class.
     if        (m_format == "plotfile"){
         m_flush_format = new FlushFormatPlotfile;

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -166,7 +166,7 @@ Diagnostics::InitBaseData ()
     nmax_lev = warpx.maxLevel() + 1;
     m_all_field_functors.resize( nmax_lev );
 
-    // For restart, move the m_lo and m_hi of the diag consistent with the 
+    // For restart, move the m_lo and m_hi of the diag consistent with the
     // current moving_window location
     if (warpx.do_moving_window) {
         int moving_dir = warpx.moving_window_dir;


### PR DESCRIPTION
This PR address Issue #1351 
The diagnostic co-ordinates at initialization are set to domain co-ordinates by default. This is set when the diagnostic object is first constructed.
Then, the checkpoint files are read and the domain co-ordinates are updated, however, the diagnostic co-ordinates were not.
This resulted in an inconsistent behaviour, particularly for moving_window simulations, restarted at a timestep, where the domain in the checkpoint file is shifted compared to the original values at the start of the simulation.

To fix this issue, after the checkpoint files are read, the diagnostic lo,hi are updated consistent with the distance of the moving window at restart.
