### PR TITLE
Fix: Typo in Extract Action

### DIFF
--- a/Docs/source/visualization/ascent.rst
+++ b/Docs/source/visualization/ascent.rst
@@ -199,7 +199,7 @@ The following block can be used in an ascent action to extract *Conduit Blueprin
 .. code-block:: yaml
 
     -
-      action: action: "add_extracts"
+      action: "add_extracts"
       extracts:
         e1:
           type: "relay"


### PR DESCRIPTION
Fix a typo in the extraction action for replay workflows.