### PR TITLE
Plotfile capability for BTD

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -9,7 +9,7 @@
 /**
  * \brief Class to read, modify, and write plotfile header when
  * back-transformed diag format is selected as plotfile.
- * This class enables multiple BTD buffers to be interweaved and stitched into 
+ * This class enables multiple BTD buffers to be interweaved and stitched into
  * a single plotfile with a single Header.
  */
 
@@ -53,7 +53,7 @@ public:
     int timestep () const noexcept {return m_timestep; }
     ///** Returns the type of coordinate system */
     //int coordsys () const noexcept {return m_coordsys; }
-    
+
     //int bwidth () const noexcept {return m_bwidth; }
     //int cur_level () const noexcept {return m_cur_level; }
     int numFabs () const noexcept {return m_numFabs; }
@@ -101,7 +101,7 @@ public:
      */
     void set_probDomain (amrex::Box domainBox) {m_prob_domain = domainBox; }
     /** Increments the number of fabs stored in the plotfile by one. */
-    void IncrementNumFabs () { m_numFabs++;}    
+    void IncrementNumFabs () { m_numFabs++;}
     void ResizeFabLo () { m_glo.resize(m_numFabs); }
     void ResizeFabHi () { m_ghi.resize(m_numFabs); }
     /** Append array of lower-corner physical coordinates corresponding to a new fab to
@@ -155,7 +155,7 @@ private:
 /**
  * \brief Class to read, modify, and write MultiFab header in Level_0/Cell_H when
  * back-transformed diag format is selected as plotfile.
- * This class enables multiple fabs to be interweaved and stitched into 
+ * This class enables multiple fabs to be interweaved and stitched into
  * a single plotfile with a single Header, Cell_H.
  */
 class BTDMultiFabHeaderImpl
@@ -188,12 +188,12 @@ class BTDMultiFabHeaderImpl
     /** Returns minimum value of all the components stored in the ith fab. */
     amrex::Vector<amrex::Real> minval(int ifab) { return m_minval[ifab];}
     /** Returns maximum value of all the components stored in the ith fab. */
-    amrex::Vector<amrex::Real> maxval(int ifab) { return m_maxval[ifab];}    
+    amrex::Vector<amrex::Real> maxval(int ifab) { return m_maxval[ifab];}
     void ResizeFabData ();
     /** Increments MultiFab size, m_ba_size, by add_mf_size.
-     *  \param[in] int add_mf_size, number of new multifabs to be appended to the existing 
+     *  \param[in] int add_mf_size, number of new multifabs to be appended to the existing
      *             Box Array.
-     */    
+     */
     void IncreaseMultiFabSize (int add_mf_size) {m_ba_size += add_mf_size;}
     /** Set Box indices of the ith-box in Box Array, m_ba, to the new Box, ba_box.
      *  \param[in] int ibox, index of the ith box in BoxArray, m_ba.

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -6,108 +6,219 @@
 #include <AMReX_MultiFab.H>
 
 
+/**
+ * \brief Class to read, modify, and write plotfile header when
+ * back-transformed diag format is selected as plotfile.
+ * This class enables multiple BTD buffers to be interweaved and stitched into 
+ * a single plotfile with a single Header.
+ */
+
 class BTDPlotfileHeaderImpl
 {
 public:
+    /** Constructor.
+     * \param[in] string containing path of Headerfile
+     */
     BTDPlotfileHeaderImpl (std::string const& Headerfile_path);
+    /** Destructor */
     ~BTDPlotfileHeaderImpl () = default;
 
+    /** Returns the Header file version for plotfile */
     std::string fileVersion () const noexcept {return m_file_version; }
+    /** Returns the number of components written in the Headerfile */
     int ncomp () const noexcept {return m_nComp; }
+    /** Returns the names of components in the Headerfile */
     const amrex::Vector<std::string>& varnames () const noexcept {return m_varnames; }
-
+    /** Returns the number of dimensions in the Headerfile */
     int spaceDim () const noexcept {return m_spacedim; }
-
+    /** Returns the physical time in the simulation in the boosted-frame */
     amrex::Real time () const noexcept {return m_time; }
-
+    /** Returns finest level output in the Headerfile */
     int finestLevel () const noexcept { return m_finest_level; }
-
+    /** Returns the physical co-ordinates of the lower corner in dimension, idim,
+     *  that corresponds the to the respective plotfile data
+     */
     amrex::Real problo (int dim) const noexcept {return m_prob_lo[dim]; }
+    /** Returns the physical co-ordinates of the upper corner in dimension, idim,
+     *  that corresponds the to the respective plotfile data.
+     */
     amrex::Real probhi (int dim) const noexcept {return m_prob_hi[dim]; }
 
-
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; }
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; }
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> cellsize () const noexcept {return m_cell_size; }
+    //amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; }
+    //amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; }
+    //amrex::Array<amrex::Real, AMREX_SPACEDIM> cellsize () const noexcept {return m_cell_size; }
+    /** Returns the bounding box of the domain spanned in the plotfile */
     amrex::Box probDomain () const noexcept {return m_prob_domain; }
+    /** Returns timestep at which the plotfile was written */
     int timestep () const noexcept {return m_timestep; }
-    int coordsys () const noexcept {return m_coordsys; }
-    int bwidth () const noexcept {return m_bwidth; }
-    int cur_level () const noexcept {return m_cur_level; }
+    ///** Returns the type of coordinate system */
+    //int coordsys () const noexcept {return m_coordsys; }
+    
+    //int bwidth () const noexcept {return m_bwidth; }
+    //int cur_level () const noexcept {return m_cur_level; }
     int numFabs () const noexcept {return m_numFabs; }
 
-    const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& glo () const noexcept {return m_glo; }
-    const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& ghi () const noexcept {return m_ghi; }
-
+   // const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& glo () const noexcept {return m_glo; }
+   // const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& ghi () const noexcept {return m_ghi; }
+    /** Returns physical co-ordinates of the lower-corner for the i-th Fab.
+     *  \param[in] iFab, id of the ith Fab in the list of Multifabs
+     *  \param[out] Array of lower-corner physical co-ordinates corresponding to the ith Fab
+     */
     amrex::Array<amrex::Real, AMREX_SPACEDIM> FabLo (int iFab) const noexcept {return m_glo[iFab]; }
+    /** Returns physical co-ordinates of the lower-corner for the i-th Fab.
+     *  \param[in] iFab, id of the ith Fab in the list of Multifabs
+     *  \param[out] Array of lower-corner physical co-ordinates corresponding to the ith Fab
+     */
     amrex::Array<amrex::Real, AMREX_SPACEDIM> FabHi (int iFab) const noexcept {return m_ghi[iFab]; }
+    /** Returns path to location of multifabs */
     std::string CellPath () const noexcept {return m_CellPath; }
 
+    /** Reads the Header file data for BTD */
     void ReadHeaderData ();
+    /** Writes Header file data for BTD */
     void WriteHeader ();
 
+    /** Sets the physical simulation time, m_time, in the Header file to a new_time.
+     *  \param[in] Real new_time
+     **/
     void set_time ( amrex::Real new_time) { m_time = new_time;}
+    /** Sets the timestep, m_timestep, in the Header file to a new_timestep
+     *  \param[in] int new_timestep
+     **/
     void set_timestep (int new_timestep) { m_timestep = new_timestep; }
+    /** Set the ith-dimension physical co-ordinate of the lower corner.
+     *  \param[in] int dim, dimension modified.
+     *  \param[in] Real lo, lower-corner physical coordinate to be stored in dimension, dim.
+     **/
     void set_problo (int dim, amrex::Real lo) { m_prob_lo[dim] = lo;}
+    /** Set the ith-dimension physical co-ordinate of the upper corner.
+     *  \param[in] int dim, dimension modified.
+     *  \param[in] Real hi, upper-corner physical coordinate to be stored in dimension, dim.
+     **/
     void set_probhi (int dim, amrex::Real hi) { m_prob_hi[dim] = hi;}
