### PR TITLE
Remove unused functions from MultiParticleContainer

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -75,14 +75,6 @@ WarpXParticleContainer::WriteHeader (std::ostream& os) const
 }
 
 void
-MultiParticleContainer::Checkpoint (const std::string& dir) const
-{
-    for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-        allcontainers[i]->Checkpoint(dir, species_names[i]);
-    }
-}
-
-void
 MultiParticleContainer::Restart (const std::string& dir)
 {
     for (unsigned i = 0, n = species_names.size(); i < n; ++i) {

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -142,10 +142,6 @@ public:
     void doQEDSchwinger ();
 #endif
 
-    void Checkpoint (const std::string& dir) const;
-
-    void WritePlotFile (const std::string& dir) const;
-
     void Restart (const std::string& dir);
 
     void PostRestart ();


### PR DESCRIPTION
These are not needed after the diagnostics refactor.