### PR TITLE
PSATD: only deposit charge if needed

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1209,7 +1209,7 @@ Numerics and algorithms
     This option guarantees charge conservation only when used in combination with ``psatd.periodic_single_box_fft=1``, namely for periodic single-box simulations with global FFTs without guard cells.
     The implementation for domain decomposition with local FFTs over guard cells is planned but not yet completed.
 
-* ``psatd.update_with_rho`` (`0` or `1`; default: `0`)
+* ``psatd.update_with_rho`` (`0` or `1`)
     If true, the update equation for the electric field is expressed in terms of both the current density and the charge density, namely :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}`, :math:`\widehat\rho^{n}`, and :math:`\widehat\rho^{n+1}`.
     If false, instead, the update equation for the electric field is expressed in terms of the current density :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}` only.
     If charge is expected to be conserved (by setting, for example, ``psatd.current_correction=1``), then the two formulations are expected to be equivalent.
@@ -1275,6 +1275,11 @@ Numerics and algorithms
        \end{split}
 
     The coefficients :math:`C`, :math:`S`, :math:`\theta`, :math:`\nu`, :math:`\chi_1`, :math:`\chi_2`, and :math:`\chi_3` are defined in (`Lehe et al, PRE 94, 2016 <https://doi.org/10.1103/PhysRevE.94.053305>`_).
+
+    The default value for ``psatd.update_with_rho`` is ``1`` if ``psatd.v_galilean`` is non-zero or
+    in RZ geometry and ``0`` otherwise.
+
+    Note that ``psatd.update_with_rho=0`` is not supported in RZ geometry.
 
 * ``pstad.v_galilean`` (`3 floats`, in units of the speed of light; default `0. 0. 0.`)
     Defines the galilean velocity.

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -72,8 +72,12 @@ namespace {
         solver.ForwardTransform(*current[1], Idx::Jy);
 #endif
         solver.ForwardTransform(*current[2], Idx::Jz);
+
+        if (rho)
+        {
         solver.ForwardTransform(*rho, Idx::rho_old, 0);
         solver.ForwardTransform(*rho, Idx::rho_new, 1);
+        }
 #ifdef WARPX_DIM_RZ
         if (WarpX::use_kspace_filter) {
             solver.ApplyFilter(Idx::rho_old);

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -73,10 +73,9 @@ namespace {
 #endif
         solver.ForwardTransform(*current[2], Idx::Jz);
 
-        if (rho)
-        {
-        solver.ForwardTransform(*rho, Idx::rho_old, 0);
-        solver.ForwardTransform(*rho, Idx::rho_new, 1);
+        if (rho) {
+            solver.ForwardTransform(*rho, Idx::rho_old, 0);
+            solver.ForwardTransform(*rho, Idx::rho_new, 1);
         }
 #ifdef WARPX_DIM_RZ
         if (WarpX::use_kspace_filter) {


### PR DESCRIPTION
With the PSATD solver, we currently deposit the charge at every timestep even if it is not necessary. In this PR, we only allocate the `rho_fp` MultiFAB when `do_dive_cleaning || (plot_rho && do_back_transformed_diagnostics) || update_with_rho || current_correction`. Charge deposition is then disabled if `rho_fp` is not allocated, as is currently done with FDTD solvers.

This also adds an assert that `update_with_rho` is true with PSATD+RZ.