### PR TITLE
Input load balance parameters as `algo.load_balance_param`

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -242,10 +242,10 @@ Distribution across MPI ranks and parallelization
     If this is `0`: the Knapsack algorithm is used instead.
 
 * ``algo.load_balance_knapsack_factor`` (`float`) optional (default `1.24`)
-    Controls the maximum number of boxes that can be assigned to a rank during                              
+    Controls the maximum number of boxes that can be assigned to a rank during
     load balance when using the 'knapsack' policy for update of the distribution
     mapping; the maximum is `load_balance_knapsack_factor*(average number of boxes
-    per rank)`. For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`, 
+    per rank)`. For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`,
     no more than 8 boxes can be assigned to any rank.
 
 * ``algo.load_balance_costs_update`` (`Heuristic` or `Timers`) optional (default `Timers`)

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -207,7 +207,7 @@ Distribution across MPI ranks and parallelization
     When using mesh refinement, this number applies to the subdomains
     of the coarsest level, but also to any of the finer level.
 
-* ``warpx.load_balance_intervals`` (`string`) optional (default `0`)
+* ``algo.load_balance_intervals`` (`string`) optional (default `0`)
     Using the `Intervals parser`_ syntax, this string defines the timesteps at which
     WarpX should try to redistribute the work across MPI ranks, in order to have
     better load balancing.
@@ -220,23 +220,23 @@ Distribution across MPI ranks and parallelization
     This relies on each MPI rank handling several (in fact many) subdomains
     (see ``max_grid_size``).
 
-* ``warpx.load_balance_with_sfc`` (`0` or `1`) optional (default `0`)
+* ``algo.load_balance_with_sfc`` (`0` or `1`) optional (default `0`)
     If this is `1`: use a Space-Filling Curve (SFC) algorithm in order to
     perform load-balancing of the simulation.
     If this is `0`: the Knapsack algorithm is used instead.
 
-* ``warpx.load_balance_efficiency_ratio_threshold`` (`float`) optional (default `1.1`)
+* ``algo.load_balance_efficiency_ratio_threshold`` (`float`) optional (default `1.1`)
     Controls whether to adopt a proposed distribution mapping computed during a load balance.
     If the the ratio of the proposed to current distribution mapping *efficiency* (i.e.,
     average cost per MPI process; efficiency is a number in the range [0, 1]) is greater
     than the threshold value, the proposed distribution mapping is adopted.  The suggested
-    range of values is ``warpx.load_balance_efficiency_ratio_threshold >= 1``, which ensures
+    range of values is ``algo.load_balance_efficiency_ratio_threshold >= 1``, which ensures
     that the new distribution mapping is adopted only if doing so would improve the load
     balance efficiency. The higher the threshold value, the more conservative is the criterion
     for adoption of a proposed distribution; for example, with
-    ``warpx.load_balance_efficiency_ratio_threshold = 1``, the proposed distribution is
+    ``algo.load_balance_efficiency_ratio_threshold = 1``, the proposed distribution is
     adopted *any* time the proposed distribution improves load balancing; if instead
-    ``warpx.load_balance_efficiency_ratio_threshold = 2``, the proposed distribution is
+    ``algo.load_balance_efficiency_ratio_threshold = 2``, the proposed distribution is
     adopted only if doing so would yield a 100% to the load balance efficiency (with this
     threshold value, if the  current efficiency is ``0.45``, the new distribution would only be
     adopted if the proposed efficiency were greater than ``0.9``).

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -246,7 +246,7 @@ Distribution across MPI ranks and parallelization
     load balance when using the 'knapsack' policy for update of the distribution
     mapping; the maximum is
     `load_balance_knapsack_factor*(average number of boxes per rank)`.
-    For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`, 
+    For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`,
     no more than 8 boxes can be assigned to any rank.
 
 * ``algo.load_balance_costs_update`` (`Heuristic` or `Timers`) optional (default `Timers`)

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -220,11 +220,6 @@ Distribution across MPI ranks and parallelization
     This relies on each MPI rank handling several (in fact many) subdomains
     (see ``max_grid_size``).
 
-* ``algo.load_balance_with_sfc`` (`0` or `1`) optional (default `0`)
-    If this is `1`: use a Space-Filling Curve (SFC) algorithm in order to
-    perform load-balancing of the simulation.
-    If this is `0`: the Knapsack algorithm is used instead.
-
 * ``algo.load_balance_efficiency_ratio_threshold`` (`float`) optional (default `1.1`)
     Controls whether to adopt a proposed distribution mapping computed during a load balance.
     If the the ratio of the proposed to current distribution mapping *efficiency* (i.e.,
@@ -240,6 +235,18 @@ Distribution across MPI ranks and parallelization
     adopted only if doing so would yield a 100% to the load balance efficiency (with this
     threshold value, if the  current efficiency is ``0.45``, the new distribution would only be
     adopted if the proposed efficiency were greater than ``0.9``).
+
+* ``algo.load_balance_with_sfc`` (`0` or `1`) optional (default `0`)
+    If this is `1`: use a Space-Filling Curve (SFC) algorithm in order to
+    perform load-balancing of the simulation.
+    If this is `0`: the Knapsack algorithm is used instead.
+
+* ``algo.load_balance_knapsack_factor`` (`float`) optional (default `1.24`)
+    Controls the maximum number of boxes that can be assigned to a rank during                              
+    load balance when using the 'knapsack' policy for update of the distribution
+    mapping; the maximum is `load_balance_knapsack_factor*(average number of boxes
+    per rank)`. For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`, 
+    no more than 8 boxes can be assigned to any rank.
 
 * ``algo.load_balance_costs_update`` (`Heuristic` or `Timers`) optional (default `Timers`)
     If this is `Heuristic`: load balance costs are updated according to a measure of

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -244,8 +244,9 @@ Distribution across MPI ranks and parallelization
 * ``algo.load_balance_knapsack_factor`` (`float`) optional (default `1.24`)
     Controls the maximum number of boxes that can be assigned to a rank during
     load balance when using the 'knapsack' policy for update of the distribution
