### PR TITLE
Change Spelling: Env AMREX_CUDA_ARCH

### DIFF
--- a/Docs/source/building/juwels.rst
+++ b/Docs/source/building/juwels.rst
@@ -56,7 +56,7 @@ We use the following modules and environments on the system.
    export GPUS_PER_NODE=4
 
    # optimize CUDA compilation for V100 (CMake hint)
-   export AMReX_CUDA_ARCH=7.0
+   export AMREX_CUDA_ARCH=7.0
 
 Note that for now WarpX must rely on OpenMPI instead of the recommended MPI implementation on this platform MVAPICH2.
 

--- a/Docs/source/building/lassen.rst
+++ b/Docs/source/building/lassen.rst
@@ -59,7 +59,7 @@ We use the following modules and environments on the system.
    shopt -s direxpand
 
    # optimize CUDA compilation for V100
-   export AMReX_CUDA_ARCH=7.0
+   export AMREX_CUDA_ARCH=7.0
 
    # compiler environment hints
    export CC=$(which gcc)

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -90,7 +90,7 @@ We use the following modules and environments on the system.
    shopt -s direxpand
 
    # optimize CUDA compilation for V100
-   export AMReX_CUDA_ARCH=7.0
+   export AMREX_CUDA_ARCH=7.0
 
    # compiler environment hints
    export CC=$(which gcc)


### PR DESCRIPTION
We change the spelling of this environment hint in AMReX, to make it more common with typical unix conventions/expectations.

Ref.:
- upstream change: https://github.com/AMReX-Codes/amrex/pull/1522
- follow-up to #1492
