### PR TITLE
Doc: Cori MPI Thread Multiple

### DIFF
--- a/Tools/BatchScripts/batch_cori.sh
+++ b/Tools/BatchScripts/batch_cori.sh
@@ -37,4 +37,7 @@ export WARPX_NTHREADS_PER_NODE=$(( ${WARPX_HYPERTHREAD_LEVEL} * ${CORI_NCORES_PE
 export OMP_NUM_THREADS=$(( ${WARPX_NTHREADS_PER_NODE} / ${WARPX_NMPI_PER_NODE} ))
 export WARPX_THREAD_COUNT=$(( ${CORI_NHYPERTHREADS_MAX} / ${WARPX_NMPI_PER_NODE} ))
 
+# for async_io support: (optional)
+export MPICH_MAX_THREAD_SAFETY=multiple
+
 srun --cpu_bind=cores -n $(( ${SLURM_JOB_NUM_NODES} * ${WARPX_NMPI_PER_NODE} )) -c ${WARPX_THREAD_COUNT} <path/to/executable> <input file>

--- a/Tools/BatchScripts/batch_cori_haswell.sh
+++ b/Tools/BatchScripts/batch_cori_haswell.sh
@@ -31,6 +31,9 @@ export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
 export OMP_NUM_THREADS=16
 
+# for async_io support: (optional)
+export MPICH_MAX_THREAD_SAFETY=multiple
+
 EXE="<path/to/executable>"
 
 srun --cpu_bind=cores -n $(( ${SLURM_JOB_NUM_NODES} * ${WARPX_NMPI_PER_NODE} )) ${EXE} <input file>


### PR DESCRIPTION
Thread multiple support is not the default on Cori. One needs to set this with an environment variable.

Follow-up to #1298

cc @kngott (thx for the hint!)

@LDAmorim I am not at work in the next two days, if you see a performance drop with this environment variable set, please let us know.