### PR TITLE
GNUmake: QED on (TRUE) by default

### DIFF
--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -194,7 +194,8 @@ Environment Variable          Default & Values                             Descr
 ``WarpX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
 ``WarpX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
 ``WarpX_PSATD``               ON/**OFF**                                   Spectral solver
-``WarpX_QED``                 **ON**/OFF                                   PICSAR QED (requires Boost and PICSAR)
+``WarpX_QED``                 **ON**/OFF                                   PICSAR QED (requires PICSAR)
+``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation (requires PICSAR and Boost)
 ``BUILD_PARALLEL``            ``2``                                        Number of threads to use for parallel builds
 ``BUILD_SHARED_LIBS``         ON/**OFF**                                   Build shared libraries for dependencies
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ WARN_ALL = TRUE
 #DIM     = 2
 DIM = 3
 
-#QED	       = TRUE
+QED	       = TRUE
 #QED_TABLE_GEN = TRUE
 
 COMP = gcc


### PR DESCRIPTION
We already enable QED now by default on CMake and do the same with GNUmake.

Follow-up to #1529