### PR TITLE
CMake: objects, shared library, Python

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,9 +33,11 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
         which nvcc || echo "nvcc not in PATH!"
 
-        mkdir build_sp && cd build_sp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_COMPUTE=CUDA -DAMReX_CUDA_ARCH=6.0 -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE -DCUDA_ERROR_CAPTURE_THIS=ON
-        make -j 2
+        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_COMPUTE=CUDA -DAMReX_CUDA_ARCH=6.0 -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE -DCUDA_ERROR_CAPTURE_THIS=ON
+        cmake --build build_sp -j 2
+
+        python3 -m pip install --upgrade pip setuptools wheel
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
@@ -69,15 +71,14 @@ jobs:
         export CXX=$(which icpc)
         export CC=$(which icc)
 
-        mkdir build_dp && cd build_dp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF
-        make -j 2
+        cmake -S . -B build_dp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF
+        cmake --build build_dp -j 2
 
-        cd ..
+        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
+        cmake --build build_sp -j 2
 
-        mkdir build_sp && cd build_sp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
-        make -j 2
+        python3 -m pip install --upgrade pip setuptools wheel
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
   build_dpcc:
     name: oneAPI DPC++ SP [Linux]
@@ -91,8 +92,8 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive
         sudo apt-get -qqq update
         sudo apt-get install -y wget build-essential pkg-config ca-certificates gnupg
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade cmake
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade cmake
         sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
@@ -116,9 +117,11 @@ jobs:
         export CXX=$(which dpcpp)
         export CC=$(which clang)
 
-        mkdir build_sp && cd build_sp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_COMPUTE=DPCPP -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
-        make -j 2
+        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_COMPUTE=DPCPP -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
+        cmake --build build_sp -j 2
+
+        python3 -m pip install --upgrade setuptools wheel
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
   build_hip:
     name: HIP SP [Linux]
@@ -136,6 +139,7 @@ jobs:
         export CXX=$(which hipcc)
         export CC=$(which hipcc)
 
-        mkdir build_sp && cd build_sp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=ON -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx900 -DWarpX_OPENPMD=ON -DWarpX_PRECISION=SINGLE
-        make -j 2
+        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=ON -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx900 -DWarpX_OPENPMD=ON -DWarpX_PRECISION=SINGLE
+        cmake --build build_sp -j 2
+
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,14 @@ set_default_install_dirs()
 
 # Options and Variants ########################################################
 #
+option(WarpX_APP           "Build the WarpX executable application"     ON)
 option(WarpX_ASCENT        "Ascent in situ diagnostics"                 OFF)
+option(WarpX_LIB           "Build WarpX as a shared library"            OFF)
 option(WarpX_MPI           "Multi-node support (message-passing)"       ON)
 option(WarpX_OPENPMD       "openPMD I/O (HDF5, ADIOS)"                  OFF)
 option(WarpX_PSATD         "spectral solver support"                    OFF)
 option(WarpX_QED           "PICSAR QED (requires Boost and PICSAR)"     OFF)
-# TODO: python, sensei, legacy hdf5?
+# TODO: sensei, legacy hdf5?
 
 set(WarpX_DIMS_VALUES 2 3 RZ)
 set(WarpX_DIMS 3 CACHE STRING "Simulation dimensionality (2/3/RZ)")
@@ -126,25 +128,57 @@ endif()
 
 # Targets #####################################################################
 #
