### PR TITLE
MSVC: '*/' found outside of comment

### DIFF
--- a/Source/Particles/Resampling/Resampling.H
+++ b/Source/Particles/Resampling/Resampling.H
@@ -20,7 +20,7 @@ struct ResamplingAlgorithm
     /**
      * \brief Virtual operator() of the abstract ResamplingAlgorithm class
      */
-    virtual void operator() (WarpXParIter& /*pti*/, const int /*lev*/, WarpXParticleContainer */*pc*/) const = 0;
+    virtual void operator() (WarpXParIter& /*pti*/, const int /*lev*/, WarpXParticleContainer* /*pc*/) const = 0;
 
     /**
      * \brief Virtual destructor of the abstract ResamplingAlgorithm class


### PR DESCRIPTION
Fix a warning
```
warning C4138: '*/' found outside of comment
```
with MSVC.