### PR TITLE
Update landing page of WarpX documentation

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -6,13 +6,6 @@
 WarpX documentation
 ===================
 
-.. warning::
-
-   This is an **alpha release** of WarpX.
-   The code is still in active development.
-   Robustness and performance may fluctuate at this stage.
-   The input and output formats may evolve.
-
 WarpX is an advanced **electromagnetic Particle-In-Cell** code.
 
 It supports many features including:
@@ -24,8 +17,8 @@ It supports many features including:
 For details on the algorithms that WarpX implements, see the section :doc:`theory/theory`.
 
 In addition, WarpX is a highly-parallel and highly-optimized code
-and features hybrid OpenMP/MPI parallelization, advanced vectorization
-techniques and load balancing capabilities.
+which can run on GPUs and multi-core CPUs, and includes load balancing
+capabilities.
 
 In order to learn to use the code, please see the sections below:
 


### PR DESCRIPTION
The landing page is a bit outdated: it mentions OpenMP but does not mention GPUs. In addition, I don't think that the warning message is still needed.