### PR TITLE
Update a couple of asserts if warpx.numprocs is used

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1462,7 +1462,10 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 * ``<diag_name>.coarsening_ratio`` (list of `int`) optional (default `1 1 1`)
     Reduce size of the field output by this ratio in each dimension.
     (This is done by averaging the field over 1 or 2 points along each direction, depending on the staggering).
-    ``plot_coarsening_ratio`` should be an integer divisor of ``blocking_factor``, defined in the :ref:`parallelization <parallelization_warpx>` section.
+    If ``blocking_factor`` and ``max_grid_size`` are used for the domain decomposition, as detailed in
+    the :ref:`parallelization <parallelization_warpx>` section, ``coarsening_ratio`` should be an integer
+    divisor of ``blocking_factor``. If ``warpx.numprocs`` is used instead, the total number of cells in a given
+    dimension must be a multiple of the coarsening_ratio multiplied by numprocs in that dimension.
 
 * ``<diag_name>.file_prefix`` (`string`) optional (default `diags/plotfiles/plt`)
     Root for output file names. Supports sub-directories.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1465,7 +1465,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     If ``blocking_factor`` and ``max_grid_size`` are used for the domain decomposition, as detailed in
     the :ref:`parallelization <parallelization_warpx>` section, ``coarsening_ratio`` should be an integer
     divisor of ``blocking_factor``. If ``warpx.numprocs`` is used instead, the total number of cells in a given
-    dimension must be a multiple of the coarsening_ratio multiplied by numprocs in that dimension.
+    dimension must be a multiple of the ``coarsening_ratio`` multiplied by ``numprocs`` in that dimension.
 
 * ``<diag_name>.file_prefix`` (`string`) optional (default `diags/plotfiles/plt`)
     Root for output file names. Supports sub-directories.

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -25,8 +25,11 @@ namespace {
         pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
         pp.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
-        // If warpx.numprocs is used for the domain decomposition, we set the blocking factor to 1
-        // so that the asserts that the number of cells is a multiple of blocking factor always pass
+        // Work-around:
+        // If warpx.numprocs is used for the domain decomposition, we will not use blocking factor
+        // to generate grids. Nonetheless, AMReX has asserts in place that validate that the
+        // number of cells is a multiple of blocking factor. We set the blocking factor to 1 so those
+        // AMReX asserts will always pass.
         amrex::ParmParse pp_warpx("warpx");
         if (pp_warpx.contains("numprocs"))
         {

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -24,6 +24,15 @@ namespace {
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
         pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
         pp.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+
+        // If warpx.numprocs is used for the domain decomposition, we set the blocking factor to 1
+        // so that the asserts that the number of cells is a multiple of blocking factor always pass
+        amrex::ParmParse pp_warpx("warpx");
+        if (pp_warpx.contains("numprocs"))
+        {
+            amrex::ParmParse pp_amr("amr");
+            pp_amr.add("blocking_factor", 1);
+        }
     }
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -491,6 +491,8 @@ public:
     const amrex::IntVect get_ng_depos_J() const {return guard_cells.ng_depos_J;}
     const amrex::IntVect get_ng_depos_rho() const {return guard_cells.ng_depos_rho;}
 
+    const amrex::IntVect get_numprocs() const {return numprocs;}
+
     void ComputeSpaceChargeField (bool const reset_fields);
     void AddSpaceChargeField (WarpXParticleContainer& pc);
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -491,6 +491,13 @@ public:
     const amrex::IntVect get_ng_depos_J() const {return guard_cells.ng_depos_J;}
     const amrex::IntVect get_ng_depos_rho() const {return guard_cells.ng_depos_rho;}
 
+    /** Coarsest-level Domain Decomposition
+     *
+     * If specified, the domain will be chopped into the exact number
+     * of pieces in each dimension as specified by this parameter.
+     *
+     * @return the number of MPI processes per dimension if specified, otherwise a 0-vector
+     */
     const amrex::IntVect get_numprocs() const {return numprocs;}
 
     void ComputeSpaceChargeField (bool const reset_fields);


### PR DESCRIPTION
This small PR is an update of a couple of asserts to deal with the possibility that `warpx.numprocs` is used for the domain decomposition. They concern the coarsening ratio for field diagnostics, as discussed in #1439. There is also a small update of the parameters doc about the coarsening ratio to discuss this.

Initially I also wanted to disable the assert that the total number of cells be a multiple of the blocking factor when `warpx.numprocs` is used. But since this assert is done in AMReX, it seems that there is no simple way of doing that. Am I correct on this last point @WeiqunZhang? In any case, it's not a big deal, I think after this PR we can always add `amr.blocking_factor = 1` if we use `warpx.numprocs`. (the error might be a bit mysterious for a user who only knows about `warpx.numprocs` and not about `amr.blocking_factor` though)