### PR TITLE
Remove instability on PML with do_nodal

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -54,11 +54,12 @@ namespace amrex {
     class FabFactory<SigmaBox>
     {
     public:
-        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
-            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta) {}
+        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta,
+                              const bool do_nodal)
+            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta), m_do_nodal(do_nodal) {}
         virtual SigmaBox* create (const Box& box, int /*ncomps*/,
                                   const FabInfo& /*info*/, int /*box_index*/) const final
-            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta); }
+            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta, m_do_nodal); }
         virtual void destroy (SigmaBox* fab) const final {
             delete fab;
         }
@@ -70,6 +71,7 @@ namespace amrex {
         const Real* m_dx;
         int m_ncell;
         int m_delta;
+        bool m_do_nodal;
     };
 }
 

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -31,11 +31,7 @@ struct Sigma : amrex::Gpu::DeviceVector<amrex::Real>
 struct SigmaBox
 {
     SigmaBox (const amrex::Box& box, const amrex::BoxArray& grids,
-              const amrex::Real* dx, int ncell, int delta
-#ifdef WARPX_USE_PSATD
-              ,const bool do_nodal
-#endif
-             );
+              const amrex::Real* dx, int ncell, int delta);
 
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
@@ -58,23 +54,11 @@ namespace amrex {
     class FabFactory<SigmaBox>
     {
     public:
-        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta
-#ifdef WARPX_USE_PSATD
-                              , const bool do_nodal
-#endif
-                              )
-            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta)
-#ifdef WARPX_USE_PSATD
-            , m_do_nodal(do_nodal)
-#endif
-            {}
+        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
+            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta) {}
         virtual SigmaBox* create (const Box& box, int /*ncomps*/,
                                   const FabInfo& /*info*/, int /*box_index*/) const final
-            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta
-#ifdef WARPX_USE_PSATD
-            , m_do_nodal
-#endif
-            ); }
+            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta); }
         virtual void destroy (SigmaBox* fab) const final {
             delete fab;
         }
@@ -86,9 +70,6 @@ namespace amrex {
         const Real* m_dx;
         int m_ncell;
         int m_delta;
-#ifdef WARPX_USE_PSATD
-        bool m_do_nodal;
-#endif
     };
 }
 
@@ -97,11 +78,7 @@ class MultiSigmaBox
 {
 public:
     MultiSigmaBox(const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta
-#ifdef WARPX_USE_PSATD
-                  ,const bool do_nodal
-#endif
-                  );
+                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta);
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
 private:

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -31,7 +31,11 @@ struct Sigma : amrex::Gpu::DeviceVector<amrex::Real>
 struct SigmaBox
 {
     SigmaBox (const amrex::Box& box, const amrex::BoxArray& grids,
-              const amrex::Real* dx, int ncell, int delta, const bool do_nodal);
+              const amrex::Real* dx, int ncell, int delta
+#ifdef WARPX_USE_PSATD
+              ,const bool do_nodal
+#endif
+             );
 
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
@@ -54,12 +58,23 @@ namespace amrex {
     class FabFactory<SigmaBox>
     {
     public:
-        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta,
-                              const bool do_nodal)
-            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta), m_do_nodal(do_nodal) {}
+        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta
+#ifdef WARPX_USE_PSATD
+                              , const bool do_nodal
+#endif
+                              )
+            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta)
+#ifdef WARPX_USE_PSATD
+            , m_do_nodal(do_nodal)
+#endif
+            {}
         virtual SigmaBox* create (const Box& box, int /*ncomps*/,
                                   const FabInfo& /*info*/, int /*box_index*/) const final
-            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta, m_do_nodal); }
+            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta
+#ifdef WARPX_USE_PSATD
+            , m_do_nodal
+#endif
+            ); }
         virtual void destroy (SigmaBox* fab) const final {
             delete fab;
         }
@@ -71,7 +86,9 @@ namespace amrex {
         const Real* m_dx;
         int m_ncell;
         int m_delta;
+#ifdef WARPX_USE_PSATD
         bool m_do_nodal;
+#endif
     };
 }
 
@@ -80,8 +97,11 @@ class MultiSigmaBox
 {
 public:
     MultiSigmaBox(const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta,
-                  const bool do_nodal);
+                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta
+#ifdef WARPX_USE_PSATD
+                  ,const bool do_nodal
+#endif
+                  );
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
 private:

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -31,7 +31,7 @@ struct Sigma : amrex::Gpu::DeviceVector<amrex::Real>
 struct SigmaBox
 {
     SigmaBox (const amrex::Box& box, const amrex::BoxArray& grids,
-              const amrex::Real* dx, int ncell, int delta);
+              const amrex::Real* dx, int ncell, int delta, const bool do_nodal);
 
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
@@ -78,7 +78,8 @@ class MultiSigmaBox
 {
 public:
     MultiSigmaBox(const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta);
+                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta,
+                  const bool do_nodal);
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
 private:

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -113,8 +113,11 @@ namespace
     }
 }
 
-SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int ncell, int delta,
-                    const bool do_nodal)
+SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int ncell, int delta
+#ifdef WARPX_USE_PSATD
+                    ,const bool do_nodal
+#endif
+                   )
 {
     BL_ASSERT(box.cellCentered());
 
@@ -122,7 +125,10 @@ SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int n
     const int*     lo = box.loVect();
     const int*     hi = box.hiVect();
 
-    const int one_if_nodal = do_nodal ? 1 : 0;
+    int one_if_nodal = 0;
+#ifdef WARPX_USE_PSATD
+    one_if_nodal = do_nodal ? 1 : 0;
+#endif
 
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
@@ -389,10 +395,17 @@ SigmaBox::ComputePMLFactorsE (const Real* a_dx, Real dt)
 }
 
 MultiSigmaBox::MultiSigmaBox (const BoxArray& ba, const DistributionMapping& dm,
-                              const BoxArray& grid_ba, const Real* dx, int ncell, int delta,
-                              const bool do_nodal)
+                              const BoxArray& grid_ba, const Real* dx, int ncell, int delta
+#ifdef WARPX_USE_PSATD
+                              ,const bool do_nodal
+#endif
+                              )
     : FabArray<SigmaBox>(ba,dm,1,0,MFInfo(),
-                         FabFactory<SigmaBox>(grid_ba,dx,ncell,delta, do_nodal))
+                         FabFactory<SigmaBox>(grid_ba,dx,ncell,delta
+#ifdef WARPX_USE_PSATD
+                         ,do_nodal
+#endif
+                         ))
 {}
 
 void
@@ -535,12 +548,18 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     }
 
     if (do_pml_in_domain){
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta,
-                                         do_nodal));
+        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta
+#ifdef WARPX_USE_PSATD
+                                         ,do_nodal
+#endif
+                                         ));
     }
     else {
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba, geom->CellSize(), ncell, delta,
-                                         do_nodal));
+        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba, geom->CellSize(), ncell, delta
+#ifdef WARPX_USE_PSATD
+                                         ,do_nodal
+#endif
+                                         ));
     }
 
 
@@ -611,11 +630,17 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         pml_j_cp[2]->setVal(0.0);
 
         if (do_pml_in_domain){
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell,
-                                             delta, do_nodal));
+            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell, delta
+#ifdef WARPX_USE_PSATD
+                                             ,do_nodal
+#endif
+                                            ));
         } else {
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta,
-                                             do_nodal));
+            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta
+#ifdef WARPX_USE_PSATD
+                                             ,do_nodal
+#endif
+                                            ));
         }
 
 #ifdef WARPX_USE_PSATD

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -113,11 +113,7 @@ namespace
     }
 }
 
-SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int ncell, int delta
-#ifdef WARPX_USE_PSATD
-                    ,const bool do_nodal
-#endif
-                   )
+SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int ncell, int delta)
 {
     BL_ASSERT(box.cellCentered());
 
@@ -125,38 +121,33 @@ SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int n
     const int*     lo = box.loVect();
     const int*     hi = box.hiVect();
 
-    int one_if_nodal = 0;
-#ifdef WARPX_USE_PSATD
-    one_if_nodal = do_nodal ? 1 : 0;
-#endif
-
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
         sigma                [idim].resize(sz[idim]+1);
         sigma_cumsum         [idim].resize(sz[idim]+1);
-        sigma_star           [idim].resize(sz[idim]+one_if_nodal);
-        sigma_star_cumsum    [idim].resize(sz[idim]+one_if_nodal);
+        sigma_star           [idim].resize(sz[idim]+1);
+        sigma_star_cumsum    [idim].resize(sz[idim]+1);
         sigma_fac            [idim].resize(sz[idim]+1);
         sigma_cumsum_fac     [idim].resize(sz[idim]+1);
-        sigma_star_fac       [idim].resize(sz[idim]+one_if_nodal);
-        sigma_star_cumsum_fac[idim].resize(sz[idim]+one_if_nodal);
+        sigma_star_fac       [idim].resize(sz[idim]+1);
+        sigma_star_cumsum_fac[idim].resize(sz[idim]+1);
 
         sigma                [idim].m_lo = lo[idim];
         sigma                [idim].m_hi = hi[idim]+1;
         sigma_cumsum         [idim].m_lo = lo[idim];
         sigma_cumsum         [idim].m_hi = hi[idim]+1;
         sigma_star           [idim].m_lo = lo[idim];
-        sigma_star           [idim].m_hi = hi[idim]+one_if_nodal;
+        sigma_star           [idim].m_hi = hi[idim]+1;
         sigma_star_cumsum    [idim].m_lo = lo[idim];
-        sigma_star_cumsum    [idim].m_hi = hi[idim]+one_if_nodal;
+        sigma_star_cumsum    [idim].m_hi = hi[idim]+1;
         sigma_fac            [idim].m_lo = lo[idim];
         sigma_fac            [idim].m_hi = hi[idim]+1;
         sigma_cumsum_fac     [idim].m_lo = lo[idim];
         sigma_cumsum_fac     [idim].m_hi = hi[idim]+1;
         sigma_star_fac       [idim].m_lo = lo[idim];
-        sigma_star_fac       [idim].m_hi = hi[idim]+one_if_nodal;
+        sigma_star_fac       [idim].m_hi = hi[idim]+1;
         sigma_star_cumsum_fac[idim].m_lo = lo[idim];
-        sigma_star_cumsum_fac[idim].m_hi = hi[idim]+one_if_nodal;
+        sigma_star_cumsum_fac[idim].m_hi = hi[idim]+1;
     }
 
     Array<Real,AMREX_SPACEDIM> fac;
