### PR TITLE
Updates for electrostatic solver

### DIFF
--- a/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
@@ -23,6 +23,12 @@ import sys
 import yt
 yt.funcs.mylog.setLevel(0)
 
+# Open plotfile specified in command line
+filename = sys.argv[1]
+ds = yt.load( filename )
+t_max = ds.current_time.item()  # time of simulation
+dt = 1.e-6
+
 # Constants and initial conditions
 xmin = ymin = zmin = -0.5  #Box dimensions
 xmax = ymax = zmax = 0.5
@@ -31,8 +37,6 @@ m_e = 9.10938356e-31  #Electron mass in kg
 q_e = -1.60217662e-19  #Electron charge in C
 pi = np.pi  #Circular constant of the universe
 r_0 = 0.1  #Initial radius of sphere
-dt = 1e-6  #Timestep used for simulation
-t_max = 3e-5  #Final time of simulation
 q_tot = -1e-15  #Total charge of sphere in C
 
 # Define functions for exact forms of v(r), t(r), Er(r) with r as the radius of
@@ -43,19 +47,15 @@ q_tot = -1e-15  #Total charge of sphere in C
 # The solution r(t) solves the ODE: r''(t) = a/(r(t)**2) with initial conditions
 # r(0) = r_0, r'(0) = 0, and a = q_e*q_tot/(4*pi*eps_0*m_e)
 #
-# Note: E might be saved on a staggered time grid shifted by dt/2 (check this!)
+# The E was calculated at the start of the last time step (hence the t_max - dt in func)
 v_exact = lambda r: np.sqrt((q_e*q_tot)/(2*pi*m_e*eps_0)*(1/r_0-1/r))
 t_exact = lambda r: np.sqrt(r_0**3*2*pi*m_e*eps_0/(q_e*q_tot)) \
     * (np.sqrt(r/r_0-1)*np.sqrt(r/r_0) \
        + np.log(np.sqrt(r/r_0-1)+np.sqrt(r/r_0)))
-func = lambda rho: t_exact(rho)-t_max+dt/2  #Objective function to find r(t_max)
+func = lambda rho: t_exact(rho) - (t_max - dt)  #Objective function to find r(t_max)
 r_end = fsolve(func,r_0)[0]  #Numerically solve for r(t_max)
 E_exact = lambda r: np.sign(r)*(q_tot/(4*pi*eps_0*r**2)*(abs(r)>=r_end) \
     + q_tot*abs(r)/(4*pi*eps_0*r_end**3)*(abs(r)<r_end))
-
-# Open plotfile specified in command line
-filename = sys.argv[1]
-ds = yt.load( filename )
 
 # Load data pertaining to fields
 data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,

--- a/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
@@ -27,7 +27,6 @@ yt.funcs.mylog.setLevel(0)
 filename = sys.argv[1]
 ds = yt.load( filename )
 t_max = ds.current_time.item()  # time of simulation
-dt = 1.e-6
 
 # Constants and initial conditions
 xmin = ymin = zmin = -0.5  #Box dimensions
@@ -47,12 +46,12 @@ q_tot = -1e-15  #Total charge of sphere in C
 # The solution r(t) solves the ODE: r''(t) = a/(r(t)**2) with initial conditions
 # r(0) = r_0, r'(0) = 0, and a = q_e*q_tot/(4*pi*eps_0*m_e)
 #
-# The E was calculated at the start of the last time step (hence the t_max - dt in func)
+# The E was calculated at the end of the last time step
 v_exact = lambda r: np.sqrt((q_e*q_tot)/(2*pi*m_e*eps_0)*(1/r_0-1/r))
 t_exact = lambda r: np.sqrt(r_0**3*2*pi*m_e*eps_0/(q_e*q_tot)) \
     * (np.sqrt(r/r_0-1)*np.sqrt(r/r_0) \
        + np.log(np.sqrt(r/r_0-1)+np.sqrt(r/r_0)))
-func = lambda rho: t_exact(rho) - (t_max - dt)  #Objective function to find r(t_max)
+func = lambda rho: t_exact(rho) - t_max  #Objective function to find r(t_max)
 r_end = fsolve(func,r_0)[0]  #Numerically solve for r(t_max)
 E_exact = lambda r: np.sign(r)*(q_tot/(4*pi*eps_0*r**2)*(abs(r)>=r_end) \
     + q_tot*abs(r)/(4*pi*eps_0*r_end**3)*(abs(r)<r_end))

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -40,6 +40,10 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
             }
         }
     }
+    // Transfer fields from 'fp' array to 'aux' array.
+    // This is needed when using momentum conservation
+    // since they are different arrays in that case.
+    UpdateAuxilaryData();
 
 }
 

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -44,6 +44,7 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
     // This is needed when using momentum conservation
     // since they are different arrays in that case.
     UpdateAuxilaryData();
+    FillBoundaryAux(guard_cells.ng_UpdateAux);
 
 }
 


### PR DESCRIPTION
This fixes a bug in the electrostatic solver when using momentum conservation. In that case, the Efield_fp and Efield_aux are separate MultiFabs. A call to UpdateAuxilaryData() is added right after the fields are calculated to transfer the fields from Efield_fp (which is where the fields are calculated) to Efield_aux (which is used when fetching the field for the particles). The fields were being transferred, but at the wrong place so that the fields were lagging behind the particles by one time step. 

While I was at it, further changes were made so that the fields are calculated at the end of the time step so that the fields are synchronized with the particle positions in the output (rather than being behind one time step).

The ElectrostaticSphere test case analysis script is also updated. It was using an ad hoc time shift of -dt/2 which apparently was accounting for the fact the the fields applied to the particles were lagging by a time step. The script now uses the current time since the saved fields are synchronized.