### PR TITLE
Remove deprecated parameters nspecies and nlasers from documentation

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -318,9 +318,6 @@ A trick to reduce this depth for the parser, e.g. when reaching the limit, is to
 Particle initialization
 -----------------------
 
-* ``particles.nspecies`` (`int`)
-    The number of species that will be used in the simulation.
-
 * ``particles.species_names`` (`strings`, separated by spaces)
     The name of each species. This is then used in the rest of the input deck ;
     in this documentation we use `<species_name>` as a placeholder.
@@ -682,10 +679,7 @@ Particle initialization
 Laser initialization
 --------------------
 
-* ``lasers.nlasers`` (`int`) optional (default `0`)
-    Number of lasers pulses.
-
-* ``lasers.names`` (list of `string`. Must contain ``lasers.nlasers`` elements)
+* ``lasers.names`` (list of `string`)
     Name of each laser. This is then used in the rest of the input deck ;
     in this documentation we use `<laser_name>` as a placeholder. The parameters below
     must be provided for each laser pulse.

--- a/Docs/source/visualization/inputs.2d
+++ b/Docs/source/visualization/inputs.2d
@@ -41,7 +41,6 @@ interpolation.noz = 3
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 3
 particles.species_names = plasma_e beam driver
 particles.use_fdtd_nci_corr = 1
 

--- a/Regression/TestFillBoundary/inputs.2d
+++ b/Regression/TestFillBoundary/inputs.2d
@@ -43,7 +43,6 @@ warpx.pml_ncell=6
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e

--- a/Tools/LibEnsemble/sim/inputs
+++ b/Tools/LibEnsemble/sim/inputs
@@ -58,7 +58,6 @@ warpx.dt_snapshots_lab=1.6678204759907604e-10
 #################################
 ############ PLASMA #############
 #################################
-particles.nspecies = 5
 particles.species_names = electrons ions electrons2 ions2 beam
 
 particles.use_fdtd_nci_corr = 1
@@ -195,7 +194,6 @@ warpx.mirror_z_npoints = 4 4
 #################################
 ############# LASER #############
 #################################
-lasers.nlasers = 2
 lasers.names = laser1 laser2
 
 laser1.profile = Gaussian

--- a/Tools/PerformanceTests/automated_test_1_uniform_rest_32ppc
+++ b/Tools/PerformanceTests/automated_test_1_uniform_rest_32ppc
@@ -25,7 +25,6 @@ warpx.do_pml = 0
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e

--- a/Tools/PerformanceTests/automated_test_2_uniform_rest_1ppc
+++ b/Tools/PerformanceTests/automated_test_2_uniform_rest_1ppc
@@ -25,7 +25,6 @@ warpx.do_pml = 1
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 1
 particles.species_names = electrons
 
 electrons.charge = -q_e

--- a/Tools/PerformanceTests/automated_test_3_uniform_drift_4ppc
+++ b/Tools/PerformanceTests/automated_test_3_uniform_drift_4ppc
@@ -26,7 +26,6 @@ warpx.do_pml = 0
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e

--- a/Tools/PerformanceTests/automated_test_4_labdiags_2ppc
+++ b/Tools/PerformanceTests/automated_test_4_labdiags_2ppc
@@ -38,7 +38,6 @@ warpx.num_snapshots_lab = 20
 warpx.dt_snapshots_lab = 7.0e-14
 
 # Species
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e
@@ -70,7 +69,6 @@ ions.momentum_distribution_type = "constant"
 ions.do_continuous_injection = 1
 
 # Laser
-lasers.nlasers = 1
 lasers.names = laser
 laser.profile      = Gaussian
 laser.position     = 0. 0. -1.e-6 # This point is on the laser plane

--- a/Tools/PerformanceTests/automated_test_5_loadimbalance
+++ b/Tools/PerformanceTests/automated_test_5_loadimbalance
@@ -24,7 +24,6 @@ warpx.do_pml = 0
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e

--- a/Tools/PerformanceTests/automated_test_6_output_2ppc
+++ b/Tools/PerformanceTests/automated_test_6_output_2ppc
@@ -25,7 +25,6 @@ warpx.do_pml = 0
 # CFL
 warpx.cfl = 1.0
 
-particles.nspecies = 2
 particles.species_names = electrons ions
 
 electrons.charge = -q_e


### PR DESCRIPTION
Since #1217 the input parameters `nspecies` and `nlasers` are deprecated. However, they still appear in the parameters documentation, so this PR removes them from there. It also removes them from some test or example input files (I don't think there's any reason to keep them here either, is there?).