### PR TITLE
Fix: PSATD Comm. Runtime Switch (FDTD)

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -80,9 +80,9 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             "WarpX build with spectral solver support.");
     }
 #else
-    amrex::Real const * p_stencil_coef_x = nullptr;
-    amrex::Real const * p_stencil_coef_y = nullptr;
-    amrex::Real const * p_stencil_coef_z = nullptr;
+    amrex::Gpu::DeviceVector<Real> d_stencil_coef_x;
+    amrex::Gpu::DeviceVector<Real> d_stencil_coef_y;
+    amrex::Gpu::DeviceVector<Real> d_stencil_coef_z;
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         const int fg_nox = WarpX::field_gathering_nox;
         const int fg_noy = WarpX::field_gathering_noy;
@@ -90,33 +90,29 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 
         // Compute real-space stencil coefficients along x
         amrex::Vector<Real> h_stencil_coef_x = getFornbergStencilCoefficients(fg_nox, false);
-        amrex::Gpu::DeviceVector<Real> d_stencil_coef_x(h_stencil_coef_x.size());
+        d_stencil_coef_x.resize(h_stencil_coef_x.size());
         amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                               h_stencil_coef_x.begin(),
                               h_stencil_coef_x.end(),
                               d_stencil_coef_x.begin());
-        amrex::Gpu::synchronize();
-        p_stencil_coef_x = d_stencil_coef_x.data();
 
         // Compute real-space stencil coefficients along y
         amrex::Vector<Real> h_stencil_coef_y = getFornbergStencilCoefficients(fg_noy, false);
-        amrex::Gpu::DeviceVector<Real> d_stencil_coef_y(h_stencil_coef_y.size());
+        d_stencil_coef_y.resize(h_stencil_coef_y.size());
         amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                               h_stencil_coef_y.begin(),
                               h_stencil_coef_y.end(),
                               d_stencil_coef_y.begin());
-        amrex::Gpu::synchronize();
-        p_stencil_coef_y = d_stencil_coef_y.data();
 
         // Compute real-space stencil coefficients along z
         amrex::Vector<Real> h_stencil_coef_z = getFornbergStencilCoefficients(fg_noz, false);
-        amrex::Gpu::DeviceVector<Real> d_stencil_coef_z(h_stencil_coef_z.size());
+        d_stencil_coef_z.resize(h_stencil_coef_z.size());
         amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                               h_stencil_coef_z.begin(),
                               h_stencil_coef_z.end(),
                               d_stencil_coef_z.begin());
+
         amrex::Gpu::synchronize();
-        p_stencil_coef_z = d_stencil_coef_z.data();
     }
 #endif
 
