### PR TITLE
scipy 1.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy~=1.15
 periodictable~=1.5
 picmistandard==0.0.13
-scipy~=1.6  # picmistandard bug: https://github.com/picmi-standard/picmi/pull/34
+scipy~=1.5  # picmistandard bug: https://github.com/picmi-standard/picmi/pull/34
 # optional, some used for testing:
 # yt
 # openpmd-api


### PR DESCRIPTION
Sufficient since it was last release in december and works well.
The 3.5 release series still builds wheels for Python 3.6 for Ubuntu oldstable (18.04).

Follow-up to #1668 