@@ -395,17 +386,9 @@ SigmaBox::ComputePMLFactorsE (const Real* a_dx, Real dt)
 }
 
 MultiSigmaBox::MultiSigmaBox (const BoxArray& ba, const DistributionMapping& dm,
-                              const BoxArray& grid_ba, const Real* dx, int ncell, int delta
-#ifdef WARPX_USE_PSATD
-                              ,const bool do_nodal
-#endif
-                              )
+                              const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
     : FabArray<SigmaBox>(ba,dm,1,0,MFInfo(),
-                         FabFactory<SigmaBox>(grid_ba,dx,ncell,delta
-#ifdef WARPX_USE_PSATD
-                         ,do_nodal
-#endif
-                         ))
+                         FabFactory<SigmaBox>(grid_ba,dx,ncell,delta))
 {}
 
 void
@@ -548,18 +531,10 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     }
 
     if (do_pml_in_domain){
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta
-#ifdef WARPX_USE_PSATD
-                                         ,do_nodal
-#endif
-                                         ));
+        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta));
     }
     else {
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba, geom->CellSize(), ncell, delta
-#ifdef WARPX_USE_PSATD
-                                         ,do_nodal
-#endif
-                                         ));
+        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba, geom->CellSize(), ncell, delta));
     }
 
 
@@ -630,17 +605,9 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         pml_j_cp[2]->setVal(0.0);
 
         if (do_pml_in_domain){
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell, delta
-#ifdef WARPX_USE_PSATD
-                                             ,do_nodal
-#endif
-                                            ));
+            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell, delta));
         } else {
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta
-#ifdef WARPX_USE_PSATD
-                                             ,do_nodal
-#endif
-                                            ));
+            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta));
         }
 
 #ifdef WARPX_USE_PSATD


### PR DESCRIPTION
I've been trying to investigate issue #1063 that we have experienced a few times. (instability occuring with PML+PSATD+GPU+do_nodal)

In nodal mode there is one extra point in the B field in the directions relevant for the PML but it looks like this was not taken into account when allocating and initializing the PML coefficients in `sigma_star`, `sigma_star_fac`, etc in the constructor of `SigmaBox` and in `SigmaBox::ComputePMLFactorsB`. As a result, the fields at the edge of the PML could be multiplied by an undefined value which could be greater than 1 (somehow this only occured on GPU), thus causing an instability.

I've noticed that the instability can be suppressed when increasing the size of the vectors `sigma_star`, `sigma_star_fac`, etc by 1 when running in nodal mode, which is exactly what is done in this PR. However, I'm not too familiar with PMLs so it would be good if someone with more experience on the topic could confirm that this is indeed a correct fix (i.e. that the PML now behaves as it should).

A few points to note:

- `do_nodal` is only passed to the constructor of `PML` when the code is compiled with PSATD. Therefore I've had to add a lot of `#ifdef WARPX_USE_PSATD` to propagate `do_nodal` up to the constructor of `SigmaBox` where the size of the vector `sigma_star` is defined. This looks a bit ugly, so if we prefer we can pass `do_nodal` to the constructor of `PML` even if the code is not compiled with PSATD.
- This fix removes the instability in the 2D input file that I have given in #1063 . However, I haven't been able to reproduce the instability in the 3D input file given by @RemiLehe in that same issue (even without this fix).