### PR TITLE
CI: Disable DPC++ oneAPI 2020-11

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -79,7 +79,10 @@ jobs:
         cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
         make -j 2
 
+# disabled since Intel patched a new CMake Compiler ID in with incomplete support
+# for dpcpp
   build_dpcc:
+    if: false
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Someone patched in a dedicated CMake compiler ID for Intel DPC++ but did not add full compiler support.

Release: 2021.1.1

Ref.: https://gitlab.kitware.com/cmake/cmake/-/issues/21551