### PR TITLE
openPMD-api: lib64 on some Systems

### DIFF
--- a/Docs/source/building/openpmd.rst
+++ b/Docs/source/building/openpmd.rst
@@ -107,6 +107,7 @@ Finally, compile WarpX:
 .. code-block:: bash
 
    cd ../WarpX
+   # Note that one some systems, /lib might need to be replaced with /lib64.
    export PKG_CONFIG_PATH=$HOME/warpx_directory/openPMD-install/lib/pkgconfig:$PKG_CONFIG_PATH
    export CMAKE_PREFIX_PATH=$HOME/warpx_directory/openPMD-install:$CMAKE_PREFIX_PATH
 


### PR DESCRIPTION
The default installation suffix for libraries on some systems with multiarch support is `lib64/`.

See https://github.com/openPMD/openPMD-api/pull/793
Close #1489

Thx to @hightower8083 for the report! :sparkles: 