### PR TITLE
Split resampling TinyProfiler entry into 2

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -715,8 +715,6 @@ MultiParticleContainer::doCoulombCollisions ()
 
 void MultiParticleContainer::doResampling (const int timestep)
 {
-    WARPX_PROFILE("MultiParticleContainer::doResampling()");
-
     for (auto& pc : allcontainers)
     {
         // do_resampling can only be true for PhysicalParticleContainers


### PR DESCRIPTION
To decide if resampling should be done we compute the total number of particles of a given species in the entire simulation domain. This requires an MPI_Allreduce and thus an MPI synchronization. Since resampling is done immediatly after the particle routines, processes with few particles in heavily load imbalanced simulations spend a lot of time at this synchronization point waiting for other processes. Currently, this shows up as `MultiParticleContainer::doResampling()` in the TinyProfiler. For example this is the start of the TinyProfiler output of my last run on Summit:

```
----------------------------------------------------------------------------------------------------------
Name                                                       NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
----------------------------------------------------------------------------------------------------------
MultiParticleContainer::doResampling()                      14000        659       2483       3180  81.31%
WarpXParticleContainer::DepositCurrent::CurrentDeposition   28575          0      247.9      843.2  21.56%
MultiParticleContainer::doQedQuantumSync()                  14000      1.357      197.8      746.3  19.08%
WarpXParticleContainer::DepositCharge::ChargeDeposition     61278          0      163.9      601.7  15.38%
ParticleCopyPlan::doHandShake                              112009      31.21        214      312.9   8.00%
PhysicalParticleContainer::Evolve::GatherAndPush            29764          0      71.94      259.6   6.64%
FabArray::ParallelCopy()                                   448108      27.36      130.2      255.4   6.53%
FillBoundary_finish()                                      336108      10.53      81.62      239.8   6.13%
Redistribute_partition                                     112009     0.2684       61.8      221.8   5.67%
MultiParticleContainer::doQedBreitWheeler()                 14000      0.705      6.769      91.43   2.34%
ParticleCopyPlan::buildMPIFinish                           112009    0.05142      9.062      87.69   2.24%
amrex::communicateParticlesFinish                          112009     0.0498      5.731       70.9   1.81%
SpectralSolver::ForwardTransform                           322000      27.24      35.01      43.78   1.12%
amrex::computeNeighborProcs                                112000      1.257      11.48         43   1.10%
ParticleContainer::SortParticlesByBin()                     28000     0.8791      9.126      35.38   0.90%
```

This is a bit misleading because a user might think that it is actual resampling that takes a lot of time. Therefore in this PR we split `MultiParticleContainer::doResampling()` into `MultiParticleContainer::doResampling::MPI_synchronization` and `MultiParticleContainer::doResampling::ActualResampling` (maybe we can find better names) to avoid confusion as much as possible on that point.