### PR TITLE
Development branch is the default, no need to specify it

### DIFF
--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -21,7 +21,7 @@ single directory (e.g. ``warpx_directory``):
     cd warpx_directory
     git clone https://github.com/ECP-WarpX/WarpX.git
     git clone https://github.com/ECP-WarpX/picsar.git
-    git clone --branch development https://github.com/AMReX-Codes/amrex.git
+    git clone https://github.com/AMReX-Codes/amrex.git
 
 Basic compilation
 -----------------

--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -23,7 +23,7 @@ Please see installation instructions below.
 
 - a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`_ compiler: e.g. GCC 5, Clang 3.6 or newer
 - `CMake 3.14.0+ <https://cmake.org>`_
-- `AMReX (development) <https://amrex-codes.github.io>`_: we automatically download and compile a copy of AMReX
+- `AMReX <https://amrex-codes.github.io>`_: we automatically download and compile a copy of AMReX
 
 Optional dependencies include:
 

--- a/Docs/source/building/juwels.rst
+++ b/Docs/source/building/juwels.rst
@@ -33,8 +33,8 @@ Use the following commands to download the WarpX source code and switch to the c
    cd ~/src
 
    git clone https://github.com/ECP-WarpX/WarpX.git warpx
-   git clone --branch development https://github.com/ECP-WarpX/picsar.git
-   git clone --branch development https://github.com/AMReX-Codes/amrex.git
+   git clone https://github.com/ECP-WarpX/picsar.git
+   git clone https://github.com/AMReX-Codes/amrex.git
 
 We use the following modules and environments on the system.
 

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -29,8 +29,8 @@ Use the following commands to download the WarpX source code and switch to the c
    cd ~/src
 
    git clone https://github.com/ECP-WarpX/WarpX.git warpx
-   git clone --branch development https://github.com/ECP-WarpX/picsar.git
-   git clone --branch development https://github.com/AMReX-Codes/amrex.git
+   git clone https://github.com/ECP-WarpX/picsar.git
+   git clone https://github.com/AMReX-Codes/amrex.git
 
 We use the following modules and environments on the system.
 

--- a/Docs/source/developers/performance_tests.rst
+++ b/Docs/source/developers/performance_tests.rst
@@ -25,7 +25,7 @@ Here is an example setup for Summit:
    cd $AUTOMATED_PERF_TESTS
    git clone https://github.com/ECP-WarpX/WarpX.git warpx
    git clone https://github.com/ECP-WarpX/picsar.git
-   git clone --branch development https://github.com/AMReX-Codes/amrex.git
+   git clone https://github.com/AMReX-Codes/amrex.git
    git clone https://github.com/ECP-WarpX/perf_logs.git
 
 Then, in ``$AUTOMATED_PERF_TESTS``, create a file ``run_automated_performance_tests_512.sh`` with the following content:

--- a/Docs/source/visualization/sensei.rst
+++ b/Docs/source/visualization/sensei.rst
@@ -251,7 +251,7 @@ First, log into cori and clone the git repo's.
    mkdir warpx
    cd warpx/
    git clone https://github.com/ECP-WarpX/WarpX.git WarpX-libsim
-   git clone --branch development https://github.com/AMReX-Codes/amrex
+   git clone https://github.com/AMReX-Codes/amrex
    git clone https://github.com/ECP-WarpX/picsar.git
    cd WarpX-libsim
    vim GNUmakefile


### PR DESCRIPTION
The documentation contains some `git clone --branch development`, which I think is superfluous because the development branch is the default on these repos (AMReX and WarpX). This PR proposes to update the doc.