### PR TITLE
CI: Always with FFTW/PSATD

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,6 +8,7 @@ jobs:
   variables:
     WARPX_CI_CCACHE: 'TRUE'
     WARPX_CI_OPENPMD: 'TRUE'
+    WARPX_CI_PSATD: 'TRUE'
     FFTW_HOME: '/usr/'
     BLASPP_HOME: '/usr/local/'
     LAPACKPP_HOME: '/usr/local/'
@@ -19,8 +20,6 @@ jobs:
         WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
       cartesian3d:
         WARPX_CI_REGULAR_CARTESIAN_3D: 'TRUE'
-      psatd:
-        WARPX_CI_PSATD: 'TRUE'
       python:
         WARPX_CI_PYTHON_MAIN: 'TRUE'
       single_precision:
@@ -53,12 +52,10 @@ jobs:
         cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.13.2 \
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
       fi
-      if [ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" ]; then
-        cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
-          -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-        cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
-          -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-      fi
+      cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
+        -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
+      cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
+        -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
     displayName: 'Install dependencies'
 
   - script: |

--- a/.github/workflows/source/test_travis_matrix.sh
+++ b/.github/workflows/source/test_travis_matrix.sh
@@ -9,13 +9,14 @@ cd Regression/
 python prepare_file_travis.py
 grep "\[" travis-tests.ini > travis_all_tests.txt
 
+
+export WARPX_CI_PSATD=TRUE
+
 # Concatenate the names of all elements in Travis matrix into another test file
 WARPX_CI_REGULAR_CARTESIAN_2D=TRUE python prepare_file_travis.py
 grep "\[" travis-tests.ini >  travis_matrix_elements.txt
 WARPX_CI_REGULAR_CARTESIAN_3D=TRUE python prepare_file_travis.py
 grep "\[" travis-tests.ini >>  travis_matrix_elements.txt
-WARPX_CI_PSATD=TRUE             python prepare_file_travis.py
-grep "\[" travis-tests.ini >> travis_matrix_elements.txt
 WARPX_CI_PYTHON_MAIN=TRUE       python prepare_file_travis.py
 grep "\[" travis-tests.ini >> travis_matrix_elements.txt
 WARPX_CI_SINGLE_PRECISION=TRUE  python prepare_file_travis.py
@@ -32,7 +33,7 @@ grep "\[" travis-tests.ini >> travis_matrix_elements.txt
         echo "test passed" &&
         exit 0
 } || {
-    rm travis_all_tests.txt travis_matrix_elements.txt travis_matrix.py &&
+        rm travis_all_tests.txt travis_matrix_elements.txt travis_matrix.py &&
         echo "tests failed" &&
         exit 1
 }

--- a/.github/workflows/source/travis_matrix.py
+++ b/.github/workflows/source/travis_matrix.py
@@ -23,4 +23,4 @@ print(list(set(matrix_elements) - set(all_tests)))
 print("Tests in initial list but not in the matrix:")
 print(list(set(all_tests) - set(matrix_elements)))
 
-assert( matrix_elements == all_tests )
+assert( set(matrix_elements) == set(all_tests) )

--- a/.github/workflows/source/travis_matrix.py
+++ b/.github/workflows/source/travis_matrix.py
@@ -23,4 +23,4 @@ print(list(set(matrix_elements) - set(all_tests)))
 print("Tests in initial list but not in the matrix:")
 print(list(set(all_tests) - set(matrix_elements)))
 
-assert( set(matrix_elements) == set(all_tests) )
+assert( matrix_elements == all_tests )

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -53,6 +53,13 @@ if ci_openpmd:
     text = re.sub('addToCompileString =',
                   'addToCompileString = USE_OPENPMD=TRUE ', text)
 
