### PR TITLE
Use pinned memory for tmp particles in diags.

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -269,7 +269,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
-        amrex::AmrParticleContainer<0,0,PIdx::nattribs,0,amrex::PinnedArenaAllocator>
+        amrex::AmrParticleContainer<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>
             tmp(&WarpX::GetInstance());
         Vector<std::string> real_names;
         Vector<std::string> int_names;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -3,6 +3,7 @@
 #include "Utils/Interpolate.H"
 #include "Particles/Filter/FilterFunctors.H"
 
+#include <AMReX_AmrParticles.H>
 #include <AMReX_buildInfo.H>
 
 using namespace amrex;
@@ -268,7 +269,8 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
-        PhysicalParticleContainer tmp(&WarpX::GetInstance());
+        amrex::AmrParticleContainer<0,0,PIdx::nattribs,0,amrex::PinnedArenaAllocator>
+            tmp(&WarpX::GetInstance());
         Vector<std::string> real_names;
         Vector<std::string> int_names;
         Vector<int> int_flags;

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -14,6 +14,7 @@
 
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 
+#include <AMReX_AmrParticles.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
@@ -51,7 +52,10 @@ private:
 class WarpXParticleCounter
 {
 public:
-  WarpXParticleCounter(WarpXParticleContainer* pc);
+  using ParticleContainer = typename amrex::AmrParticleContainer<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
+  using ParticleIter = typename amrex::ParIter<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
+
+  WarpXParticleCounter(ParticleContainer* pc);
   unsigned long GetTotalNumParticles() {return m_Total;}
 
   std::vector<unsigned long long> m_ParticleOffsetAtRank;
@@ -84,6 +88,9 @@ private:
 class WarpXOpenPMDPlot
 {
 public:
+  using ParticleContainer = typename amrex::AmrParticleContainer<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
+  using ParticleIter = typename amrex::ParConstIter<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
+
   /** Initialize openPMD I/O routines
    *
    * @param oneFilePerTS write one file per timestep
@@ -121,13 +128,16 @@ private:
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *
-  * @param[in] pc          WarpX particle container
   * @param[in] currSpecies Corresponding openPMD species
   * @param[in] np          Number of particles
+  * @param[in] charge      Charge of the particles (note: fix for ions)
+  * @param[in] mass        Mass of the particles
   */
-  void SetupPos (WarpXParticleContainer* pc,
+  void SetupPos (
         openPMD::ParticleSpecies& currSpecies,
-        const unsigned long long& np) const ;
+        const unsigned long long& np,
+        amrex::ParticleReal const charge,
+        amrex::ParticleReal const mass) const ;
 
   /** This function sets up the entries for particle properties
    *
@@ -155,7 +165,7 @@ private:
    * @param[in] write_int_comp The int attribute ids, from WarpX
    * @param[in] int_comp_names The int attribute names, from WarpX
    */
-  void SaveRealProperty (WarpXParIter& pti, //int, int,
+  void SaveRealProperty (ParticleIter& pti, //int, int,
             openPMD::ParticleSpecies& currSpecies,
             unsigned long long offset,
             const amrex::Vector<int>& write_real_comp,
@@ -172,14 +182,18 @@ private:
    * @param[in] real_comp_names The real attribute names, from WarpX
    * @param[in] write_int_comp The int attribute ids, from WarpX
    * @param[in] int_comp_names The int attribute names, from WarpX
+   * @param[in] charge         Charge of the particles (note: fix for ions)
+   * @param[in] mass           Mass of the particles
    */
-  void DumpToFile (PhysicalParticleContainer* pc,
+  void DumpToFile (ParticleContainer* pc,
             const std::string& name,
             int iteration,
             const amrex::Vector<int>& write_real_comp,
             const amrex::Vector<int>& write_int_comp,
             const amrex::Vector<std::string>& real_comp_names,
-            const amrex::Vector<std::string>&  int_comp_names) const;
+            const amrex::Vector<std::string>&  int_comp_names,
+            amrex::ParticleReal const charge,
+            amrex::ParticleReal const mass) const;
 
   // no need for ts in the name, openPMD  handles it
   void GetFileName (std::string& filename);


### PR DESCRIPTION
This avoids duplicating particles in precious device memory on IO.