### PR TITLE
CMake: Fix PSATD on CUDA

### DIFF
--- a/Source/FieldSolver/SpectralSolver/CMakeLists.txt
+++ b/Source/FieldSolver/SpectralSolver/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(WarpX
     SpectralSolver.cpp
 )
 
-if(ENABLE_CUDA)
+if(AMReX_CUDA)
     target_sources(WarpX
       PRIVATE
         WrapCuFFT.cpp


### PR DESCRIPTION
Regression build/linker error from an outdated CMake variable.

Follow-up to #1492