### PR TITLE
CI: Nvidia Apt Broken (CUDA)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,6 @@ jobs:
         sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
         sudo apt-key add 7fa2af80.pub
         echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" | sudo tee /etc/apt/sources.list.d/cuda.list
-        echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" | sudo tee /etc/apt/sources.list.d/nvidia-ml.list
         sudo apt-get update
         sudo apt-get install -y cuda-command-line-tools-11-0 cuda-compiler-11-0 cuda-cupti-dev-11-0 cuda-minimal-build-11-0 cuda-nvml-dev-11-0 cuda-nvtx-11-0 libcurand-dev-11-0
         sudo ln -s cuda-11.0 /usr/local/cuda


### PR DESCRIPTION
Try to work-around the newly broken Nvidia apt repos for CUDA 11.0.

- Refs.: https://gitlab.com/nvidia/container-images/cuda/
- Nvidia bug report: 3144329