### PR TITLE
Reset benchmarks of boosted frame tests

### DIFF
--- a/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
+++ b/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
@@ -6,39 +6,39 @@
     "particle_momentum_y": 4.51585729236226e-19,
     "particle_momentum_z": 2.666058436389631e-18,
     "particle_position_x": 0.0007815782670743121,
-    "particle_position_y": 0.35944477677650344,
+    "particle_position_y": 0.3594447784819653,
     "particle_weight": 62415090744.60765
   },
   "electrons": {
     "particle_cpu": 1140.0,
     "particle_id": 1254690.0,
-    "particle_momentum_x": 4.851314637802899e-27,
-    "particle_momentum_y": 2.1981726355513887e-22,
-    "particle_momentum_z": 3.0976485630304e-18,
-    "particle_position_x": 0.06840000000361957,
-    "particle_position_y": 0.03930013819602824,
-    "particle_weight": 6.286582210738646e+16
+    "particle_momentum_x": 4.85133026759765e-27,
+    "particle_momentum_y": 2.198179850407281e-22,
+    "particle_momentum_z": 3.0976485630303324e-18,
+    "particle_position_x": 0.06840000000361958,
+    "particle_position_y": 0.03930011372955363,
+    "particle_weight": 6.286568807682775e+16
   },
   "ions": {
     "particle_cpu": 1140.0,
     "particle_id": 1390110.0,
-    "particle_momentum_x": 3.3600544936e-30,
-    "particle_momentum_y": 2.1981727064696287e-22,
+    "particle_momentum_x": 3.360052255593508e-30,
+    "particle_momentum_y": 2.198179921323777e-22,
     "particle_momentum_z": 5.687755728408193e-15,
     "particle_position_x": 0.0684,
-    "particle_position_y": 0.0393001381332615,
-    "particle_weight": 6.286582210738646e+16
+    "particle_position_y": 0.03930011366678667,
+    "particle_weight": 6.286568807682775e+16
   },
   "lev=0": {
-    "Bx": 7187.973258845839,
-    "By": 16.403644404498884,
-    "Bz": 426.1031189173133,
-    "Ex": 4521887802.4032955,
-    "Ey": 1984359719957.4766,
-    "Ez": 6310696230.661058,
-    "jx": 5122915921.273045,
-    "jy": 551785946484956.44,
-    "jz": 448986139508.22723,
-    "rho": 1567.0144024077852
+    "Bx": 7187.9737789692945,
+    "By": 16.403644314084197,
+    "Bz": 426.1032500047571,
+    "Ex": 4521887740.546031,
+    "Ey": 1984360500005.4958,
+    "Ez": 6310696182.771291,
+    "jx": 5122916237.313671,
+    "jy": 551784296059286.56,
+    "jz": 448986163636.4643,
+    "rho": 1567.0144888546802
   }
 }

--- a/Regression/Checksum/benchmarks_json/PlasmaAccelerationBoost2d.json
+++ b/Regression/Checksum/benchmarks_json/PlasmaAccelerationBoost2d.json
@@ -20,34 +20,34 @@
     "particle_weight": 93622636116911.45
   },
   "lev=0": {
-    "Bx": 0.3506187473897375,
-    "By": 9567.64672095278,
-    "Bz": 0.3951206940970104,
-    "Ex": 1063072734436.0148,
-    "Ey": 136153820.2671091,
-    "Ez": 3013327887369.4033,
-    "jx": 5164332131.333552,
-    "jy": 4628824062.592653,
-    "jz": 102420439518871.47
+    "Bx": 0.35061866559719373,
+    "By": 9567.642706315866,
+    "Bz": 0.39512026462747296,
+    "Ex": 1063072187459.5623,
+    "Ey": 136153819.5372767,
+    "Ez": 3013326571785.375,
+    "jx": 5164328089.206846,
+    "jy": 4628811196.394387,
+    "jz": 102420396542755.11
   },
   "plasma_e": {
     "particle_cpu": 504.0,
     "particle_id": 236124.0,
-    "particle_momentum_x": 3.3723103986630875e-24,
-    "particle_momentum_y": 1.0980790746199993e-27,
-    "particle_momentum_z": 1.3694876444851278e-18,
-    "particle_position_x": 0.01771875610610223,
-    "particle_position_y": 0.020620056827222344,
-    "particle_weight": 677858073779801.2
+    "particle_momentum_x": 3.3723224011073765e-24,
+    "particle_momentum_y": 1.0980821728000302e-27,
+    "particle_momentum_z": 1.3694876444889658e-18,
+    "particle_position_x": 0.017718756106128407,
+    "particle_position_y": 0.02062006547950414,
+    "particle_weight": 677858497765697.2
   },
   "plasma_p": {
     "particle_cpu": 504.0,
     "particle_id": 272412.0,
-    "particle_momentum_x": 3.372309194522596e-24,
-    "particle_momentum_y": 1.0980892491861113e-27,
-    "particle_momentum_z": 2.514586742183712e-15,
-    "particle_position_x": 0.0177187499966745,
-    "particle_position_y": 0.0206200568109286,
-    "particle_weight": 677858073779801.2
+    "particle_momentum_x": 3.372321196955797e-24,
+    "particle_momentum_y": 1.0980923474189992e-27,
+    "particle_momentum_z": 2.5145867421837085e-15,
+    "particle_position_x": 0.017718749996674485,
+    "particle_position_y": 0.02062006546321032,
+    "particle_weight": 677858497765697.2
   }
 }

