### PR TITLE
Explicit choice of `max_iters` for MLMG solver

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -377,10 +377,10 @@ Particle initialization
     relaxed precision requirement through ``self_fields_required_precision``.
     
 * ``<species_name>.self_fields_max_iters`` (`integer`, default: 200)
-    Maximum number of iterations used for MLMG solver for initial space-charge 
-    fields calculation. In case if MLMG converges but fails to reach the desired 
+    Maximum number of iterations used for MLMG solver for initial space-charge
+    fields calculation. In case if MLMG converges but fails to reach the desired
     ``self_fields_required_precision``, this parameter may be increased.
-    
+
 * ``<species_name>.profile`` (`string`)
     Density profile for this species. The options are:
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -375,7 +375,7 @@ Particle initialization
     For highly-relativistic beams, this solver can fail to reach the default
     precision within a reasonable time ; in that case, users can set a
     relaxed precision requirement through ``self_fields_required_precision``.
-    
+
 * ``<species_name>.self_fields_max_iters`` (`integer`, default: 200)
     Maximum number of iterations used for MLMG solver for initial space-charge
     fields calculation. In case if MLMG converges but fails to reach the desired

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -375,7 +375,12 @@ Particle initialization
     For highly-relativistic beams, this solver can fail to reach the default
     precision within a reasonable time ; in that case, users can set a
     relaxed precision requirement through ``self_fields_required_precision``.
-
+    
+* ``<species_name>.self_fields_max_iters`` (`integer`, default: 200)
+    Maximum number of iterations used for MLMG solver for initial space-charge 
+    fields calculation. In case if MLMG converges but fails to reach the desired 
+    ``self_fields_required_precision``, this parameter may be increased.
+    
 * ``<species_name>.profile`` (`string`)
     Density profile for this species. The options are:
 

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -71,7 +71,7 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     for (Real& beta_comp : beta) beta_comp /= PhysConst::c; // Normalize
 
     // Compute the potential phi, by solving the Poisson equation
-    computePhi( rho, phi, beta, pc.self_fields_required_precision );
+    computePhi( rho, phi, beta, pc.self_fields_required_precision, pc.self_fields_max_iters );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
     computeE( Efield_fp, phi, beta );
@@ -96,7 +96,8 @@ void
 WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
-                   Real const required_precision) const
+                   Real const required_precision,
+                   int const max_iters) const
 {
     // Define the boundary conditions
     Array<LinOpBCType,AMREX_SPACEDIM> lobc, hibc;
@@ -127,6 +128,7 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
     // Solve the Poisson equation
     MLMG mlmg(linop);
     mlmg.setVerbose(2);
+    mlmg.setMaxIter(max_iters);
     mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho), required_precision, 0.0);
 
     // Normalize by the correct physical constant

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -116,6 +116,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp.query("do_continuous_injection", do_continuous_injection);
     pp.query("initialize_self_fields", initialize_self_fields);
     pp.query("self_fields_required_precision", self_fields_required_precision);
+    pp.query("self_fields_max_iters", self_fields_max_iters);
     // Whether to plot back-transformed (lab-frame) diagnostics
     // for this species.
     pp.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -274,6 +274,7 @@ public:
     bool do_splitting = false;
     bool initialize_self_fields = false;
     amrex::Real self_fields_required_precision = 1.e-11;
+    int self_fields_max_iters = 200;
 
     // split along diagonals (0) or axes (1)
     int split_type = 0;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -505,7 +505,8 @@ public:
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
-                     amrex::Real const required_precision=1.e-11 ) const;
+                     amrex::Real const required_precision=1.e-11,
+                     const int max_iters=200) const;
     void computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E,
                    const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<amrex::Real, 3> const beta = {{0,0,0}} ) const;


### PR DESCRIPTION
Doing the beam-driven cases, I used the `initialize_self_fields` which is kinda useful to speed-up development of the self-consistence bunch field. 

I've found however a bit annoying that the maximum number of iterations for this solver is [hard-fixed](https://github.com/AMReX-Codes/amrex/blob/9992d844099c3df81d9499519ffeb7f93a201dc6/Src/LinearSolvers/MLMG/AMReX_MLMG.H#L177) so sometimes i have to adjust the precision after changing the box parameters to make it converge in 200 steps. This PR adds an option to manually  increase `self_fields_max_iters`.