### PR TITLE
Update docs with new CoriGPU build instructions

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -70,7 +70,7 @@ Then, you need to load the following modules:
 
 ::
 
-    module load modules esslurm gcc/7.3.0 cuda mvapich2
+    module load cgpu gcc cuda mvapich2
 
 You can also use OpenMPI-UCX instead of mvapich: openmpi/4.0.1-ucx-1.6.
 


### PR DESCRIPTION
Added environment information to build WarpX on Cori GPU.
Thank you to @kngott for providing the `module load ` instructions to set up the environment..