+    /** Set the Domain box spanning the plotfile data in the modified plotfile and Header.
+     *  \param[in] amrex::Box domainBox spanning the domain corresponding to the plotfile.
+     */
     void set_probDomain (amrex::Box domainBox) {m_prob_domain = domainBox; }
-    void IncrementNumFabs () { m_numFabs++;}
+    /** Increments the number of fabs stored in the plotfile by one. */
+    void IncrementNumFabs () { m_numFabs++;}    
     void ResizeFabLo () { m_glo.resize(m_numFabs); }
     void ResizeFabHi () { m_ghi.resize(m_numFabs); }
+    /** Append array of lower-corner physical coordinates corresponding to a new fab to
+     *  the existing list of coordinates, m_glo.
+     *  \param[in] amrex::Array<Real,AMREX_SPACEDIM> newFabLo containing physical coordinates
+     *             of the newly appended fab-data to the plotfile.
+     */
     void AppendNewFabLo (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabLo);
+    /** Append array of upper-corner physical coordinates corresponding to a new fab to
+     *  the existing list of coordinates, m_ghi.
+     *  \param[in] amrex::Array<Real,AMREX_SPACEDIM> newFabHi containing physical coordinates
+     *             of the newly appended fab-data to the plotfile.
+     */
     void AppendNewFabHi (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabHi);
 private:
+    /** string containing path of the Header file. */
     std::string m_Header_path;
+    /** String containing file version of the plotfile. */
     std::string m_file_version;
+    /** Number of components in the plotfile. */
     int m_nComp;
+    /** Names of components stored in the plotfile. */
     amrex::Vector<std::string> m_varnames;
+    /** Number of dimensions stored in the plotfile, should be same as AMREX_SPACEDIM */
     int m_spacedim;
+    /** Physical time */
     amrex::Real m_time;
     int m_finest_level, m_nlevel;
+    /** Lower cornder physical coordinates of the domain spanned in the plotfile */
     amrex::Array<amrex::Real, AMREX_SPACEDIM> m_prob_lo {{AMREX_D_DECL(0.,0.,0.)}};
+    /** Upper corner physical coordinates of the domain spanned in the plotfile */
     amrex::Array<amrex::Real, AMREX_SPACEDIM> m_prob_hi {{AMREX_D_DECL(1.,1.,1.)}};
+    /** Cell size */
     amrex::Array<amrex::Real, AMREX_SPACEDIM> m_cell_size {{AMREX_D_DECL(1.,1.,1.)}};
+    /** Box covering the span of the physical domain in the plotfile */
     amrex::Box m_prob_domain;
     int m_timestep;
     int m_coordsys;
     int m_bwidth;
     int m_cur_level;
+    /** Number of Fabs in the plotfile. */
     int m_numFabs;
+    /** Lower corner physical coordinates of each fab in the plotfile. */
     amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_glo {{AMREX_D_DECL(0.,0.,0.)}};
+    /** Upper corner physical coordinates of each fab in the plotfile. */
     amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_ghi {{AMREX_D_DECL(1.,1.,1.)}};
     std::string m_CellPath;
 
 };
 
+/**
+ * \brief Class to read, modify, and write MultiFab header in Level_0/Cell_H when
+ * back-transformed diag format is selected as plotfile.
+ * This class enables multiple fabs to be interweaved and stitched into 
+ * a single plotfile with a single Header, Cell_H.
+ */
 class BTDMultiFabHeaderImpl
 {
     public:
+    /** Constructor.
+     * \param[in] string containing path of Headerfile
+     */
     BTDMultiFabHeaderImpl (std::string const& Headerfile_path);
     ~BTDMultiFabHeaderImpl () = default;
+    /** Reads the Multifab Header file and stores its data. */
     void ReadMultiFabHeader ();
+    /** Writes the meta-data of the Multifab in a header file, with path, m_Header_path. */
     void WriteMultiFabHeader ();
 
+    /** Returns size, m_ba_size, of the Box Array, m_ba.*/
     int ba_size () {return m_ba_size;}
+    /** Returns box corresponding to the ith box in the BoxArray, m_ba.
+     *  \param[in] int ibox, index of the box in the BoxArray.
+     */
     amrex::Box ba_box (int ibox) {return m_ba[ibox]; }
+    /** Returns prefix of the ith-fab on disk, i.e., ith fab of the MultiFab data.
+     *  \param[int] ifab, index of the ith fab in the MultiFab data.
+     */
     std::string fodPrefix (int ifab) {return m_FabOnDiskPrefix[ifab]; }
+    /** Returns name of the ith fab stored in the MultiFab. */
     std::string FabName (int ifab) {return m_fabname[ifab]; }
+    /** Returns the starting byte of the ith fab data */
     int FabHead (int ifab) {return m_fabhead[ifab]; }
+    /** Returns minimum value of all the components stored in the ith fab. */
     amrex::Vector<amrex::Real> minval(int ifab) { return m_minval[ifab];}
-    amrex::Vector<amrex::Real> maxval(int ifab) { return m_maxval[ifab];}
+    /** Returns maximum value of all the components stored in the ith fab. */
+    amrex::Vector<amrex::Real> maxval(int ifab) { return m_maxval[ifab];}    
     void ResizeFabData ();
+    /** Increments MultiFab size, m_ba_size, by add_mf_size.
+     *  \param[in] int add_mf_size, number of new multifabs to be appended to the existing 
+     *             Box Array.
+     */    
     void IncreaseMultiFabSize (int add_mf_size) {m_ba_size += add_mf_size;}
+    /** Set Box indices of the ith-box in Box Array, m_ba, to the new Box, ba_box.
+     *  \param[in] int ibox, index of the ith box in BoxArray, m_ba.
+     *  \param[in] amrex::Box box dimensions corresponding to the ith Fab.
+     */
     void SetBox (int ibox, amrex::Box ba_box) { m_ba.set(ibox, ba_box); }
+    /** Set Fab name of the ith fab to be written in the multifab Header file.*/
     void SetFabName (int ifab, std::string fodPrefix, std::string FabName,
                      int FabHead);
+    /** Set minimum value of all the components for the ith fab. */
     void SetMinVal (int ifab, amrex::Vector<amrex::Real> minval);
+    /** Set maximum value of all the components for the ith fab. */
     void SetMaxVal (int ifab, amrex::Vector<amrex::Real> maxval);
     private:
+    /** Header file path */
     std::string m_Header_path;
     int m_vers;
     int m_how;
+    /** number of components stored in the multifab. */
     int m_ncomp;
+    /** number of guard cells in the multifab. */
     int m_ngrow;
+    /** Size of the BoxArray, m_ba.*/
     int m_ba_size;
+    /** BoxArray corresponding to the multifab stored in the plotfile.*/
     amrex::BoxArray m_ba;
     amrex::Vector<std::string> m_FabOnDiskPrefix;
     amrex::Vector<std::string> m_fabname;
@@ -118,6 +229,7 @@ class BTDMultiFabHeaderImpl
     /** The max of each component of each FAB in the BoxArray, m_ba.
      *  To access the max value of the ith fab and jth component [ifab][jcomp]*/
     amrex::Vector<amrex::Vector< amrex::Real> > m_maxval;
+    /** Copy values of the vector from the src vector, src, to dst vector. */
     void CopyVec (amrex::Vector<amrex::Real>& dst,
                   amrex::Vector<amrex::Real> src);
 };

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -19,15 +19,15 @@ public:
     int spaceDim () const noexcept {return m_spacedim; }
 
     amrex::Real time () const noexcept {return m_time; }
-  
+
     int finestLevel () const noexcept { return m_finest_level; }
 
     amrex::Real problo (int dim) const noexcept {return m_prob_lo[dim]; }
     amrex::Real probhi (int dim) const noexcept {return m_prob_hi[dim]; }
 
 
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; } 
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; } 
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; }
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; }
     amrex::Array<amrex::Real, AMREX_SPACEDIM> cellsize () const noexcept {return m_cell_size; }
     amrex::Box probDomain () const noexcept {return m_prob_domain; }
     int timestep () const noexcept {return m_timestep; }
