### PR TITLE
Fix some double to float conversions

### DIFF
--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -71,10 +71,10 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     amrex::ignore_unused(n_rz_azimuthal_modes);
 #endif
 
-    const amrex::Real dxi = 1.0/dx[0];
-    const amrex::Real dzi = 1.0/dx[2];
+    const amrex::Real dxi = 1.0_rt/dx[0];
+    const amrex::Real dzi = 1.0_rt/dx[2];
 #if (AMREX_SPACEDIM == 3)
-    const amrex::Real dyi = 1.0/dx[1];
+    const amrex::Real dyi = 1.0_rt/dx[1];
 #endif
 
     const amrex::Real xmin = xyzmin[0];

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -14,26 +14,25 @@
 // Math constants
 namespace MathConst
 {
-    static constexpr amrex::Real pi = 3.14159265358979323846;
+    static constexpr amrex::Real pi = static_cast<amrex::Real>(3.14159265358979323846);
 }
 
 // Physical constants. Values are the 2018 CODATA recommended values
 // https://physics.nist.gov/cuu/Constants/index.html
 namespace PhysConst
 {
-    static constexpr amrex::Real c     = 299'792'458.;
-    static constexpr amrex::Real ep0   = 8.8541878128e-12;
-    static constexpr amrex::Real mu0   = 1.25663706212e-06;
-    static constexpr amrex::Real q_e   = 1.602176634e-19;
-    static constexpr amrex::Real m_e   = 9.1093837015e-31;
-    static constexpr amrex::Real m_p   = 1.67262192369e-27;
-    static constexpr amrex::Real hbar  = 1.054571817e-34;
-    static constexpr amrex::Real alpha = mu0/(4*MathConst::pi)*q_e*q_e*c/hbar;
-    static constexpr amrex::Real r_e   = 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c);
-    static constexpr double xi         = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/
-                                         (45.*m_e*m_e*m_e*m_e*c*c*c*c*c); // SI value is 1.3050122.e-52
-    static constexpr amrex::Real xi_c2 = xi * c * c; // This should be usable for single precision, though
-    // very close to smallest number possible: smallest number = 1.2e-38, xi_c2 = 1.1e-35
+    static constexpr auto c     = static_cast<amrex::Real>( 299'792'458. );
+    static constexpr auto ep0   = static_cast<amrex::Real>( 8.8541878128e-12 );
+    static constexpr auto mu0   = static_cast<amrex::Real>( 1.25663706212e-06 );
+    static constexpr auto q_e   = static_cast<amrex::Real>( 1.602176634e-19 );
+    static constexpr auto m_e   = static_cast<amrex::Real>( 9.1093837015e-31 );
+    static constexpr auto m_p   = static_cast<amrex::Real>( 1.67262192369e-27 );
+    static constexpr auto hbar  = static_cast<amrex::Real>( 1.054571817e-34 );
+    static constexpr auto alpha = static_cast<amrex::Real>( 0.007297352573748943 );//mu0/(4*MathConst::pi)*q_e*q_e*c/hbar;
+    static constexpr auto r_e   = static_cast<amrex::Real>( 2.817940326204929e-15 );//1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c);
+    static constexpr double xi  = 1.3050122447005176e-52; //(2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c);
+    static constexpr auto xi_c2 = static_cast<amrex::Real>( 1.1728865132395492e-35 ); // This should be usable for single precision, though
+    // very close to smallest number possible (1.2e-38)
 }
 
 #endif


### PR DESCRIPTION
I got some warnings related to double to float conversions when WarpX is compiled in single precision. This PR should fix the issue.