### PR TITLE
Handle units properly in the particle filter function.

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -268,7 +268,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
-        amrex::ParticleContainer<0, 0, PIdx::nattribs> tmp(pc->GetParGDB());
+        PhysicalParticleContainer tmp(&WarpX::GetInstance());
         Vector<std::string> real_names;
         Vector<std::string> int_names;
         Vector<int> int_flags;
@@ -304,16 +304,12 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         }
 #endif
 
-        // Convert momentum to SI
-        pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
-
         RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
-        ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
-                                   getParser(particle_diags[i].m_particle_filter_parser));
-        parser_filter.m_units = InputUnits::SI;
+        ParserFilter const parser_filter(particle_diags[i].m_do_parser_filter,
+                                         getParser(particle_diags[i].m_particle_filter_parser));
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
 
@@ -326,15 +322,15 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                 * parser_filter(p, engine) * geometry_filter(p, engine);
         }, true);
 
+        // Convert momentum to SI
+        tmp.ConvertUnits(ConvertDirection::WarpX_to_SI);
+
         // real_names contains a list of all particle attributes.
         // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
             dir, particle_diags[i].getSpeciesName(),
             particle_diags[i].plot_flags, int_flags,
             real_names, int_names);
-
-        // Convert momentum back to WarpX units
-        pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
     }
 }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -268,7 +268,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
-        amrex::ParticleContainer<0, 0, PIdx::nattribs> tmp(pc->GetParGDB());
+        PhysicalParticleContainer tmp(&WarpX::GetInstance());
         Vector<std::string> real_names;
         Vector<std::string> int_names;
         Vector<int> int_flags;
@@ -304,15 +304,13 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         }
 #endif
 
-        // Convert momentum to SI
-        pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
-
         RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
         ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
-                                   getParser(particle_diags[i].m_particle_filter_parser));
+                                   getParser(particle_diags[i].m_particle_filter_parser),
+                                   pc->getMass());
         parser_filter.m_units = InputUnits::SI;
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
@@ -326,15 +324,15 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                 * parser_filter(p, engine) * geometry_filter(p, engine);
         }, true);
 
+        // Convert momentum to SI
+        tmp.ConvertUnits(ConvertDirection::WarpX_to_SI);
+
         // real_names contains a list of all particle attributes.
         // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
             dir, particle_diags[i].getSpeciesName(),
             particle_diags[i].plot_flags, int_flags,
             real_names, int_names);
-
-        // Convert momentum back to WarpX units
-        pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
     }
 }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -311,9 +311,9 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
-        ParserFilter const parser_filter(particle_diags[i].m_do_parser_filter,
-                                         getParser(particle_diags[i].m_particle_filter_parser),
-                                         pc->getMass(), InputUnits::SI);
+        ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
+                                   getParser(particle_diags[i].m_particle_filter_parser));
+        parser_filter.m_units = InputUnits::SI;
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -268,7 +268,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
-        PhysicalParticleContainer tmp(&WarpX::GetInstance());
+        amrex::ParticleContainer<0, 0, PIdx::nattribs> tmp(pc->GetParGDB());
         Vector<std::string> real_names;
         Vector<std::string> int_names;
         Vector<int> int_flags;
@@ -304,6 +304,9 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         }
 #endif
 
+        // Convert momentum to SI
+        pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
+
         RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
@@ -323,15 +326,15 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                 * parser_filter(p, engine) * geometry_filter(p, engine);
         }, true);
 
-        // Convert momentum to SI
-        tmp.ConvertUnits(ConvertDirection::WarpX_to_SI);
-
         // real_names contains a list of all particle attributes.
         // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
             dir, particle_diags[i].getSpeciesName(),
             particle_diags[i].plot_flags, int_flags,
             real_names, int_names);
+
+        // Convert momentum back to WarpX units
+        pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
     }
 }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -311,9 +311,9 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
-        ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
-                                   getParser(particle_diags[i].m_particle_filter_parser));
-        parser_filter.m_units = InputUnits::SI;
+        ParserFilter const parser_filter(particle_diags[i].m_do_parser_filter,
+                                         getParser(particle_diags[i].m_particle_filter_parser),
+                                         pc->getMass(), InputUnits::SI);
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -304,6 +304,8 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         }
 #endif
 
+        pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
+
         RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
@@ -324,15 +326,14 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                 * parser_filter(p, engine) * geometry_filter(p, engine);
         }, true);
 
