### PR TITLE
[mini]Make sure that n_rz_azimuthal_modes is declared int everywhere

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -95,7 +95,7 @@ class FiniteDifferenceSolver
 
 #ifdef WARPX_DIM_RZ
         amrex::Real m_dr, m_rmin;
-        amrex::Real m_nmodes;
+        int m_nmodes;
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_r;
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
 #else

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -477,7 +477,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         int const ishift_t = (rmint > rmin ? 1 : 0);
         int const ishift_z = (rminz > rmin ? 1 : 0);
 
-        const long nmodes = n_rz_azimuthal_modes;
+        const int nmodes = n_rz_azimuthal_modes;
 
         // Grow the tileboxes to include the guard cells, except for the
         // guard cells at negative radius.

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -37,7 +37,7 @@ void doChargeDepositionShapeN(const GetParticlePosition& GetPosition,
                               const std::array<amrex::Real, 3> xyzmin,
                               const amrex::Dim3 lo,
                               const amrex::Real q,
-                              const long n_rz_azimuthal_modes)
+                              const int n_rz_azimuthal_modes)
 {
     using namespace amrex;
 

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -52,7 +52,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                         const std::array<amrex::Real,3>& xyzmin,
                         const amrex::Dim3 lo,
                         const amrex::Real q,
-                        const long n_rz_azimuthal_modes)
+                        const int n_rz_azimuthal_modes)
 {
 #if !defined(WARPX_DIM_RZ)
     amrex::ignore_unused(n_rz_azimuthal_modes);
@@ -318,7 +318,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                                   const std::array<amrex::Real, 3> xyzmin,
                                   const amrex::Dim3 lo,
                                   const amrex::Real q,
-                                  const long n_rz_azimuthal_modes)
+                                  const int n_rz_azimuthal_modes)
 {
     using namespace amrex;
 #if !defined(WARPX_DIM_RZ)
@@ -628,7 +628,7 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
                             const std::array<amrex::Real,3>& xyzmin,
                             const amrex::Dim3 lo,
                             const amrex::Real q,
-                            const long n_rz_azimuthal_modes)
+                            const int n_rz_azimuthal_modes)
 {
 #if (defined WARPX_DIM_RZ)
     amrex::ignore_unused(GetPosition,

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -59,7 +59,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                      const amrex::GpuArray<amrex::Real, 3>& dx,
                      const amrex::GpuArray<amrex::Real, 3>& xyzmin,
                      const amrex::Dim3& lo,
-                     const long n_rz_azimuthal_modes)
+                     const int n_rz_azimuthal_modes)
 {
     using namespace amrex;
 
@@ -408,7 +408,7 @@ void doGatherShapeN(const GetParticlePosition& getPosition,
                     const std::array<amrex::Real, 3>& dx,
                     const std::array<amrex::Real, 3> xyzmin,
                     const amrex::Dim3 lo,
-                    const long n_rz_azimuthal_modes)
+                    const int n_rz_azimuthal_modes)
 {
 
     amrex::GpuArray<amrex::Real, 3> dx_arr = {dx[0], dx[1], dx[2]};
@@ -490,7 +490,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                      const amrex::GpuArray<amrex::Real, 3>& dx_arr,
                      const amrex::GpuArray<amrex::Real, 3>& xyzmin_arr,
                      const amrex::Dim3& lo,
-                     const long n_rz_azimuthal_modes,
+                     const int n_rz_azimuthal_modes,
                      const int nox,
                      const bool galerkin_interpolation)
 {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -578,7 +578,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     Real density_max = plasma_injector->density_max;
 
 #ifdef WARPX_DIM_RZ
-    const long nmodes = WarpX::n_rz_azimuthal_modes;
+    const int nmodes = WarpX::n_rz_azimuthal_modes;
     bool radially_weighted = plasma_injector->radially_weighted;
 #endif
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -160,8 +160,8 @@ public:
     static int field_gathering_noz;
 
     // Number of modes for the RZ multimode version
-    static long n_rz_azimuthal_modes;
-    static long ncomps;
+    static int n_rz_azimuthal_modes;
+    static int ncomps;
 
     static bool use_fdtd_nci_corr;
     static bool galerkin_interpolation;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -74,8 +74,8 @@ int WarpX::do_dive_cleaning = 0;
 int WarpX::em_solver_medium;
 int WarpX::macroscopic_solver_algo;
 
-long WarpX::n_rz_azimuthal_modes = 1;
-long WarpX::ncomps = 1;
+int WarpX::n_rz_azimuthal_modes = 1;
+int WarpX::ncomps = 1;
 
 long WarpX::nox = 1;
 long WarpX::noy = 1;


### PR DESCRIPTION
The variable n_rz_azimuthal_modes was declared inconsistently, some places long and some places int. This fix makes it consistently an int (it will never be more than ~10 so a long is not needed). This also fixes several local copies of it (including one that was declared real). It also makes ncomps an int since it is derived from n_rz_azimuthal_modes.