### PR TITLE
Fix some warnings related to double to float conversions

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -48,12 +48,12 @@ namespace
             Real offset = static_cast<Real>(glo-i);
             p_sigma[i-slo] = fac*(offset*offset);
             // sigma_cumsum is the analytical integral of sigma function at same points than sigma
-            p_sigma_cumsum[i-slo] = (fac*(offset*offset*offset)/3.)/PhysConst::c;
+            p_sigma_cumsum[i-slo] = (fac*(offset*offset*offset)/3._rt)/PhysConst::c;
             if (i <= ohi+1) {
-                offset = static_cast<Real>(glo-i) - 0.5;
+                offset = static_cast<Real>(glo-i) - 0.5_rt;
                 p_sigma_star[i-sslo] = fac*(offset*offset);
                 // sigma_star_cumsum is the analytical integral of sigma function at same points than sigma_star
-                p_sigma_star_cumsum[i-sslo] = (fac*(offset*offset*offset)/3.)/PhysConst::c;
+                p_sigma_star_cumsum[i-sslo] = (fac*(offset*offset*offset)/3._rt)/PhysConst::c;
             }
         });
     }
@@ -78,11 +78,11 @@ namespace
             i += olo;
             Real offset = static_cast<Real>(i-ghi-1);
             p_sigma[i-slo] = fac*(offset*offset);
-            p_sigma_cumsum[i-slo] = (fac*(offset*offset*offset)/3.)/PhysConst::c;
+            p_sigma_cumsum[i-slo] = (fac*(offset*offset*offset)/3._rt)/PhysConst::c;
             if (i <= ohi+1) {
-                offset = static_cast<Real>(i-ghi) - 0.5;
+                offset = static_cast<Real>(i-ghi) - 0.5_rt;
                 p_sigma_star[i-sslo] = fac*(offset*offset);
-                p_sigma_star_cumsum[i-sslo] = (fac*(offset*offset*offset)/3.)/PhysConst::c;
+                p_sigma_star_cumsum[i-sslo] = (fac*(offset*offset*offset)/3._rt)/PhysConst::c;
             }
         });
     }
@@ -153,7 +153,7 @@ SigmaBox::SigmaBox (const Box& box, const BoxArray& grids, const Real* dx, int n
 
     Array<Real,AMREX_SPACEDIM> fac;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        fac[idim] = 4.0*PhysConst::c/(dx[idim]*static_cast<Real>(delta*delta));
+        fac[idim] = 4.0_rt*PhysConst::c/(dx[idim]*static_cast<Real>(delta*delta));
     }
 
     const std::vector<std::pair<int,Box> >& isects = grids.intersections(box, false, ncell);

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -97,11 +97,11 @@ struct InjectorDensityPredefined
             }
             // Multiply by transverse profile, and physical density
             n *= n0*(1.+4.*(x*x+y*y)/(kp*kp*rc*rc*rc*rc));
-            return n;
+            return static_cast<amrex::Real>(n);
         }
         default:
             amrex::Abort("InjectorDensityPredefined: how did we get here?");
-            return 0.0;
+            return static_cast<amrex::Real>(0.0);
         }
     }
 

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -101,7 +101,7 @@ struct InjectorDensityPredefined
         }
         default:
             amrex::Abort("InjectorDensityPredefined: how did we get here?");
-            return static_cast<amrex::Real>(0.0);
+            return amrex::Real(0.0);
         }
     }
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -85,7 +85,7 @@ struct InjectorMomentumBoltzmann
     // boost velocity/c beta,
     // and boost direction dir respectively.
     InjectorMomentumBoltzmann(amrex::Real t, amrex::Real b, int d) noexcept
-        : dir(d), beta(b), vave(std::sqrt(2*t))
+        : dir(d), beta(b), vave(std::sqrt(amrex::Real(2.)*t))
         {}
 
     AMREX_GPU_HOST_DEVICE

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -85,7 +85,7 @@ struct InjectorMomentumBoltzmann
     // boost velocity/c beta,
     // and boost direction dir respectively.
     InjectorMomentumBoltzmann(amrex::Real t, amrex::Real b, int d) noexcept
