### PR TITLE
CMake: HIP Compute Hint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(NOT WarpX_PRECISION IN_LIST WarpX_PRECISION_VALUES)
 endif()
 
 set(WarpX_COMPUTE_VALUES NOACC OMP CUDA DPCPP HIP)
-set(WarpX_COMPUTE OMP CACHE STRING "On-node, accelerated computing backend (NOACC/OMP/CUDA/DPCPP)")
+set(WarpX_COMPUTE OMP CACHE STRING "On-node, accelerated computing backend (NOACC/OMP/CUDA/DPCPP/HIP)")
 set_property(CACHE WarpX_COMPUTE PROPERTY STRINGS ${WarpX_COMPUTE_VALUES})
 if(NOT WarpX_COMPUTE IN_LIST WarpX_COMPUTE_VALUES)
     message(FATAL_ERROR "WarpX_PRECISION (${WarpX_COMPUTE}) must be one of ${WarpX_COMPUTE_VALUES}")


### PR DESCRIPTION
Add the help-string in `WarpX_COMPUTE` to include `HIP`.

Follow-up to #1436 