### PR TITLE
Electrostatic lab frame

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -61,13 +61,35 @@ Overall simulation parameters
     one should not expect to obtain the same random numbers,
     even if a fixed ``warpx.random_seed`` is provided.
 
-* ``warpx.do_electrostatic`` (``0`` or ``1``; default is ``0`` for false)
-    Run WarpX in electrostatic mode. Instead of updating the fields
-    at each iteration with the full Maxwell equations, the fields are
-    instead recomputed at each iteration from the (relativistic) Poisson
-    equation. There is no limitation on the timestep in this case, but
+* ``warpx.do_electrostatic`` (`string`) optional (default `none`)
+    Specifies the electrostatic mode. When turned on, instead of updating
+    the fields at each iteration with the full Maxwell equations, the fields
+    are recomputed at each iteration from the Poisson equation.
+    There is no limitation on the timestep in this case, but
     electromagnetic effects (e.g. propagation of radiation, lasers, etc.)
-    are not captured.
+    are not captured. There are two options:
+
+    * ``labframe``: Poisson's equation is solved in the lab frame with
+      the charge density of all species combined. There will only be E
+      fields.
+
+    * ``relativistic``: Poisson's equation is solved for each species
+      seperately taking into account their averaged velocities. The field
+      is mapped to the simulation frame and will produce both E and B
+      fields.
+
+* ``self_fields_required_precision`` (`float`, default: 1.e-11)
+    The relative precision with which the electrostatic space-charge fields should
+    be calculated. More specifically, the space-charge fields are
+    computed with an iterative Multi-Level Multi-Grid (MLMG) solver.
+    This solver can fail to reach the default precision within a reasonable
+    This only applies when warpx.do_electrostatic = labframe.
+
+* ``self_fields_max_iters`` (`integer`, default: 200)
+    Maximum number of iterations used for MLMG solver for space-charge
+    fields calculation. In case if MLMG converges but fails to reach the desired
+    ``self_fields_required_precision``, this parameter may be increased.
+    This only applies when warpx.do_electrostatic = labframe.
 
 * ``amrex.abort_on_out_of_gpu_memory``  (``0`` or ``1``; default is ``1`` for true)
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
@@ -1441,7 +1463,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
-    Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
+    Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``.
     Note that the fields are averaged on the cell centers before they are written to file.
 

--- a/Docs/source/running_cpp/pwfa.rst
+++ b/Docs/source/running_cpp/pwfa.rst
@@ -17,7 +17,7 @@ plasma_e n = 1x10^23 m^-3; w = 70 μm; lr = 8 mm; L = 200 mm
 plasma_p n = 1x10^23 m^-3; w = 70 μm; lr = 8 mm; L = 200 mm
 ======== ============================================================
 
-Where :math:`\gamma` is the beam relativisitc Lorentz factor, N is the number of particles, and σx, σy, σz are the beam widths (root-mean-squares of particle positions) in the transverse (x,y) and longitudinal directions.
+Where :math:`\gamma` is the beam relativistic Lorentz factor, N is the number of particles, and σx, σy, σz are the beam widths (root-mean-squares of particle positions) in the transverse (x,y) and longitudinal directions.
 
 The plasma, of total lenght L, has a density profile that consists of a lr long linear up-ramp, ranging from 0 to peak value n, is uniform within a transverse width of w and after the up-ramp.
 

--- a/Examples/Tests/ElectrostaticSphere/inputs_3d
+++ b/Examples/Tests/ElectrostaticSphere/inputs_3d
@@ -9,7 +9,7 @@ geometry.prob_lo     = -0.5 -0.5 -0.5
 geometry.prob_hi     =  0.5  0.5  0.5
 warpx.do_pml = 0
 warpx.const_dt = 1e-6
-warpx.do_electrostatic = 1
+warpx.do_electrostatic = relativistic
 
 particles.species_names = electron
 

