### PR TITLE
Update yt data loading in analysis scripts for Galilean tests

### DIFF
--- a/Examples/Tests/galilean/analysis_2d.py
+++ b/Examples/Tests/galilean/analysis_2d.py
@@ -31,9 +31,10 @@ dims_RZ  = True if re.search('rz', filename) else False
 
 ds = yt.load( filename )
 
-Ex= ds.index.grids[0]['boxlib', 'Ex'].squeeze().v
-Ey= ds.index.grids[0]['boxlib', 'Ey'].squeeze().v
-Ez= ds.index.grids[0]['boxlib', 'Ez'].squeeze().v
+all_data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
+Ex = all_data['boxlib', 'Ex'].squeeze().v
+Ey = all_data['boxlib', 'Ey'].squeeze().v
+Ez = all_data['boxlib', 'Ez'].squeeze().v
 
 if (averaged):
     # energyE_ref was calculated with Galilean PSATD method (v_galilean = (0,0,0.99498743710662))
@@ -67,8 +68,8 @@ assert( error_rel < tolerance_rel )
 
 # Check charge conservation (relative L-infinity norm of error) with current correction
 if current_correction:
-    divE = ds.index.grids[0]['boxlib', 'divE'].squeeze().v
-    rho  = ds.index.grids[0]['boxlib', 'rho' ].squeeze().v / scc.epsilon_0
+    divE = all_data['boxlib', 'divE'].squeeze().v
+    rho  = all_data['boxlib', 'rho' ].squeeze().v / scc.epsilon_0
     error_rel = np.amax(np.abs(divE - rho)) / max(np.amax(divE), np.amax(rho))
     tolerance = 1e-9
     print("Check charge conservation:")

--- a/Examples/Tests/galilean/analysis_3d.py
+++ b/Examples/Tests/galilean/analysis_3d.py
@@ -30,9 +30,10 @@ current_correction = True if re.search( 'current_correction', filename ) else Fa
 
 ds = yt.load( filename )
 
-Ex= ds.index.grids[0]['boxlib', 'Ex'].squeeze().v
-Ey= ds.index.grids[0]['boxlib', 'Ey'].squeeze().v
-Ez= ds.index.grids[0]['boxlib', 'Ez'].squeeze().v
+all_data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
+Ex = all_data['boxlib', 'Ex'].squeeze().v
+Ey = all_data['boxlib', 'Ey'].squeeze().v
+Ez = all_data['boxlib', 'Ez'].squeeze().v
 
 if (averaged):
     # energyE_ref was calculated with Galilean PSATD method (v_galilean = (0,0,0.99498743710662))
@@ -58,8 +59,8 @@ assert( error_rel < tolerance_rel )
 
 # Check charge conservation (relative L-infinity norm of error) with current correction
 if current_correction:
-    rho  = ds.index.grids[0]['boxlib', 'rho' ].squeeze().v
-    divE = ds.index.grids[0]['boxlib', 'divE'].squeeze().v
+    rho  = all_data['boxlib', 'rho' ].squeeze().v
+    divE = all_data['boxlib', 'divE'].squeeze().v
     error_rel = np.amax( np.abs( divE - rho/scc.epsilon_0 ) ) / np.amax( np.abs( rho/scc.epsilon_0 ) )
     tolerance = 1e-9
     print("Check charge conservation:")


### PR DESCRIPTION
This PR updates the way we load simulation data, with yt, in the analysis scripts used with the Galilean tests.

The old implementation
```py
Ez = ds.index.grids[0]['boxlib', 'Ez'].squeeze().v
```
was assuming that the computational domain has only one box (which is the case for all these tests), with grid index `0`.

It is now replaced with
```py
all_data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
Ez = all_data['boxlib', 'Ez'].squeeze().v
```

This is more correct in case we will decide to run some of these tests with domain decomposition. I would like to do so in a subsequent PR, because it would make the tests a bit more robust with respect to possible parallelization issues.