-        // Convert momentum to SI
-        tmp.ConvertUnits(ConvertDirection::WarpX_to_SI);
-
         // real_names contains a list of all particle attributes.
         // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
             dir, particle_diags[i].getSpeciesName(),
             particle_diags[i].plot_flags, int_flags,
             real_names, int_names);
+
+        pc->ConvertUnits(ConvertDirection::SI_to_WarpX);
     }
 }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -311,8 +311,9 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
-        ParserFilter const parser_filter(particle_diags[i].m_do_parser_filter,
-                                         getParser(particle_diags[i].m_particle_filter_parser));
+        ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
+                                   getParser(particle_diags[i].m_particle_filter_parser));
+        parser_filter.m_units = InputUnits::SI;
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
 

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -89,11 +89,12 @@ struct ParserFilter
     /** constructor
      * \param a_is_active whether the test is active
      */
-    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser)
-        : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
+    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser,
+                 amrex::Real a_mass, InputUnits a_units)
+        : m_is_active(a_is_active), m_function_partparser(a_filter_parser),
+          m_mass(a_mass), m_units(a_units)
     {
         m_t = WarpX::GetInstance().gett_new(0);
-        m_units = InputUnits::WarpX;
     }
 
     /**
@@ -108,14 +109,14 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real ux = p.rdata(PIdx::ux);
-        amrex::Real uy = p.rdata(PIdx::uy);
-        amrex::Real uz = p.rdata(PIdx::uz);
-        if (m_units == InputUnits::WarpX)
+        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
+        if (m_units == InputUnits::SI)
         {
-            ux /= PhysConst::c;
-            uy /= PhysConst::c;
-            uz /= PhysConst::c;
+            ux /= m_mass;
+            uy /= m_mass;
+            uz /= m_mass;
         }
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
@@ -128,6 +129,8 @@ public:
     HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
+    /** The mass of the particle species. */
+    amrex::Real m_mass;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;
 };

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -17,13 +17,6 @@
 using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
 
 /**
- *  \brief Used to keep track of what inputs units a filter function should expect.
- *         "WarpX units" means the momentum is "gamma*v"
- *         "SI" means the momentum is mass*gamma*v.
- */
-enum struct InputUnits{WarpX, SI};
-
-/**
  * \brief Functor that returns 0 or 1 depending on a random draw per particle
  */
 struct RandomFilter
@@ -93,7 +86,6 @@ struct ParserFilter
         : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
     {
         m_t = WarpX::GetInstance().gett_new(0);
-        m_units = InputUnits::WarpX;
     }
 
     /**
@@ -108,15 +100,9 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real ux = p.rdata(PIdx::ux);
-        amrex::Real uy = p.rdata(PIdx::uy);
-        amrex::Real uz = p.rdata(PIdx::uz);
-        if (m_units == InputUnits::WarpX)
-        {
-            ux /= PhysConst::c;
-            uy /= PhysConst::c;
-            uz /= PhysConst::c;
-        }
+        amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
     }
@@ -128,8 +114,6 @@ public:
     HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
-    /** keep track of momentum units particles will come in with **/
-    InputUnits m_units;
 };
 
 

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -17,6 +17,13 @@
 using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
 
 /**
+ *  \brief Used to keep track of what inputs units a filter function should expect.
+ *         "WarpX units" means the momentum is "gamma*v"
+ *         "SI" means the momentum is mass*gamma*v.
+ */
+enum struct InputUnits{WarpX, SI};
+
+/**
  * \brief Functor that returns 0 or 1 depending on a random draw per particle
  */
 struct RandomFilter
