### PR TITLE
Intel DPC++: Beta09

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,6 +40,7 @@ jobs:
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
+# note: unclear how the ICC compiler package is named in beta09, this pulls beta08
   build_icc:
     name: oneAPI ICC SP&DP [Linux]
     runs-on: ubuntu-latest
@@ -80,10 +81,7 @@ jobs:
         cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=single
         make -j 2
 
-  # [!] disabled until beta09 is fully rolled out on oneAPI apt repos
-  #   https://github.com/intel/llvm/issues/2187
   build_dpcc:
-    if: false
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-latest
     steps:
@@ -101,7 +99,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-dpcpp-compiler intel-oneapi-mkl
+        sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl
         set +e
         source /opt/intel/oneapi/setvars.sh
         source /opt/intel/oneapi/compiler/2021.1-beta08/env/vars.sh


### PR DESCRIPTION
Re-enable CI for Intel DPC++/SYCL in beta09.

The apt package name changed and we had to apply a new work-around for the beta08+ treatment of C++ user literals in AMReX: `-mlong-double-64 -Xclang -mlong-double-64`.

Refs.:
- https://github.com/AMReX-Codes/amrex/pull/1366
- https://github.com/AMReX-Codes/amrex/pull/1388