### PR TITLE
Add option to only resample cells with high enough number of macroparticles

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -607,9 +607,15 @@ Particle initialization
     default:
 
     * ``leveling_thinning`` This algorithm is defined in `Muraviev et al., arXiv:2006.08593 (2020) <https://arxiv.org/abs/2006.08593>`_.
-      The main parameter for this algorithm can be set with ``<species>.resampling_algorithm_target_ratio``.
-      It **roughly** corresponds to the ratio between the number of particles before and after
-      resampling. The default value for this parameter is 1.5.
+      It has two parameters:
+
+        * ``<species>.resampling_algorithm_target_ratio`` (`float`) optional (default `1.5`)
+            This **roughly** corresponds to the ratio between the number of particles before and
+            after resampling.
+
+        * ``<species>.resampling_algorithm_min_ppc`` (`int`) optional (default `1`)
+            Resampling is not performed in cells with a number of macroparticles strictly smaller
+            than this parameter.
 
 * ``<species>.resampling_trigger_intervals`` (`string`) optional (default `0`)
     Using the `Intervals parser`_ syntax, this string defines timesteps at which resampling is

--- a/Examples/Modules/resampling/inputs_leveling_thinning
+++ b/Examples/Modules/resampling/inputs_leveling_thinning
@@ -53,9 +53,11 @@ resampled_part2.do_not_push = 1
 resampled_part2.do_resampling = 1
 resampled_part2.resampling_algorithm = leveling_thinning
 resampled_part2.resampling_algorithm_target_ratio = 1.3
-# This should trigger resampling at timestep 7 only in this case. The rest is here to test the
+# This should prevent actual resampling at timestep 7
+resampled_part2.resampling_algorithm_min_ppc = 80000
+# This should trigger resampling at timestep 6 and 7 in this case. The rest is here to test the
 # intervals parser syntax.
-resampled_part2.resampling_trigger_intervals = 100 :120:3, 7:7:7
+resampled_part2.resampling_trigger_intervals = 100 :120:3, 6:6:6 , 7
 # This should not trigger resampling: this species only has ~391 ppc on average.
 resampled_part2.resampling_trigger_max_avg_ppc = 395
 

--- a/Source/Particles/Resampling/LevelingThinning.H
+++ b/Source/Particles/Resampling/LevelingThinning.H
@@ -43,6 +43,7 @@ public:
 
 private:
     amrex::Real m_target_ratio = amrex::Real(1.5);
+    int m_min_ppc = 1;
 };
 
 

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -22,6 +22,10 @@ LevelingThinning::LevelingThinning (const std::string species_name)
         amrex::Warning("WARNING: target ratio for leveling thinning is smaller or equal to one."
                        " It is possible that no particle will be removed during resampling");
     }
+
+    pp.query("resampling_algorithm_min_ppc", m_min_ppc);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_min_ppc >= 1,
+                                    "Resampling min_ppc should be greater than or equal to 1");
 }
 
 void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
@@ -47,6 +51,7 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
     const auto cell_offsets = bins.offsetsPtr();
 
     const amrex::Real target_ratio = m_target_ratio;
+    const int min_ppc = m_min_ppc;
 
     // Loop over cells
     amrex::ParallelFor( n_cells,
@@ -58,8 +63,8 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
             const auto cell_stop  = static_cast<int>(cell_offsets[i_cell+1]);
             const int cell_numparts = cell_stop - cell_start;
 
-            // do nothing for cells without particles
-            if (cell_numparts == 0)
+            // do nothing for cells with less particles than min_ppc
+            if (cell_numparts < min_ppc)
                 return;
             amrex::Real average_weight = 0._rt;
 

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -24,8 +24,8 @@ LevelingThinning::LevelingThinning (const std::string species_name)
     }
 
     pp.query("resampling_algorithm_min_ppc", m_min_ppc);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_min_ppc >= 1,
-                                    "Resampling min_ppc should be greater than or equal to 1");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_min_ppc >= 1,
+                                     "Resampling min_ppc should be greater than or equal to 1");
 }
 
 void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
@@ -64,6 +64,7 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
             const int cell_numparts = cell_stop - cell_start;
 
             // do nothing for cells with less particles than min_ppc
+            // (this intentionally includes skipping empty cells, too)
             if (cell_numparts < min_ppc)
                 return;
             amrex::Real average_weight = 0._rt;


### PR DESCRIPTION
This adds a parameter `<species>.resampling_algorithm_min_ppc` in the input file. If the number of macroparticles of a given species in a cell is strictly smaller than this parameter, resampling is not performed in that cell. This is useful to avoid downsampling in spatial regions which already do not have a lot a particles.