@@ -35,7 +35,7 @@ public:
     int bwidth () const noexcept {return m_bwidth; }
     int cur_level () const noexcept {return m_cur_level; }
     int numFabs () const noexcept {return m_numFabs; }
-    
+
     const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& glo () const noexcept {return m_glo; }
     const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& ghi () const noexcept {return m_ghi; }
 
@@ -45,7 +45,7 @@ public:
 
     void ReadHeaderData ();
     void WriteHeader ();
- 
+
     void set_time ( amrex::Real new_time) { m_time = new_time;}
     void set_timestep (int new_timestep) { m_timestep = new_timestep; }
     void set_problo (int dim, amrex::Real lo) { m_prob_lo[dim] = lo;}
@@ -76,7 +76,7 @@ private:
     amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_glo {{AMREX_D_DECL(0.,0.,0.)}};
     amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_ghi {{AMREX_D_DECL(1.,1.,1.)}};
     std::string m_CellPath;
-        
+
 };
 
 class BTDMultiFabHeaderImpl
@@ -103,10 +103,10 @@ class BTDMultiFabHeaderImpl
     void SetMaxVal (int ifab, amrex::Vector<amrex::Real> maxval);
     private:
     std::string m_Header_path;
-    int m_vers; 
+    int m_vers;
     int m_how;
     int m_ncomp;
-    int m_ngrow; 
+    int m_ngrow;
     int m_ba_size;
     amrex::BoxArray m_ba;
     amrex::Vector<std::string> m_FabOnDiskPrefix;

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -1,0 +1,126 @@
+#ifndef BTD_PLOTFILE_HEADER_IMPL_H
+#define BTD_PLOTFILE_HEADER_IMPL_H
+
+#include <string>
+#include <AMReX_Vector.H>
+#include <AMReX_MultiFab.H>
+
+
+class BTDPlotfileHeaderImpl
+{
+public:
+    BTDPlotfileHeaderImpl (std::string const& Headerfile_path);
+    ~BTDPlotfileHeaderImpl () = default;
+
+    std::string fileVersion () const noexcept {return m_file_version; }
+    int ncomp () const noexcept {return m_nComp; }
+    const amrex::Vector<std::string>& varnames () const noexcept {return m_varnames; }
+
+    int spaceDim () const noexcept {return m_spacedim; }
+
+    amrex::Real time () const noexcept {return m_time; }
+  
+    int finestLevel () const noexcept { return m_finest_level; }
+
+    amrex::Real problo (int dim) const noexcept {return m_prob_lo[dim]; }
+    amrex::Real probhi (int dim) const noexcept {return m_prob_hi[dim]; }
+
+
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; } 
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; } 
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> cellsize () const noexcept {return m_cell_size; }
+    amrex::Box probDomain () const noexcept {return m_prob_domain; }
+    int timestep () const noexcept {return m_timestep; }
+    int coordsys () const noexcept {return m_coordsys; }
+    int bwidth () const noexcept {return m_bwidth; }
+    int cur_level () const noexcept {return m_cur_level; }
+    int numFabs () const noexcept {return m_numFabs; }
+    
+    const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& glo () const noexcept {return m_glo; }
+    const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& ghi () const noexcept {return m_ghi; }
+
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> FabLo (int iFab) const noexcept {return m_glo[iFab]; }
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> FabHi (int iFab) const noexcept {return m_ghi[iFab]; }
+    std::string CellPath () const noexcept {return m_CellPath; }
+
+    void ReadHeaderData ();
+    void WriteHeader ();
+ 
+    void set_time ( amrex::Real new_time) { m_time = new_time;}
+    void set_timestep (int new_timestep) { m_timestep = new_timestep; }
+    void set_problo (int dim, amrex::Real lo) { m_prob_lo[dim] = lo;}
+    void set_probhi (int dim, amrex::Real hi) { m_prob_hi[dim] = hi;}
+    void set_probDomain (amrex::Box domainBox) {m_prob_domain = domainBox; }
+    void IncrementNumFabs () { m_numFabs++;}
+    void ResizeFabLo () { m_glo.resize(m_numFabs); }
+    void ResizeFabHi () { m_ghi.resize(m_numFabs); }
+    void AppendNewFabLo (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabLo);
+    void AppendNewFabHi (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabHi);
+private:
+    std::string m_Header_path;
+    std::string m_file_version;
+    int m_nComp;
+    amrex::Vector<std::string> m_varnames;
+    int m_spacedim;
+    amrex::Real m_time;
+    int m_finest_level, m_nlevel;
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> m_prob_lo {{AMREX_D_DECL(0.,0.,0.)}};
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> m_prob_hi {{AMREX_D_DECL(1.,1.,1.)}};
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> m_cell_size {{AMREX_D_DECL(1.,1.,1.)}};
+    amrex::Box m_prob_domain;
+    int m_timestep;
+    int m_coordsys;
+    int m_bwidth;
+    int m_cur_level;
+    int m_numFabs;
+    amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_glo {{AMREX_D_DECL(0.,0.,0.)}};
+    amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> > m_ghi {{AMREX_D_DECL(1.,1.,1.)}};
+    std::string m_CellPath;
+        
+};
+
+class BTDMultiFabHeaderImpl
+{
+    public:
+    BTDMultiFabHeaderImpl (std::string const& Headerfile_path);
+    ~BTDMultiFabHeaderImpl () = default;
+    void ReadMultiFabHeader ();
+    void WriteMultiFabHeader ();
+
+    int ba_size () {return m_ba_size;}
+    amrex::Box ba_box (int ibox) {return m_ba[ibox]; }
+    std::string fodPrefix (int ifab) {return m_FabOnDiskPrefix[ifab]; }
+    std::string FabName (int ifab) {return m_fabname[ifab]; }
+    int FabHead (int ifab) {return m_fabhead[ifab]; }
+    amrex::Vector<amrex::Real> minval(int ifab) { return m_minval[ifab];}
+    amrex::Vector<amrex::Real> maxval(int ifab) { return m_maxval[ifab];}
+    void ResizeFabData ();
+    void IncreaseMultiFabSize (int add_mf_size) {m_ba_size += add_mf_size;}
+    void SetBox (int ibox, amrex::Box ba_box) { m_ba.set(ibox, ba_box); }
+    void SetFabName (int ifab, std::string fodPrefix, std::string FabName,
+                     int FabHead);
+    void SetMinVal (int ifab, amrex::Vector<amrex::Real> minval);
+    void SetMaxVal (int ifab, amrex::Vector<amrex::Real> maxval);
+    private:
+    std::string m_Header_path;
+    int m_vers; 
+    int m_how;
+    int m_ncomp;
+    int m_ngrow; 
+    int m_ba_size;
+    amrex::BoxArray m_ba;
+    amrex::Vector<std::string> m_FabOnDiskPrefix;
+    amrex::Vector<std::string> m_fabname;
+    amrex::Vector<int> m_fabhead;
+    /** The min of each component of each FAB in the BoxArray, m_ba.
+     *  To access the min value of the ith fab and jth component [ifab][jcomp]*/
+    amrex::Vector<amrex::Vector< amrex::Real> > m_minval;
+    /** The max of each component of each FAB in the BoxArray, m_ba.
+     *  To access the max value of the ith fab and jth component [ifab][jcomp]*/
+    amrex::Vector<amrex::Vector< amrex::Real> > m_maxval;
+    void CopyVec (amrex::Vector<amrex::Real>& dst,
+                  amrex::Vector<amrex::Real> src);
+};
+
+#endif
+

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -64,14 +64,14 @@ BTDPlotfileHeaderImpl::ReadHeaderData ()
 
 void
 BTDPlotfileHeaderImpl::AppendNewFabLo (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabLo)
