### PR TITLE
Fix: Missing Geometry Includes

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -23,6 +23,7 @@
 #include "Particles/Gather/GetExternalFields.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
+#include <AMReX_Geometry.H>
 #include <AMReX_Print.H>
 #include <AMReX.H>
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -23,6 +23,8 @@
 #include "Gather/ScaleFields.H"
 #include "Gather/FieldGather.H"
 
+#include <AMReX_Geometry.H>
+
 #include <limits>
 #include <sstream>
 #include <algorithm>

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -45,6 +45,7 @@
 #include <AMReX_AmrCore.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_Print.H>
+#include <AMReX_Geometry.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_VisMF.H>


### PR DESCRIPTION
Add a few missing AMReX includes of Geometry.

(See if those help with the linker issues on Windows (pip). But more likely we need https://github.com/AMReX-Codes/amrex/pull/1782 as well; update: unsurprisingly, it does not. the issue comes likely from a pip build path collision)