### PR TITLE
Fix bug in loop over boxes in WarpX::UpdateAuxilaryDataStagToNodal

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -71,28 +71,10 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         Array4<Real const> const& ey_fp = Efield_fp[0][1]->const_array(mfi);
         Array4<Real const> const& ez_fp = Efield_fp[0][2]->const_array(mfi);
 
-        // We cannot loop over the full box (which would be obtained by setting bx = mfi.fabbox()),
-        // including ghost cells, because the order of interpolation might be larger than 2 and require
-        // a stencil with too many points, when we get close to the boundaries of a computational
-        // sub-domain, while interpolating inside the ghost regions (both the interior ghost regions,
-        // which will be filled in by calling FillBoundaryAux after UpdateAuxilaryData, and the exterior
-        // ghost regions, which will not be filled in because they do not overlap with any valid sub-domain).
-        Box bx = mfi.validbox();
-
-        // When gathering the fields onto the particles later on, we will use the data in a number of
-        // exterior ghost cells that depends on the order of the particle shape factors (mostly).
-        // The data in these exterior ghost cells will not have been filled in by calling FillBoundaryAux
-        // after UpdateAuxilaryData, because they do not overlap with any valid sub-domain.
-        // Hence, in order to be more consistent, we grow the valid box by that number of ghost cells,
-        // so that all the data that will be used to gather the fields later on will have been computed
-        // by performing the same type of interpolation. Note however that a loop over the valid box,
-        // without these ghost cells, would probably not alter the overall results significantly.
-#if   (AMREX_SPACEDIM == 2)
-        amrex::IntVect const& ng = amrex::IntVect(WarpX::nox/2+1, WarpX::noz/2+1);
-#elif (AMREX_SPACEDIM == 3)
-        amrex::IntVect const& ng = amrex::IntVect(WarpX::nox/2+1, WarpX::noy/2+1, WarpX::noz/2+1);
-#endif
-        bx.grow(ng);
+        // Loop over full box including ghost cells
+        // (input arrays will be padded with zeros beyond ghost cells
+        // for out-of-bound accesses due to large-stencil operations)
+        Box bx = mfi.fabbox();
 
         if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
 #ifdef WARPX_USE_PSATD

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -522,6 +522,13 @@ void warpx_interp (const int j,
 {
     using namespace amrex;
 
+    // Pad input array with zeros beyond ghost cells
+    // for out-of-bound accesses due to large-stencil operations
+    const auto arr_safe = [arr_fine] (const int jj, const int kk, const int ll) noexcept
+    {
+        return arr_fine.contains(jj,kk,ll) ? arr_fine(jj,kk,ll) : 0.0_rt;
+    };
+
     // Avoid compiler warnings
 #if (AMREX_SPACEDIM == 2)
     amrex::ignore_unused(noy, stencil_coeffs_y);
@@ -612,7 +619,7 @@ void warpx_interp (const int j,
         {
             for (int jj = jmin; jj <= jmax; jj++)
             {
-                res += arr_fine(jj,kk,ll);
+                res += arr_safe(jj,kk,ll);
             }
         }
     }
@@ -653,7 +660,7 @@ void warpx_interp (const int j,
                 dj = (j - jj > 0) ? j - jj - 1 : jj - j;
                 if (sj == 0) cj = stencil_coeffs_x[dj];
 
-                res += cj * ck * cl * arr_fine(jj,kk,ll);
+                res += cj * ck * cl * arr_safe(jj,kk,ll);
             }
         }
     }

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -496,9 +496,9 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
  * \param[in] j index along x of the output array
  * \param[in] k index along y (in 3D) or z (in 2D) of the output array
  * \param[in] l index along z (in 3D, \c l = 0 in 2D) of the output array
