### PR TITLE
Fix Box-index staggering for Coarse-fine Interpolate

### DIFF
--- a/Examples/Tests/Larmor/inputs_2d_mr
+++ b/Examples/Tests/Larmor/inputs_2d_mr
@@ -67,7 +67,12 @@ warpx.do_moving_window = 0
 warpx.do_dive_cleaning = 1
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diagraw
 diag1.period = 2
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divE divB
+
+diagraw.period = 2
+diagraw.plot_raw_fields=1
+diagraw.diag_type = Full
+diagraw.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell divE divB

--- a/Source/Utils/Interpolate.cpp
+++ b/Source/Utils/Interpolate.cpp
@@ -74,9 +74,9 @@ namespace Interpolate
 #endif
         for (MFIter mfi(*interpolated_F[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            Box const& boxx = mfi.growntilebox(fx_type);
-            Box const& boxy = mfi.growntilebox(fy_type);
-            Box const& boxz = mfi.growntilebox(fz_type);
+            Box const& boxx = mfi.tilebox(fx_type);
+            Box const& boxy = mfi.tilebox(fy_type);
+            Box const& boxz = mfi.tilebox(fz_type);
 
             Array4<Real      > const& fx = interpolated_F[0]->array(mfi);
             Array4<Real      > const& fy = interpolated_F[1]->array(mfi);


### PR DESCRIPTION
A Larmor test with MR in `Examples/Tests/Larmor ` with `diags.plot_raw_fields=1`,  was crashing with the following error message : 
`malloc.c:2379: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.`

The source of the error was in Interpolate.cpp, where the box-indices in an MFIter loop is modified to account for the staggering of the field components.
In this PR, the staggered box indices is fixed by using 'mfi.tilebox(IntVect)', which converts the BoxIndex based on the staggering stored in IntVect.