@@ -86,6 +93,7 @@ struct ParserFilter
         : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
     {
         m_t = WarpX::GetInstance().gett_new(0);
+        m_units = InputUnits::WarpX;
     }
 
     /**
@@ -100,9 +108,15 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
-        amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
-        amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
+        amrex::Real ux = p.rdata(PIdx::ux);
+        amrex::Real uy = p.rdata(PIdx::uy);
+        amrex::Real uz = p.rdata(PIdx::uz);
+        if (m_units == InputUnits::WarpX)
+        {
+            ux /= PhysConst::c;
+            uy /= PhysConst::c;
+            uz /= PhysConst::c;
+        }
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
     }
@@ -114,6 +128,8 @@ public:
     HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
+    /** keep track of momentum units particles will come in with **/
+    InputUnits m_units;
 };
 
 

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -102,9 +102,9 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
-        amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
-        amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
+        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
         if (m_units == InputUnits::SI)
         {
             ux /= m_mass;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -89,12 +89,11 @@ struct ParserFilter
     /** constructor
      * \param a_is_active whether the test is active
      */
-    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser,
-                 amrex::Real a_mass, InputUnits a_units)
-        : m_is_active(a_is_active), m_function_partparser(a_filter_parser),
-          m_mass(a_mass), m_units(a_units)
+    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser)
+        : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
     {
         m_t = WarpX::GetInstance().gett_new(0);
+        m_units = InputUnits::WarpX;
     }
 
     /**
@@ -109,14 +108,14 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
-        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
-        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
-        if (m_units == InputUnits::SI)
+        amrex::Real ux = p.rdata(PIdx::ux);
+        amrex::Real uy = p.rdata(PIdx::uy);
+        amrex::Real uz = p.rdata(PIdx::uz);
+        if (m_units == InputUnits::WarpX)
         {
-            ux /= m_mass;
-            uy /= m_mass;
-            uz /= m_mass;
+            ux /= PhysConst::c;
+            uy /= PhysConst::c;
+            uz /= PhysConst::c;
         }
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
@@ -129,8 +128,6 @@ public:
     HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
-    /** The mass of the particle species. */
-    amrex::Real m_mass;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;
 };

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -17,6 +17,13 @@
 using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
 
 /**
+ *  \brief Used to keep track of what inputs units a filter function should expect.
+ *         "WarpX units" means the momentum is "gamma*v"
+ *         "SI" means the momentum is mass*gamma*v.
+ */
+enum struct InputUnits{WarpX, SI};
+
+/**
  * \brief Functor that returns 0 or 1 depending on a random draw per particle
  */
 struct RandomFilter
@@ -102,9 +109,9 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
-        amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
-        amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
+        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
         if (m_units == InputUnits::SI)
         {
             ux /= m_mass;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -89,8 +89,8 @@ struct ParserFilter
     /** constructor
      * \param a_is_active whether the test is active
      */
-    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser)
-        : m_is_active(a_is_active), m_function_partparser(a_filter_parser)
+    ParserFilter(bool a_is_active, HostDeviceParser<7> const& a_filter_parser, amrex::Real a_mass)
+        : m_is_active(a_is_active), m_function_partparser(a_filter_parser), m_mass(a_mass)
     {
         m_t = WarpX::GetInstance().gett_new(0);
         m_units = InputUnits::WarpX;
@@ -108,14 +108,14 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real ux = p.rdata(PIdx::ux);
-        amrex::Real uy = p.rdata(PIdx::uy);
-        amrex::Real uz = p.rdata(PIdx::uz);
-        if (m_units == InputUnits::WarpX)
+        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
+        if (m_units == InputUnits::SI)
         {
-            ux /= PhysConst::c;
-            uy /= PhysConst::c;
-            uz /= PhysConst::c;
+            ux /= m_mass;
+            uy /= m_mass;
+            uz /= m_mass;
         }
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
@@ -128,6 +128,8 @@ public:
     HostDeviceParser<7> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
+    /** Mass of particle species */
+    amrex::Real m_mass;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;
 };

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -102,9 +102,9 @@ struct ParserFilter
         amrex::Real const x  = p.pos(0);
         amrex::Real const y  = p.pos(1);
         amrex::Real const z  = p.pos(2);
-        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
-        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
-        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
+        amrex::Real const ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real const uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real const uz = p.rdata(PIdx::uz)/PhysConst::c;
         if (m_units == InputUnits::SI)
         {
             ux /= m_mass;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -18,7 +18,7 @@ using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
 
 /**
  *  \brief Used to keep track of what inputs units a filter function should expect.
- *         "WarpX units" means the momentum is "gamma*v"
+ *         "WarpX units" means the momentum is "gamma*v" (aka proper velocity)
  *         "SI" means the momentum is mass*gamma*v.
  */
 enum struct InputUnits{WarpX, SI};
@@ -117,6 +117,7 @@ struct ParserFilter
             uy /= m_mass;
             uz /= m_mass;
         }
+        // ux, uy, uz are now in beta*gamma
         if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
         else return 0;
     }


### PR DESCRIPTION
After this change, the particle filter function read through the parser will work in "normalized" units, as parser functions do in other contexts in WarpX.

Fix #1574