- * \param[in,out] arr_aux output array allocated on the \c aux patch where interpolated values are stored
- * \param[in] arr_fine input array allocated on the fine patch
- * \param[in] arr_stag \c IndexType of the input array (Yee staggering)
+ * \param[in,out] dst_arr output array allocated on the \c aux patch where interpolated values are stored
+ * \param[in] src_arr input array allocated on the fine patch
+ * \param[in] src_stag \c IndexType of the input array (Yee staggering)
  * \param[in] nox order of finite-order interpolation along x
  * \param[in] noy order of finite-order interpolation along y
  * \param[in] noz order of finite-order interpolation along z
@@ -510,9 +510,9 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp (const int j,
                    const int k,
                    const int l,
-                   amrex::Array4<amrex::Real      > const& arr_aux,
-                   amrex::Array4<amrex::Real const> const& arr_fine,
-                   const amrex::IntVect& arr_stag,
+                   amrex::Array4<amrex::Real      > const& dst_arr,
+                   amrex::Array4<amrex::Real const> const& src_arr,
+                   const amrex::IntVect& src_stag,
                    const int nox = 2,
                    const int noy = 2,
                    const int noz = 2,
@@ -524,9 +524,9 @@ void warpx_interp (const int j,
 
     // Pad input array with zeros beyond ghost cells
     // for out-of-bound accesses due to large-stencil operations
-    const auto arr_safe = [arr_fine] (const int jj, const int kk, const int ll) noexcept
+    const auto src_arr_zeropad = [src_arr] (const int jj, const int kk, const int ll) noexcept
     {
-        return arr_fine.contains(jj,kk,ll) ? arr_fine(jj,kk,ll) : 0.0_rt;
+        return src_arr.contains(jj,kk,ll) ? src_arr(jj,kk,ll) : 0.0_rt;
     };
 
     // Avoid compiler warnings
@@ -540,10 +540,10 @@ void warpx_interp (const int j,
 #endif
 
     // Staggering (s = 0 if cell-centered, s = 1 if nodal)
-    const int sj = arr_stag[0];
-    const int sk = arr_stag[1];
+    const int sj = src_stag[0];
+    const int sk = src_stag[1];
 #if (AMREX_SPACEDIM == 3)
-    const int sl = arr_stag[2];
+    const int sl = src_stag[2];
 #endif
 
     // Number of points (+1) used for interpolation from the staggered grid to the nodal grid
@@ -619,7 +619,7 @@ void warpx_interp (const int j,
         {
             for (int jj = jmin; jj <= jmax; jj++)
             {
-                res += arr_safe(jj,kk,ll);
+                res += src_arr_zeropad(jj,kk,ll);
             }
         }
     }
@@ -660,14 +660,14 @@ void warpx_interp (const int j,
                 dj = (j - jj > 0) ? j - jj - 1 : jj - j;
                 if (sj == 0) cj = stencil_coeffs_x[dj];
 
-                res += cj * ck * cl * arr_safe(jj,kk,ll);
+                res += cj * ck * cl * src_arr_zeropad(jj,kk,ll);
             }
         }
     }
 
 #endif
 
-    arr_aux(j,k,l) = wj * wk * wl * res;
+    dst_arr(j,k,l) = wj * wk * wl * res;
 }
 
 #endif


### PR DESCRIPTION
This PR should close #1554.

A loop over the valid box (`mfi.validbox()`) only was not possible due to the exterior ghost cells that were not subsequently filled in by calling `FillBoundary`.

Instead of growing the valid box by an _ad hoc_ number of cells, which so far could have been expressed in terms of the orders of the shape factors only (replacing `2` with `WarpX::nox/2+1` and so forth) but in principle could depend on other algorithmic details, I think it is safer to loop over the full box (`mfi.fabbox()`), including ghost cells, and make sure that the input array is padded with zeros beyond ghost cells in order to take care of possible out-of-bound accesses due to the large stencils.

**Update**
I added the bug label, because this seems to fix a bug that became evident only by running the 3D three-stages simulation for the milestone with FDTD and momentum-conserving field gathering.