### PR TITLE
Reduced diagnostic for load balance efficiency

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1819,8 +1819,11 @@ Reduced Diagnostics
 
     * ``LoadBalanceEfficiency``
         This type computes the load balance efficiency, given the present costs
-        and distribution mapping.  Load balance efficiency is computed as the
-        mean cost over all ranks, divided by the maximum cost over all ranks.
+        and distribution mapping. Load balance efficiency is computed as the
+        mean cost over all ranks, divided by the maximum cost over all ranks. 
+        Until costs are recorded, load balance efficiency is output as `-1`; 
+        at earliest, the load balance efficiency can be output starting at step
+        `2`, since costs are not recorded until step `1`.
 
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1817,6 +1817,11 @@ Reduced Diagnostics
         :math:`n_{\text{cell}}` is the number of cells on the box, and
         :math:`w_{\text{cell}}` is the cell cost weight factor (controlled by ``algo.costs_heuristic_cells_wt``).
 
+    * ``LoadBalanceEfficiency``
+        This type computes the load balance efficiency, given the present costs
+        and distribution mapping.  Load balance efficiency is computed as the
+        mean cost over all ranks, divided by the maximum cost over all ranks.
+
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1820,8 +1820,8 @@ Reduced Diagnostics
     * ``LoadBalanceEfficiency``
         This type computes the load balance efficiency, given the present costs
         and distribution mapping. Load balance efficiency is computed as the
-        mean cost over all ranks, divided by the maximum cost over all ranks. 
-        Until costs are recorded, load balance efficiency is output as `-1`; 
+        mean cost over all ranks, divided by the maximum cost over all ranks.
+        Until costs are recorded, load balance efficiency is output as `-1`;
         at earliest, the load balance efficiency can be output starting at step
         `2`, since costs are not recorded until step `1`.
 

--- a/Source/Diagnostics/ReducedDiags/CMakeLists.txt
+++ b/Source/Diagnostics/ReducedDiags/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(WarpX
     BeamRelevant.cpp
     FieldEnergy.cpp
     LoadBalanceCosts.cpp
+    LoadBalanceEfficiency.cpp
     MultiReducedDiags.cpp
     ParticleEnergy.cpp
     ParticleHistogram.cpp

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
@@ -1,0 +1,32 @@
+/* Copyright 2020-2021 Michael Rowan, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_LOADBALANCEEFFICIENCY_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_LOADBALANCEEFFICIENCY_H_
+
+#include "WarpX.H"
+#include "ReducedDiags.H"
+#include "LoadBalanceEfficiency.H"
+
+
+/**
+ *  This class mainly contains a function that update the
+ *  costs (used in load balance) for writing to output.
+ */
+class LoadBalanceEfficiency : public ReducedDiags
+{
+public:
+
+    /** constructor
+     *  @param[in] rd_name reduced diags names */
+    LoadBalanceEfficiency(std::string rd_name);
+
+    /** This function gets the current load balance efficiency  */
+    virtual void ComputeDiags(int step) override final;
+};
+
+#endif

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
@@ -14,7 +14,7 @@
 
 
 /**
- *  This class mainly contains a function that gets the 
+ *  This class mainly contains a function that gets the
  *  current load balance efficiency for writing to output.
  */
 class LoadBalanceEfficiency : public ReducedDiags

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
@@ -14,8 +14,8 @@
 
 
 /**
- *  This class mainly contains a function that update the
- *  costs (used in load balance) for writing to output.
+ *  This class mainly contains a function that gets the 
+ *  current load balance efficiency for writing to output.
  */
 class LoadBalanceEfficiency : public ReducedDiags
 {

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -29,6 +29,7 @@ LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
+
             // write header row
             ofs << "#";
             ofs << "[1]step()";

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2020-2021 Michael Rowan, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "WarpX.H"
+#include "LoadBalanceEfficiency.H"
+
+using namespace amrex;
+
+// constructor
+LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
+    : ReducedDiags{rd_name}
+{   
+    // read number of levels
+    int nLevel = 0;
+    ParmParse pp("amr");
+    pp.query("max_level", nLevel);
+    nLevel += 1;
+
+    // resize data array
+    m_data.resize(nLevel, 0.0_rt);
+
+    if (ParallelDescriptor::IOProcessor())
+    {
+        if ( m_IsNotRestart )
+        {
+            // open file
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
+            // write header row
+            ofs << "#";
+            ofs << "[1]step()";
+            ofs << m_sep;
+            ofs << "[2]time(s)";
+            constexpr int shift = 3;
+            for (int lev = 0; lev < nLevel; ++lev)
+            {
+                ofs << m_sep;
+                ofs << "[" + std::to_string(shift+lev) + "]";
+                ofs << "lev"+std::to_string(lev);
+            }
+            ofs << std::endl;
+
+            // close file
+            ofs.close();
+        }
+    }
+}
+
+// Get the load balance efficiency
+void LoadBalanceEfficiency::ComputeDiags (int step)
+{
+    // Judge if the diags should be done
+    if (!m_intervals.contains(step+1)) { return; }
+
+    // get a reference to WarpX instance
+    auto & warpx = WarpX::GetInstance();
+
+    // get number of level
+    const auto nLevel = warpx.finestLevel() + 1;
+
+    // loop over refinement levels
+    for (int lev = 0; lev < nLevel; ++lev)
+    {
+        // save data
+        m_data[lev] = warpx.getLoadBalanceEfficiency(lev);
+    }
+    // end loop over refinement levels
+
+    /* m_data now contains up-to-date values for:
+     *  [load balance efficiency at level 0,
+     *   load balance efficiency at level 1,
+     *   load balance efficiency at level 2,
+     *   ......] */
+}

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -13,7 +13,7 @@ using namespace amrex;
 // constructor
 LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
     : ReducedDiags{rd_name}
-{   
+{
     // read number of levels
     int nLevel = 0;
     ParmParse pp("amr");

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -4,6 +4,7 @@ CEXE_sources += ParticleEnergy.cpp
 CEXE_sources += FieldEnergy.cpp
 CEXE_sources += BeamRelevant.cpp
 CEXE_sources += LoadBalanceCosts.cpp
+CEXE_sources += LoadBalanceEfficiency.cpp
 CEXE_sources += ParticleHistogram.cpp
 CEXE_sources += FieldMaximum.cpp
 CEXE_sources += ParticleExtrema.cpp

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "LoadBalanceCosts.H"
+#include "LoadBalanceEfficiency.H"
 #include "ParticleHistogram.H"
 #include "BeamRelevant.H"
 #include "ParticleEnergy.H"
@@ -77,6 +78,11 @@ MultiReducedDiags::MultiReducedDiags ()
         {
             m_multi_rd[i_rd] =
                 std::make_unique<LoadBalanceCosts>(m_rd_names[i_rd]);
+        }
+        else if (rd_type.compare("LoadBalanceEfficiency") == 0)
+        {
+            m_multi_rd[i_rd] =
+                std::make_unique<LoadBalanceEfficiency>(m_rd_names[i_rd]);
         }
         else if (rd_type.compare("ParticleHistogram") == 0)
         {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -451,6 +451,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     if (costs[lev]) {
         for (int i : costs[lev]->IndexArray()) {
             (*costs[lev])[i] = 0.0;
+            WarpX::setLoadBalanceEfficiency(lev, -1);
         }
     }
 }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -88,6 +88,9 @@ WarpX::LoadBalance ()
             }
 
             RemakeLevel(lev, t_new[lev], boxArray(lev), newdm);
+
+            // Record the load balance efficiency
+            WarpX::setLoadBalanceEfficiency(lev, proposedEfficiency);
         }
     }
     if (doLoadBalance)
@@ -293,6 +296,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             for (int i : costs[lev]->IndexArray())
             {
                 (*costs[lev])[i] = 0.0;
+                WarpX::setLoadBalanceEfficiency(lev, -1);
             }
         }
 
