### PR TITLE
Diags: <diags>.write_fields Switch

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2334,6 +2334,10 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
         <diag_name>.adios2_engine.parameters.NumAggregators = 2048
         <diag_name>.adios2_engine.parameters.BurstBufferPath="/mnt/bb/username"
 
+* ``<diag_name>.write_fields`` (`0` or `1`) optional (default `1`)
+    Whether to write field output or not.
+    For checkpoint format, always set this parameter to ``1``.
+
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
     Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe. Also, note that for ``<diag_name>.diag_type = BackTransformed``, the only scalar field currently supported is ``rho``.

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d
@@ -83,10 +83,14 @@ laser1.profile_focal_distance = 100.e-6  # Focal distance from the antenna (in m
 laser1.wavelength = 0.8e-6               # The wavelength of the laser (in m)
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diag_beam
 diag1.intervals = 200
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
+
+diag_beam.intervals = 200
+diag_beam.diag_type = Full
+diag_beam.write_fields = 0
 
 # Reduced Diagnostics
 warpx.reduced_diags_names               = FP

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -208,9 +208,7 @@ diag1.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) * (
 
 openPMDfw.intervals = 100
 openPMDfw.diag_type = Full
-openPMDfw.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
-# reduce resolution of output fields
-openPMDfw.coarsening_ratio = 4 4
+openPMDfw.write_fields = 0
 openPMDfw.electrons.variables = w ux uy uz
 openPMDfw.hydrogen.variables = w ux uy uz orig_x orig_z
 openPMDfw.format = openpmd
@@ -222,9 +220,7 @@ openPMDfw.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6)
 
 openPMDbw.intervals = 100
 openPMDbw.diag_type = Full
-openPMDbw.fields_to_plot = rho_hydrogen
-# reduce resolution of output fields
-openPMDbw.coarsening_ratio = 4 4
+openPMDfw.write_fields = 0
 openPMDbw.electrons.variables = w ux uy uz
 openPMDbw.hydrogen.variables = w ux uy uz orig_x orig_z
 openPMDbw.format = openpmd

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -72,6 +72,31 @@ Diagnostics::BaseReadParameters ()
         }
     }
 
+    // default for writing field output is 1
+    int write_fields = 1;
+    pp.query("write_fields", write_fields);
+    if (write_fields == 0) {
+        if (m_format == "checkpoint") {
+            ablastr::warn_manager::WMRecordWarning(
+                "Diagnostics",
+                "For checkpoint format, write_fields flag must be 1. Overwriting."
+            );
+            pp.add("write_fields", 1);
+        }
+        else if (m_format == "plotfile") {
+            ablastr::warn_manager::WMRecordWarning(
+                "Diagnostics",
+                "Plotfiles do not yet support write_fields = 0. Overwriting. As a work-around, consider selecting only one field in fields_to_plot and coarsening it."
+            );
+            pp.add("write_fields", 1);
+        }
+        else {
+            // if user-defined value for write_fields == 0, then clear field vector
+            m_varnames.clear();
+            varnames_specified = false;
+        }
+    }
+
     // Sanity check if user requests to plot phi
     if (utils::algorithms::is_in(m_varnames_fields, "phi")){
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -337,15 +362,20 @@ Diagnostics::InitDataAfterRestart ()
         InitializeParticleFunctors();
     }
    if (write_species == 0) {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            m_format != "checkpoint",
-            "For checkpoint format, write_species flag must be 1."
-        );
-        // if user-defined value for write_species == 0, then clear species vector
-        for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-            m_output_species.at(i_buffer).clear();
+        if (m_format == "checkpoint") {
+            ablastr::warn_manager::WMRecordWarning(
+                "Diagnostics",
+                "For checkpoint format, write_species flag must be 1. Overwriting."
+            );
+            pp_diag_name.add("write_species", 1);
         }
-        m_output_species_names.clear();
+        else {
+            // if user-defined value for write_species == 0, then clear species vector
+            for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
+                m_output_species.at(i_buffer).clear();
+            }
+            m_output_species_names.clear();
+        }
     } else {
         amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
         if ( utils::parser::queryArrWithParser(
@@ -417,15 +447,20 @@ Diagnostics::InitData ()
     }
 
     if (write_species == 0) {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            m_format != "checkpoint",
-            "For checkpoint format, write_species flag must be 1."
-        );
-        // if user-defined value for write_species == 0, then clear species vector
-        for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-            m_output_species.at(i_buffer).clear();
+        if (m_format == "checkpoint") {
+            ablastr::warn_manager::WMRecordWarning(
+                "Diagnostics",
+                "For checkpoint format, write_species flag must be 1. Overwriting."
+            );
+            pp_diag_name.add("write_species", 1);
         }
-        m_output_species_names.clear();
+        else {
+            // if user-defined value for write_species == 0, then clear species vector
+            for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
+                m_output_species.at(i_buffer).clear();
+            }
+            m_output_species_names.clear();
+        }
     } else {
         amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
         if ( utils::parser::queryArrWithParser(

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -87,15 +87,17 @@ FlushFormatPlotfile::WriteToFile (
     const VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::Version_v1);
     if (plot_raw_fields) rfs.emplace_back("raw_fields");
-    amrex::WriteMultiLevelPlotfile(filename, nlev,
-                                   amrex::GetVecOfConstPtrs(mf),
-                                   varnames, geom,
-                                   static_cast<Real>(time), iteration, warpx.refRatio(),
-                                   "HyperCLaw-V1.1",
-                                   "Level_",
-                                   "Cell",
-                                   rfs
-                                   );
+    if (varnames.size() > 0u ) {
+        amrex::WriteMultiLevelPlotfile(filename, nlev,
+                                       amrex::GetVecOfConstPtrs(mf),
+                                       varnames, geom,
+                                       static_cast<Real>(time), iteration, warpx.refRatio(),
+                                       "HyperCLaw-V1.1",
+                                       "Level_",
+                                       "Cell",
+                                       rfs
+                                       );
+    }
 
     WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards);
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -445,6 +445,9 @@ FullDiagnostics::AddRZModesToOutputNames (const std::string& field, int ncomp){
 void
 FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
     amrex::ignore_unused(restart);
+
+    if (m_varnames.size() == 0u) return;
+
     auto & warpx = WarpX::GetInstance();
     amrex::RealBox diag_dom;
     bool use_warpxba = true;
@@ -573,6 +576,8 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
         return; // We skip the rest of this function
     }
 #endif
+
+    if (m_varnames.size() == 0u) return;
 
     auto & warpx = WarpX::GetInstance();
 


### PR DESCRIPTION
As with `<diags>.write_species`, this switch can be used to disable field writes in diagnostics. This is useful to dump particle species and field data with different intervals.

Note:
Plotfiles need grid meta data to read in particles.