### PR TITLE
Generalize some interpolation functions for MR

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -309,8 +309,7 @@ WarpX::UpdateAuxilaryDataSameType ()
             MultiFab::Subtract(dBy, *Bfield_cp[lev][1], 0, 0, Bfield_cp[lev][1]->nComp(), ng);
             MultiFab::Subtract(dBz, *Bfield_cp[lev][2], 0, 0, Bfield_cp[lev][2]->nComp(), ng);
 
-            const int refinement_ratio = refRatio(lev-1)[0];
-            AMREX_ALWAYS_ASSERT(refinement_ratio == 2);
+            const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -330,15 +329,15 @@ WarpX::UpdateAuxilaryDataSameType ()
                 amrex::ParallelFor(Box(bx_aux), Box(by_aux), Box(bz_aux),
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_x(j,k,l, bx_aux, bx_fp, bx_c);
+                    warpx_interp_bfield_x(j,k,l, bx_aux, bx_fp, bx_c, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_y(j,k,l, by_aux, by_fp, by_c);
+                    warpx_interp_bfield_y(j,k,l, by_aux, by_fp, by_c, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_z(j,k,l, bz_aux, bz_fp, bz_c);
+                    warpx_interp_bfield_z(j,k,l, bz_aux, bz_fp, bz_c, refinement_ratio);
                 });
             }
         }
@@ -364,6 +363,8 @@ WarpX::UpdateAuxilaryDataSameType ()
             MultiFab::Subtract(dEy, *Efield_cp[lev][1], 0, 0, Efield_cp[lev][1]->nComp(), ng);
             MultiFab::Subtract(dEz, *Efield_cp[lev][2], 0, 0, Efield_cp[lev][2]->nComp(), ng);
 
+            const amrex::IntVect& refinement_ratio = refRatio(lev-1);
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -382,15 +383,15 @@ WarpX::UpdateAuxilaryDataSameType ()
                 amrex::ParallelFor(Box(ex_aux), Box(ey_aux), Box(ez_aux),
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_x(j,k,l, ex_aux, ex_fp, ex_c);
+                    warpx_interp_efield_x(j,k,l, ex_aux, ex_fp, ex_c, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_y(j,k,l, ey_aux, ey_fp, ey_c);
+                    warpx_interp_efield_y(j,k,l, ey_aux, ey_fp, ey_c, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_z(j,k,l, ez_aux, ez_fp, ez_c);
+                    warpx_interp_efield_z(j,k,l, ez_aux, ez_fp, ez_c, refinement_ratio);
                 });
             }
         }

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -311,6 +311,10 @@ WarpX::UpdateAuxilaryDataSameType ()
 
             const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
+            const amrex::IntVect& Bx_stag = Bfield_aux[lev-1][0]->ixType().toIntVect();
+            const amrex::IntVect& By_stag = Bfield_aux[lev-1][1]->ixType().toIntVect();
+            const amrex::IntVect& Bz_stag = Bfield_aux[lev-1][2]->ixType().toIntVect();
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -329,15 +333,15 @@ WarpX::UpdateAuxilaryDataSameType ()
                 amrex::ParallelFor(Box(bx_aux), Box(by_aux), Box(bz_aux),
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_x(j,k,l, bx_aux, bx_fp, bx_c, refinement_ratio);
+                    warpx_interp(j, k, l, bx_aux, bx_fp, bx_c, Bx_stag, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_y(j,k,l, by_aux, by_fp, by_c, refinement_ratio);
+                    warpx_interp(j, k, l, by_aux, by_fp, by_c, By_stag, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_bfield_z(j,k,l, bz_aux, bz_fp, bz_c, refinement_ratio);
+                    warpx_interp(j, k, l, bz_aux, bz_fp, bz_c, Bz_stag, refinement_ratio);
                 });
             }
         }
@@ -365,6 +369,10 @@ WarpX::UpdateAuxilaryDataSameType ()
 
             const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
