### PR TITLE
openPMD-api: 0.13.1

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -62,7 +62,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "0.13.0"
+    set(WarpX_openpmd_branch "0.13.1"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 


### PR DESCRIPTION
Update the superbuild to pull the latest patch release of openPMD-api. This mainly fixes regressions (hanging) in parallel reading.

[Changelog](https://openpmd-api.readthedocs.io/en/0.13.1/install/changelog.html)