### PR TITLE
Use amrex::ParallelForRNG for random number generation

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -315,10 +315,11 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
             dir, particle_diags[i].getSpeciesName(),
             particle_diags[i].plot_flags, int_flags,
             real_names, int_names,
-            [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
+            [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p,
+                                       const amrex::RandomEngine& engine)
             {
-                return random_filter(p) * uniform_filter(p)
-                     * parser_filter(p) * geometry_filter(p);
+                return random_filter(p,engine) * uniform_filter(p,engine)
+                     * parser_filter(p,engine) * geometry_filter(p,engine);
             });
 
         // Convert momentum back to WarpX units

--- a/Source/Initialization/CustomMomentumProb.H
+++ b/Source/Initialization/CustomMomentumProb.H
@@ -23,7 +23,7 @@ struct InjectorMomentumCustom
     // Return momentum at given position (illustration: momentum=0).
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real, amrex::Real, amrex::Real) const noexcept
+    getMomentum (amrex::Real, amrex::Real, amrex::Real, amrex::RandomEngine const&) const noexcept
     {
         return {0., 0., 0.};
     }

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -23,7 +23,8 @@ struct InjectorMomentumConstant
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real, amrex::Real, amrex::Real) const noexcept
+    getMomentum (amrex::Real, amrex::Real, amrex::Real,
+                 amrex::RandomEngine const&) const noexcept
     {
         return amrex::XDim3{m_ux,m_uy,m_uz};
     }
@@ -52,11 +53,12 @@ struct InjectorMomentumGaussian
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+                 amrex::RandomEngine const& engine) const noexcept
     {
-        return amrex::XDim3{amrex::RandomNormal(m_ux_m, m_ux_th),
-                            amrex::RandomNormal(m_uy_m, m_uy_th),
-                            amrex::RandomNormal(m_uz_m, m_uz_th)};
+        return amrex::XDim3{amrex::RandomNormal(m_ux_m, m_ux_th, engine),
+                            amrex::RandomNormal(m_uy_m, m_uy_th, engine),
+                            amrex::RandomNormal(m_uz_m, m_uz_th, engine)};
     }
 
     AMREX_GPU_HOST_DEVICE