+# always build with PSATD support (runtime controlled if used)
+if ci_psatd:
+    text = re.sub('addToCompileString =',
+                  'addToCompileString = USE_PSATD=TRUE ', text)
+    text = re.sub('USE_PSATD=FALSE',
+                  '', text)
+
 # Ccache
 if ci_ccache:
     text = re.sub('addToCompileString =',
@@ -102,7 +109,6 @@ def select_tests(blocks, match_string_list, do_test):
 if ci_regular_cartesian_2d:
     test_blocks = select_tests(test_blocks, ['dim = 2'], True)
     test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
@@ -111,18 +117,10 @@ if ci_regular_cartesian_2d:
 if ci_regular_cartesian_3d:
     test_blocks = select_tests(test_blocks, ['dim = 2'], False)
     test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
-
-if ci_psatd:
-    test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], True)
-    # Remove PSATD single-precision, which is done in ci_single_precision
-    test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT'], False)
-    # Remove PSATD RZ, which is done in ci_rz_or_nompi
-    test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
 
 if ci_python_main:
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], True)

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -87,22 +87,22 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             amrex::Real const * stencil_coeffs_z = WarpX::device_centering_stencil_coeffs_z.data();
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
             {
-                warpx_interp(j, k, l, bx_aux, bx_fp, Bx_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, bx_aux, bx_fp, Bx_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 
-                warpx_interp(j, k, l, by_aux, by_fp, By_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, by_aux, by_fp, By_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 
-                warpx_interp(j, k, l, bz_aux, bz_fp, Bz_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, bz_aux, bz_fp, Bz_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 
-                warpx_interp(j, k, l, ex_aux, ex_fp, Ex_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, ex_aux, ex_fp, Ex_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 
-                warpx_interp(j, k, l, ey_aux, ey_fp, Ey_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, ey_aux, ey_fp, Ey_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 
-                warpx_interp(j, k, l, ez_aux, ez_fp, Ez_stag, fg_nox, fg_noy, fg_noz,
+                warpx_interp<true>(j, k, l, ez_aux, ez_fp, Ez_stag, fg_nox, fg_noy, fg_noz,
                              stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
             });
 #endif

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -506,6 +506,7 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
  * \param[in] stencil_coeffs_y array of ordered Fornberg coefficients for finite-order interpolation stencil along y
  * \param[in] stencil_coeffs_z array of ordered Fornberg coefficients for finite-order interpolation stencil along z
  */
+template< bool IS_PSATD = false >
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp (const int j,
                    const int k,
@@ -590,85 +591,83 @@ void warpx_interp (const int j,
 
     amrex::Real res = 0.0_rt;
 
-#ifndef WARPX_USE_PSATD // FDTD (linear interpolation)
+    // FDTD (linear interpolation)
+    if( !IS_PSATD ) {
+        // Example of 1D linear interpolation from nodal grid to nodal grid:
+        //
+        //         j
+        // --o-----o-----o--  result(j) = f(j)
+        // --o-----o-----o--
+        //  j-1    j    j+1
+        //
+        // Example of 1D linear interpolation from staggered grid to nodal grid:
+        //
+        //         j
+        // --o-----o-----o--  result(j) = (f(j-1) + f(j)) / 2
+        // -----x-----x-----
+        //     j-1    j
 
-    // Example of 1D linear interpolation from nodal grid to nodal grid:
-    //
-    //         j
-    // --o-----o-----o--  result(j) = f(j)
-    // --o-----o-----o--
-    //  j-1    j    j+1
-    //
-    // Example of 1D linear interpolation from staggered grid to nodal grid:
-    //
-    //         j
-    // --o-----o-----o--  result(j) = (f(j-1) + f(j)) / 2
-    // -----x-----x-----
-    //     j-1    j
-
-    for (int ll = lmin; ll <= lmax; ll++)
-    {
-        for (int kk = kmin; kk <= kmax; kk++)
+        for (int ll = lmin; ll <= lmax; ll++)
         {
-            for (int jj = jmin; jj <= jmax; jj++)
+            for (int kk = kmin; kk <= kmax; kk++)
             {
-                res += src_arr_zeropad(jj,kk,ll);
+                for (int jj = jmin; jj <= jmax; jj++)
+                {
+                    res += src_arr_zeropad(jj,kk,ll);
+                }
             }
         }
-    }
+    // PSATD (finite-order interpolation)
+    } else {
+        const int nj = jmax - jmin;
+        const int nk = kmax - kmin;
+        const int nl = lmax - lmin;
 
-#else // PSATD (finite-order interpolation)
+        amrex::Real cj = 1.0_rt;
+        amrex::Real ck = 1.0_rt;
+        amrex::Real cl = 1.0_rt;
 
-    const int nj = jmax - jmin;
-    const int nk = kmax - kmin;
-    const int nl = lmax - lmin;
-
-    amrex::Real cj = 1.0_rt;
-    amrex::Real ck = 1.0_rt;
-    amrex::Real cl = 1.0_rt;
-
-    amrex::Real const* scj = stencil_coeffs_x;
-#if   (AMREX_SPACEDIM == 2)
-    amrex::Real const* sck = stencil_coeffs_z;
+        amrex::Real const* scj = stencil_coeffs_x;
+#if (AMREX_SPACEDIM == 2)
+        amrex::Real const* sck = stencil_coeffs_z;
 #elif (AMREX_SPACEDIM == 3)
-    amrex::Real const* sck = stencil_coeffs_y;
-    amrex::Real const* scl = stencil_coeffs_z;
+        amrex::Real const* sck = stencil_coeffs_y;
+        amrex::Real const* scl = stencil_coeffs_z;
 #endif
 
-    // Example of 1D finite-order interpolation from nodal grid to nodal grid:
-    //
-    //         j
-    // --o-----o-----o--  result(j) = f(j)
-    // --o-----o-----o--
-    //  j-1    j    j+1
-    //
-    // Example of 1D finite-order interpolation from staggered grid to nodal grid:
-    //
-    //                     j
-    // --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
-    // -----x-----x-----x-----x-----x-----x-----            + c_1 * (f(j-2) + f(j+1)) / 2
-    //     j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
-    //     c_2   c_1   c_0   c_0   c_1   c_2                + ...
+        // Example of 1D finite-order interpolation from nodal grid to nodal grid:
+        //
+        //         j
+        // --o-----o-----o--  result(j) = f(j)
+        // --o-----o-----o--
+        //  j-1    j    j+1
+        //
+        // Example of 1D finite-order interpolation from staggered grid to nodal grid:
+        //
+        //                     j
+        // --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
+        // -----x-----x-----x-----x-----x-----x-----            + c_1 * (f(j-2) + f(j+1)) / 2
+        //     j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
+        //     c_2   c_1   c_0   c_0   c_1   c_2                + ...
 
-    for (int ll = 0; ll <= nl; ll++)
-    {
-#if (AMREX_SPACEDIM == 3)
-        if (interp_l) cl = scl[ll];
-#endif
-        for (int kk = 0; kk <= nk; kk++)
+        for (int ll = 0; ll <= nl; ll++)
         {
-            if (interp_k) ck = sck[kk];
-
-            for (int jj = 0; jj <= nj; jj++)
+#if (AMREX_SPACEDIM == 3)
+            if (interp_l) cl = scl[ll];
+#endif
+            for (int kk = 0; kk <= nk; kk++)
             {
-                if (interp_j) cj = scj[jj];
+                if (interp_k) ck = sck[kk];
 
-                res += cj * ck * cl * src_arr_zeropad(jmin+jj,kmin+kk,lmin+ll);
+                for (int jj = 0; jj <= nj; jj++)
+                {
+                    if (interp_j) cj = scj[jj];
+
+                    res += cj * ck * cl * src_arr_zeropad(jmin+jj,kmin+kk,lmin+ll);
+                }
             }
         }
-    }
-
-#endif // PSATD (finite-order interpolation)
+    } // PSATD (finite-order interpolation)
 
     dst_arr(j,k,l) = wj * wk * wl * res;
 }


### PR DESCRIPTION
Reduce CI time by always building with FFTW and unifying PSATD tests in the regular matrix elements.

This also adds coverage for the case that we forget to make `#ifdef WARPX_USE_PSATD` runtime blocks (e.g. #1588), which can potentially be seen in FDTD runs now.

- [x] rebase after #1588 was merged
- [x] verify all tests are still run: number/names of tests run before / after per matrix entry