### PR TITLE
Fix warning with openPMD

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -27,7 +27,7 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<amrex::MultiFab>& mf,
     amrex::Vector<amrex::Geometry>& geom,
     const amrex::Vector<int> iteration, const double time,
-    const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
+    const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/,
     const std::string prefix, bool plot_raw_fields,
     bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
 {


### PR DESCRIPTION
Simply fixes one remaining warning when compiling with support for openPMD output.