@@ -85,19 +87,20 @@ struct InjectorMomentumBoltzmann
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+                 amrex::RandomEngine const& engine) const noexcept
     {
         amrex::Real x1, x2, gamma;
         amrex::Real u[3];
-        x1 = amrex::Random();
-        x2 = amrex::Random();
+        x1 = amrex::Random(engine);
+        x2 = amrex::Random(engine);
         // Each value of sqrt(-log(x1))*sin(2*pi*x2) is a sample from a Gaussian
         // distribution with sigma = average velocity / c
         // using the Box-Mueller Method.
         u[(dir+1)%3] = vave*std::sqrt(-std::log(x1)) *std::sin(2*M_PI*x2);
         u[(dir+2)%3] = vave*std::sqrt(-std::log(x1)) *std::cos(2*M_PI*x2);
-        u[dir] = vave*std::sqrt(-std::log(amrex::Random()))*
-            std::sin(2*M_PI*amrex::Random());
+        u[dir] = vave*std::sqrt(-std::log(amrex::Random(engine)))*
+            std::sin(2*M_PI*amrex::Random(engine));
         gamma = u[0]*u[0]+u[1]*u[1]+u[2]*u[2];
         gamma = std::sqrt(1+gamma);
         // The following condition is equtaion 32 in Zenitani 2015
@@ -111,7 +114,7 @@ struct InjectorMomentumBoltzmann
         // initialize the particle positions and densities in the frame moving
         // at speed beta, and then perform a Lorentz transform on the positions
         // and MB sampled velocities to the simulation frame.
-        x1 = amrex::Random();
+        x1 = amrex::Random(engine);
         if(-beta*u[dir]/gamma > x1)
         {
           u[dir] = -u[dir];
@@ -157,7 +160,8 @@ struct InjectorMomentumJuttner
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/) const noexcept
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+                 amrex::RandomEngine const& engine) const noexcept
     {
         // Sobol method for sampling MJ Speeds,
         // from Zenitani 2015 (Phys. Plasmas 22, 042116).
@@ -171,21 +175,21 @@ struct InjectorMomentumJuttner
         while(u[dir]-gamma <= x1)
         {
             u[dir] = -theta*
-                std::log(amrex::Random()*amrex::Random()*amrex::Random());
+                std::log(amrex::Random(engine)*amrex::Random(engine)*amrex::Random(engine));
             gamma = std::sqrt(1+u[dir]*u[dir]);
-            x1 = theta*std::log(amrex::Random());
+            x1 = theta*std::log(amrex::Random(engine));
         }
         // The following code samples a random unit vector
         // and multiplies the result by speed u[dir].
-        x1 = amrex::Random();
-        x2 = amrex::Random();
+        x1 = amrex::Random(engine);
+        x2 = amrex::Random(engine);
         // Direction dir is an input parameter that sets the boost direction:
         // 'x' -> d = 0, 'y' -> d = 1, 'z' -> d = 2.
         u[(dir+1)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::sin(2*M_PI*x2);
         u[(dir+2)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::cos(2*M_PI*x2);
         // The value of dir is the boost direction to be transformed.
         u[dir] = u[dir]*(2*x1-1);
-        x1 = amrex::Random();
+        x1 = amrex::Random(engine);
         // The following condition is equtaion 32 in Zenitani, called
         // The flipping method. It transforms the intergral: d3x' -> d3x
         // where d3x' is the volume element for positions in the boosted frame.
@@ -243,7 +247,8 @@ struct InjectorMomentumRadialExpansion
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z,
+                 amrex::RandomEngine const&) const noexcept
     {
         return {x*u_over_r, y*u_over_r, z*u_over_r};
     }
@@ -270,7 +275,8 @@ struct InjectorMomentumParser
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z,
+                 amrex::RandomEngine const&) const noexcept
     {
         return amrex::XDim3{m_ux_parser(x,y,z),m_uy_parser(x,y,z),m_uz_parser(x,y,z)};
     }
@@ -360,37 +366,38 @@ struct InjectorMomentum
     // (the union is called Object, and the instance is called object).
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z,
+                 amrex::RandomEngine const& engine) const noexcept
     {
         switch (type)
         {
         case Type::parser:
         {
-            return object.parser.getMomentum(x,y,z);
+            return object.parser.getMomentum(x,y,z,engine);
         }
         case Type::gaussian:
         {
-            return object.gaussian.getMomentum(x,y,z);
+            return object.gaussian.getMomentum(x,y,z,engine);
         }
         case Type::boltzmann:
         {
-            return object.boltzmann.getMomentum(x,y,z);
+            return object.boltzmann.getMomentum(x,y,z,engine);
         }
         case Type::juttner:
         {
-            return object.juttner.getMomentum(x,y,z);
+            return object.juttner.getMomentum(x,y,z,engine);
         }
         case Type::constant:
         {
-            return object.constant.getMomentum(x,y,z);
+            return object.constant.getMomentum(x,y,z,engine);
         }
         case Type::radial_expansion:
         {
-            return object.radial_expansion.getMomentum(x,y,z);
+            return object.radial_expansion.getMomentum(x,y,z,engine);
         }
         case Type::custom:
         {
-            return object.custom.getMomentum(x,y,z);
+            return object.custom.getMomentum(x,y,z,engine);
         }
         default:
         {

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -18,9 +18,10 @@ struct InjectorPositionRandom
 {
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getPositionUnitBox (int /*i_part*/, int /*ref_fac=1*/) const noexcept
+    getPositionUnitBox (int /*i_part*/, int /*ref_fac*/,
+                        amrex::RandomEngine const& engine) const noexcept
     {
-        return amrex::XDim3{amrex::Random(), amrex::Random(), amrex::Random()};
+        return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), amrex::Random(engine)};
     }
 };
 
@@ -36,7 +37,8 @@ struct InjectorPositionRegular
     // is a_ppc*(ref_fac**AMREX_SPACEDIM).
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getPositionUnitBox (int const i_part, int const ref_fac=1) const noexcept
+    getPositionUnitBox (int const i_part, int const ref_fac,
+                        amrex::RandomEngine const&) const noexcept
     {
         using namespace amrex;
 
@@ -105,17 +107,18 @@ struct InjectorPosition
     // (the union is called Object, and the instance is called object).
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getPositionUnitBox (int const i_part, int const ref_fac=1) const noexcept
+    getPositionUnitBox (int const i_part, int const ref_fac,
+                        amrex::RandomEngine const& engine) const noexcept
     {
         switch (type)
         {
         case Type::regular:
         {
-            return object.regular.getPositionUnitBox(i_part, ref_fac);
+            return object.regular.getPositionUnitBox(i_part, ref_fac, engine);
         }
         default:
         {
-            return object.random.getPositionUnitBox(i_part, ref_fac);
+            return object.random.getPositionUnitBox(i_part, ref_fac, engine);
         }
         };
     }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -565,7 +565,7 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
 
 XDim3 PlasmaInjector::getMomentum (Real x, Real y, Real z) const noexcept
 {
-    return h_inj_mom->getMomentum(x, y, z); // gamma*beta
+    return h_inj_mom->getMomentum(x, y, z, amrex::RandomEngine{}); // gamma*beta
 }
 
 bool PlasmaInjector::insideBounds (Real x, Real y, Real z) const noexcept

--- a/Source/Particles/Collision/CollisionType.cpp
+++ b/Source/Particles/Collision/CollisionType.cpp
@@ -109,8 +109,8 @@ void CollisionType::doCoulombCollisionsWithinTile
 #endif
 
         // Loop over cells
-        amrex::ParallelFor( n_cells,
-            [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+        amrex::ParallelForRNG( n_cells,
+            [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
             {
                 // The particles from species1 that are in the cell `i_cell` are
                 // given by the `indices_1[cell_start_1:cell_stop_1]`
@@ -123,7 +123,7 @@ void CollisionType::doCoulombCollisionsWithinTile
                 {
                     // shuffle
                     ShuffleFisherYates(
-                        indices_1, cell_start_1, cell_half_1 );
+                        indices_1, cell_start_1, cell_half_1, engine );
 
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
@@ -139,7 +139,8 @@ void CollisionType::doCoulombCollisionsWithinTile
                         indices_1, indices_1,
                         ux_1, uy_1, uz_1, ux_1, uy_1, uz_1, w_1, w_1,
                         q1, q1, m1, m1, Real(-1.0), Real(-1.0),
-                        dt, CoulombLog, dV );
+                        dt, CoulombLog, dV,
+                        engine);
                 }
             }
         );
@@ -199,8 +200,8 @@ void CollisionType::doCoulombCollisionsWithinTile
 #endif
 
         // Loop over cells
-        amrex::ParallelFor( n_cells,
-            [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+        amrex::ParallelForRNG( n_cells,
+            [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
             {
                 // The particles from species1 that are in the cell `i_cell` are
                 // given by the `indices_1[cell_start_1:cell_stop_1]`
@@ -219,8 +220,8 @@ void CollisionType::doCoulombCollisionsWithinTile
                      cell_stop_2 - cell_start_2 >= 1 )
                 {
                     // shuffle
-                    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1);
-                    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2);
+                    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+                    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
 
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
@@ -235,7 +236,8 @@ void CollisionType::doCoulombCollisionsWithinTile
                         indices_1, indices_2,
                         ux_1, uy_1, uz_1, ux_2, uy_2, uz_2, w_1, w_2,
                         q1, q2, m1, m2, Real(-1.0), Real(-1.0),
-                        dt, CoulombLog, dV );
+                        dt, CoulombLog, dV,
+                        engine);
                 }
             }
         );

