### PR TITLE
In Situ Vis.: Fix Rho Contouring

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -271,7 +271,10 @@ Diagnostics::ComputeAndPack ()
 {
     // prepare the field-data necessary to compute output data
     PrepareFieldDataForOutput();
-    // compute the necessary fields and stiore result in m_mf_output.
+
+    auto & warpx = WarpX::GetInstance();
+
+    // compute the necessary fields and store result in m_mf_output.
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         for(int lev=0; lev<nlev_output; lev++){
             int icomp_dst = 0;
@@ -285,6 +288,11 @@ Diagnostics::ComputeAndPack ()
             }
             // Check that the proper number of components of mf_avg were updated.
             AMREX_ALWAYS_ASSERT( icomp_dst == m_varnames.size() );
+
+            // needed for contour plots of rho, i.e. ascent/sensei
+            if (m_format == "sensei" || m_format == "ascent") {
+                m_mf_output[i_buffer][lev].FillBoundary(warpx.Geom(lev).periodicity());
+            }
         }
     }
 }
@@ -302,7 +310,7 @@ Diagnostics::FilterComputePackFlush (int step, bool force_flush)
 
         for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
             if ( !DoDump (step, i_buffer, force_flush) ) continue;
-                Flush(i_buffer);
+            Flush(i_buffer);
         }
 
     }


### PR DESCRIPTION
Fill the boundaries up to one cell after calculating fields such as `rho`/`rho_<species>` on the fly. This is necessary for properly initialized boundary cells as we pass the data on to in situ visualization libraries.

`rho_electrons` contours in `development` and in this PR (https://github.com/AMReX-Codes/amrex/pull/1488 already applied):
![replay_000200](https://user-images.githubusercontent.com/1353258/97631947-0499d280-19ef-11eb-90f6-8fe225223693.png)
![replay_000200(1)](https://user-images.githubusercontent.com/1353258/97631954-06fc2c80-19ef-11eb-8114-c83471d01e9d.png)

