### PR TITLE
Remove redundant "do_qed" option in inputfile

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -623,20 +623,15 @@ Particle initialization
     must be either electrons or positrons. Boris pusher must be used for the
     simulation
 
-* ``<species>.do_qed`` (`int`) optional (default `0`)
-    If `<species>.do_qed = 0` all the QED effects are disabled for this species.
-    If `<species>.do_qed = 1` QED effects can be enabled for this species (see below).
-    **This feature requires to compile with QED=TRUE**
-
 * ``<species>.do_qed_quantum_sync`` (`int`) optional (default `0`)
-    It only works if `<species>.do_qed = 1`. Enables Quantum synchrotron emission for this species.
+    Enables Quantum synchrotron emission for this species.
     Quantum synchrotron lookup table should be either generated or loaded from disk to enable
     this process (see "Lookup tables for QED modules" section below).
     `<species>` must be either an electron or a positron species.
     **This feature requires to compile with QED=TRUE**
 
 * ``<species>.do_qed_breit_wheeler`` (`int`) optional (default `0`)
-    It only works if `<species>.do_qed = 1`. Enables non-linear Breit-Wheeler process for this species.
+    Enables non-linear Breit-Wheeler process for this species.
     Breit-Wheeler lookup table should be either generated or loaded from disk to enable
     this process (see "Lookup tables for QED modules" section below).
     `<species>` must be a photon species.

--- a/Examples/Modules/qed/breit_wheeler/inputs_2d
+++ b/Examples/Modules/qed/breit_wheeler/inputs_2d
@@ -44,7 +44,6 @@ p1.profile = "constant"
 p1.momentum_distribution_type = "gaussian"
 p1.ux_m = 2000.0
 ##########QED####################
-p1.do_qed = 1
 p1.do_qed_breit_wheeler = 1
 p1.qed_breit_wheeler_ele_product_species = ele1
 p1.qed_breit_wheeler_pos_product_species = pos1
@@ -59,7 +58,6 @@ p2.profile = "constant"
 p2.momentum_distribution_type = "gaussian"
 p2.uy_m = 5000.0
 ##########QED####################
-p2.do_qed = 1
 p2.do_qed_breit_wheeler = 1
 p2.qed_breit_wheeler_ele_product_species = ele2
 p2.qed_breit_wheeler_pos_product_species = pos2
@@ -74,7 +72,6 @@ p3.profile = "constant"
 p3.momentum_distribution_type = "gaussian"
 p3.uz_m = 10000.0
 ##########QED####################
-p3.do_qed = 1
 p3.do_qed_breit_wheeler = 1
 p3.qed_breit_wheeler_ele_product_species = ele3
 p3.qed_breit_wheeler_pos_product_species = pos3
@@ -91,7 +88,6 @@ p4.ux_m = 57735.02691896
 p4.uy_m = 57735.02691896
 p4.uz_m = 57735.02691896
 ##########QED####################
-p4.do_qed = 1
 p4.do_qed_breit_wheeler = 1
 p4.qed_breit_wheeler_ele_product_species = ele4
 p4.qed_breit_wheeler_pos_product_species = pos4
@@ -105,7 +101,6 @@ ele1.profile = constant
 ele1.density = 0.0
 ele1.momentum_distribution_type = "gaussian"
 ele1.do_not_push = 1
-ele1.do_qed = 1
 ele1.do_qed_quantum_sync = 1
 ele1.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -116,7 +111,6 @@ ele2.profile = constant
 ele2.density = 0.0
 ele2.momentum_distribution_type = "gaussian"
 ele2.do_not_push = 1
-ele2.do_qed = 1
 ele2.do_qed_quantum_sync = 1
 ele2.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -127,7 +121,6 @@ ele3.profile = constant
 ele3.density = 0.0
 ele3.momentum_distribution_type = "gaussian"
 ele3.do_not_push = 1
-ele3.do_qed = 1
 ele3.do_qed_quantum_sync = 1
 ele3.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -138,7 +131,6 @@ ele4.profile = constant
 ele4.density = 0.0
 ele4.momentum_distribution_type = "gaussian"
 ele4.do_not_push = 1
-ele4.do_qed = 1
 ele4.do_qed_quantum_sync = 1
 ele4.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -149,7 +141,6 @@ pos1.profile = constant
 pos1.density = 0.0
 pos1.momentum_distribution_type = "gaussian"
 pos1.do_not_push = 1
