### PR TITLE
new setup.py: PYWARPX_LIB_DIR support

### DIFF
--- a/.github/workflows/dependencies/pyfull.sh
+++ b/.github/workflows/dependencies/pyfull.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The WarpX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    ccache              \
+    clang               \
+    cmake               \
+    gnupg               \
+    libblas-dev         \
+    libboost-math-dev   \
+    libfftw3-dev        \
+    libfftw3-mpi-dev    \
+    libhdf5-openmpi-dev \
+    liblapack-dev       \
+    libopenmpi-dev      \
+    make                \
+    pkg-config          \
+    python3             \
+    python3-pip         \
+    python3-setuptools  \
+    wget
+
+# cmake-easyinstall
+#
+sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
+sudo chmod a+x /usr/local/bin/cmake-easyinstall
+export CEI_SUDO="sudo"
+
+# BLAS++ & LAPACK++
+cmake-easyinstall \
+  --prefix=/usr/local                      \
+  git+https://bitbucket.org/icl/blaspp.git \
+  -Duse_openmp=OFF                         \
+  -Dbuild_tests=OFF                        \
+  -DCMAKE_VERBOSE_MAKEFILE=ON
+
+cmake-easyinstall \
+  --prefix=/usr/local                        \
+  git+https://bitbucket.org/icl/lapackpp.git \
+  -Duse_cmake_find_lapack=ON                 \
+  -Dbuild_tests=OFF                          \
+  -DCMAKE_VERBOSE_MAKEFILE=ON

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,12 +22,26 @@ jobs:
         brew install openpmd-api
     - name: build WarpX
       run: |
-        mkdir build_dp && cd build_dp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF
-        make -j 2
+        cmake -S . -B build_dp         \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_openpmd_internal=OFF
+        cmake --build build_dp -j 2
 
-        cd ..
+        cmake -S . -B build_sp         \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_LIB=ON               \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_openpmd_internal=OFF \
+          -DWarpX_PRECISION=SINGLE
+        cmake --build build_sp -j 2
 
-        mkdir build_sp && cd build_sp
-        cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
-        make -j 2
+        python3 -m pip install --upgrade pip setuptools wheel
+        export WarpX_MPI=ON
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+        python3 -m pip install *.whl
+
+    - name: run pywarpx
+      run: |
+        export OMP_NUM_THREADS=1
+        mpirun -n 2 Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: Ubuntu build
 on: [push, pull_request]
 
 jobs:
-  build_minimal:
+  build_cxxminimal:
     name: GCC Minimal w/o MPI [Linux]
     runs-on: ubuntu-20.04
     steps:
@@ -19,8 +19,29 @@ jobs:
           -DWarpX_QED=OFF
         cmake --build build -j 2
 
+  build_pyfull:
+    name: Clang pywarpx [Linux]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        .github/workflows/dependencies/pyfull.sh
+    - name: build WarpX
+      run: |
         python3 -m pip install --upgrade pip setuptools wheel
+        export WarpX_MPI=ON
+        export WarpX_OPENPMD=ON
+        export WarpX_PSATD=ON
+        export WarpX_QED_TABLE_GEN=ON
+        export CC=$(which clang)
+        export CXX=$(which clang++)
         python3 -m pip install -v .
+
+    - name: run pywarpx
+      run: |
+        export OMP_NUM_THREADS=1
+        mpirun -n 2 Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
 
 # Ref.:
 #   https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/ubuntu18.04/10.1/base/Dockerfile
@@ -45,6 +66,7 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=CUDA         \
+          -DWarpX_LIB=ON               \
           -DAMReX_CUDA_ARCH=6.0        \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \
@@ -54,7 +76,9 @@ jobs:
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+        export WarpX_MPI=ON
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+        python3 -m pip install *.whl
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
@@ -88,14 +112,25 @@ jobs:
         export CXX=$(which icpc)
         export CC=$(which icc)
 
-        cmake -S . -B build_dp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF
+        cmake -S . -B build_dp \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DWarpX_LIB=ON              \
+          -DWarpX_MPI=OFF             \
+          -DWarpX_OPENPMD=ON          \
+          -DWarpX_openpmd_internal=OFF
         cmake --build build_dp -j 2
 
-        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=OFF -DWarpX_OPENPMD=ON -DWarpX_openpmd_internal=OFF -DWarpX_PRECISION=SINGLE
+        cmake -S . -B build_sp \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_LIB=ON               \
+          -DWarpX_MPI=OFF              \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_openpmd_internal=OFF \
+          -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip install -v .
 
   build_icpx:
     name: oneAPI ICX SP [Linux]
@@ -123,6 +158,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_PRECISION=SINGLE
@@ -130,10 +166,19 @@ jobs:
 
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade setuptools wheel
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel -v .
+        python3 -m pip install *.whl
      # note: setting the CXX compiler ID is a work-around for
      # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
      # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
+
+    - name: run pywarpx
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        export OMP_NUM_THREADS=2
+        Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
 
   build_dpcc:
     name: oneAPI DPC++ SP [Linux]
@@ -159,6 +204,7 @@ jobs:
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
+          -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_PRECISION=SINGLE
@@ -166,7 +212,8 @@ jobs:
 
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade setuptools wheel
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+        python3 -m pip install *.whl
      # note: setting the CXX compiler ID is a work-around for
      # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
      # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
@@ -187,7 +234,16 @@ jobs:
         export CXX=$(which hipcc)
         export CC=$(which hipcc)
 
