### PR TITLE
fix typo in Juwels doc

### DIFF
--- a/Docs/source/building/juwels.rst
+++ b/Docs/source/building/juwels.rst
@@ -68,7 +68,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
 
 .. code-block:: bash
 
-   make -j 16 COMP=gcc USE_GPU=TRUE
+   make -j 16 COMP=gcc USE_GPU=TRUE MPI_THREAD_MULTIPLE=FALSE
 
 The other :ref:`general compile-time options <building-source>` apply as usual.
 


### PR DESCRIPTION
The doc page contains a note that the code should be compiled with `MPI_THREAD_MULTIPLE=FALSE`. This PR also adds this to the compilation instructions a few lines below.