### PR TITLE
CMake: Mark Some PICSAR options as "advanced"

### DIFF
--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -71,7 +71,6 @@ function(find_picsar)
         mark_as_advanced(PXRMP_QED_TEST)
         mark_as_advanced(PXRMP_BOOST_TEST_DYN_LINK)
         mark_as_advanced(PXRMP_DPCPP_FIX)
-        mark_as_advanced(PXRMP_QED_TOOLS)
 
 
         # PICSAR_VERSION: not yet defined

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -69,6 +69,10 @@ function(find_picsar)
         mark_as_advanced(PXRMP_QED_TABLEGEN)
         mark_as_advanced(PXRMP_QED_OMP)
         mark_as_advanced(PXRMP_QED_TEST)
+        mark_as_advanced(PXRMP_BOOST_TEST_DYN_LINK)
+        mark_as_advanced(PXRMP_DPCPP_FIX)
+        mark_as_advanced(PXRMP_QED_TOOLS)
+
 
         # PICSAR_VERSION: not yet defined
         message(STATUS "PICSAR: Using INTERNAL version (git branch '${WarpX_picsar_branch}')")


### PR DESCRIPTION
Compilation options `PXRMP_BOOST_TEST_DYN_LINK`, `PXRMP_DPCPP_FIX` and `PXRMP_QED_TOOLS` should not be relevant for WarpX users.