### PR TITLE
[mini] Fix error with Schwinger in 2D

### DIFF
--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -103,7 +103,7 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
             // to use N>1 (for now).
             const Real x = xlo_global + j*dx;
             const Real y = (spacedim == 3) ? ylo_global + k*dy : 0.0_rt;
-            const Real z = zlo_global + l*dz;
+            const Real z = (spacedim == 3) ? zlo_global + l*dz : ylo_global + k*dy;
 
             for (int n = 0; n < N; ++n)
             {


### PR DESCRIPTION
When removing some warnings in #1356 we've introduced a bug with Schwinger pair generation (which made all pairs being created at z=0).

To be honest these notations are quite confusing (we had added a comment about that, see lines 61-62) so I'm not too surprised we've introduced a bug. For now I've just fixed the bug while keeping the same notations as before. But maybe we want to change these, for examples by assigning `dz` to `geom.CellSize(2);` in 3D and to `geom.CellSize(1);` in 2D. What do you think?