### PR TITLE
Create reduced diag ouput file only with IO process

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -29,22 +29,25 @@ ReducedDiags::ReducedDiags (std::string rd_name)
     // read extension
     pp.query("extension", m_extension);
 
-    // creater folder
-    if (!UtilCreateDirectory(m_path, 0755))
-    { CreateDirectoryFailed(m_path); }
-
     // check if it is a restart run
     std::string restart_chkfile = "";
     ParmParse pp_amr("amr");
     pp_amr.query("restart", restart_chkfile);
     m_IsNotRestart = restart_chkfile.empty();
 
-    // replace / create output file
-    if ( m_IsNotRestart ) // not a restart
+    if (ParallelDescriptor::IOProcessor())
     {
-        std::ofstream ofs;
-        ofs.open(m_path+m_rd_name+"."+m_extension, std::ios::trunc);
-        ofs.close();
+        // create folder
+        if (!UtilCreateDirectory(m_path, 0755))
+        { CreateDirectoryFailed(m_path); }
+
+        // replace / create output file
+        if ( m_IsNotRestart ) // not a restart
+        {
+            std::ofstream ofs;
+            ofs.open(m_path+m_rd_name+"."+m_extension, std::ios::trunc);
+            ofs.close();
+        }
     }
 
     // read reduced diags frequency


### PR DESCRIPTION
Currently all processes create the output folder and file for reduced diagnostics. For the folder creation this seems to have no practical consequences (at least for a reasonable number of processes). However for the file creation we are in truncate mode so this can result in the first line of the output file (the header line) being deleted (we've consistently observed this when running on multiple nodes on Summit). This small PR fixes this issue by adding `if (ParallelDescriptor::IOProcessor())` before creating the folder and file.