### PR TITLE
Change import statement for openPMD-viewer

### DIFF
--- a/Docs/source/visualization/openpmdviewer.rst
+++ b/Docs/source/visualization/openpmdviewer.rst
@@ -29,7 +29,7 @@ with the following commands:
 
 ::
 
-    from opmd_viewer import OpenPMDTimeSeries
+    from openpmd_viewer import OpenPMDTimeSeries
     ts = OpenPMDTimeSeries('./diags/hdf5')
 
 .. note::

--- a/Tools/DevUtils/compare_wx_w_3d.ipynb
+++ b/Tools/DevUtils/compare_wx_w_3d.ipynb
@@ -38,7 +38,7 @@
     "from IPython.display import clear_output\n",
     "import numpy as np\n",
     "from ipywidgets import interact, RadioButtons, IntSlider\n",
-    "from opmd_viewer import OpenPMDTimeSeries\n",
+    "from openpmd_viewer import OpenPMDTimeSeries\n",
     "from yt.units import volt\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib"


### PR DESCRIPTION
With version `1.X` of `openPMD-viewer`, the import statement should now be `from openpmd_viewer ...`. 
This PR fixes this in WarpX.