### PR TITLE
 [mini-PR] MinimalBox to build PML boxarray in domain for all levels

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -442,7 +442,10 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     // In order to implement this, a reduced domain is created here (decreased by ncells in all direction)
     // and passed to `MakeBoxArray`, which surrounds it by PML boxes
     // (thus creating the PML boxes at the right position, where they overlap with the original domain)
-    Box domain0 = geom->Domain();
+    // minimalBox provides the bounding box around grid_ba for level, lev.
+    // Note that this is okay to build pml inside domain for a single patch, or joint patches
+    // with same [min,max]. But it does not support multiple disjoint refinement patches.
+    Box domain0 = grid_ba.minimalBox();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         if ( ! geom->isPeriodic(idim)) {
             if (do_pml_Lo[idim]){


### PR DESCRIPTION
Currently, when we build the box-array for pml in domain, we start with the box that defines the entire domain.
However, for level>0, with refinement patch inside the domain, the box that we need to build the box array must cover only the refinement patch, and not the entire domain. As a result, the particle j-damping was not triggered inside the refinement patch, where we expected j-damping, leading to residual electric field across the coarse-fine interface.

In this PR, `minimalBox()`, an amrex function is used, to determine the bounding box of the box-array at a given level.

Note that, although this solves the problem for a single patch at level>0, it is not generic to determine box-array for pml inside multiple disjoint patches. A "simplified_list()" can be explored to obtain multiple bounding boxes that cover the disjoint patches.
I will open a separate issue for this. 
This PR is a solution for most use-cases at present and will need modifications in the future for complex mesh-refinement patches

