### PR TITLE
[WIP] PlasmaInjector: Old libstdc++

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 
 using namespace amrex;
@@ -76,12 +77,17 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 {
     ParmParse pp(species_name);
 
+// work-around for Quartz (LLNL), which builds against an ancient libstdc++ (GCC 4.8) on RHEL 7.8
+//   https://stackoverflow.com/questions/25123458/is-trivially-copyable-is-not-a-member-of-std
+#if __GNUG__ && __GNUC__ < 5
+#else
     static_assert(std::is_trivially_copyable<InjectorPosition>::value,
                   "InjectorPosition must be trivially copyable");
     static_assert(std::is_trivially_copyable<InjectorDensity>::value,
                   "InjectorDensity must be trivially copyable");
     static_assert(std::is_trivially_copyable<InjectorMomentum>::value,
                   "InjectorMomentum must be trivially copyable");
+#endif
 
     pp.query("radially_weighted", radially_weighted);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(radially_weighted, "ERROR: Only radially_weighted=true is supported");


### PR DESCRIPTION
Apply a fix for Intel 19.1.2 when build against an ancient libstdc++ (from GCC 4.8 or 4.9? on RHEL 7.8), as present on LLNL's Quartz CPU cluster.

https://stackoverflow.com/questions/25123458/is-trivially-copyable-is-not-a-member-of-std