### PR TITLE
Cleaned calculation of current time in analysis scripts

### DIFF
--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -96,7 +96,7 @@ for field in ['particle_momentum_x',
     print('assert that this is NOT in ds.field_list', (species, field))
     assert (species, field) not in ds.field_list
 
-t0 = ds.current_time.to_ndarray().mean()
+t0 = ds.current_time.to_value()
 data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                                     dims=ds.domain_dimensions)
 

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -73,7 +73,7 @@ def get_theoretical_field( field, t ):
 
 # Read the file
 ds = yt.load(fn)
-t0 = ds.current_time.to_ndarray().mean()
+t0 = ds.current_time.to_value()
 data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                                     dims=ds.domain_dimensions)
 

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -68,7 +68,7 @@ def Ez( z, r, epsilon, k0, w0, wp, t) :
 
 # Read the file
 ds = yt.load(fn)
-t0 = ds.current_time.to_ndarray().mean()
+t0 = ds.current_time.to_value()
 data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
                         dims=ds.domain_dimensions)
 


### PR DESCRIPTION
This cleans up the fetching of the current time in several CI analysis scripts. The method that was being used was non-standard.