--- a/Regression/Checksum/benchmarks_json/ElectrostaticSphereLabFrame.json
+++ b/Regression/Checksum/benchmarks_json/ElectrostaticSphereLabFrame.json
@@ -1,0 +1,30 @@
+{
+  "electron": {
+    "particle_cpu": 0.0,
+    "particle_id": 9168752916.0,
+    "particle_momentum_x": 1.0475215560938395e-23,
+    "particle_momentum_y": 1.0475215560942127e-23,
+    "particle_momentum_z": 1.0475215560950524e-23,
+    "particle_position_x": 524.906527421018,
+    "particle_position_y": 524.9065274210888,
+    "particle_position_z": 524.9065274212362,
+    "particle_weight": 6212.501525878906
+  },
+  "lev=0": {
+    "Ex": 6.525895284178821,
+    "Ey": 6.525895284179916,
+    "Ez": 6.5258952841836555,
+    "rho": 2.6092568008333797e-10
+  },
+  "nbody": {
+    "particle_cpu": 0.0,
+    "particle_id": 9168752916.0,
+    "particle_momentum_x": 1.0475215560938395e-23,
+    "particle_momentum_y": 1.0475215560942127e-23,
+    "particle_momentum_z": 1.0475215560950524e-23,
+    "particle_position_x": 524.906527421018,
+    "particle_position_y": 524.9065274210888,
+    "particle_position_z": 524.9065274212362,
+    "particle_weight": 6212.501525878906
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1737,6 +1737,23 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
 tolerance = 1.e-12
 
+[ElectrostaticSphereLabFrame]
+buildDir = .
+inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d
+runtime_params = warpx.do_electrostatic=labframe
+dim = 3
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+tolerance = 1.e-12
+
 [initial_distribution]
 buildDir = .
 inputFile = Examples/Tests/initial_distribution/inputs

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -49,6 +49,13 @@ Diagnostics::BaseReadParameters ()
         warpx.setplot_rho(true);
     }
 
+    // Sanity check if user requests to plot phi
+    if (WarpXUtilStr::is_in(m_varnames, "phi")){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            warpx.do_electrostatic==ElectrostaticSolverAlgo::LabFrame,
+            "plot phi only works if do_electrostatic = labframe");
+    }
+
     // Sanity check if user requests to plot F
     if (WarpXUtilStr::is_in(m_varnames, "F")){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -411,6 +411,8 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
             i++;
         } else if ( m_varnames[comp] == "F" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_F_fp(lev), lev, m_crse_ratio);
+        } else if ( m_varnames[comp] == "phi" ){
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_phi_fp(lev), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "part_per_cell" ){
             m_all_field_functors[lev][comp] = std::make_unique<PartPerCellFunctor>(nullptr, lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "part_per_grid" ){

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -69,7 +69,7 @@ WarpX::ComputeDt ()
         }
     }
 