-{ 
+{
     ResizeFabLo();
     m_glo[m_numFabs-1] = newFabLo;
 }
 
 void
 BTDPlotfileHeaderImpl::AppendNewFabHi (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabHi)
-{ 
+{
     ResizeFabHi();
     m_ghi[m_numFabs-1] = newFabHi;
 }
@@ -81,7 +81,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
 {
     if ( amrex::FileExists(m_Header_path) ) {
         amrex::Print() << " removing this file : " << m_Header_path << "\n";
-        amrex::FileSystem::Remove(m_Header_path);        
+        amrex::FileSystem::Remove(m_Header_path);
     }
     std::ofstream HeaderFile;
     HeaderFile.open(m_Header_path.c_str(), std::ofstream::out |
@@ -90,8 +90,8 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     if ( !HeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
 
     HeaderFile.precision(17);
-    
-    // Genetic Plotfile type name   
+
+    // Genetic Plotfile type name
     HeaderFile << m_file_version << '\n';
     // number of components
     HeaderFile << m_varnames.size() << '\n';
@@ -107,12 +107,12 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << m_finest_level << '\n';
     // Physical coordinate of the lower corner
     for (int idim = 0; idim < m_spacedim; ++idim) {
-        HeaderFile << m_prob_lo[idim] << ' ';        
+        HeaderFile << m_prob_lo[idim] << ' ';
     }
     HeaderFile << '\n';
-    // Physical cooridnate of the upper corner 
+    // Physical cooridnate of the upper corner
     for (int idim = 0; idim < m_spacedim; ++idim) {
-        HeaderFile << m_prob_hi[idim] << ' ';       
+        HeaderFile << m_prob_hi[idim] << ' ';
     }
     HeaderFile << '\n';
     // since nlevels=0, not writing ref_ratio as seen in a typical MR Header
@@ -128,7 +128,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << '\n';
     // coordinate system (Cartesian)
     HeaderFile << m_coordsys << '\n';
-    // 
+    //
     HeaderFile << m_bwidth << '\n';
     // current level, number of Fabs, current time -- for a single level (m_level = 0)
     HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
@@ -138,11 +138,11 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     for (int iFab = 0; iFab < m_numFabs; ++iFab) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
-        }       
+        }
     }
     // MultiFabHeaderPath
     HeaderFile << m_CellPath << '\n';
-   
+
 }
 
 
@@ -173,9 +173,9 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
         is >> bx;
         m_ba.set(ibox, bx);
     }
-    is.ignore(bl_ignore_max, ')'); 
-    
-    is >> in_hash; // repeat of reading ba_size 
+    is.ignore(bl_ignore_max, ')');
+
+    is >> in_hash; // repeat of reading ba_size
     m_FabOnDiskPrefix.resize(m_ba.size());
     m_fabname.resize(m_ba.size());
     m_fabhead.resize(m_ba.size());
@@ -190,7 +190,7 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
         m_minval[ifab].resize(m_ncomp);
         for (int icomp = 0; icomp < m_ncomp; ++icomp) {
             is >> m_minval[ifab][icomp] >> ch;
-            if( ch != ',' ) amrex::Error("Expected a ',' got something else");            
+            if( ch != ',' ) amrex::Error("Expected a ',' got something else");
         }
     }
     WarpX::GotoNextLine(is);
@@ -200,11 +200,11 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
         m_maxval[ifab].resize(m_ncomp);
         for (int icomp = 0; icomp < m_ncomp; ++icomp) {
             is >> m_maxval[ifab][icomp] >> ch;
-            if( ch != ',' ) amrex::Error("Expected a ',' got something else");            
+            if( ch != ',' ) amrex::Error("Expected a ',' got something else");
         }
     }
-    
-    
+
+
 }
 
 void
