### PR TITLE
Use new parser for more real input parameters

### DIFF
--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -1,5 +1,6 @@
 #include "WarpX.H"
 #include "ParticleDiag.H"
+#include "Utils/WarpXUtil.H"
 
 #include <AMReX_ParmParse.H>
 
@@ -65,7 +66,7 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
 #endif
 
     // build filter functors
-    m_do_random_filter = pp.query("random_fraction", m_random_fraction);
+    m_do_random_filter = queryWithParser(pp, "random_fraction", m_random_fraction);
     m_do_uniform_filter = pp.query("uniform_stride",  m_uniform_stride);
     std::string buf;
     m_do_parser_filter = pp.query("plot_filter_function(t,x,y,z,ux,uy,uz)", buf);

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -39,8 +39,8 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // read bin parameters
     pp.get("bin_number",m_bin_num);
-    pp.get("bin_max",   m_bin_max);
-    pp.get("bin_min",   m_bin_min);
+    getWithParser(pp, "bin_max",   m_bin_max);
+    getWithParser(pp, "bin_min",   m_bin_min);
     m_bin_size = (m_bin_max - m_bin_min) / m_bin_num;
 
     // read histogram function

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -1,6 +1,8 @@
 #include "MacroscopicProperties.H"
-#include <AMReX_ParmParse.H>
 #include "WarpX.H"
+#include "Utils/WarpXUtil.H"
+
+#include <AMReX_ParmParse.H>
 
 #include <memory>
 
@@ -22,7 +24,7 @@ MacroscopicProperties::ReadParameters ()
 
     // Query input for material conductivity, sigma.
     bool sigma_specified = false;
-    if (pp.query("sigma", m_sigma)) {
+    if (queryWithParser(pp, "sigma", m_sigma)) {
         m_sigma_s = "constant";
         sigma_specified = true;
     }
@@ -41,7 +43,7 @@ MacroscopicProperties::ReadParameters ()
     }
 
     bool epsilon_specified = false;