+            const amrex::IntVect& Ex_stag = Efield_aux[lev-1][0]->ixType().toIntVect();
+            const amrex::IntVect& Ey_stag = Efield_aux[lev-1][1]->ixType().toIntVect();
+            const amrex::IntVect& Ez_stag = Efield_aux[lev-1][2]->ixType().toIntVect();
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -383,15 +391,15 @@ WarpX::UpdateAuxilaryDataSameType ()
                 amrex::ParallelFor(Box(ex_aux), Box(ey_aux), Box(ez_aux),
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_x(j,k,l, ex_aux, ex_fp, ex_c, refinement_ratio);
+                    warpx_interp(j, k, l, ex_aux, ex_fp, ex_c, Ex_stag, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_y(j,k,l, ey_aux, ey_fp, ey_c, refinement_ratio);
+                    warpx_interp(j, k, l, ey_aux, ey_fp, ey_c, Ey_stag, refinement_ratio);
                 },
                 [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
                 {
-                    warpx_interp_efield_z(j,k,l, ez_aux, ez_fp, ez_c, refinement_ratio);
+                    warpx_interp(j, k, l, ez_aux, ez_fp, ez_c, Ez_stag, refinement_ratio);
                 });
             }
         }

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -14,13 +14,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_bfield_x (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Bxa,
                             amrex::Array4<amrex::Real const> const& Bxf,
-                            amrex::Array4<amrex::Real const> const& Bxc)
+                            amrex::Array4<amrex::Real const> const& Bxc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
     Real const owx = 1.0_rt - wx;
@@ -31,13 +32,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_bfield_y (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Bya,
                             amrex::Array4<amrex::Real const> const& Byf,
-                            amrex::Array4<amrex::Real const> const& Byc)
+                            amrex::Array4<amrex::Real const> const& Byc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     // Note that for 2d, l=0, because the amrex convention is used here.
 
@@ -54,13 +56,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_bfield_z (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Bza,
                             amrex::Array4<amrex::Real const> const& Bzf,
-                            amrex::Array4<amrex::Real const> const& Bzc)
+                            amrex::Array4<amrex::Real const> const& Bzc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     // Note that for 2d, l=0, because the amrex convention is used here.
 
@@ -79,13 +82,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_efield_x (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Exa,
                             amrex::Array4<amrex::Real const> const& Exf,
-                            amrex::Array4<amrex::Real const> const& Exc)
+                            amrex::Array4<amrex::Real const> const& Exc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     Real const wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
     Real const owy = 1.0_rt - wy;
@@ -107,13 +111,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_efield_y (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Eya,
                             amrex::Array4<amrex::Real const> const& Eyf,
-                            amrex::Array4<amrex::Real const> const& Eyc)
+                            amrex::Array4<amrex::Real const> const& Eyc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
     Real const owx = 1.0_rt - wx;
