### PR TITLE
Replace wherever possible '.reset(new' with '= make_unique'

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <algorithm>
+#include <memory>
 
 
 using namespace amrex;
@@ -493,18 +494,18 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     ngf = ngFFT;
 #endif
 
-    pml_E_fp[0].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect() ), dm, 3, nge ) );
-    pml_E_fp[1].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect() ), dm, 3, nge ) );
-    pml_E_fp[2].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, 3, nge ) );
-    pml_B_fp[0].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,0).ixType().toIntVect() ), dm, 2, ngb ) );
-    pml_B_fp[1].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,1).ixType().toIntVect() ), dm, 2, ngb ) );
-    pml_B_fp[2].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,2).ixType().toIntVect() ), dm, 2, ngb ) );
+    pml_E_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect() ), dm, 3, nge );
+    pml_E_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect() ), dm, 3, nge );
+    pml_E_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, 3, nge );
+    pml_B_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getBfield_fp(0,0).ixType().toIntVect() ), dm, 2, ngb );
+    pml_B_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getBfield_fp(0,1).ixType().toIntVect() ), dm, 2, ngb );
+    pml_B_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getBfield_fp(0,2).ixType().toIntVect() ), dm, 2, ngb );
 
 
     pml_E_fp[0]->setVal(0.0);
@@ -514,27 +515,27 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     pml_B_fp[1]->setVal(0.0);
     pml_B_fp[2]->setVal(0.0);
 
-    pml_j_fp[0].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,0).ixType().toIntVect() ), dm, 1, ngb ) );
-    pml_j_fp[1].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,1).ixType().toIntVect() ), dm, 1, ngb ) );
-    pml_j_fp[2].reset( new MultiFab( amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,2).ixType().toIntVect() ), dm, 1, ngb ) );
+    pml_j_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getcurrent_fp(0,0).ixType().toIntVect() ), dm, 1, ngb );
+    pml_j_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getcurrent_fp(0,1).ixType().toIntVect() ), dm, 1, ngb );
+    pml_j_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
+        WarpX::GetInstance().getcurrent_fp(0,2).ixType().toIntVect() ), dm, 1, ngb );
     pml_j_fp[0]->setVal(0.0);
     pml_j_fp[1]->setVal(0.0);
     pml_j_fp[2]->setVal(0.0);
 
     if (do_dive_cleaning)
     {
-        pml_F_fp.reset(new MultiFab(amrex::convert(ba,IntVect::TheUnitVector()), dm, 3, ngf));
+        pml_F_fp = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()), dm, 3, ngf);
         pml_F_fp->setVal(0.0);
     }
 
     if (do_pml_in_domain){
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta));
+        sigba_fp = std::make_unique<MultiSigmaBox>(ba, dm, grid_ba_reduced, geom->CellSize(), ncell, delta);
     }
     else {
-        sigba_fp.reset(new MultiSigmaBox(ba, dm, grid_ba, geom->CellSize(), ncell, delta));
+        sigba_fp = std::make_unique<MultiSigmaBox>(ba, dm, grid_ba, geom->CellSize(), ncell, delta);
     }
 
 
@@ -547,8 +548,8 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     BoxArray realspace_ba = ba;  // Copy box
     Array<Real,3> v_galilean_zero = {0,0,0};
     realspace_ba.enclosedCells().grow(nge); // cell-centered + guard cells
-    spectral_solver_fp.reset( new SpectralSolver( realspace_ba, dm,
-        nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero, dx, dt, in_pml ) );
+    spectral_solver_fp = std::make_unique<SpectralSolver>(realspace_ba, dm,
+        nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero, dx, dt, in_pml );
 #endif
 
     if (cgeom)
@@ -568,18 +569,18 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
 
         DistributionMapping cdm{cba};
 
-        pml_E_cp[0].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,0).ixType().toIntVect() ), cdm, 3, nge ) );
-        pml_E_cp[1].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,1).ixType().toIntVect() ), cdm, 3, nge ) );
-        pml_E_cp[2].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,2).ixType().toIntVect() ), cdm, 3, nge ) );
-        pml_B_cp[0].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,0).ixType().toIntVect() ), cdm, 2, ngb ) );
-        pml_B_cp[1].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,1).ixType().toIntVect() ), cdm, 2, ngb ) );
-        pml_B_cp[2].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,2).ixType().toIntVect() ), cdm, 2, ngb ) );
+        pml_E_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getEfield_cp(1,0).ixType().toIntVect() ), cdm, 3, nge );
+        pml_E_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getEfield_cp(1,1).ixType().toIntVect() ), cdm, 3, nge );
+        pml_E_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getEfield_cp(1,2).ixType().toIntVect() ), cdm, 3, nge );
+        pml_B_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getBfield_cp(1,0).ixType().toIntVect() ), cdm, 2, ngb );
+        pml_B_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getBfield_cp(1,1).ixType().toIntVect() ), cdm, 2, ngb );
+        pml_B_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getBfield_cp(1,2).ixType().toIntVect() ), cdm, 2, ngb );
 
         pml_E_cp[0]->setVal(0.0);
         pml_E_cp[1]->setVal(0.0);
@@ -590,24 +591,24 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
 
         if (do_dive_cleaning)
         {
-            pml_F_cp.reset(new MultiFab(amrex::convert(cba,IntVect::TheUnitVector()), cdm, 3, ngf));
+            pml_F_cp = std::make_unique<MultiFab>(amrex::convert(cba,IntVect::TheUnitVector()), cdm, 3, ngf);
             pml_F_cp->setVal(0.0);
 
         }
-        pml_j_cp[0].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,0).ixType().toIntVect() ), cdm, 1, ngb ) );
-        pml_j_cp[1].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,1).ixType().toIntVect() ), cdm, 1, ngb ) );
-        pml_j_cp[2].reset( new MultiFab( amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,2).ixType().toIntVect() ), cdm, 1, ngb ) );
+        pml_j_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getcurrent_cp(1,0).ixType().toIntVect() ), cdm, 1, ngb );
+        pml_j_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getcurrent_cp(1,1).ixType().toIntVect() ), cdm, 1, ngb );
+        pml_j_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
+            WarpX::GetInstance().getcurrent_cp(1,2).ixType().toIntVect() ), cdm, 1, ngb );
         pml_j_cp[0]->setVal(0.0);
         pml_j_cp[1]->setVal(0.0);
         pml_j_cp[2]->setVal(0.0);
 
         if (do_pml_in_domain){
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell, delta));
+            sigba_cp = std::make_unique<MultiSigmaBox>(cba, cdm, grid_cba_reduced, cgeom->CellSize(), ncell, delta);
         } else {
-            sigba_cp.reset(new MultiSigmaBox(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta));
+            sigba_cp = std::make_unique<MultiSigmaBox>(cba, cdm, grid_cba, cgeom->CellSize(), ncell, delta);
         }
 
 #ifdef WARPX_USE_PSATD
@@ -617,8 +618,8 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         // const bool in_pml = true; // Tells spectral solver to use split-PML equations
 
         realspace_cba.enclosedCells().grow(nge); // cell-centered + guard cells
