### PR TITLE
Summit: Doc I/O Module(s)

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -40,6 +40,7 @@ We use the following modules and environments on the system.
    export proj=<yourProject>
 
    # required dependencies
+   module load cmake
    module load gcc/6.4.0
    module load cuda
 
@@ -53,11 +54,9 @@ We use the following modules and environments on the system.
    module load boost/1.66.0
 
    # optional: for openPMD support
-   module load cmake
-   module load hdf5/1.10.4
-   module load adios2/2.5.0
-   export PKG_CONFIG_PATH=$HOME/sw/openPMD-api-install/lib64/pkgconfig:$PKG_CONFIG_PATH
-   export CMAKE_PREFIX_PATH=$HOME/sw/openPMD-api-install:$CMAKE_PREFIX_PATH
+   module load ums
+   module load ums-aph114
+   module load openpmd-api/0.12.0
 
    # optional: Ascent in situ support
    #   note: build WarpX with CMake
@@ -99,7 +98,7 @@ We recommend to store the above lines in a file, such as ``$HOME/warpx.profile``
 
    source $HOME/warpx.profile
 
-Optionally, download and build openPMD-api for I/O:
+Optionally, download and build openPMD-api for I/O (only needed if you did not load our module above):
 
 .. code-block:: bash
 


### PR DESCRIPTION
We have a pilot project on Summit that allows us (me?) to deploy user-managed software. We now deploy ZPF 0.5.5, ADIOS 2.6.0 (both not yet on the official modules) as well as openPMD-api 0.12.0 (yay!).

```bash
module load ums
module load ums-aph114
module load openpmd-api/0.12.0  # this automatically load hdf5 and adios2, which loads c-blosc and zfp
```

Happy computing :rocket: