### PR TITLE
openPMD-api: 0.13.2 (internal)

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -62,7 +62,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "0.13.1"
+    set(WarpX_openpmd_branch "0.13.2"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 


### PR DESCRIPTION
Build the latest release, which adds a nice hint on how to find custom HDF5 installs.

https://openpmd-api.readthedocs.io/en/0.13.2/install/changelog.html