-        spectral_solver_cp.reset( new SpectralSolver( realspace_cba, cdm,
-            nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero, cdx, dt, in_pml ) );
+        spectral_solver_cp = std::make_unique<SpectralSolver>(realspace_cba, cdm,
+            nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero, cdx, dt, in_pml );
 #endif
     }
 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -6,9 +6,13 @@
 #include "ComputeDiagFunctors/BackTransformFunctor.H"
 #include "ComputeDiagFunctors/RhoFunctor.H"
 #include "Utils/CoarsenIO.H"
+
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_VisMF.H>
+
+#include <memory>
+
 using namespace amrex::literals;
 
 BTDiagnostics::BTDiagnostics (int i, std::string name)
@@ -303,8 +307,8 @@ BTDiagnostics::DefineCellCenteredMultiFab(int lev)
     ba.coarsen(m_crse_ratio);
     amrex::DistributionMapping dmap = warpx.DistributionMap(lev);
     int ngrow = 1;
-    m_cell_centered_data[lev].reset( new amrex::MultiFab(ba, dmap,
-                                     m_cellcenter_varnames.size(), ngrow) );
+    m_cell_centered_data[lev] = std::make_unique<amrex::MultiFab>(ba, dmap,
+                                     m_cellcenter_varnames.size(), ngrow);
 
 }
 

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -12,6 +12,8 @@
 #include "SliceDiagnostic.H"
 #include "WarpX.H"
 
+#include <memory>
+
 using namespace amrex;
 
 #ifdef WARPX_USE_HDF5
@@ -595,11 +597,11 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
         prob_domain_lab.setLo(AMREX_SPACEDIM-1, zmin_lab + v_window_lab * t_lab);
         prob_domain_lab.setHi(AMREX_SPACEDIM-1, zmax_lab + v_window_lab * t_lab);
         Box diag_box = geom.Domain();
-        m_LabFrameDiags_[i].reset(new LabFrameSnapShot(t_lab, t_boost,
+        m_LabFrameDiags_[i] = std::make_unique<LabFrameSnapShot>(t_lab, t_boost,
                                 m_inv_gamma_boost_, m_inv_beta_boost_, m_dz_lab_,
                                 prob_domain_lab, prob_ncells_lab,
                                 m_ncomp_to_dump, m_mesh_field_names, prob_domain_lab,
-                                diag_box, i));
+                                diag_box, i);
     }
 
 
@@ -675,11 +677,11 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
                                          v_window_lab * t_slice_lab );
 
         // construct labframeslice
-        m_LabFrameDiags_[i+N_snapshots].reset(new LabFrameSlice(t_slice_lab, t_boost,
+        m_LabFrameDiags_[i+N_snapshots] = std::make_unique<LabFrameSlice>(t_slice_lab, t_boost,
                                 m_inv_gamma_boost_, m_inv_beta_boost_, m_dz_lab_,
                                 prob_domain_lab, slice_ncells_lab,
                                 m_ncomp_to_dump, m_mesh_field_names, slice_dom_lab,
-                                slicediag_box, i, m_particle_slice_width_lab_));
+                                slicediag_box, i, m_particle_slice_width_lab_);
     }
     // sort diags based on their respective t_lab
     std::stable_sort(m_LabFrameDiags_.begin(), m_LabFrameDiags_.end(), compare_tlab_uptr);
@@ -826,8 +828,8 @@ writeLabFrameData(const MultiFab* cell_centered_data,
                 BoxArray buff_ba(lf_diags->m_buff_box_);
                 buff_ba.maxSize(m_max_box_size_);
                 DistributionMapping buff_dm(buff_ba);
-                lf_diags->m_data_buffer_.reset( new MultiFab(buff_ba,
-                                                buff_dm, m_ncomp_to_dump, 0) );
+                lf_diags->m_data_buffer_ = std::make_unique<MultiFab>(buff_ba,
+                                                buff_dm, m_ncomp_to_dump, 0);
             }
             // ... reset particle buffer particles_buffer_[i]
             if (WarpX::do_back_transformed_particles)
