### PR TITLE
[mini] Add clean error message when user makes a typo in fields to output

### DIFF
--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -405,7 +405,7 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(warpx.get_array_Efield_aux(lev), lev, m_crse_ratio);
         }
         else {
-            amrex::Abort("Error: " + m_varnames[comp] + "is not a known field output type");
+            amrex::Abort("Error: " + m_varnames[comp] + " is not a known field output type");
         }
     }
     AddRZModesToDiags( lev );

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -404,6 +404,9 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
         } else if ( m_varnames[comp] == "divE" ){
             m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(warpx.get_array_Efield_aux(lev), lev, m_crse_ratio);
         }
+        else {
+            amrex::Abort("Error: " + m_varnames[comp] + "is not a known field output type");
+        }
     }
     AddRZModesToDiags( lev );
 }


### PR DESCRIPTION
Currently if a user makes a typo when choosing the fields to output in full diagnostics (e.g. `diag.fields_to_plot = Ex Ez Bu`) this results in a segfault. This PR prints an error message instead.