### PR TITLE
[mini-PR] Flag to turn off species output in diags

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1468,6 +1468,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Higher corner of the output fields (if larger than ``warpx.dom_hi``, then set to ``warpx.dom_hi``). Currently, when the ``diag_hi`` is different from ``warpx.dom_hi``, particle output i
 s disabled.
 
+* ``<diag_name>.write_species`` (`0` or `1`) optional (default `1`)
+   Whether to write species output or not. For checkpoint format, always set this parameter to 1. 
 
 * ``<diag_name>.species`` (list of `string`, default all physical species in the simulation)
     Which species dumped in this diagnostics.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1472,6 +1472,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Higher corner of the output fields (if larger than ``warpx.dom_hi``, then set to ``warpx.dom_hi``). Currently, when the ``diag_hi`` is different from ``warpx.dom_hi``, particle output i
 s disabled.
 
+* ``<diag_name>.write_species`` (`0` or `1`) optional (default `1`)
+   Whether to write species output or not. For checkpoint format, always set this parameter to 1. 
 
 * ``<diag_name>.species`` (list of `string`, default all physical species in the simulation)
     Which species dumped in this diagnostics.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1469,7 +1469,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 s disabled.
 
 * ``<diag_name>.write_species`` (`0` or `1`) optional (default `1`)
-   Whether to write species output or not. For checkpoint format, always set this parameter to 1. 
+   Whether to write species output or not. For checkpoint format, always set this parameter to 1.
 
 * ``<diag_name>.species`` (list of `string`, default all physical species in the simulation)
     Which species dumped in this diagnostics.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1473,7 +1473,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 s disabled.
 
 * ``<diag_name>.write_species`` (`0` or `1`) optional (default `1`)
-   Whether to write species output or not. For checkpoint format, always set this parameter to 1. 
+   Whether to write species output or not. For checkpoint format, always set this parameter to 1.
 
 * ``<diag_name>.species`` (list of `string`, default all physical species in the simulation)
     Which species dumped in this diagnostics.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -222,7 +222,7 @@ Diagnostics::InitData ()
             amrex::Abort("For checkpoint format, write_species flag must be 1.");
     }
     // if user-defined value for write_species == 0, then clear species vector
-        m_species_names.clear();
+    m_species_names.clear();
     m_all_species.clear();
     }
 }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -220,10 +220,10 @@ Diagnostics::InitData ()
     if (write_species == 0) {
         if (m_format == "checkpoint"){
             amrex::Abort("For checkpoint format, write_species flag must be 1.");
-	}
-	// if user-defined value for write_species == 0, then clear species vector
+    }
+    // if user-defined value for write_species == 0, then clear species vector
         m_species_names.clear();
-	m_all_species.clear();
+    m_all_species.clear();
     }
 }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -105,6 +105,7 @@ Diagnostics::BaseReadParameters ()
 
     bool species_specified = pp.queryarr("species", m_species_names);
 
+
     // Prepare to dump rho per species:
     // - add the string "rho_<species_names>" to m_varnames if "rho" is listed in
     //   <diag_name>.<species_name>.variables in the input file
@@ -140,6 +141,7 @@ Diagnostics::BaseReadParameters ()
     }
     // Allocate array of species indices that dump rho per species
     m_rho_per_species_index.resize(ns_dump_rho);
+
     // ns: total number of species
     const int ns = int(m_species_names.size());
     // is_dump_rho: species index to loop over species that dump rho per species
@@ -160,6 +162,8 @@ Diagnostics::BaseReadParameters ()
         // Clear content of species_variables before moving to the next species
         species_variables.clear();
     }
+
+
 
     bool checkpoint_compatibility = false;
     if (m_format == "checkpoint"){
@@ -208,6 +212,18 @@ Diagnostics::InitData ()
         // This is a temporary fix until particle_buffer is supported in diagnostics.
         m_all_species.clear();
         amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+    }
+
+    // default for writing species output is 1
+    int write_species = 1;
+    pp.query("write_species", write_species);
+    if (write_species == 0) {
+        if (m_format == "checkpoint"){
+            amrex::Abort("For checkpoint format, write_species flag must be 1.");
+	}
+	// if user-defined value for write_species == 0, then clear species vector
+        m_species_names.clear();
+	m_all_species.clear();
     }
 }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -144,8 +144,6 @@ Diagnostics::BaseReadParameters ()
         }
     }
 
-
-
     bool checkpoint_compatibility = false;
     if (m_format == "checkpoint"){
        if ( varnames_specified == false &&


### PR DESCRIPTION
This PR add a diagnostic flag to allow the user to turn off species output.

@NeilZaim I have tested this and it works for me. Please let me know if this is the feature you were looking for?
In the input file, adding 
`<diag_name>.write_species = 0` will turn off the species output for that particular diag.

An abort statement is added to ensure that the species output is not set to 0 for checkpoint format.