-pos1.do_qed = 1
 pos1.do_qed_quantum_sync = 1
 pos1.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -160,7 +151,6 @@ pos2.profile = constant
 pos2.density = 0.0
 pos2.momentum_distribution_type = "gaussian"
 pos2.do_not_push = 1
-pos2.do_qed = 1
 pos2.do_qed_quantum_sync = 1
 pos2.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -171,7 +161,6 @@ pos3.profile = constant
 pos3.density = 0.0
 pos3.momentum_distribution_type = "gaussian"
 pos3.do_not_push = 1
-pos3.do_qed = 1
 pos3.do_qed_quantum_sync = 1
 pos3.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -182,7 +171,6 @@ pos4.profile = constant
 pos4.density = 0.0
 pos4.momentum_distribution_type = "gaussian"
 pos4.do_not_push = 1
-pos4.do_qed = 1
 pos4.do_qed_quantum_sync = 1
 pos4.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -192,7 +180,6 @@ dummy_phot.num_particles_per_cell_each_dim = 0 0
 dummy_phot.profile = constant
 dummy_phot.density = 0.0
 dummy_phot.momentum_distribution_type = "gaussian"
-dummy_phot.do_qed = 0
 
 #################################
 

--- a/Examples/Modules/qed/breit_wheeler/inputs_3d
+++ b/Examples/Modules/qed/breit_wheeler/inputs_3d
@@ -44,7 +44,6 @@ p1.profile = "constant"
 p1.momentum_distribution_type = "gaussian"
 p1.ux_m = 2000.0
 ##########QED####################
-p1.do_qed = 1
 p1.do_qed_breit_wheeler = 1
 p1.qed_breit_wheeler_ele_product_species = ele1
 p1.qed_breit_wheeler_pos_product_species = pos1
@@ -59,7 +58,6 @@ p2.profile = "constant"
 p2.momentum_distribution_type = "gaussian"
 p2.uy_m = 5000.0
 ##########QED####################
-p2.do_qed = 1
 p2.do_qed_breit_wheeler = 1
 p2.qed_breit_wheeler_ele_product_species = ele2
 p2.qed_breit_wheeler_pos_product_species = pos2
@@ -74,7 +72,6 @@ p3.profile = "constant"
 p3.momentum_distribution_type = "gaussian"
 p3.uz_m = 10000.0
 ##########QED####################
-p3.do_qed = 1
 p3.do_qed_breit_wheeler = 1
 p3.qed_breit_wheeler_ele_product_species = ele3
 p3.qed_breit_wheeler_pos_product_species = pos3
@@ -91,7 +88,6 @@ p4.ux_m = 57735.02691896
 p4.uy_m = 57735.02691896
 p4.uz_m = 57735.02691896
 ##########QED####################
-p4.do_qed = 1
 p4.do_qed_breit_wheeler = 1
 p4.qed_breit_wheeler_ele_product_species = ele4
 p4.qed_breit_wheeler_pos_product_species = pos4
@@ -105,7 +101,6 @@ ele1.profile = constant
 ele1.density = 0.0
 ele1.momentum_distribution_type = "gaussian"
 ele1.do_not_push = 1
-ele1.do_qed = 1
 ele1.do_qed_quantum_sync = 1
 ele1.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -116,7 +111,6 @@ ele2.profile = constant
 ele2.density = 0.0
 ele2.momentum_distribution_type = "gaussian"
 ele2.do_not_push = 1
-ele2.do_qed = 1
 ele2.do_qed_quantum_sync = 1
 ele2.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -127,7 +121,6 @@ ele3.profile = constant
 ele3.density = 0.0
 ele3.momentum_distribution_type = "gaussian"
 ele3.do_not_push = 1
-ele3.do_qed = 1
 ele3.do_qed_quantum_sync = 1
 ele3.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -138,7 +131,6 @@ ele4.profile = constant
 ele4.density = 0.0
 ele4.momentum_distribution_type = "gaussian"
 ele4.do_not_push = 1
-ele4.do_qed = 1
 ele4.do_qed_quantum_sync = 1
 ele4.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -149,7 +141,6 @@ pos1.profile = constant
 pos1.density = 0.0
 pos1.momentum_distribution_type = "gaussian"
 pos1.do_not_push = 1
