### PR TITLE
CI: -Werror

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -10,6 +10,7 @@ jobs:
   build_nvcc:
     name: NVCC 11.0.2 SP
     runs-on: ubuntu-18.04
+    env: {CXXFLAGS: "-Werror"}
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -6,6 +6,7 @@ jobs:
   build_hip:
     name: HIP SP
     runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-Werror -Wno-deprecated-declarations"}
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -58,6 +58,7 @@ jobs:
   build_icpx:
     name: oneAPI ICX SP
     runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-Werror -Wno-error=pass-failed"}
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
@@ -97,6 +98,7 @@ jobs:
   build_dpcc:
     name: oneAPI DPC++ SP
     runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-Werror"}
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ jobs:
   build_gcc9:
     name: AppleClang
     runs-on: macos-latest
+    env: {CXXFLAGS: "-Werror -Wno-error=pass-failed"}
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -43,6 +43,7 @@ jobs:
         export WarpX_QED_TABLE_GEN=ON
         export CC=$(which clang)
         export CXX=$(which clang++)
+        export CXXFLAGS="-Werror -Wno-error=pass-failed"
         python3 -m pip install -v .
 
     - name: run pywarpx


### PR DESCRIPTION
Compile with `-Werror` to avoid that new warnings are slipping into the code base.

- [x] GH action builds (NVCC, ICC, DPC++, HIP)
- [ ] (later) Azure builds (GCC)

Also nice to consider: https://github.com/lukka/run-cmake

Close #1455