### PR TITLE
Use the parser for more input parameters

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -308,6 +308,7 @@ Particle initialization
 
 * ``<species_name>.xmin,ymin,zmin`` (`float`) optional (default unlimited)
     When ``<species_name>.xmin`` and ``<species_name>.xmax`` (see below) are set, they delimit the region within which particles are injected.
+    The WarpXParser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand-side, so expressions like ``<species_name>.xmin = "2.+1."`` and/or using user-defined constants are accepted.
     The same is applicable in the other directions.
     If periodic boundary conditions are used in direction ``i``, then the default (i.e. if the range is not specified) range will be the simulation box, ``[geometry.prob_hi[i], geometry.prob_lo[i]]``.
 
@@ -395,13 +396,12 @@ Particle initialization
       user-defined constant, see above. WARNING: where ``density_function(x,y,z)`` is close to zero, particles will still be injected between ``xmin`` and ``xmax`` etc., with a null weight. This is undesirable because it results in useless computing. To avoid this, see option ``density_min`` below.
 
 * ``<species_name>.density_min`` (`float`) optional (default `0.`)
-    Minimum plasma density. No particle is injected where the density is below
-    this value.
+    Minimum plasma density. No particle is injected where the density is below this value.
+    The WarpXParser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand-side, so expressions like ``<species_name>.density_min = "2.+1."`` and/or using user-defined constants are accepted.
 
 * ``<species_name>.density_max`` (`float`) optional (default `infinity`)
-    Maximum plasma density. The density at each point is the minimum between
-    the value given in the profile, and `density_max`.
-
+    Maximum plasma density. The density at each point is the minimum between the value given in the profile, and `density_max`.
+    The WarpXParser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand-side, so expressions like ``<species_name>.density_max = "2.+1."`` and/or using user-defined constants are accepted.
 * ``<species_name>.radially_weighted`` (`bool`) optional (default `true`)
     Whether particle's weight is varied with their radius. This only applies to cylindrical geometry.
     The only valid value is true.

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -42,7 +42,7 @@ electrons.num_particles_per_cell_each_dim = 2 2
 electrons.momentum_distribution_type = "gaussian"
 electrons.ux_th = .01
 electrons.uz_th = .01
-electrons.zmin = 19.520e-6
+electrons.zmin = "zc-lgrad*log(400)"
 electrons.zmax = 25.47931e-6
 electrons.profile = parse_density_function
 electrons.density_function(x,y,z) = "(z<zp)*nc*exp((z-zc)/lgrad)+(z>=zp)*(z<=zp2)*2.*nc+(z>zp2)*nc*exp(-(z-zc2)/lgrad)"

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -120,15 +120,15 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     }
 #   endif
 
-    pp.query("xmin", xmin);
-    pp.query("ymin", ymin);
-    pp.query("zmin", zmin);
-    pp.query("xmax", xmax);
-    pp.query("ymax", ymax);
-    pp.query("zmax", zmax);
+    smartQuery(pp, "xmin", xmin);
+    smartQuery(pp, "ymin", ymin);
+    smartQuery(pp, "zmin", zmin);
+    smartQuery(pp, "xmax", xmax);
+    smartQuery(pp, "ymax", ymax);
+    smartQuery(pp, "zmax", zmax);
 
-    pp.query("density_min", density_min);
-    pp.query("density_max", density_max);
+    smartQuery(pp, "density_min", density_min);
+    smartQuery(pp, "density_max", density_max);
 
     std::string physical_species_s;
     bool species_is_specified = pp.query("species_type", physical_species_s);

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -120,15 +120,15 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     }
 #   endif
 
-    smartQuery(pp, "xmin", xmin);
-    smartQuery(pp, "ymin", ymin);
-    smartQuery(pp, "zmin", zmin);
-    smartQuery(pp, "xmax", xmax);
-    smartQuery(pp, "ymax", ymax);
-    smartQuery(pp, "zmax", zmax);
+    queryWithParser(pp, "xmin", xmin);
+    queryWithParser(pp, "ymin", ymin);
+    queryWithParser(pp, "zmin", zmin);
+    queryWithParser(pp, "xmax", xmax);
+    queryWithParser(pp, "ymax", ymax);
+    queryWithParser(pp, "zmax", zmax);
 
-    smartQuery(pp, "density_min", density_min);
-    smartQuery(pp, "density_max", density_max);
+    queryWithParser(pp, "density_min", density_min);
+    queryWithParser(pp, "density_max", density_max);
 
     std::string physical_species_s;
     bool species_is_specified = pp.query("species_type", physical_species_s);

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -161,6 +161,8 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
 */
 WarpXParser makeParser (std::string const& parse_function, std::vector<std::string> const& varnames);
 
