### PR TITLE
New reduced diag: number of macroparticles

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1656,6 +1656,15 @@ Reduced Diagnostics
         the maximum value of the norm :math:`|B|` of the magnetic field,
         at mesh refinement levels from  0 to :math:`n`.
 
+    * ``ParticleNumber``
+        This type computes the total number of macroparticles in the simulation (for each species
+        and summed over all species). It can be useful in particular for simulations with creation
+        (ionization, QED processes) or removal (resampling) of particles.
+
+        The output columns are
+        total number of macroparticles summed over all species and
+        total number of macroparticles of each species.
+
     * ``BeamRelevant``
         This type computes properties of a particle beam relevant for particle accelerators,
         like position, momentum, emittance, etc.

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -43,12 +43,15 @@ py = ad['electrons','particle_momentum_y'].to_ndarray()
 pz = ad['electrons','particle_momentum_z'].to_ndarray()
 w  = ad['electrons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt((px**2+py**2+pz**2)*scc.c**2+scc.m_e**2*scc.c**4)-scc.m_e*scc.c**2)*w )
+num_electron = w.shape[0]
+
 # proton
 px = ad['protons','particle_momentum_x'].to_ndarray()
 py = ad['protons','particle_momentum_y'].to_ndarray()
 pz = ad['protons','particle_momentum_z'].to_ndarray()
 w  = ad['protons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt((px**2+py**2+pz**2)*scc.c**2+scc.m_p**2*scc.c**4)-scc.m_p*scc.c**2)*w )
+num_proton = w.shape[0]
 
 # photon
 px = ad['photons','particle_momentum_x'].to_ndarray()
@@ -56,6 +59,8 @@ py = ad['photons','particle_momentum_y'].to_ndarray()
 pz = ad['photons','particle_momentum_z'].to_ndarray()
 w  = ad['photons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt(px**2+py**2+pz**2)*scc.c)*w )
+num_photon = w.shape[0]
+num_total = num_electron + num_proton + num_photon
 
 # Use raw field plotfiles to compare with maximum field reduced diag
 ad_raw = read_raw_data.read_data(fn)
@@ -94,6 +99,7 @@ EFyt = 0.5*Es*scc.epsilon_0*dV + 0.5*Bs/scc.mu_0*dV
 EFdata = np.genfromtxt("./diags/reducedfiles/EF.txt")
 EPdata = np.genfromtxt("./diags/reducedfiles/EP.txt")
 MFdata = np.genfromtxt("./diags/reducedfiles/MF.txt")
+NPdata = np.genfromtxt("./diags/reducedfiles/NP.txt")
 EF = EFdata[1][2]
 EP = EPdata[1][2]
 max_Exdata = MFdata[1][2]
@@ -104,6 +110,10 @@ max_Bxdata = MFdata[1][6]
 max_Bydata = MFdata[1][7]
 max_Bzdata = MFdata[1][8]
 max_Bdata  = MFdata[1][9]
+num_total_data = NPdata[1][2]
+num_electron_data = NPdata[1][3]
+num_proton_data = NPdata[1][4]
+num_photon_data = NPdata[1][5]
 
 # PART3: print and assert
 
@@ -111,6 +121,8 @@ max_diffEmax = max(abs(max_Exdata-max_Ex),abs(max_Eydata-max_Ey),
                    abs(max_Ezdata-max_Ez),abs(max_Edata-max_E))
 max_diffBmax = max(abs(max_Bxdata-max_Bx),abs(max_Bydata-max_By),
                    abs(max_Bzdata-max_Bz),abs(max_Bdata-max_B))
+max_diff_number = max(abs(num_total_data-num_total),abs(num_electron_data-num_electron),
+                   abs(num_proton_data-num_proton),abs(num_photon_data-num_photon))
 
 print('difference of field energy:', abs(EFyt-EF))
 print('tolerance of field energy:', 1.0e-3)
@@ -125,6 +137,7 @@ assert(abs(EFyt-EF) < 1.0e-3)
 assert(abs(EPyt-EP) < 1.0e-8)
 assert(max_diffEmax < 1.0e-9)
 assert(max_diffBmax < 1.0e-18)
+assert(max_diff_number < 0.5)
 
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -71,13 +71,15 @@ photons.uz_th = 0.2
 #################################
 ###### REDUCED DIAGS ############
 #################################
-warpx.reduced_diags_names = EP EF MF
+warpx.reduced_diags_names = EP NP EF MF
 EP.type = ParticleEnergy
 EP.frequency = 200
 EF.type = FieldEnergy
 EF.frequency = 200
 MF.type = FieldMaximum
 MF.frequency = 200
+NP.type = ParticleNumber
+NP.frequency = 200
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -694,7 +694,7 @@ void BackTransformedDiagnostic::Flush(const Geometry& /*geom*/)
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::NoFabHeader_v1);
 
-    auto & mypc = WarpX::GetInstance().GetPartContainer();
+    const auto & mypc = WarpX::GetInstance().GetPartContainer();
     const std::vector<std::string> species_names = mypc.GetSpeciesNames();
 
     // Loop over BFD snapshots
@@ -1187,7 +1187,7 @@ createLabFrameDirectories() {
     ParallelDescriptor::Barrier();
 
     if (WarpX::do_back_transformed_particles){
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
         // Loop over species to be dumped to BFD
         for (int j = 0; j < mypc.nSpeciesBackTransformedDiagnostics(); ++j)
@@ -1216,7 +1216,7 @@ createLabFrameDirectories() {
                 CreateDirectoryFailed(fullpath);
         }
 
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::vector<std::string> species_names = mypc.GetSpeciesNames();
 
         const std::string particles_prefix = "particle";

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.H
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.H
@@ -25,7 +25,7 @@ public:
     /// name of beam species
     std::string m_beam_name;
 
-    /** This funciton computes beam relevant quantites.
+    /** This function computes beam relevant quantites.
      *  \param [in] step current time step
      */
     virtual void ComputeDiags(int step) override final;

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -117,7 +117,7 @@ void BeamRelevant::ComputeDiags (int step)
     if (!m_intervals.contains(step+1)) { return; }
 
     // get MultiParticleContainer class object
-    auto & mypc = WarpX::GetInstance().GetPartContainer();
+    const auto & mypc = WarpX::GetInstance().GetPartContainer();
 
     // get number of species
     int const nSpecies = mypc.nSpecies();

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -55,9 +55,8 @@ BeamRelevant::BeamRelevant (std::string rd_name)
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
 #if (defined WARPX_DIM_3D || defined WARPX_DIM_RZ)
             ofs << "#";

--- a/Source/Diagnostics/ReducedDiags/CMakeLists.txt
+++ b/Source/Diagnostics/ReducedDiags/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(WarpX
     ParticleHistogram.cpp
     ReducedDiags.cpp
     FieldMaximum.cpp
+    ParticleNumber.cpp
 )

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.H
@@ -23,7 +23,7 @@ public:
      *  @param[in] rd_name reduced diags names */
     FieldEnergy(std::string rd_name);
 
-    /** This funciton computes the field energy (EF).
+    /** This function computes the field energy (EF).
      *  EF = E eps / 2 + B / mu / 2,
      *  where E is the electric field,
      *  B is the magnetic field,

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -44,9 +44,8 @@ FieldEnergy::FieldEnergy (std::string rd_name)
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
             ofs << "#";
             ofs << "[1]step()";

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -37,9 +37,8 @@ FieldMaximum::FieldMaximum (std::string rd_name)
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
             ofs << "#";
             ofs << "[1]step()";

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
@@ -51,7 +51,7 @@ public:
      *  @param[in] rd_name reduced diags names */
     LoadBalanceCosts(std::string rd_name);
 
-    /** This funciton updates the costs, given the current distribution mapping,
+    /** This function updates the costs, given the current distribution mapping,
      *  according to the number of particles and cells on the box  */
     virtual void ComputeDiags(int step) override final;
 

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -183,9 +183,8 @@ void LoadBalanceCosts::ComputeDiags (int step)
 void LoadBalanceCosts::WriteToFile (int step) const
 {
     // open file
-    std::ofstream ofs;
-    ofs.open(m_path + m_rd_name + "." + m_extension,
-            std::ofstream::out | std::ofstream::app);
+    std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+            std::ofstream::out | std::ofstream::app};
 
     // write step
     ofs << step+1 << m_sep;

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -6,5 +6,6 @@ CEXE_sources += BeamRelevant.cpp
 CEXE_sources += LoadBalanceCosts.cpp
 CEXE_sources += ParticleHistogram.cpp
 CEXE_sources += FieldMaximum.cpp
+CEXE_sources += ParticleNumber.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -11,6 +11,7 @@
 #include "ParticleEnergy.H"
 #include "FieldEnergy.H"
 #include "FieldMaximum.H"
+#include "ParticleNumber.H"
 #include "MultiReducedDiags.H"
 
 #include <AMReX_ParmParse.H>
@@ -75,6 +76,11 @@ MultiReducedDiags::MultiReducedDiags ()
             m_multi_rd[i_rd].reset
                 ( new ParticleHistogram(m_rd_names[i_rd]));
         }
+        else if (rd_type.compare("ParticleNumber") == 0)
+        {
+            m_multi_rd[i_rd].reset
+                ( new ParticleNumber(m_rd_names[i_rd]));
+        }
         else
         { Abort("No matching reduced diagnostics type found."); }
         // end if match diags
@@ -97,7 +103,7 @@ void MultiReducedDiags::ComputeDiags (int step)
 }
 // end void MultiReducedDiags::ComputeDiags
 
-// funciton to write data
+// function to write data
 void MultiReducedDiags::WriteToFile (int step)
 {
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.H
@@ -24,7 +24,7 @@ public:
      *  @param[in] rd_name reduced diags names */
     ParticleEnergy(std::string rd_name);
 
-    /** This funciton computes the particle relativistic
+    /** This function computes the particle relativistic
      *  kinetic energy (EP).
      *  \param [in] step current time step
      *  EP = sqrt( p^2 c^2 + m^2 c^4 ) - m c^2,

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -43,9 +43,8 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
             ofs << "#";
             ofs << "[1]step()";

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -27,16 +27,16 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
     auto & warpx = WarpX::GetInstance();
 
     // get MultiParticleContainer class object
-    auto & mypc = warpx.GetPartContainer();
+    const auto & mypc = warpx.GetPartContainer();
 
     // get number of species (int)
-    auto nSpecies = mypc.nSpecies();
+    const auto nSpecies = mypc.nSpecies();
 
     // resize data array
     m_data.resize(2*nSpecies+2,0.0);
 
     // get species names (std::vector<std::string>)
-    auto species_names = mypc.GetSpeciesNames();
+    const auto species_names = mypc.GetSpeciesNames();
 
     if (ParallelDescriptor::IOProcessor())
     {
@@ -85,13 +85,13 @@ void ParticleEnergy::ComputeDiags (int step)
     if (!m_intervals.contains(step+1)) { return; }
 
     // get MultiParticleContainer class object
-    auto & mypc = WarpX::GetInstance().GetPartContainer();
+    const auto & mypc = WarpX::GetInstance().GetPartContainer();
 
     // get number of species (int)
-    auto nSpecies = mypc.nSpecies();
+    const auto nSpecies = mypc.nSpecies();
 
     // get species names (std::vector<std::string>)
-    auto species_names = mypc.GetSpeciesNames();
+    const auto species_names = mypc.GetSpeciesNames();
 
     // speed of light squared
     auto c2 = PhysConst::c * PhysConst::c;
@@ -100,7 +100,7 @@ void ParticleEnergy::ComputeDiags (int step)
     for (int i_s = 0; i_s < nSpecies; ++i_s)
     {
         // get WarpXParticleContainer class object
-        auto & myspc = mypc.GetParticleContainer(i_s);
+        const auto & myspc = mypc.GetParticleContainer(i_s);
 
         // get mass (Real)
         auto m = myspc.getMass();

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -107,7 +107,7 @@ void ParticleEnergy::ComputeDiags (int step)
 
         using PType = typename WarpXParticleContainer::SuperParticleType;
 
-        // Use amex::ReduceSum to compute the sum of energies of all particles
+        // Use amrex::ReduceSum to compute the sum of energies of all particles
         // held by the current MPI rank, for this species. This involves a loop over all
         // boxes held by this MPI rank.
         Real Etot = 0.0_rt;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -65,7 +65,7 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
     }
 
     // get MultiParticleContainer class object
-    auto & mypc = WarpX::GetInstance().GetPartContainer();
+    const auto & mypc = WarpX::GetInstance().GetPartContainer();
     // get species names (std::vector<std::string>)
     auto const species_names = mypc.GetSpeciesNames();
     // select species
@@ -127,7 +127,7 @@ void ParticleHistogram::ComputeDiags (int step)
     auto const t = warpx.gett_new(0);
 
     // get MultiParticleContainer class object
-    auto & mypc = warpx.GetPartContainer();
+    const auto & mypc = warpx.GetPartContainer();
 
     // get WarpXParticleContainer class object
     auto const & myspc = mypc.GetParticleContainer(m_selected_species_id);

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -88,9 +88,8 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
             ofs << "#";
             ofs << "[1]step()";

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.H
@@ -1,0 +1,32 @@
+/* Copyright 2019-2020 Neil Zaim, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_PARTICLENUMBER_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_PARTICLENUMBER_H_
+
+#include "ReducedDiags.H"
+
+/**
+ *  This class mainly contains a function that computes the total number of macroparticles of each
+ *  species.
+ */
+class ParticleNumber : public ReducedDiags
+{
+public:
+
+    /** constructor
+     *  @param[in] rd_name reduced diags names */
+    ParticleNumber(std::string rd_name);
+
+    /** This function computes the total number of macroparticles of each species.
+     *  @param [in] step current time step
+     */
+    virtual void ComputeDiags(int step) override final;
+
+};
+
+#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_PARTICLENUMBER_H_

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -42,13 +42,13 @@ ParticleNumber::ParticleNumber (std::string rd_name)
             ofs << m_sep;
             ofs << "[2]time(s)";
             ofs << m_sep;
-            ofs << "[3]total";
+            ofs << "[3]total()";
             constexpr int shift_first_species = 4; // Column number of first species in output file
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
                 ofs << "[" + std::to_string(shift_first_species+i) + "]";
-                ofs << species_names[i];
+                ofs << species_names[i]+"()";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -1,0 +1,103 @@
+/* Copyright 2019-2020 Neil Zaim, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "ParticleNumber.H"
+#include "WarpX.H"
+
+// constructor
+ParticleNumber::ParticleNumber (std::string rd_name)
+: ReducedDiags{rd_name}
+{
+    // get WarpX class object
+    auto & warpx = WarpX::GetInstance();
+
+    // get MultiParticleContainer class object
+    auto & mypc = warpx.GetPartContainer();
+
+    // get number of species (int)
+    auto nSpecies = mypc.nSpecies();
+
+    // resize data array to nSpecies+1
+    // (number of particles of each species + total number of particles)
+    m_data.resize(nSpecies+1, amrex::Real(0.));
+
+    // get species names (std::vector<std::string>)
+    auto species_names = mypc.GetSpeciesNames();
+
+    if (amrex::ParallelDescriptor::IOProcessor())
+    {
+        if ( m_IsNotRestart )
+        {
+            // open file
+            std::ofstream ofs;
+            ofs.open(m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app);
+            // write header row
+            ofs << "#";
+            ofs << "[1]step()";
+            ofs << m_sep;
+            ofs << "[2]time(s)";
+            ofs << m_sep;
+            ofs << "[3]total";
+            constexpr int shift_first_species = 4; // Column number of first species in output file
+            for (int i = 0; i < nSpecies; ++i)
+            {
+                ofs << m_sep;
+                ofs << "[" + std::to_string(shift_first_species+i) + "]";
+                ofs << species_names[i];
+            }
+            ofs << std::endl;
+            // close file
+            ofs.close();
+        }
+    }
+
+}
+// end constructor
+
+// function that computes total number of macroparticles
+void ParticleNumber::ComputeDiags (int step)
+{
+
+    // Judge if the diags should be done
+    if (!m_intervals.contains(step+1)) { return; }
+
+    // get MultiParticleContainer class object
+    auto & mypc = WarpX::GetInstance().GetPartContainer();
+
+    // get number of species (int)
+    auto nSpecies = mypc.nSpecies();
+
+    // Index of total number of particles (all species) in m_data
+    constexpr int idx_total = 0;
+    // Index of first species in m_data
+    constexpr int idx_first_species = 1;
+
+    // Initialize total number of particles (all species) to 0
+    m_data[idx_total] = amrex::Real(0.);
+
+    // loop over species
+    for (int i_s = 0; i_s < nSpecies; ++i_s)
+    {
+        // get WarpXParticleContainer class object
+        auto & myspc = mypc.GetParticleContainer(i_s);
+
+        // Save result for this species
+        m_data[idx_first_species + i_s] = myspc.TotalNumberOfParticles();
+        // Increase total number of particles (all species)
+        m_data[idx_total] += m_data[idx_first_species + i_s];
+    }
+    // end loop over species
+
+    /* m_data now contains up-to-date values for:
+     *  [total number of macroparticles (all species),
+     *   total number of macroparticles (species 1),
+     *   ...,
+     *   total number of macroparticles (species n)] */
+
+}
+// end void ParticleNumber::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -66,7 +66,7 @@ void ParticleNumber::ComputeDiags (int step)
     if (!m_intervals.contains(step+1)) { return; }
 
     // get MultiParticleContainer class object
-    auto & mypc = WarpX::GetInstance().GetPartContainer();
+    const auto & mypc = WarpX::GetInstance().GetPartContainer();
 
     // get number of species (int)
     const auto nSpecies = mypc.nSpecies();

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -16,26 +16,25 @@ ParticleNumber::ParticleNumber (std::string rd_name)
     auto & warpx = WarpX::GetInstance();
 
     // get MultiParticleContainer class object
-    auto & mypc = warpx.GetPartContainer();
+    const auto & mypc = warpx.GetPartContainer();
 
     // get number of species (int)
-    auto nSpecies = mypc.nSpecies();
+    const auto nSpecies = mypc.nSpecies();
 
     // resize data array to nSpecies+1
     // (number of particles of each species + total number of particles)
     m_data.resize(nSpecies+1, amrex::Real(0.));
 
     // get species names (std::vector<std::string>)
-    auto species_names = mypc.GetSpeciesNames();
+    const auto species_names = mypc.GetSpeciesNames();
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         if ( m_IsNotRestart )
         {
             // open file
-            std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + "." + m_extension,
-                std::ofstream::out | std::ofstream::app);
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+                std::ofstream::out | std::ofstream::app};
             // write header row
             ofs << "#";
             ofs << "[1]step()";
@@ -70,7 +69,7 @@ void ParticleNumber::ComputeDiags (int step)
     auto & mypc = WarpX::GetInstance().GetPartContainer();
 
     // get number of species (int)
-    auto nSpecies = mypc.nSpecies();
+    const auto nSpecies = mypc.nSpecies();
 
     // Index of total number of particles (all species) in m_data
     constexpr int idx_total = 0;
@@ -84,7 +83,7 @@ void ParticleNumber::ComputeDiags (int step)
     for (int i_s = 0; i_s < nSpecies; ++i_s)
     {
         // get WarpXParticleContainer class object
-        auto & myspc = mypc.GetParticleContainer(i_s);
+        const auto & myspc = mypc.GetParticleContainer(i_s);
 
         // Save result for this species
         m_data[idx_first_species + i_s] = myspc.TotalNumberOfParticles();

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -44,8 +44,7 @@ ReducedDiags::ReducedDiags (std::string rd_name)
         // replace / create output file
         if ( m_IsNotRestart ) // not a restart
         {
-            std::ofstream ofs;
-            ofs.open(m_path+m_rd_name+"."+m_extension, std::ios::trunc);
+            std::ofstream ofs{m_path+m_rd_name+"."+m_extension, std::ios::trunc};
             ofs.close();
         }
     }
@@ -66,9 +65,8 @@ void ReducedDiags::WriteToFile (int step) const
 {
 
     // open file
-    std::ofstream ofs;
-    ofs.open(m_path + m_rd_name + "." + m_extension,
-        std::ofstream::out | std::ofstream::app);
+    std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
+        std::ofstream::out | std::ofstream::app};
 
     // write step
     ofs << step+1;

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -299,8 +299,8 @@ WarpX::ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<am
 {
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        auto & mypc_ref = WarpX::GetInstance().GetPartContainer();
-        auto nSpecies = mypc_ref.nSpecies();
+        const auto & mypc_ref = WarpX::GetInstance().GetPartContainer();
+        const auto nSpecies = mypc_ref.nSpecies();
 
         // Species loop
         for (int i_s = 0; i_s < nSpecies; ++i_s)

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -89,7 +89,7 @@ extern "C"
 
     int warpx_nSpecies()
     {
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
         return mypc.nSpecies();
     }
 
@@ -239,8 +239,8 @@ extern "C"
     }
 
     long warpx_getNumParticles(int speciesnumber) {
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
-        auto & myspc = mypc.GetParticleContainer(speciesnumber);
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & myspc = mypc.GetParticleContainer(speciesnumber);
         return myspc.TotalNumberOfParticles();
     }
 
@@ -352,7 +352,7 @@ extern "C"
 
     amrex::ParticleReal** warpx_getParticleStructs(int speciesnumber, int lev,
                                       int* num_tiles, int** particles_per_tile) {
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
         auto & myspc = mypc.GetParticleContainer(speciesnumber);
 
         int i = 0;
@@ -374,7 +374,7 @@ extern "C"
 
     amrex::ParticleReal** warpx_getParticleArrays(int speciesnumber, int comp, int lev,
                                      int* num_tiles, int** particles_per_tile) {
-        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
         auto & myspc = mypc.GetParticleContainer(speciesnumber);
 
         int i = 0;


### PR DESCRIPTION
This PR adds a reduced diag that computes the number of macroparticles of each species in the simulation (in my case it will be useful for simulations where I test particle resampling). It's very largely based on the ParticleEnergy reduced diag but the calculations are much simpler.

It's a bit unrelated to this PR but I've also fixed a couple of typos in the comments in the reduced diags part of the code.