@@ -843,8 +845,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
             if (lf_diags->m_t_lab != prev_t_lab ) {
                if (slice)
                {
-                 slice.reset(new MultiFab);
-                 slice.reset(nullptr);
+                 slice = nullptr;
                }
                slice = amrex::get_slice_data(m_boost_direction_,
                                              lf_diags->m_current_z_boost,
@@ -867,9 +868,9 @@ writeLabFrameData(const MultiFab* cell_centered_data,
              // Make it a BoxArray slice_ba
              BoxArray slice_ba(slice_box);
              slice_ba.maxSize(m_max_box_size_);
-             tmp_slice_ptr = std::unique_ptr<MultiFab>(new MultiFab(slice_ba,
+             tmp_slice_ptr = std::make_unique<MultiFab>(slice_ba,
                              lf_diags->m_data_buffer_->DistributionMap(),
-                             ncomp, 0));
+                             ncomp, 0);
 
              // slice is re-used if the t_lab of a diag is equal to
              // that of the previous diag.
@@ -880,8 +881,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
              tmp_slice_ptr->copy(*slice, 0, 0, ncomp);
              lf_diags->AddDataToBuffer(*tmp_slice_ptr, i_lab,
                                                map_actual_fields_to_dump);
-             tmp_slice_ptr.reset(new MultiFab);
-             tmp_slice_ptr.reset(nullptr);
+             tmp_slice_ptr = nullptr;
         }
 
         if (WarpX::do_back_transformed_particles) {

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -1,7 +1,11 @@
 #include "BackTransformFunctor.H"
 #include "WarpX.H"
+
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_MultiFabUtil_C.H>
+
+#include <memory>
+
 using namespace amrex;
 
 BackTransformFunctor::BackTransformFunctor (amrex::MultiFab const * mf_src, int lev,
@@ -50,8 +54,8 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         // Define MultiFab with the distribution map of the destination multifab and
         // containing all ten components that were in the slice generated from m_mf_src.
         std::unique_ptr< amrex::MultiFab > tmp_slice_ptr = nullptr;
-        tmp_slice_ptr.reset( new MultiFab ( slice_ba, mf_dst.DistributionMap(),
-                                            slice->nComp(), 0) );
+        tmp_slice_ptr = std::make_unique<MultiFab> ( slice_ba, mf_dst.DistributionMap(),
+                                            slice->nComp(), 0 );
         // Parallel copy the lab-frame data from "slice" MultiFab with
         // ncomp=10 and boosted-frame dmap to "tmp_slice_ptr" MultiFab with
         // ncomp=10 and dmap of the destination Multifab, which will store the final data
@@ -96,11 +100,8 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         }
 
         // Reset the temporary MultiFabs generated
-        slice.reset(new MultiFab);
-        slice.reset(nullptr);
-        tmp_slice_ptr.reset(new MultiFab);
-        tmp_slice_ptr.reset(nullptr);
-
+        slice = nullptr;
+        tmp_slice_ptr = nullptr;
     }
 
 }

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -129,9 +129,9 @@ AverageAndPackVectorField( MultiFab& mf_avg,
         ConstructTotalRZVectorField(vector_total, vector_field);
     } else {
         // Create aliases of the MultiFabs
-        vector_total[0] = std::make_unique<MultiFab>(MultiFab(*vector_field[0], amrex::make_alias, 0, 1);
-        vector_total[1] = std::make_unique<MultiFab>(MultiFab(*vector_field[1], amrex::make_alias, 0, 1);
-        vector_total[2] = std::make_unique<MultiFab>(MultiFab(*vector_field[2], amrex::make_alias, 0, 1);
+        vector_total[0] = std::make_unique<MultiFab>(*vector_field[0], amrex::make_alias, 0, 1);
+        vector_total[1] = std::make_unique<MultiFab>(*vector_field[1], amrex::make_alias, 0, 1);
+        vector_total[2] = std::make_unique<MultiFab>(*vector_field[2], amrex::make_alias, 0, 1);
     }
 #else
     const std::array<std::unique_ptr<MultiFab>,3> &vector_total = vector_field;

--- a/Source/Diagnostics/FieldIO.cpp
+++ b/Source/Diagnostics/FieldIO.cpp
@@ -20,6 +20,8 @@
 
 #include <AMReX.H>
 
+#include <memory>
+
 using namespace amrex;
 
 /** \brief
@@ -121,15 +123,15 @@ AverageAndPackVectorField( MultiFab& mf_avg,
     if (vector_field[0]->nComp() > 1) {
         // With the RZ solver, if there are more than one component, the total
         // fields needs to be constructed in temporary MultiFabs.
-        vector_total[0].reset(new MultiFab(vector_field[0]->boxArray(), dm, 1, vector_field[0]->nGrowVect()));
-        vector_total[1].reset(new MultiFab(vector_field[1]->boxArray(), dm, 1, vector_field[1]->nGrowVect()));
-        vector_total[2].reset(new MultiFab(vector_field[2]->boxArray(), dm, 1, vector_field[2]->nGrowVect()));
+        vector_total[0] = std::make_unique<MultiFab>(vector_field[0]->boxArray(), dm, 1, vector_field[0]->nGrowVect());
+        vector_total[1] = std::make_unique<MultiFab>(vector_field[1]->boxArray(), dm, 1, vector_field[1]->nGrowVect());
+        vector_total[2] = std::make_unique<MultiFab>(vector_field[2]->boxArray(), dm, 1, vector_field[2]->nGrowVect());
         ConstructTotalRZVectorField(vector_total, vector_field);
     } else {
         // Create aliases of the MultiFabs
-        vector_total[0].reset(new MultiFab(*vector_field[0], amrex::make_alias, 0, 1));
-        vector_total[1].reset(new MultiFab(*vector_field[1], amrex::make_alias, 0, 1));
-        vector_total[2].reset(new MultiFab(*vector_field[2], amrex::make_alias, 0, 1));
+        vector_total[0] = std::make_unique<MultiFab>(MultiFab(*vector_field[0], amrex::make_alias, 0, 1);
+        vector_total[1] = std::make_unique<MultiFab>(MultiFab(*vector_field[1], amrex::make_alias, 0, 1);
+        vector_total[2] = std::make_unique<MultiFab>(MultiFab(*vector_field[2], amrex::make_alias, 0, 1);
     }
 #else
     const std::array<std::unique_ptr<MultiFab>,3> &vector_total = vector_field;

--- a/Source/Diagnostics/MultiDiagnostics.H
+++ b/Source/Diagnostics/MultiDiagnostics.H
@@ -4,6 +4,8 @@
 #include "FullDiagnostics.H"
 #include "BTDiagnostics.H"
 
+#include <memory>
+
 /** All types of diagnostics. */
 enum struct DiagTypes {Full, BackTransformed};
 

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -12,9 +12,9 @@ MultiDiagnostics::MultiDiagnostics ()
     alldiags.resize( ndiags );
     for (int i=0; i<ndiags; i++){
         if ( diags_types[i] == DiagTypes::Full ){
-            alldiags[i].reset( new FullDiagnostics(i, diags_names[i]) );
+            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
-            alldiags[i].reset( new BTDiagnostics(i, diags_names[i]) );
+            alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
         } else {
             amrex::Abort("Unknown diagnostic type");
         }

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.H
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.H
@@ -5,6 +5,8 @@
 #include "Utils/WarpXUtil.H"
 #include "Particles/WarpXParticleContainer.H"
 
+#include <memory>
+
 class ParticleDiag
 {
 public:

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -74,7 +74,7 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
         std::string function_string = "";
         Store_parserString(pp,"plot_filter_function(t,x,y,z,ux,uy,uz)",
                            function_string);
-        m_particle_filter_parser.reset(new ParserWrapper<7>(
-            makeParser(function_string,{"t","x","y","z","ux","uy","uz"})));
+        m_particle_filter_parser = std::make_unique<ParserWrapper<7>>(
+            makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
     }
 }

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -9,6 +9,7 @@
 #include "LoadBalanceCosts.H"
 #include "Utils/WarpXUtil.H"
 
+#include <memory>
 
 using namespace amrex;
 
@@ -58,7 +59,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
     costs.resize(nLevels);
     for (int lev = 0; lev < nLevels; ++lev)
     {
-        costs[lev].reset(new amrex::LayoutData<Real>(*warpx.getCosts(lev)));
+        costs[lev] = std::make_unique<LayoutData<Real>>(*warpx.getCosts(lev));
     }
 
     if (warpx.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -47,33 +47,33 @@ MultiReducedDiags::MultiReducedDiags ()
         // match diags
         if (rd_type.compare("ParticleEnergy") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new ParticleEnergy(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<ParticleEnergy>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("FieldEnergy") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new FieldEnergy(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<FieldEnergy>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("FieldMaximum") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new FieldMaximum(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<FieldMaximum>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("BeamRelevant") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new BeamRelevant(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<BeamRelevant>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("LoadBalanceCosts") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new LoadBalanceCosts(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<LoadBalanceCosts>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("ParticleHistogram") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new ParticleHistogram(m_rd_names[i_rd]));
+            m_multi_rd[i_rd] =
+                std::make_unique<ParticleHistogram>(m_rd_names[i_rd]);
         }
         else
         { Abort("No matching reduced diagnostics type found."); }

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -78,8 +78,8 @@ MultiReducedDiags::MultiReducedDiags ()
         }
         else if (rd_type.compare("ParticleNumber") == 0)
         {
-            m_multi_rd[i_rd].reset
-                ( new ParticleNumber(m_rd_names[i_rd]));
+            m_multi_rd[i_rd]=
+                std::make_unique<ParticleNumber>(m_rd_names[i_rd]);
         }
         else
         { Abort("No matching reduced diagnostics type found."); }

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -8,9 +8,12 @@
 #include "ParticleHistogram.H"
 #include "WarpX.H"
 #include "Utils/WarpXUtil.H"
+
 #include <AMReX_REAL.H>
 #include <AMReX_ParticleReduce.H>
+
 #include <limits>
+#include <memory>
 
 using namespace amrex;
 
@@ -44,8 +47,8 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
     std::string function_string = "";
     Store_parserString(pp,"histogram_function(t,x,y,z,ux,uy,uz)",
                        function_string);
-    m_parser.reset(new ParserWrapper<m_nvars>(
-        makeParser(function_string,{"t","x","y","z","ux","uy","uz"})));
+    m_parser = std::make_unique<ParserWrapper<m_nvars>>(
+        makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
 
     // read normalization type
     std::string norm_string = "default";

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -11,6 +11,8 @@
 
 #include <WarpX.H>
 
+#include <memory>
+
 using namespace amrex;
 
 
@@ -113,8 +115,8 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
     Vector<DistributionMapping> sdmap(1);
     sdmap[0] = DistributionMapping{sba[0]};
 
-    smf.reset(new MultiFab(amrex::convert(sba[0],SliceType), sdmap[0],
-                           ncomp, nghost));
+    smf = std::make_unique<MultiFab>(amrex::convert(sba[0],SliceType), sdmap[0],
+                           ncomp, nghost);
 
     // Copy data from domain to slice that has same cell size as that of //
     // the domain mf. src and dst have the same number of ghost cells    //
@@ -137,8 +139,8 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
 
        AMREX_ALWAYS_ASSERT(crse_ba[0].size() == sba[0].size());
 
-       cs_mf.reset( new MultiFab(amrex::convert(crse_ba[0],SliceType),
-                    sdmap[0], ncomp,nghost));
+       cs_mf = std::make_unique<MultiFab>(amrex::convert(crse_ba[0],SliceType),
+                    sdmap[0], ncomp,nghost);
 
        MultiFab& mfSrc = *smf;
        MultiFab& mfDst = *cs_mf;
@@ -480,10 +482,3 @@ InterpolateLo(const Box& bx, FArrayBox &fabox, IntVect slice_lo,
     }
 
 }
-
-
-
-
-
-
-

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -24,6 +24,7 @@
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 
+#include <memory>
 
 using namespace amrex;
 
@@ -251,7 +252,7 @@ WarpX::GetCellCenteredData() {
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        cc[lev].reset( new MultiFab(grids[lev], dmap[lev], nc, ng) );
+        cc[lev] = std::make_unique<MultiFab>(grids[lev], dmap[lev], nc, ng );
 
         int dcomp = 0;
         // first the electric field

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -438,7 +438,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
            {
                //for std::make_shared<T[]> we should wait C++20
                //in the meanwhile, a unique_ptr can be converted in a shared_ptr
-               std::shared_ptr<amrex::ParticleReal> z =
+               std::shared_ptr<amrex::ParticleReal[]> z =
                 std::make_unique<amrex::ParticleReal[]>(numParticleOnTile);
 
               for (auto i = 0; i < numParticleOnTile; i++)
@@ -454,10 +454,10 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(int(soa.GetRealData(PIdx::theta).size()) == numParticleOnTile,
                                             "openPMD: theta and tile size do not match");
            {
-               std::shared_ptr<amrex::ParticleReal> x =
+               std::shared_ptr<amrex::ParticleReal[]> x =
                 std::make_unique<amrex::ParticleReal[]>(numParticleOnTile);
 
-                std::shared_ptr<amrex::ParticleReal> y =
+                std::shared_ptr<amrex::ParticleReal[]> y =
                  std::make_unique<amrex::ParticleReal[]>(numParticleOnTile);
 
                for (auto i=0; i<numParticleOnTile; i++) {
@@ -470,7 +470,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
            }
 #else
            for (auto currDim = 0; currDim < AMREX_SPACEDIM; currDim++) {
-                std::shared_ptr<amrex::ParticleReal> curr =
+                std::shared_ptr<amrex::ParticleReal[]> curr =
                     std::make_unique<amrex::ParticleReal[]>(numParticleOnTile);
 
                 for (auto i=0; i<numParticleOnTile; i++) {
@@ -482,7 +482,7 @@ WarpXOpenPMDPlot::DumpToFile (WarpXParticleContainer* pc,
 #endif
 
            // save particle ID after converting it to a globally unique ID
-           std::shared_ptr< uint64_t > ids =
+           std::shared_ptr<uint64_t[]> ids =
             std::make_unique<uint64_t[]>(numParticleOnTile);
 
            for (auto i=0; i<numParticleOnTile; i++) {
@@ -580,7 +580,7 @@ WarpXOpenPMDPlot::SaveRealProperty(WarpXParIter& pti,
           auto currRecord = currSpecies[record_name];
           auto currRecordComp = currRecord[component_name];
 
-          std::shared_ptr< amrex::ParticleReal > d =
+          std::shared_ptr<amrex::ParticleReal[]> d =
             std::make_unique<amrex::ParticleReal[]>(numParticleOnTile);
 
           for( auto kk=0; kk<numParticleOnTile; kk++ )

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -11,6 +11,8 @@
 
 #include <WarpX.H>
 
+#include <memory>
+
 using namespace amrex;
 
 void
@@ -52,8 +54,8 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     for (int lev = 0; lev <= max_level; lev++) {
         BoxArray nba = boxArray(lev);
         nba.surroundingNodes();
-        rho[lev].reset(new MultiFab(nba, dmap[lev], 1, ng));
-        phi[lev].reset(new MultiFab(nba, dmap[lev], 1, 1));
+        rho[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, ng);
+        phi[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, 1);
         phi[lev]->setVal(0.);
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -2,6 +2,8 @@
 #include <AMReX_ParmParse.H>
 #include "WarpX.H"
 
+#include <memory>
+
 using namespace amrex;
 
 MacroscopicProperties::MacroscopicProperties ()
@@ -34,8 +36,8 @@ MacroscopicProperties::ReadParameters ()
     // initialization of sigma (conductivity) with parser
     if (m_sigma_s == "parse_sigma_function") {
         Store_parserString(pp, "sigma_function(x,y,z)", m_str_sigma_function);
-        m_sigma_parser.reset(new ParserWrapper<3>(
-                                 makeParser(m_str_sigma_function,{"x","y","z"}) ) );
+        m_sigma_parser = std::make_unique<ParserWrapper<3>>(
+                                 makeParser(m_str_sigma_function,{"x","y","z"}));
     }
 
     bool epsilon_specified = false;
@@ -54,8 +56,8 @@ MacroscopicProperties::ReadParameters ()
     // initialization of epsilon (permittivity) with parser
     if (m_epsilon_s == "parse_epsilon_function") {
         Store_parserString(pp, "epsilon_function(x,y,z)", m_str_epsilon_function);
-        m_epsilon_parser.reset(new ParserWrapper<3>(
-                                 makeParser(m_str_epsilon_function,{"x","y","z"}) ) );
+        m_epsilon_parser = std::make_unique<ParserWrapper<3>>(
+                                 makeParser(m_str_epsilon_function,{"x","y","z"}));
     }
 
     // Query input for material permittivity, epsilon.
@@ -75,8 +77,8 @@ MacroscopicProperties::ReadParameters ()
     // initialization of mu (permeability) with parser
     if (m_mu_s == "parse_mu_function") {
         Store_parserString(pp, "mu_function(x,y,z)", m_str_mu_function);
-        m_mu_parser.reset(new ParserWrapper<3>(
-                                 makeParser(m_str_mu_function,{"x","y","z"}) ) );
+        m_mu_parser = std::make_unique<ParserWrapper<3>>(
+                                 makeParser(m_str_mu_function,{"x","y","z"}));
     }
 
 }
@@ -194,4 +196,3 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
 
 
 }
-

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/SpectralHankelTransformer.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/SpectralHankelTransformer.cpp
@@ -7,6 +7,8 @@
 #include "Utils/WarpXConst.H"
 #include "SpectralHankelTransformer.H"
 
+#include <memory>
+
 SpectralHankelTransformer::SpectralHankelTransformer (int const nr,
                                                       int const n_rz_azimuthal_modes,
                                                       amrex::Real const rmax)
@@ -18,9 +20,9 @@ SpectralHankelTransformer::SpectralHankelTransformer (int const nr,
     dhtm.resize(m_n_rz_azimuthal_modes);
 
     for (int mode=0 ; mode < m_n_rz_azimuthal_modes ; mode++) {
-        dht0[mode].reset( new HankelTransform(mode  , mode, m_nr, rmax) );
-        dhtp[mode].reset( new HankelTransform(mode+1, mode, m_nr, rmax) );
-        dhtm[mode].reset( new HankelTransform(mode-1, mode, m_nr, rmax) );
+        dht0[mode] = std::make_unique<HankelTransform>(mode  , mode, m_nr, rmax);
+        dhtp[mode] = std::make_unique<HankelTransform>(mode+1, mode, m_nr, rmax);
+        dhtm[mode] = std::make_unique<HankelTransform>(mode-1, mode, m_nr, rmax);
     }
 
     ExtractKrArray();

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -14,6 +14,8 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
 
+#include <memory>
+
 #if WARPX_USE_PSATD
 
 /* \brief Initialize the spectral Maxwell solver
@@ -53,23 +55,23 @@ SpectralSolver::SpectralSolver(
     //   Initialize the corresponding coefficients over k space
 
     if (pml) {
-        algorithm = std::unique_ptr<PMLPsatdAlgorithm>( new PMLPsatdAlgorithm(
-            k_space, dm, norder_x, norder_y, norder_z, nodal, dt ) );
+        algorithm = std::make_unique<PMLPsatdAlgorithm>(
+            k_space, dm, norder_x, norder_y, norder_z, nodal, dt);
     }
     else {
         if (fft_do_time_averaging){
-            algorithm = std::unique_ptr<AvgGalileanAlgorithm>( new AvgGalileanAlgorithm(
-                k_space, dm, norder_x, norder_y, norder_z, nodal, v_galilean, dt ) );
+            algorithm = std::make_unique<AvgGalileanAlgorithm>(
+                k_space, dm, norder_x, norder_y, norder_z, nodal, v_galilean, dt);
         }
         else {
             if ((v_galilean[0]==0) && (v_galilean[1]==0) && (v_galilean[2]==0)){
                 // v_galilean is 0: use standard PSATD algorithm
-                algorithm = std::unique_ptr<PsatdAlgorithm>( new PsatdAlgorithm(
-                   k_space, dm, norder_x, norder_y, norder_z, nodal, dt, update_with_rho ) );
+                algorithm = std::make_unique<PsatdAlgorithm>(
+                   k_space, dm, norder_x, norder_y, norder_z, nodal, dt, update_with_rho);
             }
             else {
-                algorithm = std::unique_ptr<GalileanAlgorithm>( new GalileanAlgorithm(
-                    k_space, dm, norder_x, norder_y, norder_z, nodal, v_galilean, dt, update_with_rho ) );
+                algorithm = std::make_unique<GalileanAlgorithm>(
+                    k_space, dm, norder_x, norder_y, norder_z, nodal, v_galilean, dt, update_with_rho);
             }
         }
     }

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
@@ -45,12 +45,12 @@ SpectralSolverRZ::SpectralSolverRZ (amrex::BoxArray const & realspace_ba,
     //   PML is not supported.
     if (v_galilean[2] == 0) {
          // v_galilean is 0: use standard PSATD algorithm
-        algorithm = std::unique_ptr<PsatdAlgorithmRZ>(
-            new PsatdAlgorithmRZ(k_space, dm, n_rz_azimuthal_modes, norder_z, nodal, dt));
+        algorithm = std::make_unique<PsatdAlgorithmRZ>(
+            k_space, dm, n_rz_azimuthal_modes, norder_z, nodal, dt);
     } else {
         // Otherwise: use the Galilean algorithm
-        algorithm = std::unique_ptr<GalileanPsatdAlgorithmRZ>(
-            new GalileanPsatdAlgorithmRZ(k_space, dm, n_rz_azimuthal_modes, norder_z, nodal, v_galilean, dt));
+        algorithm = std::make_unique<GalileanPsatdAlgorithmRZ>(
+            k_space, dm, n_rz_azimuthal_modes, norder_z, nodal, v_galilean, dt);
     }
 
     // - Initialize arrays for fields in spectral space + FFT plans

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -26,6 +26,7 @@
 #endif
 
 #include <array>
+#include <memory>
 
 ///
 /// The PlasmaInjector class parses and stores information about the plasma

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <memory>
 
 
 using namespace amrex;
@@ -230,8 +231,9 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             "(Please visit PR#765 for more information.)");
 #endif
         // Construct InjectorPosition with InjectorPositionRandom.
-        h_inj_pos.reset(new InjectorPosition((InjectorPositionRandom*)nullptr,
-                                             xmin, xmax, ymin, ymax, zmin, zmax));
+        h_inj_pos = std::make_unique<InjectorPosition>(
+            (InjectorPositionRandom*)nullptr,
+            xmin, xmax, ymin, ymax, zmin, zmax);
         parseDensity(pp);
         parseMomentum(pp);
     } else if (part_pos_s == "nuniformpercell") {
@@ -250,11 +252,12 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             "n_rz_azimuthal_modes (Please visit PR#765 for more information.)");
 #endif
         // Construct InjectorPosition from InjectorPositionRegular.
-        h_inj_pos.reset(new InjectorPosition((InjectorPositionRegular*)nullptr,
-                                             xmin, xmax, ymin, ymax, zmin, zmax,
-                                             Dim3{num_particles_per_cell_each_dim[0],
-                                                  num_particles_per_cell_each_dim[1],
-                                                  num_particles_per_cell_each_dim[2]}));
+        h_inj_pos = std::make_unique<InjectorPosition>(
+            (InjectorPositionRegular*)nullptr,
+            xmin, xmax, ymin, ymax, zmin, zmax,
+            Dim3{num_particles_per_cell_each_dim[0],
+                num_particles_per_cell_each_dim[1],
+                num_particles_per_cell_each_dim[2]});
         num_particles_per_cell = num_particles_per_cell_each_dim[0] *
                                  num_particles_per_cell_each_dim[1] *
                                  num_particles_per_cell_each_dim[2];

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <cstdlib>
 
+#include <memory>
+
 using namespace amrex;
 
 void
@@ -114,12 +116,13 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             Array<std::unique_ptr<MultiFab>,3> Btmp;
             if (Bfield_cax[lev][0]) {
                 for (int i = 0; i < 3; ++i) {
-                    Btmp[i].reset(new MultiFab(*Bfield_cax[lev][i], amrex::make_alias, 0, 1));
+                    Btmp[i] = std::make_unique<MultiFab>(
+                        *Bfield_cax[lev][i], amrex::make_alias, 0, 1);
                 }
             } else {
                 IntVect ngtmp = Bfield_aux[lev-1][0]->nGrowVect();
                 for (int i = 0; i < 3; ++i) {
-                    Btmp[i].reset(new MultiFab(cnba, dm, 1, ngtmp));
+                    Btmp[i] = std::make_unique<MultiFab>(cnba, dm, 1, ngtmp);
                 }
             }
             // ParallelCopy from coarse level
@@ -162,12 +165,14 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             Array<std::unique_ptr<MultiFab>,3> Etmp;
             if (Efield_cax[lev][0]) {
                 for (int i = 0; i < 3; ++i) {
-                    Etmp[i].reset(new MultiFab(*Efield_cax[lev][i], amrex::make_alias, 0, 1));
+                    Etmp[i] = std::make_unique<MultiFab>(
+                        *Efield_cax[lev][i], amrex::make_alias, 0, 1);
                 }
             } else {
                 IntVect ngtmp = Efield_aux[lev-1][0]->nGrowVect();
                 for (int i = 0; i < 3; ++i) {
-                    Etmp[i].reset(new MultiFab(cnba, dm, 1, ngtmp));
+                    Etmp[i] = std::make_unique<MultiFab>(
+                        cnba, dm, 1, ngtmp);
                 }
             }
             // ParallelCopy from coarse level

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -11,6 +11,8 @@
 
 #include <AMReX_BLProfiler.H>
 
+#include <memory>
+
 using namespace amrex;
 
 void
@@ -107,29 +109,29 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         {
             {
                 const IntVect& ng = Bfield_fp[lev][idim]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Bfield_fp[lev][idim]->boxArray(),
-                                                                  dm, Bfield_fp[lev][idim]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(Bfield_fp[lev][idim]->boxArray(),
+                                                                  dm, Bfield_fp[lev][idim]->nComp(), ng);
                 pmf->Redistribute(*Bfield_fp[lev][idim], 0, 0, Bfield_fp[lev][idim]->nComp(), ng);
                 Bfield_fp[lev][idim] = std::move(pmf);
             }
             {
                 const IntVect& ng = Efield_fp[lev][idim]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Efield_fp[lev][idim]->boxArray(),
-                                                                  dm, Efield_fp[lev][idim]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(Efield_fp[lev][idim]->boxArray(),
+                                                                  dm, Efield_fp[lev][idim]->nComp(), ng);
                 pmf->Redistribute(*Efield_fp[lev][idim], 0, 0, Efield_fp[lev][idim]->nComp(), ng);
                 Efield_fp[lev][idim] = std::move(pmf);
             }
             {
                 const IntVect& ng = current_fp[lev][idim]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(current_fp[lev][idim]->boxArray(),
-                                                                  dm, current_fp[lev][idim]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(current_fp[lev][idim]->boxArray(),
+                                                                  dm, current_fp[lev][idim]->nComp(), ng);
                 current_fp[lev][idim] = std::move(pmf);
             }
             if (current_store[lev][idim])
             {
                 const IntVect& ng = current_store[lev][idim]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(current_store[lev][idim]->boxArray(),
-                                                                  dm, current_store[lev][idim]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(current_store[lev][idim]->boxArray(),
+                                                                  dm, current_store[lev][idim]->nComp(), ng);
                 // no need to redistribute
                 current_store[lev][idim] = std::move(pmf);
             }
@@ -137,8 +139,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 
         if (F_fp[lev] != nullptr) {
             const IntVect& ng = F_fp[lev]->nGrowVect();
-            auto pmf = std::unique_ptr<MultiFab>(new MultiFab(F_fp[lev]->boxArray(),
-                                                              dm, F_fp[lev]->nComp(), ng));
+            auto pmf = std::make_unique<MultiFab>(F_fp[lev]->boxArray(),
+                                                              dm, F_fp[lev]->nComp(), ng);
             pmf->Redistribute(*F_fp[lev], 0, 0, F_fp[lev]->nComp(), ng);
             F_fp[lev] = std::move(pmf);
         }
@@ -146,8 +148,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         if (rho_fp[lev] != nullptr) {
             const int nc = rho_fp[lev]->nComp();
             const IntVect& ng = rho_fp[lev]->nGrowVect();
-            auto pmf = std::unique_ptr<MultiFab>(new MultiFab(rho_fp[lev]->boxArray(),
-                                                              dm, nc, ng));
+            auto pmf = std::make_unique<MultiFab>(rho_fp[lev]->boxArray(),
+                                                              dm, nc, ng);
             rho_fp[lev] = std::move(pmf);
         }
 
@@ -155,23 +157,23 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         if (lev == 0 && Bfield_aux[0][0]->ixType() == Bfield_fp[0][0]->ixType())
         {
             for (int idim = 0; idim < 3; ++idim) {
-                Bfield_aux[lev][idim].reset(new MultiFab(*Bfield_fp[lev][idim], amrex::make_alias, 0, Bfield_aux[lev][idim]->nComp()));
-                Efield_aux[lev][idim].reset(new MultiFab(*Efield_fp[lev][idim], amrex::make_alias, 0, Efield_aux[lev][idim]->nComp()));
+                Bfield_aux[lev][idim] = std::make_unique<MultiFab>(*Bfield_fp[lev][idim], amrex::make_alias, 0, Bfield_aux[lev][idim]->nComp());
+                Efield_aux[lev][idim] = std::make_unique<MultiFab>(*Efield_fp[lev][idim], amrex::make_alias, 0, Efield_aux[lev][idim]->nComp());
             }
         } else {
             for (int idim=0; idim < 3; ++idim)
             {
                 {
                     const IntVect& ng = Bfield_aux[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Bfield_aux[lev][idim]->boxArray(),
-                                                                      dm, Bfield_aux[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Bfield_aux[lev][idim]->boxArray(),
+                                                                      dm, Bfield_aux[lev][idim]->nComp(), ng);
                     // pmf->Redistribute(*Bfield_aux[lev][idim], 0, 0, Bfield_aux[lev][idim]->nComp(), ng);
                     Bfield_aux[lev][idim] = std::move(pmf);
                 }
                 {
                     const IntVect& ng = Efield_aux[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Efield_aux[lev][idim]->boxArray(),
-                                                                      dm, Efield_aux[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Efield_aux[lev][idim]->boxArray(),
+                                                                      dm, Efield_aux[lev][idim]->nComp(), ng);
                     // pmf->Redistribute(*Efield_aux[lev][idim], 0, 0, Efield_aux[lev][idim]->nComp(), ng);
                     Efield_aux[lev][idim] = std::move(pmf);
                 }
@@ -184,30 +186,30 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             {
                 {
                     const IntVect& ng = Bfield_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Bfield_cp[lev][idim]->boxArray(),
-                                                                      dm, Bfield_cp[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Bfield_cp[lev][idim]->boxArray(),
+                                                                      dm, Bfield_cp[lev][idim]->nComp(), ng);
                     pmf->Redistribute(*Bfield_cp[lev][idim], 0, 0, Bfield_cp[lev][idim]->nComp(), ng);
                     Bfield_cp[lev][idim] = std::move(pmf);
                 }
                 {
                     const IntVect& ng = Efield_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Efield_cp[lev][idim]->boxArray(),
-                                                                      dm, Efield_cp[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Efield_cp[lev][idim]->boxArray(),
+                                                                      dm, Efield_cp[lev][idim]->nComp(), ng);
                     pmf->Redistribute(*Efield_cp[lev][idim], 0, 0, Efield_cp[lev][idim]->nComp(), ng);
                     Efield_cp[lev][idim] = std::move(pmf);
                 }
                 {
                     const IntVect& ng = current_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>( new MultiFab(current_cp[lev][idim]->boxArray(),
-                                                                       dm, current_cp[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(current_cp[lev][idim]->boxArray(),
+                                                                       dm, current_cp[lev][idim]->nComp(), ng);
                     current_cp[lev][idim] = std::move(pmf);
                 }
             }
 
             if (F_cp[lev] != nullptr) {
                 const IntVect& ng = F_cp[lev]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(F_cp[lev]->boxArray(),
-                                                                  dm, F_cp[lev]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(F_cp[lev]->boxArray(),
+                                                                  dm, F_cp[lev]->nComp(), ng);
                 pmf->Redistribute(*F_cp[lev], 0, 0, F_cp[lev]->nComp(), ng);
                 F_cp[lev] = std::move(pmf);
             }
@@ -215,8 +217,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             if (rho_cp[lev] != nullptr) {
                 const int nc = rho_cp[lev]->nComp();
                 const IntVect& ng = rho_cp[lev]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(rho_cp[lev]->boxArray(),
-                                                                  dm, nc, ng));
+                auto pmf  = std::make_unique<MultiFab>(rho_cp[lev]->boxArray(),
+                                                                  dm, nc, ng);
                 rho_cp[lev] = std::move(pmf);
             }
         }
@@ -227,24 +229,24 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 if (Bfield_cax[lev][idim])
                 {
                     const IntVect& ng = Bfield_cax[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Bfield_cax[lev][idim]->boxArray(),
-                                                                      dm, Bfield_cax[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Bfield_cax[lev][idim]->boxArray(),
+                                                                      dm, Bfield_cax[lev][idim]->nComp(), ng);
                     // pmf->ParallelCopy(*Bfield_cax[lev][idim], 0, 0, Bfield_cax[lev][idim]->nComp(), ng, ng);
                     Bfield_cax[lev][idim] = std::move(pmf);
                 }
                 if (Efield_cax[lev][idim])
                 {
                     const IntVect& ng = Efield_cax[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(Efield_cax[lev][idim]->boxArray(),
-                                                                      dm, Efield_cax[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(Efield_cax[lev][idim]->boxArray(),
+                                                                      dm, Efield_cax[lev][idim]->nComp(), ng);
                     // pmf->ParallelCopy(*Efield_cax[lev][idim], 0, 0, Efield_cax[lev][idim]->nComp(), ng, ng);
                     Efield_cax[lev][idim] = std::move(pmf);
                 }
                 if (current_buf[lev][idim])
                 {
                     const IntVect& ng = current_buf[lev][idim]->nGrowVect();
-                    auto pmf = std::unique_ptr<MultiFab>(new MultiFab(current_buf[lev][idim]->boxArray(),
-                                                                      dm, current_buf[lev][idim]->nComp(), ng));
+                    auto pmf = std::make_unique<MultiFab>(current_buf[lev][idim]->boxArray(),
+                                                                      dm, current_buf[lev][idim]->nComp(), ng);
                     // pmf->ParallelCopy(*current_buf[lev][idim], 0, 0, current_buf[lev][idim]->nComp(), ng, ng);
                     current_buf[lev][idim] = std::move(pmf);
                 }
@@ -252,24 +254,24 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             if (charge_buf[lev])
             {
                 const IntVect& ng = charge_buf[lev]->nGrowVect();
-                auto pmf = std::unique_ptr<MultiFab>(new MultiFab(charge_buf[lev]->boxArray(),
-                                                                  dm, charge_buf[lev]->nComp(), ng));
+                auto pmf = std::make_unique<MultiFab>(charge_buf[lev]->boxArray(),
+                                                                  dm, charge_buf[lev]->nComp(), ng);
                 // pmf->ParallelCopy(*charge_buf[lev][idim], 0, 0, charge_buf[lev]->nComp(), ng, ng);
                 charge_buf[lev] = std::move(pmf);
             }
             if (current_buffer_masks[lev])
             {
                 const IntVect& ng = current_buffer_masks[lev]->nGrowVect();
-                auto pmf = std::unique_ptr<iMultiFab>(new iMultiFab(current_buffer_masks[lev]->boxArray(),
-                                                                    dm, current_buffer_masks[lev]->nComp(), ng));
+                auto pmf = std::make_unique<iMultiFab>(current_buffer_masks[lev]->boxArray(),
+                                                                    dm, current_buffer_masks[lev]->nComp(), ng);
                 // pmf->ParallelCopy(*current_buffer_masks[lev], 0, 0, current_buffer_masks[lev]->nComp(), ng, ng);
                 current_buffer_masks[lev] = std::move(pmf);
             }
             if (gather_buffer_masks[lev])
             {
                 const IntVect& ng = gather_buffer_masks[lev]->nGrowVect();
-                auto pmf = std::unique_ptr<iMultiFab>(new iMultiFab(gather_buffer_masks[lev]->boxArray(),
-                                                                    dm, gather_buffer_masks[lev]->nComp(), ng));
+                auto pmf = std::make_unique<iMultiFab>(gather_buffer_masks[lev]->boxArray(),
+                                                                    dm, gather_buffer_masks[lev]->nComp(), ng);
                 // pmf->ParallelCopy(*gather_buffer_masks[lev], 0, 0, gather_buffer_masks[lev]->nComp(), ng, ng);
                 gather_buffer_masks[lev] = std::move(pmf);
             }
@@ -277,7 +279,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 
         if (costs[lev] != nullptr)
         {
-            costs[lev].reset(new amrex::LayoutData<Real>(ba, dm));
+            costs[lev] = std::make_unique<LayoutData<Real>>(ba, dm);
             for (int i : costs[lev]->IndexArray())
             {
                 (*costs[lev])[i] = 0.0;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -39,23 +39,23 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     allcontainers.resize(nspecies + nlasers);
     for (int i = 0; i < nspecies; ++i) {
         if (species_types[i] == PCTypes::Physical) {
-            allcontainers[i].reset(new PhysicalParticleContainer(amr_core, i, species_names[i]));
+            allcontainers[i] = std::make_unique<PhysicalParticleContainer>(amr_core, i, species_names[i]);
         }
         else if (species_types[i] == PCTypes::RigidInjected) {
-            allcontainers[i].reset(new RigidInjectedParticleContainer(amr_core, i, species_names[i]));
+            allcontainers[i] = std::make_unique<RigidInjectedParticleContainer>(amr_core, i, species_names[i]);
         }
         else if (species_types[i] == PCTypes::Photon) {
-            allcontainers[i].reset(new PhotonParticleContainer(amr_core, i, species_names[i]));
+            allcontainers[i] = std::make_unique<PhotonParticleContainer>(amr_core, i, species_names[i]);
         }
         allcontainers[i]->m_deposit_on_main_grid = m_deposit_on_main_grid[i];
         allcontainers[i]->m_gather_from_main_grid = m_gather_from_main_grid[i];
     }
 
     for (int i = nspecies; i < nspecies+nlasers; ++i) {
-        allcontainers[i].reset(new LaserParticleContainer(amr_core, i, lasers_names[i-nspecies]));
+        allcontainers[i] = std::make_unique<LaserParticleContainer>(amr_core, i, lasers_names[i-nspecies]);
     }
 
-    pc_tmp.reset(new PhysicalParticleContainer(amr_core));
+    pc_tmp = std::make_unique<PhysicalParticleContainer>(amr_core);
 
     // Compute the number of species for which lab-frame data is dumped
     // nspecies_lab_frame_diags, and map their ID to MultiParticleContainer
@@ -75,8 +75,8 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     auto const ncollisions = collision_names.size();
     allcollisions.resize(ncollisions);
     for (int i = 0; i < static_cast<int>(ncollisions); ++i) {
-        allcollisions[i].reset
-            (new CollisionType(species_names, collision_names[i]));
+        allcollisions[i] =
+            std::make_unique<CollisionType>(species_names, collision_names[i]);
     }
 
 }
@@ -139,12 +139,12 @@ MultiParticleContainer::ReadParameters ()
                                       str_Bz_ext_particle_function);
 
            // Parser for B_external on the particle
-           m_Bx_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_Bx_ext_particle_function,{"x","y","z","t"})));
-           m_By_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_By_ext_particle_function,{"x","y","z","t"})));
-           m_Bz_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_Bz_ext_particle_function,{"x","y","z","t"})));
+           m_Bx_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_Bx_ext_particle_function,{"x","y","z","t"}));
+           m_By_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_By_ext_particle_function,{"x","y","z","t"}));
+           m_Bz_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_Bz_ext_particle_function,{"x","y","z","t"}));
 
         }
 
@@ -164,12 +164,12 @@ MultiParticleContainer::ReadParameters ()
            Store_parserString(pp, "Ez_external_particle_function(x,y,z,t)",
                                       str_Ez_ext_particle_function);
            // Parser for E_external on the particle
-           m_Ex_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_Ex_ext_particle_function,{"x","y","z","t"})));
-           m_Ey_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_Ey_ext_particle_function,{"x","y","z","t"})));
-           m_Ez_particle_parser.reset(new ParserWrapper<4>(
-                                    makeParser(str_Ez_ext_particle_function,{"x","y","z","t"})));
+           m_Ex_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_Ex_ext_particle_function,{"x","y","z","t"}));
+           m_Ey_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_Ey_ext_particle_function,{"x","y","z","t"}));
+           m_Ez_particle_parser = std::make_unique<ParserWrapper<4>>(
+                                    makeParser(str_Ez_ext_particle_function,{"x","y","z","t"}));
 
         }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -96,7 +96,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 {
     BackwardCompatibility();
 
-    plasma_injector.reset(new PlasmaInjector(species_id, species_name));
+    plasma_injector = std::make_unique<PlasmaInjector>(species_id, species_name);
     physical_species = plasma_injector->getPhysicalSpecies();
     charge = plasma_injector->getCharge();
     mass = plasma_injector->getMass();
@@ -179,8 +179,8 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         std::string function_string = "";
         Store_parserString(pp,"plot_filter_function(t,x,y,z,ux,uy,uz)",
                            function_string);
-        m_particle_filter_parser.reset(new ParserWrapper<7>(
-            makeParser(function_string,{"t","x","y","z","ux","uy","uz"})));
+        m_particle_filter_parser = std::make_unique<ParserWrapper<7>>(
+            makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
     }
 
 }
@@ -188,7 +188,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
     : WarpXParticleContainer(amr_core, 0)
 {
-    plasma_injector.reset(new PlasmaInjector());
+    plasma_injector = std::make_unique<PlasmaInjector>();
 }
 
 void

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -632,7 +632,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     WarpX& warpx = WarpX::GetInstance();
     const int ng_rho = warpx.get_ng_depos_rho().max();
 
-    auto rho = std::unique_ptr<MultiFab>(new MultiFab(nba,dm,WarpX::ncomps,ng_rho));
+    auto rho = std::make_unique<MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
     rho->setVal(0.0);
 
 #ifdef _OPENMP

--- a/Source/Utils/Interpolate.H
+++ b/Source/Utils/Interpolate.H
@@ -3,6 +3,8 @@
 
 #include "WarpX.H"
 
+#include<memory>
+
 namespace Interpolate
 {
     using namespace amrex;

--- a/Source/Utils/Interpolate.cpp
+++ b/Source/Utils/Interpolate.cpp
@@ -13,7 +13,7 @@ namespace Interpolate
     {
         // Prepare the structure that will contain the returned fields
         std::unique_ptr<MultiFab> interpolated_F;
-        interpolated_F.reset( new MultiFab(F_fp.boxArray(), dm, 1, ngrow) );
+        interpolated_F = std::make_unique<MultiFab>(F_fp.boxArray(), dm, 1, ngrow);
         interpolated_F->setVal(0.);
 
         // Loop through the boxes and interpolate the values from the _cp data
@@ -61,9 +61,9 @@ namespace Interpolate
 
         // Prepare the structure that will contain the returned fields
         std::array<std::unique_ptr<MultiFab>, 3> interpolated_F;
-        interpolated_F[0].reset( new MultiFab(Fx_fp->boxArray(), dm, 1, ngrow) );
-        interpolated_F[1].reset( new MultiFab(Fy_fp->boxArray(), dm, 1, ngrow) );
-        interpolated_F[2].reset( new MultiFab(Fz_fp->boxArray(), dm, 1, ngrow) );
+        interpolated_F[0] = std::make_unique<MultiFab>(Fx_fp->boxArray(), dm, 1, ngrow);
+        interpolated_F[1] = std::make_unique<MultiFab>(Fy_fp->boxArray(), dm, 1, ngrow);
+        interpolated_F[2] = std::make_unique<MultiFab>(Fz_fp->boxArray(), dm, 1, ngrow);
 
         IntVect fx_type = interpolated_F[0]->ixType().toIntVect();
         IntVect fy_type = interpolated_F[1]->ixType().toIntVect();


### PR DESCRIPTION
Following https://github.com/ECP-WarpX/WarpX/pull/1398, this PR replaces code like `uptr.reset ( new Type(vars))` with `uptr = make_unique<Type>(vars)` everywhere in the code, except in very few cases where a custom deleter is used (e.g. for most plasma injectors and for shared pointers to arrays in `WarpXOpenPMD.cpp`)