@@ -141,13 +146,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_efield_z (int j, int k, int l,
                             amrex::Array4<amrex::Real      > const& Eza,
                             amrex::Array4<amrex::Real const> const& Ezf,
-                            amrex::Array4<amrex::Real const> const& Ezc)
+                            amrex::Array4<amrex::Real const> const& Ezc,
+                            const amrex::IntVect& refinement_ratio)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l,2);
-    int const kg = amrex::coarsen(k,2);
-    int const jg = amrex::coarsen(j,2);
+    int const lg = amrex::coarsen(l, refinement_ratio[0]);
+    int const kg = amrex::coarsen(k, refinement_ratio[0]);
+    int const jg = amrex::coarsen(j, refinement_ratio[0]);
 
     Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
     Real const owx = 1.0_rt - wx;

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -11,164 +11,57 @@
 #include <AMReX.H>
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_bfield_x (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Bxa,
-                            amrex::Array4<amrex::Real const> const& Bxf,
-                            amrex::Array4<amrex::Real const> const& Bxc,
-                            const amrex::IntVect& refinement_ratio)
+void warpx_interp (int j, int k, int l,
+                   amrex::Array4<amrex::Real      > const& arr_aux,
+                   amrex::Array4<amrex::Real const> const& arr_fine,
+                   amrex::Array4<amrex::Real const> const& arr_coarse,
+                   const amrex::IntVect& arr_stag,
+                   const amrex::IntVect& rr)
 {
     using namespace amrex;
 
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
+    // NOTE Indices (j,k,l) in the following refer to (x,z,-) in 2D and (x,y,z) in 3D
 
-    Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
-    Real const owx = 1.0_rt - wx;
-    Bxa(j,k,l) = owx * Bxc(jg,kg,lg) + wx * Bxc(jg+1,kg,lg) + Bxf(j,k,l);
-}
+    // Refinement ratio
+    const int rj = rr[0];
+    const int rk = rr[1];
+    const int rl = (AMREX_SPACEDIM == 2) ? 1 : rr[2];
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_bfield_y (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Bya,
-                            amrex::Array4<amrex::Real const> const& Byf,
-                            amrex::Array4<amrex::Real const> const& Byc,
-                            const amrex::IntVect& refinement_ratio)
-{
-    using namespace amrex;
+    // Staggering (0: cell-centered; 1: nodal)
+    const int sj = arr_stag[0];
+    const int sk = arr_stag[1];
+    const int sl = (AMREX_SPACEDIM == 2) ? 0 : arr_stag[2];
 
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
+    // Number of points used for interpolation from coarse grid to fine grid
+    const int nj = (sj == 0) ? 1 : 2;
+    const int nk = (sk == 0) ? 1 : 2;
+    const int nl = (sl == 0) ? 1 : 2;
 
-    // Note that for 2d, l=0, because the amrex convention is used here.
+    const int jc = amrex::coarsen(j, rj);
+    const int kc = amrex::coarsen(k, rk);
+    const int lc = amrex::coarsen(l, rl);
 
-#if (AMREX_SPACEDIM == 3)
-    Real const wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
-    Real const owy = 1.0_rt - wy;
-    Bya(j,k,l) = owy * Byc(jg,kg,lg) + wy * Byc(jg,kg+1,lg) + Byf(j,k,l);
-#else
-    Bya(j,k,l) = Byc(jg,kg,lg) + Byf(j,k,l);
-#endif
-}
+    amrex::Real wj;
+    amrex::Real wk;
+    amrex::Real wl;
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_bfield_z (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Bza,
-                            amrex::Array4<amrex::Real const> const& Bzf,
-                            amrex::Array4<amrex::Real const> const& Bzc,
-                            const amrex::IntVect& refinement_ratio)
-{
-    using namespace amrex;
-
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
-
-    // Note that for 2d, l=0, because the amrex convention is used here.
-
-#if (AMREX_SPACEDIM == 3)
-    Real const wz = (l == lg*2) ? 0.0_rt : 0.5_rt;
-    Real const owz = 1.0_rt - wz;
-    Bza(j,k,l) = owz * Bzc(jg,kg,lg) + wz * Bzc(jg,kg,lg+1) + Bzf(j,k,l);
-#else
-    Real const wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
-    Real const owy = 1.0_rt - wy;
-    Bza(j,k,l) = owy * Bzc(jg,kg,lg) + wy * Bzc(jg,kg+1,lg) + Bzf(j,k,l);
-#endif
-}
-
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_efield_x (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Exa,
-                            amrex::Array4<amrex::Real const> const& Exf,
-                            amrex::Array4<amrex::Real const> const& Exc,
-                            const amrex::IntVect& refinement_ratio)
-{
-    using namespace amrex;
-
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
-
-    Real const wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
-    Real const owy = 1.0_rt - wy;
-
-#if (AMREX_SPACEDIM == 3)
-    Real const wz = (l == lg*2) ? 0.0_rt : 0.5_rt;
-    Real const owz = 1.0_rt - wz;
-    Exa(j,k,l) = owy * owz * Exc(jg  ,kg  ,lg  )
-        +         wy * owz * Exc(jg  ,kg+1,lg  )
-        +        owy *  wz * Exc(jg  ,kg  ,lg+1)
-        +         wy *  wz * Exc(jg  ,kg+1,lg+1)
-        + Exf(j,k,l);
-#else
-    Exa(j,k,l) = owy * Exc(jg,kg,lg) + wy * Exc(jg,kg+1,lg) + Exf(j,k,l);
-#endif
-}
-
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_efield_y (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Eya,
-                            amrex::Array4<amrex::Real const> const& Eyf,
-                            amrex::Array4<amrex::Real const> const& Eyc,
-                            const amrex::IntVect& refinement_ratio)
-{
-    using namespace amrex;
-
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
-
-    Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
-    Real const owx = 1.0_rt - wx;
-
-#if (AMREX_SPACEDIM == 3)
-    Real const wz = (l == lg*2) ? 0.0_rt : 0.5_rt;
-    Real const owz = 1.0_rt - wz;
-    Eya(j,k,l) = owx * owz * Eyc(jg  ,kg  ,lg  )
-        +         wx * owz * Eyc(jg+1,kg  ,lg  )
-        +        owx *  wz * Eyc(jg  ,kg  ,lg+1)
-        +         wx *  wz * Eyc(jg+1,kg  ,lg+1)
-        + Eyf(j,k,l);
-#else
-    Real const wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
-    Real const owy = 1.0_rt - wy;
-    Eya(j,k,l) = owx * owy * Eyc(jg  ,kg  ,lg)
-        +         wx * owy * Eyc(jg+1,kg  ,lg)
-        +        owx *  wy * Eyc(jg  ,kg+1,lg)
-        +         wx *  wy * Eyc(jg+1,kg+1,lg)
-        + Eyf(j,k,l);
-#endif
-}
-
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_efield_z (int j, int k, int l,
-                            amrex::Array4<amrex::Real      > const& Eza,
-                            amrex::Array4<amrex::Real const> const& Ezf,
-                            amrex::Array4<amrex::Real const> const& Ezc,
-                            const amrex::IntVect& refinement_ratio)
-{
-    using namespace amrex;
-
-    int const lg = amrex::coarsen(l, refinement_ratio[0]);
-    int const kg = amrex::coarsen(k, refinement_ratio[0]);
-    int const jg = amrex::coarsen(j, refinement_ratio[0]);
-
-    Real const wx = (j == jg*2) ? 0.0_rt : 0.5_rt;
-    Real const owx = 1.0_rt - wx;
-
-#if (AMREX_SPACEDIM == 3)
-    Real wy = (k == kg*2) ? 0.0_rt : 0.5_rt;
-    Real owy = 1.0_rt - wy;
-    Eza(j,k,l) = owx * owy * Ezc(jg  ,kg  ,lg  )
-        +         wx * owy * Ezc(jg+1,kg  ,lg  )
-        +        owx *  wy * Ezc(jg  ,kg+1,lg  )
-        +         wx *  wy * Ezc(jg+1,kg+1,lg  )
-        + Ezf(j,k,l);
-#else
-    Eza(j,k,l) = owx * Ezc(jg,kg,lg) + wx * Ezc(jg+1,kg,lg) + Ezf(j,k,l);
-#endif
+    // Interpolate from coarse grid to fine grid using either 1 point with weight 1, if both grids
+    // are cell-centered, or 2 points with weights depending on the distance, if both grids are nodal
+    amrex::Real res = 0.0_rt;
+    for         (int jj = 0; jj < nj; jj++) {
+        for     (int kk = 0; kk < nk; kk++) {
+            for (int ll = 0; ll < nl; ll++) {
+                wj = (sj == 0) ? 1.0_rt : (rj - amrex::Math::abs(j - (jc + jj) * rj))
+                                          / static_cast<amrex::Real>(rj);
+                wk = (sk == 0) ? 1.0_rt : (rk - amrex::Math::abs(k - (kc + kk) * rk))
+                                          / static_cast<amrex::Real>(rk);
+                wl = (sl == 0) ? 1.0_rt : (rl - amrex::Math::abs(l - (lc + ll) * rl))
+                                          / static_cast<amrex::Real>(rl);
+                res += wj * wk * wl * arr_coarse(jc+jj,kc+kk,lc+ll);
+            }
+        }
+    }
+    arr_aux(j,k,l) = arr_fine(j,k,l) + res;
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE


### PR DESCRIPTION
This PR generalizes, with respect to the refinement ratio, the interpolation functions called within `WarpX::UpdateAuxilaryDataSameType` to interpolate data from the coarse and fine grids to the fine `aux` grid.

These calls occur when all grids have the same staggering, either nodal (`IndexType = 1`) or cell-centered (`IndexType = 0`).

The new function `warpx_interp` replaces the following old functions:
- `warpx_interp_bfield_x`
- `warpx_interp_bfield_y`
- `warpx_interp_bfield_z`
- `warpx_interp_efield_x`
- `warpx_interp_efield_y`
- `warpx_interp_efield_z`