--- a/Source/Particles/Collision/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/ElasticCollisionPerez.H
@@ -46,7 +46,8 @@ void ElasticCollisionPerez (
     T_R const  q1, T_R const  q2,
     T_R const  m1, T_R const  m2,
     T_R const  T1, T_R const  T2,
-    T_R const  dt, T_R const   L, T_R const dV)
+    T_R const  dt, T_R const   L, T_R const dV,
+    amrex::RandomEngine const& engine)
 {
 
     int NI1 = I1e - I1s;
@@ -101,7 +102,8 @@ void ElasticCollisionPerez (
               u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
               n1, n2, n12,
               q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
-              dt, L, lmdD);
+              dt, L, lmdD,
+              engine);
           ++i1; if ( i1 == static_cast<int>(I1e) ) { i1 = I1s; }
           ++i2; if ( i2 == static_cast<int>(I2e) ) { i2 = I2s; }
       }

--- a/Source/Particles/Collision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/ShuffleFisherYates.H
@@ -17,14 +17,15 @@
 
 template <typename T_index>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void ShuffleFisherYates (T_index *array, T_index const is, T_index const ie)
+void ShuffleFisherYates (T_index *array, T_index const is, T_index const ie,
+                         amrex::RandomEngine const& engine)
 {
     int     j;
     T_index buf;
     for (int i = ie-1; i >= static_cast<int>(is+1); --i)
     {
         // get random number j: is <= j <= i
-        j = amrex::Random_int(i-is+1) + is;
+        j = amrex::Random_int(i-is+1, engine) + is;
         // swop the ith array element with the jth
         buf      = array[i];
         array[i] = array[j];

--- a/Source/Particles/Collision/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/UpdateMomentumPerezElastic.H
@@ -32,7 +32,8 @@ void UpdateMomentumPerezElastic (
     T_R const n1, T_R const n2, T_R const n12,
     T_R const q1, T_R const m1, T_R const w1,
     T_R const q2, T_R const m2, T_R const w2,
-    T_R const dt, T_R const L,  T_R const lmdD)
+    T_R const dt, T_R const L,  T_R const lmdD,
+    amrex::RandomEngine const& engine)
 {
 
     // If g = u1 - u2 = 0, do not collide.
@@ -126,7 +127,7 @@ void UpdateMomentumPerezElastic (
     s = amrex::min(s,sp);
 
     // Get random numbers
-    T_R r = amrex::Random();
+    T_R r = amrex::Random(engine);
 
     // Compute scattering angle
     T_R cosXs;
@@ -138,7 +139,7 @@ void UpdateMomentumPerezElastic (
             cosXs = T_R(1.0) + s * std::log(r);
             // Avoid the bug when r is too small such that cosXs < -1
             if ( cosXs >= T_R(-1.0) ) { break; }
-            r = amrex::Random();
+            r = amrex::Random(engine);
         }
     }
     else if ( s > T_R(0.1) && s <= T_R(3.0) )
@@ -161,7 +162,7 @@ void UpdateMomentumPerezElastic (
     sinXs = std::sqrt(T_R(1.0) - cosXs*cosXs);
 
     // Get random azimuthal angle
-    T_R const phis = amrex::Random() * T_R(2.0) * MathConst::pi;
+    T_R const phis = amrex::Random(engine) * T_R(2.0) * MathConst::pi;
     T_R const cosphis = std::cos(phis);
     T_R const sinphis = std::sin(phis);
 
@@ -237,7 +238,7 @@ void UpdateMomentumPerezElastic (
     }
 
     // Rejection method
-    r = amrex::Random();
+    r = amrex::Random(engine);
     if ( w2 > r*amrex::max(w1, w2) )
     {
         u1x  = p1fx / m1;
@@ -248,7 +249,7 @@ void UpdateMomentumPerezElastic (
         AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
 #endif
     }
-    r = amrex::Random();
+    r = amrex::Random(engine);
     if ( w1 > r*amrex::max(w1, w2) )
     {
         u2x  = p2fx / m2;

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -69,7 +69,7 @@ struct IonizationFilterFunc
 
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const PData& ptd, int i) const noexcept
+    bool operator() (const PData& ptd, int i, amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
 
@@ -115,7 +115,7 @@ struct IonizationFilterFunc
                 std::exp( m_adk_exp_prefactor[ion_lev]/E );
             amrex::Real p = 1. - std::exp( - w_dtau );
 
-            amrex::Real random_draw = amrex::Random();
+            amrex::Real random_draw = amrex::Random(engine);
             if (random_draw < p)
             {
                 return true;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -78,12 +78,12 @@ public:
      */
     AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
-    amrex::Real operator() () const noexcept
+    amrex::Real operator() (amrex::RandomEngine const& engine) const noexcept
     {
         namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
 
         //A random number in [0,1) should be provided as an argument.
-        return pxr_bw::get_optical_depth(amrex::Random());
+        return pxr_bw::get_optical_depth(amrex::Random(engine));
     }
 };
 //____________________________________________

--- a/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
@@ -38,7 +38,8 @@ amrex::Real
 getSchwingerProductionNumber (const amrex::Real dV, const amrex::Real dt,
               const amrex::Real Ex, const amrex::Real Ey, const amrex::Real Ez,
               const amrex::Real Bx, const amrex::Real By, const amrex::Real Bz,
-              const amrex::Real PoissonToGaussianThreshold)
+              const amrex::Real PoissonToGaussianThreshold,
+              amrex::RandomEngine const& engine)
 {
     using namespace amrex;
     namespace pxr_p = picsar::multi_physics::phys;
@@ -49,10 +50,10 @@ getSchwingerProductionNumber (const amrex::Real dV, const amrex::Real dt,
             Ex, Ey, Ez, Bx, By, Bz, dV, dt);
 
     if (expectedPairNumber <= PoissonToGaussianThreshold) {
-        return amrex::RandomPoisson(expectedPairNumber);
+        return amrex::RandomPoisson(expectedPairNumber, engine);
     } else {
         const auto numpairs =
-            amrex::RandomNormal(expectedPairNumber,sqrt(expectedPairNumber));
+            amrex::RandomNormal(expectedPairNumber,std::sqrt(expectedPairNumber));
         return numpairs > 0._rt ? numpairs : 0._rt;
     }
 }

--- a/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
@@ -53,7 +53,7 @@ getSchwingerProductionNumber (const amrex::Real dV, const amrex::Real dt,
         return amrex::RandomPoisson(expectedPairNumber, engine);
     } else {
         const auto numpairs =
-            amrex::RandomNormal(expectedPairNumber,std::sqrt(expectedPairNumber));
+            amrex::RandomNormal(expectedPairNumber, std::sqrt(expectedPairNumber), engine);
         return numpairs > 0._rt ? numpairs : 0._rt;
     }
 }

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -48,7 +48,7 @@ public:
     */
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const PData& ptd, int const i) const noexcept
+    bool operator() (const PData& ptd, int const i, amrex::RandomEngine const&) const noexcept
     {
         using namespace amrex;
 

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -50,7 +50,7 @@ public:
     */
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const PData& ptd, int const i) const noexcept
+    bool operator() (const PData& ptd, int const i, amrex::RandomEngine const&) const noexcept
     {
         using namespace amrex;
 

--- a/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
+++ b/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
@@ -31,8 +31,9 @@ struct SchwingerFilterFunc
      */
     template <typename FABs>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    amrex::Real operator() (const FABs& src_FABs, const int i,
-                                        const int j, const int k) const noexcept
+    amrex::Real operator() (const FABs& src_FABs,
+                            const int i, const int j, const int k,
+                            amrex::RandomEngine const& engine) const noexcept
     {
         const auto& arrEx = src_FABs[0];
         const auto& arrEy = src_FABs[1];
@@ -44,7 +45,7 @@ struct SchwingerFilterFunc
         return getSchwingerProductionNumber( m_dV, m_dt,
                     arrEx(i,j,k),arrEy(i,j,k),arrEz(i,j,k),
                     arrBx(i,j,k),arrBy(i,j,k),arrBz(i,j,k),
-                    m_threshold_poisson_gaussian);
+                    m_threshold_poisson_gaussian,engine);
     }
 };
 

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -34,10 +34,10 @@ struct RandomFilter
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const SuperParticleType& /*p*/) const noexcept
+    bool operator () (const SuperParticleType& /*p*/, const amrex::RandomEngine& engine) const noexcept
     {
         if ( !m_is_active ) return 1;
-        else if ( amrex::Random() < m_fraction ) return 1;
+        else if ( amrex::Random(engine) < m_fraction ) return 1;
         else return 0;
     }
 private:
@@ -63,7 +63,7 @@ struct UniformFilter
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const SuperParticleType& p) const noexcept
+    bool operator () (const SuperParticleType& p, const amrex::RandomEngine&) const noexcept
     {
         if ( !m_is_active ) return 1;
         else if ( p.id()%m_stride == 0 ) return 1;
@@ -94,7 +94,7 @@ struct ParserFilter
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const SuperParticleType& p) const noexcept
+    bool operator () (const SuperParticleType& p, const amrex::RandomEngine&) const noexcept
     {
         if ( !m_is_active ) return 1;
         amrex::Real const x  = p.pos(0);
@@ -133,7 +133,7 @@ struct GeometryFilter
      * \return whether or not the particle is inside the region defined by m_domain
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const SuperParticleType& p) const noexcept
+    bool operator () (const SuperParticleType& p, const amrex::RandomEngine&) const noexcept
     {
         if ( !m_is_active ) return 1;
         return ! (AMREX_D_TERM( (p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ),

--- a/Source/Particles/ParticleCreation/DefaultInitialization.H
+++ b/Source/Particles/ParticleCreation/DefaultInitialization.H
@@ -53,13 +53,13 @@ static std::map<std::string, InitializationPolicy> initialization_policies = {
 };
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-amrex::ParticleReal initializeRealValue (const InitializationPolicy policy) noexcept
+amrex::ParticleReal initializeRealValue (const InitializationPolicy policy, amrex::RandomEngine const& engine) noexcept
 {
     switch (policy) {
         case InitializationPolicy::Zero : return 0.0;
         case InitializationPolicy::One  : return 1.0;
         case InitializationPolicy::RandomExp : {
-            return -log(amrex::Random());
+            return -log(amrex::Random(engine));
         }
         default : {
             amrex::Abort("Initialization Policy not recognized");

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -59,14 +59,8 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     if (np == 0) return 0;
 
     Gpu::DeviceVector<Index> offsets(np);
-    Gpu::exclusive_scan(mask, mask+np, offsets.begin());
-
-    Index last_mask, last_offset;
-    Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
-    Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
-
-    Gpu::streamSynchronize();
-    const Index num_added = N * (last_mask + last_offset);
+    auto total = amrex::Scan::ExclusiveSum(np, mask, offsets.data());
+    const Index num_added = N * total;
     dst.resize(std::max(dst_index + num_added, dst.numParticles()));
 
     const auto p_offsets = offsets.dataPtr();
@@ -74,17 +68,19 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
     const auto src_data = src.getParticleTileData();
     const auto dst_data = dst.getParticleTileData();
 
-    AMREX_HOST_DEVICE_FOR_1D( np, i,
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
         if (mask[i])
         {
-            for (int j = 0; j < N; ++j)
-                copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j);
+            for (int j = 0; j < N; ++j) {
+                copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j, engine);
+            }
             transform(dst_data, src_data, i, N*p_offsets[i] + dst_index);
         }
-    })
+    });
 
-    Gpu::streamSynchronize();
+    Gpu::synchronize();
     return num_added;
 }
 
