### PR TITLE
[WIP] Implement PSATD time-averaging on a per-species basis

### DIFF
--- a/Examples/Tests/averaged_galilean/inputs_avg_2d
+++ b/Examples/Tests/averaged_galilean/inputs_avg_2d
@@ -9,8 +9,6 @@ amr.blocking_factor = 128
 amr.max_level = 0
 psatd.v_galilean = 0 0 -0.99498743710662
 
-psatd.do_time_averaging  = 1
-
 geometry.coord_sys   = 0
 geometry.is_periodic = 1 1
 
@@ -59,6 +57,7 @@ electrons.zmax =  49.5104
 electrons.ux_th = 1e-4
 electrons.uy_th = 1e-4
 electrons.uz_th = 1e-4
+electrons.psatd_time_averaging  = 1
 
 ions.charge = q_e
 ions.mass = m_p
@@ -75,6 +74,7 @@ ions.zmax = 49.5104
 ions.ux_th = 1e-4
 ions.uy_th = 1e-4
 ions.uz_th = 1e-4
+ions.psatd_time_averaging  = 1
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/averaged_galilean/inputs_avg_3d
+++ b/Examples/Tests/averaged_galilean/inputs_avg_3d
@@ -59,6 +59,7 @@ electrons.zmax =   19.34
 electrons.ux_th = 0.0001
 electrons.uy_th = 0.0001
 electrons.uz_th = 0.0001
+electrons.psatd_time_averaging = 1
 
 ions.charge = q_e
 ions.mass = m_p
@@ -77,6 +78,7 @@ ions.zmax = 19.34
 ions.ux_th = 0.0001
 ions.uy_th = 0.0001
 ions.uz_th = 0.0001
+ions.psatd_time_averaging = 1
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -105,6 +105,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     pp.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
     pp.query("do_backward_propagation", do_backward_propagation);
+    pp.query("psatd_time_averaging", m_psatd_time_averaging);
 
     // Initialize splitting
     pp.query("do_splitting", do_splitting);
@@ -994,12 +995,12 @@ PhysicalParticleContainer::Evolve (int lev,
             const long np = pti.numParticles();
 
             // Data on the grid
-            FArrayBox const* exfab = WarpX::fft_do_time_averaging ? &(Ex_avg[pti]) : &(Ex[pti]);
-            FArrayBox const* eyfab = WarpX::fft_do_time_averaging ? &(Ey_avg[pti]) : &(Ey[pti]);
-            FArrayBox const* ezfab = WarpX::fft_do_time_averaging ? &(Ez_avg[pti]) : &(Ez[pti]);
-            FArrayBox const* bxfab = WarpX::fft_do_time_averaging ? &(Bx_avg[pti]) : &(Bx[pti]);
-            FArrayBox const* byfab = WarpX::fft_do_time_averaging ? &(By_avg[pti]) : &(By[pti]);
-            FArrayBox const* bzfab = WarpX::fft_do_time_averaging ? &(Bz_avg[pti]) : &(Bz[pti]);
+            FArrayBox const* exfab = m_psatd_time_averaging ? &(Ex_avg[pti]) : &(Ex[pti]);
+            FArrayBox const* eyfab = m_psatd_time_averaging ? &(Ey_avg[pti]) : &(Ey[pti]);
+            FArrayBox const* ezfab = m_psatd_time_averaging ? &(Ez_avg[pti]) : &(Ez[pti]);
+            FArrayBox const* bxfab = m_psatd_time_averaging ? &(Bx_avg[pti]) : &(Bx[pti]);
+            FArrayBox const* byfab = m_psatd_time_averaging ? &(By_avg[pti]) : &(By[pti]);
+            FArrayBox const* bzfab = m_psatd_time_averaging ? &(Bz_avg[pti]) : &(Bz[pti]);
 
             Elixir exeli, eyeli, ezeli, bxeli, byeli, bzeli;
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -366,6 +366,8 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
+    bool m_psatd_time_averaging = false;
+
     int do_not_push = 0;
     int do_not_deposit = 0;
     int do_not_gather = 0;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -745,7 +745,21 @@ WarpX::ReadParameters ()
         pp.query("current_correction", current_correction);
         pp.query("v_galilean", m_v_galilean);
         pp.query("v_comoving", m_v_comoving);
-        pp.query("do_time_averaging", fft_do_time_averaging);
+        // Check if PSATD time averaging should be used
+        {
+            // Loop through particle species
+            std::vector<std::string> species_names;
+            ParmParse p_species_names("particles");
+            p_species_names.queryarr("species_names", species_names);
+            for (auto const& name : species_names) {
+                // By default fft_do_time_averaging is false
+                // if any particle species has psatd_time_averaging=1
+                // then fft_do_time_averaging becomes true and the loop stops
+                ParmParse p_species(name);
+                p_species.query("psatd_time_averaging", fft_do_time_averaging);
+                if (fft_do_time_averaging) break;
+            }
+        }
 
         // Scale the velocity by the speed of light
         for (int i=0; i<3; i++) m_v_galilean[i] *= PhysConst::c;


### PR DESCRIPTION
Remains to be done:
- [ ] Edit the documentation accordingly
- [ ] Raise error when user tries to use the deprecated parameter `do_time_averaging`
- [ ] Ignore the flag `psatd_time_averaging` when the solver is not PSATD