### PR TITLE
Fix includes in RhoFunctor.cpp

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -2,7 +2,7 @@
 #include "RhoFunctor.H"
 #include "Utils/CoarsenIO.H"
 
-#ifdef WARPX_DIM_RZ
+#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
 #include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
 


### PR DESCRIPTION
This fixes an include statement in RhoFunctor.cpp so that it only includes SpectralFieldData.H when RZ and PSATD are used.

This should fix issue #1497 