### PR TITLE
CI: Output CPU Type

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -28,6 +28,7 @@ strategy:
 
 steps:
 - script: |
+    cat /proc/cpuinfo | grep "model name" | sort -u
     sudo apt-get update
     sudo apt-get install -y ccache gcc gfortran g++ openmpi-bin libopenmpi-dev \
       libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \


### PR DESCRIPTION
Since our CI is cloud-based, we can get various kinds of CPUs in different runs. For machine-precision tests, I got the feeling that some tests that rely heavily on exact numbers are overly strict with respect to guarantees between various CPU generations, esp. since we rely on fastmath.

This will output the CPU type at the beginning of runs, so we can find out more when tests fail with "checksum" (output data fingerprint) errors.