### PR TITLE
Finite-order field centering: few small optimizations

### DIFF
--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -571,10 +571,6 @@ void warpx_interp (const int j,
     amrex::Real cj = 1.0_rt;
     amrex::Real ck = 1.0_rt;
     amrex::Real cl = 1.0_rt;
-    int dj, dk;
-#if (AMREX_SPACEDIM == 3)
-    int dl;
-#endif
 #endif
 
     // Min and max for interpolation loop along j
@@ -641,26 +637,23 @@ void warpx_interp (const int j,
     //     j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
     //     c_2   c_1   c_0   c_0   c_1   c_2                + ...
 
-    for (int ll = lmin; ll <= lmax; ll++)
+    for (int ll = 0; ll <= lmax-lmin; ll++)
     {
 #if (AMREX_SPACEDIM == 3)
-        dl = (l - ll > 0) ? l - ll - 1 : ll - l;
-        if (sl == 0) cl = stencil_coeffs_z[dl];
+        if (sl == 0) cl = stencil_coeffs_z[ll];
 #endif
-        for (int kk = kmin; kk <= kmax; kk++)
+        for (int kk = 0; kk <= kmax-kmin; kk++)
         {
-            dk = (k - kk > 0) ? k - kk - 1 : kk - k;
 #if   (AMREX_SPACEDIM == 2)
-            if (sk == 0) ck = stencil_coeffs_z[dk];
+            if (sk == 0) ck = stencil_coeffs_z[kk];
 #elif (AMREX_SPACEDIM == 3)
-            if (sk == 0) ck = stencil_coeffs_y[dk];
+            if (sk == 0) ck = stencil_coeffs_y[kk];
 #endif
-            for (int jj = jmin; jj <= jmax; jj++)
+            for (int jj = 0; jj <= jmax-jmin; jj++)
             {
-                dj = (j - jj > 0) ? j - jj - 1 : jj - j;
-                if (sj == 0) cj = stencil_coeffs_x[dj];
+                if (sj == 0) cj = stencil_coeffs_x[jj];
 
-                res += cj * ck * cl * src_arr_zeropad(jj,kk,ll);
+                res += cj * ck * cl * src_arr_zeropad(jmin+jj,kmin+kk,lmin+ll);
             }
         }
     }

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -502,9 +502,9 @@ void warpx_interp_nd_efield_z (int j, int k, int l,
  * \param[in] nox order of finite-order interpolation along x
  * \param[in] noy order of finite-order interpolation along y
  * \param[in] noz order of finite-order interpolation along z
- * \param[in] stencil_coeffs_x array of Fornberg coefficients for finite-order interpolation stencil along x
- * \param[in] stencil_coeffs_y array of Fornberg coefficients for finite-order interpolation stencil along y
- * \param[in] stencil_coeffs_z array of Fornberg coefficients for finite-order interpolation stencil along z
+ * \param[in] stencil_coeffs_x array of ordered Fornberg coefficients for finite-order interpolation stencil along x
+ * \param[in] stencil_coeffs_y array of ordered Fornberg coefficients for finite-order interpolation stencil along y
+ * \param[in] stencil_coeffs_z array of ordered Fornberg coefficients for finite-order interpolation stencil along z
  */
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void warpx_interp (const int j,
@@ -546,40 +546,37 @@ void warpx_interp (const int j,
     const int sl = src_stag[2];
 #endif
 
-    // Number of points (+1) used for interpolation from the staggered grid to the nodal grid
-    // (if the input field is nodal along a given direction, then s = 1, the variable n = 0
-    // is actually never used, and there is no interpolation, only a copy of one single value)
-    const int nj = (sj == 0) ? nox/2 + 1 : 0;
+    // Interpolate along j,k,l only if source MultiFab is staggered along j,k,l
+    const bool interp_j = (sj == 0);
+    const bool interp_k = (sk == 0);
+#if (AMREX_SPACEDIM == 3)
+    const bool interp_l = (sl == 0);
+#endif
+
+    const int noj = nox;
 #if   (AMREX_SPACEDIM == 2)
-    const int nk = (sk == 0) ? noz/2 + 1 : 0;
+    const int nok = noz;
 #elif (AMREX_SPACEDIM == 3)
-    const int nk = (sk == 0) ? noy/2 + 1 : 0;
-    const int nl = (sl == 0) ? noz/2 + 1 : 0;
+    const int nok = noy;
+    const int nol = noz;
 #endif
 
     // Additional normalization factor
-    const amrex::Real wj = (sj == 0) ? 0.5_rt : 1.0_rt;
-    const amrex::Real wk = (sk == 0) ? 0.5_rt : 1.0_rt;
+    const amrex::Real wj = (interp_j) ? 0.5_rt : 1.0_rt;
+    const amrex::Real wk = (interp_k) ? 0.5_rt : 1.0_rt;
 #if   (AMREX_SPACEDIM == 2)
     constexpr amrex::Real wl = 1.0_rt;
 #elif (AMREX_SPACEDIM == 3)
-    const amrex::Real wl = (sl == 0) ? 0.5_rt : 1.0_rt;
-#endif
-
-    // Auxiliary variables for stencil coefficients
-#ifdef WARPX_USE_PSATD
-    amrex::Real cj = 1.0_rt;
-    amrex::Real ck = 1.0_rt;
-    amrex::Real cl = 1.0_rt;
+    const amrex::Real wl = (interp_l) ? 0.5_rt : 1.0_rt;
 #endif
 
     // Min and max for interpolation loop along j
-    const int jmin = (sj == 0) ? j - nj + 1 : j;
-    const int jmax = (sj == 0) ? j + nj - 2 : j;
+    const int jmin = (interp_j) ? j - noj/2 : j;
+    const int jmax = (interp_j) ? j + noj/2 - 1 : j;
 
     // Min and max for interpolation loop along k
-    const int kmin = (sk == 0) ? k - nk + 1 : k;
-    const int kmax = (sk == 0) ? k + nk - 2 : k;
+    const int kmin = (interp_k) ? k - nok/2 : k;
+    const int kmax = (interp_k) ? k + nok/2 - 1 : k;
 
     // Min and max for interpolation loop along l
 #if   (AMREX_SPACEDIM == 2)
@@ -587,22 +584,22 @@ void warpx_interp (const int j,
     const int lmin = l;
     const int lmax = l;
 #elif (AMREX_SPACEDIM == 3)
-    const int lmin = (sl == 0) ? l - nl + 1 : l;
-    const int lmax = (sl == 0) ? l + nl - 2 : l;
+    const int lmin = (interp_l) ? l - nol/2 : l;
+    const int lmax = (interp_l) ? l + nol/2 - 1 : l;
 #endif
 
     amrex::Real res = 0.0_rt;
 
 #ifndef WARPX_USE_PSATD // FDTD (linear interpolation)
 
-    // Example of 1D interpolation from nodal grid to nodal grid:
+    // Example of 1D linear interpolation from nodal grid to nodal grid:
     //
     //         j
     // --o-----o-----o--  result(j) = f(j)
     // --o-----o-----o--
     //  j-1    j    j+1
     //
-    // Example of 1D interpolation from staggered grid to nodal grid:
+    // Example of 1D linear interpolation from staggered grid to nodal grid:
     //
     //         j
     // --o-----o-----o--  result(j) = (f(j-1) + f(j)) / 2
@@ -622,14 +619,30 @@ void warpx_interp (const int j,
 
 #else // PSATD (finite-order interpolation)
 
-    // Example of 1D interpolation from nodal grid to nodal grid:
+    const int nj = jmax - jmin;
+    const int nk = kmax - kmin;
+    const int nl = lmax - lmin;
+
+    amrex::Real cj = 1.0_rt;
+    amrex::Real ck = 1.0_rt;
+    amrex::Real cl = 1.0_rt;
+
+    amrex::Real const* scj = stencil_coeffs_x;
+#if   (AMREX_SPACEDIM == 2)
+    amrex::Real const* sck = stencil_coeffs_z;
+#elif (AMREX_SPACEDIM == 3)
+    amrex::Real const* sck = stencil_coeffs_y;
+    amrex::Real const* scl = stencil_coeffs_z;
+#endif
+
+    // Example of 1D finite-order interpolation from nodal grid to nodal grid:
     //
     //         j
     // --o-----o-----o--  result(j) = f(j)
     // --o-----o-----o--
     //  j-1    j    j+1
     //
-    // Example of 1D interpolation from staggered grid to nodal grid:
+    // Example of 1D finite-order interpolation from staggered grid to nodal grid:
     //
     //                     j
     // --o-----o-----o-----o-----o-----o-----o--  result(j) = c_0 * (f(j-1) + f(j)  ) / 2
@@ -637,28 +650,25 @@ void warpx_interp (const int j,
     //     j-3   j-2   j-1    j    j+1   j+2                + c_2 * (f(j-3) + f(j+2)) / 2
     //     c_2   c_1   c_0   c_0   c_1   c_2                + ...
 
-    for (int ll = 0; ll <= lmax-lmin; ll++)
+    for (int ll = 0; ll <= nl; ll++)
     {
 #if (AMREX_SPACEDIM == 3)
-        if (sl == 0) cl = stencil_coeffs_z[ll];
+        if (interp_l) cl = scl[ll];
 #endif
-        for (int kk = 0; kk <= kmax-kmin; kk++)
+        for (int kk = 0; kk <= nk; kk++)
         {
-#if   (AMREX_SPACEDIM == 2)
-            if (sk == 0) ck = stencil_coeffs_z[kk];
-#elif (AMREX_SPACEDIM == 3)
-            if (sk == 0) ck = stencil_coeffs_y[kk];
-#endif
-            for (int jj = 0; jj <= jmax-jmin; jj++)
+            if (interp_k) ck = sck[kk];
+
+            for (int jj = 0; jj <= nj; jj++)
             {
-                if (sj == 0) cj = stencil_coeffs_x[jj];
+                if (interp_j) cj = scj[jj];
 
                 res += cj * ck * cl * src_arr_zeropad(jmin+jj,kmin+kk,lmin+ll);
             }
         }
     }
 
-#endif
+#endif // PSATD (finite-order interpolation)
 
     dst_arr(j,k,l) = wj * wk * wl * res;
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -590,7 +590,7 @@ public:
     void ApplyFilterandSumBoundaryRho (int lev, int glev, amrex::MultiFab& rho, int icomp, int ncomp);
 
 #ifdef WARPX_USE_PSATD
-    // Host and device vectors for Fornberg stencil coefficients used for finite-order centering
+    // Host and device vectors for ordered Fornberg stencil coefficients used for finite-order centering
     amrex::Vector<amrex::Real> host_centering_stencil_coeffs_x;
     amrex::Vector<amrex::Real> host_centering_stencil_coeffs_y;
     amrex::Vector<amrex::Real> host_centering_stencil_coeffs_z;
@@ -744,6 +744,10 @@ private:
     const amrex::iMultiFab* getGatherBufferMasks (int lev) const {
         return gather_buffer_masks[lev].get();
     }
+
+    void ReorderFornbergCoefficients(amrex::Vector<amrex::Real>& ordered_coeffs,
+                                     amrex::Vector<amrex::Real>& unordered_coeffs,
+                                     const int order);
 
     void AllocLevelMFs (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
                         const amrex::IntVect& ngE, const amrex::IntVect& ngJ,


### PR DESCRIPTION
The main optimization consists in re-ordering the Fornberg coefficients used for finite-order field centering at initialization.

Let's consider finite-order field centering of order 6, to fix the ideas.

**Before this PR**, we used to store 6/2=3 stencil coefficients (c0,c1,c2) and interpolate over 6 points using the coefficients (c2,c1,c0,c0,c1,c2) as weights, going from the leftmost interpolation point to the rightmost one. The logic for choosing the correct coefficient index was implemented as
https://github.com/ECP-WarpX/WarpX/blob/c659a94a95188d66176a251123ef87f526b0c9a4/Source/Parallelization/WarpXComm_K.H#L660-L661
this code block being inserted within a loop over `jj`. The purpose of using the ternary operator for the assignement of `dj` was simply to pick the correct coefficient's index, depending on the relative location of the interpolation point, so that the actual order of the weights would be (c2,c1,c0,c0,c1,c2), as mentioned above.

**After this PR**, we store directly an array of 6 stencil coefficients, already re-ordered at initialization as (c2,c1,c0,c0,c1,c2), and use this array in the innermost loops of the interpolation kernel. The new arrays of stencil coefficients are still named `host_centering_stencil_coeffs_<xyz>` as before and they are obtained by re-ordering the Fornberg coefficients through the new function `WarpX::ReorderFornbergCoefficients`, called only once at initialization (once for each direction). This simplifies the code overall and avoids an additional `if/else` logic inside the innermost nested loops.

I have tested the performance with a 3D Galilean setup, with 84 grids of size 64 x 64 x 64 distributed on 7 Summit nodes, so 7 x 6 = 42 GPUs, and compared the profiling times for the function `WarpX::UpdateAuxilaryData`, which calls the functions modified in this PR, between ECP-WarpX:development and EZoni:optimize_high_order_interp:

| | ECP-WarpX:development | EZoni:optimize_high_order_interp |
| -- | -- | -- |
| average exclusive/inclusive time | 0.8444 s |  0.7644 s |
| max. % of time spent across all MPI ranks | 2.07% | 1.88% |

The overall effect on the final run time is not large, but the specific kernel is slightly faster and certainly implemented in a cleaner way.