### PR TITLE
Separate rho per species diagnostics from particle output

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1425,9 +1425,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Whether to write one file per timestep.
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
-    Fields written to plotfiles. Possible values: ``Ex`` ``Ey`` ``Ez``
-    ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho``
-    ``F`` ``part_per_grid`` ``part_per_proc`` ``divE`` ``divB``.
+    Fields written to output.
+    Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``F`` ``part_per_grid`` ``part_per_proc`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``.
 
 * ``<diag_name>.plot_raw_fields`` (`0` or `1`) optional (default `0`)
@@ -1473,18 +1472,10 @@ s disabled.
     Which species dumped in this diagnostics.
 
 * ``<diag_name>.<species_name>.variables`` (list of `strings` separated by spaces, optional)
-    List of particle quantities or species-specific field quantities to write to output file.
-    Choices are
-
-    * ``w`` for the particle weight,
-
-    * ``ux`` ``uy`` ``uz`` for the particle momentum,
-
-    * ``rho`` to dump the charge density of the particles belonging to species ``<species_name>``.
-
-    By defaults, all quantities are written to output file, except the charge density.
-    The particle positions are always included.
-    Use ``<species>.variables = none`` to plot no particle data, except particle position.
+    List of particle quantities to write to output.
+    Choices are ``w`` for the particle weight and ``ux`` ``uy`` ``uz`` for the particle momenta.
+    By default, all particle quantities are written.
+    If ``<diag_name>.<species_name>.variables = none``, no particle data are written, except for particle positions, which are always included.
 
 * ``<diag_name>.<species_name>.random_fraction`` (`float`) optional
     If provided ``<diag_name>.<species_name>.random_fraction = a``, only `a` fraction of the particle data of this species will be dumped randomly in diag ``<diag_name>``, i.e. if `rand() < a`, this particle will be dumped, where `rand()` denotes a random number generator.

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -172,15 +172,15 @@ diagnostics.diags_names = diag1 openPMDh5
 
 diag1.period = 100
 diag1.diag_type = Full
-diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
-diag1.electrons.variables = w ux uy uz rho
-diag1.hydrogen.variables = w ux uy uz rho
+diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
+diag1.electrons.variables = w ux uy uz
+diag1.hydrogen.variables = w ux uy uz
 
 openPMDh5.period = 100
 openPMDh5.diag_type = Full
-openPMDh5.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
-openPMDh5.electrons.variables = w ux uy uz rho
-openPMDh5.hydrogen.variables = w ux uy uz rho
+openPMDh5.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
+openPMDh5.electrons.variables = w ux uy uz
+openPMDh5.hydrogen.variables = w ux uy uz
 openPMDh5.format = openpmd
 openPMDh5.openpmd_backend = h5
 

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -131,8 +131,10 @@ protected:
     int nmax_lev; /**< max_level to allocate output multifab and vector of field functors. */
     /** Number of levels to be output*/
     int nlev_output;
-    /** Name of species to write to file */
-    std::vector< std::string > m_species_names;
+    /** Names of species to write to output */
+    std::vector< std::string > m_output_species_names;
+    /** Names of all species in the simulation */
+    std::vector< std::string > m_all_species_names;
     /** Each element of this vector handles output for 1 species */
     amrex::Vector< ParticleDiag > m_all_species;
     /** Vector of (pointers to) functors to compute output fields, per level,

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -136,7 +136,7 @@ protected:
     /** Names of all species in the simulation */
     std::vector< std::string > m_all_species_names;
     /** Each element of this vector handles output for 1 species */
-    amrex::Vector< ParticleDiag > m_all_species;
+    amrex::Vector< ParticleDiag > m_output_species;
     /** Vector of (pointers to) functors to compute output fields, per level,
      * per component. This allows for simple operations (averaging to
      * cell-center for standard EB fields) as well as more involved operations

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -120,7 +120,7 @@ Diagnostics::BaseReadParameters ()
     // Loop over all fields stored in m_varnames
     for (const auto& var : m_varnames) {
         // Check if m_varnames contains a string of the form rho_<species_name>
-        if (var.find("rho_") != std::string::npos) {
+        if (var.rfind("rho_", 0) == 0) {
             // Extract species name from the string rho_<species_name>
             species = var.substr(var.find("rho_") + 4);
             // Boolean used to check if species name was misspelled
@@ -137,9 +137,10 @@ Diagnostics::BaseReadParameters ()
                 }
             }
             // If species name was misspelled, abort with error message
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ! species_name_is_wrong,
-                "Input error: string rho_<species_name> provided by the user does not match any species");
+            if (species_name_is_wrong) {
+                amrex::Abort("Input error: string " + var + " in " + m_diag_name +
+                             ".fields_to_plot does not match any species");
+            }
         }
     }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -31,26 +31,31 @@ bool
 Diagnostics::BaseReadParameters ()
 {
     auto & warpx = WarpX::GetInstance();
-    // Read list of fields requested by the user.
+
     amrex::ParmParse pp(m_diag_name);
     m_file_prefix = "diags/" + m_diag_name;
     pp.query("file_prefix", m_file_prefix);
     pp.query("format", m_format);
+
+    // Query list of grid fields to write to output
     bool varnames_specified = pp.queryarr("fields_to_plot", m_varnames);
     if (!varnames_specified){
         m_varnames = {"Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"};
     }
+
     // If user requests rho with back-transformed diagnostics, we set plot_rho=true
     // and compute rho at each iteration
     if (WarpXUtilStr::is_in(m_varnames, "rho") && WarpX::do_back_transformed_diagnostics) {
         warpx.setplot_rho(true);
     }
+
     // Sanity check if user requests to plot F
     if (WarpXUtilStr::is_in(m_varnames, "F")){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             warpx.do_dive_cleaning,
             "plot F only works if warpx.do_dive_cleaning = 1");
     }
+
     // If user requests to plot proc_number for a serial run,
     // delete proc_number from fields_to_plot
     if (amrex::ParallelDescriptor::NProcs() == 1){
@@ -105,60 +110,36 @@ Diagnostics::BaseReadParameters ()
 
     bool species_specified = pp.queryarr("species", m_species_names);
 
-    // Prepare to dump rho per species:
-    // - add the string "rho_<species_names>" to m_varnames if "rho" is listed in
-    //   <diag_name>.<species_name>.variables in the input file
-    // - while looping over all species, count the number ns_dump_rho of species
-    //   that request to dump rho per species
-    // - allocate and fill the array m_rho_per_species_index, which contains the
-    //   indices of the species that request to dump rho per species; the indices
-    //   will be then passed to the constructor of RhoFunctor and used in
-    //   RhoFunctor::operator() to get the correct particle container for the given species
-    amrex::Vector<std::string> species_variables;
-    const MultiParticleContainer& mpc = warpx.GetPartContainer();
-    // If <diag_name>.species is not provided, loop over all species to check whether
-    // rho per species is requested
-    if (m_species_names.size() == 0u) m_species_names = mpc.GetSpeciesNames();
-    // ns_dump_rho: number of species that dump rho per species
-    int ns_dump_rho = 0;
-    // Loop over all species
-    for (const auto& species_name : m_species_names) {
-        // Parse input argument <diag_name>.<species_name>.variables
-        amrex::ParmParse pp_sp(m_diag_name + "." + species_name);
-        if (pp_sp.queryarr("variables", species_variables)) {
-            for (const auto& var : species_variables) {
-                if (var == "rho") {
-                    // Add string "rho_<species_name>" to m_varnames
-                    m_varnames.push_back("rho_" + species_name);
-                    // Count number of species that dump rho per species
-                    ns_dump_rho++;
+    // Get names of all species in the simulation, independently of the subset
+    // of species requested in <diag_name>.species and stored in m_species_names
+    const std::vector<std::string> species_names = warpx.GetPartContainer().GetSpeciesNames();
+    // Auxiliary variables
+    std::string species;
+    bool species_name_is_wrong;
+    // Loop over all fields stored in m_varnames
+    for (const auto& var : m_varnames) {
+        // Check if m_varnames contains a string of the form rho_<species_name>
+        if (var.find("rho_") != std::string::npos) {
+            // Extract species name from the string rho_<species_name>
+            species = var.substr(var.find("rho_") + 4);
+            // Boolean used to check if species name was misspelled
+            species_name_is_wrong = true;
+            // Loop over all species
+            for (int i = 0, n = int(species_names.size()); i < n; i++) {
+                // Check if species name extracted from the string rho_<species_name>
+                // matches any of the species in the simulation
+                if (species == species_names[i]) {
+                    // Store species index: will be used in RhoFunctor to dump
+                    // rho for this species
+                    m_rho_per_species_index.push_back(i);
+                    species_name_is_wrong = false;
                 }
             }
+            // If species name was misspelled, abort with error message
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                ! species_name_is_wrong,
+                "Input error: string rho_<species_name> provided by the user does not match any species");
         }
-        // Clear content of species_variables before moving to the next species
-        species_variables.clear();
-    }
-    // Allocate array of species indices that dump rho per species
-    m_rho_per_species_index.resize(ns_dump_rho);
-    // ns: total number of species
-    const int ns = int(m_species_names.size());
-    // is_dump_rho: species index to loop over species that dump rho per species
-    int is_dump_rho = 0;
-    // Loop over all species
-    for (int is = 0; is < ns; is++) {
-        // Parse input argument <diag_name>.<species_name>.variables
-        amrex::ParmParse pp_sp(m_diag_name + "." + m_species_names[is]);
-        if (pp_sp.queryarr("variables", species_variables)) {
-            for (const auto& var : species_variables) {
-                if (var == "rho") {
-                    // Fill array of species indices that dump rho per species
-                    m_rho_per_species_index.at(is_dump_rho) = is;
-                    is_dump_rho++;
-                }
-            }
-        }
-        // Clear content of species_variables before moving to the next species
-        species_variables.clear();
     }
 
     bool checkpoint_compatibility = false;

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -183,13 +183,13 @@ Diagnostics::InitData ()
     if ( pp.queryarr("diag_lo", dummy_val) || pp.queryarr("diag_hi", dummy_val) ) {
         // set geometry filter for particle-diags to true when the diagnostic domain-extent
         // is specified by the user
-        for (int i = 0; i < m_all_species.size(); ++i) {
-            m_all_species[i].m_do_geom_filter = true;
+        for (int i = 0; i < m_output_species.size(); ++i) {
+            m_output_species[i].m_do_geom_filter = true;
         }
         // Disabling particle-io for reduced domain diagnostics by reducing
         // the particle-diag vector to zero.
         // This is a temporary fix until particle_buffer is supported in diagnostics.
-        m_all_species.clear();
+        m_output_species.clear();
         amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
     }
 }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -108,11 +108,12 @@ Diagnostics::BaseReadParameters ()
        }
     }
 
-    bool species_specified = pp.queryarr("species", m_species_names);
+    // Names of species to write to output
+    bool species_specified = pp.queryarr("species", m_output_species_names);
 
-    // Get names of all species in the simulation, independently of the subset
-    // of species requested in <diag_name>.species and stored in m_species_names
-    const std::vector<std::string> species_names = warpx.GetPartContainer().GetSpeciesNames();
+    // Names of all species in the simulation
+    m_all_species_names = warpx.GetPartContainer().GetSpeciesNames();
+
     // Auxiliary variables
     std::string species;
     bool species_name_is_wrong;
@@ -125,10 +126,10 @@ Diagnostics::BaseReadParameters ()
             // Boolean used to check if species name was misspelled
             species_name_is_wrong = true;
             // Loop over all species
-            for (int i = 0, n = int(species_names.size()); i < n; i++) {
+            for (int i = 0, n = int(m_all_species_names.size()); i < n; i++) {
                 // Check if species name extracted from the string rho_<species_name>
                 // matches any of the species in the simulation
-                if (species == species_names[i]) {
+                if (species == m_all_species_names[i]) {
                     // Store species index: will be used in RhoFunctor to dump
                     // rho for this species
                     m_rho_per_species_index.push_back(i);

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -35,9 +35,9 @@ FullDiagnostics::InitializeParticleBuffer ()
 
     const MultiParticleContainer& mpc = warpx.GetPartContainer();
     // If not specified, dump all species
-    if (m_species_names.size() == 0) m_species_names = mpc.GetSpeciesNames();
+    if (m_output_species_names.size() == 0) m_output_species_names = mpc.GetSpeciesNames();
     // Initialize one ParticleDiag per species requested
-    for (auto const& species : m_species_names){
+    for (auto const& species : m_output_species_names){
         const int idx = mpc.getSpeciesID(species);
         m_all_species.push_back(ParticleDiag(m_diag_name, species,
                                              mpc.GetParticleContainerPtr(idx)));

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -39,8 +39,7 @@ FullDiagnostics::InitializeParticleBuffer ()
     // Initialize one ParticleDiag per species requested
     for (auto const& species : m_output_species_names){
         const int idx = mpc.getSpeciesID(species);
-        m_all_species.push_back(ParticleDiag(m_diag_name, species,
-                                             mpc.GetParticleContainerPtr(idx)));
+        m_output_species.push_back(ParticleDiag(m_diag_name, species, mpc.GetParticleContainerPtr(idx)));
     }
 }
 
@@ -87,7 +86,7 @@ FullDiagnostics::Flush ( int i_buffer )
 
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
-        warpx.gett_new(0), m_all_species, nlev_output, m_file_prefix,
+        warpx.gett_new(0), m_output_species, nlev_output, m_file_prefix,
         m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F);
 
     FlushRaw();
@@ -428,8 +427,8 @@ FullDiagnostics::PrepareFieldDataForOutput ()
     warpx.UpdateAuxilaryData();
 
     // Update the RealBox used for the geometry filter in particle diags
-    for (int i = 0; i < m_all_species.size(); ++i) {
-        m_all_species[i].m_diag_domain = m_geom_output[0][0].ProbDomain();
+    for (int i = 0; i < m_output_species.size(); ++i) {
+        m_output_species[i].m_diag_domain = m_geom_output[0][0].ProbDomain();
     }
 }
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -349,11 +349,12 @@ void
 FullDiagnostics::InitializeFieldFunctors (int lev)
 {
     auto & warpx = WarpX::GetInstance();
+
     // Clear any pre-existing vector to release stored data.
     m_all_field_functors[lev].clear();
 
     // Species index to loop over species that dump rho per species
-    int is_dump_rho = 0;
+    int i = 0;
 
     m_all_field_functors[lev].resize( m_varnames.size() );
     // Fill vector of functors for all components except individual cylindrical modes.
@@ -392,8 +393,8 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
             }
         } else if ( m_varnames[comp].find("rho_") != std::string::npos ){
             // Initialize rho functor to dump rho per species
-            m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, m_rho_per_species_index[is_dump_rho]);
-            is_dump_rho++;
+            m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, m_rho_per_species_index[i]);
+            i++;
         } else if ( m_varnames[comp] == "F" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_F_fp(lev), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "part_per_cell" ){

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -391,7 +391,7 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
                 // Initialize rho functor to dump total rho
                 m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio);
             }
-        } else if ( m_varnames[comp].find("rho_") != std::string::npos ){
+        } else if ( m_varnames[comp].rfind("rho_", 0) == 0 ){
             // Initialize rho functor to dump rho per species
             m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, m_rho_per_species_index[i]);
             i++;


### PR DESCRIPTION
**Goal**
Separate rho per species diagnostics from particle output and close #1400.

**Description**
Following the suggestions in #1400, in order to dump rho for given species, the user must now add the string `rho_<species_name>` in the list `<diag_name>.fields_to_plot`. For example,
```
particles.species_names = electrons positrons
diagnostics.diags_names = diag
...
...
diag.fields_to_plot = Ez jz rho_electrons rho_positrons
```
A few more comments:
- If the species name specified in the string `rho_<species_name>` does not match any of the species in the simulation, the code aborts with an error message. The check is done against all species in the simulation, not just the ones requested by the user by setting `<diag_name>.species`, which are related to the particle output.
- The order of the fields requested in `diag.fields_to_plot` does not matter.
- The documentation was also updated.
- I tested various input configurations (including some that would cause a runtime crash) and the implementation seems robust.

**Warning**
With the current default behavior of WarpX, some particle data are always written to output, even when `<diag_name>.<species_name>.variables = none`. This holds for all particle species by default or for all species specified in `<diag_name>.species` in the input file. If necessary, this default behavior will be changed in a separate PR.