### PR TITLE
Use correct PML sigma coeffs depending on staggering

### DIFF
--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -51,33 +51,17 @@ WarpX::DampPML (int lev, PatchType patch_type)
         const auto& sigba = (patch_type == PatchType::fine) ? pml[lev]->GetMultiSigmaBox_fp()
                                                               : pml[lev]->GetMultiSigmaBox_cp();
 
-        amrex::GpuArray<int, AMREX_SPACEDIM> Ex_stag;
-        amrex::GpuArray<int, AMREX_SPACEDIM> Ey_stag;
-        amrex::GpuArray<int, AMREX_SPACEDIM> Ez_stag;
+        const amrex::IntVect Ex_stag = pml_E[0]->ixType().toIntVect();
+        const amrex::IntVect Ey_stag = pml_E[1]->ixType().toIntVect();
+        const amrex::IntVect Ez_stag = pml_E[2]->ixType().toIntVect();
 
-        amrex::GpuArray<int, AMREX_SPACEDIM> Bx_stag;
-        amrex::GpuArray<int, AMREX_SPACEDIM> By_stag;
-        amrex::GpuArray<int, AMREX_SPACEDIM> Bz_stag;
+        const amrex::IntVect Bx_stag = pml_B[0]->ixType().toIntVect();
+        const amrex::IntVect By_stag = pml_B[1]->ixType().toIntVect();
+        const amrex::IntVect Bz_stag = pml_B[2]->ixType().toIntVect();
 