--- a/Regression/Checksum/benchmarks_json/PlasmaAccelerationBoost3d.json
+++ b/Regression/Checksum/benchmarks_json/PlasmaAccelerationBoost3d.json
@@ -33,36 +33,36 @@
     "particle_weight": 6241509074.460762
   },
   "lev=0": {
-    "Bx": 44941.49413640603,
-    "By": 44979.43825578673,
-    "Bz": 13.934939072805953,
-    "Ex": 1826216104868.1426,
-    "Ey": 1823330229384.404,
-    "Ez": 15903140534253.645,
-    "jx": 478635383386.41437,
-    "jy": 287752998229.3329,
-    "jz": 1808527844770048.0
+    "Bx": 44941.402928515585,
+    "By": 44979.346973401756,
+    "Bz": 13.934932422707037,
+    "Ex": 1826219875574.1472,
+    "Ey": 1823334082844.482,
+    "Ez": 15903102110534.135,
+    "jx": 478634143211.2581,
+    "jy": 287751006794.0503,
+    "jz": 1808524174499033.2
   },
   "plasma_e": {
     "particle_cpu": 3600.0,
     "particle_id": 9721800.0,
-    "particle_momentum_x": 2.0860691311063257e-24,
-    "particle_momentum_y": 2.016377109103382e-24,
-    "particle_momentum_z": 9.78204978521714e-18,
-    "particle_position_x": 0.12656250418442266,
-    "particle_position_y": 0.12656250385223128,
-    "particle_position_z": 0.06789177847668806,
-    "particle_weight": 3869103021.387059
+    "particle_momentum_x": 2.0860985336375993e-24,
+    "particle_momentum_y": 2.0164052227295357e-24,
+    "particle_momentum_z": 9.78204978524379e-18,
+    "particle_position_x": 0.12656250418448325,
+    "particle_position_y": 0.12656250385228734,
+    "particle_position_z": 0.06789191625822297,
+    "particle_weight": 3869115015.619221
   },
   "plasma_p": {
     "particle_cpu": 3600.0,
     "particle_id": 16201800.0,
-    "particle_momentum_x": 2.086070789386721e-24,
-    "particle_momentum_y": 2.016379117137924e-24,
-    "particle_momentum_z": 1.7961333877559267e-14,
-    "particle_position_x": 0.1265624999977211,
-    "particle_position_y": 0.12656249999790198,
-    "particle_position_z": 0.0678917784374789,
-    "particle_weight": 3869103021.387059
+    "particle_momentum_x": 2.086100191957863e-24,
+    "particle_momentum_y": 2.0164072308156736e-24,
+    "particle_momentum_z": 1.7961333877559242e-14,
+    "particle_position_x": 0.12656249999772107,
+    "particle_position_y": 0.12656249999790195,
+    "particle_position_z": 0.06789191621901314,
+    "particle_weight": 3869115015.619221
   }
 }

