### PR TITLE
Replace an always false test with an abort

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -273,7 +273,7 @@ void CheckGriddingForRZSpectral ()
 {
 #ifndef WARPX_DIM_RZ
     amrex::Abort("CheckGriddingForRZSpectral: WarpX was not built with RZ geometry.");
-#endif
+#else
 
     ParmParse pp("algo");
     int maxwell_solver_id = GetAlgorithmInteger(pp, "maxwell_solver");
@@ -346,6 +346,7 @@ void CheckGriddingForRZSpectral ()
         mg[0] /= 2;
     }
     pp_amr.addarr("max_grid_size_y", mg);
+#endif
 }
 
 namespace WarpXUtilMsg{

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -272,8 +272,7 @@ getWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real
 void CheckGriddingForRZSpectral ()
 {
 #ifndef WARPX_DIM_RZ
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
-        "CheckGriddingForRZSpectral: WarpX was not built with RZ geometry.");
+    amrex::Abort("CheckGriddingForRZSpectral: WarpX was not built with RZ geometry.");
 #endif
 
     ParmParse pp("algo");


### PR DESCRIPTION
I am not completely sure about replacing an `assert(false, msg)` with `abort(msg)`. However, adding `#else ... #endif` also fixes a `potential null pointer dereference` warning