-    if (do_electrostatic) {
+    if (do_electrostatic != ElectrostaticSolverAlgo::None) {
         dt[0] = const_dt;
     }
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -178,7 +178,7 @@ WarpX::Evolve (int numsteps)
         mypc->ApplyBoundaryConditions();
 
         // Electrostatic solver: particles can move by an arbitrary number of cells
-        if( do_electrostatic )
+        if( do_electrostatic != ElectrostaticSolverAlgo::None )
         {
             mypc->Redistribute();
         } else
@@ -252,7 +252,7 @@ void
 WarpX::OneStep_nosub (Real cur_time)
 {
 
-    if (do_electrostatic) {
+    if( do_electrostatic != ElectrostaticSolverAlgo::None ) {
         // Electrostatic solver:
         // For each species: deposit charge and add the associated space-charge
         // E and B field to the grid ; this is done at the beginning of the PIC
@@ -322,7 +322,7 @@ WarpX::OneStep_nosub (Real cur_time)
     if (do_pml && pml_has_particles) CopyJPML();
     if (do_pml && do_pml_j_damping) DampJPML();
 
-    if (!do_electrostatic) {
+    if( do_electrostatic == ElectrostaticSolverAlgo::None ) {
     // Electromagnetic solver:
     // Push E and B from {n} to {n+1}
     // (And update guard cells immediately afterwards)
@@ -397,7 +397,7 @@ WarpX::OneStep_nosub (Real cur_time)
 void
 WarpX::OneStep_sub1 (Real curtime)
 {
-    if( do_electrostatic )
+    if( do_electrostatic != ElectrostaticSolverAlgo::None )
     {
         amrex::Abort("Electrostatic solver cannot be used with sub-cycling.");
     }

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -31,9 +31,14 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
     // Loop over the species and add their space-charge contribution to E and B
     for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
         WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
-        if (species.initialize_self_fields || do_electrostatic) {
+        if (species.initialize_self_fields ||
+            (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
             AddSpaceChargeField(species);
         }
+    }
+
+    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+        AddSpaceChargeFieldLabFrame();
     }
 }
 
@@ -76,6 +81,53 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     // Compute the corresponding electric and magnetic field, from the potential phi
     computeE( Efield_fp, phi, beta );
     computeB( Bfield_fp, phi, beta );
+
+}
+
+void
+WarpX::AddSpaceChargeFieldLabFrame ()
+{
+
+#ifdef WARPX_DIM_RZ
+    amrex::Abort("The calculation of space-charge field has not yet been implemented in RZ geometry.");
+#endif
+
+    // Allocate fields for charge
+    // Also, zero out the phi data
+    const int num_levels = max_level + 1;
+    Vector<std::unique_ptr<MultiFab> > rho(num_levels);
+    // Use number of guard cells used for local deposition of rho
+    const int ng = guard_cells.ng_depos_rho.max();
+    for (int lev = 0; lev <= max_level; lev++) {
+        BoxArray nba = boxArray(lev);
+        nba.surroundingNodes();
+        rho[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, ng);
+        rho[lev]->setVal(0.);
+        phi_fp[lev]->setVal(0.);
+    }
+
+    // Deposit particle charge density (source of Poisson solver)
+    for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
+        WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
+        bool const local = true;
+        bool const reset = false;
+        bool const do_rz_volume_scaling = false;
+        species.DepositCharge(rho, local, reset, do_rz_volume_scaling);
+    }
+    for (int lev = 0; lev <= max_level; lev++) {
+        ApplyFilterandSumBoundaryRho (lev, lev, *rho[lev], 0, 1);
+    }
+
+    // beta is zero in lab frame
+    // Todo: use simpler finite difference form with beta=0
+    std::array<Real, 3> beta = {0._rt};
+
+    // Compute the potential phi, by solving the Poisson equation
+    computePhi( rho, phi_fp, beta, self_fields_required_precision, self_fields_max_iters );
+
+    // Compute the corresponding electric and magnetic field, from the potential phi
+    computeE( Efield_fp, phi_fp, beta );
+    computeB( Bfield_fp, phi_fp, beta );
 
 }
 

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -28,18 +28,19 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
         }
     }
 
-    // Loop over the species and add their space-charge contribution to E and B
-    for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
-        WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
-        if (species.initialize_self_fields ||
-            (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
-            AddSpaceChargeField(species);
+    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+        AddSpaceChargeFieldLabFrame();
+    } else {
+        // Loop over the species and add their space-charge contribution to E and B
+        for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
+            WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
+            if (species.initialize_self_fields ||
+                (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
+                AddSpaceChargeField(species);
+            }
         }
     }
 
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
-        AddSpaceChargeFieldLabFrame();
-    }
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1107,7 +1107,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 //
                 // Current Deposition (only needed for electromagnetic solver)
                 //
-                if (!WarpX::do_electrostatic) {
+                if (WarpX::do_electrostatic == ElectrostaticSolverAlgo::None) {
                     int* AMREX_RESTRICT ion_lev;
                     if (do_field_ionization){
                         ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
@@ -1124,13 +1124,13 @@ PhysicalParticleContainer::Evolve (int lev,
                                        np_current, np-np_current, thread_num,
                                        lev, lev-1, dt);
                     }
-                } // end of "if !do_electrostatic"
+                } // end of "if do_electrostatic == ElectrostaticSolverAlgo::None"
             } // end of "if do_not_push"
 
             if (rho) {
                 // Deposit charge after particle push, in component 1 of MultiFab rho.
                 // (Skipped for electrostatic solver, as this may lead to out-of-bounds)
-                if (!WarpX::do_electrostatic) {
+                if (WarpX::do_electrostatic == ElectrostaticSolverAlgo::None) {
                     int* AMREX_RESTRICT ion_lev;
                     if (do_field_ionization){
                         ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -42,6 +42,14 @@ struct MaxwellSolverAlgo {
     };
 };
 
+struct ElectrostaticSolverAlgo {
+    enum {
+        None = 0,
+        Relativistic = 1,
+        LabFrame = 2
+    };
+};
+
 struct ParticlePusherAlgo {
     enum {
         Boris = 0,

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -24,6 +24,13 @@ const std::map<std::string, int> maxwell_solver_algo_to_int = {
     {"default", MaxwellSolverAlgo::Yee }
 };
 
+const std::map<std::string, int> electrostatic_solver_algo_to_int = {
+    {"none", ElectrostaticSolverAlgo::None },
+    {"relativistic", ElectrostaticSolverAlgo::Relativistic},
+    {"labframe", ElectrostaticSolverAlgo::LabFrame},
+    {"default", ElectrostaticSolverAlgo::None }
+};
+
 const std::map<std::string, int> particle_pusher_algo_to_int = {
     {"boris",   ParticlePusherAlgo::Boris },
     {"vay",     ParticlePusherAlgo::Vay },
@@ -84,6 +91,8 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
     std::map<std::string, int> algo_to_int;
     if (0 == std::strcmp(pp_search_key, "maxwell_solver")) {
         algo_to_int = maxwell_solver_algo_to_int;
+    } else if (0 == std::strcmp(pp_search_key, "do_electrostatic")) {
+        algo_to_int = electrostatic_solver_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "particle_pusher")) {
         algo_to_int = particle_pusher_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "current_deposition")) {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -228,6 +228,7 @@ public:
     amrex::MultiFab * get_pointer_current_fp  (int lev, int direction) const { return current_fp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_rho_fp  (int lev) const { return rho_fp[lev].get(); }
     amrex::MultiFab * get_pointer_F_fp  (int lev) const { return F_fp[lev].get(); }
+    amrex::MultiFab * get_pointer_phi_fp  (int lev) const { return phi_fp[lev].get(); }
 
     amrex::MultiFab * get_pointer_Efield_cp  (int lev, int direction) const { return Efield_cp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_Bfield_cp  (int lev, int direction) const { return Bfield_cp[lev][direction].get(); }
@@ -248,6 +249,7 @@ public:
     const amrex::MultiFab& getEfield_fp  (int lev, int direction) {return *Efield_fp[lev][direction];}
     const amrex::MultiFab& getBfield_fp  (int lev, int direction) {return *Bfield_fp[lev][direction];}
     const amrex::MultiFab& getrho_fp (int lev) {return *rho_fp[lev];}
+    const amrex::MultiFab& getphi_fp (int lev) {return *phi_fp[lev];}
     const amrex::MultiFab& getF_fp (int lev) {return *F_fp[lev];}
     bool DoPML () const {return do_pml;}
 
@@ -462,6 +464,11 @@ public:
     static const amrex::iMultiFab* GatherBufferMasks (int lev);
 
     static int do_electrostatic;
+
+    // Parameters for lab frame electrostatic
+    static amrex::Real self_fields_required_precision;
+    static int self_fields_max_iters;
+
     static int do_moving_window;
     static int moving_window_dir;
     static amrex::Real moving_window_v;
@@ -502,6 +509,7 @@ public:
 
     void ComputeSpaceChargeField (bool const reset_fields);
     void AddSpaceChargeField (WarpXParticleContainer& pc);
+    void AddSpaceChargeFieldLabFrame ();
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
@@ -724,6 +732,7 @@ private:
     // Fine patch
     amrex::Vector<            std::unique_ptr<amrex::MultiFab>      > F_fp;
     amrex::Vector<            std::unique_ptr<amrex::MultiFab>      > rho_fp;
+    amrex::Vector<            std::unique_ptr<amrex::MultiFab>      > phi_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > current_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_fp;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -110,7 +110,10 @@ Real WarpX::particle_slice_width_lab = 0.0;
 
 bool WarpX::do_dynamic_scheduling = true;
 
-int WarpX::do_electrostatic = 0;
+int WarpX::do_electrostatic;
+Real WarpX::self_fields_required_precision = 1.e-11;
+int WarpX::self_fields_max_iters = 200;
+
 int WarpX::do_subcycling = 0;
 bool WarpX::safe_guard_cells = 0;
 
@@ -200,6 +203,7 @@ WarpX::WarpX ()
 
     F_fp.resize(nlevs_max);
     rho_fp.resize(nlevs_max);
+    phi_fp.resize(nlevs_max);
     current_fp.resize(nlevs_max);
     Efield_fp.resize(nlevs_max);
     Bfield_fp.resize(nlevs_max);
@@ -456,7 +460,15 @@ WarpX::ReadParameters ()
                    "The boosted frame diagnostic currently only works if the moving window is in the z direction.");
         }
 
-        pp.query("do_electrostatic", do_electrostatic);
+        do_electrostatic = GetAlgorithmInteger(pp, "do_electrostatic");
+
+        if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+            pp.query("self_fields_required_precision", self_fields_required_precision);
+            pp.query("self_fields_max_iters", self_fields_max_iters);
+            // Note that with the relativistic version, these parameters would be
+            // input for each species.
+        }
+
         pp.query("n_buffer", n_buffer);
         pp.query("const_dt", const_dt);
 
@@ -843,6 +855,7 @@ WarpX::ClearLevel (int lev)
 
     F_fp  [lev].reset();
     rho_fp[lev].reset();
+    phi_fp[lev].reset();
     F_cp  [lev].reset();
     rho_cp[lev].reset();
 
@@ -901,6 +914,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     IntVect Bx_nodal_flag, By_nodal_flag, Bz_nodal_flag;
     IntVect jx_nodal_flag, jy_nodal_flag, jz_nodal_flag;
     IntVect rho_nodal_flag;
+    IntVect phi_nodal_flag;
 
     // Set nodal flags
 #if   (AMREX_SPACEDIM == 2)
@@ -926,6 +940,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     jz_nodal_flag = IntVect(1,1,0);
 #endif
     rho_nodal_flag = IntVect( AMREX_D_DECL(1,1,1) );
+    phi_nodal_flag = IntVect::TheNodeVector();
 
     // Overwrite nodal flags if necessary
     if (do_nodal) {
@@ -998,6 +1013,12 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     if (deposit_charge)
     {
         rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,2*ncomps,ngRho);
+    }
+
+    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
+    {
+        IntVect ngPhi = IntVect( AMREX_D_DECL(1,1,1) );
+        phi_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,phi_nodal_flag),dm,ncomps,ngPhi);
     }
 
     if (do_subcycling == 1 && lev == 0)


### PR DESCRIPTION
This implements a new electrostatic mode that operates in the lab frame. The input parameter do_electrostatic has been changed to a string, with the possible values of none, relativistic, and labframe. The relativistic option turns on the existing mode, where a Poisson solve is done for each species separately accounting for the species averaged velocity. With the new mode, labframe, a single Poisson solve is done combining the charge density of all of the species. Also, with the labframe option, phi is saved in a single top level array and can be written out into the diagnostic output.

Note that the same MLMG solver is used for the lab frame (for simplicity), but has beta set to zero. A future change would use a simpler version with the beta terms removed for optimization, though there doesn't seem to be a simpler version in AMReX.

I've tested this with the ElectrostaticSphere test case and it produces essentially the same result. I can add a CI test that runs with the same input file but sets do_electrostatic = labframe.