### PR TITLE
[mini-PR] Make reading a TXYE laser file more efficient

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -271,7 +271,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int
             m_params.h_x_coords.size()*sizeof(double) +
             m_params.h_y_coords.size()*sizeof(double) +
             sizeof(double)*t_begin*m_params.nx*m_params.ny;
-        inp.ignore(skip_amount);
+        inp.seekg(skip_amount);
         if(!inp) Abort("Failed to read field data from txye file");
         const int read_size = (i_last - i_first + 1)*
             m_params.nx*m_params.ny;


### PR DESCRIPTION
Since TXYE laser files can be very large, they can be read in chunks.
Currently, this feature relies on `inp.ignore(skip_amount);`  (`inp` is an `std::ifstream`). 
`ifstream::ignore` actually reads the content of the file up to `skip_amount`, which takes a **long** time for multi-GB files (guess how I found this issue ;-) ...)! Replacing this line with `inp.seekg(skip_amount);` should fix the issue.

I've performed a test on Summit in which the laser field file is ~ 15 GB. 
With the currently implemented strategy I observe a constant growth of the time spent in reading the TXYE file:
```
STEP 23 ; Reading [76, 151) data chunk    ; This step = 1.988431181 s;
STEP 45 ; Reading [152, 227) data chunk   ; This step = 2.88819222  s;
STEP 67 ; Reading [228, 303) data chunk   ; This step = 3.785026602 s;
STEP 89 ; Reading [304, 379) data chunk   ; This step = 4.971282902 s;
STEP 111; Reading [380, 455) data chunk   ; This step = 5.537481175 s;
STEP 133; Reading [456, 531) data chunk   ; This step = 6.514349927 s;
STEP 155; Reading [532, 607) data chunk   ; This step = 7.255408595 s;
STEP 177; Reading [609, 684) data chunk   ; This step = 8.194176288 s;
STEP 199; Reading [685, 760) data chunk   ; This step = 9.032770221 s;
STEP 221; Reading [761, 836) data chunk   ; This step = 9.979706029 s;
STEP 243; Reading [837, 912) data chunk   ; This step = 10.84418869 s;
STEP 265; Reading [913, 988) data chunk   ; This step = 11.64474893 s;
STEP 287; Reading [989, 1064) data chunk  ; This step = 12.58355406 s;
STEP 309; Reading [1065, 1140) data chunk ; This step = 13.48952502 s;
STEP 331; Reading [1142, 1217) data chunk ; This step = 14.46891537 s;
STEP 353; Reading [1218, 1293) data chunk ; This step = 15.29878951 s;
STEP 375; Reading [1294, 1369) data chunk ; This step = 16.14003995 s;
STEP 397; Reading [1370, 1445) data chunk ; This step = 16.92163946 s;
STEP 419; Reading [1446, 1521) data chunk ; This step = 17.64232812 s;
```

With the strategy implemented in this PR the reading time is roughly constant (and smaller, except for the first few steps!)
```
STEP 23 ; Reading [76, 151) data chunk    ; This step = 3.775765839 s;
STEP 45 ; Reading [152, 227) data chunk   ; This step = 3.798425114 s;
STEP 67 ; Reading [228, 303) data chunk   ; This step = 3.751181312 s;
[...]
STEP 375; Reading [1294, 1369) data chunk ; This step = 3.756207271 s;
STEP 397; Reading [1370, 1445) data chunk ; This step = 3.73545679  s;
STEP 419; Reading [1446, 1521) data chunk ; This step = 0.943642502 s;
```