### PR TITLE
material properties are cell-centered, not nodal

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -96,11 +96,11 @@ MacroscopicProperties::InitData ()
     int ng = 3;
     // Define material property multifabs using ba and dmap from WarpX instance
     // sigma is cell-centered MultiFab
-    m_sigma_mf = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()), dmap, 1, ng);
+    m_sigma_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
     // epsilon is cell-centered MultiFab
-    m_eps_mf = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()), dmap, 1, ng);
+    m_eps_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
     // mu is cell-centered MultiFab
-    m_mu_mf = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()), dmap, 1, ng);
+    m_mu_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
     // Initialize sigma
     if (m_sigma_s == "constant") {
 


### PR DESCRIPTION
The macroparameters multifabs used for storing permittivity, permeability, and conductivity must be all cell-centered as mentioned in the comments. Not nodal.
cell-centering these properties allows for easier implementation of material interfaces.