--- a/Regression/Checksum/benchmarks_json/comoving_hybrid_2d.json
+++ b/Regression/Checksum/benchmarks_json/comoving_hybrid_2d.json
@@ -2,43 +2,43 @@
   "beam": {
     "particle_cpu": 0.0,
     "particle_id": 466643.0,
-    "particle_momentum_x": 5.941160578359215e-19,
-    "particle_momentum_y": 4.2079275234179535e-19,
-    "particle_momentum_z": 9.069349021470616e-18,
-    "particle_position_x": 0.0013704262607235095,
-    "particle_position_y": 0.14863689916243195,
+    "particle_momentum_x": 5.9412655400697425e-19,
+    "particle_momentum_y": 4.2079277409692354e-19,
+    "particle_momentum_z": 9.069326487230642e-18,
+    "particle_position_x": 0.0013704026432938836,
+    "particle_position_y": 0.14863693502202852,
     "particle_weight": 2911663983235.947
   },
   "electrons": {
     "particle_cpu": 155246.0,
-    "particle_id": 26815693996.0,
-    "particle_momentum_x": 9.187410049462863e-19,
-    "particle_momentum_y": 8.099121697787876e-19,
-    "particle_momentum_z": 5.716164078859215e-16,
-    "particle_position_x": 6.63439726869906,
-    "particle_position_y": 58.08983414523721,
-    "particle_weight": 3.2127956593462216e+18
+    "particle_id": 26701298988.0,
+    "particle_momentum_x": 9.187015830864461e-19,
+    "particle_momentum_y": 8.099264984923782e-19,
+    "particle_momentum_z": 5.716180412531198e-16,
+    "particle_position_x": 6.634393845168809,
+    "particle_position_y": 58.08977454115495,
+    "particle_weight": 3.212795210423339e+18
   },
   "ions": {
     "particle_cpu": 155246.0,
-    "particle_id": 26944220940.0,
-    "particle_momentum_x": 2.004467333164708e-18,
-    "particle_momentum_y": 8.197797665435143e-19,
-    "particle_momentum_z": 1.0089822640682548e-12,
-    "particle_position_x": 6.622297127075528,
-    "particle_position_y": 58.08883471941903,
-    "particle_weight": 3.2127948166359685e+18
+    "particle_id": 26830093836.0,
+    "particle_momentum_x": 2.0044234712622248e-18,
+    "particle_momentum_y": 8.197960287574731e-19,
+    "particle_momentum_z": 1.0089822624453072e-12,
+    "particle_position_x": 6.622297128431678,
+    "particle_position_y": 58.08877603287398,
+    "particle_weight": 3.212794492131793e+18
   },
   "lev=0": {
-    "Bx": 1301454.5123286666,
-    "By": 4006388.349363823,
-    "Bz": 203188.54824514763,
-    "Ex": 1203058895690623.5,
-    "Ey": 407300997244359.06,
-    "Ez": 217625260358163.25,
-    "jx": 3.5138542156184092e+16,
-    "jy": 2.308243907235026e+16,
-    "jz": 4.13100816515469e+17,
-    "rho": 1350505422.379793
+    "Bx": 1301454.4704659446,
+    "By": 4006246.3097266722,
+    "Bz": 203187.9759392533,
+    "Ex": 1203019275346943.8,
+    "Ey": 407301005006001.3,
+    "Ez": 217578664296718.34,
+    "jx": 3.5138380865245516e+16,
+    "jy": 2.308237971134435e+16,
+    "jz": 4.1310239752617536e+17,
+    "rho": 1350509119.2828336
   }
 }

