### PR TITLE
CMake: Quick, Local Dependencies

### DIFF
--- a/Docs/source/building/cmake.rst
+++ b/Docs/source/building/cmake.rst
@@ -9,6 +9,8 @@ Until we have transitioned our documentation and functionality completely, pleas
 Progress status: `see on GitHub <https://github.com/ECP-WarpX/WarpX/projects/10>`_
 
 
+.. _building-cmake-intro:
+
 Introduction to CMake
 =====================
 
@@ -121,9 +123,9 @@ You can inspect and modify build options after running ``cmake -S . -B build`` w
 
 or by providing arguments to the CMake call: ``cmake -S . -B build -D<OPTION_A>=<VALUE_A> -D<OPTION_B>=<VALUE_B>``
 
-============================= ============================================ =======================================================
+============================= ============================================ ========================================================
 CMake Option                  Default & Values                             Description
-============================= ============================================ =======================================================
+============================= ============================================ ========================================================
 ``CMAKE_BUILD_TYPE``          **RelWithDebInfo**/Release/Debug             Type of build, symbols & optimizations
 ``WarpX_APP``                 **ON**/OFF                                   Build the WarpX executable application
 ``WarpX_ASCENT``              ON/**OFF**                                   Ascent in situ visualization
@@ -139,16 +141,40 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_PSATD``               ON/**OFF**                                   Spectral solver
 ``WarpX_QED``                 **ON**/OFF                                   QED support (requires PICSAR)
 ``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation support (requires PICSAR and Boost)
-``WarpX_amrex_repo``          ``https://github.com/AMReX-Codes/amrex.git`` Repository URI to pull and build AMReX from
-``WarpX_amrex_branch``        ``development``                              Repository branch for ``WarpX_amrex_repo``
-``WarpX_amrex_internal``      **ON**/OFF                                   Needs a pre-installed AMReX library if set to ``OFF``
-``WarpX_openpmd_internal``    **ON**/OFF                                   Needs a pre-installed openPMD library if set to ``OFF``
-============================= ============================================ =======================================================
+============================= ============================================ ========================================================
 
-For example, one can also build against a local AMReX git repo.
-Assuming AMReX' source is located in ``$HOME/src/amrex`` and changes are committed into a branch such as ``my-amrex-branch`` then pass to ``cmake`` the arguments: ``-DWarpX_amrex_repo=file://$HOME/src/amrex -DWarpX_amrex_branch=my-amrex-branch``.
+WarpX can be configured in further detail with options from AMReX, which are `documented in the AMReX manual <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options>`_.
 
-For developers, WarpX can be configured in further detail with options from AMReX, which are `documented in the AMReX manual <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options>`_.
+**Developers** might be interested in additional options that control dependencies of WarpX.
+By default, the most important dependencies of WarpX are automatically downloaded for convenience:
+
+============================= ============================================== ===========================================================
+CMake Option                  Default & Values                               Description
+============================= ============================================== ===========================================================
+``WarpX_amrex_src``           *None*                                         Path to AMReX source directory (preferred if set)
+``WarpX_amrex_repo``          ``https://github.com/AMReX-Codes/amrex.git``   Repository URI to pull and build AMReX from
+``WarpX_amrex_branch``        ``development``                                Repository branch for ``WarpX_amrex_repo``
+``WarpX_amrex_internal``      **ON**/OFF                                     Needs a pre-installed AMReX library if set to ``OFF``
+``WarpX_openpmd_src``         *None*                                         Path to openPMD-api source directory (preferred if set)
+``WarpX_openpmd_repo``        ``https://github.com/openPMD/openPMD-api.git`` Repository URI to pull and build openPMD-api from
+``WarpX_openpmd_branch``      ``0.13.2``                                     Repository branch for ``WarpX_openpmd_repo``
+``WarpX_openpmd_internal``    **ON**/OFF                                     Needs a pre-installed openPMD-api library if set to ``OFF``
+``WarpX_picsar_src``          *None*                                         Path to PICSAR source directory (preferred if set)
+``WarpX_picsar_repo``         ``https://github.com/ECP-WarpX/picsar.git``    Repository URI to pull and build PICSAR from
+``WarpX_picsar_branch``       ``development``                                Repository branch for ``WarpX_picsar_repo``
+``WarpX_picsar_internal``     **ON**/OFF                                     Needs a pre-installed PICSAR library if set to ``OFF``
+============================= ============================================== ===========================================================
+
+For example, one can also build against a local AMReX copy.
+Assuming AMReX' source is located in ``$HOME/src/amrex``, add the ``cmake`` argument ``-DWarpX_amrex_src=$HOME/src/amrex``.
+Relative paths are also supported, e.g. ``-DWarpX_amrex_src=../amrex``.
+
+Or build against an AMReX feature branch of a colleague.
+Assuming your colleague pushed AMReX to ``https://github.com/WeiqunZhang/amrex/`` in a branch ``new-feature`` then pass to ``cmake`` the arguments: ``-DWarpX_amrex_repo=https://github.com/WeiqunZhang/amrex.git -DWarpX_amrex_branch=new-feature``.
+
+You can speed up the install further if you pre-install these dependencies, e.g. with a package manager.
+Set ``-DWarpX_<dependency-name>_internal=OFF`` and add installation prefix of the dependency to the environment variable [CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/latest/envvar/CMAKE_PREFIX_PATH.html).
+Please see the :ref:`introduction to CMake <building-cmake-intro>` if this sounds new to you.
 
 
 Run