-    if (pp.query("epsilon", m_epsilon)) {
+    if (queryWithParser(pp, "epsilon", m_epsilon)) {
         m_epsilon_s = "constant";
         epsilon_specified = true;
     }
@@ -62,7 +64,7 @@ MacroscopicProperties::ReadParameters ()
 
     // Query input for material permittivity, epsilon.
     bool mu_specified = false;
-    if (pp.query("mu", m_mu)) {
+    if (queryWithParser(pp, "mu", m_mu)) {
         m_mu_s = "constant";
         mu_specified = true;
     }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -148,7 +148,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         for (auto& x : single_particle_vel) {
             x *= PhysConst::c;
         }
-        pp.get("single_particle_weight", single_particle_weight);
+        getWithParser(pp, "single_particle_weight", single_particle_weight);
         add_single_particle = true;
         return;
     } else if (part_pos_s == "gaussian_beam") {
@@ -361,7 +361,7 @@ void PlasmaInjector::parseDensity (ParmParse& pp)
     std::transform(rho_prof_s.begin(), rho_prof_s.end(),
                    rho_prof_s.begin(), ::tolower);
     if (rho_prof_s == "constant") {
-        pp.get("density", density);
+        getWithParser(pp, "density", density);
         // Construct InjectorDensity with InjectorDensityConstant.
         h_inj_rho.reset(new InjectorDensity((InjectorDensityConstant*)nullptr, density));
     } else if (rho_prof_s == "custom") {

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -7,6 +7,7 @@
 #include "Laser/LaserProfiles.H"
 #include "Utils/WarpX_Complex.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/WarpXUtil.H"
 
 
 using namespace amrex;
@@ -18,9 +19,9 @@ WarpXLaserProfiles::HarrisLaserProfile::init (
     CommonLaserParameters params)
 {
     // Parse the properties of the Harris profile
-    ppl.get("profile_waist", m_params.waist);
-    ppl.get("profile_duration", m_params.duration);
-    ppl.get("profile_focal_distance", m_params.focal_distance);
+    getWithParser(ppl, "profile_waist", m_params.waist);
+    getWithParser(ppl, "profile_duration", m_params.duration);
+    getWithParser(ppl, "profile_focal_distance", m_params.focal_distance);
     //Copy common params
     m_common_params = params;
 }

--- a/Source/Particles/Collision/CollisionType.cpp
+++ b/Source/Particles/Collision/CollisionType.cpp
@@ -8,6 +8,7 @@
 #include "ShuffleFisherYates.H"
 #include "ElasticCollisionPerez.H"
 #include "Utils/ParticleUtils.H"
+#include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
 CollisionType::CollisionType(
@@ -24,7 +25,7 @@ CollisionType::CollisionType(
 
     // default Coulomb log, if < 0, will be computed automatically
     m_CoulombLog = -1.0;
-    pp.query("CoulombLog", m_CoulombLog);
+    queryWithParser(pp, "CoulombLog", m_CoulombLog);
 
     // number of time steps between collisions
     m_ndt = 1;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -275,17 +275,17 @@ MultiParticleContainer::ReadParameters ()
             ppq.get("ele_product_species", m_qed_schwinger_ele_product_name);
             ppq.get("pos_product_species", m_qed_schwinger_pos_product_name);
 #if (AMREX_SPACEDIM == 2)
-            ppq.get("y_size",m_qed_schwinger_y_size);
+            getWithParser(ppq, "y_size",m_qed_schwinger_y_size);
 #endif
             ppq.query("threshold_poisson_gaussian", m_qed_schwinger_threshold_poisson_gaussian);
-            ppq.query("xmin", m_qed_schwinger_xmin);
-            ppq.query("xmax", m_qed_schwinger_xmax);
+            queryWithParser(ppq, "xmin", m_qed_schwinger_xmin);
+            queryWithParser(ppq, "xmax", m_qed_schwinger_xmax);
 #if (AMREX_SPACEDIM == 3)
-            ppq.query("ymin", m_qed_schwinger_ymin);
-            ppq.query("ymax", m_qed_schwinger_ymax);
+            queryWithParser(ppq, "ymin", m_qed_schwinger_ymin);
+            queryWithParser(ppq, "ymax", m_qed_schwinger_ymax);
 #endif
-            ppq.query("zmin", m_qed_schwinger_zmin);
-            ppq.query("zmax", m_qed_schwinger_zmax);
+            queryWithParser(ppq, "zmin", m_qed_schwinger_zmin);
+            queryWithParser(ppq, "zmax", m_qed_schwinger_zmax);
         }
 #endif
         initialized = true;
@@ -828,7 +828,7 @@ void MultiParticleContainer::InitQuantumSync ()
     //If specified, use a user-defined energy threshold for photon creaction
     ParticleReal temp;
     constexpr auto mec2 = PhysConst::c * PhysConst::c * PhysConst::m_e;
-    if(pp.query("photon_creation_energy_threshold", temp)){
+    if(queryWithParser(pp, "photon_creation_energy_threshold", temp)){
         temp *= mec2;
         m_quantum_sync_photon_creation_energy_threshold = temp;
     }
@@ -841,7 +841,7 @@ void MultiParticleContainer::InitQuantumSync ()
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real qs_minimum_chi_part;
-    pp.get("chi_min", qs_minimum_chi_part);
+    getWithParser(pp, "chi_min", qs_minimum_chi_part);
 
 
     pp.query("lookup_table_mode", lookup_table_mode);
@@ -892,7 +892,7 @@ void MultiParticleContainer::InitBreitWheeler ()
     // considered for pair production. If a photon has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real bw_minimum_chi_part;
-    if(!pp.query("chi_min", bw_minimum_chi_part))
+    if(!queryWithParser(pp, "chi_min", bw_minimum_chi_part))
         amrex::Abort("qed_bw.chi_min should be provided!");
 
     pp.query("lookup_table_mode", lookup_table_mode);
@@ -947,7 +947,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real qs_minimum_chi_part;
-    pp.get("chi_min", qs_minimum_chi_part);
+    getWithParser(pp, "chi_min", qs_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){
         PicsarQuantumSyncCtrl ctrl;
@@ -960,11 +960,11 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         //Minimun chi for the table. If a lepton has chi < tab_dndt_chi_min,
         //chi is considered as if it were equal to tab_dndt_chi_min
-        pp.get("tab_dndt_chi_min", ctrl.dndt_params.chi_part_min);
+        getWithParser(pp, "tab_dndt_chi_min", ctrl.dndt_params.chi_part_min);
 
         //Maximum chi for the table. If a lepton has chi > tab_dndt_chi_max,
         //chi is considered as if it were equal to tab_dndt_chi_max
-        pp.get("tab_dndt_chi_max", ctrl.dndt_params.chi_part_max);
+        getWithParser(pp, "tab_dndt_chi_max", ctrl.dndt_params.chi_part_max);
 
         //How many points should be used for chi in the table
         pp.get("tab_dndt_how_many", ctrl.dndt_params.chi_part_how_many);
@@ -977,11 +977,11 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         //Minimun chi for the table. If a lepton has chi < tab_em_chi_min,
         //chi is considered as if it were equal to tab_em_chi_min
-        pp.get("tab_em_chi_min", ctrl.phot_em_params.chi_part_min);
+        getWithParser(pp, "tab_em_chi_min", ctrl.phot_em_params.chi_part_min);
 
         //Maximum chi for the table. If a lepton has chi > tab_em_chi_max,
         //chi is considered as if it were equal to tab_em_chi_max
-        pp.get("tab_em_chi_max", ctrl.phot_em_params.chi_part_max);
+        getWithParser(pp, "tab_em_chi_max", ctrl.phot_em_params.chi_part_max);
 
         //How many points should be used for chi in the table
         pp.get("tab_em_chi_how_many", ctrl.phot_em_params.chi_part_how_many);
@@ -989,7 +989,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
         //The other axis of the table is the ratio between the quantum
         //parameter of the emitted photon and the quantum parameter of the
         //lepton. This parameter is the minimum ratio to consider for the table.
-        pp.get("tab_em_frac_min", ctrl.phot_em_params.frac_min);
+        getWithParser(pp, "tab_em_frac_min", ctrl.phot_em_params.frac_min);
 
         //This parameter is the number of different points to consider for the second
         //axis
@@ -1028,7 +1028,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
     // considered for pair production. If a photon has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real bw_minimum_chi_part;
-    pp.get("chi_min", bw_minimum_chi_part);
+    getWithParser(pp, "chi_min", bw_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){
         PicsarBreitWheelerCtrl ctrl;
@@ -1041,11 +1041,11 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         //Minimun chi for the table. If a photon has chi < tab_dndt_chi_min,
         //an analytical approximation is used.
-        pp.get("tab_dndt_chi_min", ctrl.dndt_params.chi_phot_min);
+        getWithParser(pp, "tab_dndt_chi_min", ctrl.dndt_params.chi_phot_min);
 
         //Maximum chi for the table. If a photon has chi > tab_dndt_chi_max,
         //an analytical approximation is used.
-        pp.get("tab_dndt_chi_max", ctrl.dndt_params.chi_phot_max);
+        getWithParser(pp, "tab_dndt_chi_max", ctrl.dndt_params.chi_phot_max);
 
         //How many points should be used for chi in the table
         pp.get("tab_dndt_how_many", ctrl.dndt_params.chi_phot_how_many);
@@ -1058,11 +1058,11 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         //Minimun chi for the table. If a photon has chi < tab_pair_chi_min
         //chi is considered as it were equal to chi_phot_tpair_min
-        pp.get("tab_pair_chi_min", ctrl.pair_prod_params.chi_phot_min);
+        getWithParser(pp, "tab_pair_chi_min", ctrl.pair_prod_params.chi_phot_min);
 
         //Maximum chi for the table. If a photon has chi > tab_pair_chi_max
         //chi is considered as it were equal to chi_phot_tpair_max
-        pp.get("tab_pair_chi_max", ctrl.pair_prod_params.chi_phot_max);
+        getWithParser(pp, "tab_pair_chi_max", ctrl.pair_prod_params.chi_phot_max);
 
         //How many points should be used for chi in the table
         pp.get("tab_pair_chi_how_many", ctrl.pair_prod_params.chi_phot_how_many);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -115,7 +115,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     pp.query("do_continuous_injection", do_continuous_injection);
     pp.query("initialize_self_fields", initialize_self_fields);
-    pp.query("self_fields_required_precision", self_fields_required_precision);
+    queryWithParser(pp, "self_fields_required_precision", self_fields_required_precision);
     pp.query("self_fields_max_iters", self_fields_max_iters);
     // Whether to plot back-transformed (lab-frame) diagnostics
     // for this species.
@@ -172,7 +172,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     for (int i=0; i<3; i++) m_v_galilean[i] *= PhysConst::c;
 
     // build filter functors
-    m_do_random_filter  = pp.query("random_fraction", m_random_fraction);
+    m_do_random_filter  = queryWithParser(pp, "random_fraction", m_random_fraction);
     m_do_uniform_filter = pp.query("uniform_stride",  m_uniform_stride);
     std::string buf;
     m_do_parser_filter  = pp.query("plot_filter_function(t,x,y,z,ux,uy,uz)", buf);

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -6,6 +6,7 @@
  */
 #include "LevelingThinning.H"
 #include "Utils/ParticleUtils.H"
+#include "Utils/WarpXUtil.H"
 
 #include <AMReX_Particles.H>
 
@@ -14,7 +15,7 @@ LevelingThinning::LevelingThinning (const std::string species_name)
     using namespace amrex::literals;
 
     amrex::ParmParse pp(species_name);
-    pp.query("resampling_algorithm_target_ratio", m_target_ratio);
+    queryWithParser(pp, "resampling_algorithm_target_ratio", m_target_ratio);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_target_ratio > 0._rt,
                                     "Resampling target ratio should be strictly greater than 0");
     if (m_target_ratio <= 1._rt)

--- a/Source/Particles/Resampling/ResamplingTrigger.cpp
+++ b/Source/Particles/Resampling/ResamplingTrigger.cpp
@@ -6,6 +6,7 @@
  */
 #include "ResamplingTrigger.H"
 #include "WarpX.H"
+#include "Utils/WarpXUtil.H"
 
 ResamplingTrigger::ResamplingTrigger (const std::string species_name)
 {
@@ -15,7 +16,7 @@ ResamplingTrigger::ResamplingTrigger (const std::string species_name)
     pprt.queryarr("resampling_trigger_intervals", resampling_trigger_int_string_vec);
     m_resampling_intervals = IntervalsParser(resampling_trigger_int_string_vec);
 
-    pprt.query("resampling_trigger_max_avg_ppc", m_max_avg_ppc);
+    queryWithParser(pprt, "resampling_trigger_max_avg_ppc", m_max_avg_ppc);
 }
 
 bool ResamplingTrigger::triggered (const int timestep, const amrex::Real global_numparts) const

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -454,7 +454,7 @@ WarpX::ReadParameters ()
                 snapshot_interval_is_specified,
                 "When using back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab.");
 
-            pp.get("gamma_boost", gamma_boost);
+            getWithParser(pp, "gamma_boost", gamma_boost);
 
             pp.query("do_back_transformed_fields", do_back_transformed_fields);
 
@@ -469,7 +469,7 @@ WarpX::ReadParameters ()
         do_electrostatic = GetAlgorithmInteger(pp, "do_electrostatic");
 
         if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
-            pp.query("self_fields_required_precision", self_fields_required_precision);
+            queryWithParser(pp, "self_fields_required_precision", self_fields_required_precision);
             pp.query("self_fields_max_iters", self_fields_max_iters);
             // Note that with the relativistic version, these parameters would be
             // input for each species.
@@ -599,7 +599,8 @@ WarpX::ReadParameters ()
         load_balance_intervals = IntervalsParser(load_balance_int_string_vec);
         pp.query("load_balance_with_sfc", load_balance_with_sfc);
         pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
-        pp.query("load_balance_efficiency_ratio_threshold", load_balance_efficiency_ratio_threshold);
+        queryWithParser(pp, "load_balance_efficiency_ratio_threshold",
+                             load_balance_efficiency_ratio_threshold);
 
         pp.query("do_dynamic_scheduling", do_dynamic_scheduling);
 
@@ -638,8 +639,8 @@ WarpX::ReadParameters ()
         if (em_solver_medium == MediumForEM::Macroscopic ) {
             macroscopic_solver_algo = GetAlgorithmInteger(pp,"macroscopic_sigma_method");
         }
-        pp.query("costs_heuristic_cells_wt", costs_heuristic_cells_wt);
-        pp.query("costs_heuristic_particles_wt", costs_heuristic_particles_wt);
+        queryWithParser(pp, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
+        queryWithParser(pp, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
     }
 
     {
@@ -787,8 +788,8 @@ WarpX::ReadParameters ()
                  "gamma_boost must be > 1 to use the boost frame diagnostic");
           pp.query("num_slice_snapshots_lab", num_slice_snapshots_lab);
           if (num_slice_snapshots_lab > 0) {
-             pp.get("dt_slice_snapshots_lab", dt_slice_snapshots_lab );
-             pp.get("particle_slice_width_lab",particle_slice_width_lab);
+             getWithParser(pp, "dt_slice_snapshots_lab", dt_slice_snapshots_lab );
+             getWithParser(pp, "particle_slice_width_lab",particle_slice_width_lab);
           }
        }
 


### PR DESCRIPTION
This is a follow-up to #1501. I've looked at all input parameters in the documentation, and if I haven't missed any, all single real numbers should now be read by the parser.