### PR TITLE
Remove a few segfaults when there is zero particle species

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1433,7 +1433,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
-    Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``F`` ``part_per_grid`` ``part_per_proc`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
+    Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``.
 
 * ``<diag_name>.plot_raw_fields`` (`0` or `1`) optional (default `0`)

--- a/Examples/Tests/Langmuir/README.md
+++ b/Examples/Tests/Langmuir/README.md
@@ -12,7 +12,7 @@ in this directory.
    mv plt00010 to plt00010.nolb
 
 4) amrvis3d plt00010.lb plt00010.nolb
-   set the field to "part_per_proc"
+   set the field to "part_per_cell"
 
 You should see the effect of load balancing based of the number of particles.
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -112,6 +112,14 @@ public:
                 const amrex::MultiFab& Ex, const amrex::MultiFab& Ey, const amrex::MultiFab& Ez,
                 const amrex::MultiFab& Bx, const amrex::MultiFab& By, const amrex::MultiFab& Bz);
 
+    /**
+    * \brief This returns a MultiFAB filled with zeros. It is used to return the charge density
+    * when there is no particle species.
+    *
+    * @param[in] lev the index of the refinement level.
+    */
+    std::unique_ptr<amrex::MultiFab> GetZeroChargeDensity(const int lev);
+
     ///
     /// This deposits the particle charge onto a node-centered MultiFab and returns a unique ptr
     /// to it. The charge density is accumulated over all the particles in the MultiParticleContainer
@@ -159,6 +167,15 @@ public:
     /** Apply BC. For now, just discard particles outside the domain, regardless
      *  of the whole simulation BC. */
     void ApplyBoundaryConditions ();
+
+    /**
+    * \brief This returns a vector filled with zeros whose size is the number of boxes in the
+    * simulation boxarray. It is used to return the number of particles in each grid when there is
+    * no particle species.
+    *
+    * @param[in] lev the index of the refinement level.
+    */
+    amrex::Vector<long> GetZeroParticlesInGrid(const int lev) const;
 
     amrex::Vector<long> NumberOfParticlesInGrid(int lev) const;
 


### PR DESCRIPTION
Two methods of the `MultiParticleContainer` class (`GetChargeDensity` and `NumberOfParticlesInGrid`) directly access `allcontainers[0]`. These methods are used when computing the field diagnostics `rho` and `part_per_grid` (maybe they're used in other parts of the code I'm not entirely sure). If we try to output these fields when there is zero particle species in the simulation (not even a laser), we obtain a segfault.

The solution proposed here is to test if the number of particles in the simulation is zero and if so return an array/a MultiFab filled with zeros. However, there may be more elegant solutions for this so feel free to suggest anything else.