### PR TITLE
[Tiny] use_fdtd_nci_corr set to false for RZ

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -276,6 +276,7 @@ Particle initialization
 
 * ``particles.use_fdtd_nci_corr`` (`0` or `1`) optional (default `0`)
     Whether to activate the FDTD Numerical Cherenkov Instability corrector.
+    Not currently available in the RZ configuration.
 
 * ``particles.boundary_conditions`` (`string`) optional (default `none`)
     Boundary conditions applied to particles. Options are:

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -246,8 +246,9 @@ MultiParticleContainer::ReadParameters ()
             pc.queryarr("collision_names", collision_names);
 
         }
-
+#ifndef WARPX_DIM_RZ
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
+#endif
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 
         std::string boundary_conditions = "none";

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -248,7 +248,7 @@ MultiParticleContainer::ReadParameters ()
         }
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
 #ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==1,
                             "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -246,10 +246,8 @@ MultiParticleContainer::ReadParameters ()
             pc.queryarr("collision_names", collision_names);
 
         }
+#ifndef WARPX_DIM_RZ
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
-#ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
-                            "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -248,7 +248,7 @@ MultiParticleContainer::ReadParameters ()
         }
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
 #ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==1,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
                             "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -246,8 +246,10 @@ MultiParticleContainer::ReadParameters ()
             pc.queryarr("collision_names", collision_names);
 
         }
-#ifndef WARPX_DIM_RZ
         pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
+#ifdef WARPX_DIM_RZ
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
+                            "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
         pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 


### PR DESCRIPTION
Hi all,
It seems that the current version of our NCI FDTD filter does not work with RZ.

This PR introduces an AMREX ALWAYS ASSERT (abort with message) when `use_fdtd_nci_corr` is not its default (`false`) for RZ.

Without this PR, running with that parameter set to `true` led to SIGBRT error messages.
I tested this using:
[inputs_2d_rz.txt](https://github.com/ECP-WarpX/WarpX/files/5313879/inputs_2d_rz.txt)

Not sure if it is relevant, but I also verified that this was the case when using our code versions of Jun 25.
```
    cd ~/amrex
    git checkout development
    git reset --hard 87c998a
    cd ../picsar
    git checkout development
    git reset --hard a86859d
    cd ../WarpX
    git checkout development
    git reset --hard f44fde7
```

Sorry if anyone is already working on this, but I didn't find it in any open PR / issue.

Closes #1399

Cheers,
Diana 