### PR TITLE
Cleaned up field diagnostic in picmi interface

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -770,7 +770,7 @@ class Simulation(picmistandard.PICMI_Simulation):
 # ----------------------------
 
 
-class _WarpX_FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic):
+class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic):
     def init(self, kw):
 
         self.plot_raw_fields = kw.pop('warpx_plot_raw_fields', None)
@@ -858,16 +858,7 @@ class _WarpX_FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic):
             self.diagnostic.file_prefix = write_dir + '/' + file_prefix
 
 
-class FieldDiagnostic(_WarpX_FieldDiagnostic, picmistandard.PICMI_FieldDiagnostic):
-    pass
-
-
-class ElectrostaticFieldDiagnostic(_WarpX_FieldDiagnostic, picmistandard.PICMI_ElectrostaticFieldDiagnostic):
-    def initialize_inputs(self):
-        if 'phi' in self.data_list:
-            # --- phi is not supported by WarpX, but is in the default data_list
-            self.data_list.remove('phi')
-        _WarpX_FieldDiagnostic.initialize_inputs(self)
+ElectrostaticFieldDiagnostic = FieldDiagnostic
 
 
 class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic):


### PR DESCRIPTION
This cleans up the field diagnostic classes in the picmi interface. There was an issue where the ElectrostaticFieldDiagnostic was not being initialized properly. To fix that, the best way was to remove the multiple inheritance and make the ElectrostaticFieldDiagnostic the same as the FieldDiagnostic. This works since the acceptable elements of the data list are nearly the same for both diagnostics. This lets the c++ check the validity of the data list, which is more robust than trying to replicate the checks at the Python level. For example, if the user requests "phi", the FieldDiagnostic will let is pass but the c++ will raise an error if electrostatic is not being used.