### PR TITLE
CI: Intel ICX/ICPX

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -92,7 +92,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-shared-runtime-2021.1.1
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -100,6 +100,7 @@ jobs:
           -DCMAKE_C_COMPILER_ID="Clang"                  \
           -DCMAKE_C_COMPILER_VERSION=12.0                \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="11"     \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -97,6 +97,8 @@ jobs:
         export CC=$(which icx)
 
         cmake -S . -B build_sp         \
+          -DCMAKE_C_COMPILER_ID="Clang"                  \
+          -DCMAKE_C_COMPILER_VERSION=12.0                \ 
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,32 +78,17 @@ jobs:
         python3 -m pip install --upgrade pip setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
-  build_icx:
-    name: oneAPI ICX SP&DP [Linux]
-    runs-on: ubuntu-latest
+  build_icpx:
+    name: oneAPI ICX SP [Linux]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
+      shell: bash
       run: |
-        export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get -qqq update
-        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
-        sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-        sudo apt-get install -y intel-oneapi-dpcpp-cpp-2021.1.2 intel-oneapi-compiler-shared-runtime-2021.1.2 build-essential cmake intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel
-        set +e
-        source /opt/intel/oneapi/setvars.sh
-        set -e
-        sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
-        sudo chmod a+x /usr/local/bin/cmake-easyinstall
-        export CEI_SUDO="sudo"
-        CXX=$(which icpx) CC=$(which icx) cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF \
-          -DCMAKE_CXX_COMPILER_ID="Clang"                \
-          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
+        .github/workflows/dependencies/dpcpp.sh
     - name: build WarpX
+      shell: bash
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
@@ -111,20 +96,23 @@ jobs:
         export CXX=$(which icpx)
         export CC=$(which icx)
 
-        cmake -S . -B build_dp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF \
+        cmake -S . -B build_sp         \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
-        cmake --build build_dp -j 2
-
-        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE \
-          -DCMAKE_CXX_COMPILER_ID="Clang"                \
-          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_COMPUTE=SYCL         \
+          -DWarpX_MPI=OFF              \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
-        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+     # note: setting the CXX compiler ID is a work-around for
+     # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
+     # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
   build_dpcc:
     name: oneAPI DPC++ SP [Linux]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -92,7 +92,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-dpcpp-cpp-2021.1.2 intel-oneapi-compiler-shared-runtime-2021.1.2
+        sudo apt-get install -y intel-oneapi-dpcpp-cpp-2021.1.2 intel-oneapi-compiler-shared-runtime-2021.1.2 build-essential cmake intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,7 +98,7 @@ jobs:
 
         cmake -S . -B build_sp         \
           -DCMAKE_C_COMPILER_ID="Clang"                  \
-          -DCMAKE_C_COMPILER_VERSION=12.0                \ 
+          -DCMAKE_C_COMPILER_VERSION=12.0                \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -102,7 +102,7 @@ jobs:
         CXX=$(which icpx) CC=$(which icx) cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
     - name: build WarpX
       run: |
         set +e

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -99,12 +99,11 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_C_COMPILER_ID="Clang"                  \
           -DCMAKE_C_COMPILER_VERSION=12.0                \
-          -DCMAKE_C_STANDARD_COMPUTED_DEFAULT="11"     \
+          -DCMAKE_C_STANDARD_COMPUTED_DEFAULT="11"       \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
-          -DWarpX_COMPUTE=SYCL         \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_PRECISION=SINGLE

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,6 +78,54 @@ jobs:
         python3 -m pip install --upgrade pip setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
 
+  build_icx:
+    name: oneAPI ICX SP&DP [Linux]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get -qqq update
+        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
+        sudo chmod a+x /usr/local/bin/cmake-easyinstall
+        export CEI_SUDO="sudo"
+        CXX=$(which icpx) CC=$(which icx) cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF \
+          -DCMAKE_CXX_COMPILER_ID="Clang"                \
+          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+    - name: build WarpX
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        export CXX=$(which icpx)
+        export CC=$(which icx)
+
+        cmake -S . -B build_dp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF \
+          -DCMAKE_CXX_COMPILER_ID="Clang"                \
+          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+        cmake --build build_dp -j 2
+
+        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE \
+          -DCMAKE_CXX_COMPILER_ID="Clang"                \
+          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+        cmake --build build_sp -j 2
+
+        python3 -m pip install --upgrade pip setuptools wheel
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+
   build_dpcc:
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-20.04

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -114,13 +114,13 @@ jobs:
         cmake -S . -B build_dp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
         cmake --build build_dp -j 2
 
         cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -92,7 +92,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-shared-runtime-2021.1.1
+        sudo apt-get install -y intel-oneapi-dpcpp-cpp-2021.1.2 intel-oneapi-compiler-shared-runtime-2021.1.2
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -99,10 +99,10 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_C_COMPILER_ID="Clang"                  \
           -DCMAKE_C_COMPILER_VERSION=12.0                \
+          -DCMAKE_C_STANDARD_COMPUTED_DEFAULT="11"     \
           -DCMAKE_CXX_COMPILER_ID="Clang"                \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="11"     \
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
           -DWarpX_MPI=OFF              \


### PR DESCRIPTION
Add coverage for Intels icx/icpx compilers.
Those are the next-gen intel compilers, while icc/icpc are considered "classic" (read as: legacy).