### PR TITLE
Lassen (LLNL): HDF5

### DIFF
--- a/Docs/source/building/lassen.rst
+++ b/Docs/source/building/lassen.rst
@@ -44,7 +44,8 @@ We use the following modules and environments on the system.
    module load boost/1.70.0
 
    # optional: for openPMD support
-   # TODO ADIOS2 & HDF5
+   # TODO ADIOS2
+   module load hdf5-parallel/1.10.4
 
    # optional: for PSATD in RZ geometry support
    # TODO: blaspp lapackpp


### PR DESCRIPTION
Document the new parallel HDF5 module, which we can use for openPMD output.

cc @bzdjordje et al.