### PR TITLE
Enable laser polarizations other than linear

### DIFF
--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -81,6 +81,7 @@ private:
     amrex::Vector<amrex::Real> m_position; //! Coordinates of one of the point of the antenna
     amrex::Vector<amrex::Real> m_nvec; //! Normal of the plane of the antenna
     amrex::Vector<amrex::Real> m_p_X;// ! Polarization
+    amrex::Real m_ellipticity = 0.0; // ! Ellipticity
 
     long                      m_pusher_algo = -1;
     amrex::Real               m_e_max       = std::numeric_limits<amrex::Real>::quiet_NaN();

--- a/Source/Laser/LaserParticleContainer.H
+++ b/Source/Laser/LaserParticleContainer.H
@@ -68,7 +68,8 @@ public:
                                 amrex::ParticleReal * AMREX_RESTRICT const puyp,
                                 amrex::ParticleReal * AMREX_RESTRICT const puzp,
                                 amrex::ParticleReal const * AMREX_RESTRICT const pwp,
-                                amrex::Real const * AMREX_RESTRICT const amplitude,
+                                amrex::Real const * AMREX_RESTRICT const amplitude_X,
+                                amrex::Real const * AMREX_RESTRICT const amplitude_Y,
                                 const amrex::Real dt);
 
 protected:

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -50,6 +50,8 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     pp.query("do_continuous_injection", do_continuous_injection);
     pp.query("min_particles_per_mode", m_min_particles_per_mode);
 
+    pp.query("ellipticity", m_ellipticity);
+
     if (m_e_max == amrex::Real(0.)){
         amrex::Print() << m_laser_name << " with zero amplitude disabled.\n";
         return; // Disable laser if amplitude is 0
@@ -156,6 +158,7 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     common_params.p_X = m_p_X;
     common_params.p_Y = m_p_Y;
     common_params.nvec = m_nvec;
+    common_params.ellipticity = m_ellipticity;
     m_up_laser_profile->init(pp, ParmParse{"my_constants"}, common_params);
 }
 

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -8,6 +8,7 @@
  */
 #include "WarpX.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
 #include "Utils/WarpX_Complex.H"
 #include "Utils/WarpXMathUtils.H"
 #include "Particles/MultiParticleContainer.H"
@@ -52,10 +53,14 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 
     pp.query("ellipticity", m_ellipticity);
 
