### PR TITLE
Updates to match picmi version 0.0.14

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -28,6 +28,7 @@ class constants:
     m_p = 1.67262192369e-27
     hbar = 1.054571817e-34
 
+picmistandard.register_constants(constants)
 
 class Species(picmistandard.PICMI_Species):
     def init(self, kw):

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -54,12 +54,12 @@ else:
     package_data = {}
 
 setup(name = 'pywarpx',
-      version = '20.12',
+      version = '21.02',
       packages = ['pywarpx'],
       package_dir = {'pywarpx': 'pywarpx'},
       description = """Wrapper of WarpX""",
       package_data = package_data,
-      install_requires = ['numpy', 'picmistandard==0.0.13', 'periodictable'],
+      install_requires = ['numpy', 'picmistandard==0.0.14', 'periodictable'],
       python_requires = '>=3.6',
       zip_safe=False
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy~=1.15
 periodictable~=1.5
-picmistandard==0.0.13
-scipy~=1.5  # picmistandard bug: https://github.com/picmi-standard/picmi/pull/34
+picmistandard==0.0.14
 # optional, some used for testing:
 # yt
 # openpmd-api

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ with open('./requirements.txt') as f:
 setup(
     name='pywarpx',
     # note PEP-440 syntax: x.y.zaN but x.y.z.devN
-    version = '21.01',
+    version = '21.02',
     packages = ['pywarpx'],
     package_dir = {'pywarpx': 'Python/pywarpx'},
     author='Jean-Luc Vay, David P. Grote, Maxence Thévenet, Rémi Lehe, Andrew Myers, Weiqun Zhang, Axel Huebl, et al.',


### PR DESCRIPTION
In picmi version 0.0.14, a reference to scipy was removed and replaced by requiring the implementation to register the constants object (so it is accessible at the picmistandard level). This PR makes the needed changes, adding the call to register constants and removing scipy from the requirements.

Note that this will fail the CI tests until picmistandard is updated on PyPI.