### PR TITLE
[mini]Fix check of m_do_scale in ScaleFields

### DIFF
--- a/Source/Particles/Gather/ScaleFields.H
+++ b/Source/Particles/Gather/ScaleFields.H
@@ -41,7 +41,7 @@ struct ScaleFields
     {
         using namespace amrex::literals;
 
-        if (m_do_scale != 0.0_rt) return;
+        if (!m_do_scale) return;
 
         // Scale the fields of particles about to cross the injection plane.
         // This only approximates what should be happening. The particles


### PR DESCRIPTION
In `Particles/Gather/ScaleFields.H`, the check of the bool `m_do_scale` was bad which meant that the scaling was attempted even when `m_do_scale` was set to false. This was affecting versions compiled with g++ and with clang++. In both cases, the `dtscale` was being calculated with garbage values but by chance, with gcc, the if test on `dtscale` was always false, but sometimes with clang it was true, causing the fields to be scaled by garbage. Presumably the memory layout is different for the two compilers so different garbage was used.

This bug was discovered by tracing down a problem with the ElectrostaticSphere test which was giving bad answers when compiled with clang and using libomp on macOS.