-        for (int i = 0; i < AMREX_SPACEDIM; i++)
-        {
-            Ex_stag[i] = pml_E[0]->ixType().toIntVect()[i];
-            Ey_stag[i] = pml_E[1]->ixType().toIntVect()[i];
-            Ez_stag[i] = pml_E[2]->ixType().toIntVect()[i];
-
-            Bx_stag[i] = pml_B[0]->ixType().toIntVect()[i];
-            By_stag[i] = pml_B[1]->ixType().toIntVect()[i];
-            Bz_stag[i] = pml_B[2]->ixType().toIntVect()[i];
-        }
-
-        amrex::GpuArray<int, AMREX_SPACEDIM> F_stag;
-
-        if (pml_F)
-        {
-            for (int i = 0; i < AMREX_SPACEDIM; i++)
-            {
-                F_stag[i] = pml_F->ixType().toIntVect()[i];
-            }
+        amrex::IntVect F_stag;
+        if (pml_F) {
+            F_stag = pml_F->ixType().toIntVect();
         }
 
 #ifdef _OPENMP

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -206,64 +206,211 @@ void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
 #endif
 }
 
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_bx (int i, int j, int k, Array4<Real> const& Bx,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Bx_stag,
+                        const Real* const sigma_fac_y,
+                        const Real* const sigma_fac_z,
                         const Real* const sigma_star_fac_y,
                         const Real* const sigma_star_fac_z,
                         int ylo, int zlo)
 {
-#if (AMREX_SPACEDIM == 3)
-   Bx(i,j,k,PMLComp::xy) *= sigma_star_fac_y[j-ylo];
-   Bx(i,j,k,PMLComp::xz) *= sigma_star_fac_z[k-zlo];
-#else
-   Bx(i,j,k,PMLComp::xz) *= sigma_star_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
    amrex::ignore_unused(sigma_star_fac_y, ylo);
+
+    // sz = 0 means that Bx is staggered in z, while sz = 1 means that Bx is nodal in z
+    const int sz = Bx_stag[1];
+
+   // Bxz
+   if (sz == 0) {
+       Bx(i,j,k,PMLComp::xz) *= sigma_star_fac_z[j-zlo];
+   } else {
+       Bx(i,j,k,PMLComp::xz) *= sigma_fac_z[j-zlo];
+   }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sy = 0 means that Bx is staggered in y, while sy = 1 means that Bx is nodal in y (same for z)
+    const int sy = Bx_stag[1];
+    const int sz = Bx_stag[2];
+
+   // Bxy
+   if (sy == 0) {
+       Bx(i,j,k,PMLComp::xy) *= sigma_star_fac_y[j-ylo];
+   } else {
+       Bx(i,j,k,PMLComp::xy) *= sigma_fac_y[j-ylo];
+   }
+
+   // Bxz
+   if (sz == 0) {
+       Bx(i,j,k,PMLComp::xz) *= sigma_star_fac_z[k-zlo];
+   } else {
+       Bx(i,j,k,PMLComp::xz) *= sigma_fac_z[k-zlo];
+   }
+
 #endif
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_by (int i, int j, int k, Array4<Real> const& By,
-                        const Real* const sigma_star_fac_z,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& By_stag,
+                        const Real* const sigma_fac_x,
+                        const Real* const sigma_fac_z,
                         const Real* const sigma_star_fac_x,
-                        int zlo, int xlo)
+                        const Real* const sigma_star_fac_z,
+                        int xlo, int zlo)
 {
-#if (AMREX_SPACEDIM == 3)
-   By(i,j,k,PMLComp::yz) *= sigma_star_fac_z[k-zlo];
-#else
-   By(i,j,k,PMLComp::yz) *= sigma_star_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
+    // sx = 0 means that By is staggered in x, while sx = 1 means that By is nodal in x (same for z)
+    const int sx = By_stag[0];
+    const int sz = By_stag[1];
+
+   // Byx
+   if (sx == 0) {
+       By(i,j,k,PMLComp::yx) *= sigma_star_fac_x[i-xlo];
+   } else {
+       By(i,j,k,PMLComp::yx) *= sigma_fac_x[i-xlo];
+   }
+
+   // Byz
+   if (sz == 0) {
+       By(i,j,k,PMLComp::yz) *= sigma_star_fac_z[j-zlo];
+   } else {
+       By(i,j,k,PMLComp::yz) *= sigma_fac_z[j-zlo];
+   }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that By is staggered in x, while sx = 1 means that By is nodal in x (same for z)
+    const int sx = By_stag[0];
+    const int sz = By_stag[2];
+
+   // Byx
+   if (sx == 0) {
+       By(i,j,k,PMLComp::yx) *= sigma_star_fac_x[i-xlo];
+   } else {
+       By(i,j,k,PMLComp::yx) *= sigma_fac_x[i-xlo];
+   }
+
+   // Byz
+   if (sz == 0) {
+       By(i,j,k,PMLComp::yz) *= sigma_star_fac_z[k-zlo];
+   } else {
+       By(i,j,k,PMLComp::yz) *= sigma_fac_z[k-zlo];
+   }
+
 #endif
-   By(i,j,k,PMLComp::yx) *= sigma_star_fac_x[i-xlo];
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_bz (int i, int j, int k, Array4<Real> const& Bz,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Bz_stag,
+                        const Real* const sigma_fac_x,
+                        const Real* const sigma_fac_y,
                         const Real* const sigma_star_fac_x,
                         const Real* const sigma_star_fac_y,
                         int xlo, int ylo)
 {
-   Bz(i,j,k,PMLComp::zx) *= sigma_star_fac_x[i-xlo];
-#if (AMREX_SPACEDIM == 3)
-   Bz(i,j,k,PMLComp::zy) *= sigma_star_fac_y[j-ylo];
-#else
+#if (AMREX_SPACEDIM == 2)
+
    amrex::ignore_unused(sigma_star_fac_y, ylo);
+
+    // sx = 0 means that Bz is staggered in x, while sx = 1 means that Bz is nodal in x
+    const int sx = Bz_stag[0];
+
+   // Bzx
+   if (sx == 0) {
+       Bz(i,j,k,PMLComp::zx) *= sigma_star_fac_x[i-xlo];
+   } else {
+       Bz(i,j,k,PMLComp::zx) *= sigma_fac_x[i-xlo];
+   }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that Bz is staggered in x, while sx = 1 means that Bz is nodal in x (same for y)
+    const int sx = Bz_stag[0];
+    const int sy = Bz_stag[1];
+
+   // Bzx
+   if (sx == 0) {
+       Bz(i,j,k,PMLComp::zx) *= sigma_star_fac_x[i-xlo];
+   } else {
+       Bz(i,j,k,PMLComp::zx) *= sigma_fac_x[i-xlo];
+   }
+
+   // Bzy
+   if (sy == 0) {
+       Bz(i,j,k,PMLComp::zy) *= sigma_star_fac_y[j-ylo];
+   } else {
+       Bz(i,j,k,PMLComp::zy) *= sigma_fac_y[j-ylo];
+   }
+
 #endif
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_F (int i, int j, int k, Array4<Real> const& F_fab,
-                      const Real* const sigma_fac_x,
-                      const Real* const sigma_fac_y,
-                      const Real* const sigma_fac_z,
-                      int xlo, int ylo, int zlo)
+                       amrex::GpuArray<int, AMREX_SPACEDIM> const& F_stag,
+                       const Real* const sigma_fac_x,
+                       const Real* const sigma_fac_y,
+                       const Real* const sigma_fac_z,
+                       const Real* const sigma_star_fac_x,
+                       const Real* const sigma_star_fac_y,
+                       const Real* const sigma_star_fac_z,
+                       int xlo, int ylo, int zlo)
 {
-   F_fab(i,j,k,PMLComp::x) *= sigma_fac_x[i-xlo];
-#if (AMREX_SPACEDIM == 3)
-   F_fab(i,j,k,PMLComp::y) *= sigma_fac_y[j-ylo];
-   F_fab(i,j,k,PMLComp::z) *= sigma_fac_z[k-zlo];
-#else
-   F_fab(i,j,k,PMLComp::z) *= sigma_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
    amrex::ignore_unused(sigma_fac_y, ylo);
+
+    // sx = 0 means that F is staggered in x, while sx = 1 means that F is nodal in x (same for z)
+    const int sx = F_stag[0];
+    const int sz = F_stag[1];
+
+   // Fx
+   if (sx == 0) {
+       F_fab(i,j,k,PMLComp::x) *= sigma_star_fac_x[i-xlo];
+   } else {
+       F_fab(i,j,k,PMLComp::x) *= sigma_fac_x[i-xlo];
+   }
+
+   // Fz
+   if (sz == 0) {
+       F_fab(i,j,k,PMLComp::z) *= sigma_star_fac_z[j-zlo];
+   } else {
+       F_fab(i,j,k,PMLComp::z) *= sigma_fac_z[j-zlo];
+   }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that F is staggered in x, while sx = 1 means that F is nodal in x (same for y, z)
+    const int sx = F_stag[0];
+    const int sy = F_stag[1];
+    const int sz = F_stag[2];
+
+   // Fx
+   if (sx == 0) {
+       F_fab(i,j,k,PMLComp::x) *= sigma_star_fac_x[i-xlo];
+   } else {
+       F_fab(i,j,k,PMLComp::x) *= sigma_fac_x[i-xlo];
+   }
+
+   // Fy
+   if (sy == 0) {
+       F_fab(i,j,k,PMLComp::y) *= sigma_star_fac_y[j-ylo];
+   } else {
+       F_fab(i,j,k,PMLComp::y) *= sigma_fac_y[j-ylo];
+   }
+
+   // Fz
+   if (sz == 0) {
+       F_fab(i,j,k,PMLComp::z) *= sigma_star_fac_z[k-zlo];
+   } else {
+       F_fab(i,j,k,PMLComp::z) *= sigma_fac_z[k-zlo];
+   }
+
 #endif
 }
 

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -16,52 +16,193 @@ using namespace amrex;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ex (int i, int j, int k, Array4<Real> const& Ex,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ex_stag,
+                        const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_fac_z,
                         const Real* const sigma_star_fac_x,
-                        int xlo,int ylo, int zlo)
+                        const Real* const sigma_star_fac_y,
+                        const Real* const sigma_star_fac_z,
+                        int xlo, int ylo, int zlo)
 {
-#if (AMREX_SPACEDIM == 3)
-    Ex(i,j,k,PMLComp::xy) *= sigma_fac_y[j-ylo];
-    Ex(i,j,k,PMLComp::xz) *= sigma_fac_z[k-zlo];
-#else
-    Ex(i,j,k,PMLComp::xz) *= sigma_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
     amrex::ignore_unused(sigma_fac_y, ylo);
+
+    // sx = 0 means that Ex is staggered in x, while sx = 1 means that Ex is nodal in x (same for z)
+    const int sx = Ex_stag[0];
+    const int sz = Ex_stag[1];
+
+    // Exx
+    if (sx == 0) {
+        Ex(i,j,k,PMLComp::xx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ex(i,j,k,PMLComp::xx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Exz
+    if (sz == 0) {
+        Ex(i,j,k,PMLComp::xz) *= sigma_star_fac_z[j-zlo];
+    } else {
+        Ex(i,j,k,PMLComp::xz) *= sigma_fac_z[j-zlo];
+    }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that Ex is staggered in x, while sx = 1 means that Ex is nodal in x (same for y, z)
+    const int sx = Ex_stag[0];
+    const int sy = Ex_stag[1];
+    const int sz = Ex_stag[2];
+
+    // Exx
+    if (sx == 0) {
+        Ex(i,j,k,PMLComp::xx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ex(i,j,k,PMLComp::xx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Exy
+    if (sy == 0) {
+        Ex(i,j,k,PMLComp::xy) *= sigma_star_fac_y[j-ylo];
+    } else {
+        Ex(i,j,k,PMLComp::xy) *= sigma_fac_y[j-ylo];
+    }
+
+    // Exz
+    if (sz == 0) {
+        Ex(i,j,k,PMLComp::xz) *= sigma_star_fac_z[k-zlo];
+    } else {
+        Ex(i,j,k,PMLComp::xz) *= sigma_fac_z[k-zlo];
+    }
+
 #endif
-    Ex(i,j,k,PMLComp::xx) *= sigma_star_fac_x[i-xlo];
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ey (int i, int j, int k, Array4<Real> const& Ey,
-                        const Real* const sigma_fac_z,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ey_stag,
                         const Real* const sigma_fac_x,
+                        const Real* const sigma_fac_y,
+                        const Real* const sigma_fac_z,
+                        const Real* const sigma_star_fac_x,
                         const Real* const sigma_star_fac_y,
-                        int xlo,int ylo, int zlo)
+                        const Real* const sigma_star_fac_z,
+                        int xlo, int ylo, int zlo)
 {
-#if (AMREX_SPACEDIM == 3)
-    Ey(i,j,k,PMLComp::yz) *= sigma_fac_z[k-zlo];
-    Ey(i,j,k,PMLComp::yy) *= sigma_star_fac_y[j-ylo];
-#else
-    Ey(i,j,k,PMLComp::yz) *= sigma_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
     amrex::ignore_unused(sigma_star_fac_y, ylo);
+
+    // sx = 0 means that Ey is staggered in x, while sx = 1 means that Ey is nodal in x (same for z)
+    const int sx = Ey_stag[0];
+    const int sz = Ey_stag[1];
+
+    // Eyx
+    if (sx == 0) {
+        Ey(i,j,k,PMLComp::yx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ey(i,j,k,PMLComp::yx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Eyz
+    if (sz == 0) {
+        Ey(i,j,k,PMLComp::yz) *= sigma_star_fac_z[j-zlo];
+    } else {
+        Ey(i,j,k,PMLComp::yz) *= sigma_fac_z[j-zlo];
+    }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that Ey is staggered in x, while sx = 1 means that Ey is nodal in x (same for y, z)
+    const int sx = Ey_stag[0];
+    const int sy = Ey_stag[1];
+    const int sz = Ey_stag[2];
+
+    // Eyx
+    if (sx == 0) {
+        Ey(i,j,k,PMLComp::yx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ey(i,j,k,PMLComp::yx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Eyy
+    if (sy == 0) {
+        Ey(i,j,k,PMLComp::yy) *= sigma_star_fac_y[j-ylo];
+    } else {
+        Ey(i,j,k,PMLComp::yy) *= sigma_fac_y[j-ylo];
+    }
+
+    // Eyz
+    if (sz == 0) {
+        Ey(i,j,k,PMLComp::yz) *= sigma_star_fac_z[k-zlo];
+    } else {
+        Ey(i,j,k,PMLComp::yz) *= sigma_fac_z[k-zlo];
+    }
+
 #endif
-    Ey(i,j,k,PMLComp::yx) *= sigma_fac_x[i-xlo];
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
+                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ez_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
+                        const Real* const sigma_fac_z,
+                        const Real* const sigma_star_fac_x,
+                        const Real* const sigma_star_fac_y,
                         const Real* const sigma_star_fac_z,
-                        int xlo,int ylo, int zlo)
+                        int xlo, int ylo, int zlo)
 {
-    Ez(i,j,k,PMLComp::zx) *= sigma_fac_x[i-xlo];
-#if (AMREX_SPACEDIM == 3)
-    Ez(i,j,k,PMLComp::zy) *= sigma_fac_y[j-ylo];
-    Ez(i,j,k,PMLComp::zz) *= sigma_star_fac_z[k-zlo];
-#else
-    Ez(i,j,k,PMLComp::zz) *= sigma_star_fac_z[j-zlo];
+#if (AMREX_SPACEDIM == 2)
+
     amrex::ignore_unused(sigma_fac_y, ylo);
+
+    // sx = 0 means that Ez is staggered in x, while sx = 1 means that Ez is nodal in x (same for z)
+    const int sx = Ez_stag[0];
+    const int sz = Ez_stag[1];
+
+    // Ezx
+    if (sx == 0) {
+        Ez(i,j,k,PMLComp::zx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ez(i,j,k,PMLComp::zx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Ezz
+    if (sz == 0) {
+        Ez(i,j,k,PMLComp::zz) *= sigma_star_fac_z[j-zlo];
+    } else {
+        Ez(i,j,k,PMLComp::zz) *= sigma_fac_z[j-zlo];
+    }
+
+#elif (AMREX_SPACEDIM == 3)
+
+    // sx = 0 means that Ez is staggered in x, while sx = 1 means that Ez is nodal in x (same for y, z)
+    const int sx = Ez_stag[0];
+    const int sy = Ez_stag[1];
+    const int sz = Ez_stag[2];
+
+    // Ezx
+    if (sx == 0) {
+        Ez(i,j,k,PMLComp::zx) *= sigma_star_fac_x[i-xlo];
+    } else {
+        Ez(i,j,k,PMLComp::zx) *= sigma_fac_x[i-xlo];
+    }
+
+    // Ezy
+    if (sy == 0) {
+        Ez(i,j,k,PMLComp::zy) *= sigma_star_fac_y[j-ylo];
+    } else {
+        Ez(i,j,k,PMLComp::zy) *= sigma_fac_y[j-ylo];
+    }
+
+    // Ezz
+    if (sz == 0) {
+        Ez(i,j,k,PMLComp::zz) *= sigma_star_fac_z[k-zlo];
+    } else {
+        Ez(i,j,k,PMLComp::zz) *= sigma_fac_z[k-zlo];
+    }
+
 #endif
 }
 

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -16,7 +16,7 @@ using namespace amrex;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ex (int i, int j, int k, Array4<Real> const& Ex,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ex_stag,
+                        const amrex::IntVect& Ex_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_fac_z,
@@ -80,7 +80,7 @@ void warpx_damp_pml_ex (int i, int j, int k, Array4<Real> const& Ex,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ey (int i, int j, int k, Array4<Real> const& Ey,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ey_stag,
+                        const amrex::IntVect& Ey_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_fac_z,
@@ -144,7 +144,7 @@ void warpx_damp_pml_ey (int i, int j, int k, Array4<Real> const& Ey,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Ez_stag,
+                        const amrex::IntVect& Ez_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_fac_z,
@@ -208,7 +208,7 @@ void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_bx (int i, int j, int k, Array4<Real> const& Bx,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Bx_stag,
+                        const amrex::IntVect& Bx_stag,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_fac_z,
                         const Real* const sigma_star_fac_y,
@@ -254,7 +254,7 @@ void warpx_damp_pml_bx (int i, int j, int k, Array4<Real> const& Bx,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_by (int i, int j, int k, Array4<Real> const& By,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& By_stag,
+                        const amrex::IntVect& By_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_z,
                         const Real* const sigma_star_fac_x,
@@ -306,7 +306,7 @@ void warpx_damp_pml_by (int i, int j, int k, Array4<Real> const& By,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_bz (int i, int j, int k, Array4<Real> const& Bz,
-                        amrex::GpuArray<int, AMREX_SPACEDIM> const& Bz_stag,
+                        const amrex::IntVect& Bz_stag,
                         const Real* const sigma_fac_x,
                         const Real* const sigma_fac_y,
                         const Real* const sigma_star_fac_x,
@@ -352,7 +352,7 @@ void warpx_damp_pml_bz (int i, int j, int k, Array4<Real> const& Bz,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void warpx_damp_pml_F (int i, int j, int k, Array4<Real> const& F_fab,
-                       amrex::GpuArray<int, AMREX_SPACEDIM> const& F_stag,
+                       const amrex::IntVect& F_stag,
                        const Real* const sigma_fac_x,
                        const Real* const sigma_fac_y,
                        const Real* const sigma_fac_z,

--- a/Source/BoundaryConditions/WarpX_PML_kernels.H
+++ b/Source/BoundaryConditions/WarpX_PML_kernels.H
@@ -27,7 +27,7 @@ void warpx_damp_pml_ex (int i, int j, int k, Array4<Real> const& Ex,
 {
 #if (AMREX_SPACEDIM == 2)
 
-    amrex::ignore_unused(sigma_fac_y, ylo);
+    amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sx = 0 means that Ex is staggered in x, while sx = 1 means that Ex is nodal in x (same for z)
     const int sx = Ex_stag[0];
@@ -91,7 +91,7 @@ void warpx_damp_pml_ey (int i, int j, int k, Array4<Real> const& Ey,
 {
 #if (AMREX_SPACEDIM == 2)
 
-    amrex::ignore_unused(sigma_star_fac_y, ylo);
+    amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sx = 0 means that Ey is staggered in x, while sx = 1 means that Ey is nodal in x (same for z)
     const int sx = Ey_stag[0];
@@ -155,7 +155,7 @@ void warpx_damp_pml_ez (int i, int j, int k, Array4<Real> const& Ez,
 {
 #if (AMREX_SPACEDIM == 2)
 
-    amrex::ignore_unused(sigma_fac_y, ylo);
+    amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sx = 0 means that Ez is staggered in x, while sx = 1 means that Ez is nodal in x (same for z)
     const int sx = Ez_stag[0];
@@ -217,7 +217,7 @@ void warpx_damp_pml_bx (int i, int j, int k, Array4<Real> const& Bx,
 {
 #if (AMREX_SPACEDIM == 2)
 
-   amrex::ignore_unused(sigma_star_fac_y, ylo);
+   amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sz = 0 means that Bx is staggered in z, while sz = 1 means that Bx is nodal in z
     const int sz = Bx_stag[1];
@@ -315,7 +315,7 @@ void warpx_damp_pml_bz (int i, int j, int k, Array4<Real> const& Bz,
 {
 #if (AMREX_SPACEDIM == 2)
 
-   amrex::ignore_unused(sigma_star_fac_y, ylo);
+   amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sx = 0 means that Bz is staggered in x, while sx = 1 means that Bz is nodal in x
     const int sx = Bz_stag[0];
@@ -363,7 +363,7 @@ void warpx_damp_pml_F (int i, int j, int k, Array4<Real> const& F_fab,
 {
 #if (AMREX_SPACEDIM == 2)
 
-   amrex::ignore_unused(sigma_fac_y, ylo);
+   amrex::ignore_unused(sigma_fac_y, sigma_star_fac_y, ylo);
 
     // sx = 0 means that F is staggered in x, while sx = 1 means that F is nodal in x (same for z)
     const int sx = F_stag[0];


### PR DESCRIPTION
The coefficients used for the damping of the fields in the PML should depend on the staggering of the field in the various directions.

The changes suggested in this PR make sure that we use the coefficients `sigma_fac_<xyz>` to damp fields that are nodal in the respective directions and the coefficients `sigma_star_fac_<xyz>` to damp fields that are staggered (that is, cell-centered) instead.

The staggerings of the given `MultiFab`s are extracted from their `IndexType`s and stored in `AMREX_SPACEDIM`-dimensional arrays of type `amrex::GpuArray` in Source/BoundaryConditions/WarpXEvolvePML.cpp, which are then passed to the kernel damping functions defined in Source/BoundaryConditions/WarpX_PML_kernels.H.

This is one possible fix, please feel free to suggest other solutions. It is quite verbose now...

Also, in the future we might want to merge the various damping functions into two main variants, vector and scalar. However, I would prefer to postpone this further refactoring to another PR, if you agree.