@@ -140,10 +136,11 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index dst_index,
     auto p_mask = mask.dataPtr();
     const auto src_data = src.getParticleTileData();
 
-    AMREX_HOST_DEVICE_FOR_1D(np, i,
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = filter(src_data, i);
-    })
+        p_mask[i] = filter(src_data, i, engine);
+    });
 
     return filterCopyTransformParticles<N>(dst, src, mask.dataPtr(), dst_index,
                                                       std::forward<CopyFunc>(copy),
@@ -205,14 +202,8 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     if (np == 0) return 0;
 
     Gpu::DeviceVector<Index> offsets(np);
-    Gpu::exclusive_scan(mask, mask+np, offsets.begin());
-
-    Index last_mask, last_offset;
-    Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
-    Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);
-
-    Gpu::streamSynchronize();
-    const Index num_added = N*(last_mask + last_offset);
+    auto total = amrex::Scan::ExclusiveSum(np, mask, offsets.data());
+    const Index num_added = N * total;
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
 
@@ -222,22 +213,23 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
     const auto dst1_data = dst1.getParticleTileData();
     const auto dst2_data = dst2.getParticleTileData();
 
-    AMREX_HOST_DEVICE_FOR_1D( np, i,
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
         if (mask[i])
         {
             for (int j = 0; j < N; ++j)
             {
-                copy1(dst1_data, src_data, i, N*p_offsets[i] + dst1_index + j);
-                copy2(dst2_data, src_data, i, N*p_offsets[i] + dst2_index + j);
+                copy1(dst1_data, src_data, i, N*p_offsets[i] + dst1_index + j, engine);
+                copy2(dst2_data, src_data, i, N*p_offsets[i] + dst2_index + j, engine);
             }
             transform(dst1_data, dst2_data, src_data, i,
                       N*p_offsets[i] + dst1_index,
                       N*p_offsets[i] + dst2_index);
         }
-    })
+    });
 
