### PR TITLE
Add CI coverage for the plotfile particle filters

### DIFF
--- a/Examples/Modules/qed/schwinger/analysis_schwinger.py
+++ b/Examples/Modules/qed/schwinger/analysis_schwinger.py
@@ -112,7 +112,7 @@ def do_analysis(Ex,Ey,Ez,Bx,By,Bz):
         # Sorting the arrays is required because electrons and positrons are not necessarily
         # dumped in the same order.
         assert(np.array_equal(np.sort(ele_data),np.sort(pos_data)))
-        # 5 sigma test that has an intrisic probability to fail of 1 over ~2 millions
+        # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
         error = np.abs(np.sum(ele_data)-expected_total_physical_pairs_created)
         print("difference between expected and actual number of pairs created: " + str(error))
         print("tolerance: " + str(5*std_total_physical_pairs_created))

--- a/Examples/Modules/resampling/analysis_leveling_thinning.py
+++ b/Examples/Modules/resampling/analysis_leveling_thinning.py
@@ -55,7 +55,7 @@ numparts_final = w.shape[0]
 expected_numparts_final = numparts_init/t_r**2
 error = np.abs(numparts_final - expected_numparts_final)
 std_numparts_final = np.sqrt(numparts_init/t_r**2*(1.-1./t_r**2))
-# 5 sigma test that has an intrisic probability to fail of 1 over ~2 millions
+# 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
 print("difference between expected and actual final number of particles (1st species): " + str(error))
 print("tolerance: " + str(5*std_numparts_final))
 assert(error<5*std_numparts_final)
@@ -89,7 +89,7 @@ expected_mean_initial_weight = 2.*np.sqrt(2.)
 error = np.abs(mean_initial_weight - expected_mean_initial_weight)
 expected_std_initial_weight = 1./np.sqrt(2.)
 std_mean_initial_weight = expected_std_initial_weight/np.sqrt(numparts_init)
-# 5 sigma test that has an intrisic probability to fail of 1 over ~2 millions
+# 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
 print("difference between expected and actual mean initial weight (2nd species): " + str(error))
 print("tolerance: " + str(5*std_mean_initial_weight))
 assert(error<5*std_mean_initial_weight)
@@ -99,7 +99,7 @@ variance_initial_weight = np.var(w0)
 expected_variance_initial_weight = 0.5
 error = np.abs(variance_initial_weight - expected_variance_initial_weight)
 std_variance_initial_weight = expected_variance_initial_weight*np.sqrt(2./numparts_init)
-# 5 sigma test that has an intrisic probability to fail of 1 over ~2 millions
+# 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
 print("difference between expected and actual variance of initial weight (2nd species): " + str(error))
 print("tolerance: " + str(5*std_variance_initial_weight))
 
@@ -122,7 +122,7 @@ std_numparts_leveled = np.sqrt(expected_numparts_leveled - numparts_init/np.sqrt
                        (2.*expected_mean_initial_weight**2+1.)*(1.-erf(expected_mean_initial_weight* \
                        (t_r-1.)))-0.5*np.exp(-(expected_mean_initial_weight*(t_r-1.))**2* \
                        (expected_mean_initial_weight*(t_r+1.)))))
-# 5 sigma test that has an intrisic probability to fail of 1 over ~2 millions
+# 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
 print("difference between expected and actual number of leveled particles (2nd species): " + str(error))
 print("tolerance: " + str(5*std_numparts_leveled))
 

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -12,6 +12,8 @@
 # The electric field in the simulation is given (in theory) by:
 # $$ E_r = -\partial_r \phi = \epsilon \,\frac{mc^2}{e}\frac{2\,r}{w_0^2} \exp\left(-\frac{r^2}{w_0^2}\right) \sin(k_0 z) \sin(\omega_p t)
 # $$ E_z = -\partial_z \phi = - \epsilon \,\frac{mc^2}{e} k_0 \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \sin(\omega_p t)
+# Unrelated to the Langmuir waves, we also test the plotfile particle filter function in this
+# analysis script.
 import sys
 import re
 import matplotlib
@@ -127,5 +129,100 @@ if current_correction:
     print("error_rel = {}".format(error_rel))
     print("tolerance = {}".format(tolerance))
     assert( error_rel < tolerance )
