### PR TITLE
AnyFFT: `AMReX_Config.H`

### DIFF
--- a/Source/FieldSolver/SpectralSolver/AnyFFT.H
+++ b/Source/FieldSolver/SpectralSolver/AnyFFT.H
@@ -8,6 +8,8 @@
 #ifndef ANYFFT_H_
 #define ANYFFT_H_
 
+#include <AMReX_Config.H>
+
 #if defined(AMREX_USE_CUDA)
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)


### PR DESCRIPTION
We reduce the number of command line arguments passed in the AMReX build systems by placing defines in an `AMReX_Config.H` file that is configured at AMReX build time. Files like `AMReX.H` will pull it in as well.

In the case of `AnyFFT.H`, we need to make sure this is included before we check the preprocessor defines.