### PR TITLE
Fix 2D/RZ: GeometryFilter

### DIFF
--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -161,7 +161,7 @@ struct GeometryFilter
                   (p.pos(2) < m_domain.lo(2)) || (p.pos(2) > m_domain.hi(2) ));
 #else
         return ! ((p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ) ||
-                  (p.pos(1) < m_domain.lo(1)) || (p.pos(1) > m_domain.hi(1) )); // double-check
+                  (p.pos(1) < m_domain.lo(1)) || (p.pos(1) > m_domain.hi(1) ));
 #endif
     }
 private:

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -155,9 +155,14 @@ struct GeometryFilter
     bool operator () (const SuperParticleType& p, const amrex::RandomEngine&) const noexcept
     {
         if ( !m_is_active ) return 1;
-        return ! (AMREX_D_TERM( (p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ),
-                            ||  (p.pos(1) < m_domain.lo(1)) || (p.pos(1) > m_domain.hi(1) ),
-                            ||  (p.pos(2) < m_domain.lo(2)) || (p.pos(2) > m_domain.hi(2) )));
+#if AMREX_SPACEDIM == 3
+        return ! ((p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ) ||
+                  (p.pos(1) < m_domain.lo(1)) || (p.pos(1) > m_domain.hi(1) ) ||
+                  (p.pos(2) < m_domain.lo(2)) || (p.pos(2) > m_domain.hi(2) ));
+#else
+        return ! ((p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ) ||
+                  (p.pos(1) < m_domain.lo(2)) || (p.pos(1) > m_domain.hi(2) )); // double-check
+#endif
     }
 private:
     /** Whether this diagnostics is activated. Select all particles if false */

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -161,7 +161,7 @@ struct GeometryFilter
                   (p.pos(2) < m_domain.lo(2)) || (p.pos(2) > m_domain.hi(2) ));
 #else
         return ! ((p.pos(0) < m_domain.lo(0)) || (p.pos(0) > m_domain.hi(0) ) ||
-                  (p.pos(1) < m_domain.lo(2)) || (p.pos(1) > m_domain.hi(2) )); // double-check
+                  (p.pos(1) < m_domain.lo(1)) || (p.pos(1) > m_domain.hi(1) )); // double-check
 #endif
     }
 private:


### PR DESCRIPTION
Fix an out-of-bounds access for `.pos()` in `z` in the `GeometryFilter` for non-3D geometries *or* mis-comparison of z-position with y dimension. (Needs validation.)