-pos1.do_qed = 1
 pos1.do_qed_quantum_sync = 1
 pos1.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -160,7 +151,6 @@ pos2.profile = constant
 pos2.density = 0.0
 pos2.momentum_distribution_type = "gaussian"
 pos2.do_not_push = 1
-pos2.do_qed = 1
 pos2.do_qed_quantum_sync = 1
 pos2.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -171,7 +161,6 @@ pos3.profile = constant
 pos3.density = 0.0
 pos3.momentum_distribution_type = "gaussian"
 pos3.do_not_push = 1
-pos3.do_qed = 1
 pos3.do_qed_quantum_sync = 1
 pos3.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -182,7 +171,6 @@ pos4.profile = constant
 pos4.density = 0.0
 pos4.momentum_distribution_type = "gaussian"
 pos4.do_not_push = 1
-pos4.do_qed = 1
 pos4.do_qed_quantum_sync = 1
 pos4.qed_quantum_sync_phot_product_species = dummy_phot
 
@@ -192,7 +180,6 @@ dummy_phot.num_particles_per_cell_each_dim = 0 0
 dummy_phot.profile = constant
 dummy_phot.density = 0.0
 dummy_phot.momentum_distribution_type = "gaussian"
-dummy_phot.do_qed = 0
 
 #################################
 

--- a/Examples/Modules/qed/quantum_synchrotron/inputs_2d
+++ b/Examples/Modules/qed/quantum_synchrotron/inputs_2d
@@ -44,7 +44,6 @@ p1.profile = "constant"
 p1.momentum_distribution_type = "gaussian"
 p1.ux_m = 10.0
 ##########QED####################
-p1.do_qed = 1
 p1.do_qed_quantum_sync = 1
 p1.qed_quantum_sync_phot_product_species = qsp_1
 #################################
@@ -58,7 +57,6 @@ p2.profile = "constant"
 p2.momentum_distribution_type = "gaussian"
 p2.uy_m = 100.0
 ##########QED####################
-p2.do_qed = 1
 p2.do_qed_quantum_sync = 1
 p2.qed_quantum_sync_phot_product_species = qsp_2
 #################################
@@ -72,7 +70,6 @@ p3.profile = "constant"
 p3.momentum_distribution_type = "gaussian"
 p3.uz_m = 1000.0
 ##########QED####################
-p3.do_qed = 1
 p3.do_qed_quantum_sync = 1
 p3.qed_quantum_sync_phot_product_species = qsp_3
 #################################
@@ -88,7 +85,6 @@ p4.ux_m = 5773.502691896
 p4.uy_m = 5773.502691896
 p4.uz_m = 5773.502691896
 ##########QED####################
-p4.do_qed = 1
 p4.do_qed_quantum_sync = 1
 p4.qed_quantum_sync_phot_product_species = qsp_4
 #################################
@@ -100,7 +96,6 @@ qsp_1.num_particles_per_cell_each_dim = 0 0
 qsp_1.profile = constant
 qsp_1.density = 0.0
 qsp_1.momentum_distribution_type = "gaussian"
-qsp_1.do_qed = 1
 qsp_1.do_qed_breit_wheeler = 1
 qsp_1.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_1.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -111,7 +106,6 @@ qsp_2.num_particles_per_cell_each_dim = 0 0
 qsp_2.profile = constant
 qsp_2.density = 0.0
 qsp_2.momentum_distribution_type = "gaussian"
-qsp_2.do_qed = 1
 qsp_2.do_qed_breit_wheeler = 1
 qsp_2.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_2.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -122,7 +116,6 @@ qsp_3.num_particles_per_cell_each_dim = 0 0
 qsp_3.profile = constant
 qsp_3.density = 0.0
 qsp_3.momentum_distribution_type = "gaussian"
-qsp_3.do_qed = 1
 qsp_3.do_qed_breit_wheeler = 1
 qsp_3.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_3.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -133,7 +126,6 @@ qsp_4.num_particles_per_cell_each_dim = 0 0
 qsp_4.profile = constant
 qsp_4.density = 0.0
 qsp_4.momentum_distribution_type = "gaussian"