-    if (m_e_max == amrex::Real(0.)){
+    if (m_e_max == 0.0_rt){
         amrex::Print() << m_laser_name << " with zero amplitude disabled.\n";
         return; // Disable laser if amplitude is 0
     }
+
+    WarpXUtilMsg::AlwaysAssert(
+        m_ellipticity >= -1.0_rt && m_ellipticity <= 1.0_rt,
+        "ellipticity must be in the range [-1,1]");
 
     //Select laser profile
     if(laser_profiles_dictionary.count(laser_type_s) == 0){

--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -33,6 +33,7 @@ struct CommonLaserParameters
     amrex::Real wavelength; //! central wavelength
     amrex::Real e_max;  //! maximum electric field at peak
     amrex::Vector<amrex::Real> p_X;// ! Polarization
+    amrex::Vector<amrex::Real> p_Y;// ! Second polarization axis
     amrex::Vector<amrex::Real> nvec; //! Normal of the plane of the antenna
 };
 
@@ -87,7 +88,8 @@ public:
      * @param[in] Xp X coordinate of the particles of the antenna
      * @param[in] Yp Y coordinate of the particles of the antenna
      * @param[in] t time (seconds)
-     * @param[out] amplitude of the electric field (V/m)
+     * @param[out] amplitude_X of the electric field (V/m) (X component)
+     * @param[out] amplitude_X of the electric field (V/m) (Y component)
      */
     virtual void
     fill_amplitude (
@@ -95,7 +97,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const = 0;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const = 0;
 
     virtual ~ILaserProfile(){}
 };
@@ -123,7 +126,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const override final;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const override final;
 
 private:
     struct {
@@ -165,7 +169,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const override final;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const override final;
 
 private:
     struct {
@@ -200,7 +205,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const override final;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const override final;
 
 private:
     struct{
@@ -245,7 +251,8 @@ public:
     * \param Xp: pointer to first component of positions of laser particles
     * \param Yp: pointer to second component of positions of laser particles
     * \param t: Current physical time
-    * \param amplitude: pointer to array of field amplitude.
+    * \param amplitude_X: pointer to array of field amplitude (X component)
+    * \param amplitude_Y: pointer to array of field amplitude (Y component)
     */
     void
     fill_amplitude (
@@ -253,7 +260,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const override final;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const override final;
 
     /** \brief Function to fill the amplitude in case of a uniform grid.
     * This function cannot be private due to restrictions related to
@@ -264,7 +272,8 @@ public:
     * \param Xp: pointer to first component of positions of laser particles
     * \param Yp: pointer to second component of positions of laser particles
     * \param t: Current physical time
-    * \param amplitude: pointer to array of field amplitude.
+    * \param amplitude_X: pointer to array of field amplitude (X component)
+    * \param amplitude_Y: pointer to array of field amplitude (Y component)
     */
     void internal_fill_amplitude_uniform(
         const int idx_t_left,
@@ -272,7 +281,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const;
 
     /** \brief Function to fill the amplitude in case of a non-uniform grid.
     * This function cannot be private due to restrictions related to
@@ -283,7 +293,8 @@ public:
     * \param Xp: pointer to first component of positions of laser particles
     * \param Yp: pointer to second component of positions of laser particles
     * \param t: Current physical time
-    * \param amplitude: pointer to array of field amplitude.
+    * \param amplitude_X: pointer to array of field amplitude (X component)
+    * \param amplitude_Y: pointer to array of field amplitude (Y component)
     */
     void internal_fill_amplitude_nonuniform(
         const int idx_t_left,
@@ -291,7 +302,8 @@ public:
         amrex::Real const * AMREX_RESTRICT const Xp,
         amrex::Real const * AMREX_RESTRICT const Yp,
         amrex::Real t,
-        amrex::Real * AMREX_RESTRICT const amplitude) const;
+        amrex::Real * AMREX_RESTRICT const amplitude_X,
+        amrex::Real * AMREX_RESTRICT const amplitude_Y) const;
 
 private:
     /** \brief parse a field file in the binary 'txye' format (whose details are given below).

--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -35,6 +35,7 @@ struct CommonLaserParameters
     amrex::Vector<amrex::Real> p_X;// ! Polarization
     amrex::Vector<amrex::Real> p_Y;// ! Second polarization axis
     amrex::Vector<amrex::Real> nvec; //! Normal of the plane of the antenna
+    amrex::Real ellipticity; //! Ellipticity of the beam (-1,+1: circular polarization, 0: linear polarization)
 };
 
 
@@ -141,6 +142,10 @@ private:
 
         amrex::Vector<amrex::Real> stc_direction; //! Direction of the spatio-temporal couplings
         amrex::Real theta_stc; //! Angle between polarization (p_X) and direction of spatiotemporal coupling (stc_direction)
+
+        amrex::Real dephasing = 0.0;
+        amrex::Real pol_amp_x_coeff = 0.0;
+        amrex::Real pol_amp_y_coeff = 0.0;
     } m_params;
 
     CommonLaserParameters m_common_params;

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -43,12 +43,15 @@ WarpXLaserProfiles::FieldFunctionLaserProfile::init (
 
 void
 WarpXLaserProfiles::FieldFunctionLaserProfile::fill_amplitude (
-    const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
-    Real t, Real * AMREX_RESTRICT const amplitude) const
+    const int np,
+    Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
+    Real t,
+    Real * AMREX_RESTRICT const amplitude_X, Real * AMREX_RESTRICT const amplitude_Y) const
 {
     auto parser = getParser(m_gpu_parser);
     amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
     {
-        amplitude[i] = parser(Xp[i], Yp[i], t);
+        amplitude_X[i] = parser(Xp[i], Yp[i], t);
+        amplitude_Y[i] = 0.0_rt;
     });
 }

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -73,12 +73,15 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
  * \param Xp: pointer to first component of positions of laser particles
  * \param Yp: pointer to second component of positions of laser particles
  * \param t: Current physical time
- * \param amplitude: pointer to array of field amplitude.
+ * \param amplitude: pointer to array of field amplitude (x component)
+ * \param amplitude: pointer to array of field amplitude (y component)
  */
 void
 WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
-    const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
-    Real t, Real * AMREX_RESTRICT const amplitude) const
+    const int np,
+    Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
+    Real t,
+    Real * AMREX_RESTRICT const amplitude_X, Real * AMREX_RESTRICT const amplitude_Y) const
 {
     Complex I(0,1);
     // Calculate a few factors which are independent of the macroparticle
@@ -134,7 +137,8 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
             // Exp argument for transverse envelope
             const Complex exp_argument = - ( Xp[i]*Xp[i] + Yp[i]*Yp[i] ) * inv_complex_waist_2;
             // stcfactor + transverse envelope
-            amplitude[i] = ( stcfactor * amrex::exp( exp_argument ) ).real();
+            amplitude_X[i] = ( stcfactor * amrex::exp( exp_argument ) ).real();
+            amplitude_Y[i] = 0.0_rt;
         }
         );
 }

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -35,12 +35,16 @@ WarpXLaserProfiles::HarrisLaserProfile::init (
  * \param Xp: pointer to first component of positions of laser particles
  * \param Yp: pointer to second component of positions of laser particles
  * \param t: Current physical time
- * \param amplitude: pointer to array of field amplitude.
+ * \param amplitude: pointer to array of field amplitude (x component)
+ * \param amplitude: pointer to array of field amplitude (y component)
  */
 void
 WarpXLaserProfiles::HarrisLaserProfile::fill_amplitude (
-    const int np, Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
-    Real t, Real * AMREX_RESTRICT const amplitude) const
+    const int np,
+    Real const * AMREX_RESTRICT const Xp, Real const * AMREX_RESTRICT const Yp,
+    Real t,
+    Real * AMREX_RESTRICT const amplitude_X,
+    Real * AMREX_RESTRICT const amplitude_Y) const
 {
     // This function uses the Harris function as the temporal profile of the pulse
     const Real omega0 =
@@ -77,8 +81,9 @@ WarpXLaserProfiles::HarrisLaserProfile::fill_amplitude (
             const Real arg_osc = omega0*t - omega0/PhysConst::c*
                 (Xp[i]*Xp[i] + Yp[i]*Yp[i]) * inv_Rz / 2._rt;
             const Real oscillations = std::cos(arg_osc);
-            amplitude[i] = tmp_e_max * time_envelope *
+            amplitude_X[i] = tmp_e_max * time_envelope *
                 space_envelope * oscillations;
+            amplitude_Y[i] = 0.0_rt;
         }
         );
 }