@@ -212,7 +212,7 @@ BTDMultiFabHeaderImpl::WriteMultiFabHeader ()
 {
     if ( amrex::FileExists(m_Header_path) ) {
         amrex::Print() << " removing this file : " << m_Header_path << "\n";
-        amrex::FileSystem::Remove(m_Header_path);        
+        amrex::FileSystem::Remove(m_Header_path);
     }
     std::ofstream FabHeaderFile;
     FabHeaderFile.open(m_Header_path.c_str(), std::ofstream::out |
@@ -221,7 +221,7 @@ BTDMultiFabHeaderImpl::WriteMultiFabHeader ()
     if ( !FabHeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
 
     FabHeaderFile.precision(17);
-    
+
     // multifab header version
     FabHeaderFile << m_vers << '\n';
     // VisMF :: how
@@ -239,23 +239,23 @@ BTDMultiFabHeaderImpl::WriteMultiFabHeader ()
         FabHeaderFile << m_FabOnDiskPrefix[ifab] << ' ' << m_fabname[ifab] << ' ' << m_fabhead[ifab];
         FabHeaderFile << '\n';
     }
-    FabHeaderFile << '\n'; 
+    FabHeaderFile << '\n';
     // Write minvalue of all the components for each fab in the multifab
     FabHeaderFile << m_ba.size() << ',' << m_ncomp << '\n';
     for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
         for (int icomp = 0; icomp < m_ncomp; ++icomp) {
-            FabHeaderFile << m_minval[ifab][icomp] << ',';              
+            FabHeaderFile << m_minval[ifab][icomp] << ',';
         }
-        FabHeaderFile << '\n'; 
+        FabHeaderFile << '\n';
     }
-    FabHeaderFile << '\n'; 
+    FabHeaderFile << '\n';
     // Write minvalue of all the components for each fab in the multifab
     FabHeaderFile << m_ba.size() << ',' << m_ncomp << '\n';
     for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
         for (int icomp = 0; icomp < m_ncomp; ++icomp) {
             FabHeaderFile << m_maxval[ifab][icomp] << ',';
-        }              
-        FabHeaderFile << '\n'; 
+        }
+        FabHeaderFile << '\n';
     }
 }
 

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -1,0 +1,305 @@
+#include "BTD_Plotfile_Header_Impl.H"
+#include "WarpX.H"
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_FileSystem.H>
+#include <memory>
+
+using namespace amrex::literals;
+
+
+BTDPlotfileHeaderImpl::BTDPlotfileHeaderImpl (std::string const & Headerfile_path)
+    : m_Header_path(Headerfile_path)
+{
+
+}
+
+void
+BTDPlotfileHeaderImpl::ReadHeaderData ()
+{
+    // Read existing snapshot Header first
+    amrex::Vector<char> HeaderCharPtr;
+    amrex::ParallelDescriptor::ReadAndBcastFile(m_Header_path, HeaderCharPtr);
+    std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
+
+    is >> m_file_version;
+
+    is >> m_nComp;
+    m_varnames.resize(m_nComp);
+    for (int icomp=0; icomp < m_nComp; ++icomp) {
+        is >> m_varnames[icomp];
+    }
+    is >> m_spacedim ;
+    is >> m_time;
+    is >> m_finest_level;
+    m_nlevel = m_finest_level + 1;
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        is >> m_prob_lo[idim];
+    }
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        is >> m_prob_hi[idim];
+    }
+    WarpX::GotoNextLine(is);
+
+    is >> m_prob_domain;
+
+    is >> m_timestep;
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        is >> m_cell_size[idim];
+    }
+    is >> m_coordsys;
+    is >> m_bwidth;
+    is >> m_cur_level >> m_numFabs >> m_time;
+    is >> m_timestep;
+    m_glo.resize(m_numFabs);
+    m_ghi.resize(m_numFabs);
+    for (int igrid = 0; igrid < m_numFabs; ++igrid) {
+        for (int idim = 0; idim < m_spacedim; ++idim ) {
+            is >> m_glo[igrid][idim] >> m_ghi[igrid][idim];
+        }
+    }
+    is >> m_CellPath;
+}
+
+void
+BTDPlotfileHeaderImpl::AppendNewFabLo (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabLo)
+{ 
+    ResizeFabLo();
+    m_glo[m_numFabs-1] = newFabLo;
+}
+
+void
+BTDPlotfileHeaderImpl::AppendNewFabHi (amrex::Array<amrex::Real, AMREX_SPACEDIM> newFabHi)
+{ 
+    ResizeFabHi();
+    m_ghi[m_numFabs-1] = newFabHi;
+}
+
+void
+BTDPlotfileHeaderImpl::WriteHeader ()
+{
+    if ( amrex::FileExists(m_Header_path) ) {
+        amrex::Print() << " removing this file : " << m_Header_path << "\n";
+        amrex::FileSystem::Remove(m_Header_path);        
+    }
+    std::ofstream HeaderFile;
+    HeaderFile.open(m_Header_path.c_str(), std::ofstream::out |
+                                           std::ofstream::trunc |
+                                           std::ofstream::binary);
+    if ( !HeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
+
+    HeaderFile.precision(17);
+    
+    // Genetic Plotfile type name   
+    HeaderFile << m_file_version << '\n';
+    // number of components
+    HeaderFile << m_varnames.size() << '\n';
+    // write the component string
+    for (int icomp = 0; icomp < m_varnames.size(); ++icomp ) {
+        HeaderFile << m_varnames[icomp] << '\n';
+    }
+    // space dim
+    HeaderFile << m_spacedim << '\n';
+    // time
+    HeaderFile << m_time << '\n';
+    // finest level
+    HeaderFile << m_finest_level << '\n';
+    // Physical coordinate of the lower corner
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        HeaderFile << m_prob_lo[idim] << ' ';        
+    }
+    HeaderFile << '\n';
+    // Physical cooridnate of the upper corner 
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        HeaderFile << m_prob_hi[idim] << ' ';       
+    }
+    HeaderFile << '\n';
+    // since nlevels=0, not writing ref_ratio as seen in a typical MR Header
+    HeaderFile << '\n';
+    // Indices of the box covering the entire domain
+    HeaderFile << m_prob_domain << '\n';
+    // timestep in boosted frame
+    HeaderFile << m_timestep << '\n';
+    // cell-size in the back-transformed lab-frame
+    for (int idim = 0; idim < m_spacedim; ++idim) {
+        HeaderFile << m_cell_size[idim] << ' ';
+    }
+    HeaderFile << '\n';
+    // coordinate system (Cartesian)
+    HeaderFile << m_coordsys << '\n';
+    // 
+    HeaderFile << m_bwidth << '\n';
+    // current level, number of Fabs, current time -- for a single level (m_level = 0)
+    HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
+    // timestep for level=0
+    HeaderFile << m_timestep << '\n';
+    // Physical (lo,hi) in each dimension for all the Fabs in the snapshot
+    for (int iFab = 0; iFab < m_numFabs; ++iFab) {
+        for (int idim = 0; idim < m_spacedim; ++idim) {
+            HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
+        }       
+    }
+    // MultiFabHeaderPath
+    HeaderFile << m_CellPath << '\n';
+   
+}
+
+
+BTDMultiFabHeaderImpl::BTDMultiFabHeaderImpl (std::string const & Headerfile_path)
+    : m_Header_path(Headerfile_path)
+{
+
+}
+
+void
+BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
+{
+    amrex::Vector<char> HeaderCharPtr;
+    amrex::ParallelDescriptor::ReadAndBcastFile(m_Header_path, HeaderCharPtr);
+    std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
+
+    is >> m_vers;
+    is >> m_how;
+    is >> m_ncomp;
+    is >> m_ngrow;
+    // can also call readBoxArray(m_ba, is, True);
+    int in_hash;
+    int bl_ignore_max = 100000;
+    is.ignore(bl_ignore_max,'(') >> m_ba_size >> in_hash;
+    m_ba.resize(m_ba_size);
+    for (int ibox = 0; ibox < m_ba.size(); ++ibox) {
+        amrex::Box bx;
+        is >> bx;
+        m_ba.set(ibox, bx);
+    }
+    is.ignore(bl_ignore_max, ')'); 
+    
+    is >> in_hash; // repeat of reading ba_size 
+    m_FabOnDiskPrefix.resize(m_ba.size());
+    m_fabname.resize(m_ba.size());
+    m_fabhead.resize(m_ba.size());
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        is >> m_FabOnDiskPrefix[ifab] >> m_fabname[ifab] >> m_fabhead[ifab];
+    }
+    WarpX::GotoNextLine(is);
+    char ch;
+    is >> in_hash >> ch >> in_hash;
+    m_minval.resize(m_ba.size());
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        m_minval[ifab].resize(m_ncomp);
+        for (int icomp = 0; icomp < m_ncomp; ++icomp) {
+            is >> m_minval[ifab][icomp] >> ch;
+            if( ch != ',' ) amrex::Error("Expected a ',' got something else");            
+        }
+    }
+    WarpX::GotoNextLine(is);
+    is >> in_hash >> ch >> in_hash;
+    m_maxval.resize(m_ba.size());
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        m_maxval[ifab].resize(m_ncomp);
+        for (int icomp = 0; icomp < m_ncomp; ++icomp) {
+            is >> m_maxval[ifab][icomp] >> ch;
+            if( ch != ',' ) amrex::Error("Expected a ',' got something else");            
+        }
+    }
+    
+    
+}
+
+void
+BTDMultiFabHeaderImpl::WriteMultiFabHeader ()
+{
+    if ( amrex::FileExists(m_Header_path) ) {
+        amrex::Print() << " removing this file : " << m_Header_path << "\n";
+        amrex::FileSystem::Remove(m_Header_path);        
+    }
+    std::ofstream FabHeaderFile;
+    FabHeaderFile.open(m_Header_path.c_str(), std::ofstream::out |
+                                           std::ofstream::trunc |
+                                           std::ofstream::binary);
+    if ( !FabHeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
+
+    FabHeaderFile.precision(17);
+    
+    // multifab header version
+    FabHeaderFile << m_vers << '\n';
+    // VisMF :: how
+    FabHeaderFile << m_how << '\n';
+    // number of components
+    FabHeaderFile << m_ncomp << '\n';
+    // number of guard cells
+    FabHeaderFile << m_ngrow << '\n';
+    // WriteBoxArray
+    m_ba.writeOn(FabHeaderFile);
+    FabHeaderFile << '\n';
+    // Write ba size
+    FabHeaderFile << m_ba.size() << '\n';
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        FabHeaderFile << m_FabOnDiskPrefix[ifab] << ' ' << m_fabname[ifab] << ' ' << m_fabhead[ifab];
+        FabHeaderFile << '\n';
+    }
+    FabHeaderFile << '\n'; 
+    // Write minvalue of all the components for each fab in the multifab
+    FabHeaderFile << m_ba.size() << ',' << m_ncomp << '\n';
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        for (int icomp = 0; icomp < m_ncomp; ++icomp) {
+            FabHeaderFile << m_minval[ifab][icomp] << ',';              
+        }
+        FabHeaderFile << '\n'; 
+    }
+    FabHeaderFile << '\n'; 
+    // Write minvalue of all the components for each fab in the multifab
+    FabHeaderFile << m_ba.size() << ',' << m_ncomp << '\n';
+    for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
+        for (int icomp = 0; icomp < m_ncomp; ++icomp) {
+            FabHeaderFile << m_maxval[ifab][icomp] << ',';
+        }              
+        FabHeaderFile << '\n'; 
+    }
+}
+
+void
+BTDMultiFabHeaderImpl::ResizeFabData ()
+{
+    m_ba.resize(m_ba_size);
+    m_FabOnDiskPrefix.resize(m_ba_size);
+    m_fabname.resize(m_ba_size);
+    m_fabhead.resize(m_ba_size);
+    m_minval.resize(m_ba_size);
+    m_maxval.resize(m_ba_size);
+}
+
+void
+BTDMultiFabHeaderImpl::SetFabName (int ifab, std::string fodPrefix, std::string FabName,
+                                   int FabHead)
+{
+    m_FabOnDiskPrefix[ifab] = fodPrefix;
+    m_fabname[ifab] = FabName;
+    m_fabhead[ifab] = FabHead;
+
+}
+
+void
+BTDMultiFabHeaderImpl::SetMinVal (int ifab, amrex::Vector<amrex::Real> minval)
+{
+    CopyVec(m_minval[ifab], minval);
+}
+
+void
+BTDMultiFabHeaderImpl::SetMaxVal (int ifab, amrex::Vector<amrex::Real> maxval)
+{
+    CopyVec(m_maxval[ifab], maxval);
+}
+
+void
+BTDMultiFabHeaderImpl::CopyVec(amrex::Vector<amrex::Real>& dst,
+                               amrex::Vector<amrex::Real> src)
+{
+    dst.resize(src.size());
+    for (int i = 0; i < src.size(); ++i) {
+        dst[i] = src[i];
+    }
+}
+
+

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -4,6 +4,7 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_FileSystem.H>
+#include <AMReX_INT.H>
 #include <memory>
 
 using namespace amrex::literals;
