### PR TITLE
Fixed calls to amrex::Random() to enable HIP compilation

### DIFF
--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -129,7 +129,9 @@ struct IonizationTransformFunc
 {
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (DstData& /*dst*/, SrcData& src, int i_src, int /*i_dst*/) const noexcept
+    void operator() (DstData& /*dst*/, SrcData& src,
+        int i_src, int /*i_dst*/,
+        amrex::RandomEngine const& /*engine*/) const noexcept
     {
         src.m_runtime_idata[0][i_src] += 1;
     }

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -203,6 +203,7 @@ public:
      * @param[in] bx,by,bz magnetic field components (SI units)
      * @param[out] e_ux,e_uy,e_uz gamma*v components of generated electron (SI units)
      * @param[out] p_ux,p_uy,p_uz gamma*v components of generated positron (SI units)
+     * @param[in] engine random number generator engine
      * @return a flag which is 1 if chi_photon was out of table
      */
     AMREX_GPU_DEVICE
@@ -212,14 +213,15 @@ public:
     const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
     const amrex::Real bx, const amrex::Real by, const amrex::Real bz,
     amrex::Real& e_ux, amrex::Real& e_uy, amrex::Real& e_uz,
-    amrex::Real& p_ux, amrex::Real& p_uy, amrex::Real& p_uz) const noexcept
+    amrex::Real& p_ux, amrex::Real& p_uy, amrex::Real& p_uz,
+    amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
         namespace pxr_m = picsar::multi_physics::math;
         namespace pxr_p = picsar::multi_physics::phys;
         namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
 
-        const auto rand_zero_one_minus_epsi = amrex::Random();
+        const auto rand_zero_one_minus_epsi = amrex::Random(engine);
 
         constexpr ParticleReal me = PhysConst::m_e;
         constexpr ParticleReal one_over_me = 1._prt/me;

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
@@ -78,12 +78,12 @@ public:
      */
     AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
-    amrex::Real operator() () const noexcept
+    amrex::Real operator() (amrex::RandomEngine const& engine) const noexcept
     {
         namespace pxr_qs = picsar::multi_physics::phys::quantum_sync;
 
         //A random number in [0,1) should be provided as an argument.
-        return pxr_qs::get_optical_depth(amrex::Random());
+        return pxr_qs::get_optical_depth(amrex::Random(engine));
     }
 };
 //____________________________________________
@@ -194,6 +194,7 @@ public:
      * @param[in] ex,ey,ez electric field components (SI units)
      * @param[in] bx,by,bz magnetic field components (SI units)
      * @param[out] g_ux,g_uy,g_uz gamma*v components of the generated photon (SI units)
+     * @param[in] engine random number generator engine
      * @return a flag which is 1 if chi_photon was out of table
      */
     AMREX_GPU_DEVICE
@@ -202,14 +203,15 @@ public:
     amrex::Real& ux, amrex::Real& uy, amrex::Real& uz,
     const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
     const amrex::Real bx, const amrex::Real by, const amrex::Real bz,
-    amrex::Real& g_ux, amrex::Real& g_uy, amrex::Real& g_uz) const noexcept
+    amrex::Real& g_ux, amrex::Real& g_uy, amrex::Real& g_uz,
+    amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
         namespace pxr_m = picsar::multi_physics::math;
         namespace pxr_p = picsar::multi_physics::phys;
         namespace pxr_qs = picsar::multi_physics::phys::quantum_sync;
 
-        const auto rand_zero_one_minus_epsi = amrex::Random();
+        const auto rand_zero_one_minus_epsi = amrex::Random(engine);
 
         constexpr ParticleReal me = PhysConst::m_e;
         constexpr ParticleReal one_over_me = 1._prt/me;

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -98,11 +98,13 @@ public:
     * @param[in] i_src particle index of the source species
     * @param[in] i_dst1 particle index of target species 1
     * @param[in] i_dst2 particle index of target species 2
+    * @param[in] engine random number generator engine
     */
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (DstData& dst1, DstData& dst2, SrcData& src,
-        int const i_src, int const i_dst1, int const i_dst2) const noexcept
+        int const i_src, int const i_dst1, int const i_dst2,
+        amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
 
@@ -139,7 +141,8 @@ public:
             ex, ey, ez,
             bx, by, bz,
             e_ux, e_uy, e_uz,
-            p_ux, p_uy, p_uz);
+            p_ux, p_uy, p_uz,
+            engine);
 
         src.m_aos[i_src].id() = -1; //destroy photon after pair generation
     }

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -107,10 +107,12 @@ public:
     * @param[in, out] src source species (either electrons or positrons)
     * @param[in] i_src particle index of the source species
     * @param[in] i_dst particle index of target species
+    * @param[in] engine random number generator engine
     */
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (DstData& dst, SrcData& src, int i_src, int i_dst) const noexcept
+    void operator() (DstData& dst, SrcData& src, int i_src, int i_dst,
+        amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
 
@@ -140,11 +142,12 @@ public:
             ux, uy, uz,
             ex, ey, ez,
             bx, by, bz,
-            g_ux, g_uy, g_uz);
+            g_ux, g_uy, g_uz,
+            engine);
 
         //Initialize the optical depth component of the source species.
         src.m_runtime_rdata[m_opt_depth_runtime_comp][i_src] =
-            m_opt_depth_functor();
+            m_opt_depth_functor(engine);
     }
 
 private:

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -76,7 +76,7 @@ Index filterCopyTransformParticles (DstTile& dst, SrcTile& src, Index* mask, Ind
             for (int j = 0; j < N; ++j) {
                 copy(dst_data, src_data, i, N*p_offsets[i] + dst_index + j, engine);
             }
-            transform(dst_data, src_data, i, N*p_offsets[i] + dst_index);
+            transform(dst_data, src_data, i, N*p_offsets[i] + dst_index, engine);
         }
     });
 
@@ -225,7 +225,8 @@ Index filterCopyTransformParticles (DstTile& dst1, DstTile& dst2, SrcTile& src, 
             }
             transform(dst1_data, dst2_data, src_data, i,
                       N*p_offsets[i] + dst1_index,
-                      N*p_offsets[i] + dst2_index);
+                      N*p_offsets[i] + dst2_index,
+                      engine);
         }
     });
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -867,7 +867,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
 #ifdef WARPX_QED
                 if(loc_has_quantum_sync){
-                    p_optical_depth_QSR[ip] = quantum_sync_get_opt();
+                    p_optical_depth_QSR[ip] = quantum_sync_get_opt(engine);
                 }
 
                 if(loc_has_breit_wheeler){


### PR DESCRIPTION
Thanks to https://github.com/ECP-WarpX/WarpX/pull/1486, I noticed that WarpX cannt be compiled with QED and HIP. 
This is due to some residual calls to `amrex::Random()` without the engine argument. This PR should fix the issue.

The test `PlasmaAccelerationBoost3d` has failed (the checksum is different), but I don't understand why!