-        : dir(d), beta(b), vave(std::sqrt(2.*t))
+        : dir(d), beta(b), vave(std::sqrt(2*t))
         {}
 
     AMREX_GPU_HOST_DEVICE
@@ -100,10 +100,10 @@ struct InjectorMomentumBoltzmann
         // Each value of sqrt(-log(x1))*sin(2*pi*x2) is a sample from a Gaussian
         // distribution with sigma = average velocity / c
         // using the Box-Mueller Method.
-        u[(dir+1)%3] = vave*std::sqrt(-std::log(x1)) *std::sin(2*M_PI*x2);
-        u[(dir+2)%3] = vave*std::sqrt(-std::log(x1)) *std::cos(2*M_PI*x2);
+        u[(dir+1)%3] = vave*std::sqrt(-std::log(x1)) *std::sin(2*MathConst::pi*x2);
+        u[(dir+2)%3] = vave*std::sqrt(-std::log(x1)) *std::cos(2*MathConst::pi*x2);
         u[dir] = vave*std::sqrt(-std::log(amrex::Random(engine)))*
-            std::sin(2*M_PI*amrex::Random(engine));
+            std::sin(2*MathConst::pi*amrex::Random(engine));
         gamma = u[0]*u[0]+u[1]*u[1]+u[2]*u[2];
         gamma = std::sqrt(1+gamma);
         // The following condition is equtaion 32 in Zenitani 2015
@@ -138,7 +138,7 @@ struct InjectorMomentumBoltzmann
         using namespace amrex;
         Real u[3];
         for (int idim = 0; idim < 3; ++idim) u[idim] = 0.0_rt;
-        const Real gamma = 1./sqrt(1+beta*beta);
+        const Real gamma = static_cast<amrex::Real>(1./sqrt(1+beta*beta));
         u[dir] = gamma*beta;
         return XDim3 {u[0],u[1],u[2]};
     }
@@ -170,9 +170,9 @@ struct InjectorMomentumJuttner
         // from Zenitani 2015 (Phys. Plasmas 22, 042116).
         amrex::Real x1, x2, gamma;
         amrex::Real u [3];
-        x1 = 0.;
-        gamma = 0.;
-        u[dir] = 0.;
+        x1 = static_cast<amrex::Real>(0.);
+        gamma = static_cast<amrex::Real>(0.);
+        u[dir] = static_cast<amrex::Real>(0.);
         // This condition is equation 10 in Zenitani,
         // though x1 is defined differently.
         while(u[dir]-gamma <= x1)
@@ -188,8 +188,8 @@ struct InjectorMomentumJuttner
         x2 = amrex::Random(engine);
         // Direction dir is an input parameter that sets the boost direction:
         // 'x' -> d = 0, 'y' -> d = 1, 'z' -> d = 2.
