### PR TITLE
[mini-PR] Prevent the compilation of picsar qed tests when WarpX is compiled with QED support via cmake

### DIFF
--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -15,7 +15,7 @@ function(find_picsar)
 
         if(NOT fetchedpicsar_POPULATED)
             FetchContent_Populate(fetchedpicsar)
-            add_subdirectory(${fetchedpicsar_SOURCE_DIR}/src/multi_physics ${fetchedpicsar_BINARY_DIR})
+            add_subdirectory(${fetchedpicsar_SOURCE_DIR}/src/multi_physics/QED ${fetchedpicsar_BINARY_DIR})
         endif()
 
         # advanced fetch options


### PR DESCRIPTION
This small PR avoid that picsar QED unit tests are compiled when Warpx is built with QED support via cmake.