### PR TITLE
Fix Warning for SigmaBox FabFactory

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -49,29 +49,36 @@ struct SigmaBox
 
 };
 
-namespace amrex {
-    template<>
-    class FabFactory<SigmaBox>
-    {
-    public:
-        FabFactory<SigmaBox> (const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
-            : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta) {}
-        virtual SigmaBox* create (const Box& box, int /*ncomps*/,
-                                  const FabInfo& /*info*/, int /*box_index*/) const final
-            { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta); }
-        virtual void destroy (SigmaBox* fab) const final {
-            delete fab;
-        }
-        virtual FabFactory<SigmaBox>* clone () const {
-            return new FabFactory<SigmaBox>(*this);
-        }
-    private:
-        const BoxArray& m_grids;
-        const Real* m_dx;
-        int m_ncell;
-        int m_delta;
-    };
-}
+class SigmaBoxFactory
+    : public amrex::FabFactory<SigmaBox>
+{
+public:
+    SigmaBoxFactory (const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta)
+        : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta) {}
+    virtual ~SigmaBoxFactory () = default;
+
+    SigmaBoxFactory (const SigmaBoxFactory&) = default;
+    SigmaBoxFactory (SigmaBoxFactory&&) noexcept = default;
+
+    SigmaBoxFactory () = delete;
+    SigmaBoxFactory& operator= (const SigmaBoxFactory&) = delete;
+    SigmaBoxFactory& operator= (SigmaBoxFactory&&) = delete;
+
+    virtual SigmaBox* create (const amrex::Box& box, int /*ncomps*/,
+                              const amrex::FabInfo& /*info*/, int /*box_index*/) const final
+        { return new SigmaBox(box, m_grids, m_dx, m_ncell, m_delta); }
+    virtual void destroy (SigmaBox* fab) const final {
+        delete fab;
+    }
+    virtual SigmaBoxFactory* clone () const final {
+        return new SigmaBoxFactory(*this);
+    }
+private:
+    const amrex::BoxArray& m_grids;
+    const amrex::Real* m_dx;
+    int m_ncell;
+    int m_delta;
+};
 
 class MultiSigmaBox
     : public amrex::FabArray<SigmaBox>

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -389,7 +389,7 @@ SigmaBox::ComputePMLFactorsE (const Real* a_dx, Real dt)
 MultiSigmaBox::MultiSigmaBox (const BoxArray& ba, const DistributionMapping& dm,
                               const BoxArray& grid_ba, const Real* dx, int ncell, int delta)
     : FabArray<SigmaBox>(ba,dm,1,0,MFInfo(),
-                         FabFactory<SigmaBox>(grid_ba,dx,ncell,delta))
+                         SigmaBoxFactory(grid_ba,dx,ncell,delta))
 {}
 
 void

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -16,8 +16,7 @@ FlushFormatSensei::FlushFormatSensei (amrex::AmrMesh *amr_mesh,
     m_amr_mesh(amr_mesh)
 {
 #ifndef BL_USE_SENSEI_INSITU
-    (void)amr_mesh;
-    (void)diag_name;
+    amrex::ignore_unused(m_insitu_pin_mesh, m_insitu_bridge, m_amr_mesh, diag_name);
 #else
     amrex::ParmParse pp(diag_name);
 

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -109,6 +109,7 @@ void Filter::DoFilter (const Box& tbx,
 #endif
     amrex::Real const* AMREX_RESTRICT sz = stencil_z.data();
     Dim3 slen_local = slen;
+#if (AMREX_SPACEDIM == 3)
     AMREX_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
     {
         Real d = 0.0;
@@ -116,12 +117,7 @@ void Filter::DoFilter (const Box& tbx,
         for         (int iz=0; iz < slen_local.z; ++iz){
             for     (int iy=0; iy < slen_local.y; ++iy){
                 for (int ix=0; ix < slen_local.x; ++ix){
-#if (AMREX_SPACEDIM == 3)
                     Real sss = sx[ix]*sy[iy]*sz[iz];
-#else
-                    Real sss = sx[ix]*sz[iy];
-#endif
-#if (AMREX_SPACEDIM == 3)
                     d += sss*( tmp(i-ix,j-iy,k-iz,scomp+n)
                               +tmp(i+ix,j-iy,k-iz,scomp+n)
                               +tmp(i-ix,j+iy,k-iz,scomp+n)
@@ -130,18 +126,32 @@ void Filter::DoFilter (const Box& tbx,
                               +tmp(i+ix,j-iy,k+iz,scomp+n)
                               +tmp(i-ix,j+iy,k+iz,scomp+n)
                               +tmp(i+ix,j+iy,k+iz,scomp+n));
-#else
-                    d += sss*( tmp(i-ix,j-iy,k,scomp+n)
-                              +tmp(i+ix,j-iy,k,scomp+n)
-                              +tmp(i-ix,j+iy,k,scomp+n)
-                              +tmp(i+ix,j+iy,k,scomp+n));
-#endif
                 }
             }
         }
 
         dst(i,j,k,dcomp+n) = d;
     });
+#else
+    AMREX_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
+    {
+        Real d = 0.0;
+
+        for         (int iz=0; iz < slen_local.z; ++iz){
+            for     (int iy=0; iy < slen_local.y; ++iy){
+                for (int ix=0; ix < slen_local.x; ++ix){
+                    Real sss = sx[ix]*sz[iy];
+                    d += sss*( tmp(i-ix,j-iy,k,scomp+n)
+                              +tmp(i+ix,j-iy,k,scomp+n)
+                              +tmp(i-ix,j+iy,k,scomp+n)
+                              +tmp(i+ix,j+iy,k,scomp+n));
+                }
+            }
+        }
+
+        dst(i,j,k,dcomp+n) = d;
+    });
+#endif
 }
 
 #else

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -272,14 +272,17 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
         tilebox = amrex::coarsen(pti.tilebox(),ref_ratio);
     }
 
+#ifndef AMREX_USE_GPU
     // Staggered tile boxes (different in each direction)
     Box tbx = convert( tilebox, jx->ixType().toIntVect() );
     Box tby = convert( tilebox, jy->ixType().toIntVect() );
     Box tbz = convert( tilebox, jz->ixType().toIntVect() );
+#endif
 
     tilebox.grow(ng_J);
 
 #ifdef AMREX_USE_GPU
+    amrex::ignore_unused(thread_num);
     // GPU, no tiling: j<xyz>_arr point to the full j<xyz> arrays
     auto & jx_fab = jx->get(pti);
     auto & jy_fab = jy->get(pti);
@@ -474,14 +477,17 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector& wp,
         tilebox = amrex::coarsen(pti.tilebox(),ref_ratio);
     }
 
+#ifndef AMREX_USE_GPU
     // Staggered tile box
     Box tb = amrex::convert( tilebox, rho->ixType().toIntVect() );
+#endif
 
     tilebox.grow(ng_rho);
 
     const int nc = WarpX::ncomps;
 
 #ifdef AMREX_USE_GPU
+    amrex::ignore_unused(thread_num);
     // GPU, no tiling: rho_fab points to the full rho array
     MultiFab rhoi(*rho, amrex::make_alias, icomp*nc, nc);
     auto & rho_fab = rhoi.get(pti);

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -125,7 +125,7 @@ extern "C"
     }
 #endif
 
-    void amrex_finalize (int finalize_mpi)
+    void amrex_finalize (int /*finalize_mpi*/)
     {
         amrex::Finalize();
     }


### PR DESCRIPTION
Reimplemented FabFactory for SigmaBox to get rid of warning.  Also fix a number of other warnings.  My test with DPC++ shows WarpX is warning free now.
