### PR TITLE
Cori: RZ/FFTW issue on CORI

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -12,7 +12,7 @@ you need to type the following command when compiling:
 
 .. note::
 
-   In order to compile the code with a spectral solver, type
+   In order to compile the code with RZ or with a spectral solver, type
 
    ::
 


### PR DESCRIPTION
Hi everyone,

This super tiny PR is just to avoid confusion.
So that users can remember to load the module when compiling *WarpX* in CORI@NERSC with the RZ geometry (even if without the spectral solver) so the code finds: `<fftw3.h>` (Otherwise the build breaks).

Cheers,
Diana