### PR TITLE
CI: Ubuntu-latest -> 20.04

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -11,7 +11,7 @@ on: [push, pull_request]
 jobs:
   style:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
 # intel-basekit intel-hpckit are too large in size
   build_icc:
     name: oneAPI ICC SP&DP [Linux]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies


### PR DESCRIPTION
Removes a warning:

Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see
https://github.com/actions/virtual-environments/issues/1816