--- a/Source/Utils/WarpXMathUtils.H
+++ b/Source/Utils/WarpXMathUtils.H
@@ -1,0 +1,35 @@
+/* Copyright 2020 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_MATH_UTILS_
+#define WARPX_MATH_UTILS_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_Extension.H>
+
+namespace utils{
+
+    /* \brief calculates the cross product between two vectors (must have size >=3)
+    *
+    * \tparam VectorType: the vector type
+    * \param va: the first vector
+    * \param vb: the second vector
+    * \return a VectorType v1 x v2
+    */
+    template<typename VectorType>
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    VectorType CrossProduct (const VectorType& va, const VectorType& vb)
+    {
+        return {
+            va[1]*vb[2]-va[2]*vb[1],
+            va[2]*vb[0]-va[0]*vb[2],
+            va[0]*vb[1]-va[1]*vb[0] };
+    }
+
+}
+
+#endif //WARPX_MATH_UTILS_


### PR DESCRIPTION
This PR will enable circularly polarized laser beams (and more in general beams having a polarization other than linear).
More specifically it will be possible to

- Inject a Gaussian/Harris/TXYE/field_function beam with a real `ellipticity` parameter (`ellipticity = 0` means linear polarization,  `ellipticity = ± 1` means circular polarization)

In a future PR we could add the support for TXYE  and field function beams having arbitrary polarizations (i.e. two filed components for each spatio-temporal point).



