### PR TITLE
Fix rz with single precision

### DIFF
--- a/Source/Particles/Collision/CollisionType.cpp
+++ b/Source/Particles/Collision/CollisionType.cpp
@@ -132,7 +132,7 @@ void CollisionType::doCoulombCollisionsWithinTile
 
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
-                    auto dV = MathConst::pi*(2.0*ri+1.0)*dr*dr*dz;
+                    auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
 #else
                     amrex::ignore_unused(nz);
 #endif
@@ -229,7 +229,7 @@ void CollisionType::doCoulombCollisionsWithinTile
 
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
-                    auto dV = MathConst::pi*(2.0*ri+1.0)*dr*dr*dz;
+                    auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
 #else
                     amrex::ignore_unused(nz);
 #endif

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -249,12 +249,12 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                     Complex xy = xy0; // Note that xy is equal to e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 on the weighting comes from the normalization of the modes
-                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode-1), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.real());
-                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode  ), 2.*sx_jx[ix]*sz_jx[iz]*wqx*xy.imag());
-                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode-1), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.real());
-                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode  ), 2.*sx_jy[ix]*sz_jy[iz]*wqy*xy.imag());
-                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode-1), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.real());
-                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode  ), 2.*sx_jz[ix]*sz_jz[iz]*wqz*xy.imag());
+                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode-1), 2._rt*sx_jx[ix]*sz_jx[iz]*wqx*xy.real());
+                        amrex::Gpu::Atomic::Add( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode  ), 2._rt*sx_jx[ix]*sz_jx[iz]*wqx*xy.imag());
+                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode-1), 2._rt*sx_jy[ix]*sz_jy[iz]*wqy*xy.real());
+                        amrex::Gpu::Atomic::Add( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode  ), 2._rt*sx_jy[ix]*sz_jy[iz]*wqy*xy.imag());
+                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode-1), 2._rt*sx_jz[ix]*sz_jz[iz]*wqz*xy.real());
+                        amrex::Gpu::Atomic::Add( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode  ), 2._rt*sx_jz[ix]*sz_jz[iz]*wqz*xy.imag());
                         xy = xy*xy0;
                     }
 #endif
@@ -552,8 +552,12 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         // The minus sign comes from the different convention with respect to Davidson et al.
-                        const Complex djt_cmplx = -2._rt * I*(i_new-1 + i + xmin*dxi)*wq*invdtdx/(amrex::Real)imode*
-                                                  (sx_new[i]*sz_new[k]*(xy_new - xy_mid) + sx_old[i]*sz_old[k]*(xy_mid - xy_old));
+                        const Real djt_coeff = -2._rt*(i_new-1 + i + xmin*dxi)*wq*invdtdx/(amrex::Real)imode;
+                        // For single precision, s_new and s_old are made single since multiplication of a double
+                        // and a single complex (the xy_ varianles) has not been implemented.
+                        const Real s_new = sx_new[i]*sz_new[k];
+                        const Real s_old = sx_old[i]*sz_old[k];
+                        const Complex djt_cmplx = djt_coeff*I*(s_new*(xy_new - xy_mid) + s_old*(xy_mid - xy_old));
                         amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djt_cmplx.real());
                         amrex::Gpu::Atomic::Add( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djt_cmplx.imag());
                         xy_new = xy_new*xy_new0;


### PR DESCRIPTION
Several fixes were needed to allow compilation with single precision and USE_RZ=TRUE.

@mrowan137 Can you check the way I did the conversion of the particle weighting factors from double to single? Will it avoid the problem with using single precision weighting factors?