### PR TITLE
[mini] Fix number of guard cells in PML with 2D PSATD

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -482,9 +482,17 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         // of the stencil for the spectral solver
         IntVect ngFFT;
         if (do_nodal) {
-            ngFFT = IntVect(AMREX_D_DECL(nox_fft, noy_fft, noz_fft));
+#if (AMREX_SPACEDIM==3)
+            ngFFT = IntVect(nox_fft, noy_fft, noz_fft);
+#else
+            ngFFT = IntVect(nox_fft, noz_fft);
+#endif
         } else {
-            ngFFT = IntVect(AMREX_D_DECL(nox_fft / 2, noy_fft / 2, noz_fft / 2));
+#if (AMREX_SPACEDIM==3)
+            ngFFT = IntVect(nox_fft / 2, noy_fft / 2, noz_fft / 2);
+#else
+            ngFFT = IntVect(nox_fft / 2, noz_fft / 2);
+#endif
         }
         // Set the number of guard cells to the maximum of each field
         // (all fields should have the same number of guard cells)
@@ -547,6 +555,9 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
         amrex::ignore_unused(dt);
+#   if(AMREX_SPACEDIM!=3)
+        amrex::ignore_unused(noy_fft);
+#   endif
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
                                          "PML: PSATD solver selected but not built.");
 #else


### PR DESCRIPTION
I think the `AMREX_D_DECL` is incorrect here in 2D/RZ. This ought to be a really harmless bug, but I guess we don't want it to be hanging around in the code.

I've also removed an unused parameter warning.