### PR TITLE
FieldMaximum reduced diag: average all components to cell centers

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1435,9 +1435,10 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Fields written to output.
     Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``F`` ``part_per_grid`` ``part_per_proc`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``.
+    Note that the fields are averaged on the cell centers before they are written to file.
 
 * ``<diag_name>.plot_raw_fields`` (`0` or `1`) optional (default `0`)
-    By default, the fields written in the plot files are averaged on the nodes.
+    By default, the fields written in the plot files are averaged on the cell centers.
     When ```warpx.plot_raw_fields`` is `1`, then the raw (i.e. unaveraged)
     fields are also saved in the output files.
     Only works with ``<diag_name>.format = plotfile``.
@@ -1660,6 +1661,9 @@ Reduced Diagnostics
         the maximum value of the :math:`B_z` field and
         the maximum value of the norm :math:`|B|` of the magnetic field,
         at mesh refinement levels from  0 to :math:`n`.
+
+        Note that the fields are averaged on the cell centers before their maximum values are
+        computed.
 
     * ``ParticleNumber``
         This type computes the total number of macroparticles in the simulation (for each species

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -25,7 +25,6 @@ import sys
 import yt
 import numpy as np
 import scipy.constants as scc
-import read_raw_data
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
@@ -62,21 +61,6 @@ EPyt = EPyt + np.sum( (np.sqrt(px**2+py**2+pz**2)*scc.c)*w )
 num_photon = w.shape[0]
 num_total = num_electron + num_proton + num_photon
 
-# Use raw field plotfiles to compare with maximum field reduced diag
-ad_raw = read_raw_data.read_data(fn)
-Ex_raw = ad_raw[0]['Ex_aux']
-Ey_raw = ad_raw[0]['Ey_aux']
-Ez_raw = ad_raw[0]['Ez_aux']
-Bx_raw = ad_raw[0]['Bx_aux']
-By_raw = ad_raw[0]['By_aux']
-Bz_raw = ad_raw[0]['Bz_aux']
-max_Ex = np.amax(np.abs(Ex_raw))
-max_Ey = np.amax(np.abs(Ey_raw))
-max_Ez = np.amax(np.abs(Ez_raw))
-max_Bx = np.amax(np.abs(Bx_raw))
-max_By = np.amax(np.abs(By_raw))
-max_Bz = np.amax(np.abs(Bz_raw))
-
 ad = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
 Ex = ad['Ex'].to_ndarray()
 Ey = ad['Ey'].to_ndarray()
@@ -84,15 +68,19 @@ Ez = ad['Ez'].to_ndarray()
 Bx = ad['Bx'].to_ndarray()
 By = ad['By'].to_ndarray()
 Bz = ad['Bz'].to_ndarray()
-# Maximum value of |E| and |B| are obtained after interpolation so we do not use raw fields for
-# these
-max_E = np.sqrt(np.amax(Ex**2+Ey**2+Ez**2))
-max_B = np.sqrt(np.amax(Bx**2+By**2+Bz**2))
 Es = np.sum(Ex**2)+np.sum(Ey**2)+np.sum(Ez**2)
 Bs = np.sum(Bx**2)+np.sum(By**2)+np.sum(Bz**2)
 N  = np.array( ds.domain_width / ds.domain_dimensions )
 dV = N[0]*N[1]*N[2]
 EFyt = 0.5*Es*scc.epsilon_0*dV + 0.5*Bs/scc.mu_0*dV
+max_Ex = np.amax(np.abs(Ex))
+max_Ey = np.amax(np.abs(Ey))
+max_Ez = np.amax(np.abs(Ez))
+max_Bx = np.amax(np.abs(Bx))
+max_By = np.amax(np.abs(By))
+max_Bz = np.amax(np.abs(Bz))
+max_E = np.sqrt(np.amax(Ex**2+Ey**2+Ez**2))
+max_B = np.sqrt(np.amax(Bx**2+By**2+Bz**2))
 
 # PART2: get results from reduced diagnostics
 

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -85,4 +85,3 @@ NP.frequency = 200
 diagnostics.diags_names = diag1
 diag1.period = 200
 diag1.diag_type = Full
-diag1.plot_raw_fields = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1542,7 +1542,6 @@ numthreads = 2
 compileTest = 0
 doVis = 0
 compareParticles = 0
-aux1File = Tools/PostProcessing/read_raw_data.py
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
 tolerance = 1e-12
 

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -122,44 +122,56 @@ void FieldMaximum::ComputeDiags (int step)
         constexpr int index_Bz = 6;
         constexpr int index_absB = 7;
 
-        // get Maximums of E field components
-        m_data[lev*noutputs+index_Ex] = Ex.norm0();
-        m_data[lev*noutputs+index_Ey] = Ey.norm0();
-        m_data[lev*noutputs+index_Ez] = Ez.norm0();
-
-        // get Maximums of B field components
-        m_data[lev*noutputs+index_Bx] = Bx.norm0();
-        m_data[lev*noutputs+index_By] = By.norm0();
-        m_data[lev*noutputs+index_Bz] = Bz.norm0();
-
-        // General preparation of interpolation and reduction to compute the maximum value of
-        // |E| and |B|
+        // General preparation of interpolation and reduction operations
         const GpuArray<int,3> cellCenteredtype{0,0,0};
         const GpuArray<int,3> reduction_coarsening_ratio{1,1,1};
         constexpr int reduction_comp = 0;
 
-        // Prepare reduction for maximum value of |E|
+        ReduceOps<ReduceOpMax> reduceEx_op;
+        ReduceOps<ReduceOpMax> reduceEy_op;
+        ReduceOps<ReduceOpMax> reduceEz_op;
+        ReduceOps<ReduceOpMax> reduceBx_op;
+        ReduceOps<ReduceOpMax> reduceBy_op;
+        ReduceOps<ReduceOpMax> reduceBz_op;
         ReduceOps<ReduceOpMax> reduceE_op;
+        ReduceOps<ReduceOpMax> reduceB_op;
+
+        ReduceData<Real> reduceEx_data(reduceEx_op);
+        ReduceData<Real> reduceEy_data(reduceEy_op);
+        ReduceData<Real> reduceEz_data(reduceEz_op);
+        ReduceData<Real> reduceBx_data(reduceBx_op);
+        ReduceData<Real> reduceBy_data(reduceBy_op);
+        ReduceData<Real> reduceBz_data(reduceBz_op);
         ReduceData<Real> reduceE_data(reduceE_op);
-        using ReduceTuple = typename decltype(reduceE_data)::Type;
+        ReduceData<Real> reduceB_data(reduceB_op);
+
+        using ReduceTuple = typename decltype(reduceEx_data)::Type;
 
         // Prepare interpolation of E field components to cell center
         GpuArray<int,3> Extype;
         GpuArray<int,3> Eytype;
         GpuArray<int,3> Eztype;
+        GpuArray<int,3> Bxtype;
+        GpuArray<int,3> Bytype;
+        GpuArray<int,3> Bztype;
         for (int i = 0; i < AMREX_SPACEDIM; ++i){
             Extype[i] = Ex.ixType()[i];
             Eytype[i] = Ey.ixType()[i];
             Eztype[i] = Ez.ixType()[i];
+            Bxtype[i] = Bx.ixType()[i];
+            Bytype[i] = By.ixType()[i];
+            Bztype[i] = Bz.ixType()[i];
         }
 #if   (AMREX_SPACEDIM == 2)
         Extype[2] = 0;
         Eytype[2] = 0;
         Eztype[2] = 0;
+        Bxtype[2] = 0;
+        Bytype[2] = 0;
+        Bztype[2] = 0;
 #endif
 
-        // MFIter loop to interpolate E field components to cell center and get maximum value
-        // of |E|
+        // MFIter loop to interpolate fields to cell center and get maximum values
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -170,6 +182,52 @@ void FieldMaximum::ComputeDiags (int step)
             const auto& arrEx = Ex[mfi].array();
             const auto& arrEy = Ey[mfi].array();
             const auto& arrEz = Ez[mfi].array();
+            const auto& arrBx = Bx[mfi].array();
+            const auto& arrBy = By[mfi].array();
+            const auto& arrBz = Bz[mfi].array();
+
+            reduceEx_op.eval(box, reduceEx_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real Ex_interp = CoarsenIO::Interp(arrEx, Extype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(Ex_interp);
+            });
+            reduceEy_op.eval(box, reduceEy_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real Ey_interp = CoarsenIO::Interp(arrEy, Eytype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(Ey_interp);
+            });
+            reduceEz_op.eval(box, reduceEz_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real Ez_interp = CoarsenIO::Interp(arrEz, Eztype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(Ez_interp);
+            });
+            reduceBx_op.eval(box, reduceBx_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real Bx_interp = CoarsenIO::Interp(arrBx, Bxtype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(Bx_interp);
+            });
+            reduceBy_op.eval(box, reduceBy_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real By_interp = CoarsenIO::Interp(arrBy, Bytype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(By_interp);
+            });
+            reduceBz_op.eval(box, reduceBz_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const Real Bz_interp = CoarsenIO::Interp(arrBz, Bztype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return amrex::Math::abs(Bz_interp);
+            });
             reduceE_op.eval(box, reduceE_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
@@ -181,47 +239,6 @@ void FieldMaximum::ComputeDiags (int step)
                                         reduction_coarsening_ratio, i, j, k, reduction_comp);
                 return Ex_interp*Ex_interp + Ey_interp*Ey_interp + Ez_interp*Ez_interp;
             });
