### PR TITLE
Summit & Cori: Update openPMD & ADIOS2

### DIFF
--- a/Docs/source/building/cori.rst
+++ b/Docs/source/building/cori.rst
@@ -105,25 +105,36 @@ First, load the appropriate modules:
    module swap PrgEnv-intel PrgEnv-gnu
    module load cmake/3.18.2
    module load cray-hdf5-parallel
-   module load adios2/2.5.0
 
-Then, in the ``warpx_directory``, download and build openPMD-api:
+Then, in the ``warpx_directory``, download and build ADIOS2:
 
 .. code-block:: bash
 
-   git clone https://github.com/openPMD/openPMD-api.git
-   mkdir openPMD-api-build
-   cd openPMD-api-build
-   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=../openPMD-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
-   cmake --build . --target install --parallel 16
+   git clone -b v2.7.1 https://github.com/ornladios/ADIOS2.git adios2
+   cmake -S adios2 -B adios2-build -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DCMAKE_INSTALL_PREFIX=adios2-2.7.1-install
+   cmake --build adios2-build --target install --parallel 16
+   export CMAKE_PREFIX_PATH=$PWD/adios2-2.7.1-install:$CMAKE_PREFIX_PATH
 
 Finally, compile WarpX:
 
 .. code-block:: bash
 
-   cd ../WarpX
-   export PKG_CONFIG_PATH=$PWD/../openPMD-install/lib64/pkgconfig:$PKG_CONFIG_PATH
-   export CMAKE_PREFIX_PATH=$PWD/../openPMD-install:$CMAKE_PREFIX_PATH
+   cd WarpX
+   cmake -S . -B build -DWarpX_OPENPMD=ON
+   cmake --build build -j 16
+
+Alternatively, in GNUmake (legacy) logic, we also need to pre-compile openPMD-api:
+
+.. code-block:: bash
+
+   git clone -b 0.13.2 https://github.com/openPMD/openPMD-api.git
+   cmake -S openPMD-api -B openPMD-api-build -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=openPMD-0.13.2-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
+   cmake --build openPMD-api-build --target install --parallel 16
+
+.. code-block:: bash
+
+   export PKG_CONFIG_PATH=$PWD/openPMD-0.13.2-install/lib64/pkgconfig:$PKG_CONFIG_PATH
+   cd WarpX
    make -j 16 COMP=gcc USE_OPENPMD=TRUE
 
 In order to run WarpX, load the same modules again.

--- a/Docs/source/building/summit.rst
+++ b/Docs/source/building/summit.rst
@@ -56,7 +56,7 @@ We use the following modules and environments on the system.
    # optional: for openPMD support
    module load ums
    module load ums-aph114
-   module load openpmd-api/0.12.0
+   module load openpmd-api/0.13.2
 
    # optional: for PSATD in RZ geometry support
    #   note: needs the ums modules above
@@ -106,16 +106,6 @@ We recommend to store the above lines in a file, such as ``$HOME/warpx.profile``
 
    source $HOME/warpx.profile
 
-Optionally, download and build openPMD-api for I/O (only needed if you did not load our module above):
-
-.. code-block:: bash
-
-   git clone https://github.com/openPMD/openPMD-api.git
-   mkdir openPMD-api-build
-   cd openPMD-api-build
-   cmake ../openPMD-api -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/openPMD-api-install/ -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN' -DMPIEXEC_EXECUTABLE=$(which jsrun)
-   cmake --build . --target install --parallel 16
-
 Optionally, download and install :ref:`libEnsemble <libensemble>` for dynamic ensemble optimizations:
 
 .. code-block:: bash
@@ -137,10 +127,9 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
 
 .. code-block:: bash
 
-   mkdir -p build
-   cd build
-   cmake .. -DWarpX_OPENPMD=ON -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA
-   make -j 10
+   rm -rf build
+   cmake -S build -B build -DWarpX_OPENPMD=ON -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA
+   cmake --build build -j 10
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
 


### PR DESCRIPTION
Provide new modules and instructions to use ADIOS2 (2.7.1) and openPMD-api (0.13.2) on Summit (OLCF) & Cori (NERSC).

I compiled on both systems as a test.