@@ -18,9 +19,23 @@ BTDPlotfileHeaderImpl::BTDPlotfileHeaderImpl (std::string const & Headerfile_pat
 void
 BTDPlotfileHeaderImpl::ReadHeaderData ()
 {
+
     // Read existing snapshot Header first
     amrex::Vector<char> HeaderCharPtr;
-    amrex::ParallelDescriptor::ReadAndBcastFile(m_Header_path, HeaderCharPtr);
+    amrex::Long fileLength(0), fileLengthPadded(0);
+    std::ifstream iss;
+
+    iss.open(m_Header_path.c_str(), std::ios::in);
+    iss.seekg(0, std::ios::end);
+    fileLength = static_cast<std::streamoff>(iss.tellg());
+    iss.seekg(0, std::ios::beg);
+
+    fileLengthPadded = fileLength + 1;
+    HeaderCharPtr.resize(fileLengthPadded);
+    iss.read(HeaderCharPtr.dataPtr(), fileLength);
+    iss.close();
+    HeaderCharPtr[fileLength] = '\0';
+
     std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
 
     is >> m_file_version;
@@ -155,8 +170,22 @@ BTDMultiFabHeaderImpl::BTDMultiFabHeaderImpl (std::string const & Headerfile_pat
 void
 BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
 {
+    // Read existing fab Header first
     amrex::Vector<char> HeaderCharPtr;
-    amrex::ParallelDescriptor::ReadAndBcastFile(m_Header_path, HeaderCharPtr);
+    amrex::Long fileLength(0), fileLengthPadded(0);
+    std::ifstream iss;
+
+    iss.open(m_Header_path.c_str(), std::ios::in);
+    iss.seekg(0, std::ios::end);
+    fileLength = static_cast<std::streamoff>(iss.tellg());
+    iss.seekg(0, std::ios::beg);
+
+    fileLengthPadded = fileLength + 1;
+    HeaderCharPtr.resize(fileLengthPadded);
+    iss.read(HeaderCharPtr.dataPtr(), fileLength);
+    iss.close();
+    HeaderCharPtr[fileLength] = '\0';
+
     std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
 
     is >> m_vers;

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -293,6 +293,13 @@ private:
 
     /** Temporarily clear species output for BTD until particle buffer is added */
     void TMP_ClearSpeciesDataForBTD();
+
+    void StitchBuffersForPlotfile (int i_snapshot);
+    void InterleaveBufferAndSnapshotHeader ( std::string buffer_Header,
+                                             std::string snapshot_Header);
+    void InterleaveFabArrayHeader( std::string Buffer_FabHeaderFilename,
+                                   std::string snapshot_FabHeaderFilename,
+                                   std::string newsnapshot_FabFilename);
 };
 
 #endif // WARPX_BTDIAGNOSTICS_H_

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -11,6 +11,14 @@ public:
     BTDiagnostics (int i, std::string name);
 
 private:
+    /** Whether to plot raw (i.e., NOT cell-centered) fields */
+    bool m_plot_raw_fields = false;
+    /** Whether to plot guard cells of raw fields */
+    bool m_plot_raw_fields_guards = false;
+    /** Whether to plot charge density rho in raw fields */
+    bool m_plot_raw_rho = false;
+    /** Whether to plot F (charge conservation error) in raw fields */
+    bool m_plot_raw_F = false;
     /** Read relevant parameters for BTD */
     void ReadParameters ();
     /** \brief Flush m_mf_output and particles to file.

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -128,11 +128,17 @@ private:
     amrex::Vector<amrex::RealBox> m_prob_domain_lab;
     /** Vector of user-defined physical region for diagnostics in lab-frame
      *  for each back-transformed snapshot */
+    amrex::Vector<amrex::RealBox> m_snapshot_domain_lab;
+    /** Vector of physical region corresponding to the buffer that spans a part
+     *  of the full back-transformed snapshot */
     amrex::Vector<amrex::RealBox> m_buffer_domain_lab;
     /** Vector of number of cells in the lab-frame for each back-transformed snapshot */
-    amrex::Vector<amrex::IntVect> m_buffer_ncells_lab;
+    amrex::Vector<amrex::IntVect> m_snapshot_ncells_lab;
     /** Vector of Box-dimension in boosted-frame index space
      *  for each back-transformed snapshot */
+    amrex::Vector<amrex::Box> m_snapshot_box;
+    /** Vector of Box-dimension in boosted-frame index space corresponding to the
+     *  buffer that covers a part of the full backtransformed snapshot */
     amrex::Vector<amrex::Box> m_buffer_box;
     /** Vector of lab-frame z co-ordinate of each back-transformed snapshot
      *  at the current timestep */
@@ -140,6 +146,17 @@ private:
     /** Vector of boosted-frame z co-ordinate corresponding to each back-transformed
         snapshot at the current timestep */
     amrex::Vector<amrex::Real> m_current_z_boost;
+    /** Geometry that defines the domain attributes corresponding to the
+     *  full snapshot in the back-transformed lab-frame.
+     *  Specifically, the user-defined physical co-ordinates for the diagnostics
+     *  is used to construct the geometry information for each snapshot at
+     *  the respective levels. This geometry will be used to integrate all
+     *  the buffers that were dumped out with partial field data
+     *  in the back-transformed frame at a particle snapshot, t_lab.
+     *  WriteToFile() for BTD will include this additional geometry information
+     *  to guide the integration process.
+     */
+    amrex::Vector< amrex::Vector <amrex::Geometry> > m_geom_snapshot;
     /** Vector of counters tracking number of back-transformed z-slices filled
      *  in the output buffer multifab, m_mf_output, for each snapshot.
      *  When the buffer counter for a snapshot is equal to the maximum number
@@ -147,6 +164,9 @@ private:
      *  stored in the buffer multifab is flushed out and the counter is reset is zero.
      */
     amrex::Vector<int> m_buffer_counter;
+    /** Vector of counters tracking number of times the buffer of multifab is
+     *  flushed out and emptied before being refilled again for each snapshot */
+    amrex::Vector<int> m_buffer_flush_counter;
     /** Multi-level cell-centered multifab with all field-data components, namely,
      *  Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho.
      *  This cell-centered data extending over the entire domain
@@ -164,7 +184,6 @@ private:
      *  using the coarsening-ratio provided by the user.
      */
     amrex::Vector< amrex::Vector <std::unique_ptr<ComputeDiagFunctor const> > > m_cell_center_functors;
-
     /** Customized (temporary) function to flush out back-transformed data */
     void TMP_writeMetaData ();
     /** Customized (temporary) functions creating lab-frame directories
@@ -191,12 +210,21 @@ private:
      */
     void DefineCellCenteredMultiFab(int lev);
     /** Define the cell-centered multi-component output buffer MultiFab for
-     *  snapshot, i_buffer, at level, lev.
+     *  snapshot, i_buffer, at level, lev
      *
      * \param[in] i_buffer buffer-id of the back-transformed snapshot
      * \param[in] lev, level at which the output buffer MultiFab is defined
      */
     void DefineFieldBufferMultiFab (const int i_buffer, const int lev);
+
+    /** Define the geometry object that spans the user-defined region for the
+     *  ith snapshot, i_buffer, at level, lev.
+     *
+     * \param[in] i_buffer id of the back-transformed snapshot
+     * \param[in] lev, level at which the geometry object is defined
+     */
+    void DefineSnapshotGeometry (const int i_buffer, const int lev);
+
     /** Compute and return z-position in the boosted-frame at the current timestep
       * \param[in] t_lab, lab-frame time of the snapshot
       * \param[in] t_boost, boosted-frame time at level, lev
@@ -244,10 +272,16 @@ private:
     }
 
     /** Reset buffer counter to zero.
-     * \param[in] i_buffer, ith buffer for which the bounter is set to zero.
+     * \param[in] i_buffer, ith buffer for which the counter is set to zero.
      */
     void ResetBufferCounter(int i_buffer) {
         m_buffer_counter[i_buffer] = 0;
+    }
+    /** Increment buffer counter by one when the buffer of a snapshot has been flushed.
+     * \param[in] i_buffer, ith buffer for which the counter is incremented.
+     */
+    void IncrementBufferFlushCounter(int i_buffer) {
+        m_buffer_flush_counter[i_buffer]++;
     }
     /** Vector of field-data stored in the cell-centered multifab, m_cell_centered_data.
      *  All the fields are stored regardless of the specific fields to plot selected
@@ -257,6 +291,8 @@ private:
                                                           "Bx", "By", "Bz",
                                                           "jx", "jy", "jz", "rho"};
 
+    /** Temporarily clear species output for BTD until particle buffer is added */
+    void TMP_ClearSpeciesDataForBTD();
 };
 
 #endif // WARPX_BTDIAGNOSTICS_H_

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -294,7 +294,7 @@ private:
     /** Temporarily clear species output for BTD until particle buffer is added */
     void TMP_ClearSpeciesDataForBTD();
 
-    void StitchBuffersForPlotfile (int i_snapshot);
+    void MergeBuffersForPlotfile (int i_snapshot);
     void InterleaveBufferAndSnapshotHeader ( std::string buffer_Header,
                                              std::string snapshot_Header);
     void InterleaveFabArrayHeader( std::string Buffer_FabHeaderFilename,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -757,10 +757,10 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
         if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-	    Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
-			                new_snapshotFabFilename,
-					Buffer_FabHeader.FabHead(0));
-	    Buffer_FabHeader.WriteMultiFabHeader();
+        Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
+                            new_snapshotFabFilename,
+                    Buffer_FabHeader.FabHead(0));
+        Buffer_FabHeader.WriteMultiFabHeader();
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());
             std::rename(recent_Buffer_FabFilename.c_str(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -594,7 +594,7 @@ BTDiagnostics::Flush (int i_buffer)
     std::string tmp_file_name = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_buffer,5);
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
-        warpx.gett_new(0), m_all_species, nlev_output, tmp_file_name,
+        warpx.gett_new(0), m_output_species, nlev_output, tmp_file_name,
         m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F);
 
     TMP_FlushLabFrameData (i_buffer);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -211,7 +211,7 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
         diag_dom.setLo(idim, std::max(m_lo[idim],warpx.Geom(lev).ProbLo(idim)) );
         // Setting hi-coordinate for the diag domain by taking the max of user-defined
         // hi-cordinate and hi-coordinate of the simulation domain at level, lev