-        u[(dir+1)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::sin(2*M_PI*x2);
-        u[(dir+2)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::cos(2*M_PI*x2);
+        u[(dir+1)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::sin(2*MathConst::pi*x2);
+        u[(dir+2)%3] = 2*u[dir]*std::sqrt(x1*(1-x1))*std::cos(2*MathConst::pi*x2);
         // The value of dir is the boost direction to be transformed.
         u[dir] = u[dir]*(2*x1-1);
         x1 = amrex::Random(engine);
@@ -225,7 +225,7 @@ struct InjectorMomentumJuttner
         using namespace amrex;
         Real u[3];
         for (int idim = 0; idim < 3; ++idim) u[idim] = 0.0_rt;
-        const Real gamma = 1./sqrt(1+beta*beta);
+        const Real gamma = static_cast<Real>(1./sqrt(1+beta*beta));
         u[dir] = gamma*beta;
         return XDim3 {u[0],u[1],u[2]};
     }

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -225,7 +225,7 @@ struct InjectorMomentumJuttner
         using namespace amrex;
         Real u[3];
         for (int idim = 0; idim < 3; ++idim) u[idim] = 0.0_rt;
-        const Real gamma = static_cast<Real>(1./sqrt(1+beta*beta));
+        const Real gamma = static_cast<Real>(1./sqrt(1.+beta*beta));
         u[dir] = gamma*beta;
         return XDim3 {u[0],u[1],u[2]};
     }

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -191,9 +191,9 @@ wp_call_f1 (enum wp_f1_t type, T a)
     case WP_COSH:        return std::cosh(a);
     case WP_TANH:        return std::tanh(a);
     case WP_ABS:         return amrex::Math::abs(a);
-    case WP_POW_M3:      return static_cast<amrex::Real>(1.0)/(a*a*a);
-    case WP_POW_M2:      return static_cast<amrex::Real>(1.0)/(a*a);
-    case WP_POW_M1:      return static_cast<amrex::Real>(1.0)/a;
+    case WP_POW_M3:      return amrex::Real(1.0)/(a*a*a);
+    case WP_POW_M2:      return amrex::Real(1.0)/(a*a);
+    case WP_POW_M1:      return amrex::Real(1.0)/a;
     case WP_POW_P1:      return a;
     case WP_POW_P2:      return a*a;
     case WP_POW_P3:      return a*a*a;

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -236,7 +236,7 @@ wp_call_f2 (enum wp_f2_t type, T a, T b)
     case WP_OR:
         return ((a != T(0)) || (b != T(0))) ? 1.0 : 0.0;
     case WP_HEAVISIDE:
-        return static_cast<amrex::Real>((a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b));
+        return (a < 0.0) ? amrex::Real(0.0) : ((a > 0.0) ? amrex::Real(1.0) : b);
     case WP_MIN:
         return (a < b) ? a : b;
     case WP_MAX:

--- a/Source/Parser/wp_parser_y.h
+++ b/Source/Parser/wp_parser_y.h
@@ -191,9 +191,9 @@ wp_call_f1 (enum wp_f1_t type, T a)
     case WP_COSH:        return std::cosh(a);
     case WP_TANH:        return std::tanh(a);
     case WP_ABS:         return amrex::Math::abs(a);
-    case WP_POW_M3:      return 1.0/(a*a*a);
-    case WP_POW_M2:      return 1.0/(a*a);
-    case WP_POW_M1:      return 1.0/a;
+    case WP_POW_M3:      return static_cast<amrex::Real>(1.0)/(a*a*a);
+    case WP_POW_M2:      return static_cast<amrex::Real>(1.0)/(a*a);
+    case WP_POW_M1:      return static_cast<amrex::Real>(1.0)/a;
     case WP_POW_P1:      return a;
     case WP_POW_P2:      return a*a;
     case WP_POW_P3:      return a*a*a;
@@ -236,7 +236,7 @@ wp_call_f2 (enum wp_f2_t type, T a, T b)
     case WP_OR:
         return ((a != T(0)) || (b != T(0))) ? 1.0 : 0.0;
     case WP_HEAVISIDE:
-        return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
+        return static_cast<amrex::Real>((a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b));
     case WP_MIN:
         return (a < b) ? a : b;
     case WP_MAX:

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -77,7 +77,7 @@ struct IonizationFilterFunc
         if (ion_lev < m_atomic_number)
         {
             constexpr amrex::Real c = PhysConst::c;
-            constexpr amrex::Real c2_inv = static_cast<amrex::Real>(1.)/c/c;
+            constexpr amrex::Real c2_inv = amrex::Real(1.)/c/c;
 
             // gather E and B
             amrex::ParticleReal xp, yp, zp;

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -77,7 +77,7 @@ struct IonizationFilterFunc
         if (ion_lev < m_atomic_number)
         {
             constexpr amrex::Real c = PhysConst::c;
-            constexpr amrex::Real c2_inv = 1./c/c;
+            constexpr amrex::Real c2_inv = static_cast<amrex::Real>(1.)/c/c;
 
             // gather E and B
             amrex::ParticleReal xp, yp, zp;

--- a/Source/Particles/ParticleCreation/DefaultInitialization.H
+++ b/Source/Particles/ParticleCreation/DefaultInitialization.H
@@ -59,7 +59,7 @@ amrex::ParticleReal initializeRealValue (const InitializationPolicy policy, amre
         case InitializationPolicy::Zero : return 0.0;
         case InitializationPolicy::One  : return 1.0;
         case InitializationPolicy::RandomExp : {
-            return -log(amrex::Random(engine));
+            return -std::log(amrex::Random(engine));
         }
         default : {
             amrex::Abort("Initialization Policy not recognized");

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -273,7 +273,8 @@ public:
 
     bool do_splitting = false;
     bool initialize_self_fields = false;
-    amrex::Real self_fields_required_precision = 1.e-11;
+    amrex::Real self_fields_required_precision =
+        static_cast<amrex::Real>(1.e-11);
     int self_fields_max_iters = 200;
 
     // split along diagonals (0) or axes (1)

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -274,7 +274,7 @@ public:
     bool do_splitting = false;
     bool initialize_self_fields = false;
     amrex::Real self_fields_required_precision =
-        static_cast<amrex::Real>(1.e-11);
+        amrex::Real(1.e-11);
     int self_fields_max_iters = 200;
 
     // split along diagonals (0) or axes (1)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -505,7 +505,7 @@ public:
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
-                     amrex::Real const required_precision=1.e-11,
+                     amrex::Real const required_precision=static_cast<amrex::Real>(1.e-11),
                      const int max_iters=200) const;
     void computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E,
                    const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
@@ -771,7 +771,7 @@ private:
     amrex::Vector<int> injected_plasma_species;
 
     int n_buffer = 4;
-    amrex::Real const_dt = 0.5e-11;
+    amrex::Real const_dt = static_cast<amrex::Real>(0.5e-11);
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;
@@ -790,25 +790,25 @@ private:
      * load balance via the 'knapsack' strategy; e.g., if there are 4 boxes per rank,
      * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
      * be assigned to a rank to 8. */
-    amrex::Real load_balance_knapsack_factor = 1.24;
+    amrex::Real load_balance_knapsack_factor = static_cast<amrex::Real>(1.24);
     /** Threshold value that controls whether to adopt the proposed distribution
      * mapping during load balancing.  The new distribution mapping is adopted
      * if the ratio of proposed distribution mapping efficiency to current
      * distribution mapping efficiency is larger than the threshold; 'efficiency'
      * here means the average cost per MPI rank.  */
-    amrex::Real load_balance_efficiency_ratio_threshold = 1.1;
+    amrex::Real load_balance_efficiency_ratio_threshold = static_cast<amrex::Real>(1.1);
     /** Weight factor for cells in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is an empty (i.e. no particles) domain
      * of size 256 by 256 by 256 cells, from which the average time per iteration
      * per cell is computed. */
-    amrex::Real costs_heuristic_cells_wt = -1;
+    amrex::Real costs_heuristic_cells_wt = static_cast<amrex::Real>(-1);
     /** Weight factor for particles in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is a high-ppc (27 particles per cell)
      * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate
      * time per iteration per particle is computed. */
-    amrex::Real costs_heuristic_particles_wt = -1;
+    amrex::Real costs_heuristic_particles_wt = static_cast<amrex::Real>(-1);
 
     // Determines timesteps for override sync
     IntervalsParser override_sync_intervals;
@@ -823,7 +823,7 @@ private:
 
     int regrid_int = -1;
 
-    amrex::Real cfl = 0.7;
+    amrex::Real cfl = static_cast<amrex::Real>(0.7);
 
     std::string restart_chkfile;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -808,7 +808,7 @@ private:
      * The problem setup for these tests is a high-ppc (27 particles per cell)
      * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate
      * time per iteration per particle is computed. */
-    amrex::Real costs_heuristic_particles_wt = static_cast<amrex::Real>(-1);
+    amrex::Real costs_heuristic_particles_wt = amrex::Real(-1);
 
     // Determines timesteps for override sync
     IntervalsParser override_sync_intervals;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -771,7 +771,7 @@ private:
     amrex::Vector<int> injected_plasma_species;
 
     int n_buffer = 4;
-    amrex::Real const_dt = static_cast<amrex::Real>(0.5e-11);
+    amrex::Real const_dt = amrex::Real(0.5e-11);
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -823,7 +823,7 @@ private:
 
     int regrid_int = -1;
 
-    amrex::Real cfl = static_cast<amrex::Real>(0.7);
+    amrex::Real cfl = amrex::Real(0.7);
 
     std::string restart_chkfile;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -802,7 +802,7 @@ private:
      * The problem setup for these tests is an empty (i.e. no particles) domain
      * of size 256 by 256 by 256 cells, from which the average time per iteration
      * per cell is computed. */
-    amrex::Real costs_heuristic_cells_wt = static_cast<amrex::Real>(-1);
+    amrex::Real costs_heuristic_cells_wt = amrex::Real(-1);
     /** Weight factor for particles in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is a high-ppc (27 particles per cell)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -505,7 +505,7 @@ public:
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
-                     amrex::Real const required_precision=static_cast<amrex::Real>(1.e-11),
+                     amrex::Real const required_precision=amrex::Real(1.e-11),
                      const int max_iters=200) const;
     void computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E,
                    const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -796,7 +796,7 @@ private:
      * if the ratio of proposed distribution mapping efficiency to current
      * distribution mapping efficiency is larger than the threshold; 'efficiency'
      * here means the average cost per MPI rank.  */
-    amrex::Real load_balance_efficiency_ratio_threshold = static_cast<amrex::Real>(1.1);
+    amrex::Real load_balance_efficiency_ratio_threshold = amrex::Real(1.1);
     /** Weight factor for cells in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is an empty (i.e. no particles) domain

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -790,7 +790,7 @@ private:
      * load balance via the 'knapsack' strategy; e.g., if there are 4 boxes per rank,
      * `load_balance_knapsack_factor=2` limits the maximum number of boxes that can
      * be assigned to a rank to 8. */
-    amrex::Real load_balance_knapsack_factor = static_cast<amrex::Real>(1.24);
+    amrex::Real load_balance_knapsack_factor = amrex::Real(1.24);
     /** Threshold value that controls whether to adopt the proposed distribution
      * mapping during load balancing.  The new distribution mapping is adopted
      * if the ratio of proposed distribution mapping efficiency to current

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1304,7 +1304,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
         "ComputeDivB not implemented with do_nodal."
         "Shouldn't be too hard to make it general with class FiniteDifferenceSolver");
 
-    Real dxinv = 1./dx[0], dyinv = 1./dx[1], dzinv = 1./dx[2];
+    Real dxinv = 1._rt/dx[0], dyinv = 1._rt/dx[1], dzinv = 1._rt/dx[2];
 
 #ifdef WARPX_DIM_RZ
     const Real rmin = GetInstance().Geom(0).ProbLo(0);
@@ -1342,7 +1342,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
         "ComputeDivB not implemented with do_nodal."
         "Shouldn't be too hard to make it general with class FiniteDifferenceSolver");
 
-    Real dxinv = 1./dx[0], dyinv = 1./dx[1], dzinv = 1./dx[2];
+    Real dxinv = 1._rt/dx[0], dyinv = 1._rt/dx[1], dzinv = 1._rt/dx[2];
 
 #ifdef WARPX_DIM_RZ
     const Real rmin = GetInstance().Geom(0).ProbLo(0);


### PR DESCRIPTION
I compiled `WarpX` in single precision with ` make DIM=2 QED=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE -j4` (using `g++ (Ubuntu 10.2.0-13ubuntu1) 10.2.0` ). I got several warnings related to casts from `double` to `float`. This PR should fix some of these warnings.