### PR TITLE
Remove unused lines about particle filters

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -171,19 +171,6 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     // Scale the velocity by the speed of light
     for (int i=0; i<3; i++) m_v_galilean[i] *= PhysConst::c;
 
-    // build filter functors
-    m_do_random_filter  = queryWithParser(pp, "random_fraction", m_random_fraction);
-    m_do_uniform_filter = pp.query("uniform_stride",  m_uniform_stride);
-    std::string buf;
-    m_do_parser_filter  = pp.query("plot_filter_function(t,x,y,z,ux,uy,uz)", buf);
-    if (m_do_parser_filter) {
-        std::string function_string = "";
-        Store_parserString(pp,"plot_filter_function(t,x,y,z,ux,uy,uz)",
-                           function_string);
-        m_particle_filter_parser = std::make_unique<ParserWrapper<7>>(
-            makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
-    }
-
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -321,14 +321,6 @@ public:
     virtual bool has_quantum_sync() const {return false;}
     virtual bool has_breit_wheeler() const {return false;}
 
-    // build filter functors
-    bool m_do_random_filter  = false;
-    bool m_do_uniform_filter = false;
-    bool m_do_parser_filter  = false;
-    amrex::Real m_random_fraction = 1.0;
-    int m_uniform_stride = 1;
-    std::unique_ptr<ParserWrapper<7>> m_particle_filter_parser;
-
     /* \brief This function tests if the current species
     *  is of a given PhysicalSpecies (specified as a template parameter).
     * @tparam PhysSpec the PhysicalSpecies to test against


### PR DESCRIPTION
It looks to me like these lines are remnants of the old diagnostics and are currently unused.