--- a/Regression/Checksum/benchmarks_json/galilean_hybrid_2d.json
+++ b/Regression/Checksum/benchmarks_json/galilean_hybrid_2d.json
@@ -2,43 +2,43 @@
   "beam": {
     "particle_cpu": 0.0,
     "particle_id": 445160.0,
-    "particle_momentum_x": 5.430834035225301e-19,
-    "particle_momentum_y": 3.9842069158425636e-19,
-    "particle_momentum_z": 8.084063041252451e-18,
-    "particle_position_x": 0.001373742271887886,
-    "particle_position_y": 0.14010474568397213,
+    "particle_momentum_x": 5.430855258630549e-19,
+    "particle_momentum_y": 3.984206980723684e-19,
+    "particle_momentum_z": 8.084044038911465e-18,
+    "particle_position_x": 0.0013737429012070034,
+    "particle_position_y": 0.14010476401881042,
     "particle_weight": 2761867765448.888
   },
   "electrons": {
     "particle_cpu": 155383.0,
-    "particle_id": 26835869872.0,
-    "particle_momentum_x": 7.384584964940151e-19,
-    "particle_momentum_y": 5.668475917285874e-19,
-    "particle_momentum_z": 5.697498214252073e-16,
-    "particle_position_x": 6.6399009521226775,
-    "particle_position_y": 58.21053755262918,
-    "particle_weight": 3.2159040630929684e+18
+    "particle_id": 26721507984.0,
+    "particle_momentum_x": 7.384569499870267e-19,
+    "particle_momentum_y": 5.668587261205458e-19,
+    "particle_momentum_z": 5.697497123966546e-16,
+    "particle_position_x": 6.639900924688325,
+    "particle_position_y": 58.21047886468016,
+    "particle_weight": 3.215903744897337e+18
   },
   "ions": {
     "particle_cpu": 155428.0,
-    "particle_id": 26929185010.0,
-    "particle_momentum_x": 1.675401940244253e-18,
-    "particle_momentum_y": 5.735868875445285e-19,
-    "particle_momentum_z": 1.0101677791766743e-12,
-    "particle_position_x": 6.630050032809573,
-    "particle_position_y": 58.249206333900666,
-    "particle_weight": 3.2166263190283034e+18
+    "particle_id": 26814790002.0,
+    "particle_momentum_x": 1.6753926430545967e-18,
+    "particle_momentum_y": 5.735995901770564e-19,
+    "particle_momentum_z": 1.0101677792943862e-12,
+    "particle_position_x": 6.6300500323791915,
+    "particle_position_y": 58.249147627010196,
+    "particle_weight": 3.21662600232034e+18
   },
   "lev=0": {
-    "Bx": 1222318.3061449106,
-    "By": 3469477.9008946754,
-    "Bz": 194604.66603560798,
-    "Ex": 1041749458022846.5,
-    "Ey": 383519102369694.1,
-    "Ez": 200675667206614.2,
-    "jx": 3.1058213172293296e+16,
-    "jy": 2.220521164151684e+16,
-    "jz": 2.9099894358577344e+17,
-    "rho": 990366010.1719986
+    "Bx": 1222314.326298828,
+    "By": 3469458.700059423,
+    "Bz": 194604.08108686682,
+    "Ex": 1041743595886049.6,
+    "Ey": 383518705133115.0,
+    "Ez": 200674815779204.9,
+    "jx": 3.1058053345516452e+16,
+    "jy": 2.2205197753586972e+16,
+    "jz": 2.9099707530640435e+17,
+    "rho": 990359715.0656134
   }
 }

--- a/Regression/Checksum/benchmarks_json/ionization_boost.json
+++ b/Regression/Checksum/benchmarks_json/ionization_boost.json
@@ -2,33 +2,33 @@
   "electrons": {
     "particle_cpu": 184.0,
     "particle_id": 1300726794.0,
-    "particle_momentum_x": 2.1044665659277051e-17,
+    "particle_momentum_x": 2.098113570957052e-17,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.7277353083595162e-17,
-    "particle_position_x": 0.11095542762920491,
-    "particle_position_y": 1.7109490717635509,
-    "particle_weight": 3.0702525710937457e-09
+    "particle_momentum_z": 1.7268821693904448e-17,
+    "particle_position_x": 0.11034569656973041,
+    "particle_position_y": 1.7106214131701365,
+    "particle_weight": 3.0702532354579605e-09
   },
   "ions": {
     "particle_cpu": 0.0,
     "particle_id": 89142848.0,
     "particle_ionization_level": 52651.0,
-    "particle_momentum_x": 3.586054549170934e-18,
+    "particle_momentum_x": 3.586036810957103e-18,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.0432995298789921e-13,
-    "particle_position_x": 0.021439915649144235,
-    "particle_position_y": 0.47267660340600026,
-    "particle_weight": 5.000946999999993e-10
+    "particle_momentum_z": 1.0432995298791402e-13,
+    "particle_position_x": 0.021439915568523423,
+    "particle_position_y": 0.47267670568729886,
+    "particle_weight": 5.000948082142308e-10
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 18262982.96212995,
+    "By": 18262991.064426593,
     "Bz": 0.0,
-    "Ex": 5472946208913378.0,
+    "Ex": 5472952295140504.0,
     "Ey": 0.0,
-    "Ez": 949.050591426419,
-    "jx": 12255073032842.436,
+    "Ez": 923.6823445233051,
+    "jx": 12440722989281.025,
     "jy": 0.0,
-    "jz": 93304.0000011232
+    "jz": 166080.0000011085
   }
 }