@@ -171,9 +197,9 @@ Build and install ``pywarpx`` from the root of the WarpX source tree:
 
 Environment variables can be used to control the build step:
 
-============================= ============================================ =======================================================
+============================= ============================================ ================================================================
 Environment Variable          Default & Values                             Description
-============================= ============================================ =======================================================
+============================= ============================================ ================================================================
 ``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
 ``WarpX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
 ``WarpX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
@@ -186,8 +212,14 @@ Environment Variable          Default & Values                             Descr
 ``BUILD_SHARED_LIBS``         ON/**OFF**                                   Build shared libraries for dependencies
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)
 ``ADIOS_USE_STATIC_LIBS``     ON/**OFF**                                   Prefer static libraries for ADIOS1 dependency (openPMD)
-``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built C++ libraries (see below)
-============================= ============================================ =======================================================
+``WarpX_amrex_src``           *None*                                       Absolute path to AMReX source directory (preferred if set)
+``WarpX_amrex_internal``      **ON**/OFF                                   Needs a pre-installed AMReX library if set to ``OFF``
+``WarpX_openpmd_src``         *None*                                       Absolute path to openPMD-api source directory (preferred if set)
+``WarpX_openpmd_internal``    **ON**/OFF                                   Needs a pre-installed openPMD-api library if set to ``OFF``
+``WarpX_picsar_src``          *None*                                       Absolute path to PICSAR source directory (preferred if set)
+``WarpX_picsar_internal``     **ON**/OFF                                   Needs a pre-installed PICSAR library if set to ``OFF``
+``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built WarpX C++ libraries (see below)
+============================= ============================================ ================================================================
 
 
 Python Bindings (Developers)
@@ -198,6 +230,22 @@ Python Bindings (Developers)
 .. code-block:: bash
 
    python3 -m pip install --force-reinstall -v .
