### PR TITLE
PICMI: read flag for laser continuous injection

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -542,6 +542,8 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         self.laser.beta = self.beta
         self.laser.phi2 = self.phi2
 
+        if self.fill_in:
+            self.laser.do_continuous_injection = 1
 
 class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
     def initialize_inputs(self):
@@ -557,9 +559,11 @@ class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
         self.laser.polarization = self.polarization_direction  # The main polarization vector
         self.laser.__setattr__('field_function(X,Y,t)', self.field_expression)
 
+        if self.fill_in:
+            self.laser.do_continuous_injection = 1
+
         for k,v in self.user_defined_kw.items():
             setattr(pywarpx.my_constants, k, v)
-
 
 class LaserAntenna(picmistandard.PICMI_LaserAntenna):
     def initialize_inputs(self, laser):

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -542,8 +542,7 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         self.laser.beta = self.beta
         self.laser.phi2 = self.phi2
 
-        if self.fill_in:
-            self.laser.do_continuous_injection = 1
+        self.laser.do_continuous_injection = self.fill_in
 
 class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
     def initialize_inputs(self):
@@ -559,8 +558,7 @@ class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
         self.laser.polarization = self.polarization_direction  # The main polarization vector
         self.laser.__setattr__('field_function(X,Y,t)', self.field_expression)
 
-        if self.fill_in:
-            self.laser.do_continuous_injection = 1
+        self.laser.do_continuous_injection = self.fill_in
 
         for k,v in self.user_defined_kw.items():
             setattr(pywarpx.my_constants, k, v)

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -33,6 +33,6 @@ setup (name = 'pywarpx',
        package_dir = {'pywarpx':'pywarpx'},
        description = """Wrapper of WarpX""",
        package_data = package_data,
-       install_requires=['numpy', 'picmistandard==0.0.11', 'periodictable'],
+       install_requires=['numpy', 'picmistandard==0.0.12', 'periodictable'],
        python_requires = '>=3.6'
        )


### PR DESCRIPTION
This PR adds the capability to read the PICMI flag `fill_in` for laser continuous injection in the classes `GaussianLaser` and `AnalyticLaser`. Depends on [PR #32](https://github.com/picmi-standard/picmi/pull/32) for the PICMI standard.