-        }
-
-        Real hv_E = amrex::get<0>(reduceE_data.value()); // highest value of |E|**2
-        // MPI reduce
-        ParallelDescriptor::ReduceRealMax(hv_E);
-
-        m_data[lev*noutputs+index_absE] = std::sqrt(hv_E);
-
-        // Prepare reduction for maximum value of |B|
-        ReduceOps<ReduceOpMax> reduceB_op;
-        ReduceData<Real> reduceB_data(reduceB_op);
-        using ReduceTuple = typename decltype(reduceB_data)::Type;
-
-        // Prepare interpolation of B field components to cell center
-        GpuArray<int,3> Bxtype;
-        GpuArray<int,3> Bytype;
-        GpuArray<int,3> Bztype;
-        for (int i = 0; i < AMREX_SPACEDIM; ++i){
-            Bxtype[i] = Bx.ixType()[i];
-            Bytype[i] = By.ixType()[i];
-            Bztype[i] = Bz.ixType()[i];
-        }
-#if   (AMREX_SPACEDIM == 2)
-        Bxtype[2] = 0;
-        Bytype[2] = 0;
-        Bztype[2] = 0;
-#endif
-
-        // MFIter loop to interpolate B field components to cell center and get maximum value
-        // of |B|
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for ( MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi )
-        {
-            // Make the box cell centered to avoid including ghost cells in the calculation
-            const Box& box = enclosedCells(mfi.nodaltilebox());
-            const auto& arrBx = Bx[mfi].array();
-            const auto& arrBy = By[mfi].array();
-            const auto& arrBz = Bz[mfi].array();
-
             reduceB_op.eval(box, reduceB_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
@@ -235,10 +252,33 @@ void FieldMaximum::ComputeDiags (int step)
             });
         }
 
