### PR TITLE
Ascent: Fix Contour Plots

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -16,7 +16,6 @@ FlushFormatAscent::WriteToFile (
     bool plot_raw_fields_guards, bool /*plot_raw_rho*/, bool plot_raw_F) const
 {
 #ifdef AMREX_USE_ASCENT
-
     auto & warpx = WarpX::GetInstance();
 
     // wrap mesh data
@@ -43,9 +42,10 @@ FlushFormatAscent::WriteToFile (
 
 #else
     amrex::ignore_unused(varnames, mf, geom, iteration, time,
-        particle_diags, nlev, prefix, plot_raw_fields,
-        plot_raw_fields_guards, plot_raw_F);
+        particle_diags, nlev);
 #endif // AMREX_USE_ASCENT
+    amrex::ignore_unused(prefix, plot_raw_fields, plot_raw_fields_guards,
+        plot_raw_F);
 }
 
 #ifdef AMREX_USE_ASCENT

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -75,7 +75,7 @@ FullDiagnostics::ReadParameters ()
             "to file for a restart");
     }
     // Number of buffers = 1 for FullDiagnostics.
-    // It is used to allocate the number of output multu-level MultiFab, m_mf_output
+    // It is used to allocate the number of output multi-level MultiFab, m_mf_output
     m_num_buffers = 1;
 }
 
@@ -323,7 +323,7 @@ FullDiagnostics::InitializeFieldBufferData (int i_buffer, int lev ) {
     // is different from the lo and hi physical co-ordinates of the simulation domain.
     if (use_warpxba == false) dmap = amrex::DistributionMapping{ba};
     // Allocate output MultiFab for diagnostics. The data will be stored at cell-centers.
-    int ngrow = (m_format == "sensei") ? 1 : 0;
+    int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
     // The zero is hard-coded since the number of output buffers = 1 for FullDiagnostics
     m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, m_varnames.size(), ngrow);
 


### PR DESCRIPTION
Fix the missing ngrow of one cells for Ascent, which guarantees that the `FillBoundary` calls after centering field data provide an extra cell for contouring.

Also fix a doc typo and unused variable warnings.

### PR
![replay_000400(2)](https://user-images.githubusercontent.com/1353258/97071395-e5d1b100-1594-11eb-9231-8d744d146446.png)

### Pre PR
![replay_000400(1)](https://user-images.githubusercontent.com/1353258/97071396-e66a4780-1594-11eb-9c21-1a7552d02650.png)