-    Gpu::streamSynchronize();
+    Gpu::synchronize();
     return num_added;
 }
 
@@ -300,10 +292,11 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src,
     auto p_mask = mask.dataPtr();
     const auto src_data = src.getParticleTileData();
 
-    AMREX_HOST_DEVICE_FOR_1D(np, i,
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine)
     {
-        p_mask[i] = filter(src_data, i);
-    })
+        p_mask[i] = filter(src_data, i, engine);
+    });
 
     return filterCopyTransformParticles<N>(dst1, dst2, src, mask.dataPtr(),
                                         dst1_index, dst2_index,

--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -74,16 +74,8 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
 
     const auto arrNumPartCreation = src_FAB->array();
     Gpu::DeviceVector<Index> offsets(ncells);
-    Gpu::exclusive_scan(mask, mask+ncells, offsets.begin());
-
-    Index last_mask, last_offset;
-    Gpu::copyAsync(Gpu::deviceToHost, mask+ncells-1, mask + ncells, &last_mask);
-    Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+ncells-1,
-                                      offsets.data()+ncells, &last_offset);
-
-    Gpu::streamSynchronize();
-
-    const Index num_added = N*(last_mask + last_offset);
+    auto total = amrex::Scan::ExclusiveSum(ncells, mask, offsets.data());
+    const Index num_added = N*total;
     dst1.resize(std::max(dst1_index + num_added, dst1.numParticles()));
     dst2.resize(std::max(dst2_index + num_added, dst2.numParticles()));
 
