### PR TITLE
[mini-PR] Flag to diable all diagnostics.

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1381,6 +1381,9 @@ Note that some parameter (those that do not start with a ``<diag_name>.`` prefix
 This should be changed in the future.
 In-situ capabilities can be used by turning on Sensei or Ascent (provided they are installed) through the output format, see below.
 
+* ``diagnostics.enable`` (`0` or `1`, optional, default `1`)
+    Whether to enable or disable diagnostics. This flag Will over-ride all other diagnostics input parameters.
+
 * ``diagnostics.diags_names`` (list of `string` optional, default `empty`)
     Name of each diagnostics.
     example: ``diagnostics.diags_names = diag1 my_second_diag``.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1382,7 +1382,7 @@ This should be changed in the future.
 In-situ capabilities can be used by turning on Sensei or Ascent (provided they are installed) through the output format, see below.
 
 * ``diagnostics.enable`` (`0` or `1`, optional, default `1`)
-    Whether to enable or disable diagnostics. This flag Will over-ride all other diagnostics input parameters.
+    Whether to enable or disable diagnostics. This flag overwrites all other diagnostics input parameters.
 
 * ``diagnostics.diags_names`` (list of `string` optional, default `empty`)
     Name of each diagnostics.

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -43,9 +43,13 @@ MultiDiagnostics::ReadParameters ()
 {
     ParmParse pp("diagnostics");
 
-    pp.queryarr("diags_names", diags_names);
-    ndiags = diags_names.size();
-    Print()<<"ndiags "<<ndiags<<'\n';
+    int enable_diags = 1;
+    pp.query("enable", enable_diags);
+    if (enable_diags == 1) {
+        pp.queryarr("diags_names", diags_names);
+        ndiags = diags_names.size();
+        Print()<<"ndiags "<<ndiags<<'\n';
+    }
 
     diags_types.resize( ndiags );
     for (int i=0; i<ndiags; i++){


### PR DESCRIPTION
In this PR, a flag is introduced to allow users to disable diagnostics.

The parameter `diagnostics.enable = 0` will disable all diagnostics and override all other diag-related input parameters.