+        Real hv_Ex = amrex::get<0>(reduceEx_data.value()); // highest value of |Ex|
+        Real hv_Ey = amrex::get<0>(reduceEy_data.value()); // highest value of |Ey|
+        Real hv_Ez = amrex::get<0>(reduceEz_data.value()); // highest value of |Ez|
+        Real hv_Bx = amrex::get<0>(reduceBx_data.value()); // highest value of |Bx|
+        Real hv_By = amrex::get<0>(reduceBy_data.value()); // highest value of |By|
+        Real hv_Bz = amrex::get<0>(reduceBz_data.value()); // highest value of |Bz|
+        Real hv_E = amrex::get<0>(reduceE_data.value()); // highest value of |E|**2
         Real hv_B = amrex::get<0>(reduceB_data.value()); // highest value of |B|**2
+
         // MPI reduce
+        ParallelDescriptor::ReduceRealMax(hv_Ex);
+        ParallelDescriptor::ReduceRealMax(hv_Ey);
+        ParallelDescriptor::ReduceRealMax(hv_Ez);
+        ParallelDescriptor::ReduceRealMax(hv_Bx);
+        ParallelDescriptor::ReduceRealMax(hv_By);
+        ParallelDescriptor::ReduceRealMax(hv_Bz);
+        ParallelDescriptor::ReduceRealMax(hv_E);
         ParallelDescriptor::ReduceRealMax(hv_B);
 
+        // Fill output array
+        m_data[lev*noutputs+index_Ex] = hv_Ex;
+        m_data[lev*noutputs+index_Ey] = hv_Ey;
+        m_data[lev*noutputs+index_Ez] = hv_Ez;
+        m_data[lev*noutputs+index_Bx] = hv_Bx;
+        m_data[lev*noutputs+index_By] = hv_By;
+        m_data[lev*noutputs+index_Bz] = hv_Bz;
+        m_data[lev*noutputs+index_absE] = std::sqrt(hv_E);
         m_data[lev*noutputs+index_absB] = std::sqrt(hv_B);
     }
     // end loop over refinement levels

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -147,7 +147,7 @@ void FieldMaximum::ComputeDiags (int step)
 
         using ReduceTuple = typename decltype(reduceEx_data)::Type;
 
-        // Prepare interpolation of E field components to cell center
+        // Prepare interpolation of field components to cell center
         GpuArray<int,3> Extype;
         GpuArray<int,3> Eytype;
         GpuArray<int,3> Eztype;


### PR DESCRIPTION
Currently in the FieldMaximum reduced diag we use the raw fields to compute the maximum value the Ex, Ey, Ez, Bx, By and Bz and we interpolate the fields to cell centers to compute the maximum of |E| and |B|. This can lead to situations where for instance the maximum value of By is greater than the maximum value of |B| (if the fields are sharply peaked or if By is the only non-zero component of the B field).

To avoid this, and to make this diag consistent with the FullDiagnostics, all maximum values are now obtained after averaging the fields on the cell centers.

This slightly simplifies the tests because we no longer need to output and read raw fields. I've also modified the diag to reflect this change and added one sentence in the FullDiagnostics docs to clarify that the output fields are averaged to cell centers (currently it says that they're averaged on the nodes).