-qsp_4.do_qed = 1
 qsp_4.do_qed_breit_wheeler = 1
 qsp_4.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_4.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -146,7 +138,6 @@ dummy_ele.num_particles_per_cell_each_dim = 0 0
 dummy_ele.profile = constant
 dummy_ele.density = 0.0
 dummy_ele.momentum_distribution_type = "gaussian"
-dummy_ele.do_qed = 0
 
 dummy_pos.species_type = "positron"
 dummy_pos.injection_style = nuniformpercell
@@ -154,8 +145,6 @@ dummy_pos.num_particles_per_cell_each_dim = 0 0
 dummy_pos.profile = constant
 dummy_pos.density = 0.0
 dummy_pos.momentum_distribution_type = "gaussian"
-dummy_pos.do_qed = 0
-
 
 #################################
 

--- a/Examples/Modules/qed/quantum_synchrotron/inputs_3d
+++ b/Examples/Modules/qed/quantum_synchrotron/inputs_3d
@@ -44,7 +44,6 @@ p1.profile = "constant"
 p1.momentum_distribution_type = "gaussian"
 p1.ux_m = 10.0
 ##########QED####################
-p1.do_qed = 1
 p1.do_qed_quantum_sync = 1
 p1.qed_quantum_sync_phot_product_species = qsp_1
 #################################
@@ -58,7 +57,6 @@ p2.profile = "constant"
 p2.momentum_distribution_type = "gaussian"
 p2.uy_m = 100.0
 ##########QED####################
-p2.do_qed = 1
 p2.do_qed_quantum_sync = 1
 p2.qed_quantum_sync_phot_product_species = qsp_2
 #################################
@@ -72,7 +70,6 @@ p3.profile = "constant"
 p3.momentum_distribution_type = "gaussian"
 p3.uz_m = 1000.0
 ##########QED####################
-p3.do_qed = 1
 p3.do_qed_quantum_sync = 1
 p3.qed_quantum_sync_phot_product_species = qsp_3
 #################################
@@ -88,7 +85,6 @@ p4.ux_m = 5773.502691896
 p4.uy_m = 5773.502691896
 p4.uz_m = 5773.502691896
 ##########QED####################
-p4.do_qed = 1
 p4.do_qed_quantum_sync = 1
 p4.qed_quantum_sync_phot_product_species = qsp_4
 #################################
@@ -100,7 +96,6 @@ qsp_1.num_particles_per_cell_each_dim = 0 0
 qsp_1.profile = constant
 qsp_1.density = 0.0
 qsp_1.momentum_distribution_type = "gaussian"
-qsp_1.do_qed = 1
 qsp_1.do_qed_breit_wheeler = 1
 qsp_1.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_1.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -111,7 +106,6 @@ qsp_2.num_particles_per_cell_each_dim = 0 0
 qsp_2.profile = constant
 qsp_2.density = 0.0
 qsp_2.momentum_distribution_type = "gaussian"
-qsp_2.do_qed = 1
 qsp_2.do_qed_breit_wheeler = 1
 qsp_2.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_2.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -122,7 +116,6 @@ qsp_3.num_particles_per_cell_each_dim = 0 0
 qsp_3.profile = constant
 qsp_3.density = 0.0
 qsp_3.momentum_distribution_type = "gaussian"
-qsp_3.do_qed = 1
 qsp_3.do_qed_breit_wheeler = 1
 qsp_3.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_3.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -133,7 +126,6 @@ qsp_4.num_particles_per_cell_each_dim = 0 0
 qsp_4.profile = constant
 qsp_4.density = 0.0
 qsp_4.momentum_distribution_type = "gaussian"
-qsp_4.do_qed = 1
 qsp_4.do_qed_breit_wheeler = 1
 qsp_4.qed_breit_wheeler_ele_product_species = dummy_ele
 qsp_4.qed_breit_wheeler_pos_product_species = dummy_pos
@@ -146,7 +138,6 @@ dummy_ele.num_particles_per_cell_each_dim = 0 0
 dummy_ele.profile = constant
 dummy_ele.density = 0.0
 dummy_ele.momentum_distribution_type = "gaussian"
-dummy_ele.do_qed = 0
 
 dummy_pos.species_type = "positron"
 dummy_pos.injection_style = nuniformpercell
@@ -154,8 +145,6 @@ dummy_pos.num_particles_per_cell_each_dim = 0 0
 dummy_pos.profile = constant
 dummy_pos.density = 0.0
 dummy_pos.momentum_distribution_type = "gaussian"
