### PR TITLE
SYCL 2020/DPC++: C++17

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -2,11 +2,15 @@ AMREX_HOME ?= ../../../amrex
 PICSAR_HOME ?= ../../../picsar
 OPENBC_HOME ?= ../../../openbc_poisson
 
-CXXSTD        = c++14
 USE_MPI       = TRUE
 USE_PARTICLES = TRUE
 USE_RPATH     = TRUE
 BL_NO_FORT    = TRUE
+ifeq ($(USE_DPCPP),TRUE)
+  CXXSTD        = c++17
+else
+  CXXSTD        = c++14
+endif
 
 # required for AMReX async I/O
 MPI_THREAD_MULTIPLE = TRUE


### PR DESCRIPTION
Request C++17 in GNUmake for DPC++ builds. This is now required since we use MKL headers that are in C++17 and since SYCL 2020 and later rely on C++17 or newer. (In fact, `dpcpp` beta07 and newer already defaulted to C++17.)

This updates the explicit GNUmake flag (request exactly one standard).

The CMake flags in WarpX are "request C++14 or newer" and AMReX' CMake target pushes those up to "request C++17 or newer" for DPC++: https://github.com/AMReX-Codes/amrex/pull/1402