### PR TITLE
PSATD: do not store first Fornberg coefficient

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -61,7 +61,16 @@ class SpectralKSpace
         amrex::RealVect dx;
 };
 
+/**
+ * \brief Returns an array of coefficients (Fornberg coefficients), corresponding
+ * to the weight of each point in a finite-difference approximation of a derivative
+ * (up to order \c n_order).
+ *
+ * \param[in] n_order order of the finite-difference approximation
+ * \param[in] nodal   whether the finite-difference approximation is computed
+ *                    on a nodal grid or a staggered grid
+ */
 amrex::Vector<amrex::Real>
-getFonbergStencilCoefficients( const int n_order, const bool nodal );
+getFornbergStencilCoefficients(const int n_order, const bool nodal);
 
 #endif


### PR DESCRIPTION
The number of Fornberg coefficients needed for a finite-difference approximation of order `N` is `N/2`. So far we have been storing `N/2+1` coefficients, because of the recurrence relation used to compute them, and used only those with index `1,...,N/2`. This PR avoids storing the first coefficient (old index `0`), which was never used. The new index runs from `0` to `N/2-1`.