### PR TITLE
sx_node_galerkin: fix access to uninitialized memory

### DIFF
--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -105,6 +105,10 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     amrex::Real sx_cell[depos_order + 1];
     amrex::Real sx_node_galerkin[depos_order + 1 - galerkin_interpolation];
     amrex::Real sx_cell_galerkin[depos_order + 1 - galerkin_interpolation];
+
+    for (auto& el : sx_node_galerkin) el = 0.0_rt;
+    for (auto& el : sx_cell_galerkin) el = 0.0_rt;
+
     int j_node = 0;
     int j_cell = 0;
     int j_node_v = 0;

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -103,11 +103,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     // arrays will be needed.
     amrex::Real sx_node[depos_order + 1];
     amrex::Real sx_cell[depos_order + 1];
-    amrex::Real sx_node_galerkin[depos_order + 1 - galerkin_interpolation];
-    amrex::Real sx_cell_galerkin[depos_order + 1 - galerkin_interpolation];
-
-    for (auto& el : sx_node_galerkin) el = 0.0_rt;
-    for (auto& el : sx_cell_galerkin) el = 0.0_rt;
+    amrex::Real sx_node_galerkin[depos_order + 1 - galerkin_interpolation] = {0._rt};
+    amrex::Real sx_cell_galerkin[depos_order + 1 - galerkin_interpolation] = {0._rt};
 
     int j_node = 0;
     int j_cell = 0;


### PR DESCRIPTION
This PR fixes a warning stating that `sx_node_galerkin` could be used before initialization.