-        cmake -S . -B build_sp -DCMAKE_VERBOSE_MAKEFILE=ON -DWarpX_MPI=ON -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx900 -DWarpX_OPENPMD=ON -DWarpX_PRECISION=SINGLE
+        cmake -S . -B build_sp \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DAMReX_AMD_ARCH=gfx900     \
+          -DWarpX_COMPUTE=HIP         \
+          -DWarpX_LIB=ON              \
+          -DWarpX_MPI=ON              \
+          -DWarpX_OPENPMD=ON          \
+          -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel Python/
+        export WarpX_MPI=ON
+        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+        python3 -m pip install *.whl

--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -178,6 +178,7 @@ Environment Variable          Default & Values                             Descr
 ``WarpX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
 ``WarpX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
 ``WarpX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
+``WarpX_PRECISION``           SINGLE/**DOUBLE**                            Floating point precision (single/double)
 ``WarpX_PSATD``               ON/**OFF**                                   Spectral solver
 ``WarpX_QED``                 **ON**/OFF                                   PICSAR QED (requires PICSAR)
 ``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation (requires PICSAR and Boost)

--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -159,30 +159,15 @@ An executable WarpX binary with the current compile-time options encoded in its 
 Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`_ named ``warpx`` can be found in that directory, which points to the last built WarpX executable.
 
 
-Python Wrapper (New Scripts)
-============================
+Python Bindings
+===============
 
-Build and install a wheel from the root of the WarpX source tree:
+Build and install ``pywarpx`` from the root of the WarpX source tree:
 
 .. code-block:: bash
 
    python3 -m pip wheel -v .
    python3 -m pip install *whl
-
-Maintainers might also want to generate a self-contained source package that can be distributed to exotic architectures:
-
-.. code-block:: bash
-
-   python setup.py sdist --dist-dir .
-   pip wheel -v pywarpx-*.tar.gz
-   python3 -m pip install *whl
-
-The above steps can also be executed in one go to build from source on a machine:
-
-.. code-block:: bash
-
-   python setup.py sdist --dist-dir .
-   pip install -v pywarpx-*.tar.gz
 
 Environment variables can be used to control the build step:
 
@@ -200,26 +185,49 @@ Environment Variable          Default & Values                             Descr
 ``BUILD_SHARED_LIBS``         ON/**OFF**                                   Build shared libraries for dependencies
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)
 ``ADIOS_USE_STATIC_LIBS``     ON/**OFF**                                   Prefer static libraries for ADIOS1 dependency (openPMD)
+``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built C++ libraries (see below)
 ============================= ============================================ =======================================================
 
 
-Python Wrapper (Legacy Scripts)
-===============================
+Python Bindings (Developers)
+============================
 
-This is a manual workflow using the GNUmake-like Python install logic.
-The Python wrapper library can be built by pre-building WarpX into one or more shared libraries.
-For full functionality in 2D, 3D and RZ geometry, the following workflow can be executed:
+**Developers** might have all Python dependencies already installed and want to just overwrite an already installed ``pywarpx`` package:
 
 .. code-block:: bash
 
-   # build
+   python3 -m pip install --force-reinstall -v .
+
+The Python library ``pywarpx`` can also be created by pre-building WarpX into one or more shared libraries externally.
+For example, a package manager might split WarpX into a C++ package and a Python package.
+If the C++ libraries are already pre-compiled, we can pick them up in the Python build step instead of compiling them again:
+
+.. code-block:: bash
+
+   # build WarpX executables and libraries
    for d in 2 3 RZ; do
      cmake -S . -B build -DWarpX_DIMS=$d -DWarpX_LIB=ON
      cmake --build build -j 4
    done
 
-   # package
-   PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel Python/
+   # Python package
+   PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
 
    # install
    python3 -m pip install pywarpx-*whl
+
+
+WarpX release managers might also want to generate a self-contained source package that can be distributed to exotic architectures:
+
+.. code-block:: bash
+
+   python setup.py sdist --dist-dir .
+   python3 -m pip wheel -v pywarpx-*.tar.gz
+   python3 -m pip install *whl
+
+The above steps can also be executed in one go to build from source on a machine:
+
+.. code-block:: bash
+
+   python3 setup.py sdist --dist-dir .
+   python3 -m pip install -v pywarpx-*.tar.gz

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 import numpy as np
 from pywarpx import picmi
 #from warp import picmi

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ class CMakeBuild(build_ext):
             '-DWarpX_COMPUTE=' + WarpX_COMPUTE,
             '-DWarpX_MPI:BOOL=' + WarpX_MPI,
             '-DWarpX_OPENPMD:BOOL=' + WarpX_OPENPMD,
+            '-DWarpX_PRECISION=' + WarpX_PRECISION,
             '-DWarpX_PSATD:BOOL=' + WarpX_PSATD,
             '-DWarpX_QED:BOOL=' + WarpX_QED,
             '-DWarpX_QED_TABLE_GEN:BOOL=' + WarpX_QED_TABLE_GEN,
@@ -162,6 +163,7 @@ PYWARPX_LIB_DIR = os.environ.get('PYWARPX_LIB_DIR')
 WarpX_COMPUTE = os.environ.get('WarpX_COMPUTE', 'OMP')
 WarpX_MPI = os.environ.get('WarpX_MPI', 'OFF')
 WarpX_OPENPMD = os.environ.get('WarpX_OPENPMD', 'OFF')
+WarpX_PRECISION = os.environ.get('WarpX_PRECISION', 'DOUBLE')
 WarpX_PSATD = os.environ.get('WarpX_PSATD', 'OFF')
 WarpX_QED = os.environ.get('WarpX_QED', 'ON')
 WarpX_QED_TABLE_GEN = os.environ.get('WarpX_QED_TABLE_GEN', 'OFF')


### PR DESCRIPTION
Add support to build in a quick and modular way against pre-built C++ WarpX libraries through a `PYWARPX_LIB_DIR` hint to the root `setup.py`.