-        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) ); 
+        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) );
     }
     // Initializing the m_buffer_box for the i^th snapshot.
     // At initialization, the Box has the same index space as the boosted-frame
@@ -452,15 +452,15 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                 m_current_z_lab[i_buffer] = UpdateCurrentZLabCoordinate(m_t_lab[i_buffer],
                                                                       warpx.gett_new(lev) );
                 // Check if the zslice is in domain
-                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);                
+                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
                 // Initialize and define field buffer multifab if buffer is empty
                 if (ZSliceInDomain) {
-                    if ( buffer_empty(i_buffer) ) { 
+                    if ( buffer_empty(i_buffer) ) {
                         if ( m_buffer_flush_counter[i_buffer] == 0) {
                             // Compute the geometry, snapshot lab-domain extent
                             // and box-indices
                             DefineSnapshotGeometry(i_buffer, lev);
-                        }                        
+                        }
                         DefineFieldBufferMultiFab(i_buffer, lev);
                     }
                 }
@@ -582,7 +582,7 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
                                                    &m_snapshot_domain_lab[i_buffer],
                                                    amrex::CoordSys::cartesian,
                                                    BTdiag_periodicity.data() );
-            
+
         } else if (lev > 0) {
             // Refine the geometry object defined at the previous level, lev-1
             auto & warpx = WarpX::GetInstance();
@@ -673,7 +673,7 @@ BTDiagnostics::Flush (int i_buffer)
         StitchBuffersForPlotfile(i_buffer);
     }
 
-    
+
     TMP_FlushLabFrameData (i_buffer);
     // Reset the buffer counter to zero after flushing out data stored in the buffer.
     ResetBufferCounter(i_buffer);
@@ -718,7 +718,7 @@ void BTDiagnostics::TMP_ClearSpeciesDataForBTD ()
 {
     m_output_species.clear();
     m_output_species_names.clear();
-    
+
 }
 
 void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
@@ -736,10 +736,10 @@ void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
             amrex::UtilCreateDirectory(snapshot_Level0_path, 0755);
         }
 
-        // Path of the buffer recently flushed 
+        // Path of the buffer recently flushed
         std::string BufferPath_prefix = snapshot_path + "/buffer";
         const std::string recent_Buffer_filepath = amrex::Concatenate(BufferPath_prefix,iteration[0]);
-    
+
         // Header file of the recently flushed buffer
         std::string recent_Header_filename = recent_Buffer_filepath+"/Header";
         std::string recent_Buffer_Level0_path = recent_Buffer_filepath + "/Level_0";
@@ -748,7 +748,7 @@ void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
         std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
         std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], 5);
-        
+
 
         if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
@@ -770,11 +770,11 @@ void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
             // Check if buffer*istep file is present
         }
         amrex::Print() << " I am destroying " << recent_Buffer_filepath << "\n";
-        amrex::FileSystem::RemoveAll(recent_Buffer_filepath);        
+        amrex::FileSystem::RemoveAll(recent_Buffer_filepath);
 
     } // ParallelContext if ends
     amrex::ParallelDescriptor::Barrier();
-}  
+}
 
 void
 BTDiagnostics::InterleaveBufferAndSnapshotHeader ( std::string buffer_Header_path,
@@ -809,10 +809,10 @@ BTDiagnostics::InterleaveBufferAndSnapshotHeader ( std::string buffer_Header_pat
                                   snapshot_Box.bigEnd(idim));
     }
     amrex::Box domain_box(box_lo, box_hi);
-    snapshot_HeaderImpl.set_probDomain(domain_box);    
+    snapshot_HeaderImpl.set_probDomain(domain_box);
 
     // Increment numFabs
-    snapshot_HeaderImpl.IncrementNumFabs(); 
+    snapshot_HeaderImpl.IncrementNumFabs();
     snapshot_HeaderImpl.AppendNewFabLo( buffer_HeaderImpl.FabLo(0));
     snapshot_HeaderImpl.AppendNewFabHi( buffer_HeaderImpl.FabHi(0));
 
@@ -834,7 +834,7 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     // Increment existing fabs in snapshot with the number of fabs in the buffer
     snapshot_FabHeader.IncreaseMultiFabSize( Buffer_FabHeader.ba_size() );
     snapshot_FabHeader.ResizeFabData();
-    
+
     for (int ifab = 0; ifab < Buffer_FabHeader.ba_size(); ++ifab) {
         int new_ifab = snapshot_FabHeader.ba_size() - 1 + ifab;
         snapshot_FabHeader.SetBox(new_ifab, Buffer_FabHeader.ba_box(ifab) );

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -742,8 +742,13 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         std::string recent_Header_filename = recent_Buffer_filepath+"/Header";
         std::string recent_Buffer_Level0_path = recent_Buffer_filepath + "/Level_0";
         std::string recent_Buffer_FabHeaderFilename = recent_Buffer_Level0_path + "/Cell_H";
+        // Read the header file to get the fab on disk string
+        BTDMultiFabHeaderImpl Buffer_FabHeader(recent_Buffer_FabHeaderFilename);
+        Buffer_FabHeader.ReadMultiFabHeader();
+        if (Buffer_FabHeader.ba_size() > 1) amrex::Abort("BTD Buffer has more than one fabs.");
         // Every buffer that is flushed only has a single fab.
-        std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/Cell_D_00000";
+        std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/"
+                                              + Buffer_FabHeader.FabName(0);
         // Existing snapshot Fab Header Filename
         std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
         std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], 5);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -243,6 +243,7 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
     }
     amrex::Box diag_box( lo, hi );
     m_buffer_box[i_buffer] = diag_box;