@@ -343,6 +347,7 @@ WarpX::ResetCosts ()
     {
         for (int i : costs[lev]->IndexArray())
         {
+            // Reset costs and load balance efficiency
             (*costs[lev])[i] = 0.0;
         }
     }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -347,7 +347,7 @@ WarpX::ResetCosts ()
     {
         for (int i : costs[lev]->IndexArray())
         {
-            // Reset costs and load balance efficiency
+            // Reset costs
             (*costs[lev])[i] = 0.0;
         }
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -267,6 +267,28 @@ public:
         }
     }
 
+    void setLoadBalanceEfficiency (const int lev, const amrex::Real efficiency)
+    {
+        if (m_instance)
+        {
+            m_instance->load_balance_efficiency[lev] = efficiency;
+        } else
+        {
+            return;
+        }
+    }
+
+    amrex::Real getLoadBalanceEfficiency (const int lev)
+    {
+        if (m_instance)
+        {
+            return m_instance->load_balance_efficiency[lev];
+        } else
+        {
+            return -1;
+        }
+    }
+    
     static amrex::IntVect filter_npass_each_dir;
     BilinearFilter bilinear_filter;
     amrex::Vector< std::unique_ptr<NCIGodfreyFilter> > nci_godfrey_filter_exeybz;
@@ -810,6 +832,8 @@ private:
      * distribution mapping efficiency is larger than the threshold; 'efficiency'
      * here means the average cost per MPI rank.  */
     amrex::Real load_balance_efficiency_ratio_threshold = amrex::Real(1.1);
+    /** Current load balance efficiency for each level.  */
+    amrex::Vector<amrex::Real> load_balance_efficiency;
     /** Weight factor for cells in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is an empty (i.e. no particles) domain

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -288,7 +288,7 @@ public:
             return -1;
         }
     }
-    
+
     static amrex::IntVect filter_npass_each_dir;
     BilinearFilter bilinear_filter;
     amrex::Vector< std::unique_ptr<NCIGodfreyFilter> > nci_godfrey_filter_exeybz;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -237,6 +237,7 @@ WarpX::WarpX ()
 
     pml.resize(nlevs_max);
     costs.resize(nlevs_max);
+    load_balance_efficiency.resize(nlevs_max);
 
     m_field_factory.resize(nlevs_max);
 
@@ -947,6 +948,7 @@ WarpX::ClearLevel (int lev)
     rho_cp[lev].reset();
 
     costs[lev].reset();
+    load_balance_efficiency[lev] = -1;
 }
 
 void
@@ -1371,6 +1373,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     if (load_balance_intervals.isActivated())
     {
         costs[lev] = std::make_unique<LayoutData<Real>>(ba, dm);
+        load_balance_efficiency[lev] = -1;
     }
 }
 


### PR DESCRIPTION
Adds reduced diagnostic for monitoring load balance efficiency.  Sample output could look like this (for this test, just one level, and the load balance and reduced diagnostic intervals are 2 and 1, respectively):
```
#[1]step() [2]time(s) [3]lev0
0 0.00000000000000e+00 -1.00000000000000e+00
1 6.01816857254517e-11 -1.00000000000000e+00
2 1.20363371450903e-10 8.97156788703472e-01
3 1.80545057176355e-10 8.97156788703472e-01
4 2.40726742901807e-10 8.99164256575965e-01
5 3.00908428627259e-10 8.99164256575965e-01
6 3.61090114352710e-10 8.99490752404783e-01
7 4.21271800078162e-10 8.99490752404783e-01
```