### PR TITLE
Define: _OPENMP -> AMREX_USE_OMP

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -16,7 +16,7 @@
 #include <AMReX_Print.H>
 #include <AMReX_VisMF.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 
@@ -400,7 +400,7 @@ MultiSigmaBox::ComputePMLFactorsB (const Real* dx, Real dt)
 
     dt_B = dt;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -416,7 +416,7 @@ MultiSigmaBox::ComputePMLFactorsE (const Real* dx, Real dt)
 
     dt_E = dt;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -938,7 +938,7 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         if (ngr.max() > 0) {
             MultiFab::Copy(tmpregmf, reg, 0, 0, 1, ngr);
             tmpregmf.ParallelCopy(totpmlmf, 0, 0, 1, IntVect(0), ngr, period);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(reg); mfi.isValid(); ++mfi)

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -401,7 +401,7 @@ MultiSigmaBox::ComputePMLFactorsB (const Real* dx, Real dt)
     dt_B = dt;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this); mfi.isValid(); ++mfi)
     {
@@ -417,7 +417,7 @@ MultiSigmaBox::ComputePMLFactorsE (const Real* dx, Real dt)
     dt_E = dt;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this); mfi.isValid(); ++mfi)
     {

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -66,7 +66,7 @@ WarpX::DampPML (int lev, PatchType patch_type)
             F_stag = pml_F->ixType().toIntVect();
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for ( MFIter mfi(*pml_E[0], TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -188,7 +188,7 @@ WarpX::DampJPML (int lev, PatchType patch_type)
         const auto& sigba = (patch_type == PatchType::fine) ? pml[lev]->GetMultiSigmaBox_fp()
                                                             : pml[lev]->GetMultiSigmaBox_cp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for ( MFIter mfi(*pml_j[0], TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -477,7 +477,7 @@ LorentzTransformZ(MultiFab& data, Real gamma_boost, Real beta_boost)
 {
     // Loop over tiles/boxes and in-place convert each slice from boosted
     // frame to back-transformed lab frame.
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(data, TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -152,7 +152,7 @@ void
 BackTransformFunctor::LorentzTransformZ (amrex::MultiFab& data, amrex::Real gamma_boost,
                                          amrex::Real beta_boost) const
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(data, TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.cpp
@@ -22,7 +22,7 @@ PartPerGridFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const i
     // Temporary MultiFab containing number of particles per grid.
     // (stored as constant for all cells in each grid)
     amrex::MultiFab ppg_mf(warpx.boxArray(m_lev), warpx.DistributionMap(m_lev), 1, ng);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (amrex::MFIter mfi(ppg_mf); mfi.isValid(); ++mfi) {

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -78,7 +78,7 @@ FlushFormatPlotfile::WriteJobInfo(const std::string& dir) const
         jobInfoFile << PrettyLine;
 
         jobInfoFile << "number of MPI processes: " << ParallelDescriptor::NProcs() << "\n";
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         jobInfoFile << "number of threads:       " << omp_get_max_threads() << "\n";
 #endif
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -125,7 +125,7 @@ PhysicalParticleContainer::ConvertUnits(ConvertDirection convert_direction)
 
     const int nLevels = finestLevel();
     for (int lev=0; lev<=nLevels; lev++){
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -171,7 +171,7 @@ void FieldMaximum::ComputeDiags (int step)
 #endif
 
         // MFIter loop to interpolate fields to cell center and get maximum values
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for ( MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -215,7 +215,7 @@ WarpX::computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >
 
         const Real* dx = Geom(lev).CellSize();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #    pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for ( MFIter mfi(*phi[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -317,7 +317,7 @@ WarpX::computeB (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >
 
         const Real* dx = Geom(lev).CellSize();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #    pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for ( MFIter mfi(*phi[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -63,7 +63,7 @@ void FiniteDifferenceSolver::ComputeDivECartesian (
     amrex::MultiFab& divEfield ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(divEfield, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
@@ -109,7 +109,7 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
     amrex::MultiFab& divEfield ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(divEfield, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -63,7 +63,7 @@ void FiniteDifferenceSolver::EvolveBCartesian (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Bfield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
@@ -122,7 +122,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Bfield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
@@ -64,7 +64,7 @@ void FiniteDifferenceSolver::EvolveBPMLCartesian (
     const bool dive_cleaning) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Bfield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -71,7 +71,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
     Real constexpr c2 = PhysConst::c * PhysConst::c;
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
@@ -165,7 +165,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -76,7 +76,7 @@ void FiniteDifferenceSolver::EvolveEPMLCartesian (
     Real constexpr c2 = PhysConst::c * PhysConst::c;
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -69,7 +69,7 @@ void FiniteDifferenceSolver::EvolveFCartesian (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Ffield, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
@@ -122,7 +122,7 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Ffield, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
@@ -62,7 +62,7 @@ void FiniteDifferenceSolver::EvolveFPMLCartesian (
     amrex::Real const dt ) {
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Ffield, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -94,7 +94,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
 
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -89,7 +89,7 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, Real a_dt)
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
     // Loop through the grids, and over the tiles within each grid
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(*Bx, TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Source/Filter/BilinearFilter.cpp
+++ b/Source/Filter/BilinearFilter.cpp
@@ -10,7 +10,7 @@
 
 #include <AMReX_REAL.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -8,7 +8,7 @@
 #include "Filter.H"
 #include "WarpX.H"
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 
@@ -168,7 +168,7 @@ Filter::ApplyStencil (amrex::MultiFab& dstmf, const amrex::MultiFab& srcmf, int 
 {
     WARPX_PROFILE("Filter::ApplyStencil(MultiFab)");
     ncomp = std::min(ncomp, srcmf.nComp());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -169,6 +169,7 @@ Filter::ApplyStencil (amrex::MultiFab& dstmf, const amrex::MultiFab& srcmf, int 
     WARPX_PROFILE("Filter::ApplyStencil(MultiFab)");
     ncomp = std::min(ncomp, srcmf.nComp());
 #ifdef AMREX_USE_OMP
+// never runs on GPU since in the else branch of AMREX_USE_GPU
 #pragma omp parallel
 #endif
     {

--- a/Source/Filter/NCIGodfreyFilter.cpp
+++ b/Source/Filter/NCIGodfreyFilter.cpp
@@ -10,7 +10,7 @@
 
 #include <AMReX_REAL.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -429,11 +429,11 @@ LaserParticleContainer::Evolve (int lev,
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         int const thread_num = omp_get_thread_num();
 #else
         int const thread_num = 0;

--- a/Source/Laser/LaserParticleContainer.cpp
+++ b/Source/Laser/LaserParticleContainer.cpp
@@ -430,7 +430,7 @@ LaserParticleContainer::Evolve (int lev,
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     {
 #ifdef AMREX_USE_OMP

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -79,7 +79,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 #endif
 
     // For level 0, we only need to do the average.
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*Bfield_aux[0][0]); mfi.isValid(); ++mfi)
@@ -163,7 +163,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 Btmp[i]->ParallelCopy(*Bfield_aux[lev-1][i], 0, 0, 1, ng, ng, cperiod);
             }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*Bfield_aux[lev][0]); mfi.isValid(); ++mfi)
@@ -213,7 +213,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 Etmp[i]->ParallelCopy(*Efield_aux[lev-1][i], 0, 0, 1, ng, ng, cperiod);
             }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*Efield_aux[lev][0]); mfi.isValid(); ++mfi)
@@ -280,7 +280,7 @@ WarpX::UpdateAuxilaryDataSameType ()
             const amrex::IntVect& By_stag = Bfield_aux[lev-1][1]->ixType().toIntVect();
             const amrex::IntVect& Bz_stag = Bfield_aux[lev-1][2]->ixType().toIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*Bfield_aux[lev][0]); mfi.isValid(); ++mfi)
@@ -338,7 +338,7 @@ WarpX::UpdateAuxilaryDataSameType ()
             const amrex::IntVect& Ey_stag = Efield_aux[lev-1][1]->ixType().toIntVect();
             const amrex::IntVect& Ez_stag = Efield_aux[lev-1][2]->ixType().toIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*Efield_aux[lev][0]); mfi.isValid(); ++mfi)

--- a/Source/Parser/GpuParser.H
+++ b/Source/Parser/GpuParser.H
@@ -52,7 +52,7 @@ public:
 
 #else
 // WarpX compiled for CPU
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         int tid = omp_get_thread_num();
 #else
         int tid = 0;
@@ -100,28 +100,28 @@ GpuParser<N>::GpuParser (WarpXParser const& wp)
 
 #else // not defined AMREX_USE_GPU
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     nthreads = omp_get_max_threads();
-#else // _OPENMP
+#else // AMREX_USE_OMP
     nthreads = 1;
-#endif // _OPENMP
+#endif // AMREX_USE_OMP
 
     m_parser = ::new struct wp_parser*[nthreads];
     m_var = ::new amrex::GpuArray<amrex::Real,N>[nthreads];
 
     for (int tid = 0; tid < nthreads; ++tid)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         m_parser[tid] = wp_parser_dup(wp.m_parser[tid]);
         for (int i = 0; i < N; ++i) {
             wp_parser_regvar(m_parser[tid], wp.m_varnames[tid][i].c_str(), &(m_var[tid][i]));
         }
-#else // _OPENMP
+#else // AMREX_USE_OMP
         m_parser[tid] = wp_parser_dup(wp.m_parser);
         for (int i = 0; i < N; ++i) {
             wp_parser_regvar(m_parser[tid], wp.m_varnames[i].c_str(), &(m_var[tid][i]));
         }
-#endif // _OPENMP
+#endif // AMREX_USE_OMP
     }
 
 #endif // AMREX_USE_GPU

--- a/Source/Parser/WarpXParser.H
+++ b/Source/Parser/WarpXParser.H
@@ -17,7 +17,7 @@
 #include "wp_parser_c.h"
 #include "wp_parser_y.h"
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -70,7 +70,7 @@ private:
     void unpack (amrex::Real* p, T x, Ts... yz) const noexcept;
 
     std::string m_expression;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     std::vector<struct wp_parser*> m_parser;
     mutable std::vector<std::array<amrex::Real,16> > m_variables;
     mutable std::vector<std::vector<std::string> > m_varnames;
@@ -85,7 +85,7 @@ inline
 amrex::Real
 WarpXParser::eval () const noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     return wp_ast_eval<0>(m_parser[omp_get_thread_num()]->ast,nullptr);
 #else
     return wp_ast_eval<0>(m_parser->ast,nullptr);
@@ -97,7 +97,7 @@ inline
 amrex::Real
 WarpXParser::eval (T x, Ts... yz) const noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     unpack(m_variables[omp_get_thread_num()].data(), x, yz...);
 #else
     unpack(m_variables.data(), x, yz...);

--- a/Source/Parser/WarpXParser.cpp
+++ b/Source/Parser/WarpXParser.cpp
@@ -23,7 +23,7 @@ WarpXParser::define (std::string const& func_body)
                        m_expression.end());
     std::string f = m_expression + "\n";
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 
     int nthreads = omp_get_max_threads();
     m_variables.resize(nthreads);
@@ -56,7 +56,7 @@ WarpXParser::clear ()
     m_expression.clear();
     m_varnames.clear();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 
     if (!m_parser.empty())
     {
@@ -80,7 +80,7 @@ void
 WarpXParser::registerVariable (std::string const& name, amrex::Real& var)
 {
     // We assume this is called inside OMP parallel region
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     wp_parser_regvar(m_parser[omp_get_thread_num()], name.c_str(), &var);
     m_varnames[omp_get_thread_num()].push_back(name);
 #else
@@ -92,7 +92,7 @@ WarpXParser::registerVariable (std::string const& name, amrex::Real& var)
 void
 WarpXParser::registerVariables (std::vector<std::string> const& names)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 
 // This must be called outside OpenMP parallel region.
 #pragma omp parallel
@@ -119,7 +119,7 @@ WarpXParser::registerVariables (std::vector<std::string> const& names)
 void
 WarpXParser::setConstant (std::string const& name, amrex::Real c)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 
     bool in_parallel = omp_in_parallel();
     // We don't know if this is inside OMP parallel region or not
@@ -138,7 +138,7 @@ WarpXParser::setConstant (std::string const& name, amrex::Real c)
 void
 WarpXParser::print () const
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical(warpx_parser_pint)
     wp_ast_print(m_parser[omp_get_thread_num()]->ast);
 #else
@@ -150,7 +150,7 @@ int
 WarpXParser::depth () const
 {
     int n = 0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     wp_ast_depth(m_parser[omp_get_thread_num()]->ast, &n);
 #else
     wp_ast_depth(m_parser->ast, &n);
@@ -168,7 +168,7 @@ std::set<std::string>
 WarpXParser::symbols () const
 {
     std::set<std::string> results;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     wp_ast_get_symbols(m_parser[omp_get_thread_num()]->ast, results);
 #else
     wp_ast_get_symbols(m_parser->ast, results);

--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -51,7 +51,7 @@ PairWiseCoulombCollision::doCollisions (amrex::Real cur_time, MultiParticleConta
     for (int lev = 0; lev <= species1.finestLevel(); ++lev){
 
         // Loop over all grids/tiles at this level
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         info.SetDynamic(true);
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -322,7 +322,7 @@ protected:
             info.EnableTiling(pc_src.tile_size);
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         info.SetDynamic(true);
 #endif
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -698,7 +698,7 @@ MultiParticleContainer::doFieldIonization (int lev,
 
         auto info = getMFItInfo(*pc_source, *pc_product);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (WarpXParIter pti(*pc_source, lev, info); pti.isValid(); ++pti)
@@ -1102,7 +1102,7 @@ MultiParticleContainer::doQEDSchwinger ()
     const MultiFab & By = warpx.getBfield(level_0,1);
     const MultiFab & Bz = warpx.getBfield(level_0,2);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
      for (MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -1273,7 +1273,7 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
 
         auto info = getMFItInfo(*pc_source, *pc_product_ele, *pc_product_pos);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (WarpXParIter pti(*pc_source, lev, info); pti.isValid(); ++pti)
@@ -1334,7 +1334,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
 
         auto info = getMFItInfo(*pc_source, *pc_product_phot);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (WarpXParIter pti(*pc_source, lev, info); pti.isValid(); ++pti)

--- a/Source/Particles/ParticleCreation/SmartUtils.H
+++ b/Source/Particles/ParticleCreation/SmartUtils.H
@@ -40,7 +40,7 @@ template <typename PTile>
 void setNewParticleIDs (PTile& ptile, int old_size, int num_added)
 {
     amrex::Long pid;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (ionization_nextid)
 #endif
     {

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -16,7 +16,7 @@
 #include "Particles/Gather/FieldGather.H"
 #include "Particles/Gather/GetExternalFields.H"
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -586,7 +586,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     if (do_tiling && Gpu::notInLaunchRegion()) {
         info.EnableTiling(tile_size);
     }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     info.SetDynamic(true);
 #pragma omp parallel if (not WarpX::serialize_ics)
 #endif
@@ -683,7 +683,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
         // Update NextID to include particles created in this function
         Long pid;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (add_plasma_nextid)
 #endif
         {
@@ -961,11 +961,11 @@ PhysicalParticleContainer::Evolve (int lev,
         }
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         int thread_num = omp_get_thread_num();
 #else
         int thread_num = 0;
@@ -1419,7 +1419,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
 
     const std::array<amrex::Real,3>& dx = WarpX::CellSize(std::max(lev,0));
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {
@@ -1587,7 +1587,7 @@ PhysicalParticleContainer::GetParticleSlice (
             diagnostic_particles[lev][index];
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -7,7 +7,7 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 
@@ -82,7 +82,7 @@ RigidInjectedParticleContainer::RemapParticles()
 
         for (int lev = 0; lev <= finestLevel(); lev++) {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             {
@@ -147,7 +147,7 @@ RigidInjectedParticleContainer::BoostandRemapParticles()
 
     const Real csqi = 1./(PhysConst::c*PhysConst::c);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -390,7 +390,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
 
     const std::array<Real,3>& dx = WarpX::CellSize(std::max(lev,0));
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -599,7 +599,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
         // Loop over particle tiles and deposit charge on each level
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
         {
         int thread_num = omp_get_thread_num();
 #else
@@ -675,7 +675,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     rho->setVal(0.0);
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
     {
 #endif
 #ifdef AMREX_USE_OMP
@@ -870,7 +870,7 @@ WarpXParticleContainer::PushX (int lev, amrex::Real dt)
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     {
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -56,7 +56,7 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
 
     // Initialize temporary local arrays for charge/current deposition
     int num_threads = 1;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #pragma omp single
     num_threads = omp_get_num_threads();
@@ -598,7 +598,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
         if (reset) rho[lev]->setVal(0.0, rho[lev]->nGrow());
 
         // Loop over particle tiles and deposit charge on each level
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
         {
         int thread_num = omp_get_thread_num();
@@ -619,7 +619,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
             DepositCharge(pti, wp, ion_lev, rho[lev].get(), 0, 0, np, thread_num, lev, lev);
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         }
 #endif
 
@@ -674,11 +674,11 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     auto rho = std::make_unique<MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
     rho->setVal(0.0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
     {
 #endif
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         int thread_num = omp_get_thread_num();
 #else
         int thread_num = 0;
@@ -699,7 +699,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
             DepositCharge(pti, wp, ion_lev, rho.get(), 0, 0, np,
                           thread_num, lev, lev);
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     }
 #endif
 
@@ -720,7 +720,7 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
     for (int lev = 0; lev < nLevels; ++lev)
     {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:total_charge)
 #endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -786,7 +786,7 @@ std::array<Real, 3> WarpXParticleContainer::meanParticleVelocity(bool local) {
 #endif
     {
         for (int lev = 0; lev <= nLevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:vx_total, vy_total, vz_total, np_total)
 #endif
             for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -833,7 +833,7 @@ Real WarpXParticleContainer::maxParticleVelocity(bool local) {
     for (int lev = 0; lev <= nLevels; ++lev)
     {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:max_v)
 #endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -869,7 +869,7 @@ WarpXParticleContainer::PushX (int lev, amrex::Real dt)
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -34,7 +34,7 @@ namespace
             static_cast<amrex::Real**>(malloc((*num_boxes) * sizeof(amrex::Real*)));
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for ( amrex::MFIter mfi(mf, false); mfi.isValid(); ++mfi ) {
             int i = mfi.LocalIndex();
@@ -480,4 +480,3 @@ extern "C"
     }
 
 }
-

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -33,7 +33,7 @@ namespace
         auto data =
             static_cast<amrex::Real**>(malloc((*num_boxes) * sizeof(amrex::Real*)));
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for ( amrex::MFIter mfi(mf, false); mfi.isValid(); ++mfi ) {

--- a/Source/Utils/CoarsenIO.cpp
+++ b/Source/Utils/CoarsenIO.cpp
@@ -50,7 +50,7 @@ CoarsenIO::Loop ( MultiFab& mf_dst,
     cr[2] = crse_ratio[2];
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     // Loop over boxes (or tiles if not on GPU)

--- a/Source/Utils/CoarsenMR.cpp
+++ b/Source/Utils/CoarsenMR.cpp
@@ -42,7 +42,7 @@ CoarsenMR::Loop ( MultiFab& mf_dst,
     cr[2] = crse_ratio[2];
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     // Loop over boxes (or tiles if not on GPU)

--- a/Source/Utils/Interpolate.cpp
+++ b/Source/Utils/Interpolate.cpp
@@ -18,7 +18,7 @@ namespace Interpolate
 
         // Loop through the boxes and interpolate the values from the _cp data
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         {
             FArrayBox ffab; // Temporary array ; contains interpolated fields
@@ -70,7 +70,7 @@ namespace Interpolate
         IntVect fz_type = interpolated_F[2]->ixType().toIntVect();
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*interpolated_F[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {

--- a/Source/Utils/Interpolate.cpp
+++ b/Source/Utils/Interpolate.cpp
@@ -17,7 +17,7 @@ namespace Interpolate
         interpolated_F->setVal(0.);
 
         // Loop through the boxes and interpolate the values from the _cp data
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {
@@ -69,7 +69,7 @@ namespace Interpolate
         IntVect fy_type = interpolated_F[1]->ixType().toIntVect();
         IntVect fz_type = interpolated_F[2]->ixType().toIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*interpolated_F[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -303,7 +303,7 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     const RealBox& real_box = geom.ProbDomain();
     const auto dx = geom.CellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -19,7 +19,7 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
     const Real* problo = Geom(lev).ProbLo();
     const Real* dx = Geom(lev).CellSize();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(tags); mfi.isValid(); ++mfi)

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -20,7 +20,7 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
     const Real* dx = Geom(lev).CellSize();
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(tags); mfi.isValid(); ++mfi)
     {
@@ -38,4 +38,3 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
         }
     }
 }
-

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -129,7 +129,7 @@ void ConvertLabParamsToBoost()
  */
 void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax){
     WARPX_PROFILE("WarpXUtil::NullifyMF()");
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for(amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -52,7 +52,7 @@
 #include <AMReX_Interpolater.H>
 #include <AMReX_FillPatchUtil.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -23,7 +23,7 @@
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #   include <omp.h>
 #endif
 
@@ -1427,7 +1427,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
     const Real rmin = GetInstance().Geom(0).ProbLo(0);
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(divB, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1465,7 +1465,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
     const Real rmin = GetInstance().Geom(0).ProbLo(0);
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(divB, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1551,7 +1551,7 @@ WarpX::BuildBufferMasks ()
                 const Box& dom = Geom(lev).Domain();
                 const auto& period = Geom(lev).periodicity();
                 tmp.BuildMask(dom, period, covered, notcovered, physbnd, interior);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(*bmasks, true); mfi.isValid(); ++mfi)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1552,7 +1552,7 @@ WarpX::BuildBufferMasks ()
                 const auto& period = Geom(lev).periodicity();
                 tmp.BuildMask(dom, period, covered, notcovered, physbnd, interior);
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
                 for (MFIter mfi(*bmasks, true); mfi.isValid(); ++mfi)
                 {


### PR DESCRIPTION
Replace the define check of `_OPENMP` with the explicit backend control of `AMREX_USE_OMP` for compute constructs.

Doing so avoids that we accidentially turn on OpenMP, e.g. if a dependency pulls it in for linear algebra, I/O, etc. This can led to confusion if the user explicitly requested a serial build. Also, we might want to use OpenMP functionality here and there for auxiliary functions w/o having to use the AMReX OpenMP backend, i.e. because we compile for GPUs.

- [x] search & replace
- [x] self-review and review

Related to: https://github.com/AMReX-Codes/amrex/pull/1558#discussion_r526466768 https://github.com/AMReX-Codes/amrex/pull/1560