-    mapping; the maximum is `load_balance_knapsack_factor*(average number of boxes
-    per rank)`. For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`,
+    mapping; the maximum is
+    `load_balance_knapsack_factor*(average number of boxes per rank)`.
+    For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`, 
     no more than 8 boxes can be assigned to any rank.
 
 * ``algo.load_balance_costs_update`` (`Heuristic` or `Timers`) optional (default `Timers`)

--- a/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
+++ b/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
@@ -21,9 +21,9 @@ interpolation.noy = 3
 interpolation.noz = 3
 warpx.cfl = 0.98
 warpx.do_dynamic_scheduling = 0
-warpx.load_balance_intervals = -1
 warpx.use_filter = 0
 algo.maxwell_solver = ckc
+algo.load_balance_intervals = -1
 
 #################################
 ############# LASER #############

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -45,9 +45,9 @@ amr.blocking_factor = 64
 warpx.do_dynamic_scheduling = 0
 
 # load balancing
-warpx.load_balance_intervals = 10
-warpx.load_balance_with_sfc = 0
-#warpx.load_balance_efficiency_ratio_threshold = 1.1
+algo.load_balance_intervals = 10
+algo.load_balance_with_sfc = 0
+#algo.load_balance_efficiency_ratio_threshold = 1.1
 algo.load_balance_costs_update = Heuristic
 #algo.costs_heuristic_particles_wt = 0.9
 #algo.costs_heuristic_cells_wt = 0.1

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -27,8 +27,8 @@ my_constants.zp2   = 24.e-6
 my_constants.zc2   = 24.05545177444479562e-6
 warpx.cfl = 1.0
 warpx.do_dynamic_scheduling = 0
-warpx.load_balance_intervals = 66
 warpx.use_filter = 1
+algo.load_balance_intervals = 66
 
 #################################
 ############ PLASMA #############

--- a/Examples/Tests/reduced_diags/inputs_loadbalancecosts
+++ b/Examples/Tests/reduced_diags/inputs_loadbalancecosts
@@ -24,7 +24,7 @@ warpx.use_filter = 1
 algo.maxwell_solver = yee # or ckc
 
 # Load balancing
-warpx.load_balance_intervals = 2
+algo.load_balance_intervals = 2
 #algo.load_balance_costs_update = Timers
 
 # Interpolation

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -665,8 +665,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.use_filter = kw.pop('warpx_use_filter', None)
         self.serialize_ics = kw.pop('warpx_serialize_ics', None)
         self.do_dynamic_scheduling = kw.pop('warpx_do_dynamic_scheduling', None)
-        self.load_balance_intervals_algo = kw.pop('warpx_load_balance_intervals_algo', None)
-        self.load_balance_with_sfc_algo = kw.pop('warpx_load_balance_with_sfc_algo', None)
+        self.load_balance_intervals = kw.pop('warpx_load_balance_intervals', None)
+        self.load_balance_with_sfc = kw.pop('warpx_load_balance_with_sfc', None)
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
 
         self.inputs_initialized = False
@@ -690,8 +690,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         pywarpx.algo.charge_deposition = self.charge_deposition_algo
         pywarpx.algo.field_gathering = self.field_gathering_algo
         pywarpx.algo.particle_pusher = self.particle_pusher_algo
-        pywarpx.algo.load_balance_intervals = self.load_balance_intervals_algo
-        pywarpx.algo.load_balance_with_sfc = self.load_balance_with_sfc_algo
+        pywarpx.algo.load_balance_intervals = self.load_balance_intervals
+        pywarpx.algo.load_balance_with_sfc = self.load_balance_with_sfc
 
         pywarpx.warpx.use_filter = self.use_filter
         pywarpx.warpx.serialize_ics = self.serialize_ics

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -666,7 +666,12 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.serialize_ics = kw.pop('warpx_serialize_ics', None)
         self.do_dynamic_scheduling = kw.pop('warpx_do_dynamic_scheduling', None)
         self.load_balance_intervals = kw.pop('warpx_load_balance_intervals', None)
+        self.load_balance_efficiency_ratio_threshold = kw.pop('warpx_load_balance_efficiency_ratio_threshold', None)
         self.load_balance_with_sfc = kw.pop('warpx_load_balance_with_sfc', None)
+        self.load_balance_knapsack_factor = kw.pop('warpx_load_balance_knapsack_factor', None)
+        self.load_balance_costs_update = kw.pop('warpx_load_balance_costs_update', None)
+        self.costs_heuristic_particles_wt = kw.pop('warpx_costs_heuristic_particles_wt', None)
+        self.costs_heuristic_cells_wt = kw.pop('warpx_costs_heuristic_cells_wt', None)
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
 
         self.inputs_initialized = False
@@ -691,7 +696,12 @@ class Simulation(picmistandard.PICMI_Simulation):
         pywarpx.algo.field_gathering = self.field_gathering_algo
         pywarpx.algo.particle_pusher = self.particle_pusher_algo
         pywarpx.algo.load_balance_intervals = self.load_balance_intervals
+        pywarpx.algo.load_balance_efficiency_ratio_threshold = self.load_balance_efficiency_ratio_threshold
         pywarpx.algo.load_balance_with_sfc = self.load_balance_with_sfc
+        pywarpx.algo.load_balance_knapsack_factor = self.load_balance_knapsack_factor
+        pywarpx.algo.load_balance_costs_update = self.load_balance_costs_update
+        pywarpx.algo.costs_heuristic_particles_wt = self.costs_heuristic_particles_wt
+        pywarpx.algo.costs_heuristic_cells_wt = self.costs_heuristic_cells_wt
 
         pywarpx.warpx.use_filter = self.use_filter
         pywarpx.warpx.serialize_ics = self.serialize_ics

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -665,8 +665,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.use_filter = kw.pop('warpx_use_filter', None)
         self.serialize_ics = kw.pop('warpx_serialize_ics', None)
         self.do_dynamic_scheduling = kw.pop('warpx_do_dynamic_scheduling', None)
-        self.load_balance_intervals = kw.pop('warpx_load_balance_intervals', None)
-        self.load_balance_with_sfc = kw.pop('warpx_load_balance_with_sfc', None)
+        self.load_balance_intervals_algo = kw.pop('warpx_load_balance_intervals_algo', None)
+        self.load_balance_with_sfc_algo = kw.pop('warpx_load_balance_with_sfc_algo', None)
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
 
         self.inputs_initialized = False
