### PR TITLE
Refactor finite-order interpolation functions for momentum-conserving field gathering

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -78,6 +78,14 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
     }
 #endif
 
+    const amrex::IntVect& Bx_stag = Bfield_fp[0][0]->ixType().toIntVect();
+    const amrex::IntVect& By_stag = Bfield_fp[0][1]->ixType().toIntVect();
+    const amrex::IntVect& Bz_stag = Bfield_fp[0][2]->ixType().toIntVect();
+
+    const amrex::IntVect& Ex_stag = Efield_fp[0][0]->ixType().toIntVect();
+    const amrex::IntVect& Ey_stag = Efield_fp[0][1]->ixType().toIntVect();
+    const amrex::IntVect& Ez_stag = Efield_fp[0][2]->ixType().toIntVect();
+
     // For level 0, we only need to do the average.
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -114,12 +122,23 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             amrex::Real const * r_stencil_coef_z = d_stencil_coef_z.data();
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
             {
-                warpx_interp_nd_bfield_x(j,k,l, bx_aux, bx_fp, fg_noy, fg_noz, r_stencil_coef_y, r_stencil_coef_z);
-                warpx_interp_nd_bfield_y(j,k,l, by_aux, by_fp, fg_nox, fg_noz, r_stencil_coef_x, r_stencil_coef_z);
-                warpx_interp_nd_bfield_z(j,k,l, bz_aux, bz_fp, fg_nox, fg_noy, r_stencil_coef_x, r_stencil_coef_y);
-                warpx_interp_nd_efield_x(j,k,l, ex_aux, ex_fp, fg_nox, r_stencil_coef_x);
-                warpx_interp_nd_efield_y(j,k,l, ey_aux, ey_fp, fg_noy, r_stencil_coef_y);
-                warpx_interp_nd_efield_z(j,k,l, ez_aux, ez_fp, fg_noz, r_stencil_coef_z);
+                warpx_interp(j, k, l, bx_aux, bx_fp, Bx_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
+
+                warpx_interp(j, k, l, by_aux, by_fp, By_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
+
+                warpx_interp(j, k, l, bz_aux, bz_fp, Bz_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
+
+                warpx_interp(j, k, l, ex_aux, ex_fp, Ex_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
+
+                warpx_interp(j, k, l, ey_aux, ey_fp, Ey_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
+
+                warpx_interp(j, k, l, ez_aux, ez_fp, Ez_stag, fg_nox, fg_noy, fg_noz,
+                             r_stencil_coef_x, r_stencil_coef_y, r_stencil_coef_z);
             });
 #endif
         } else { // FDTD

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -144,12 +144,12 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         } else { // FDTD
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int j, int k, int l) noexcept
             {
-                warpx_interp_nd_bfield_x(j,k,l, bx_aux, bx_fp);
-                warpx_interp_nd_bfield_y(j,k,l, by_aux, by_fp);
-                warpx_interp_nd_bfield_z(j,k,l, bz_aux, bz_fp);
-                warpx_interp_nd_efield_x(j,k,l, ex_aux, ex_fp);
-                warpx_interp_nd_efield_y(j,k,l, ey_aux, ey_fp);
-                warpx_interp_nd_efield_z(j,k,l, ez_aux, ez_fp);
+                warpx_interp(j, k, l, bx_aux, bx_fp, Bx_stag);
+                warpx_interp(j, k, l, by_aux, by_fp, By_stag);
+                warpx_interp(j, k, l, bz_aux, bz_fp, Bz_stag);
+                warpx_interp(j, k, l, ex_aux, ex_fp, Ex_stag);
+                warpx_interp(j, k, l, ey_aux, ey_fp, Ey_stag);
+                warpx_interp(j, k, l, ez_aux, ez_fp, Ez_stag);
             });
         }
     }

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -277,58 +277,6 @@ void warpx_interp_nd_bfield_z (int j, int k, int l,
     Bza(j,k,l) = bg + (bf-bc);
 }
 
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the Bx field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_x (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bxa,
-                               amrex::Array4<amrex::Real const> const& Bxf)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    Bxa(j,k,0) = 0.5_rt*(Bxf(j,k-1,0) + Bxf(j,k,0));
-    amrex::ignore_unused(l);
-#else
-    Bxa(j,k,l) = 0.25_rt*(Bxf(j,k-1,l-1) + Bxf(j,k,l-1) + Bxf(j,k-1,l) + Bxf(j,k,l));
-#endif
-}
-
-
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the By field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_y (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bya,
-                               amrex::Array4<amrex::Real const> const& Byf)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    Bya(j,k,0) = 0.25_rt*(Byf(j,k,0) + Byf(j-1,k,0) + Byf(j,k-1,0) + Byf(j-1,k-1,0));
-    amrex::ignore_unused(l);
-#else
-    Bya(j,k,l) = 0.25_rt*(Byf(j-1,k,l-1) + Byf(j,k,l-1) + Byf(j-1,k,l) + Byf(j,k,l));
-#endif
-}
-
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the Bz field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_z (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bza,
-                               amrex::Array4<amrex::Real const> const& Bzf)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    Bza(j,k,0) = 0.5_rt*(Bzf(j-1,k,0) + Bzf(j,k,0));
-    amrex::ignore_unused(l);
-#else
-    Bza(j,k,l) = 0.25_rt*(Bzf(j-1,k-1,l) + Bzf(j,k-1,l) + Bzf(j-1,k,l) + Bzf(j,k,l));
-#endif
-}
-
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp_nd_efield_x (int j, int k, int l,
                                amrex::Array4<amrex::Real> const& Exa,
@@ -538,56 +486,11 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
     Eza(j,k,l) = eg + (ef-ec);
 }
 
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the Ex field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_x (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Exa,
-                               amrex::Array4<amrex::Real const> const& Exf)
-{
-    using namespace amrex;
-    Exa(j,k,l) = 0.5_rt*(Exf(j-1,k,l) + Exf(j,k,l));
-}
-
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the Ey field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_y (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Eya,
-                               amrex::Array4<amrex::Real const> const& Eyf)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    Eya(j,k,0) = Eyf(j,k,0);
-    amrex::ignore_unused(l);
-#else
-    Eya(j,k,l) = 0.5_rt*(Eyf(j,k-1,l) + Eyf(j,k,l));
-#endif
-}
-
-// With the FDTD Maxwell solver, this is the linear interpolation function used to
-// interpolate the Ez field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_z (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Eza,
-                               amrex::Array4<amrex::Real const> const& Ezf)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    Eza(j,k,0) = 0.5_rt*(Ezf(j,k-1,0) + Ezf(j,k,0));
-    amrex::ignore_unused(l);
-#else
-    Eza(j,k,l) = 0.5_rt*(Ezf(j,k,l-1) + Ezf(j,k,l));
-#endif
-}
-
 /**
- * \brief With the PSATD Maxwell solver, this is the arbitrary-order interpolation function, based
- * on the Fornberg coefficients, used to interpolate a given field from the Yee grid to the nodal grid,
- * before gathering the field from the nodes to the particle positions (momentum-conserving field gathering).
+ * \brief Arbitrary-order interpolation function used to interpolate a given field from the Yee grid
+ * to the nodal grid, before gathering the field from the nodes to the particle positions
+ * (momentum-conserving field gathering). With the FDTD solver, this performs simple linear interpolation.
+ * With the PSATD solver, this performs arbitrary-order interpolation based on the Fornberg coefficients.
  * The result is stored in the output array \c arr_aux, allocated on the \c aux patch.
  *
  * \param[in] j index along x of the output array
@@ -610,12 +513,12 @@ void warpx_interp (const int j,
                    amrex::Array4<amrex::Real      > const& arr_aux,
                    amrex::Array4<amrex::Real const> const& arr_fine,
                    const amrex::IntVect& arr_stag,
-                   const int nox,
-                   const int noy,
-                   const int noz,
-                   amrex::Real const* stencil_coef_x,
-                   amrex::Real const* stencil_coef_y,
-                   amrex::Real const* stencil_coef_z)
+                   const int nox = 2,
+                   const int noy = 2,
+                   const int noz = 2,
+                   amrex::Real const* stencil_coef_x = nullptr,
+                   amrex::Real const* stencil_coef_y = nullptr,
+                   amrex::Real const* stencil_coef_z = nullptr)
 {
     using namespace amrex;
 
@@ -678,19 +581,19 @@ void warpx_interp (const int j,
         ld = l - ll;
         lu = l + ll - 1;
         // Reset stencil coefficients if necessary
-        if (sl == 0) cl = stencil_coef_z[ll-1];
+        if (sl == 0 && nl > 2) cl = stencil_coef_z[ll-1];
         for (int kk = 1; kk < nk; kk++) {
             // First values: kd = k-1, ku = k
             kd = k - kk;
             ku = k + kk - 1;
             // Reset stencil coefficients if necessary
-            if (sk == 0) ck = (AMREX_SPACEDIM == 2) ? stencil_coef_z[kk-1] : stencil_coef_y[kk-1];
+            if (sk == 0 && nk > 2) ck = (AMREX_SPACEDIM == 2) ? stencil_coef_z[kk-1] : stencil_coef_y[kk-1];
             for (int jj = 1; jj < nj; jj++) {
                 // First values: jd = j-1, ju = j
                 jd = j - jj;
                 ju = j + jj - 1;
                 // Reset stencil coefficients if necessary
-                if (sj == 0) cj = stencil_coef_x[jj-1];
+                if (sj == 0 && nj > 2) cj = stencil_coef_x[jj-1];
                 // Accumulate temporary partial sum
                 tmp = arr_fine(ju,ku,lu);
                 if (sj == 0) tmp += arr_fine(jd,ku,lu);
@@ -707,7 +610,6 @@ void warpx_interp (const int j,
             }
         }
     }
-
     arr_aux(j,k,l) = res;
 }
 

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -522,95 +522,109 @@ void warpx_interp (const int j,
 {
     using namespace amrex;
 
-    // NOTE Indices (j,k,l) in the following refer to (x,z,-) in 2D and (x,y,z) in 3D
-
 #if (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(noy);
+    amrex::ignore_unused(noy, stencil_coef_y);
 #endif
 
-    // Staggering (0: cell-centered; 1: nodal)
+    // Staggering (s = 0 if cell-centered, s = 1 if nodal)
     const int sj = arr_stag[0];
     const int sk = arr_stag[1];
-    const int sl = (AMREX_SPACEDIM == 2) ? 1 : arr_stag[2];
+#if (AMREX_SPACEDIM == 3)
+    const int sl = arr_stag[2];
+#endif
 
     // Number of points (+1) used for interpolation from the staggered grid to the nodal grid
-    // (if the field is nodal along a given direction, there is no interpolation at all)
-    const int nj = (sj == 0) ? nox/2+1 : 2;
+    // (if the input field is nodal along a given direction, then s = 1, the variable n = 0
+    // is actually never used, and there is no interpolation, only a copy of one single value)
+    const int nj = (sj == 0) ? nox/2 + 1 : 0;
 #if   (AMREX_SPACEDIM == 2)
-    const int nk = (sk == 0) ? noz/2+1 : 2;
+    const int nk = (sk == 0) ? noz/2 + 1 : 0;
 #elif (AMREX_SPACEDIM == 3)
-    const int nk = (sk == 0) ? noy/2+1 : 2;
+    const int nk = (sk == 0) ? noy/2 + 1 : 0;
+    const int nl = (sl == 0) ? noz/2 + 1 : 0;
 #endif
-    const int nl = (sl == 0) ? noz/2+1 : 2;
 
     // Additional normalization factor
     const amrex::Real wj = (sj == 0) ? 0.5_rt : 1.0_rt;
     const amrex::Real wk = (sk == 0) ? 0.5_rt : 1.0_rt;
+#if   (AMREX_SPACEDIM == 2)
+    constexpr amrex::Real wl = 1.0_rt;
+#elif (AMREX_SPACEDIM == 3)
     const amrex::Real wl = (sl == 0) ? 0.5_rt : 1.0_rt;
+#endif
 
-    // Arbitrary-order stencil coefficients (possibly reset in the interpolation loop below)
+    // Arbitrary-order stencil coefficients
+    // (with PSATD they are reassigned in the interpolation loop below)
     amrex::Real cj = 1.0_rt;
     amrex::Real ck = 1.0_rt;
     amrex::Real cl = 1.0_rt;
 
-    // Temporary results
-    amrex::Real tmp = 0.0_rt;
+    // Min and max for interpolation loop along j
+    const int jmin = (sj == 0) ? j - nj + 1 : j;
+    const int jmax = (sj == 0) ? j + nj - 2 : j;
+
+    // Min and max for interpolation loop along k
+    const int kmin = (sk == 0) ? k - nk + 1 : k;
+    const int kmax = (sk == 0) ? k + nk - 2 : k;
+
+    // Min and max for interpolation loop along l
+#if   (AMREX_SPACEDIM == 2)
+    // l = 0 always
+    const int lmin = l;
+    const int lmax = l;
+#elif (AMREX_SPACEDIM == 3)
+    const int lmin = (sl == 0) ? l - nl + 1 : l;
+    const int lmax = (sl == 0) ? l + nl - 2 : l;
+#endif
+
+    // Integer indices to access arbitrary-order stencil coefficients
+    int dj, dk;
+#if (AMREX_SPACEDIM == 3)
+    int dl;
+#endif
+
+    // Interpolation loop (see below examples and illustrations for 1D case).
+    // So far, with FDTD we use only interpolation order 2 and we do not have access
+    // to the Fornberg coefficients. In the future, we might want to use the Fornberg
+    // coefficients with both FDTD and PSATD, in which case the #ifdef WARPX_USE_PSATD condition
+    // below will be removed. Currently, with FDTD we set cj = ck = cl = 1 and do not change them.
+    //
+    // - example and illustration: nodal to nodal
+    //
+    //           j
+    //   --o-----o-----o--  result(j) = f(j)
+    //   --o-----o-----o--
+    //    j-1    j    j+1
+    //
+    // - example and illustration: staggered to nodal
+    //
+    //                       j
+    //   --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
+    //   -----x-----x-----x-----x-----x-----x-----            + c_1 * (f(j-2) + f(j+1)) / 2
+    //       j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
+    //       c_2   c_1   c_0   c_0   c_1   c_2                + ...
+    //
     amrex::Real res = 0.0_rt;
-
-    // Auxiliary indices
-    int ju, jd;
-    int ku, kd;
-    int lu, ld;
-
-    // Interpolation loop
-    //
-    // Examples in 1D for order 2 (f stands for arr_fine):
-    //
-    //  j-1    j    j+1
-    // --o-----o-----o--  result(j) = 1/2 * (f(j) + f(j-1)) (only one Fornberg coefficient equal to 1.0)
-    // -----x-----x-----  f staggered
-    //     j-1    j
-    //
-    //  j-1    j    j+1
-    // --o-----o-----o--  result(j) = f(j)
-    // --o-----o-----o--  f nodal
-    //  j-1    j    j+1
-    //
-    for (int ll = 1; ll < nl; ll++) {
-        // First values: ld = l-1, lu = l
-        ld = l - ll;
-        lu = l + ll - 1;
-        // Reset stencil coefficients if necessary
-        if (sl == 0 && nl > 2) cl = stencil_coef_z[ll-1];
-        for (int kk = 1; kk < nk; kk++) {
-            // First values: kd = k-1, ku = k
-            kd = k - kk;
-            ku = k + kk - 1;
-            // Reset stencil coefficients if necessary
-            if (sk == 0 && nk > 2) ck = (AMREX_SPACEDIM == 2) ? stencil_coef_z[kk-1] : stencil_coef_y[kk-1];
-            for (int jj = 1; jj < nj; jj++) {
-                // First values: jd = j-1, ju = j
-                jd = j - jj;
-                ju = j + jj - 1;
-                // Reset stencil coefficients if necessary
-                if (sj == 0 && nj > 2) cj = stencil_coef_x[jj-1];
-                // Accumulate temporary partial sum
-                tmp = arr_fine(ju,ku,lu);
-                if (sj == 0) tmp += arr_fine(jd,ku,lu);
-                if (sk == 0) tmp += arr_fine(ju,kd,lu);
-                if (sl == 0) tmp += arr_fine(ju,ku,ld);
-                if (sj == 0 && sk == 0) tmp += arr_fine(jd,kd,lu);
-                if (sk == 0 && sl == 0) tmp += arr_fine(ju,kd,ld);
-                if (sj == 0 && sl == 0) tmp += arr_fine(jd,ku,ld);
-                if (sj == 0 && sk == 0 && sl == 0) tmp += arr_fine(jd,kd,ld);
-                // Multiply by normalization factors and stencil coefficients
-                tmp *= wj * wk * wl * cj * ck * cl;
-                // Add temporary partial result to global result
-                res += tmp;
+    for         (int ll = lmin; ll <= lmax; ll++) {
+        for     (int kk = kmin; kk <= kmax; kk++) {
+            for (int jj = jmin; jj <= jmax; jj++) {
+#ifdef WARPX_USE_PSATD
+                dj = (j - jj > 0) ? j - jj - 1 : jj - j;
+                dk = (k - kk > 0) ? k - kk - 1 : kk - k;
+                if (sj == 0) cj = stencil_coef_x[dj];
+#if   (AMREX_SPACEDIM == 2)
+                if (sk == 0) ck = stencil_coef_z[dk];
+#elif (AMREX_SPACEDIM == 3)
+                dl = (l - ll > 0) ? l - ll - 1 : ll - l;
+                if (sk == 0) ck = stencil_coef_y[dk];
+                if (sl == 0) cl = stencil_coef_z[dl];
+#endif
+#endif
+                res += cj * ck * cl * arr_fine(jj,kk,ll);
             }
         }
     }
-    arr_aux(j,k,l) = res;
+    arr_aux(j,k,l) = wj * wk * wl * res;
 }
 
 #endif

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -294,39 +294,6 @@ void warpx_interp_nd_bfield_x (int j, int k, int l,
 #endif
 }
 
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the Bx field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_x (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bxa,
-                               amrex::Array4<amrex::Real const> const& Bxf,
-                               const int noy,
-                               const int noz,
-                               amrex::Real const* stencil_coef_y,
-                               amrex::Real const* stencil_coef_z)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(noy);
-    amrex::ignore_unused(stencil_coef_y);
-    amrex::Real res = 0.;
-    for (int nz = 1; nz < noz/2+1; nz++) {
-        res += 0.5_rt * stencil_coef_z[nz-1] * (Bxf(j, k + nz - 1, l) + Bxf(j, k - nz, l));
-    }
-    Bxa(j,k,l) = res;
-#else
-    amrex::Real res = 0.;
-    for     (int nz = 1; nz < noz/2+1; nz++) {
-        for (int ny = 1; ny < noy/2+1; ny++) {
-            res += 0.25_rt * stencil_coef_y[ny-1] * stencil_coef_z[nz-1] *
-                   (Bxf(j, k + ny - 1, l + nz - 1) + Bxf(j, k - ny, l + nz - 1)
-                  + Bxf(j, k + ny - 1, l - nz    ) + Bxf(j, k - ny, l - nz    ));
-        }
-    }
-    Bxa(j,k,l) = res;
-#endif
-}
 
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the By field from a staggered grid to a nodal grid, before gathering
@@ -345,42 +312,6 @@ void warpx_interp_nd_bfield_y (int j, int k, int l,
 #endif
 }
 
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the By field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_y (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bya,
-                               amrex::Array4<amrex::Real const> const& Byf,
-                               const int nox,
-                               const int noz,
-                               amrex::Real const* stencil_coef_x,
-                               amrex::Real const* stencil_coef_z)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    amrex::Real res = 0.;
-    for     (int nz = 1; nz < noz/2+1; nz++) {
-        for (int nx = 1; nx < nox/2+1; nx++) {
-            res += 0.25_rt * stencil_coef_x[nx-1] * stencil_coef_z[nz-1] *
-                   (Byf(j + nx - 1, k + nz - 1, l) + Byf(j - nx, k + nz - 1, l)
-                  + Byf(j + nx - 1, k - nz    , l) + Byf(j - nx, k - nz    , l));
-        }
-    }
-    Bya(j,k,l) = res;
-#else
-    amrex::Real res = 0.;
-    for     (int nz = 1; nz < noz/2+1; nz++) {
-        for (int nx = 1; nx < nox/2+1; nx++) {
-            res += 0.25_rt * stencil_coef_x[nx-1] * stencil_coef_z[nz-1] *
-                   (Byf(j + nx - 1, k, l + nz - 1) + Byf(j - nx, k, l + nz - 1)
-                  + Byf(j + nx - 1, k, l - nz    ) + Byf(j - nx, k, l - nz    ));
-        }
-    }
-    Bya(j,k,l) = res;
-#endif
-}
-
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Bz field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
@@ -395,40 +326,6 @@ void warpx_interp_nd_bfield_z (int j, int k, int l,
     amrex::ignore_unused(l);
 #else
     Bza(j,k,l) = 0.25_rt*(Bzf(j-1,k-1,l) + Bzf(j,k-1,l) + Bzf(j-1,k,l) + Bzf(j,k,l));
-#endif
-}
-
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the Bz field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_bfield_z (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Bza,
-                               amrex::Array4<amrex::Real const> const& Bzf,
-                               const int nox,
-                               const int noy,
-                               amrex::Real const* stencil_coef_x,
-                               amrex::Real const* stencil_coef_y)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(noy);
-    amrex::ignore_unused(stencil_coef_y);
-    amrex::Real res = 0.;
-    for (int nx = 1; nx < nox/2+1; nx++) {
-        res += 0.5_rt * stencil_coef_x[nx-1] * (Bzf(j + nx - 1, k, l) + Bzf(j - nx, k, l));
-    }
-    Bza(j,k,l) = res;
-#else
-    amrex::Real res = 0.;
-    for     (int ny = 1; ny < noy/2+1; ny++) {
-        for (int nx = 1; nx < nox/2+1; nx++) {
-            res += 0.25_rt * stencil_coef_x[nx-1] * stencil_coef_y[ny-1] *
-                   (Bzf(j + nx - 1, k + ny - 1, l) + Bzf(j - nx, k + ny - 1, l)
-                  + Bzf(j + nx - 1, k - ny    , l) + Bzf(j - nx, k - ny    , l));
-        }
-    }
-    Bza(j,k,l) = res;
 #endif
 }
 
@@ -653,24 +550,6 @@ void warpx_interp_nd_efield_x (int j, int k, int l,
     Exa(j,k,l) = 0.5_rt*(Exf(j-1,k,l) + Exf(j,k,l));
 }
 
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the Ex field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_x (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Exa,
-                               amrex::Array4<amrex::Real const> const& Exf,
-                               const int nox,
-                               amrex::Real const* stencil_coef_x)
-{
-    using namespace amrex;
-    amrex::Real res = 0.;
-    for (int nx = 1; nx < nox/2+1; nx++) {
-        res += 0.5_rt * stencil_coef_x[nx-1] * (Exf(j + nx - 1, k, l) + Exf(j - nx, k, l));
-    }
-    Exa(j,k,l) = res;
-}
-
 // With the FDTD Maxwell solver, this is the linear interpolation function used to
 // interpolate the Ey field from a staggered grid to a nodal grid, before gathering
 // the field from the nodes to the particle positions (momentum-conserving gathering)
@@ -685,30 +564,6 @@ void warpx_interp_nd_efield_y (int j, int k, int l,
     amrex::ignore_unused(l);
 #else
     Eya(j,k,l) = 0.5_rt*(Eyf(j,k-1,l) + Eyf(j,k,l));
-#endif
-}
-
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the Ey field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_y (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Eya,
-                               amrex::Array4<amrex::Real const> const& Eyf,
-                               const int noy,
-                               amrex::Real const* stencil_coef_y)
-{
-    using namespace amrex;
-#if (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(noy);
-    amrex::ignore_unused(stencil_coef_y);
-    Eya(j,k,l) = Eyf(j,k,l);
-#else
-    amrex::Real res = 0._rt;
-    for (int ny = 1; ny < noy/2+1; ny++) {
-        res += 0.5_rt * stencil_coef_y[ny-1] * (Eyf(j, k + ny - 1, l) + Eyf(j, k - ny, l));
-    }
-    Eya(j,k,l) = res;
 #endif
 }
 
@@ -729,30 +584,114 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
 #endif
 }
 
+// TODO Add Doxygen documentation
 // With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the Ez field from a staggered grid to a nodal grid, before gathering
-// the field from the nodes to the particle positions (momentum-conserving gathering)
+// interpolate the field from a staggered grid to a nodal grid, before gathering the field
+// from the nodes to the particle positions (momentum-conserving field gathering)
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp_nd_efield_z (int j, int k, int l,
-                               amrex::Array4<amrex::Real> const& Eza,
-                               amrex::Array4<amrex::Real const> const& Ezf,
-                               const int noz,
-                               amrex::Real const* stencil_coef_z)
+void warpx_interp (int j, int k, int l,
+                   amrex::Array4<amrex::Real      > const& arr_aux,
+                   amrex::Array4<amrex::Real const> const& arr_fine,
+                   const amrex::IntVect& arr_stag,
+                   const int nox,
+                   const int noy,
+                   const int noz,
+                   amrex::Real const* stencil_coef_x,
+                   amrex::Real const* stencil_coef_y,
+                   amrex::Real const* stencil_coef_z)
 {
     using namespace amrex;
+
+    // NOTE Indices (j,k,l) in the following refer to (x,z,-) in 2D and (x,y,z) in 3D
+
 #if (AMREX_SPACEDIM == 2)
-    amrex::Real res = 0._rt;
-    for (int nz = 1; nz < noz/2+1; nz++) {
-        res += 0.5_rt * stencil_coef_z[nz-1] * (Ezf(j, k + nz - 1, l) + Ezf(j, k - nz, l));
-    }
-    Eza(j,k,l) = res;
-#else
-    amrex::Real res = 0.;
-    for (int nz = 1; nz < noz/2+1; nz++) {
-        res += 0.5_rt * stencil_coef_z[nz-1] * (Ezf(j, k, l + nz - 1) + Ezf(j, k, l - nz));
-    }
-    Eza(j,k,l) = res;
+    amrex::ignore_unused(noy);
 #endif
+
+    // Staggering (0: cell-centered; 1: nodal)
+    const int sj = arr_stag[0];
+    const int sk = arr_stag[1];
+    const int sl = (AMREX_SPACEDIM == 2) ? 1 : arr_stag[2];
+
+    // Number of points (+1) used for interpolation from the staggered grid to the nodal grid
+    // (if the field is nodal along a given direction, there is no interpolation at all)
+    const int nj = (sj == 0) ? nox/2+1 : 2;
+#if   (AMREX_SPACEDIM == 2)
+    const int nk = (sk == 0) ? noz/2+1 : 2;
+#elif (AMREX_SPACEDIM == 3)
+    const int nk = (sk == 0) ? noy/2+1 : 2;
+#endif
+    const int nl = (sl == 0) ? noz/2+1 : 2;
+
+    // Additional normalization factor
+    const amrex::Real wj = (sj == 0) ? 0.5_rt : 1.0_rt;
+    const amrex::Real wk = (sk == 0) ? 0.5_rt : 1.0_rt;
+    const amrex::Real wl = (sl == 0) ? 0.5_rt : 1.0_rt;
+
+    // Arbitrary-order stencil coefficients (possibly reset in the interpolation loop below)
+    amrex::Real cj = 1.0_rt;
+    amrex::Real ck = 1.0_rt;
+    amrex::Real cl = 1.0_rt;
+
+    // Temporary results
+    amrex::Real tmp = 0.0_rt;
+    amrex::Real res = 0.0_rt;
+
+    // Auxiliary indices
+    int ju, jd;
+    int ku, kd;
+    int lu, ld;
+
+    // Interpolation loop
+    //
+    // Examples in 1D for order 2 (f stands for arr_fine):
+    //
+    //  j-1    j    j+1
+    // --o-----o-----o--  result(j) = 1/2 * (f(j) + f(j-1)) (only one Fornberg coefficient equal to 1.0)
+    // -----x-----x-----  f staggered
+    //     j-1    j
+    //
+    //  j-1    j    j+1
+    // --o-----o-----o--  result(j) = f(j)
+    // --o-----o-----o--  f nodal
+    //  j-1    j    j+1
+    //
+    for (int ll = 1; ll < nl; ll++) {
+        // First values: ld = l-1, lu = l
+        ld = l - ll;
+        lu = l + ll - 1;
+        // Reset stencil coefficients if necessary
+        if (sl == 0) cl = stencil_coef_z[ll-1];
+        for (int kk = 1; kk < nk; kk++) {
+            // First values: kd = k-1, ku = k
+            kd = k - kk;
+            ku = k + kk - 1;
+            // Reset stencil coefficients if necessary
+            if (sk == 0) ck = (AMREX_SPACEDIM == 2) ? stencil_coef_z[kk-1] : stencil_coef_y[kk-1];
+            for (int jj = 1; jj < nj; jj++) {
+                // First values: jd = j-1, ju = j
+                jd = j - jj;
+                ju = j + jj - 1;
+                // Reset stencil coefficients if necessary
+                if (sj == 0) cj = stencil_coef_x[jj-1];
+                // Accumulate temporary partial sum
+                tmp = arr_fine(ju,ku,lu);
+                if (sj == 0) tmp += arr_fine(jd,ku,lu);
+                if (sk == 0) tmp += arr_fine(ju,kd,lu);
+                if (sl == 0) tmp += arr_fine(ju,ku,ld);
+                if (sj == 0 && sk == 0) tmp += arr_fine(jd,kd,lu);
+                if (sk == 0 && sl == 0) tmp += arr_fine(ju,kd,ld);
+                if (sj == 0 && sl == 0) tmp += arr_fine(jd,ku,ld);
+                if (sj == 0 && sk == 0 && sl == 0) tmp += arr_fine(jd,kd,ld);
+                // Multiply by normalization factors and stencil coefficients
+                tmp *= wj * wk * wl * cj * ck * cl;
+                // Add temporary partial result to global result
+                res += tmp;
+            }
+        }
+    }
+
+    arr_aux(j,k,l) = res;
 }
 
 #endif

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -584,12 +584,29 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
 #endif
 }
 
-// TODO Add Doxygen documentation
-// With the PSATD Maxwell solver, this is the arbitrary-order interpolation function used to
-// interpolate the field from a staggered grid to a nodal grid, before gathering the field
-// from the nodes to the particle positions (momentum-conserving field gathering)
+/**
+ * \brief With the PSATD Maxwell solver, this is the arbitrary-order interpolation function, based
+ * on the Fornberg coefficients, used to interpolate a given field from the Yee grid to the nodal grid,
+ * before gathering the field from the nodes to the particle positions (momentum-conserving field gathering).
+ * The result is stored in the output array \c arr_aux, allocated on the \c aux patch.
+ *
+ * \param[in] j index along x of the output array
+ * \param[in] k index along y (in 3D) or z (in 2D) of the output array
+ * \param[in] l index along z (in 3D, \c l = 0 in 2D) of the output array
+ * \param[in,out] arr_aux output array allocated on the \c aux patch where interpolated values are stored
+ * \param[in] arr_fine input array allocated on the fine patch
+ * \param[in] arr_stag \c IndexType of the input array (Yee staggering)
+ * \param[in] nox order of finite-order interpolation along x
+ * \param[in] noy order of finite-order interpolation along y
+ * \param[in] noz order of finite-order interpolation along z
+ * \param[in] stencil_coef_x array of Fornberg coefficients for finite-order interpolation stencil along x
+ * \param[in] stencil_coef_y array of Fornberg coefficients for finite-order interpolation stencil along y
+ * \param[in] stencil_coef_z array of Fornberg coefficients for finite-order interpolation stencil along z
+ */
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void warpx_interp (int j, int k, int l,
+void warpx_interp (const int j,
+                   const int k,
+                   const int l,
                    amrex::Array4<amrex::Real      > const& arr_aux,
                    amrex::Array4<amrex::Real const> const& arr_fine,
                    const amrex::IntVect& arr_stag,

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -502,9 +502,9 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
  * \param[in] nox order of finite-order interpolation along x
  * \param[in] noy order of finite-order interpolation along y
  * \param[in] noz order of finite-order interpolation along z
- * \param[in] stencil_coef_x array of Fornberg coefficients for finite-order interpolation stencil along x
- * \param[in] stencil_coef_y array of Fornberg coefficients for finite-order interpolation stencil along y
- * \param[in] stencil_coef_z array of Fornberg coefficients for finite-order interpolation stencil along z
+ * \param[in] stencil_coeffs_x array of Fornberg coefficients for finite-order interpolation stencil along x
+ * \param[in] stencil_coeffs_y array of Fornberg coefficients for finite-order interpolation stencil along y
+ * \param[in] stencil_coeffs_z array of Fornberg coefficients for finite-order interpolation stencil along z
  */
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp (const int j,
@@ -516,14 +516,20 @@ void warpx_interp (const int j,
                    const int nox = 2,
                    const int noy = 2,
                    const int noz = 2,
-                   amrex::Real const* stencil_coef_x = nullptr,
-                   amrex::Real const* stencil_coef_y = nullptr,
-                   amrex::Real const* stencil_coef_z = nullptr)
+                   amrex::Real const* stencil_coeffs_x = nullptr,
+                   amrex::Real const* stencil_coeffs_y = nullptr,
+                   amrex::Real const* stencil_coeffs_z = nullptr)
 {
     using namespace amrex;
 
+    // Avoid compiler warnings
 #if (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(noy, stencil_coef_y);
+    amrex::ignore_unused(noy, stencil_coeffs_y);
+#endif
+
+    // Avoid compiler warnings
+#ifndef WARPX_USE_PSATD
+    amrex::ignore_unused(stencil_coeffs_x, stencil_coeffs_y, stencil_coeffs_z);
 #endif
 
     // Staggering (s = 0 if cell-centered, s = 1 if nodal)
@@ -553,11 +559,16 @@ void warpx_interp (const int j,
     const amrex::Real wl = (sl == 0) ? 0.5_rt : 1.0_rt;
 #endif
 
-    // Arbitrary-order stencil coefficients
-    // (with PSATD they are reassigned in the interpolation loop below)
+    // Auxiliary variables for stencil coefficients
+#ifdef WARPX_USE_PSATD
     amrex::Real cj = 1.0_rt;
     amrex::Real ck = 1.0_rt;
     amrex::Real cl = 1.0_rt;
+    int dj, dk;
+#if (AMREX_SPACEDIM == 3)
+    int dl;
+#endif
+#endif
 
     // Min and max for interpolation loop along j
     const int jmin = (sj == 0) ? j - nj + 1 : j;
@@ -577,53 +588,78 @@ void warpx_interp (const int j,
     const int lmax = (sl == 0) ? l + nl - 2 : l;
 #endif
 
-    // Integer indices to access arbitrary-order stencil coefficients
-    int dj, dk;
-#if (AMREX_SPACEDIM == 3)
-    int dl;
-#endif
-
-    // Interpolation loop (see below examples and illustrations for 1D case).
-    // So far, with FDTD we use only interpolation order 2 and we do not have access
-    // to the Fornberg coefficients. In the future, we might want to use the Fornberg
-    // coefficients with both FDTD and PSATD, in which case the #ifdef WARPX_USE_PSATD condition
-    // below will be removed. Currently, with FDTD we set cj = ck = cl = 1 and do not change them.
-    //
-    // - example and illustration: nodal to nodal
-    //
-    //           j
-    //   --o-----o-----o--  result(j) = f(j)
-    //   --o-----o-----o--
-    //    j-1    j    j+1
-    //
-    // - example and illustration: staggered to nodal
-    //
-    //                       j
-    //   --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
-    //   -----x-----x-----x-----x-----x-----x-----            + c_1 * (f(j-2) + f(j+1)) / 2
-    //       j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
-    //       c_2   c_1   c_0   c_0   c_1   c_2                + ...
-    //
     amrex::Real res = 0.0_rt;
-    for         (int ll = lmin; ll <= lmax; ll++) {
-        for     (int kk = kmin; kk <= kmax; kk++) {
-            for (int jj = jmin; jj <= jmax; jj++) {
-#ifdef WARPX_USE_PSATD
-                dj = (j - jj > 0) ? j - jj - 1 : jj - j;
-                dk = (k - kk > 0) ? k - kk - 1 : kk - k;
-                if (sj == 0) cj = stencil_coef_x[dj];
+
+#ifndef WARPX_USE_PSATD // FDTD (linear interpolation)
+
+    // Example of 1D interpolation from nodal grid to nodal grid:
+    //
+    //         j
+    // --o-----o-----o--  result(j) = f(j)
+    // --o-----o-----o--
+    //  j-1    j    j+1
+    //
+    // Example of 1D interpolation from staggered grid to nodal grid:
+    //
+    //         j
+    // --o-----o-----o--  result(j) = (f(j-1) + f(j)) / 2
+    // -----x-----x-----
+    //     j-1    j
+
+    for (int ll = lmin; ll <= lmax; ll++)
+    {
+        for (int kk = kmin; kk <= kmax; kk++)
+        {
+            for (int jj = jmin; jj <= jmax; jj++)
+            {
+                res += arr_fine(jj,kk,ll);
+            }
+        }
+    }
+
+#else // PSATD (finite-order interpolation)
+
+    // Example of 1D interpolation from nodal grid to nodal grid:
+    //
+    //         j
+    // --o-----o-----o--  result(j) = f(j)
+    // --o-----o-----o--
+    //  j-1    j    j+1
+    //
+    // Example of 1D interpolation from staggered grid to nodal grid:
+    //
+    //                     j
+    // --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
+    // -----x-----x-----x-----x-----x-----x-----            + c_1 * (f(j-2) + f(j+1)) / 2
+    //     j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
+    //     c_2   c_1   c_0   c_0   c_1   c_2                + ...
+
+    for (int ll = lmin; ll <= lmax; ll++)
+    {
+#if (AMREX_SPACEDIM == 3)
+        dl = (l - ll > 0) ? l - ll - 1 : ll - l;
+        if (sl == 0) cl = stencil_coeffs_z[dl];
+#endif
+        for (int kk = kmin; kk <= kmax; kk++)
+        {
+            dk = (k - kk > 0) ? k - kk - 1 : kk - k;
 #if   (AMREX_SPACEDIM == 2)
-                if (sk == 0) ck = stencil_coef_z[dk];
+            if (sk == 0) ck = stencil_coeffs_z[dk];
 #elif (AMREX_SPACEDIM == 3)
-                dl = (l - ll > 0) ? l - ll - 1 : ll - l;
-                if (sk == 0) ck = stencil_coef_y[dk];
-                if (sl == 0) cl = stencil_coef_z[dl];
+            if (sk == 0) ck = stencil_coeffs_y[dk];
 #endif
-#endif
+            for (int jj = jmin; jj <= jmax; jj++)
+            {
+                dj = (j - jj > 0) ? j - jj - 1 : jj - j;
+                if (sj == 0) cj = stencil_coeffs_x[dj];
+
                 res += cj * ck * cl * arr_fine(jj,kk,ll);
             }
         }
     }
+
+#endif
+
     arr_aux(j,k,l) = wj * wk * wl * res;
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -558,6 +558,16 @@ public:
 
     void ApplyFilterandSumBoundaryRho (int lev, int glev, amrex::MultiFab& rho, int icomp, int ncomp);
 
+#ifdef WARPX_USE_PSATD
+    // Host and device vectors for Fornberg stencil coefficients used for finite-order centering
+    amrex::Vector<amrex::Real> host_centering_stencil_coeffs_x;
+    amrex::Vector<amrex::Real> host_centering_stencil_coeffs_y;
+    amrex::Vector<amrex::Real> host_centering_stencil_coeffs_z;
+    amrex::Gpu::DeviceVector<amrex::Real> device_centering_stencil_coeffs_x;
+    amrex::Gpu::DeviceVector<amrex::Real> device_centering_stencil_coeffs_y;
+    amrex::Gpu::DeviceVector<amrex::Real> device_centering_stencil_coeffs_z;
+#endif
+
 protected:
 
     /**

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -698,24 +698,24 @@ WarpX::ReadParameters ()
             }
 
             // Host vectors for Fornberg stencil coefficients used for finite-order centering
-            WarpX::host_centering_stencil_coeffs_x = getFornbergStencilCoefficients(field_gathering_nox, false);
-            WarpX::host_centering_stencil_coeffs_y = getFornbergStencilCoefficients(field_gathering_noy, false);
-            WarpX::host_centering_stencil_coeffs_z = getFornbergStencilCoefficients(field_gathering_noz, false);
+            host_centering_stencil_coeffs_x = getFornbergStencilCoefficients(field_gathering_nox, false);
+            host_centering_stencil_coeffs_y = getFornbergStencilCoefficients(field_gathering_noy, false);
+            host_centering_stencil_coeffs_z = getFornbergStencilCoefficients(field_gathering_noz, false);
 
             // Device vectors for Fornberg stencil coefficients used for finite-order centering
-            WarpX::device_centering_stencil_coeffs_x.resize(host_centering_stencil_coeffs_x.size());
+            device_centering_stencil_coeffs_x.resize(host_centering_stencil_coeffs_x.size());
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   host_centering_stencil_coeffs_x.begin(),
                                   host_centering_stencil_coeffs_x.end(),
                                   device_centering_stencil_coeffs_x.begin());
 
-            WarpX::device_centering_stencil_coeffs_y.resize(host_centering_stencil_coeffs_y.size());
+            device_centering_stencil_coeffs_y.resize(host_centering_stencil_coeffs_y.size());
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   host_centering_stencil_coeffs_y.begin(),
                                   host_centering_stencil_coeffs_y.end(),
                                   device_centering_stencil_coeffs_y.begin());
 
-            WarpX::device_centering_stencil_coeffs_z.resize(host_centering_stencil_coeffs_z.size());
+            device_centering_stencil_coeffs_z.resize(host_centering_stencil_coeffs_z.size());
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   host_centering_stencil_coeffs_z.begin(),
                                   host_centering_stencil_coeffs_z.end(),


### PR DESCRIPTION
This PR unifies the arbitrary-order interpolation functions called within `WarpX::UpdateAuxilaryDataStagToNodal` to interpolate data from the fine grid to the `aux` grid, with momentum-conserving field gathering (hence between grids with different staggerings), without mesh refinement.

The new function `warpx_interp` (overload) replaces the following old functions:
- `warpx_interp_nd_bfield_x` (x2)
- `warpx_interp_nd_bfield_y` (x2)
- `warpx_interp_nd_bfield_z` (x2)
- `warpx_interp_nd_efield_x` (x2)
- `warpx_interp_nd_efield_y` (x2)
- `warpx_interp_nd_efield_z` (x2)

These overloads replaced here were used either with the FDTD solver (only linear interpolation) or with the PSATD solver (finite-order interpolation based on the Fornberg coefficients). They are different from the ones generalized and replaced in #1650, which are used with mesh refinement.

This PR should make it easier to reuse/extend the finite-order interpolation functions to perform interpolation in the opposite way, from a nodal grid to a Yee grid, which is planned to be done in the near future.

**To-do**
- [x] Test second order in 2D and 3D (CI)
- [x] Test high order in 2D (CI)
- [x] Test high order in 3D (manually, on GPU)
- [x] Add Doxygen