### PR TITLE
requirements.txt: fix overspecification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy~=1.15.0
-periodictable~=1.5.3
+numpy~=1.15
+periodictable~=1.5
 picmistandard==0.0.13
-scipy~=1.6.0  # picmistandard bug: https://github.com/picmi-standard/picmi/pull/34
+scipy~=1.6  # picmistandard bug: https://github.com/picmi-standard/picmi/pull/34
 # optional, some used for testing:
 # yt
 # openpmd-api

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ setup(
     #    ]
     #},
     extras_require={
-        'all': ['openPMD-api~=0.13.0', 'openPMD-viewer~=1.1.0', 'yt~=3.6.1', 'matplotlib'],
+        'all': ['openPMD-api~=0.13.0', 'openPMD-viewer~=1.1', 'yt~=3.6', 'matplotlib'],
     },
     # cmdclass={'test': PyTest},
     # platforms='any',


### PR DESCRIPTION
I accidentally added the patch-level for version-compatible matching/

This removes the patch-level for `~=` matching for the packages that have a >=1 major version already.

Ref.:  https://www.python.org/dev/peps/pep-0440/#compatible-release