### PR TITLE
For python regression tests, fix the setup step

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -493,7 +493,7 @@ tolerance = 5e-11
 # inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
 # customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
 # dim = 2
-# addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE USE_GPU=TRUE PYINSTALLOPTIONS=--user
+# addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE USE_GPU=TRUE PYINSTALLOPTIONS="--user --prefix="
 # restartTest = 0
 # useMPI = 1
 # numprocs = 4
@@ -613,7 +613,7 @@ buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
 customRunCmd = python PICMI_inputs_langmuir_rt.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_GPU=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_GPU=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -665,7 +665,7 @@ inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.p
 runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -792,7 +792,7 @@ inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
 runtime_params =
 customRunCmd = python PICMI_inputs_langmuir_rt.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1188,7 +1188,7 @@ buildDir = .
 inputFile = Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
 customRunCmd = python PICMI_inputs_gaussian_beam.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1223,7 +1223,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasm
 runtime_params =
 customRunCmd = python PICMI_inputs_plasma_acceleration.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1242,7 +1242,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasm
 runtime_params =
 customRunCmd = python PICMI_inputs_plasma_acceleration_mr.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1345,7 +1345,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_
 runtime_params =
 customRunCmd = python PICMI_inputs_laser_acceleration.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1364,7 +1364,7 @@ inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
 runtime_params =
 customRunCmd = python PICMI_inputs_langmuir2d.py
 dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS=--user
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
 numprocs = 2


### PR DESCRIPTION
The option `--prefix=` was added to the setup since on some systems `--prefix` is set by default and this conflicts with `--user`. This avoids the `error: can't combine user with prefix, exec_prefix/home, or install_(plat)base` which causes the Python test cases to fail.

Note that this is not needed for the Azure CI, but only for when running the tests locally.