### PR TITLE
openPMD-api: 0.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.14.0)
+cmake_minimum_required(VERSION 3.15.0)
 project(WarpX VERSION 0.20.5)
 
 include(${WarpX_SOURCE_DIR}/cmake/WarpXFunctions.cmake)

--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -22,7 +22,7 @@ WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`_ compiler: e.g. GCC 5, Clang 3.6 or newer
-- `CMake 3.14.0+ <https://cmake.org>`_
+- `CMake 3.15.0+ <https://cmake.org>`_
 - `AMReX <https://amrex-codes.github.io>`_: we automatically download and compile a copy of AMReX
 
 Optional dependencies include:

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -62,7 +62,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "dev"
+    set(WarpX_openpmd_branch "0.13.0"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 


### PR DESCRIPTION
We still run with 0.12.0+, but will by default now pull the 0.13.0 release.

This bumps the transitive dependencies to CMake 3.15.0+.
All documented deployment targets/systems provide this version already.

Changelog: https://github.com/openPMD/openPMD-api/blob/0.13.0/CHANGELOG.rst