+    m_snapshot_box[i_buffer] = diag_box;
     // Define box array
     amrex::BoxArray diag_ba(diag_box);
     diag_ba.maxSize( warpx.maxGridSize( lev ) );

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -752,7 +752,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
 
 
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {            
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -523,7 +523,6 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
         // TMP
         amrex::IntVect ref_ratio = amrex::IntVect(1);
         if (lev > 0 ) ref_ratio = WarpX::RefRatio(lev-1);
-        amrex::RealBox buffer_domain_lab;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             amrex::Real cellsize;
             if (idim < AMREX_SPACEDIM-1) {

--- a/Source/Diagnostics/CMakeLists.txt
+++ b/Source/Diagnostics/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(WarpX
     WarpXIO.cpp
     WarpXOpenPMD.cpp
     BTDiagnostics.cpp
+    BTD_Plotfile_Header_Impl.cpp
 )
 
 add_subdirectory(ComputeDiagFunctors)

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -156,6 +156,8 @@ protected:
     int m_num_buffers;
     /** Array of species indices that dump rho per species */
     amrex::Vector<int> m_rho_per_species_index;
+    /** Temporarily clear species output for BTD until particle buffer is added */
+    void TMP_ClearSpeciesDataForBTD() {}
 };
 
 #endif // WARPX_DIAGNOSTICS_H_

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -157,7 +157,7 @@ protected:
     /** Array of species indices that dump rho per species */
     amrex::Vector<int> m_rho_per_species_index;
     /** Temporarily clear species output for BTD until particle buffer is added */
-    void TMP_ClearSpeciesDataForBTD() {}
+    virtual void TMP_ClearSpeciesDataForBTD() {}
 };
 
 #endif // WARPX_DIAGNOSTICS_H_

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -210,6 +210,8 @@ Diagnostics::InitData ()
         m_output_species.clear();
         m_output_species_names.clear();
     }
+    // temporarily clear out species output sincce particle buffers are not supported.
+    TMP_ClearSpeciesDataForBTD();
 }
 
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -210,6 +210,8 @@ Diagnostics::InitData ()
         m_output_species.clear();
         m_output_species_names.clear();
     }
+    // temporarily disabling species output
+    m_all_species.clear();
 }
 
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -210,8 +210,6 @@ Diagnostics::InitData ()
         m_output_species.clear();
         m_output_species_names.clear();
     }
-    // temporarily disabling species output
-    m_all_species.clear();
 }
 
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -15,7 +15,7 @@ void
 FlushFormatCheckpoint::WriteToFile (
         const amrex::Vector<std::string> /*varnames*/,
         const amrex::Vector<amrex::MultiFab>& /*mf*/,
-        amrex::Vector<amrex::Geometry>& /*geom*/,
+        amrex::Vector<amrex::Geometry>& geom,
         const amrex::Vector<int> iteration, const double /*time*/,
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool /*plot_raw_fields*/,
@@ -36,7 +36,7 @@ FlushFormatCheckpoint::WriteToFile (
     // const int nlevels = finestLevel()+1;
     amrex::PreBuildDirectorHierarchy(checkpointname, default_level_prefix, nlev, true);
 
-    WriteWarpXHeader(checkpointname, particle_diags);
+    WriteWarpXHeader(checkpointname, particle_diags, geom);
 
     WriteJobInfo(checkpointname);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -26,7 +26,7 @@ public:
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;
     /** Write WarpX-specific plotfile header */
-    void WriteWarpXHeader(const std::string& name, const amrex::Vector<ParticleDiag>& particle_diags) const;
+    void WriteWarpXHeader(const std::string& name, const amrex::Vector<ParticleDiag>& particle_diags, amrex::Vector<amrex::Geometry>& geom) const;
     void WriteAllRawFields (const bool plot_raw_fields, const int nlevels,
                             const std::string& plotfilename,
                             const bool plot_raw_fields_guards,

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -49,7 +49,7 @@ FlushFormatPlotfile::WriteToFile (
 
     WriteJobInfo(filename);
 
-    WriteWarpXHeader(filename, particle_diags);
+    WriteWarpXHeader(filename, particle_diags, geom);
 
     VisMF::SetHeaderVersion(current_version);
 }
@@ -179,7 +179,8 @@ FlushFormatPlotfile::WriteJobInfo(const std::string& dir) const
 void
 FlushFormatPlotfile::WriteWarpXHeader(
     const std::string& name,
-    const amrex::Vector<ParticleDiag>& particle_diags) const
+    const amrex::Vector<ParticleDiag>& particle_diags,
+    amrex::Vector<amrex::Geometry>& geom) const
 {
     auto & warpx = WarpX::GetInstance();
     if (ParallelDescriptor::IOProcessor())
@@ -232,11 +233,11 @@ FlushFormatPlotfile::WriteWarpXHeader(
 
         // Geometry
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            HeaderFile << warpx.Geom(0).ProbLo(i) << ' ';
+            HeaderFile << geom[0].ProbLo(i) << ' ';
         }
         HeaderFile << '\n';
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            HeaderFile << warpx.Geom(0).ProbHi(i) << ' ';
+            HeaderFile << geom[0].ProbHi(i) << ' ';
         }
         HeaderFile << '\n';
 

--- a/Source/Diagnostics/Make.package
+++ b/Source/Diagnostics/Make.package
@@ -7,6 +7,7 @@ CEXE_sources += ParticleIO.cpp
 CEXE_sources += FieldIO.cpp
 CEXE_sources += SliceDiagnostic.cpp
 CEXE_sources += BTDiagnostics.cpp
+CEXE_sources += BTD_Plotfile_Header_Impl.cpp
 
 ifeq ($(USE_OPENPMD), TRUE)
   CEXE_sources += WarpXOpenPMD.cpp

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,7 +241,6 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
-  amrex::Print() << " m_CurrentStep : " << m_CurrentStep << " ts : " << ts << "\n";
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,7 +241,7 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
-
+  amrex::Print() << " m_CurrentStep : " << m_CurrentStep << " ts : " << ts << "\n";
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series
@@ -257,8 +257,8 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 
 void WarpXOpenPMDPlot::CloseStep ()
 {
-    if (m_Series)
-        m_Series->iterations[m_CurrentStep].close();
+    //if (m_Series)
+    //    m_Series->iterations[m_CurrentStep].close();
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -257,8 +257,8 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 
 void WarpXOpenPMDPlot::CloseStep ()
 {
-    //if (m_Series)
-    //    m_Series->iterations[m_CurrentStep].close();
+    if (m_Series)
+        m_Series->iterations[m_CurrentStep].close();
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,6 +241,7 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
+
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series


### PR DESCRIPTION

This PR adds the capability to visualize BTD using plotfile format instead of the currently used customized output for lab-frame BTD.

In this PR, 
1. A geometry object is added such that it has the information that is consistent with the buffers that fill the snapshot in the lab-frame.
2. The buffer files, written as individual plotfiles at different times in the simulation are interweaved and merged so that they can be read as a single plotfile.

Below is the test file from `Examples/Physics_applications/laser_acceleration/inputs_2d_boost`.
The input file is modified to include the reformatted BTD diagnostics options, given below.
[inputs_2d_boost_BTD.txt](https://github.com/ECP-WarpX/WarpX/files/5947215/inputs_2d_boost_BTD.txt)

![Screenshot from 2021-02-08 14-47-34](https://user-images.githubusercontent.com/41089244/107291208-a6808080-6a1c-11eb-8edc-f8a4c742a7f6.png)

Question to reviewers:
The plotfile is written in `diags/lab_frame_data/<diag_name>/snapshots_plotfile`
This is because I kept some temporary functions that had customized data output for comparison, in `diags/lab_frame_data/<diag_name>/snapshots/`
Should I delete them in this PR or in a separate PR after merging this?


Update : 
The above input file was tested also with 1GPU and 2 GPUs on Cori and it gives the same result as shown above.