--- a/Regression/Checksum/benchmarks_json/restart.json
+++ b/Regression/Checksum/benchmarks_json/restart.json
@@ -2,12 +2,12 @@
   "beam": {
     "particle_cpu": 0.0,
     "particle_id": 1500500.0,
-    "particle_momentum_x": 4.210792547406655e-19,
-    "particle_momentum_y": 4.1138261241282522e-19,
-    "particle_momentum_z": 2.7237823576076308e-17,
-    "particle_position_x": 0.0015091134663564845,
-    "particle_position_y": 0.0014849015469885784,
-    "particle_position_z": 1.9017767912786123,
+    "particle_momentum_x": 4.210792541741028e-19,
+    "particle_momentum_y": 4.1138261183560033e-19,
+    "particle_momentum_z": 2.723782366817271e-17,
+    "particle_position_x": 0.0015091134632009644,
+    "particle_position_y": 0.001484901544080785,
+    "particle_position_z": 1.9017767912783692,
     "particle_weight": 3120754537.230381
   },
   "driver": {
@@ -33,36 +33,36 @@
     "particle_weight": 6241509074.460762
   },
   "lev=0": {
-    "Bx": 98161.89939899123,
-    "By": 98172.52375014294,
-    "Bz": 31.901455104271527,
-    "Ex": 14057110264127.549,
-    "Ey": 14054769293579.486,
-    "Ez": 33309068457842.8,
-    "jx": 656450205498.9073,
-    "jy": 646505379718.3479,
-    "jz": 904278316755332.5
+    "Bx": 98161.70008968459,
+    "By": 98172.32439526827,
+    "Bz": 31.901351990962468,
+    "Ex": 14057086473507.713,
+    "Ey": 14054746454266.889,
+    "Ez": 33308979480924.473,
+    "jx": 656449539734.6744,
+    "jy": 646503950937.1055,
+    "jz": 904276481605925.0
   },
   "plasma_e": {
     "particle_cpu": 4116.0,
     "particle_id": 22919946.0,
-    "particle_momentum_x": 5.408171514250065e-22,
-    "particle_momentum_y": 5.385149011535136e-22,
-    "particle_momentum_z": 1.1184395632243283e-17,
-    "particle_position_x": 0.1350593467277345,
-    "particle_position_y": 0.13505932414714705,
-    "particle_position_z": 0.20362682066642418,
-    "particle_weight": 126911972493.45099
+    "particle_momentum_x": 5.4081725205908615e-22,
+    "particle_momentum_y": 5.385150045424111e-22,
+    "particle_momentum_z": 1.1184395632328821e-17,
+    "particle_position_x": 0.13505934672940284,
+    "particle_position_y": 0.13505932414882538,
+    "particle_position_z": 0.20362721013846616,
+    "particle_weight": 126912632943.3621
   },
   "plasma_p": {
     "particle_cpu": 4116.0,
     "particle_id": 25328394.0,
-    "particle_momentum_x": 5.408305135713714e-22,
-    "particle_momentum_y": 5.385290113762784e-22,
-    "particle_momentum_z": 2.0535791481240024e-14,
-    "particle_position_x": 0.13505624831336982,
-    "particle_position_y": 0.13505624832566657,
-    "particle_position_z": 0.2036268054747269,
-    "particle_weight": 126911972493.45099
+    "particle_momentum_x": 5.408306142946863e-22,
+    "particle_momentum_y": 5.385291148559078e-22,
+    "particle_momentum_z": 2.0535791481239935e-14,
+    "particle_position_x": 0.13505624831336888,
+    "particle_position_y": 0.13505624832566565,
+    "particle_position_z": 0.2036271949467523,
+    "particle_weight": 126912632943.3621
   }
 }


### PR DESCRIPTION
Some boosted frame benchmarks need to be reset, due to https://github.com/AMReX-Codes/amrex/pull/1783. Thanks @dpgrote for pointing this out.