### PR TITLE
Summit: Doc Modules for RZ+PSATD

### DIFF
--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -58,6 +58,11 @@ We use the following modules and environments on the system.
    module load ums-aph114
    module load openpmd-api/0.12.0
 
+   # optional: for PSATD in RZ geometry support
+   #   note: needs the ums modules above
+   module load blaspp
+   module load lapackpp
+
    # optional: Ascent in situ support
    #   note: build WarpX with CMake
    export Alpine=/gpfs/alpine/world-shared/csc340/software/ascent/0.5.3-pre/summit/cuda/gnu


### PR DESCRIPTION
This provide another (#1369) two user-managed software modules on Summit: BlasPP and LapackPP.

This saves us and our users from manually installing them when building WarpX with PSATD support in RZ geometry.

Compile tested with:
```bash
cmake .. -DWarpX_OPENPMD=ON -DWarpX_PSATD=ON -DWarpX_DIMS=RZ -DWarpX_COMPUTE=CUDA -DCMAKE_CUDA_ARCHITECTURES=70 -DCUDA_ARCH=7.0
make -j 16
```
(runtime test needs to be done, please. heading into PTO the next days)