### PR TITLE
[mini-PR] Fix warning concerning unnecessary ';'

### DIFF
--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -70,7 +70,7 @@ public:
      * does not require control parameters or lookup tables.
      */
     BreitWheelerGetOpticalDepth ()
-    {};
+    {}
 
     /**
      * () operator is just a thin wrapper around a very simple function to
@@ -111,7 +111,7 @@ public:
     BreitWheelerEvolveOpticalDepth (
         const BW_dndt_table_view table_view,
         const amrex::ParticleReal bw_minimum_chi_phot):
-        m_table_view{table_view}, m_bw_minimum_chi_phot{bw_minimum_chi_phot}{};
+        m_table_view{table_view}, m_bw_minimum_chi_phot{bw_minimum_chi_phot}{}
 
     /**
      * Evolves the optical depth. It can be used on GPU.
@@ -190,7 +190,7 @@ public:
      * @param[in] table_view a BW_pair_prod_table_view
      */
     BreitWheelerGeneratePairs (const BW_pair_prod_table_view table_view):
-        m_table_view{table_view}{};
+        m_table_view{table_view}{}
 
     /**
      * Generates pairs according to Breit Wheeler process.

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
@@ -70,7 +70,7 @@ public:
      * does not require control parameters or lookup tables.
      */
     QuantumSynchrotronGetOpticalDepth ()
-    {};
+    {}
 
     /**
      * () operator is just a thin wrapper around a very simple function to
@@ -110,7 +110,7 @@ public:
     QuantumSynchrotronEvolveOpticalDepth (
         const QS_dndt_table_view table_view,
         const amrex::ParticleReal qs_minimum_chi_part):
-        m_table_view{table_view}, m_qs_minimum_chi_part{qs_minimum_chi_part}{};
+        m_table_view{table_view}, m_qs_minimum_chi_part{qs_minimum_chi_part}{}
 
     /**
      * Evolves the optical depth. It can be used on GPU.
@@ -184,7 +184,7 @@ public:
      */
     QuantumSynchrotronPhotonEmission (
         const QS_phot_em_table_view table_view):
-        m_table_view{table_view}{};
+        m_table_view{table_view}{}
 
     /**
      * Generates photons according to Quantum Synchrotron process.

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -396,9 +396,9 @@ protected:
     //Species can receive a shared pointer to a QED engine (species for
     //which this is relevant should override these functions)
     virtual void
-    set_breit_wheeler_engine_ptr(std::shared_ptr<BreitWheelerEngine>){};
+    set_breit_wheeler_engine_ptr(std::shared_ptr<BreitWheelerEngine>){}
     virtual void
-    set_quantum_sync_engine_ptr(std::shared_ptr<QuantumSynchrotronEngine>){};
+    set_quantum_sync_engine_ptr(std::shared_ptr<QuantumSynchrotronEngine>){}
 
     int m_qed_breit_wheeler_ele_product;
     std::string m_qed_breit_wheeler_ele_product_name;


### PR DESCRIPTION
`clang` was complaining about some unnecessary `;` . This PR removes them.