+
+
+## In the final past of the test, we verify that the diagnostic particle filter function works as
+## expected in RZ geometry. For this, we only use the last simulation timestep.
+
+## This is a generic function to test a particle filter. We reproduce the filter in python and
+## verify that the results are the same as with the filtered diagnostic.
+def check_particle_filter(fn, filtered_fn, filter_expression):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Load arrays from the unfiltered diagnostic
+    ids = ad['electrons', 'particle_id'].to_ndarray()
+    r = ad['electrons', 'particle_position_x'].to_ndarray()
+    z = ad['electrons', 'particle_position_y'].to_ndarray()
+    theta = ad['electrons', 'particle_theta'].to_ndarray()
+    px  = ad['electrons', 'particle_momentum_x'].to_ndarray()
+    py  = ad['electrons', 'particle_momentum_y'].to_ndarray()
+    pz  = ad['electrons', 'particle_momentum_z'].to_ndarray()
+    w  = ad['electrons', 'particle_weight'].to_ndarray()
+
+    ## Load arrays from the filtered diagnostic
+    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
+    r_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
+    z_filtered_warpx = ad_filtered['particle_position_y'].to_ndarray()
+    theta_filtered_warpx = ad_filtered['particle_theta'].to_ndarray()
+    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
+    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
+    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
+    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
+
+    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
+    ## unfiltered arrays.
+    ind_filtered_python, = np.where(eval(filter_expression))
+
+    ## Sort the indices of the filtered arrays by particle id.
+    sorted_ind_filtered_python = ind_filtered_python[np.argsort(ids[ind_filtered_python])]
+    sorted_ind_filtered_warpx = np.argsort(ids_filtered_warpx)
+
+    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
+    ## reproduced in python
+    assert(np.array_equal(ids[sorted_ind_filtered_python],
+                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
+
+    ## Finally, we check that the sum of the particles quantities are the same to machine precision
+    tolerance_checksum = 1.e-12
+    check_array_sum(r[sorted_ind_filtered_python], r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python], z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(theta[sorted_ind_filtered_python], theta_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(px[sorted_ind_filtered_python], px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python], py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python], pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python], w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+
+## This function checks that the absolute sums of two arrays are the same to a required precision
+def check_array_sum(array1, array2, tolerance_checksum):
+    sum1 = np.sum(np.abs(array1))
+    sum2 = np.sum(np.abs(array2))
+    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
+
+## This function is specifically used to test the random filter. First, we check that the number of
+## dumped particles is as expected. Next, we call the generic check_particle_filter function.
+def check_random_filter(fn, filtered_fn, random_fraction):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Check that the number of particles is as expected
+    numparts = ad['electrons', 'particle_id'].to_ndarray().shape[0]
+    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
+    expected_numparts_filtered = random_fraction*numparts
+    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
+    std_numparts_filtered = np.sqrt(expected_numparts_filtered)
+    error = abs(numparts_filtered-expected_numparts_filtered)
+    print("Random filter: difference between expected and actual number of dumped particles: " + str(error))
+    print("tolerance: " + str(5*std_numparts_filtered))
+    assert(error<5*std_numparts_filtered)
+
+    random_filter_expression = 'np.isin(ids, ids_filtered_warpx)'
+    check_particle_filter(fn, filtered_fn, random_filter_expression)
+
+parser_filter_fn = "diags/diag_parser_filter00080"
+parser_filter_expression = "(py-pz < 0) * (r<10e-6) * (z > 0)"
+check_particle_filter(fn, parser_filter_fn, parser_filter_expression)
+
+uniform_filter_fn = "diags/diag_uniform_filter00080"
+uniform_filter_expression = "ids%3 == 0"
+check_particle_filter(fn, uniform_filter_fn, uniform_filter_expression)
+
+random_filter_fn = "diags/diag_random_filter00080"
+random_fraction = 0.66
+check_random_filter(fn, random_filter_fn, random_fraction)
 
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -23,6 +23,7 @@ import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
 from scipy.constants import e, m_e, epsilon_0, c
+import post_processing_utils
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
@@ -134,110 +135,22 @@ if current_correction:
 ## In the final past of the test, we verify that the diagnostic particle filter function works as
 ## expected in RZ geometry. For this, we only use the last simulation timestep.
 
-## This is a generic function to test a particle filter. We reproduce the filter in python and
-## verify that the results are the same as with the filtered diagnostic.
-def check_particle_filter(fn, filtered_fn, filter_expression):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Load arrays from the unfiltered diagnostic
-    ids = ad['electrons', 'particle_id'].to_ndarray()
-    cpus = ad['electrons', 'particle_cpu'].to_ndarray()
-    r = ad['electrons', 'particle_position_x'].to_ndarray()
-    z = ad['electrons', 'particle_position_y'].to_ndarray()
-    theta = ad['electrons', 'particle_theta'].to_ndarray()
-    px  = ad['electrons', 'particle_momentum_x'].to_ndarray()
-    py  = ad['electrons', 'particle_momentum_y'].to_ndarray()
-    pz  = ad['electrons', 'particle_momentum_z'].to_ndarray()
-    w  = ad['electrons', 'particle_weight'].to_ndarray()
-
-    ## Load arrays from the filtered diagnostic
-    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
-    cpus_filtered_warpx = ad_filtered['particle_cpu'].to_ndarray()
-    r_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
-    z_filtered_warpx = ad_filtered['particle_position_y'].to_ndarray()
-    theta_filtered_warpx = ad_filtered['particle_theta'].to_ndarray()
-    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
-    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
-    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
-    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
-
-    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
-    ## unfiltered arrays.
-    ind_filtered_python, = np.where(eval(filter_expression))
-
-    ## Sort the indices of the filtered arrays by particle id.
-    sorted_ind_filtered_python = ind_filtered_python[np.argsort(ids[ind_filtered_python])]
-    sorted_ind_filtered_warpx = np.argsort(ids_filtered_warpx)
-
-    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
-    ## reproduced in python
-    assert(np.array_equal(ids[sorted_ind_filtered_python],
-                          ids_filtered_warpx[sorted_ind_filtered_warpx]))
-    assert(np.array_equal(cpus[sorted_ind_filtered_python],
-                          cpus_filtered_warpx[sorted_ind_filtered_warpx]))
-
-    ## Finally, we check that the sum of the particles quantities are the same to machine precision
-    tolerance_checksum = 1.e-12
-    check_array_sum(r[sorted_ind_filtered_python],
-                    r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(z[sorted_ind_filtered_python],
-                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(theta[sorted_ind_filtered_python],
-                    theta_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(px[sorted_ind_filtered_python],
-                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(py[sorted_ind_filtered_python],
-                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(pz[sorted_ind_filtered_python],
-                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(w[sorted_ind_filtered_python],
-                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-
-## This function checks that the absolute sums of two arrays are the same to a required precision
-def check_array_sum(array1, array2, tolerance_checksum):
-    sum1 = np.sum(np.abs(array1))
-    sum2 = np.sum(np.abs(array2))
-    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
-
-## This function is specifically used to test the random filter. First, we check that the number of
-## dumped particles is as expected. Next, we call the generic check_particle_filter function.
-def check_random_filter(fn, filtered_fn, random_fraction):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Check that the number of particles is as expected
-    numparts = ad['electrons', 'particle_id'].to_ndarray().shape[0]
-    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
-    expected_numparts_filtered = random_fraction*numparts
-    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
-    std_numparts_filtered = np.sqrt(expected_numparts_filtered)
-    error = abs(numparts_filtered-expected_numparts_filtered)
-    print("Random filter: difference between expected and actual number of dumped particles: " \
-          + str(error))
-    print("tolerance: " + str(5*std_numparts_filtered))
-    assert(error<5*std_numparts_filtered)
-
-    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
-    ## MPI ranks)
-    random_filter_expression = 'np.isin(ids + 0.1*cpus,' \
-                                       'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
-    check_particle_filter(fn, filtered_fn, random_filter_expression)
+dim = "rz"
+species_name = "electrons"
 
 parser_filter_fn = "diags/diag_parser_filter00080"
 parser_filter_expression = "(py-pz < 0) * (r<10e-6) * (z > 0)"
-check_particle_filter(fn, parser_filter_fn, parser_filter_expression)
+post_processing_utils.check_particle_filter(fn, parser_filter_fn, parser_filter_expression,
+                                            dim, species_name)
 
 uniform_filter_fn = "diags/diag_uniform_filter00080"
 uniform_filter_expression = "ids%3 == 0"
-check_particle_filter(fn, uniform_filter_fn, uniform_filter_expression)
+post_processing_utils.check_particle_filter(fn, uniform_filter_fn, uniform_filter_expression,
+                                            dim, species_name)
 
 random_filter_fn = "diags/diag_random_filter00080"
 random_fraction = 0.66
-check_random_filter(fn, random_filter_fn, random_fraction)
+post_processing_utils.check_random_filter(fn, random_filter_fn, random_fraction,
+                                          dim, species_name)
 
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -175,12 +175,12 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
     ## Check that the sorted ids are exactly the same with the warpx filter and the filter
     ## reproduced in python
     assert(np.array_equal(ids[sorted_ind_filtered_python],
-                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
+                          ids_filtered_warpx[sorted_ind_filtered_warpx]))
+    assert(np.array_equal(cpus[sorted_ind_filtered_python],
+                          cpus_filtered_warpx[sorted_ind_filtered_warpx]))
 
     ## Finally, we check that the sum of the particles quantities are the same to machine precision
     tolerance_checksum = 1.e-12
-    check_array_sum(cpus[sorted_ind_filtered_python],
-                    cpus_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(r[sorted_ind_filtered_python],
                     r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(z[sorted_ind_filtered_python],

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -144,6 +144,7 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Load arrays from the unfiltered diagnostic
     ids = ad['electrons', 'particle_id'].to_ndarray()
+    cpus = ad['electrons', 'particle_cpu'].to_ndarray()
     r = ad['electrons', 'particle_position_x'].to_ndarray()
     z = ad['electrons', 'particle_position_y'].to_ndarray()
     theta = ad['electrons', 'particle_theta'].to_ndarray()
@@ -154,6 +155,7 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Load arrays from the filtered diagnostic
     ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
+    cpus_filtered_warpx = ad_filtered['particle_cpu'].to_ndarray()
     r_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
     z_filtered_warpx = ad_filtered['particle_position_y'].to_ndarray()
     theta_filtered_warpx = ad_filtered['particle_theta'].to_ndarray()
@@ -177,13 +179,22 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Finally, we check that the sum of the particles quantities are the same to machine precision
     tolerance_checksum = 1.e-12
-    check_array_sum(r[sorted_ind_filtered_python], r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(z[sorted_ind_filtered_python], z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(theta[sorted_ind_filtered_python], theta_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(px[sorted_ind_filtered_python], px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(py[sorted_ind_filtered_python], py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(pz[sorted_ind_filtered_python], pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(w[sorted_ind_filtered_python], w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(cpus[sorted_ind_filtered_python],
+                    cpus_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(r[sorted_ind_filtered_python],
+                    r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python],
+                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(theta[sorted_ind_filtered_python],
+                    theta_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(px[sorted_ind_filtered_python],
+                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python],
+                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python],
+                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python],
+                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
 
 ## This function checks that the absolute sums of two arrays are the same to a required precision
 def check_array_sum(array1, array2, tolerance_checksum):
@@ -206,11 +217,15 @@ def check_random_filter(fn, filtered_fn, random_fraction):
     # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
     std_numparts_filtered = np.sqrt(expected_numparts_filtered)
     error = abs(numparts_filtered-expected_numparts_filtered)
-    print("Random filter: difference between expected and actual number of dumped particles: " + str(error))
+    print("Random filter: difference between expected and actual number of dumped particles: " \
+          + str(error))
     print("tolerance: " + str(5*std_numparts_filtered))
     assert(error<5*std_numparts_filtered)
 
-    random_filter_expression = 'np.isin(ids, ids_filtered_warpx)'
+    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
+    ## MPI ranks)
+    random_filter_expression = 'np.isin(ids + 0.1*cpus,' \
+                                       'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
     check_particle_filter(fn, filtered_fn, random_filter_expression)
 
 parser_filter_fn = "diags/diag_parser_filter00080"

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -83,7 +83,25 @@ ions.uy = 0.
 ions.uz = 0.
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter
 diag1.intervals = 40
 diag1.diag_type = Full
 diag1.fields_to_plot = jx jz Ex Ez By
+
+## diag_parser_filter is a diag used to test the particle filter function.
+diag_parser_filter.intervals = 80:80:
+diag_parser_filter.diag_type = Full
+diag_parser_filter.species = electrons
+diag_parser_filter.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = "(uy-uz < 0) * (sqrt(x**2+y**2)<10e-6) * (z > 0)"
+
+## diag_uniform_filter is a diag used to test the particle uniform filter.
+diag_uniform_filter.intervals = 80:80:
+diag_uniform_filter.diag_type = Full
+diag_uniform_filter.species = electrons
+diag_uniform_filter.electrons.uniform_stride = 3
+
+## diag_random_filter is a diag used to test the particle random filter.
+diag_random_filter.intervals = 80:80:
+diag_random_filter.diag_type = Full
+diag_random_filter.species = electrons
+diag_random_filter.electrons.random_fraction = 0.66

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -92,7 +92,8 @@ diag1.fields_to_plot = jx jz Ex Ez By
 diag_parser_filter.intervals = 80:80:
 diag_parser_filter.diag_type = Full
 diag_parser_filter.species = electrons
-diag_parser_filter.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = "(uy-uz < 0) * (sqrt(x**2+y**2)<10e-6) * (z > 0)"
+diag_parser_filter.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = "(uy-uz < 0) *
+                                                                 (sqrt(x**2+y**2)<10e-6) * (z > 0)"
 
 ## diag_uniform_filter is a diag used to test the particle uniform filter.
 diag_uniform_filter.intervals = 80:80:

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# Copyright 2019-2020 Yin-YinjiaZhao, Yinjian Zhao
+# Copyright 2019-2020 Yinjian Zhao
 #
 # This file is part of WarpX.
 #
@@ -10,12 +10,14 @@
 # using electron-ion temperature relaxation in 2D.
 # Initially, electrons and ions are both in equilibrium
 # (gaussian) distributions, but have different temperatures.
-# Relaxation occurs to bring the two temeratures to be
+# Relaxation occurs to bring the two temperatures to be
 # a final same temperature through collisions.
 # The code was tested to be valid, more detailed results
-# were used to obtian an exponential fit with
+# were used to obtain an exponential fit with
 # coefficients a and b.
 # This automated test compares the results with the fit.
+# Unrelated to the collision module, we also test the plotfile particle filter function in this
+# analysis script.
 
 # Possible errors:
 # tolerance: 0.001
@@ -23,7 +25,6 @@
 
 import sys
 import yt
-import re
 import math
 import numpy
 from glob import glob
@@ -41,14 +42,16 @@ c  = 299792458.0
 me = 9.10938356e-31
 mi = me * 5.0
 
+## In the first part of the test we verify that the output data is consistent with the exponential
+## fit.
+
 # exponential fit coefficients
 a =  0.041817463099883
 b = -0.083851393560288
 
 last_fn = sys.argv[1]
-temp = re.compile("([a-zA-Z_]+)([0-9]+)")
-res = temp.match(last_fn).groups()
-fn_list = glob(res[0] + "?????")
+if (last_fn[-1] == "/"): last_fn = last_fn[:-1]
+fn_list = glob(last_fn[:-5] + "?????")
 
 error = 0.0
 nt = 0
@@ -58,8 +61,7 @@ for fn in fn_list:
     ad  = ds.all_data()
     px  = ad['particle_momentum_x'].to_ndarray()
     # get time index j
-    buf = temp.match(fn).groups()
-    j = int(buf[1])
+    j = int(fn[-5:])
     # compute error
     vxe = numpy.mean(px[ 0:ne])/me/c
     vxi = numpy.mean(px[ne:np])/mi/c
@@ -74,6 +76,30 @@ print('error = ', error)
 print('tolerance = ', tolerance)
 assert(error < tolerance)
 
-fn = fn_list[-1]
-test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
+
+## In the second past of the test, we verify that the diagnostic particle filter function works as
+## expected. For this, we only use the last simulation timestep.
+
+last_fn_filtered = last_fn.replace("diag1", "diag_filter")
+ds  = yt.load( last_fn )
+ds_filtered  = yt.load( last_fn_filtered )
+ad  = ds.all_data()
+ad_filtered  = ds_filtered.all_data()
+
+# Load data from the non-filtered diagnostic. [:ne] is here so that we discard the ions, which are
+# not dumped by the filtered diag
+ids = ad['particle_id'].to_ndarray()[:ne]
+x = ad['particle_position_x'].to_ndarray()[:ne]
+px  = ad['particle_momentum_x'].to_ndarray()[:ne]
+z = ad['particle_position_y'].to_ndarray()[:ne]
+pz  = ad['particle_momentum_z'].to_ndarray()[:ne]
+
+## Reproduce the filter in python using the non-filtered data
+ids_filtered_python = numpy.sort(ids[ (x>200) * (z<200) * (px-3*pz>0)])
+## Load data from the filtered diagnostic
+ids_filtered_warpx = numpy.sort(ad_filtered['particle_id'].to_ndarray())
+
+assert(numpy.array_equal(ids_filtered_python, ids_filtered_warpx))
+
+test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -80,7 +80,7 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-last_fn_filtered = last_fn.replace("diag1", "diag_filter")
+last_fn_filtered = "diags/diag_filter"+last_fn[-5:]
 ds  = yt.load( last_fn )
 ds_filtered  = yt.load( last_fn_filtered )
 ad  = ds.all_data()

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -120,11 +120,11 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
     ## reproduced in python
     assert(numpy.array_equal(ids[sorted_ind_filtered_python],
                              ids_filtered_warpx[sorted_ind_filtered_warpx]))
+    assert(numpy.array_equal(cpus[sorted_ind_filtered_python],
+                             cpus_filtered_warpx[sorted_ind_filtered_warpx]))
 
     ## Finally, we check that the sum of the particles quantities are the same to machine precision
     tolerance_checksum = 1.e-12
-    check_array_sum(cpus[sorted_ind_filtered_python],
-                    cpus_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(x[sorted_ind_filtered_python],
                     x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(px[sorted_ind_filtered_python],

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -28,6 +28,7 @@ import yt
 import math
 import numpy
 from glob import glob
+import post_processing_utils
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
@@ -80,107 +81,23 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-## This is a generic function to test a particle filter. We reproduce the filter in python and
-## verify that the results are the same as with the filtered diagnostic.
-def check_particle_filter(fn, filtered_fn, filter_expression):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Load arrays from the unfiltered diagnostic
-    ids = ad['electron', 'particle_id'].to_ndarray()
-    cpus = ad['electron', 'particle_cpu'].to_ndarray()
-    x = ad['electron', 'particle_position_x'].to_ndarray()
-    px  = ad['electron', 'particle_momentum_x'].to_ndarray()
-    z = ad['electron', 'particle_position_y'].to_ndarray()
-    pz  = ad['electron', 'particle_momentum_z'].to_ndarray()
-    py  = ad['electron', 'particle_momentum_y'].to_ndarray()
-    w  = ad['electron', 'particle_weight'].to_ndarray()
-
-    ## Load arrays from the filtered diagnostic
-    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
-    cpus_filtered_warpx = ad_filtered['particle_cpu'].to_ndarray()
-    x_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
-    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
-    z_filtered_warpx = ad_filtered['particle_position_y'].to_ndarray()
-    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
-    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
-    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
-
-    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
-    ## unfiltered arrays.
-    ind_filtered_python, = numpy.where(eval(filter_expression))
-
-    ## Sort the indices of the filtered arrays by particle id.
-    sorted_ind_filtered_python = ind_filtered_python[numpy.argsort(ids[ind_filtered_python])]
-    sorted_ind_filtered_warpx = numpy.argsort(ids_filtered_warpx)
-
-    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
-    ## reproduced in python
-    assert(numpy.array_equal(ids[sorted_ind_filtered_python],
-                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
-    assert(numpy.array_equal(cpus[sorted_ind_filtered_python],
-                             cpus_filtered_warpx[sorted_ind_filtered_warpx]))
-
-    ## Finally, we check that the sum of the particles quantities are the same to machine precision
-    tolerance_checksum = 1.e-12
-    check_array_sum(x[sorted_ind_filtered_python],
-                    x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(px[sorted_ind_filtered_python],
-                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(z[sorted_ind_filtered_python],
-                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(pz[sorted_ind_filtered_python],
-                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(py[sorted_ind_filtered_python],
-                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(w[sorted_ind_filtered_python],
-                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-
-## This function checks that the absolute sums of two arrays are the same to a required precision
-def check_array_sum(array1, array2, tolerance_checksum):
-    sum1 = numpy.sum(numpy.abs(array1))
-    sum2 = numpy.sum(numpy.abs(array2))
-    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
-
-## This function is specifically used to test the random filter. First, we check that the number of
-## dumped particles is as expected. Next, we call the generic check_particle_filter function.
-def check_random_filter(fn, filtered_fn, random_fraction):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Check that the number of particles is as expected
-    numparts = ad['electron', 'particle_id'].to_ndarray().shape[0]
-    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
-    expected_numparts_filtered = random_fraction*numparts
-    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
-    std_numparts_filtered = numpy.sqrt(expected_numparts_filtered)
-    error = abs(numparts_filtered-expected_numparts_filtered)
-    print("Random filter: difference between expected and actual number of dumped particles: " \
-          + str(error))
-    print("tolerance: " + str(5*std_numparts_filtered))
-    assert(error<5*std_numparts_filtered)
-
-    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
-    ## MPI ranks)
-    random_filter_expression = 'numpy.isin(ids + 0.1*cpus,' \
-                                          'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
-    check_particle_filter(fn, filtered_fn, random_filter_expression)
+dim = "2d"
+species_name = "electron"
 
 parser_filter_fn = "diags/diag_parser_filter00150"
 parser_filter_expression = "(x>200) * (z<200) * (px-3*pz>0)"
-check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression)
+post_processing_utils.check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression,
+                                            dim, species_name)
 
 uniform_filter_fn = "diags/diag_uniform_filter00150"
 uniform_filter_expression = "ids%6 == 0"
-check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression)
+post_processing_utils.check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression,
+                                            dim, species_name)
 
 random_filter_fn = "diags/diag_random_filter00150"
 random_fraction = 0.77
-check_random_filter(last_fn, random_filter_fn, random_fraction)
+post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_fraction,
+                                          dim, species_name)
 
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -80,26 +80,93 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-last_fn_filtered = "diags/diag_filter"+last_fn[-5:]
-ds  = yt.load( last_fn )
-ds_filtered  = yt.load( last_fn_filtered )
-ad  = ds.all_data()
-ad_filtered  = ds_filtered.all_data()
+## This is a generic function to test a particle filter. We reproduce the filter in python and
+## verify that the results are the same as with the filtered diagnostic.
+def check_particle_filter(fn, filtered_fn, filter_expression):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
 
-# Load data from the non-filtered diagnostic. [:ne] is here so that we discard the ions, which are
-# not dumped by the filtered diag
-ids = ad['particle_id'].to_ndarray()[:ne]
-x = ad['particle_position_x'].to_ndarray()[:ne]
-px  = ad['particle_momentum_x'].to_ndarray()[:ne]
-z = ad['particle_position_y'].to_ndarray()[:ne]
-pz  = ad['particle_momentum_z'].to_ndarray()[:ne]
+    ## Load arrays from the unfiltered diagnostic
+    ids = ad['electron', 'particle_id'].to_ndarray()
+    x = ad['electron', 'particle_position_x'].to_ndarray()
+    px  = ad['electron', 'particle_momentum_x'].to_ndarray()
+    z = ad['electron', 'particle_position_y'].to_ndarray()
+    pz  = ad['electron', 'particle_momentum_z'].to_ndarray()
+    py  = ad['electron', 'particle_momentum_y'].to_ndarray()
+    w  = ad['electron', 'particle_weight'].to_ndarray()
 
-## Reproduce the filter in python using the non-filtered data
-ids_filtered_python = numpy.sort(ids[ (x>200) * (z<200) * (px-3*pz>0)])
-## Load data from the filtered diagnostic
-ids_filtered_warpx = numpy.sort(ad_filtered['particle_id'].to_ndarray())
+    ## Load arrays from the filtered diagnostic
+    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
+    x_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
+    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
+    z_filtered_warpx = ad_filtered['particle_position_y'].to_ndarray()
+    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
+    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
+    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
 
-assert(numpy.array_equal(ids_filtered_python, ids_filtered_warpx))
+    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
+    ## unfiltered arrays.
+    ind_filtered_python, = numpy.where(eval(filter_expression))
+
+    ## Sort the indices of the filtered arrays by particle id.
+    sorted_ind_filtered_python = ind_filtered_python[numpy.argsort(ids[ind_filtered_python])]
+    sorted_ind_filtered_warpx = numpy.argsort(ids_filtered_warpx)
+
+    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
+    ## reproduced in python
+    assert(numpy.array_equal(ids[sorted_ind_filtered_python],
+                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
+
+    ## Finally, we check that the sum of the particles quantities are the same to machine precision
+    tolerance_checksum = 1.e-12
+    check_array_sum(x[sorted_ind_filtered_python], x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(px[sorted_ind_filtered_python], px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python], z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python], pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python], py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python], w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+
+## This function checks that the absolute sums of two arrays are the same to a required precision
+def check_array_sum(array1, array2, tolerance_checksum):
+    sum1 = numpy.sum(numpy.abs(array1))
+    sum2 = numpy.sum(numpy.abs(array2))
+    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
+
+## This function is specifically used to test the random filter. First, we check that the number of
+## dumped particles is as expected. Next, we call the generic check_particle_filter function.
+def check_random_filter(fn, filtered_fn, random_fraction):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Check that the number of particles is as expected
+    numparts = ad['electron', 'particle_id'].to_ndarray().shape[0]
+    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
+    expected_numparts_filtered = random_fraction*numparts
+    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
+    std_numparts_filtered = numpy.sqrt(expected_numparts_filtered)
+    error = abs(numparts_filtered-expected_numparts_filtered)
+    print("Random filter: difference between expected and actual number of dumped particles: " + str(error))
+    print("tolerance: " + str(5*std_numparts_filtered))
+    assert(error<5*std_numparts_filtered)
+
+    random_filter_expression = 'numpy.isin(ids, ids_filtered_warpx)'
+    check_particle_filter(fn, filtered_fn, random_filter_expression)
+
+parser_filter_fn = "diags/diag_parser_filter00150"
+parser_filter_expression = "(x>200) * (z<200) * (px-3*pz>0)"
+check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression)
+
+uniform_filter_fn = "diags/diag_uniform_filter00150"
+uniform_filter_expression = "ids%6 == 0"
+check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression)
+
+random_filter_fn = "diags/diag_random_filter00150"
+random_fraction = 0.77
+check_random_filter(last_fn, random_filter_fn, random_fraction)
 
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -28,6 +28,7 @@ import yt
 import math
 import numpy
 from glob import glob
+import post_processing_utils
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
@@ -80,111 +81,23 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-## This is a generic function to test a particle filter. We reproduce the filter in python and
-## verify that the results are the same as with the filtered diagnostic.
-def check_particle_filter(fn, filtered_fn, filter_expression):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Load arrays from the unfiltered diagnostic
-    ids = ad['electron', 'particle_id'].to_ndarray()
-    cpus = ad['electron', 'particle_cpu'].to_ndarray()
-    x = ad['electron', 'particle_position_x'].to_ndarray()
-    px  = ad['electron', 'particle_momentum_x'].to_ndarray()
-    y = ad['electron', 'particle_position_y'].to_ndarray()
-    py  = ad['electron', 'particle_momentum_y'].to_ndarray()
-    z = ad['electron', 'particle_position_z'].to_ndarray()
-    pz  = ad['electron', 'particle_momentum_z'].to_ndarray()
-    w  = ad['electron', 'particle_weight'].to_ndarray()
-
-    ## Load arrays from the filtered diagnostic
-    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
-    cpus_filtered_warpx = ad_filtered['particle_cpu'].to_ndarray()
-    x_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
-    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
-    y_filtered_warpx  = ad_filtered['particle_position_y'].to_ndarray()
-    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
-    z_filtered_warpx = ad_filtered['particle_position_z'].to_ndarray()
-    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
-    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
-
-    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
-    ## unfiltered arrays.
-    ind_filtered_python, = numpy.where(eval(filter_expression))
-
-    ## Sort the indices of the filtered arrays by particle id.
-    sorted_ind_filtered_python = ind_filtered_python[numpy.argsort(ids[ind_filtered_python])]
-    sorted_ind_filtered_warpx = numpy.argsort(ids_filtered_warpx)
-
-    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
-    ## reproduced in python
-    assert(numpy.array_equal(ids[sorted_ind_filtered_python],
-                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
-    assert(numpy.array_equal(cpus[sorted_ind_filtered_python],
-                             cpus_filtered_warpx[sorted_ind_filtered_warpx]))
-
-    ## Finally, we check that the sum of the particles quantities are the same to machine precision
-    tolerance_checksum = 1.e-12
-    check_array_sum(x[sorted_ind_filtered_python],
-                    x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(px[sorted_ind_filtered_python],
-                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(y[sorted_ind_filtered_python],
-                    y_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(py[sorted_ind_filtered_python],
-                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(z[sorted_ind_filtered_python],
-                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(pz[sorted_ind_filtered_python],
-                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(w[sorted_ind_filtered_python],
-                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-
-## This function checks that the absolute sums of two arrays are the same to a required precision
-def check_array_sum(array1, array2, tolerance_checksum):
-    sum1 = numpy.sum(numpy.abs(array1))
-    sum2 = numpy.sum(numpy.abs(array2))
-    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
-
-## This function is specifically used to test the random filter. First, we check that the number of
-## dumped particles is as expected. Next, we call the generic check_particle_filter function.
-def check_random_filter(fn, filtered_fn, random_fraction):
-    ds  = yt.load( fn )
-    ds_filtered  = yt.load( filtered_fn )
-    ad  = ds.all_data()
-    ad_filtered  = ds_filtered.all_data()
-
-    ## Check that the number of particles is as expected
-    numparts = ad['electron', 'particle_id'].to_ndarray().shape[0]
-    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
-    expected_numparts_filtered = random_fraction*numparts
-    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
-    std_numparts_filtered = numpy.sqrt(expected_numparts_filtered)
-    error = abs(numparts_filtered-expected_numparts_filtered)
-    print("Random filter: difference between expected and actual number of dumped particles: " \
-          + str(error))
-    print("tolerance: " + str(5*std_numparts_filtered))
-    assert(error<5*std_numparts_filtered)
-
-    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
-    ## MPI ranks)
-    random_filter_expression = 'numpy.isin(ids + 0.1*cpus,' \
-                                          'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
-    check_particle_filter(fn, filtered_fn, random_filter_expression)
+dim = "3d"
+species_name = "electron"
 
 parser_filter_fn = "diags/diag_parser_filter00150"
-parser_filter_expression = "(px*py*pz < 0) * (numpy.sqrt(x**2+y**2+z**2)<100)"
-check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression)
+parser_filter_expression = "(px*py*pz < 0) * (np.sqrt(x**2+y**2+z**2)<100)"
+post_processing_utils.check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression,
+                                            dim, species_name)
 
 uniform_filter_fn = "diags/diag_uniform_filter00150"
 uniform_filter_expression = "ids%11 == 0"
-check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression)
+post_processing_utils.check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression,
+                                            dim, species_name)
 
 random_filter_fn = "diags/diag_random_filter00150"
 random_fraction = 0.88
-check_random_filter(last_fn, random_filter_fn, random_fraction)
+post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_fraction,
+                                          dim, species_name)
 
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# Copyright 2019-2020 Yin-YinjiaZhao, Yinjian Zhao
+# Copyright 2019-2020 Yinjian Zhao
 #
 # This file is part of WarpX.
 #
@@ -10,12 +10,14 @@
 # using electron-ion temperature relaxation in 3D.
 # Initially, electrons and ions are both in equilibrium
 # (gaussian) distributions, but have different temperatures.
-# Relaxation occurs to bring the two temeratures to be
+# Relaxation occurs to bring the two temperatures to be
 # a final same temperature through collisions.
 # The code was tested to be valid, more detailed results
-# were used to obtian an exponential fit with
+# were used to obtain an exponential fit with
 # coefficients a and b.
 # This automated test compares the results with the fit.
+# Unrelated to the collision module, we also test the plotfile particle filter function in this
+# analysis script.
 
 # Possible errors:
 # tolerance: 0.001
@@ -23,7 +25,6 @@
 
 import sys
 import yt
-import re
 import math
 import numpy
 from glob import glob
@@ -41,14 +42,16 @@ c  = 299792458.0
 me = 9.10938356e-31
 mi = me * 5.0
 
+## In the first part of the test we verify that the output data is consistent with the exponential
+## fit.
+
 # exponential fit coefficients
 a =  0.041817463099883
 b = -0.083851393560288
 
 last_fn = sys.argv[1]
-temp = re.compile("([a-zA-Z_]+)([0-9]+)")
-res = temp.match(last_fn).groups()
-fn_list = glob(res[0] + "?????")
+if (last_fn[-1] == "/"): last_fn = last_fn[:-1]
+fn_list = glob(last_fn[:-5] + "?????")
 
 error = 0.0
 nt = 0
@@ -58,8 +61,7 @@ for fn in fn_list:
     ad  = ds.all_data()
     px  = ad['particle_momentum_x'].to_ndarray()
     # get time index j
-    buf = temp.match(fn).groups()
-    j = int(buf[1])
+    j = int(fn[-5:])
     # compute error
     vxe = numpy.mean(px[ 0:ne])/me/c
     vxi = numpy.mean(px[ne:np])/mi/c
@@ -74,5 +76,32 @@ print('error = ', error)
 print('tolerance = ', tolerance)
 assert(error < tolerance)
 
+
+## In the second past of the test, we verify that the diagnostic particle filter function works as
+## expected. For this, we only use the last simulation timestep.
+
+last_fn_filtered = last_fn.replace("diag1", "diag_filter")
+ds  = yt.load( last_fn )
+ds_filtered  = yt.load( last_fn_filtered )
+ad  = ds.all_data()
+ad_filtered  = ds_filtered.all_data()
+
+# Load data from the non-filtered diagnostic. [:ne] is here so that we discard the ions, which are
+# not dumped by the filtered diag
+ids = ad['particle_id'].to_ndarray()[:ne]
+x = ad['particle_position_x'].to_ndarray()[:ne]
+y = ad['particle_position_y'].to_ndarray()[:ne]
+z = ad['particle_position_z'].to_ndarray()[:ne]
+px  = ad['particle_momentum_x'].to_ndarray()[:ne]
+py  = ad['particle_momentum_y'].to_ndarray()[:ne]
+pz  = ad['particle_momentum_z'].to_ndarray()[:ne]
+
+## Reproduce the filter in python using the non-filtered data
+ids_filtered_python = numpy.sort(ids[ (px*py*pz<0) * (numpy.sqrt(x**2+y**2+z**2)<100)])
+## Load data from the filtered diagnostic
+ids_filtered_warpx = numpy.sort(ad_filtered['particle_id'].to_ndarray())
+
+assert(numpy.array_equal(ids_filtered_python, ids_filtered_warpx))
+
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, last_fn, do_particles=False)
+checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -122,11 +122,11 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
     ## reproduced in python
     assert(numpy.array_equal(ids[sorted_ind_filtered_python],
                              ids_filtered_warpx[sorted_ind_filtered_warpx]))
+    assert(numpy.array_equal(cpus[sorted_ind_filtered_python],
+                             cpus_filtered_warpx[sorted_ind_filtered_warpx]))
 
     ## Finally, we check that the sum of the particles quantities are the same to machine precision
     tolerance_checksum = 1.e-12
-    check_array_sum(cpus[sorted_ind_filtered_python],
-                    cpus_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(x[sorted_ind_filtered_python],
                     x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
     check_array_sum(px[sorted_ind_filtered_python],

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -80,28 +80,96 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-last_fn_filtered = "diags/diag_filter"+last_fn[-5:]
-ds  = yt.load( last_fn )
-ds_filtered  = yt.load( last_fn_filtered )
-ad  = ds.all_data()
-ad_filtered  = ds_filtered.all_data()
+## This is a generic function to test a particle filter. We reproduce the filter in python and
+## verify that the results are the same as with the filtered diagnostic.
+def check_particle_filter(fn, filtered_fn, filter_expression):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
 
-# Load data from the non-filtered diagnostic. [:ne] is here so that we discard the ions, which are
-# not dumped by the filtered diag
-ids = ad['particle_id'].to_ndarray()[:ne]
-x = ad['particle_position_x'].to_ndarray()[:ne]
-y = ad['particle_position_y'].to_ndarray()[:ne]
-z = ad['particle_position_z'].to_ndarray()[:ne]
-px  = ad['particle_momentum_x'].to_ndarray()[:ne]
-py  = ad['particle_momentum_y'].to_ndarray()[:ne]
-pz  = ad['particle_momentum_z'].to_ndarray()[:ne]
+    ## Load arrays from the unfiltered diagnostic
+    ids = ad['electron', 'particle_id'].to_ndarray()
+    x = ad['electron', 'particle_position_x'].to_ndarray()
+    px  = ad['electron', 'particle_momentum_x'].to_ndarray()
+    y = ad['electron', 'particle_position_y'].to_ndarray()
+    py  = ad['electron', 'particle_momentum_y'].to_ndarray()
+    z = ad['electron', 'particle_position_z'].to_ndarray()
+    pz  = ad['electron', 'particle_momentum_z'].to_ndarray()
+    w  = ad['electron', 'particle_weight'].to_ndarray()
 
-## Reproduce the filter in python using the non-filtered data
-ids_filtered_python = numpy.sort(ids[ (px*py*pz<0) * (numpy.sqrt(x**2+y**2+z**2)<100)])
-## Load data from the filtered diagnostic
-ids_filtered_warpx = numpy.sort(ad_filtered['particle_id'].to_ndarray())
+    ## Load arrays from the filtered diagnostic
+    ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
+    x_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
+    px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
+    y_filtered_warpx  = ad_filtered['particle_position_y'].to_ndarray()
+    py_filtered_warpx  = ad_filtered['particle_momentum_y'].to_ndarray()
+    z_filtered_warpx = ad_filtered['particle_position_z'].to_ndarray()
+    pz_filtered_warpx  = ad_filtered['particle_momentum_z'].to_ndarray()
+    w_filtered_warpx  = ad_filtered['particle_weight'].to_ndarray()
 
-assert(numpy.array_equal(ids_filtered_python, ids_filtered_warpx))
+    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
+    ## unfiltered arrays.
+    ind_filtered_python, = numpy.where(eval(filter_expression))
+
+    ## Sort the indices of the filtered arrays by particle id.
+    sorted_ind_filtered_python = ind_filtered_python[numpy.argsort(ids[ind_filtered_python])]
+    sorted_ind_filtered_warpx = numpy.argsort(ids_filtered_warpx)
+
+    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
+    ## reproduced in python
+    assert(numpy.array_equal(ids[sorted_ind_filtered_python],
+                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
+
+    ## Finally, we check that the sum of the particles quantities are the same to machine precision
+    tolerance_checksum = 1.e-12
+    check_array_sum(x[sorted_ind_filtered_python], x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(px[sorted_ind_filtered_python], px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(y[sorted_ind_filtered_python], y_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python], py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python], z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python], pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python], w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+
+## This function checks that the absolute sums of two arrays are the same to a required precision
+def check_array_sum(array1, array2, tolerance_checksum):
+    sum1 = numpy.sum(numpy.abs(array1))
+    sum2 = numpy.sum(numpy.abs(array2))
+    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
+
+## This function is specifically used to test the random filter. First, we check that the number of
+## dumped particles is as expected. Next, we call the generic check_particle_filter function.
+def check_random_filter(fn, filtered_fn, random_fraction):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Check that the number of particles is as expected
+    numparts = ad['electron', 'particle_id'].to_ndarray().shape[0]
+    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
+    expected_numparts_filtered = random_fraction*numparts
+    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
+    std_numparts_filtered = numpy.sqrt(expected_numparts_filtered)
+    error = abs(numparts_filtered-expected_numparts_filtered)
+    print("Random filter: difference between expected and actual number of dumped particles: " + str(error))
+    print("tolerance: " + str(5*std_numparts_filtered))
+    assert(error<5*std_numparts_filtered)
+
+    random_filter_expression = 'numpy.isin(ids, ids_filtered_warpx)'
+    check_particle_filter(fn, filtered_fn, random_filter_expression)
+
+parser_filter_fn = "diags/diag_parser_filter00150"
+parser_filter_expression = "(px*py*pz < 0) * (numpy.sqrt(x**2+y**2+z**2)<100)"
+check_particle_filter(last_fn, parser_filter_fn, parser_filter_expression)
+
+uniform_filter_fn = "diags/diag_uniform_filter00150"
+uniform_filter_expression = "ids%11 == 0"
+check_particle_filter(last_fn, uniform_filter_fn, uniform_filter_expression)
+
+random_filter_fn = "diags/diag_random_filter00150"
+random_fraction = 0.88
+check_random_filter(last_fn, random_filter_fn, random_fraction)
 
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -80,7 +80,7 @@ assert(error < tolerance)
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
-last_fn_filtered = last_fn.replace("diag1", "diag_filter")
+last_fn_filtered = "diags/diag_filter"+last_fn[-5:]
 ds  = yt.load( last_fn )
 ds_filtered  = yt.load( last_fn_filtered )
 ad  = ds.all_data()

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -90,6 +90,7 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Load arrays from the unfiltered diagnostic
     ids = ad['electron', 'particle_id'].to_ndarray()
+    cpus = ad['electron', 'particle_cpu'].to_ndarray()
     x = ad['electron', 'particle_position_x'].to_ndarray()
     px  = ad['electron', 'particle_momentum_x'].to_ndarray()
     y = ad['electron', 'particle_position_y'].to_ndarray()
@@ -100,6 +101,7 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Load arrays from the filtered diagnostic
     ids_filtered_warpx = ad_filtered['particle_id'].to_ndarray()
+    cpus_filtered_warpx = ad_filtered['particle_cpu'].to_ndarray()
     x_filtered_warpx = ad_filtered['particle_position_x'].to_ndarray()
     px_filtered_warpx  = ad_filtered['particle_momentum_x'].to_ndarray()
     y_filtered_warpx  = ad_filtered['particle_position_y'].to_ndarray()
@@ -123,13 +125,22 @@ def check_particle_filter(fn, filtered_fn, filter_expression):
 
     ## Finally, we check that the sum of the particles quantities are the same to machine precision
     tolerance_checksum = 1.e-12
-    check_array_sum(x[sorted_ind_filtered_python], x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(px[sorted_ind_filtered_python], px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(y[sorted_ind_filtered_python], y_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(py[sorted_ind_filtered_python], py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(z[sorted_ind_filtered_python], z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(pz[sorted_ind_filtered_python], pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
-    check_array_sum(w[sorted_ind_filtered_python], w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(cpus[sorted_ind_filtered_python],
+                    cpus_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(x[sorted_ind_filtered_python],
+                    x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(px[sorted_ind_filtered_python],
+                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(y[sorted_ind_filtered_python],
+                    y_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python],
+                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python],
+                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python],
+                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python],
+                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
 
 ## This function checks that the absolute sums of two arrays are the same to a required precision
 def check_array_sum(array1, array2, tolerance_checksum):
@@ -152,11 +163,15 @@ def check_random_filter(fn, filtered_fn, random_fraction):
     # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
     std_numparts_filtered = numpy.sqrt(expected_numparts_filtered)
     error = abs(numparts_filtered-expected_numparts_filtered)
-    print("Random filter: difference between expected and actual number of dumped particles: " + str(error))
+    print("Random filter: difference between expected and actual number of dumped particles: " \
+          + str(error))
     print("tolerance: " + str(5*std_numparts_filtered))
     assert(error<5*std_numparts_filtered)
 
-    random_filter_expression = 'numpy.isin(ids, ids_filtered_warpx)'
+    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
+    ## MPI ranks)
+    random_filter_expression = 'numpy.isin(ids + 0.1*cpus,' \
+                                          'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
     check_particle_filter(fn, filtered_fn, random_filter_expression)
 
 parser_filter_fn = "diags/diag_parser_filter00150"

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -61,13 +61,24 @@ collision2.CoulombLog = 15.9
 collision3.CoulombLog = 15.9
 
 # Diagnostics
-diagnostics.diags_names = diag1 diag_filter
+diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter
 diag1.intervals = 10
 diag1.diag_type = Full
 
-## diag_filter is another diag used to test the particle filter function.
-diag_filter.intervals = 150:150:
-diag_filter.diag_type = Full
-diag_filter.species = electron
-diag_filter.electron.variables = none ## only dump position and id
-diag_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(x > 200) * (z < 200) * (ux-3*uz>0)"
+## diag_parser_filter is a diag used to test the particle filter function.
+diag_parser_filter.intervals = 150:150:
+diag_parser_filter.diag_type = Full
+diag_parser_filter.species = electron
+diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(x > 200) * (z < 200) * (ux-3*uz>0)"
+
+## diag_uniform_filter is a diag used to test the particle uniform filter.
+diag_uniform_filter.intervals = 150:150:
+diag_uniform_filter.diag_type = Full
+diag_uniform_filter.species = electron
+diag_uniform_filter.electron.uniform_stride = 6
+
+## diag_random_filter is a diag used to test the particle random filter.
+diag_random_filter.intervals = 150:150:
+diag_random_filter.diag_type = Full
+diag_random_filter.species = electron
+diag_random_filter.electron.random_fraction = 0.77

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -69,7 +69,8 @@ diag1.diag_type = Full
 diag_parser_filter.intervals = 150:150:
 diag_parser_filter.diag_type = Full
 diag_parser_filter.species = electron
-diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(x > 200) * (z < 200) * (ux-3*uz>0)"
+diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(x > 200) * (z < 200) *
+                                                                      (ux-3*uz>0)"
 
 ## diag_uniform_filter is a diag used to test the particle uniform filter.
 diag_uniform_filter.intervals = 150:150:

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -61,6 +61,13 @@ collision2.CoulombLog = 15.9
 collision3.CoulombLog = 15.9
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diag_filter
 diag1.intervals = 10
 diag1.diag_type = Full
+
+## diag_filter is another diag used to test the particle filter function.
+diag_filter.intervals = 150:150:
+diag_filter.diag_type = Full
+diag_filter.species = electron
+diag_filter.electron.variables = none ## only dump position and id
+diag_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(x > 200) * (z < 200) * (ux-3*uz>0)"

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -72,7 +72,8 @@ diag1.diag_type = Full
 diag_parser_filter.intervals = 150:150:
 diag_parser_filter.diag_type = Full
 diag_parser_filter.species = electron
-diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(ux*uy*uz < 0) * (sqrt(x**2+y**2+z**2)<100)"
+diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(ux*uy*uz < 0) *
+                                                                      (sqrt(x**2+y**2+z**2)<100)"
 
 ## diag_uniform_filter is a diag used to test the particle uniform filter.
 diag_uniform_filter.intervals = 150:150:

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -64,6 +64,13 @@ collision2.ndt = 10
 collision3.ndt = 10
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diag_filter
 diag1.intervals = 10
 diag1.diag_type = Full
+
+## diag_filter is another diag used to test the particle filter function.
+diag_filter.intervals = 150:150:
+diag_filter.diag_type = Full
+diag_filter.species = electron
+diag_filter.electron.variables = none ## only dump position and id
+diag_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(ux*uy*uz < 0) * (sqrt(x**2+y**2+z**2)<100)"

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -64,13 +64,24 @@ collision2.ndt = 10
 collision3.ndt = 10
 
 # Diagnostics
-diagnostics.diags_names = diag1 diag_filter
+diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter
 diag1.intervals = 10
 diag1.diag_type = Full
 
-## diag_filter is another diag used to test the particle filter function.
-diag_filter.intervals = 150:150:
-diag_filter.diag_type = Full
-diag_filter.species = electron
-diag_filter.electron.variables = none ## only dump position and id
-diag_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(ux*uy*uz < 0) * (sqrt(x**2+y**2+z**2)<100)"
+## diag_parser_filter is a diag used to test the particle filter function.
+diag_parser_filter.intervals = 150:150:
+diag_parser_filter.diag_type = Full
+diag_parser_filter.species = electron
+diag_parser_filter.electron.plot_filter_function(t,x,y,z,ux,uy,uz) = "(ux*uy*uz < 0) * (sqrt(x**2+y**2+z**2)<100)"
+
+## diag_uniform_filter is a diag used to test the particle uniform filter.
+diag_uniform_filter.intervals = 150:150:
+diag_uniform_filter.diag_type = Full
+diag_uniform_filter.species = electron
+diag_uniform_filter.electron.uniform_stride = 11
+
+## diag_random_filter is a diag used to test the particle random filter.
+diag_random_filter.intervals = 150:150:
+diag_random_filter.diag_type = Full
+diag_random_filter.species = electron
+diag_random_filter.electron.random_fraction = 0.88

--- a/Regression/PostProcessingUtils/post_processing_utils.py
+++ b/Regression/PostProcessingUtils/post_processing_utils.py
@@ -1,0 +1,129 @@
+# Copyright 2021-2021 Neil Zaim
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+## This file contains functions that are used in multiple CI analysis scripts.
+
+import numpy as np
+import yt
+
+## This is a generic function to test a particle filter. We reproduce the filter in python and
+## verify that the results are the same as with the WarpX filtered diagnostic.
+def check_particle_filter(fn, filtered_fn, filter_expression, dim, species_name):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Load arrays from the unfiltered diagnostic
+    ids = ad[species_name, 'particle_id'].to_ndarray()
+    cpus = ad[species_name, 'particle_cpu'].to_ndarray()
+    px  = ad[species_name, 'particle_momentum_x'].to_ndarray()
+    pz  = ad[species_name, 'particle_momentum_z'].to_ndarray()
+    py  = ad[species_name, 'particle_momentum_y'].to_ndarray()
+    w  = ad[species_name, 'particle_weight'].to_ndarray()
+    if (dim == "2d"):
+        x = ad[species_name, 'particle_position_x'].to_ndarray()
+        z = ad[species_name, 'particle_position_y'].to_ndarray()
+    elif (dim == "3d"):
+        x = ad[species_name, 'particle_position_x'].to_ndarray()
+        y = ad[species_name, 'particle_position_y'].to_ndarray()
+        z = ad[species_name, 'particle_position_z'].to_ndarray()
+    elif (dim == "rz"):
+        r = ad[species_name, 'particle_position_x'].to_ndarray()
+        z = ad[species_name, 'particle_position_y'].to_ndarray()
+        theta = ad[species_name, 'particle_theta'].to_ndarray()
+
+    ## Load arrays from the filtered diagnostic
+    ids_filtered_warpx = ad_filtered[species_name, 'particle_id'].to_ndarray()
+    cpus_filtered_warpx = ad_filtered[species_name, 'particle_cpu'].to_ndarray()
+    px_filtered_warpx  = ad_filtered[species_name, 'particle_momentum_x'].to_ndarray()
+    pz_filtered_warpx  = ad_filtered[species_name, 'particle_momentum_z'].to_ndarray()
+    py_filtered_warpx  = ad_filtered[species_name, 'particle_momentum_y'].to_ndarray()
+    w_filtered_warpx  = ad_filtered[species_name, 'particle_weight'].to_ndarray()
+    if (dim == "2d"):
+        x_filtered_warpx = ad_filtered[species_name, 'particle_position_x'].to_ndarray()
+        z_filtered_warpx = ad_filtered[species_name, 'particle_position_y'].to_ndarray()
+    elif (dim == "3d"):
+        x_filtered_warpx = ad_filtered[species_name, 'particle_position_x'].to_ndarray()
+        y_filtered_warpx = ad_filtered[species_name, 'particle_position_y'].to_ndarray()
+        z_filtered_warpx = ad_filtered[species_name, 'particle_position_z'].to_ndarray()
+    elif (dim == "rz"):
+        r_filtered_warpx = ad_filtered[species_name, 'particle_position_x'].to_ndarray()
+        z_filtered_warpx = ad_filtered[species_name, 'particle_position_y'].to_ndarray()
+        theta_filtered_warpx = ad_filtered[species_name, 'particle_theta'].to_ndarray()
+
+    ## Reproduce the filter in python: this returns the indices of the filtered particles in the
+    ## unfiltered arrays.
+    ind_filtered_python, = np.where(eval(filter_expression))
+
+    ## Sort the indices of the filtered arrays by particle id.
+    sorted_ind_filtered_python = ind_filtered_python[np.argsort(ids[ind_filtered_python])]
+    sorted_ind_filtered_warpx = np.argsort(ids_filtered_warpx)
+
+    ## Check that the sorted ids are exactly the same with the warpx filter and the filter
+    ## reproduced in python
+    assert(np.array_equal(ids[sorted_ind_filtered_python],
+                             ids_filtered_warpx[sorted_ind_filtered_warpx]))
+    assert(np.array_equal(cpus[sorted_ind_filtered_python],
+                             cpus_filtered_warpx[sorted_ind_filtered_warpx]))
+
+    ## Finally, we check that the sum of the particles quantities are the same to machine precision
+    tolerance_checksum = 1.e-12
+    check_array_sum(px[sorted_ind_filtered_python],
+                    px_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(pz[sorted_ind_filtered_python],
+                    pz_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(py[sorted_ind_filtered_python],
+                    py_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(w[sorted_ind_filtered_python],
+                    w_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    check_array_sum(z[sorted_ind_filtered_python],
+                    z_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    if (dim == "2d"):
+        check_array_sum(x[sorted_ind_filtered_python],
+                        x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    elif (dim == "3d"):
+        check_array_sum(x[sorted_ind_filtered_python],
+                        x_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+        check_array_sum(y[sorted_ind_filtered_python],
+                        y_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+    elif (dim == "rz"):
+        check_array_sum(r[sorted_ind_filtered_python],
+                        r_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+        check_array_sum(theta[sorted_ind_filtered_python],
+                        theta_filtered_warpx[sorted_ind_filtered_warpx], tolerance_checksum)
+
+## This function checks that the absolute sums of two arrays are the same to a required precision
+def check_array_sum(array1, array2, tolerance_checksum):
+    sum1 = np.sum(np.abs(array1))
+    sum2 = np.sum(np.abs(array2))
+    assert(abs(sum2-sum1)/sum1 < tolerance_checksum)
+
+## This function is specifically used to test the random filter. First, we check that the number of
+## dumped particles is as expected. Next, we call the generic check_particle_filter function.
+def check_random_filter(fn, filtered_fn, random_fraction, dim, species_name):
+    ds  = yt.load( fn )
+    ds_filtered  = yt.load( filtered_fn )
+    ad  = ds.all_data()
+    ad_filtered  = ds_filtered.all_data()
+
+    ## Check that the number of particles is as expected
+    numparts = ad[species_name, 'particle_id'].to_ndarray().shape[0]
+    numparts_filtered = ad_filtered['particle_id'].to_ndarray().shape[0]
+    expected_numparts_filtered = random_fraction*numparts
+    # 5 sigma test that has an intrinsic probability to fail of 1 over ~2 millions
+    std_numparts_filtered = np.sqrt(expected_numparts_filtered)
+    error = abs(numparts_filtered-expected_numparts_filtered)
+    print("Random filter: difference between expected and actual number of dumped particles: " \
+          + str(error))
+    print("tolerance: " + str(5*std_numparts_filtered))
+    assert(error<5*std_numparts_filtered)
+
+    ## Dirty trick to find particles with the same ID + same CPU (does not work with more than 10
+    ## MPI ranks)
+    random_filter_expression = 'np.isin(ids + 0.1*cpus,' \
+                                          'ids_filtered_warpx + 0.1*cpus_filtered_warpx)'
+    check_particle_filter(fn, filtered_fn, random_filter_expression, dim, species_name)

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -619,6 +619,7 @@ compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_analysis.png
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 tolerance = 1.e-14
 
 [Langmuir_multi_rz_psatd]
@@ -638,6 +639,7 @@ compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 tolerance = 1.e-14
 
 [Langmuir_multi_rz_psatd_current_correction]
@@ -657,6 +659,7 @@ compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 tolerance = 1.e-14
 
 [Python_Langmuir_rz_multimode]
@@ -1491,6 +1494,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_3d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 tolerance = 1.e-14
 
 [collisionXZ]
@@ -1508,6 +1512,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 tolerance = 1.e-14
 
 [Maxwell_Hybrid_QED_solver]


### PR DESCRIPTION
Currently the plotfile particle filter function is not tested in CI, so I've hijacked the collision tests (no real reason to use this test in particular), both in 2D and 3D, to test the filter.

**Edit:** We've realized that the particle filter function was already tested by the checksums of the laser ion example so there was not much use in this PR as it was.

Therefore, we now test all 3 particle filters (parser function, uniform filter and random filter) in 2D+3D+RZ. The 2D and 3D tests are still done with the collision test while the RZ one is done with the Langmuir test (no real reason for that; I think this can be changed easily if needed, we could for instance use the Langmuir tests for everything).

I'm doing pretty much the same thing in all 3 analysis script so there's quite a bit of duplicate code.