### PR TITLE
CI: Fix Brew CMake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,8 +11,8 @@ jobs:
     - name: install dependencies
       run: |
         set +e
+        rm -rf /usr/local/bin/2to3
         brew update
-        brew install cmake
         brew install fftw
         brew install libomp
         brew install open-mpi


### PR DESCRIPTION
Fixes:
```
Error: cmake 3.19.1 is already installed
To upgrade to 3.19.2, run `brew upgrade cmake`.
```

in our macOS CI.