@@ -97,7 +89,8 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
     // For loop over all cells in the box. If mask is true in the given cell,
     // we create the particles in the cell and apply a transform function to the
     // created particles.
-    AMREX_HOST_DEVICE_FOR_1D( ncells, i,
+    amrex::ParallelForRNG(ncells,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
         if (mask[i])
         {
@@ -114,15 +107,15 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
 
             for (int n = 0; n < N; ++n)
             {
-                create1(dst1_data, N*p_offsets[i] + dst1_index + n, x, y, z);
-                create2(dst2_data, N*p_offsets[i] + dst2_index + n, x, y, z);
+                create1(dst1_data, N*p_offsets[i] + dst1_index + n, engine, x, y, z);
+                create2(dst2_data, N*p_offsets[i] + dst2_index + n, engine, x, y, z);
             }
             transform(dst1_data, dst2_data, N*p_offsets[i] + dst1_index,
                     N*p_offsets[i] + dst2_index, N, arrNumPartCreation(j,k,l));
         }
     });
 
-    Gpu::streamSynchronize();
+    Gpu::synchronize();
     return num_added;
 }
 
@@ -185,8 +178,9 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
     // for loop over all cells in the box. We apply the filter function to each cell
     // and store the result in arrNumPartCreation. If the result is strictly greater than
     // 0, the mask is set to true at the given cell position.
