### PR TITLE
[mini] Fix error in FieldMaximum reduced diag in 2D

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -135,8 +135,8 @@ void FieldMaximum::ComputeDiags (int step)
 
         // General preparation of interpolation and reduction to compute the maximum value of
         // |E| and |B|
-        const GpuArray<int,3> cellCenteredtype{AMREX_D_DECL(0,0,0)};
-        const GpuArray<int,3> reduction_coarsening_ratio{AMREX_D_DECL(1,1,1)};
+        const GpuArray<int,3> cellCenteredtype{0,0,0};
+        const GpuArray<int,3> reduction_coarsening_ratio{1,1,1};
         constexpr int reduction_comp = 0;
 
         // Prepare reduction for maximum value of |E|


### PR DESCRIPTION
I've found a bug in the very recently merged reduced diag that computes the maximum value of the fields (#988). Using `AMREX_D_DECL` here is incorrect because in 2D the third component of the arrays is undefined, which results in undefined behaviour during the interpolation to cell centers. I'm sorry about that.

Another thing we might consider changing for this diagnostic is the fact that the maximum value for Ex, Ey, Ez, Bx, By and Bz is computed at their position in the grid but the maximum value for |E| and |B| is computed after interpolation to cell centers. In some cases if the field is very peaked, we can have a situation where the maximum value for Ex is greater than the maximum value for |E|, which is a bit weird. Maybe we want to interpolate all field components to cell centers before doing the reduction? (or simply add a warning for this in the doc?)