@@ -690,13 +690,13 @@ class Simulation(picmistandard.PICMI_Simulation):
         pywarpx.algo.charge_deposition = self.charge_deposition_algo
         pywarpx.algo.field_gathering = self.field_gathering_algo
         pywarpx.algo.particle_pusher = self.particle_pusher_algo
+        pywarpx.algo.load_balance_intervals = self.load_balance_intervals_algo
+        pywarpx.algo.load_balance_with_sfc = self.load_balance_with_sfc_algo
 
         pywarpx.warpx.use_filter = self.use_filter
         pywarpx.warpx.serialize_ics = self.serialize_ics
 
         pywarpx.warpx.do_dynamic_scheduling = self.do_dynamic_scheduling
-        pywarpx.warpx.load_balance_intervals = self.load_balance_intervals
-        pywarpx.warpx.load_balance_with_sfc = self.load_balance_with_sfc
 
         pywarpx.particles.use_fdtd_nci_corr = self.use_fdtd_nci_corr
 

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -62,7 +62,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
         costs[lev] = std::make_unique<LayoutData<Real>>(*warpx.getCosts(lev));
     }
 
-    if (warpx.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+    if (algo.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
     {
         warpx.ComputeCostsHeuristic(costs);
     }

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -62,7 +62,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
         costs[lev] = std::make_unique<LayoutData<Real>>(*warpx.getCosts(lev));
     }
 
-    if (algo.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+    if (warpx.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
     {
         warpx.ComputeCostsHeuristic(costs);
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -874,7 +874,7 @@ WarpX::BackwardCompatibility ()
             "my_diag.intervals = 10\n"
             "for output every 10 iterations. See documentation for more information");
     }
-
+    
     std::string backward_str;
     if (ppa.query("plot_file", backward_str)){
         amrex::Abort("amr.plot_file is not supported anymore. "
@@ -882,7 +882,6 @@ WarpX::BackwardCompatibility ()
     }
 
     ParmParse ppw("warpx");
-    std::vector<std::string> backward_strings;
     if (ppw.queryarr("fields_to_plot", backward_strings)){
         amrex::Abort("warpx.fields_to_plot is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
@@ -898,6 +897,24 @@ WarpX::BackwardCompatibility ()
     if (ppw.queryarr("load_balance_int", backward_strings)){
         amrex::Abort("warpx.load_balance_int is no longer a valid option. "
                      "Please use the renamed option algo.load_balance_intervals instead.");
+    }
+    if (ppw.queryarr("load_balance_intervals", backward_strings)){
+        amrex::Abort("warpx.load_balance_intervals is no longer a valid option. "
+                     "Please use the renamed option algo.load_balance_intervals instead.");
+    }
+
+    amrex::Real backward_Real;
+    if (ppw.query("load_balance_efficiency_ratio_threshold", backward_Real)){
+        amrex::Abort("warpx.load_balance_efficiency_ratio_threshold is not supported anymore. "
+                     "Please use the renamed option algo.load_balance_efficiency_ratio_threshold.");
+    }
+    if (ppw.query("load_balance_with_sfc", backward_int)){
+        amrex::Abort("warpx.load_balance_with_sfc is not supported anymore. "
+                     "Please use the renamed option algo.load_balance_with_sfc.");
+    }
+    if (ppw.query("load_balance_knapsack_factor", backward_Real)){
+        amrex::Abort("warpx.load_balance_knapsack_factor is not supported anymore. "
+                     "Please use the renamed option algo.load_balance_knapsack_factor.");
     }
     if (ppw.queryarr("override_sync_int", backward_strings)){
         amrex::Abort("warpx.override_sync_int is no longer a valid option. "

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -874,7 +874,7 @@ WarpX::BackwardCompatibility ()
             "my_diag.intervals = 10\n"
             "for output every 10 iterations. See documentation for more information");
     }
-    
+
     std::string backward_str;
     if (ppa.query("plot_file", backward_str)){
         amrex::Abort("amr.plot_file is not supported anymore. "

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -612,14 +612,6 @@ WarpX::ReadParameters ()
             fine_tag_hi = RealVect{hi};
         }
 
-        std::vector<std::string> load_balance_intervals_string_vec = {"0"};
-        pp.queryarr("load_balance_intervals", load_balance_intervals_string_vec);
-        load_balance_intervals = IntervalsParser(load_balance_intervals_string_vec);
-        pp.query("load_balance_with_sfc", load_balance_with_sfc);
-        pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
-        queryWithParser(pp, "load_balance_efficiency_ratio_threshold",
-                             load_balance_efficiency_ratio_threshold);
-
         pp.query("do_dynamic_scheduling", do_dynamic_scheduling);
 
         pp.query("do_nodal", do_nodal);
@@ -668,11 +660,21 @@ WarpX::ReadParameters ()
             // Use same shape factors in all directions, for gathering
             galerkin_interpolation = false;
         }
-        load_balance_costs_update_algo = GetAlgorithmInteger(pp, "load_balance_costs_update");
+
         em_solver_medium = GetAlgorithmInteger(pp, "em_solver_medium");
         if (em_solver_medium == MediumForEM::Macroscopic ) {
             macroscopic_solver_algo = GetAlgorithmInteger(pp,"macroscopic_sigma_method");
         }
+
+        // Load balancing parameters
+        std::vector<std::string> load_balance_intervals_string_vec = {"0"};
+        pp.queryarr("load_balance_intervals", load_balance_intervals_string_vec);
+        load_balance_intervals = IntervalsParser(load_balance_intervals_string_vec);
+        pp.query("load_balance_with_sfc", load_balance_with_sfc);
+        pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
+        queryWithParser(pp, "load_balance_efficiency_ratio_threshold",
+                        load_balance_efficiency_ratio_threshold);
+        load_balance_costs_update_algo = GetAlgorithmInteger(pp, "load_balance_costs_update");
         queryWithParser(pp, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
         queryWithParser(pp, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
     }
@@ -895,7 +897,7 @@ WarpX::BackwardCompatibility ()
     }
     if (ppw.queryarr("load_balance_int", backward_strings)){
         amrex::Abort("warpx.load_balance_int is no longer a valid option. "
-                     "Please use the renamed option warpx.load_balance_intervals instead.");
+                     "Please use the renamed option algo.load_balance_intervals instead.");
     }
     if (ppw.queryarr("override_sync_int", backward_strings)){
         amrex::Abort("warpx.override_sync_int is no longer a valid option. "

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -882,6 +882,7 @@ WarpX::BackwardCompatibility ()
     }
 
     ParmParse ppw("warpx");
+    std::vector<std::string> backward_strings;
     if (ppw.queryarr("fields_to_plot", backward_strings)){
         amrex::Abort("warpx.fields_to_plot is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");

--- a/Tools/LibEnsemble/sim/inputs
+++ b/Tools/LibEnsemble/sim/inputs
@@ -31,6 +31,7 @@ algo.charge_deposition = standard
 algo.field_gathering = momentum-conserving
 algo.particle_pusher = vay
 algo.maxwell_solver = ckc
+algo.load_balance_intervals = -1
 interpolation.nox = 3
 interpolation.noy = 3
 interpolation.noz = 3
@@ -39,7 +40,6 @@ warpx.filter_npass_each_dir = 1 4
 warpx.cfl = .9999
 warpx.do_pml = 0
 warpx.do_dynamic_scheduling = 1
-warpx.load_balance_intervals = -1
 # Moving window
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z

--- a/Tools/PerformanceTests/automated_test_5_loadimbalance
+++ b/Tools/PerformanceTests/automated_test_5_loadimbalance
@@ -15,7 +15,7 @@ geometry.prob_lo     = -20.e-6   -20.e-6   -20.e-6    # physical domain
 geometry.prob_hi     =  20.e-6    20.e-6    20.e-6
 
 warpx.verbose = 1
-warpx.load_balance_intervals = -5
+algo.load_balance_intervals = -5
 interpolation.nox = 3
 interpolation.noy = 3
 interpolation.noz = 3


### PR DESCRIPTION
This PR makes the change that load balance parameters are all input as `algo.` instead of split between `warpx.` and `algo.`.  This makes it easier to input load balance parameters because you do not have to remember which ones are `algo.` and which are `warpx.`.
An entry for `load_balance_knapsack_factor` is also added to documentation.