### PR TITLE
Cori: Newer CMake

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -103,7 +103,7 @@ First, load the appropriate modules:
 
    module swap craype-haswell craype-mic-knl
    module swap PrgEnv-intel PrgEnv-gnu
-   module load cmake/3.14.4
+   module load cmake/3.18.2
    module load cray-hdf5-parallel
    module load adios2/2.5.0
 


### PR DESCRIPTION
Use a newer CMake on Cori.

Needed by upcoming openPMD-api releases (and provides solid new `FindPython.cmake` support that goes brrrr).