### PR TITLE
[mini-PR] fix bug in CMakeLists.txt

### DIFF
--- a/Source/Particles/ElementaryProcess/CMakeLists.txt
+++ b/Source/Particles/ElementaryProcess/CMakeLists.txt
@@ -3,7 +3,7 @@ target_sources(WarpX
     Ionization.cpp
 )
 
-if(WarpX_HAVE_QED)
+if(WarpX_QED)
     target_sources(WarpX
       PRIVATE
         QEDPairGeneration.cpp


### PR DESCRIPTION
This small PR fixes a typo which prevented the compilation of WarpX with QED support via cmake