-    amrex::ParallelFor(box,  [=] AMREX_GPU_DEVICE (int i, int j, int k){
-        arrNumPartCreation(i,j,k) = filter(src_FABs,i,j,k);
+    amrex::ParallelForRNG(box,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::RandomEngine const& engine){
+        arrNumPartCreation(i,j,k) = filter(src_FABs,i,j,k,engine);
         const IntVect iv(AMREX_D_DECL(i,j,k));
         const auto mask_position = box.index(iv);
         p_mask[mask_position] = (arrNumPartCreation(i,j,k) > 0);

--- a/Source/Particles/ParticleCreation/SmartCopy.H
+++ b/Source/Particles/ParticleCreation/SmartCopy.H
@@ -45,16 +45,17 @@ struct SmartCopy
 
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (DstData& dst, const SrcData& src, int i_src, int i_dst) const noexcept
+    void operator() (DstData& dst, const SrcData& src, int i_src, int i_dst,
+                     amrex::RandomEngine const& engine) const noexcept
     {
         // the particle struct is always copied over
         dst.m_aos[i_dst] = src.m_aos[i_src];
 
         // initialize the real components
         for (int j = 0; j < DstData::NAR; ++j)
-            dst.m_rdata[j][i_dst] = initializeRealValue(m_policy_real[j]);
+            dst.m_rdata[j][i_dst] = initializeRealValue(m_policy_real[j], engine);
         for (int j = 0; j < dst.m_num_runtime_real; ++j)
-            dst.m_runtime_rdata[j][i_dst] = initializeRealValue(m_policy_real[j+DstData::NAR]);
+            dst.m_runtime_rdata[j][i_dst] = initializeRealValue(m_policy_real[j+DstData::NAR], engine);
 
         // initialize the int components
         for (int j = 0; j < DstData::NAI; ++j)

--- a/Source/Particles/ParticleCreation/SmartCreate.H
+++ b/Source/Particles/ParticleCreation/SmartCreate.H
@@ -39,6 +39,7 @@ struct SmartCreate
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (
         PartData& prt, const int i_prt,
+        amrex::RandomEngine const& engine,
         const amrex::Real x = 0.0,
         const amrex::Real y = 0.0,
         const amrex::Real z = 0.0,
@@ -59,9 +60,9 @@ struct SmartCreate
 
          // initialize the real components
          for (int j = 0; j < PartData::NAR; ++j)
-             prt.m_rdata[j][i_prt] = initializeRealValue(m_policy_real[j]);
+             prt.m_rdata[j][i_prt] = initializeRealValue(m_policy_real[j], engine);
          for (int j = 0; j < prt.m_num_runtime_real; ++j)
-             prt.m_runtime_rdata[j][i_prt] = initializeRealValue(m_policy_real[j+PartData::NAR]);
+             prt.m_runtime_rdata[j][i_prt] = initializeRealValue(m_policy_real[j+PartData::NAR], engine);
 
          // initialize the int components
          for (int j = 0; j < PartData::NAI; ++j)

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -752,7 +752,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         // The invalid ones are given negative ID and are deleted during the
         // next redistribute.
         const auto poffset = offset.data();
-        amrex::For(overlap_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        amrex::ParallelForRNG(overlap_box,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::RandomEngine const& engine) noexcept
         {
             IntVect iv = IntVect(AMREX_D_DECL(i, j, k));
             const auto index = overlap_box.index(iv);
@@ -764,7 +765,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 p.cpu() = cpuid;
 
                 const XDim3 r =
-                    inj_pos->getPositionUnitBox(i_part, lrrfac);
+                    inj_pos->getPositionUnitBox(i_part, lrrfac, engine);
                 auto pos = getCellCoords(overlap_corner, dx, r, iv);
 
 #if (AMREX_SPACEDIM == 3)
@@ -792,7 +793,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 if (nmodes == 1) {
                     // With only 1 mode, the angle doesn't matter so
                     // choose it randomly.
-                    theta = 2._rt*MathConst::pi*amrex::Random();
+                    theta = 2._rt*MathConst::pi*amrex::Random(engine);
                 } else {
                     theta = 2._rt*MathConst::pi*r.y;
                 }
@@ -816,7 +817,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                         continue;
                     }
 
-                    u = inj_mom->getMomentum(pos.x, pos.y, z0);
+                    u = inj_mom->getMomentum(pos.x, pos.y, z0, engine);
                     dens = inj_rho->getDensity(pos.x, pos.y, z0);
 
                     // Remove particle if density below threshold
@@ -848,7 +849,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                     dens = amrex::min(dens, density_max);
 
                     // get the full momentum, including thermal motion
-                    u = inj_mom->getMomentum(pos.x, pos.y, 0._rt);
+                    u = inj_mom->getMomentum(pos.x, pos.y, 0._rt, engine);
                     const Real gamma_lab = std::sqrt( 1._rt+(u.x*u.x+u.y*u.y+u.z*u.z) );
                     const Real betaz_lab = u.z/(gamma_lab);
 
@@ -868,7 +869,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 }
 
                 if(loc_has_breit_wheeler){
-                    p_optical_depth_BW[ip] = breit_wheeler_get_opt();
+                    p_optical_depth_BW[ip] = breit_wheeler_get_opt(engine);
                 }
 #endif
 

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -49,8 +49,8 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
     const amrex::Real target_ratio = m_target_ratio;
 
     // Loop over cells
-    amrex::ParallelFor( n_cells,
-        [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+    amrex::ParallelForRNG( n_cells,
+        [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
         {
             // The particles that are in the cell `i_cell` are
             // given by the `indices[cell_start:cell_stop]`
@@ -79,7 +79,7 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
                 // Particles with weight greater than level_weight are left unchanged
                 if (w[indices[i]] > level_weight) {continue;}
 
-                amrex::Real const random_number = amrex::Random();
+                amrex::Real const random_number = amrex::Random(engine);
                 // Remove particle with probability 1 - particle_weight/level_weight
                 if (random_number > w[indices[i]]/level_weight)
                 {


### PR DESCRIPTION
In order to support RNG on non-Nvidia GPUs, we need to use
amrex::ParallelForRNG for kernels with calls to AMReX random number
generation functions.