### PR TITLE
ParticleHistogram: Fix Performance Regression

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -177,6 +177,7 @@ void ParticleHistogram::ComputeDiags (int step)
         auto const uz = p.rdata(PIdx::uz)/PhysConst::c;
         auto const f = fun_partparser(t,x,y,z,ux,uy,uz);
         int i = int(std::floor((f-bin_min)/bin_size));
+        if ( i<0 || i>=m_bin_num ) return 0.0_rt;
         if ( is_unity_particle_weight ) {
             amrex::HostDevice::Atomic::Add(&m_data[i],1.0_rt);
         } else {

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Yinjian Zhao
+/* Copyright 2019-2021 Yinjian Zhao, Axel Huebl
  *
  * This file is part of WarpX.
  *
@@ -11,11 +11,14 @@
 #include "Utils/WarpXUtil.H"
 #include "Particles/Filter/FilterFunctors.H"
 
-#include <AMReX_REAL.H>
+#include <AMReX_GpuContainers.H>
 #include <AMReX_ParticleReduce.H>
+#include <AMReX_REAL.H>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
+
 
 using namespace amrex;
 
@@ -143,15 +146,13 @@ void ParticleHistogram::ComputeDiags (int step)
     const auto & mypc = warpx.GetPartContainer();
 
     // get WarpXParticleContainer class object
-    auto const & myspc = mypc.GetParticleContainer(m_selected_species_id);
-
-    using PType = typename WarpXParticleContainer::SuperParticleType;
+    auto & myspc = mypc.GetParticleContainer(m_selected_species_id);
 
     // get parser
     HostDeviceParser<m_nvars> fun_partparser = getParser(m_parser);
 
     // get filter parser
-    ParserFilter fun_filterparser(m_do_parser_filter, getParser(m_parser_filter), myspc.getMass());
+    HostDeviceParser<m_nvars> fun_filterparser = getParser(m_parser_filter);
 
     // declare local variables
     Real const bin_min  = m_bin_min;
@@ -159,32 +160,63 @@ void ParticleHistogram::ComputeDiags (int step)
     const bool is_unity_particle_weight =
         (m_norm == NormalizationType::unity_particle_weight) ? true : false;
 
-    // compute the histogram
-    for ( int i = 0; i < m_bin_num; ++i ) {
-        m_data[i] = 0.0_rt;
-    }
-    ReduceSum( myspc,
-    [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
-    {
-        // return 0 if the particle is filtered out
-        if (!fun_filterparser(p, amrex::RandomEngine())) {return 0.0_rt;}
-        // continue function if particle is not filtered out
-        auto const w  = p.rdata(PIdx::w);
-        amrex::ParticleReal x, y, z;
-        get_particle_position(p, x, y, z);
-        auto const ux = p.rdata(PIdx::ux)/PhysConst::c;
-        auto const uy = p.rdata(PIdx::uy)/PhysConst::c;
-        auto const uz = p.rdata(PIdx::uz)/PhysConst::c;
-        auto const f = fun_partparser(t,x,y,z,ux,uy,uz);
-        int i = int(std::floor((f-bin_min)/bin_size));
-        if ( i<0 || i>=m_bin_num ) return 0.0_rt;
-        if ( is_unity_particle_weight ) {
-            amrex::HostDevice::Atomic::Add(&m_data[i],1.0_rt);
-        } else {
-            amrex::HostDevice::Atomic::Add(&m_data[i],w);
+    // zero-out old data on the host
+    std::fill(m_data.begin(), m_data.end(), amrex::Real(0.0));
+    amrex::Gpu::DeviceVector< amrex::Real > d_data( m_data.size(), 0.0 );
+    amrex::Real* const AMREX_RESTRICT dptr_data = d_data.dataPtr();
+
+    int const nlevs = std::max(0, myspc.finestLevel()+1);
+    for (int lev = 0; lev < nlevs; ++lev) {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        {
+            for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
+            {
+                auto const GetPosition = GetParticlePosition(pti);
+
+                auto & attribs = pti.GetAttribs();
+                Real* const AMREX_RESTRICT d_w = attribs[PIdx::w].dataPtr();
+                Real* const AMREX_RESTRICT d_ux = attribs[PIdx::ux].dataPtr();
+                Real* const AMREX_RESTRICT d_uy = attribs[PIdx::uy].dataPtr();
+                Real* const AMREX_RESTRICT d_uz = attribs[PIdx::uz].dataPtr();
+
+                const long np = pti.numParticles();
+
+                //Flag particles that need to be copied if they cross the z_slice
+                amrex::ParallelFor(np,
+                   [=] AMREX_GPU_DEVICE(int i)
+                {
+                    amrex::ParticleReal x, y, z;
+                    GetPosition(i, x, y, z);
+                    auto const w  = d_w[i];
+                    auto const ux = d_ux[i] / PhysConst::c;
+                    auto const uy = d_uy[i] / PhysConst::c;
+                    auto const uz = d_uz[i] / PhysConst::c;
+
+                    // don't count a particle if it is filtered out
+                    if (!fun_filterparser(t, x, y, z, ux, uy, uz)) return;
+                    // continue function if particle is not filtered out
+                    auto const f = fun_partparser(t, x, y, z, ux, uy, uz);
+
+                    // determine particle bin
+                    int const bin = int(std::floor((f-bin_min)/bin_size));
+                    if ( bin<0 || bin>=m_bin_num ) return; // discard if out-of-range
+
+                    if ( is_unity_particle_weight ) {
+                        amrex::HostDevice::Atomic::Add(&dptr_data[bin], 1.0_rt);
+                    } else {
+                        amrex::HostDevice::Atomic::Add(&dptr_data[bin], w);
+                    }
+                });
+            }
         }
-        return 0.0_rt;
-    });
+    }
+
+    // blocking copy from device to host
+    amrex::Gpu::copy(amrex::Gpu::deviceToDevice,
+        d_data.begin(), d_data.end(), m_data.begin());
+
     // reduced sum over mpi ranks
     ParallelDescriptor::ReduceRealSum
         (m_data.data(), m_data.size(), ParallelDescriptor::IOProcessorNumber());

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -205,6 +205,10 @@ void ParticleHistogram::ComputeDiags (int step)
                     int const bin = int(Math::floor((f-bin_min)/bin_size));
                     if ( bin<0 || bin>=num_bins ) return; // discard if out-of-range
 
+                    // add particle to histogram bin
+                    //! @todo performance: on CPU, we are probably faster by
+                    //        letting each thread compute its own histogram and
+                    //        then we reduce the histograms after the loop
                     if ( is_unity_particle_weight ) {
                         amrex::HostDevice::Atomic::Add(&dptr_data[bin], 1.0_rt);
                     } else {

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -12,6 +12,7 @@
 #include "Particles/Filter/FilterFunctors.H"
 
 #include <AMReX_GpuContainers.H>
+#include <AMReX_Math.H>
 #include <AMReX_ParticleReduce.H>
 #include <AMReX_REAL.H>
 
@@ -201,7 +202,7 @@ void ParticleHistogram::ComputeDiags (int step)
                     auto const f = fun_partparser(t, x, y, z, ux, uy, uz);
 
                     // determine particle bin
-                    int const bin = int(std::floor((f-bin_min)/bin_size));
+                    int const bin = int(Math::floor((f-bin_min)/bin_size));
                     if ( bin<0 || bin>=num_bins ) return; // discard if out-of-range
 
                     if ( is_unity_particle_weight ) {

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -214,7 +214,7 @@ void ParticleHistogram::ComputeDiags (int step)
     }
 
     // blocking copy from device to host
-    amrex::Gpu::copy(amrex::Gpu::deviceToDevice,
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
         d_data.begin(), d_data.end(), m_data.begin());
 
     // reduced sum over mpi ranks

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -155,6 +155,7 @@ void ParticleHistogram::ComputeDiags (int step)
     HostDeviceParser<m_nvars> fun_filterparser = getParser(m_parser_filter);
 
     // declare local variables
+    auto const num_bins = m_bin_num;
     Real const bin_min  = m_bin_min;
     Real const bin_size = m_bin_size;
     const bool is_unity_particle_weight =
@@ -181,7 +182,7 @@ void ParticleHistogram::ComputeDiags (int step)
                 Real* const AMREX_RESTRICT d_uy = attribs[PIdx::uy].dataPtr();
                 Real* const AMREX_RESTRICT d_uz = attribs[PIdx::uz].dataPtr();
 
-                const long np = pti.numParticles();
+                long const np = pti.numParticles();
 
                 //Flag particles that need to be copied if they cross the z_slice
                 amrex::ParallelFor(np,
@@ -201,7 +202,7 @@ void ParticleHistogram::ComputeDiags (int step)
 
                     // determine particle bin
                     int const bin = int(std::floor((f-bin_min)/bin_size));
-                    if ( bin<0 || bin>=m_bin_num ) return; // discard if out-of-range
+                    if ( bin<0 || bin>=num_bins ) return; // discard if out-of-range
 
                     if ( is_unity_particle_weight ) {
                         amrex::HostDevice::Atomic::Add(&dptr_data[bin], 1.0_rt);


### PR DESCRIPTION
This PR fixes #1693 by "reverting" the outer and the inner loops.
In addition, it is found that `m_data` should be set to zero initially before computing.

- [ ] tested on CPUs
- [ ] tested on GPUs