-# executable
-add_executable(WarpX)
-add_executable(WarpX::WarpX ALIAS WarpX)
+if(NOT WarpX_APP AND NOT WarpX_LIB)
+    message(FATAL_ERROR "Need to build at least WarpX app or "
+                        "library/Python bindings")
+endif()
+
+# collect all objects for compilation
+add_library(WarpX OBJECT)
+set(_ALL_TARGETS WarpX)
+
+# executable application
+#   note: we currently avoid a dependency on a core library
+#         for simpler usage, but could make this an option
+if(WarpX_APP)
+    add_executable(app)
+    add_executable(WarpX::app ALIAS app)
+    target_link_libraries(app PRIVATE WarpX)
+    set(_BUILDINFO_SRC app)
+    list(APPEND _ALL_TARGETS app)
+endif()
+
+# link into a shared library
+if(WarpX_LIB)
+    add_library(shared MODULE)
+    add_library(WarpX::shared ALIAS shared)
+    target_link_libraries(shared PUBLIC WarpX)
+    set(_BUILDINFO_SRC shared)
+    list(APPEND _ALL_TARGETS shared)
+
+    set_target_properties(WarpX shared PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
+endif()
 
 # own headers
-target_include_directories(WarpX PRIVATE
+target_include_directories(WarpX PUBLIC
     $<BUILD_INTERFACE:${WarpX_SOURCE_DIR}/Source>
 )
 
 # if we include <AMReX_buildInfo.H> we will need to call:
 include(AMReXBuildInfo)
-generate_buildinfo(WarpX "${WarpX_SOURCE_DIR}")
+generate_buildinfo(${_BUILDINFO_SRC} "${WarpX_SOURCE_DIR}")
+target_link_libraries(WarpX PRIVATE buildInfo::${_BUILDINFO_SRC})
+unset(_BUILDINFO_SRC)
 
 # add sources
-target_sources(WarpX
-  PRIVATE
-    Source/main.cpp
-    Source/WarpX.cpp
-)
+target_sources(WarpX PRIVATE Source/WarpX.cpp)
+if(WarpX_APP)
+    target_sources(app PRIVATE Source/main.cpp)
+endif()
+
 add_subdirectory(Source/BoundaryConditions)
 add_subdirectory(Source/Diagnostics)
 add_subdirectory(Source/Evolve)
@@ -159,8 +193,10 @@ add_subdirectory(Source/Python)
 add_subdirectory(Source/Utils)
 
 # C++ properties: at least a C++14 capable compiler is needed
-target_compile_features(WarpX PUBLIC cxx_std_14)
-set_target_properties(WarpX PROPERTIES
+foreach(warpx_tgt IN LISTS _ALL_TARGETS)
+    target_compile_features(${warpx_tgt} PUBLIC cxx_std_14)
+endforeach()
+set_target_properties(${_ALL_TARGETS} PROPERTIES
     CXX_EXTENSIONS OFF
     CXX_STANDARD_REQUIRED ON
 )
@@ -200,9 +236,14 @@ endif()
 # AMReX helper function: propagate CUDA specific target & source properties
 if(AMReX_CUDA)
     setup_target_for_cuda_compilation(WarpX)
+    foreach(warpx_tgt IN LISTS _ALL_TARGETS)
+        setup_target_for_cuda_compilation(${warpx_tgt})
+    endforeach()
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        target_compile_features(WarpX PUBLIC cuda_std_14)
-        set_target_properties(WarpX PROPERTIES
+        foreach(warpx_tgt IN LISTS _ALL_TARGETS)
+            target_compile_features(${warpx_tgt} PUBLIC cuda_std_14)
+        endforeach()
+        set_target_properties(${_ALL_TARGETS} PROPERTIES
             CUDA_EXTENSIONS OFF
             CUDA_STANDARD_REQUIRED ON
         )
@@ -216,29 +257,29 @@ set_warpx_binary_name()
 # Defines #####################################################################
 #
 if(WarpX_DIMS STREQUAL 3)
-    target_compile_definitions(WarpX PRIVATE WARPX_DIM_3D)
+    target_compile_definitions(WarpX PUBLIC WARPX_DIM_3D)
 elseif(WarpX_DIMS STREQUAL 2)
-    target_compile_definitions(WarpX PRIVATE WARPX_DIM_XZ)
+    target_compile_definitions(WarpX PUBLIC WARPX_DIM_XZ)
 elseif(WarpX_DIMS STREQUAL RZ)
-    target_compile_definitions(WarpX PRIVATE WARPX_DIM_RZ)
+    target_compile_definitions(WarpX PUBLIC WARPX_DIM_RZ)
 endif()
 
 if(WarpX_OPENPMD)
-    target_compile_definitions(WarpX PRIVATE WARPX_USE_OPENPMD)
+    target_compile_definitions(WarpX PUBLIC WARPX_USE_OPENPMD)
 endif()
 
 if(WarpX_QED)
-    target_compile_definitions(WarpX PRIVATE WARPX_QED)
+    target_compile_definitions(WarpX PUBLIC WARPX_QED)
     if(WarpX_QED_TABLE_GEN)
-        target_compile_definitions(WarpX PRIVATE WarpX_QED_TABLE_GEN)
+        target_compile_definitions(WarpX PUBLIC WarpX_QED_TABLE_GEN)
     endif()
 endif()
 
 if(WarpX_PSATD)
-    target_compile_definitions(WarpX PRIVATE WARPX_USE_PSATD)
+    target_compile_definitions(WarpX PUBLIC WARPX_USE_PSATD)
 endif()
 
-target_compile_definitions(WarpX PRIVATE
+target_compile_definitions(WarpX PUBLIC
     WARPX_PARSER_DEPTH=${WarpX_PARSER_DEPTH})
 
 # <cmath>: M_PI
@@ -269,7 +310,13 @@ set_cxx_warnings()
 # Installs ####################################################################
 #
 # headers, libraries and executables
-set(WarpX_INSTALL_TARGET_NAMES WarpX)
+set(WarpX_INSTALL_TARGET_NAMES)
+if(WarpX_APP)
+    list(APPEND WarpX_INSTALL_TARGET_NAMES app)
+endif()
+if(WarpX_LIB)
+    list(APPEND WarpX_INSTALL_TARGET_NAMES shared)
+endif()
 
 install(TARGETS ${WarpX_INSTALL_TARGET_NAMES}
     EXPORT WarpXTargets

--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -99,32 +99,31 @@ From the base of the WarpX source directory, execute:
 
 .. code-block:: bash
 
-   mkdir -p build
-   cd build
-
    # find dependencies & configure
-   cmake ..
+   cmake -S . -B build
 
    # build using up to four threads
-   make -j 4
+   cmake --build build -j 4
 
    # run tests (todo)
 
-You can inspect and modify build options after running ``cmake ..`` with either
+You can inspect and modify build options after running ``cmake -S . -B build`` with either
 
 .. code-block:: bash
 
-   ccmake .
+   ccmake build
 
-or by providing arguments to the CMake call: ``cmake .. -D<OPTION_A>=<VALUE_A> -D<OPTION_B>=<VALUE_B>``
+or by providing arguments to the CMake call: ``cmake -S . -B build -D<OPTION_A>=<VALUE_A> -D<OPTION_B>=<VALUE_B>``
 
 ============================= ============================================ =======================================================
 CMake Option                  Default & Values                             Description
 ============================= ============================================ =======================================================
 ``CMAKE_BUILD_TYPE``          **RelWithDebInfo**/Release/Debug             Type of build, symbols & optimizations
+``WarpX_APP``                 **ON**/OFF                                   Build the WarpX executable application
 ``WarpX_ASCENT``              ON/**OFF**                                   Ascent in situ visualization
 ``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/DPCPP/HIP                 On-node, accelerated computing backend
 ``WarpX_DIMS``                **3**/2/RZ                                   Simulation dimensionality
+``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a shared library
 ``WarpX_MPI``                 **ON**/OFF                                   Multi-node support (message-passing)
 ``WarpX_MPI_THREAD_MULTIPLE`` **ON**/OFF                                   MPI thread-multiple support, i.e. for ``async_io``
 ``WarpX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
@@ -146,6 +145,26 @@ For developers, WarpX can be configured in further detail with options from AMRe
 Run
 ===
 
-An executable WarpX binary with the current compile-time options encoded in its file name will be created in ``bin/``.
+An executable WarpX binary with the current compile-time options encoded in its file name will be created in ``build/bin/``.
 
 Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`_ named ``warpx`` can be found in that directory, which points to the last built WarpX executable.
+
+Python Wrapper
+==============
+
+The Python wrapper library can be built by pre-building WarpX into one or more shared libraries.
+For full functionality in 2D, 3D and RZ geometry, the following workflow can be executed:
+
+.. code-block:: bash
+
+   # build
+   for d in 2 3 RZ; do
+     cmake -S . -B build -DWarpX_DIMS=$d -DWarpX_LIB=ON
+     cmake --build build -j 4
+   done
+
+   # package
+   PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel Python/
+
+   # install
+   python3 -m pip install pywarpx-*whl

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -59,10 +59,18 @@ else:
 
 _libc = ctypes.CDLL(_find_library('c'))
 
+# macOS/Linux use .so, Windows uses .pyd
+# https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll
+if os.name == 'nt':
+    mod_ext = "pyd"
+else:
+    mod_ext = "so"
+libname = "libwarpx{0}.{1}".format(geometry_dim, mod_ext)
+
 try:
-    libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), "libwarpx%s.so"%geometry_dim))
+    libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), libname))
 except OSError:
-    raise Exception('libwarpx%s.so was not installed. It can be installed by running "make" in the Python directory of WarpX'%geometry_dim)
+    raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname)
 
 # WarpX can be compiled using either double or float
 libwarpx.warpx_Real_size.restype = ctypes.c_int

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -12,27 +12,54 @@
 setup.py file for WarpX
 """
 
-import sys
 import argparse
+import os
+import sys
 
 from setuptools import setup
 
 argparser = argparse.ArgumentParser(add_help=False)
-argparser.add_argument('--with-libwarpx', type=str, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the makefile.')
+argparser.add_argument('--with-libwarpx', type=str, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the GNU makefile build system.')
+argparser.add_argument('--with-lib-dir', type=str, default=None, help='Install with all libwarpx* binaries found in a directory.')
 args, unknown = argparser.parse_known_args()
 sys.argv = [sys.argv[0]] + unknown
 
+allowed_dims = ["2d", "3d", "rz"]
+
+# Allow to control options via environment vars.
+# Work-around for https://github.com/pypa/setuptools/issues/1712
+PYWARPX_LIB_DIR = os.environ.get('PYWARPX_LIB_DIR')
+
 if args.with_libwarpx:
-    package_data = {'pywarpx' : ['libwarpx%s.so'%args.with_libwarpx]}
+    # GNUmake
+    if args.with_libwarpx not in allowed_dims:
+        print("WARNING: '%s' is not an allowed WarpX DIM" % args.with_libwarpx)
+    package_data = {'pywarpx' : ['libwarpx%s.so' % args.with_libwarpx]}
+    data_files = []
+elif args.with_lib_dir or PYWARPX_LIB_DIR:
+    # CMake and Package Managers
+    package_data = {'pywarpx' : []}
+    lib_dir = args.with_lib_dir if args.with_lib_dir else PYWARPX_LIB_DIR
+    my_path = os.path.dirname(os.path.realpath(__file__))
+    for dim in allowed_dims:
+        lib_name = 'libwarpx%s.so' % dim
+        lib_path = os.path.join(lib_dir, lib_name)
+        link_name = os.path.join(my_path, "pywarpx", lib_name)
+        if os.path.isfile(link_name):
+            os.remove(link_name)
+        if os.path.isfile(lib_path) and os.access(lib_path, os.R_OK):
+            os.symlink(lib_path, link_name)
+            package_data['pywarpx'].append(lib_name)
 else:
     package_data = {}
 
-setup (name = 'pywarpx',
-       version = '20.12',
-       packages = ['pywarpx'],
-       package_dir = {'pywarpx':'pywarpx'},
-       description = """Wrapper of WarpX""",
-       package_data = package_data,
-       install_requires=['numpy', 'picmistandard==0.0.12', 'periodictable'],
-       python_requires = '>=3.6'
-       )
+setup(name = 'pywarpx',
+      version = '20.12',
+      packages = ['pywarpx'],
+      package_dir = {'pywarpx': 'pywarpx'},
+      description = """Wrapper of WarpX""",
+      package_data = package_data,
+      install_requires = ['numpy', 'picmistandard==0.0.12', 'periodictable'],
+      python_requires = '>=3.6',
+      zip_safe=False
+)

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -129,55 +129,86 @@ endfunction()
 # warpx symlink to it. Only sets options relevant for users (see summary).
 #
 function(set_warpx_binary_name)
-    set_target_properties(WarpX PROPERTIES OUTPUT_NAME "warpx")
-    if(WarpX_DIMS STREQUAL 3)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".3d")
-    elseif(WarpX_DIMS STREQUAL 2)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".2d")
-    elseif(WarpX_DIMS STREQUAL RZ)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".RZ")
+    set(warpx_bin_names)
+    if(WarpX_APP)
+        list(APPEND warpx_bin_names app)
     endif()
-
-    if(WarpX_MPI)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".MPI")
-    else()
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".NOMPI")
+    if(WarpX_LIB)
+        list(APPEND warpx_bin_names shared)
     endif()
+    foreach(tgt IN LISTS _ALL_TARGETS)
+        set_target_properties(${tgt} PROPERTIES OUTPUT_NAME "warpx")
+        if(WarpX_DIMS STREQUAL 3)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".3d")
+        elseif(WarpX_DIMS STREQUAL 2)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".2d")
+        elseif(WarpX_DIMS STREQUAL RZ)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".RZ")
+        endif()
 
-    set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".${WarpX_COMPUTE}")
+        if(WarpX_MPI)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".MPI")
+        else()
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".NOMPI")
+        endif()
 
-    if(WarpX_PRECISION STREQUAL "DOUBLE")
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".DP")
-    else()
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".SP")
+        set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".${WarpX_COMPUTE}")
+
+        if(WarpX_PRECISION STREQUAL "DOUBLE")
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".DP")
+        else()
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".SP")
+        endif()
+
+        if(WarpX_ASCENT)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".ASCENT")
+        endif()
+
+        if(WarpX_OPENPMD)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".OPMD")
+        endif()
+
+        if(WarpX_PSATD)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".PSATD")
+        endif()
+
+        if(WarpX_QED)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".QED")
+        endif()
+
+        if(CMAKE_BUILD_TYPE MATCHES "Debug")
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".DEBUG")
+        endif()
+    endforeach()
+    
+    if(WarpX_APP)
+        # alias to the latest build, because using the full name is often confusing
+        add_custom_command(TARGET app POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E create_symlink
+                $<TARGET_FILE:app>
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/warpx
+        )
     endif()
-
-    if(WarpX_ASCENT)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".ASCENT")
+    if(WarpX_LIB)
+        # alias to the latest build; this is the one expected by Python bindings
+        if(WarpX_DIMS STREQUAL 3)
+            set(lib_suffix "3d")
+        elseif(WarpX_DIMS STREQUAL 2)
+            set(lib_suffix "2d")
+        elseif(WarpX_DIMS STREQUAL RZ)
+            set(lib_suffix "rz")
+        endif()
+        if(WIN32)
+            set(mod_ext "pyd")
+        else()
+            set(mod_ext "so")
+        endif()
+        add_custom_command(TARGET shared POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E create_symlink
+                $<TARGET_FILE:shared>
+                ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwarpx${lib_suffix}.${mod_ext}
+        )
     endif()
-
-    if(WarpX_OPENPMD)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".OPMD")
-    endif()
-
-    if(WarpX_PSATD)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".PSATD")
-    endif()
-
-    if(WarpX_QED)
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".QED")
-    endif()
-
-    if(CMAKE_BUILD_TYPE MATCHES "Debug")
-        set_property(TARGET WarpX APPEND_STRING PROPERTY OUTPUT_NAME ".DEBUG")
-    endif()
-
-    # alias to the latest build, because using the full name is often confusing
-    add_custom_command(TARGET WarpX POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E create_symlink
-            $<TARGET_FILE:WarpX>
-            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/warpx
-    )
 endfunction()
 
 
@@ -236,9 +267,11 @@ function(warpx_print_summary)
     #message("  Invasive Tests: ${WarpX_USE_INVASIVE_TESTS}")
     #message("  Internal VERIFY: ${WarpX_USE_VERIFY}")
     message("  Build options:")
+    message("    APP: ${WarpX_APP}")
     message("    ASCENT: ${WarpX_ASCENT}")
     message("    COMPUTE: ${WarpX_COMPUTE}")
     message("    DIMS: ${WarpX_DIMS}")
+    message("    LIB: ${WarpX_LIB}")
     message("    MPI: ${WarpX_MPI}")
     if(MPI)
         message("    MPI (thread multiple): ${WarpX_MPI_THREAD_MULTIPLE}")

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -72,8 +72,10 @@ macro(find_amrex)
         set(AMReX_TINY_PROFILE ON CACHE BOOL "")
 
         # AMReX_SENSEI
-        # we'll need this for Python bindings
-        #set(AMReX_PIC ON CACHE INTERNAL "")
+        # shared libs, i.e. for Python bindings, need relocatable code
+        if(WarpX_LIB)
+            set(AMReX_PIC ON CACHE INTERNAL "")
+        endif()
 
         if(WarpX_DIMS STREQUAL RZ)
             set(AMReX_SPACEDIM 2 CACHE INTERNAL "")
@@ -147,9 +149,14 @@ macro(find_amrex)
         else()
             set(COMPONENT_DIM ${WarpX_DIMS}D)
         endif()
+        if(WarpX_LIB)
+            set(COMPONENT_PIC PIC)
+        else()
+            set(COMPONENT_PIC)
+        endif()
         set(COMPONENT_PRECISION ${WarpX_PRECISION} P${WarpX_PRECISION})
 
-        find_package(AMReX 20.11 CONFIG REQUIRED COMPONENTS ${COMPONENT_ASCENT} ${COMPONENT_DIM} PARTICLES ${COMPONENT_PRECISION} TINYP LSOLVERS)
+        find_package(AMReX 20.11 CONFIG REQUIRED COMPONENTS ${COMPONENT_ASCENT} ${COMPONENT_DIM} PARTICLES ${COMPONENT_PIC} ${COMPONENT_PRECISION} TINYP LSOLVERS)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
     endif()
 endmacro()


### PR DESCRIPTION
Reorder CMake builds to collect everything in an object file library, which is then used to link out a shared library and the WarpX executable app.

Also establish a workflow that can install and uninstall a Python wheel with proper book keeping (for uninstall).