### PR TITLE
Plot raw fields: fix bugs for rho and F data

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -478,7 +478,13 @@ FlushFormatPlotfile::WriteAllRawFields(
         WriteRawMF( warpx.getBfield_fp(lev, 0), dm, raw_pltname, default_level_prefix, "Bx_fp", lev, plot_raw_fields_guards);
         WriteRawMF( warpx.getBfield_fp(lev, 1), dm, raw_pltname, default_level_prefix, "By_fp", lev, plot_raw_fields_guards);
         WriteRawMF( warpx.getBfield_fp(lev, 2), dm, raw_pltname, default_level_prefix, "Bz_fp", lev, plot_raw_fields_guards);
-        if (plot_raw_F) WriteRawMF( warpx.getF_fp(lev), dm, raw_pltname, default_level_prefix, "F_fp", lev, plot_raw_fields_guards);
+        if (plot_raw_F) {
+            if (warpx.get_pointer_F_fp(lev) == nullptr) {
+                amrex::Warning("The user requested to write raw F data, but F_fp was not allocated");
+            } else {
+                WriteRawMF(warpx.getF_fp(lev), dm, raw_pltname, default_level_prefix, "F_fp", lev, plot_raw_fields_guards);
+            }
+        }
         if (plot_raw_rho) {
             if (warpx.get_pointer_rho_fp(lev) == nullptr) {
                 amrex::Warning("The user requested to write raw rho data, but rho_fp was not allocated");
@@ -486,7 +492,7 @@ FlushFormatPlotfile::WriteAllRawFields(
                 // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
                 // If nComp > 1, this is the upper half of the list of components.
                 MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
-                WriteRawMF( rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
+                WriteRawMF(rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
             }
         }
 
@@ -504,9 +510,16 @@ FlushFormatPlotfile::WriteAllRawFields(
                                warpx.get_pointer_current_cp(lev, 0), warpx.get_pointer_current_cp(lev, 1), warpx.get_pointer_current_cp(lev, 2),
                                warpx.get_pointer_current_fp(lev, 0), warpx.get_pointer_current_fp(lev, 1), warpx.get_pointer_current_fp(lev, 2),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
-            if (plot_raw_F)
-                WriteCoarseScalar("F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
-                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 0);
+            if (plot_raw_F) {
+                if (warpx.get_pointer_F_fp(lev) == nullptr) {
+                    amrex::Warning("The user requested to write raw F data, but F_fp was not allocated");
+                } else if (warpx.get_pointer_F_cp(lev) == nullptr) {
+                    amrex::Warning("The user requested to write raw F data, but F_cp was not allocated");
+                } else {
+                    WriteCoarseScalar("F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
+                        dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 0);
+                }
+            }
             if (plot_raw_rho) {
                 if (warpx.get_pointer_rho_fp(lev) == nullptr) {
                     amrex::Warning("The user requested to write raw rho data, but rho_fp was not allocated");
@@ -515,7 +528,7 @@ FlushFormatPlotfile::WriteAllRawFields(
                 } else {
                     // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
                     WriteCoarseScalar("rho", warpx.get_pointer_rho_cp(lev), warpx.get_pointer_rho_fp(lev),
-                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
+                        dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
                 }
             }
         }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -482,7 +482,7 @@ FlushFormatPlotfile::WriteAllRawFields(
         if (plot_raw_rho) {
             // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
             // If nComp > 1, this is the upper half of the list of components.
-            MultiFab rho_new(warpx.getF_fp(lev), amrex::make_alias, warpx.getF_fp(lev).nComp()/2, warpx.getF_fp(lev).nComp()/2);
+            MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
             WriteRawMF( rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
         }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -480,14 +480,18 @@ FlushFormatPlotfile::WriteAllRawFields(
         WriteRawMF( warpx.getBfield_fp(lev, 2), dm, raw_pltname, default_level_prefix, "Bz_fp", lev, plot_raw_fields_guards);
         if (plot_raw_F) WriteRawMF( warpx.getF_fp(lev), dm, raw_pltname, default_level_prefix, "F_fp", lev, plot_raw_fields_guards);
         if (plot_raw_rho) {
-            // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
-            // If nComp > 1, this is the upper half of the list of components.
-            MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
-            WriteRawMF( rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
+            if (warpx.get_pointer_rho_fp(lev) == nullptr) {
+                amrex::Warning("The user requested to write raw rho data, but rho_fp was not allocated");
+            } else {
+                // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
+                // If nComp > 1, this is the upper half of the list of components.
+                MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
+                WriteRawMF( rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
+            }
         }
 
         // Coarse path
-        if (lev > 0){
+        if (lev > 0) {
             WriteCoarseVector( "E",
                                warpx.get_pointer_Efield_cp(lev, 0), warpx.get_pointer_Efield_cp(lev, 1), warpx.get_pointer_Efield_cp(lev, 2),
                                warpx.get_pointer_Efield_fp(lev, 0), warpx.get_pointer_Efield_fp(lev, 1), warpx.get_pointer_Efield_fp(lev, 2),
@@ -500,15 +504,20 @@ FlushFormatPlotfile::WriteAllRawFields(
                                warpx.get_pointer_current_cp(lev, 0), warpx.get_pointer_current_cp(lev, 1), warpx.get_pointer_current_cp(lev, 2),
                                warpx.get_pointer_current_fp(lev, 0), warpx.get_pointer_current_fp(lev, 1), warpx.get_pointer_current_fp(lev, 2),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
+            if (plot_raw_F)
+                WriteCoarseScalar("F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
+                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 0);
+            if (plot_raw_rho) {
+                if (warpx.get_pointer_rho_fp(lev) == nullptr) {
+                    amrex::Warning("The user requested to write raw rho data, but rho_fp was not allocated");
+                } else if (warpx.get_pointer_rho_cp(lev) == nullptr) {
+                    amrex::Warning("The user requested to write raw rho data, but rho_cp was not allocated");
+                } else {
+                    // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
+                    WriteCoarseScalar("rho", warpx.get_pointer_rho_cp(lev), warpx.get_pointer_rho_fp(lev),
+                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
+                }
+            }
         }
-        if (plot_raw_F) WriteCoarseScalar(
-            "F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
-            dm, raw_pltname, default_level_prefix, lev,
-            plot_raw_fields_guards, 0);
-        if (plot_raw_rho) WriteCoarseScalar(
-            "rho", warpx.get_pointer_rho_cp(lev), warpx.get_pointer_rho_fp(lev),
-            dm, raw_pltname, default_level_prefix, lev,
-            plot_raw_fields_guards, 1);
-        // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
     }
 }

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -60,6 +60,7 @@ FullDiagnostics::ReadParameters ()
     m_intervals = IntervalsParser(period_string_vec);
     bool raw_specified = pp.query("plot_raw_fields", m_plot_raw_fields);
     raw_specified += pp.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
+    raw_specified += pp.query("plot_raw_rho", m_plot_raw_rho);
 
 #ifdef WARPX_DIM_RZ
     pp.query("dump_rz_modes", m_dump_rz_modes);


### PR DESCRIPTION
I believe this fixes a bug for the raw rho data, when `<diag_name>.plot_raw_fields = 1`. The function `getF_fp` was used instead of `getrho_fp`.