+int smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val);
+
 namespace WarpXUtilMsg{
 
 /** \brief If is_expression_true is false, this function prints msg and calls amrex::abort()

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -161,7 +161,19 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
 */
 WarpXParser makeParser (std::string const& parse_function, std::vector<std::string> const& varnames);
 
-int smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val);
+/**
+ * \brief Similar to amrex::ParmParse::query, but also supports math expressions for the value.
+ *
+ * amrex::ParmParse::query reads a name and a value from the input file. This function does the
+ * same, and applies the WarpXParser to the value, so the user has the choice to specify a value or
+ * a math expression (including user-defined constants).
+ * Only works for amrex::Real numbers, one would need another version for integers etc.
+ *
+ * \param[in] a_pp amrex::ParmParse object
+ * \param[in] str name of the parameter to read
+ * \param[out] val where the value queried and parsed is stored
+ */
+int queryWithParser (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val);
 
 namespace WarpXUtilMsg{
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -222,10 +222,10 @@ smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
         std::string str_val;
         Store_parserString(a_pp, str, str_val);
 
-        std::unique_ptr<ParserWrapper<1>> local_parser =
+        std::unique_ptr<ParserWrapper<1>> local_parser_ptr =
             std::make_unique<ParserWrapper<1>>(makeParser(str_val,{"DONOTUSETHATSTRING"}));
-        HostDeviceParser<1> const& loc = getParser(local_parser);
-        val = loc(0.);
+        HostDeviceParser<1> const& local_parser = getParser(local_parser_ptr);
+        val = local_parser(0.);
     }
 
     return is_specified;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -190,7 +190,6 @@ void Store_parserString(amrex::ParmParse& pp, std::string query_string,
     f.clear();
 }
 
-
 WarpXParser makeParser (std::string const& parse_function, std::vector<std::string> const& varnames)
 {
     WarpXParser parser(parse_function);
@@ -211,6 +210,25 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
         amrex::Abort("makeParser::Unknown symbol "+s);
     }
     return parser;
+}
+
+int
+smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
+{
+    std::string tmp_str;
+    int is_specified = a_pp.query(str, tmp_str);
+    if (is_specified)
+    {
+        std::string str_val;
+        Store_parserString(a_pp, str, str_val);
+
+        std::unique_ptr<ParserWrapper<1>> local_parser =
+            std::make_unique<ParserWrapper<1>>(makeParser(str_val,{"DONOTUSETHATSTRING"}));
+        HostDeviceParser<1> const& loc = getParser(local_parser);
+        val = loc(0.);
+    }
+
+    return is_specified;
 }
 
 /**

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -213,19 +213,21 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
 }
 
 int
-smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
+queryWithParser (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
 {
+    // call amrex::ParmParse::query, check if the user specified str.
     std::string tmp_str;
     int is_specified = a_pp.query(str, tmp_str);
     if (is_specified)
     {
+        // If so, create a parser object and apply it to the value provided by the user.
         std::string str_val;
         Store_parserString(a_pp, str, str_val);
 
         auto parser = makeParser(str_val, {});
         val = parser.eval();
     }
-
+    // return the same output as amrex::ParmParse::query
     return is_specified;
 }
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -222,10 +222,8 @@ smartQuery (amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
         std::string str_val;
         Store_parserString(a_pp, str, str_val);
 
-        std::unique_ptr<ParserWrapper<1>> local_parser_ptr =
-            std::make_unique<ParserWrapper<1>>(makeParser(str_val,{"DONOTUSETHATSTRING"}));
-        HostDeviceParser<1> const& local_parser = getParser(local_parser_ptr);
-        val = local_parser(0.);
+        auto parser = makeParser(str_val, {});
+        val = parser.eval();
     }
 
     return is_specified;


### PR DESCRIPTION
This PR proposes to use the parser for more input parameters, not only for the plasma density and laser profile. Instead of `amrex::ParmParse.query`, one can use `queryWithParser` to read `amrex::Real` input parameters. In the previous implementation, you could use the parser to specify the plasma density, but the plasma `zmin` and `zmax` had to be modified by hand, which was not very handy. With this PR, `zmin` and `zmax` can now take math expressions interpreted by the parser, so they can be adapted automatically.

@WeiqunZhang in `WarpXUtil.cpp` I did not manage to declare the parser with `std::unique_ptr<ParserWrapper<0>>` and call its bracket operator, I had an error
```
./Source/Utils/WarpXUtil.cpp:235:15: error: no matching function for call to object of type 'const HostDeviceParser<0>'
        val = loc();
```
so I used a workaround to (`std::unique_ptr<ParserWrapper<1>>` and just have a dummy useless variable). Am I using the parser properly? Note that this workaround is not too nice, but I don't think it'll ever be problematic.

@WeiqunZhang This would result in many instances of the parser created at initialisation. Could that be a problem somehow?

@RemiLehe @ax3l potentially, we could use this process in many places of the code (I only used it for a few variables just for the illustration). Do you think we should generalise this?