### PR TITLE
RZ spectral - add default value of i_comp in scalar transforms

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -45,11 +45,11 @@ class SpectralFieldDataRZ
         ~SpectralFieldDataRZ ();
 
         void ForwardTransform (const amrex::MultiFab& mf, const int field_index,
-                               const int i_comp);
+                               const int i_comp=0);
         void ForwardTransform (const amrex::MultiFab& mf_r, const int field_index_r,
                                const amrex::MultiFab& mf_t, const int field_index_t);
         void BackwardTransform (amrex::MultiFab& mf, const int field_index,
-                                const int i_comp);
+                                const int i_comp=0);
         void BackwardTransform (amrex::MultiFab& mf_r, const int field_index_r,
                                 amrex::MultiFab& mf_t, const int field_index_t);
 


### PR DESCRIPTION
This fixes an oversight. The default value of i_comp in the scalar Forward and BackwardTransform had been left out. Though somehow the code was working fine without it (mostly).