+
+Some Developers like to code directly against a local copy of AMReX, changing both code-bases at a time:
+
+.. code-block:: bash
+
+   WarpX_amrex_src=$PWD/../amrex python3 -m pip install --force-reinstall -v .
+
+Additional environment control as common for CMake (:ref:`see above <building-cmake-intro>`) can be set as well, e.g.``CC``, `CXX``, and ``CMAKE_PREFIX_PATH`` hints.
+So another sophisticated example might be: use Clang as the compiler, build with local source copies of PICSAR and AMReX, support the PSATD solver, MPI and openPMD, hint a parallel HDF5 installation in ``$HOME/sw/hdf5-parallel-1.10.4``, and only build 3D geometry:
+
+.. code-block:: bash
+
+   CC=$(which clang) CXX=$(which clang++) WarpX_amrex_src=$PWD/../amrex WarpX_picsar_src=$PWD/../picsar WarpX_PSATD=ON WarpX_MPI=ON WarpX_OPENPMD=ON WarpX_DIMS=3 CMAKE_PREFIX_PATH=$HOME/sw/hdf5-parallel-1.10.4:$CMAKE_PREFIX_PATH python3 -m pip install --force-reinstall -v .
+
+Here we wrote this all in one line, but one can also set all environment variables in a development environment and keep the pip call nice and short as in the beginning.
+Note that you need to use absolute paths for external source trees, because pip builds in a temporary directory, e.g. ``export WarpX_amrex_src=$HOME/src/amrex``.
 
 The Python library ``pywarpx`` can also be created by pre-building WarpX into one or more shared libraries externally.
 For example, a package manager might split WarpX into a C++ package and a Python package.
@@ -232,3 +280,7 @@ The above steps can also be executed in one go to build from source on a machine
 
    python3 setup.py sdist --dist-dir .
    python3 -m pip install -v pywarpx-*.tar.gz
+
+Last but not least, you can uninstall ``pywarpx`` as usual with:
+
+   python3 -m pip uninstall pywarpx

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -1,7 +1,13 @@
 macro(find_amrex)
-    if(WarpX_amrex_internal)
+    if(WarpX_amrex_src)
+        message(STATUS "Compiling local AMReX ...")
+        message(STATUS "AMReX source path: ${WarpX_amrex_src}")
+    elseif(WarpX_amrex_internal)
         message(STATUS "Downloading AMReX ...")
+        message(STATUS "AMReX repository: ${WarpX_amrex_repo} (${WarpX_amrex_branch})")
         include(FetchContent)
+    endif()
+    if(WarpX_amrex_internal OR WarpX_amrex_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
         # see https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options
@@ -74,30 +80,39 @@ macro(find_amrex)
             set(AMReX_SPACEDIM ${WarpX_DIMS} CACHE INTERNAL "")
         endif()
 
-        FetchContent_Declare(fetchedamrex
-            GIT_REPOSITORY ${WarpX_amrex_repo}
-            GIT_TAG        ${WarpX_amrex_branch}
-            BUILD_IN_SOURCE 0
-        )
-        FetchContent_GetProperties(fetchedamrex)
-
-        if(NOT fetchedamrex_POPULATED)
-            FetchContent_Populate(fetchedamrex)
-            list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
+        if(WarpX_amrex_src)
+            list(APPEND CMAKE_MODULE_PATH "${WarpX_amrex_src}/Tools/CMake")
             if(WarpX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
                 include(AMReX_SetupCUDA)
             endif()
-            add_subdirectory(${fetchedamrex_SOURCE_DIR} ${fetchedamrex_BINARY_DIR})
-        endif()
+            add_subdirectory(${WarpX_amrex_src} _deps/localamrex-build/)
+        else()
+            FetchContent_Declare(fetchedamrex
+                GIT_REPOSITORY ${WarpX_amrex_repo}
+                GIT_TAG        ${WarpX_amrex_branch}
+                BUILD_IN_SOURCE 0
+            )
+            FetchContent_GetProperties(fetchedamrex)
 
-        # advanced fetch options
-        mark_as_advanced(FETCHCONTENT_BASE_DIR)
-        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_QUIET)
-        mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDAMREX)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDAMREX)
+            if(NOT fetchedamrex_POPULATED)
+                FetchContent_Populate(fetchedamrex)
+                list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
+                if(WarpX_COMPUTE STREQUAL CUDA)
+                    enable_language(CUDA)
+                    include(AMReX_SetupCUDA)
+                endif()
+                add_subdirectory(${fetchedamrex_SOURCE_DIR} ${fetchedamrex_BINARY_DIR})
+            endif()
+
+            # advanced fetch options
+            mark_as_advanced(FETCHCONTENT_BASE_DIR)
+            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+            mark_as_advanced(FETCHCONTENT_QUIET)
+            mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDAMREX)
+            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDAMREX)
+        endif()
 
         # AMReX options not relevant to WarpX users
         mark_as_advanced(AMREX_BUILD_DATETIME)
@@ -132,6 +147,7 @@ macro(find_amrex)
 
         message(STATUS "AMReX: Using INTERNAL version '${AMREX_PKG_VERSION}' (${AMREX_GIT_VERSION})")
     else()
+        message(STATUS "Searching for pre-installed AMReX ...")
         # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#importing-amrex-into-your-cmake-project
         if(WarpX_ASCENT)
             set(COMPONENT_ASCENT AMReX_ASCENT AMReX_CONDUIT)
@@ -160,6 +176,12 @@ macro(find_amrex)
     endif()
 endmacro()
 
+# local source-tree
+set(WarpX_amrex_src ""
+    CACHE PATH
+    "Local path to AMReX source directory (preferred if set)")
+
+# Git fetcher
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -1,7 +1,13 @@
 function(find_openpmd)
-    if(WarpX_openpmd_internal)
+    if(WarpX_openpmd_src)
+        message(STATUS "Compiling local openPMD-api ...")
+        message(STATUS "openPMD-api source path: ${WarpX_openpmd_src}")
+    elseif(WarpX_openpmd_internal)
         message(STATUS "Downloading openPMD-api ...")
+        message(STATUS "openPMD-api repository: ${WarpX_openpmd_repo} (${WarpX_openpmd_branch})")
         include(FetchContent)
+    endif()
+    if(WarpX_openpmd_internal OR WarpX_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
         # see https://openpmd-api.readthedocs.io/en/0.12.0-alpha/dev/buildoptions.html
@@ -12,25 +18,29 @@ function(find_openpmd)
         set(BUILD_TESTING      OFF           CACHE INTERNAL "")  # FIXME
         set(openPMD_INSTALL    ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
 
-        FetchContent_Declare(fetchedopenpmd
-            GIT_REPOSITORY ${WarpX_openpmd_repo}
-            GIT_TAG        ${WarpX_openpmd_branch}
-            BUILD_IN_SOURCE 0
-        )
-        FetchContent_GetProperties(fetchedopenpmd)
+        if(WarpX_openpmd_src)
+            add_subdirectory(${WarpX_openpmd_src} _deps/localopenpmd-build/)
+        else()
+            FetchContent_Declare(fetchedopenpmd
+                GIT_REPOSITORY ${WarpX_openpmd_repo}
+                GIT_TAG        ${WarpX_openpmd_branch}
+                BUILD_IN_SOURCE 0
+            )
+            FetchContent_GetProperties(fetchedopenpmd)
 
-        if(NOT fetchedopenpmd_POPULATED)
-            FetchContent_Populate(fetchedopenpmd)
-            add_subdirectory(${fetchedopenpmd_SOURCE_DIR} ${fetchedopenpmd_BINARY_DIR})
+            if(NOT fetchedopenpmd_POPULATED)
+                FetchContent_Populate(fetchedopenpmd)
+                add_subdirectory(${fetchedopenpmd_SOURCE_DIR} ${fetchedopenpmd_BINARY_DIR})
+            endif()
+
+            # advanced fetch options
+            mark_as_advanced(FETCHCONTENT_BASE_DIR)
+            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+            mark_as_advanced(FETCHCONTENT_QUIET)
+            mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDOPENPMD)
+            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDOPENPMD)
         endif()
-
-        # advanced fetch options
-        mark_as_advanced(FETCHCONTENT_BASE_DIR)
-        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_QUIET)
-        mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDOPENPMD)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDOPENPMD)
 
         # openPMD options not relevant to WarpX users
         mark_as_advanced(openPMD_USE_INTERNAL_VARIANT)
@@ -40,9 +50,14 @@ function(find_openpmd)
         mark_as_advanced(openPMD_HAVE_PKGCONFIG)
         mark_as_advanced(openPMD_USE_INVASIVE_TESTS)
         mark_as_advanced(openPMD_USE_VERIFY)
-        mark_as_advanced(ADIOS2_DOR)
+        mark_as_advanced(ADIOS2_DIR)
         mark_as_advanced(ADIOS_CONFIG)
         mark_as_advanced(HDF5_DIR)
+        mark_as_advanced(HDF5_C_LIBRARY_dl)
+        mark_as_advanced(HDF5_C_LIBRARY_hdf5)
+        mark_as_advanced(HDF5_C_LIBRARY_m)
+        mark_as_advanced(HDF5_C_LIBRARY_z)
+        mark_as_advanced(JSON_ImplicitConversions)
         mark_as_advanced(JSON_MultipleHeaders)
 
         message(STATUS "openPMD-api: Using INTERNAL version '${WarpX_openpmd_branch}'")
@@ -58,6 +73,11 @@ function(find_openpmd)
 endfunction()
 
 if(WarpX_OPENPMD)
+    # local source-tree
+    set(WarpX_openpmd_src ""
+        CACHE PATH
+        "Local path to openPMD-api source directory (preferred if set)")
+
     option(WarpX_openpmd_internal   "Download & build openPMD-api" ON)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ class CMakeBuild(build_ext):
             '-DWarpX_PSATD:BOOL=' + WarpX_PSATD,
             '-DWarpX_QED:BOOL=' + WarpX_QED,
             '-DWarpX_QED_TABLE_GEN:BOOL=' + WarpX_QED_TABLE_GEN,
+            ## dependency control (developers & package managers)
+            '-DWarpX_amrex_internal=' + WarpX_amrex_internal,
+            #        see PICSAR and openPMD below
             ## static/shared libs
             '-DBUILD_SHARED_LIBS:BOOL=' + BUILD_SHARED_LIBS,
             ## Unix: rpath to current dir when packaged
@@ -102,11 +105,22 @@ class CMakeBuild(build_ext):
             # Windows: has no RPath concept, all `.dll`s must be in %PATH%
             #          or same dir as calling executable
         ]
+        if WarpX_QED.upper() in ['1', 'ON', 'TRUE', 'YES']:
+            cmake_args.append('-DWarpX_picsar_internal=' + WarpX_picsar_internal)
         if WarpX_OPENPMD.upper() in ['1', 'ON', 'TRUE', 'YES']:
             cmake_args += [
                 '-DHDF5_USE_STATIC_LIBRARIES:BOOL=' + HDF5_USE_STATIC_LIBRARIES,
                 '-DADIOS_USE_STATIC_LIBS:BOOL=' + ADIOS_USE_STATIC_LIBS,
+                '-DWarpX_openpmd_internal=' + WarpX_openpmd_internal,
             ]
+        # further dependency control (developers & package managers)
+        if WarpX_amrex_src:
+            cmake_args.append('-DWarpX_amrex_src=' + WarpX_amrex_src)
+        if WarpX_openpmd_src:
+            cmake_args.append('-DWarpX_openpmd_src=' + WarpX_openpmd_src)
+        if WarpX_picsar_src:
+            cmake_args.append('-DWarpX_picsar_src=' + WarpX_picsar_src)
+
         if sys.platform == "darwin":
             cmake_args.append('-DCMAKE_INSTALL_RPATH=@loader_path')
         else:
@@ -158,7 +172,8 @@ with open('./README.md', encoding='utf-8') as f:
 #   Work-around for https://github.com/pypa/setuptools/issues/1712
 # Pick up existing WarpX libraries or...
 PYWARPX_LIB_DIR = os.environ.get('PYWARPX_LIB_DIR')
-# ... build WarpX libraries
+
+# ... build WarpX libraries with CMake
 #   note: changed default for SHARED, MPI, TESTING and EXAMPLES
 WarpX_COMPUTE = os.environ.get('WarpX_COMPUTE', 'OMP')
 WarpX_MPI = os.environ.get('WarpX_MPI', 'OFF')
@@ -178,6 +193,13 @@ BUILD_SHARED_LIBS = os.environ.get('WarpX_BUILD_SHARED_LIBS',
 # openPMD-api sub-control
 HDF5_USE_STATIC_LIBRARIES = os.environ.get('HDF5_USE_STATIC_LIBRARIES', 'OFF')
 ADIOS_USE_STATIC_LIBS = os.environ.get('ADIOS_USE_STATIC_LIBS', 'OFF')
+# CMake dependency control (developers & package managers)
+WarpX_amrex_src = os.environ.get('WarpX_amrex_src')
+WarpX_amrex_internal = os.environ.get('WarpX_amrex_internal', 'ON')
+WarpX_openpmd_src = os.environ.get('WarpX_openpmd_src')
+WarpX_openpmd_internal = os.environ.get('WarpX_openpmd_internal', 'ON')
+WarpX_picsar_src = os.environ.get('WarpX_picsar_src')
+WarpX_picsar_internal = os.environ.get('WarpX_picsar_internal', 'ON')
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
 if WarpX_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:


### PR DESCRIPTION
This adds new options to CMake for developers that like to build against local dependencies. For example:

```bash
cmake -S . -B build -DWarpX_amrex_src=../amrex
cmake --build build -j 8
```

brings back the full "build my local source, I am working on it"-experience.

The *Python* equivalent looks like this:

```bash
WarpX_amrex_src=$PWD/../amrex python3 -m pip install -v .
```
(`pip` runs in a temporary directory, so path hints need to be absolute. All details in the docs.)

Added for all auto-downloaded dependencies:
- AMReX
- openPMD-api
- PICSAR

### To Do

- [x] rebase after #1698 was merged
- [x] add to Python options in `setup.py`

### Follow-Up PR

- [x] add same PR to *private-repo*-code (cc @MaxThevenet)