### PR TITLE
DPC++: Re-Enable with Work-around

### DIFF
--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The WarpX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
+  | sudo apt-key add -
+echo "deb https://apt.repos.intel.com/oneapi all main" \
+  | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+sudo apt-get update
+
+sudo apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake           \
+    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
+    g++ gfortran    \
+    libopenmpi-dev  \
+    openmpi-bin

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -121,9 +121,7 @@ jobs:
           -DWarpX_COMPUTE=DPCPP        \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \
-          -DWarpX_PRECISION=SINGLE     \
-          -DWarpX_amrex_repo=https://github.com/ax3l/amrex.git \
-          -DWarpX_amrex_branch=topic-dpcppCmakeMPI
+          -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -121,7 +121,9 @@ jobs:
           -DWarpX_COMPUTE=DPCPP        \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \
-          -DWarpX_PRECISION=SINGLE
+          -DWarpX_PRECISION=SINGLE     \
+          -DWarpX_amrex_repo=https://github.com/ax3l/amrex.git \
+          -DWarpX_amrex_branch=topic-dpcppCmakeMPI
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -80,37 +80,30 @@ jobs:
         python3 -m pip install --upgrade pip setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
-# disabled since Intel patched a new CMake Compiler ID in with incomplete support
-# for dpcpp
   build_dpcc:
-    if: false
     name: oneAPI DPC++ SP [Linux]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
       shell: bash
       run: |
-        set -ex
-        export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get -qqq update
-        sudo apt-get install -y wget build-essential pkg-config ca-certificates gnupg
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade cmake
-        sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-        sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel
+        .github/workflows/dependencies/dpcpp.sh
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
         git clone https://github.com/openPMD/openPMD-api.git
-        mkdir openPMD-api/build
-        cd openPMD-api/build
-        CXX=$(which dpcpp) CC=$(which clang) cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
-        make -j 2
-        sudo make install
+        CXX=$(which dpcpp) CC=$(which clang) cmake   \
+          -S openPMD-api -B build_openPMD            \
+          -DCMAKE_CXX_COMPILER_ID="Clang"            \
+          -DCMAKE_CXX_COMPILER_VERSION=12.0          \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17" \
+          -DCMAKE_VERBOSE_MAKEFILE=ON                \
+          -DopenPMD_USE_PYTHON=OFF                   \
+          -DBUILD_TESTING=OFF                        \
+          -DBUILD_EXAMPLES=OFF
+        cmake --build build_openPMD -j 2
+        sudo cmake --build build_openPMD --target install
     - name: build WarpX
       shell: bash
       run: |
@@ -120,11 +113,23 @@ jobs:
         export CXX=$(which dpcpp)
         export CC=$(which clang)
 
-        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_COMPUTE=DPCPP -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
+        cmake -S . -B build_sp         \
+          -DCMAKE_CXX_COMPILER_ID="Clang"                \
+          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_COMPUTE=DPCPP        \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_openpmd_internal=OFF \
+          -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
+        python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+     # note: setting the CXX compiler ID is a work-around for
+     # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
+     # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
   build_hip:
     name: HIP SP [Linux]


### PR DESCRIPTION
My former colleagues shared a work-around that we can use to overwrite the compiler identification:
  https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580

This regression will also be fixed in CMake 3.19.2