### PR TITLE
ParticleNumber reduced diag: also output total number of physical particles

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1679,13 +1679,16 @@ Reduced Diagnostics
         computed.
 
     * ``ParticleNumber``
-        This type computes the total number of macroparticles in the simulation (for each species
-        and summed over all species). It can be useful in particular for simulations with creation
-        (ionization, QED processes) or removal (resampling) of particles.
+        This type computes the total number of macroparticles and of physical particles (i.e. the
+        sum of their weights) in the whole simulation domain (for each species and summed over all
+        species). It can be useful in particular for simulations with creation (ionization, QED
+        processes) or removal (resampling) of particles.
 
         The output columns are
-        total number of macroparticles summed over all species and
-        total number of macroparticles of each species.
+        total number of macroparticles summed over all species,
+        total number of macroparticles of each species,
+        sum of the particles' weight summed over all species,
+        sum of the particles' weight of each species.
 
     * ``BeamRelevant``
         This type computes properties of a particle beam relevant for particle accelerators,

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -43,6 +43,7 @@ pz = ad['electrons','particle_momentum_z'].to_ndarray()
 w  = ad['electrons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt((px**2+py**2+pz**2)*scc.c**2+scc.m_e**2*scc.c**4)-scc.m_e*scc.c**2)*w )
 num_electron = w.shape[0]
+sum_weight_electron = np.sum(w)
 
 # proton
 px = ad['protons','particle_momentum_x'].to_ndarray()
@@ -51,6 +52,7 @@ pz = ad['protons','particle_momentum_z'].to_ndarray()
 w  = ad['protons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt((px**2+py**2+pz**2)*scc.c**2+scc.m_p**2*scc.c**4)-scc.m_p*scc.c**2)*w )
 num_proton = w.shape[0]
+sum_weight_proton = np.sum(w)
 
 # photon
 px = ad['photons','particle_momentum_x'].to_ndarray()
@@ -59,7 +61,10 @@ pz = ad['photons','particle_momentum_z'].to_ndarray()
 w  = ad['photons','particle_weight'].to_ndarray()
 EPyt = EPyt + np.sum( (np.sqrt(px**2+py**2+pz**2)*scc.c)*w )
 num_photon = w.shape[0]
+sum_weight_photon = np.sum(w)
+
 num_total = num_electron + num_proton + num_photon
+sum_weight_total = sum_weight_electron + sum_weight_proton + sum_weight_photon
 
 ad = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
 Ex = ad['Ex'].to_ndarray()
@@ -102,6 +107,10 @@ num_total_data = NPdata[1][2]
 num_electron_data = NPdata[1][3]
 num_proton_data = NPdata[1][4]
 num_photon_data = NPdata[1][5]
+sum_weight_total_data = NPdata[1][6]
+sum_weight_electron_data = NPdata[1][7]
+sum_weight_proton_data = NPdata[1][8]
+sum_weight_photon_data = NPdata[1][9]
 
 # PART3: print and assert
 
@@ -111,6 +120,10 @@ max_diffBmax = max(abs(max_Bxdata-max_Bx),abs(max_Bydata-max_By),
                    abs(max_Bzdata-max_Bz),abs(max_Bdata-max_B))
 max_diff_number = max(abs(num_total_data-num_total),abs(num_electron_data-num_electron),
                    abs(num_proton_data-num_proton),abs(num_photon_data-num_photon))
+max_diff_sum_weight = max(abs(sum_weight_total_data-sum_weight_total),
+                          abs(sum_weight_electron_data-sum_weight_electron),
+                          abs(sum_weight_proton_data-sum_weight_proton),
+                          abs(sum_weight_photon_data-sum_weight_photon))
 
 print('difference of field energy:', abs(EFyt-EF))
 print('tolerance of field energy:', 1.0e-3)
@@ -120,12 +133,15 @@ print('maximum difference of maximum electric field:', max_diffEmax)
 print('tolerance of maximum electric field difference:', 1.0e-9)
 print('maximum difference of maximum magnetic field:', max_diffBmax)
 print('tolerance of maximum magnetic field difference:', 1.0e-18)
+print('maximum difference of particle weight sum:', max_diff_sum_weight)
+print('tolerance of particle weight sum:', 0.5)
 
 assert(abs(EFyt-EF) < 1.0e-3)
 assert(abs(EPyt-EP) < 1.0e-8)
 assert(max_diffEmax < 1.0e-9)
 assert(max_diffBmax < 1.0e-18)
 assert(max_diff_number < 0.5)
+assert(max_diff_sum_weight < 0.5)
 
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.H
@@ -11,8 +11,8 @@
 #include "ReducedDiags.H"
 
 /**
- *  This class mainly contains a function that computes the total number of macroparticles of each
- *  species.
+ *  This class mainly contains a function that computes the total number of macroparticles and of
+ *  physical particles (i.e. the sum of the weights) of each species.
  */
 class ParticleNumber : public ReducedDiags
 {
@@ -22,7 +22,8 @@ public:
      *  @param[in] rd_name reduced diags names */
     ParticleNumber(std::string rd_name);
 
-    /** This function computes the total number of macroparticles of each species.
+    /** This function computes the total number of macroparticles and physical particles of each
+     *  species.
      *  @param [in] step current time step
      */
     virtual void ComputeDiags(int step) override final;


### PR DESCRIPTION
A recent PR (#1414) has added the `ParticleNumber` reduced diagnostic, which computes the total number of macroparticles of each species in the simulation (useful for scenarios with ionization, QED particle creation or particle resampling).

I've also found it useful to have the total number of _physical_ particles (i.e. the sum of their weights), so in this PR I propose to add this quantity in the `ParticleNumber` reduced diag (which now outputs both the total number of macroparticles and of physical particles of each species).

In practice the sum of the weights was already calculated in the `ParticleEnergy` reduced diag so I just reused these lines of code.