### PR TITLE
use_filter now controls physical and k-space filtering

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1012,21 +1012,15 @@ Numerics and algorithms
     Whether to smooth the charge and currents on the mesh, after depositing
     them from the macroparticles. This uses a bilinear filter
     (see the sub-section **Filtering** in :doc:`../theory/theory`).
-
-* ``warpx.use_kspace_filter`` (`0` or `1`; default: `0`)
-    Whether to smooth the charge and currents on the mesh, after depositing
-    them from the macroparticles. This uses a bilinear filter, applying the
-    filter in k-space. It is only supported with the RZ spectral solver.
-    (see the sub-section **Filtering** in :doc:`../theory/theory`).
+    When using the RZ spectral solver, the filtering is done in k-space.
 
 * ``warpx.filter_npass_each_dir`` (`3 int`) optional (default `1 1 1`)
     Number of passes along each direction for the bilinear filter.
     In 2D simulations, only the first two values are read.
 
 * ``warpx.use_filter_compensation`` (`0` or `1`; default: `0`)
-    Whether to add compensation when applying k-space filtering.
-    This requires `warpx.use_kspace_filter=1` and is only supported
-    with the RZ spectral solver.
+    Whether to add compensation when applying filtering.
+    This is only supported with the RZ spectral solver.
 
 * ``warpx.use_damp_fields_in_z_guard`` (`0` or `1`)
     When using the RZ spectrol solver, specifies whether to apply a

--- a/Examples/Tests/galilean/inputs_rz
+++ b/Examples/Tests/galilean/inputs_rz
@@ -34,7 +34,7 @@ interpolation.noz = 3
 particles.species_names = electrons ions
 
 warpx.do_nodal = 1
-warpx.use_kspace_filter = 1
+warpx.use_filter = 1
 warpx.do_pml = 0
 
 psatd.nox = 16

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -313,13 +313,8 @@ class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
 class BinomialSmoother(picmistandard.PICMI_BinomialSmoother):
 
     def initialize_inputs(self, solver):
-        use_spectral = solver.method == 'PSATD' and isinstance(solver.grid, picmistandard.PICMI_CylindricalGrid)
-        if use_spectral:
-            pywarpx.warpx.use_kspace_filter = 1
-            if self.compensation is not None:
-                pywarpx.warpx.use_filter_compensation = self.compensation[0] and self.compensation[1]
-        else:
-            pywarpx.warpx.use_filter = 1
+        pywarpx.warpx.use_filter = 1
+        pywarpx.warpx.use_filter_compensation = np.all(self.compensation)
         if self.n_pass is None:
             # If not specified, do at least one pass in each direction.
             self.n_pass = 1

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -463,7 +463,6 @@ WarpX::ReadParameters ()
         // Read filter and fill IntVect filter_npass_each_dir with
         // proper size for AMREX_SPACEDIM
         pp.query("use_filter", use_filter);
-        pp.query("use_kspace_filter", use_kspace_filter);
         pp.query("use_filter_compensation", use_filter_compensation);
         Vector<int> parse_filter_npass_each_dir(AMREX_SPACEDIM,1);
         pp.queryarr("filter_npass_each_dir", parse_filter_npass_each_dir);
@@ -471,6 +470,12 @@ WarpX::ReadParameters ()
         filter_npass_each_dir[1] = parse_filter_npass_each_dir[1];
 #if (AMREX_SPACEDIM == 3)
         filter_npass_each_dir[2] = parse_filter_npass_each_dir[2];
+#endif
+
+#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
+        // With RZ spectral, only use k-space filtering
+        use_kspace_filter = use_filter;
+        use_filter = false;
 #endif
 
         pp.query("num_mirrors", num_mirrors);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -776,6 +776,10 @@ WarpX::BackwardCompatibility ()
         amrex::Abort("warpx.plot_crsepatch is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
+    if (ppw.query("use_kspace_filter", backward_int)){
+        amrex::Abort("warpx.use_kspace_filter is not supported anymore. "
+                     "Please use the flag use_filter, see documentation.");
+    }
 
     ParmParse ppalgo("algo");
     int backward_mw_solver;


### PR DESCRIPTION
This unifies the flags for turning on filtering. The flag `use_filter` is now used for both physical space filtering (same as before) and k-space filtering (which only applied to the RZ spectral solver).

Note that use_kspace_filter is not longer queried as an input parameter and an error is raised if it is set in an input file.