### PR TITLE
Call FillBoundaryAux after UpdateAuxilaryData

### DIFF
--- a/Regression/Checksum/benchmarks_json/PlasmaAccelerationMR.json
+++ b/Regression/Checksum/benchmarks_json/PlasmaAccelerationMR.json
@@ -45,7 +45,7 @@
     "particle_cpu": 3600.0,
     "particle_id": 6546600.0,
     "particle_momentum_x": 1.6052131138342664e-19,
-    "particle_momentum_y": 7.604979610181107e-24,
+    "particle_momentum_y": 7.604979650174618e-24,
     "particle_momentum_z": 1.6653769795689464e-19,
     "particle_position_x": 0.13410927422500246,
     "particle_position_y": 0.10349153092104842,

--- a/Regression/Checksum/benchmarks_json/momentum-conserving-gather.json
+++ b/Regression/Checksum/benchmarks_json/momentum-conserving-gather.json
@@ -44,9 +44,9 @@
   "plasma_e": {
     "particle_cpu": 3600.0,
     "particle_id": 6546600.0,
-    "particle_momentum_x": 1.513031320030241e-19,
-    "particle_momentum_y": 7.700274017007927e-24,
-    "particle_momentum_z": 1.7302395904705498e-19,
+    "particle_momentum_x": 1.513031314612992e-19,
+    "particle_momentum_y": 7.700274073846612e-24,
+    "particle_momentum_z": 1.7302395932501682e-19,
     "particle_position_x": 0.1336825415948561,
     "particle_position_y": 0.10348762049276918,
     "particle_weight": 823974609374999.9

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -436,10 +436,8 @@ FullDiagnostics::PrepareFieldDataForOutput ()
     auto & warpx = WarpX::GetInstance();
     warpx.FillBoundaryE(warpx.getngE(), warpx.getngExtra());
     warpx.FillBoundaryB(warpx.getngE(), warpx.getngExtra());
-#ifndef WARPX_USE_PSATD
-    warpx.FillBoundaryAux(warpx.getngUpdateAux());
-#endif
     warpx.UpdateAuxilaryData();
+    warpx.FillBoundaryAux(warpx.getngUpdateAux());
 
     // Update the RealBox used for the geometry filter in particle diags
     for (int i = 0; i < m_output_species.size(); ++i) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -91,6 +91,7 @@ WarpX::Evolve (int numsteps)
             FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
             FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
             UpdateAuxilaryData();
+            FillBoundaryAux(guard_cells.ng_UpdateAux);
             // on first step, push p by -0.5*dt
             for (int lev = 0; lev <= finest_level; ++lev)
             {
@@ -114,9 +115,11 @@ WarpX::Evolve (int numsteps)
                 FillBoundaryB_avg(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
             }
 #ifndef WARPX_USE_PSATD
+            // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
             FillBoundaryAux(guard_cells.ng_UpdateAux);
 #endif
             UpdateAuxilaryData();
+            FillBoundaryAux(guard_cells.ng_UpdateAux);
         }
         if (do_subcycling == 0 || finest_level == 0) {
             OneStep_nosub(cur_time);
@@ -141,6 +144,7 @@ WarpX::Evolve (int numsteps)
         if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
             // At the end of last step, push p by 0.5*dt to synchronize
             UpdateAuxilaryData();
+            FillBoundaryAux(guard_cells.ng_UpdateAux);
             for (int lev = 0; lev <= finest_level; ++lev) {
                 mypc->PushP(lev, 0.5*dt[lev],
                             *Efield_aux[lev][0],*Efield_aux[lev][1],
@@ -471,9 +475,11 @@ WarpX::OneStep_sub1 (Real curtime)
     EvolveE(coarse_lev, PatchType::fine, 0.5*dt[coarse_lev]);
     FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather + guard_cells.ng_Extra);
 
+    // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
     FillBoundaryAux(guard_cells.ng_UpdateAux);
     // iii) Get auxiliary fields on the fine grid, at dt[fine_lev]
     UpdateAuxilaryData();
+    FillBoundaryAux(guard_cells.ng_UpdateAux);
 
     // iv) Push particles and fields on the fine patch (second fine step)
     PushParticlesandDepose(fine_lev, curtime+dt[fine_lev], DtType::SecondHalf);


### PR DESCRIPTION
**Goal**
This PR adds a few calls to `FillBoundaryAux` **after** those to `UpdateAuxilaryData`, in preparation for some of the changes implemented in #1468 (including the CI benchmarks updates, which will be fully overwritten by the ones implemented here). Filling the guard cells after updating the valid cells seems more logical than its reverse.

**Note**
It seems that removing the calls to `FillBoundaryAux` located right **before** those to `UpdateAuxilaryData` in the file Source/Evolve/WarpXEvolve.cpp makes the CI test `nci_correctorMR` (more precisely, its physics analysis) crash:
```
working on test: nci_correctorMR
   building...
   make -j8 AMREX_HOME=/tmp/ci-0RLWYwveUD/amrex/  DEBUG=FALSE USE_ACC=FALSE USE_MPI=TRUE USE_OMP=TRUE DIM=2   COMP=g++ TEST=TRUE USE_ASSERTION=TRUE WarpxBinDir= 
   copying files to run directory...
   running the test...
   mpiexec -n 2 ./main2d.gnu.TEST.TPROF.MTMPI.OMP.ex inputs_2d  diag1.file_prefix=nci_correctorMR_plt   amrex.abort_on_unused_inputs=1  amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
   WARNING: unable to open the job_info file
   doing the analysis...
   WARNING: analysis failed...
./analysis_ncicorr.py  nci_correctorMR_plt00600
use_MR: True
energy if corrector off (from benchmark): 5e+32
energy threshold (from benchmark): 1e+28
energy from this run: 5.19202635736217e+34
Traceback (most recent call last):
  File "./analysis_ncicorr.py", line 43, in <module>
    assert( energy < energy_threshold )
AssertionError
```
Hence, those calls (which, I think, had been introduced originally in #504, see [here](https://github.com/ECP-WarpX/WarpX/pull/504/files#diff-140169a8e394017bac0dd16e554a7fd7a9f4aa5adfb0991fe37f821b395398d2)) have not been removed in this PR yet. A `TODO` comment has been added as a temporary reminder.