-dummy_pos.do_qed = 0
-
 
 #################################
 

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -51,7 +51,7 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
         // get WarpXParticleContainer class object
         auto & myspc = mypc.GetParticleContainer(i_s);
 
-        if (myspc.has_breit_wheeler() || myspc.has_quantum_sync())
+        if (myspc.DoQED())
         {
             // resize data array for QED species
             const int num_quantities = 18;
@@ -114,7 +114,7 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
                 ofs << m_sep;
                 ofs << "[18]wmax(1/m)";
 #endif
-                if (myspc.has_breit_wheeler() || myspc.has_quantum_sync())
+                if (myspc.DoQED())
                 {
                     ofs << m_sep;
                     ofs << "[19]chimin()";
@@ -351,7 +351,7 @@ void ParticleExtrema::ComputeDiags (int step)
         GetExternalEField get_externalE;
         GetExternalBField get_externalB;
 
-        if (myspc.has_breit_wheeler() || myspc.has_quantum_sync())
+        if (myspc.DoQED())
         {
 
             // declare chi arrays
@@ -478,7 +478,7 @@ void ParticleExtrema::ComputeDiags (int step)
         m_data[14] = wmin;
         m_data[15] = wmax;
 #if (defined WARPX_QED)
-        if (myspc.has_breit_wheeler() || myspc.has_quantum_sync())
+        if (myspc.DoQED())
         {
             m_data[16] = chimin_f;
             m_data[17] = chimax_f;

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -34,9 +34,8 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core, int ispecie
     ParmParse pp(species_name);
 
 #ifdef WARPX_QED
-        //IF m_do_qed is enabled, find out if Breit Wheeler process is enabled
-        if(m_do_qed)
-            pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
+        //Find out if Breit Wheeler process is enabled
+        pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
 
         //If Breit Wheeler process is enabled, look for the target electron and positron
         //species

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -146,23 +146,18 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     //_____________________________
 
 #ifdef WARPX_QED
-    pp.query("do_qed", m_do_qed);
-    if(m_do_qed){
-        //If do_qed is enabled, find out if Quantum Synchrotron process is enabled
-        pp.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
-        if (m_do_qed_quantum_sync)
-            AddRealComp("optical_depth_QSR");
-        pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
-        if (m_do_qed_breit_wheeler)
-            AddRealComp("optical_depth_BW");
-    }
+    pp.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
+    if (m_do_qed_quantum_sync)
+        AddRealComp("optical_depth_QSR");
+
+    pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
+    if (m_do_qed_breit_wheeler)
+        AddRealComp("optical_depth_BW");
 
     if(m_do_qed_quantum_sync){
         pp.get("qed_quantum_sync_phot_product_species",
             m_qed_quantum_sync_phot_product_name);
     }
-
-
 #endif
 
     // Get Galilean velocity

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -310,16 +310,16 @@ public:
     amrex::ParticleReal getMass () const {return mass;}
 
     int DoFieldIonization() const { return do_field_ionization; }
-    int DoQED() const {
+
 #ifdef WARPX_QED
-        return m_do_qed;
-#else
-        return false;
-#endif
-    }
     //Species for which QED effects are relevant should override these methods
     virtual bool has_quantum_sync() const {return false;}
     virtual bool has_breit_wheeler() const {return false;}
+
+    int DoQED() const { return has_quantum_sync() || has_breit_wheeler(); }
+#else
+    int DoQED() const { return false; }
+#endif
 
     /* \brief This function tests if the current species
     *  is of a given PhysicalSpecies (specified as a template parameter).
@@ -384,8 +384,6 @@ protected:
     int do_back_transformed_diagnostics = 1;
 
 #ifdef WARPX_QED
-    bool m_do_qed = false;
-
     //Species can receive a shared pointer to a QED engine (species for
     //which this is relevant should override these functions)
     virtual void


### PR DESCRIPTION
This PR removes the redundant inputfile option `do_qed`.
Before, in order to enable a QED process the user had to write:
```
spec.do_qed = 1
spec.do_qed_breit_wheeler = 1
```
or
```
spec.do_qed = 1
spec.do_qed_quantum_sync = 1
```

now `spec.do_qed_breit_wheeler = 1` or `spec.do_qed_quantum_sync = 1` are enough to enable a QED effect.