@@ -153,12 +149,12 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             const int fg_noz = WarpX::field_gathering_noz;
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
             {
-                warpx_interp_nd_bfield_x(j,k,l, bx_aux, bx_fp, fg_noy, fg_noz, p_stencil_coef_y, p_stencil_coef_z);
-                warpx_interp_nd_bfield_y(j,k,l, by_aux, by_fp, fg_nox, fg_noz, p_stencil_coef_x, p_stencil_coef_z);
-                warpx_interp_nd_bfield_z(j,k,l, bz_aux, bz_fp, fg_nox, fg_noy, p_stencil_coef_x, p_stencil_coef_y);
-                warpx_interp_nd_efield_x(j,k,l, ex_aux, ex_fp, fg_nox, p_stencil_coef_x);
-                warpx_interp_nd_efield_y(j,k,l, ey_aux, ey_fp, fg_noy, p_stencil_coef_y);
-                warpx_interp_nd_efield_z(j,k,l, ez_aux, ez_fp, fg_noz, p_stencil_coef_z);
+                warpx_interp_nd_bfield_x(j,k,l, bx_aux, bx_fp, fg_noy, fg_noz, d_stencil_coef_y.data(), d_stencil_coef_z.data());
+                warpx_interp_nd_bfield_y(j,k,l, by_aux, by_fp, fg_nox, fg_noz, d_stencil_coef_x.data(), d_stencil_coef_z.data());
+                warpx_interp_nd_bfield_z(j,k,l, bz_aux, bz_fp, fg_nox, fg_noy, d_stencil_coef_x.data(), d_stencil_coef_y.data());
+                warpx_interp_nd_efield_x(j,k,l, ex_aux, ex_fp, fg_nox, d_stencil_coef_x.data());
+                warpx_interp_nd_efield_y(j,k,l, ey_aux, ey_fp, fg_noy, d_stencil_coef_y.data());
+                warpx_interp_nd_efield_z(j,k,l, ez_aux, ez_fp, fg_noz, d_stencil_coef_z.data());
             });
 #endif
         } else { // FDTD

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -381,7 +381,6 @@ void warpx_interp_nd_bfield_z (int j, int k, int l,
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Bx field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_x (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bxa,
@@ -398,7 +397,6 @@ void warpx_interp_nd_bfield_x (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the Bx field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_x (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bxa,
@@ -428,12 +426,10 @@ void warpx_interp_nd_bfield_x (int j, int k, int l,
     Bxa(j,k,l) = res;
 #endif
 }
-#endif
 
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the By field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_y (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bya,
@@ -450,7 +446,6 @@ void warpx_interp_nd_bfield_y (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the By field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_y (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bya,
@@ -482,12 +477,10 @@ void warpx_interp_nd_bfield_y (int j, int k, int l,
     Bya(j,k,l) = res;
 #endif
 }
-#endif
 
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Bz field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_z (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bza,
@@ -504,7 +497,6 @@ void warpx_interp_nd_bfield_z (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the Bz field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_bfield_z (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Bza,
@@ -534,7 +526,6 @@ void warpx_interp_nd_bfield_z (int j, int k, int l,
     Bza(j,k,l) = res;
 #endif
 }
-#endif
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_x (int j, int k, int l,
@@ -743,7 +734,6 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Ex field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_x (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Exa,
@@ -755,7 +745,6 @@ void warpx_interp_nd_efield_x (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the Ex field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_x (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Exa,
@@ -769,12 +758,10 @@ void warpx_interp_nd_efield_x (int j, int k, int l,
     }
     Exa(j,k,l) = res;
 }
-#endif
 
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Ey field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_y (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Eya,
@@ -791,7 +778,6 @@ void warpx_interp_nd_efield_y (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the Ey field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_y (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Eya,
@@ -811,12 +797,10 @@ void warpx_interp_nd_efield_y (int j, int k, int l,
     Eya(j,k,l) = res;
 #endif
 }
-#endif
 
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Ez field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#ifndef WARPX_USE_PSATD
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_z (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Eza,
@@ -833,7 +817,6 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
 // interpolate the Ez field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
-#else
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_z (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Eza,
@@ -855,6 +838,5 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
     Eza(j,k,l) = res;
 #endif
 }
-#endif
 
 #endif

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -342,6 +342,11 @@ WarpX::ReadParameters ()
     }
 
     {
+        ParmParse pp("algo");
+        maxwell_solver_id = GetAlgorithmInteger(pp, "maxwell_solver");
+    }
+
+    {
         ParmParse pp("warpx");
 
         std::vector<int> numprocs_in;
@@ -620,7 +625,6 @@ WarpX::ReadParameters ()
 
     {
         ParmParse pp("algo");
-        maxwell_solver_id = GetAlgorithmInteger(pp, "maxwell_solver");
 #ifdef WARPX_DIM_RZ
         if (maxwell_solver_id == MaxwellSolverAlgo::CKC) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -494,10 +494,12 @@ WarpX::ReadParameters ()
         filter_npass_each_dir[2] = parse_filter_npass_each_dir[2];
 #endif
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
-        // With RZ spectral, only use k-space filtering
-        use_kspace_filter = use_filter;
-        use_filter = false;
+#ifdef WARPX_DIM_RZ
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+            // With RZ spectral, only use k-space filtering
+            use_kspace_filter = use_filter;
+            use_filter = false;
+        }
 #endif
 
         pp.query("num_mirrors", num_mirrors);
@@ -670,18 +672,20 @@ WarpX::ReadParameters ()
         pp.query("noz", noz);
 
 #ifdef WARPX_USE_PSATD
-        // For momentum-conserving field gathering, read from input the order of
-        // interpolation from the staggered positions to the grid nodes
-        if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
-            pp.query("field_gathering_nox", field_gathering_nox);
-            pp.query("field_gathering_noy", field_gathering_noy);
-            pp.query("field_gathering_noz", field_gathering_noz);
-        }
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+            // For momentum-conserving field gathering, read from input the order of
+            // interpolation from the staggered positions to the grid nodes
+            if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
+                pp.query("field_gathering_nox", field_gathering_nox);
+                pp.query("field_gathering_noy", field_gathering_noy);
+                pp.query("field_gathering_noz", field_gathering_noz);
+            }
 
-        if (maxLevel() > 0) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                field_gathering_nox == 2 && field_gathering_noy == 2 && field_gathering_noz == 2,
-                "High-order interpolation (order > 2) is not implemented with mesh refinement");
+            if (maxLevel() > 0) {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    field_gathering_nox == 2 && field_gathering_noy == 2 && field_gathering_noz == 2,
+                    "High-order interpolation (order > 2) is not implemented with mesh refinement");
+            }
         }
 #endif
 
@@ -1069,12 +1073,11 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     Efield_avg_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE);
     Efield_avg_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE);
 
-#ifdef WARPX_USE_PSATD
-    const bool deposit_charge = do_dive_cleaning || (plot_rho && do_back_transformed_diagnostics)
-                                || update_with_rho || current_correction;
-#else
-    const bool deposit_charge = do_dive_cleaning || (plot_rho && do_back_transformed_diagnostics);
-#endif
+    bool deposit_charge = do_dive_cleaning || (plot_rho && do_back_transformed_diagnostics);
+    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        deposit_charge = do_dive_cleaning || (plot_rho && do_back_transformed_diagnostics)
+                         || update_with_rho || current_correction;
+    }
     if (deposit_charge)
     {
         rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,2*ncomps,ngRho);
@@ -1097,11 +1100,6 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     {
         F_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()),dm,ncomps, ngF.max());
     }
-#ifdef WARPX_USE_PSATD
-#   ifndef WARPX_DIM_RZ
-    bool const pml_flag_false = false;
-#   endif
-#endif
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
     {
         // Allocate and initialize the spectral solver
@@ -1148,6 +1146,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         if ( fft_periodic_single_box == false ) {
             realspace_ba.grow(ngE); // add guard cells
         }
+        bool const pml_flag_false = false;
         spectral_solver_fp[lev] = std::make_unique<SpectralSolver>( realspace_ba, dm,
             nox_fft, noy_fft, noz_fft, do_nodal, m_v_galilean, m_v_comoving, dx_vect, dt[lev],
             pml_flag_false, fft_periodic_single_box, update_with_rho, fft_do_time_averaging );
@@ -1273,6 +1272,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             }
 #   else
             c_realspace_ba.grow(ngE); // add guard cells
+            bool const pml_flag_false = false;
             spectral_solver_cp[lev] = std::make_unique<SpectralSolver>( c_realspace_ba, dm,
                 nox_fft, noy_fft, noz_fft, do_nodal, m_v_galilean, m_v_comoving, cdx_vect, dt[lev],
                 pml_flag_false, fft_periodic_single_box, update_with_rho, fft_do_time_averaging );


### PR DESCRIPTION
Fix a missing PSATD runtime conversion in communication. Follow-up to #1300.

This switch could have potentially influenced FDTD simulations if PSATD was compiled but not used. Coverage will be fixed for CI in #1587.

Spotted by @dpgrote - thank you!