### PR TITLE
Add 2D Langmuir Test with MR

### DIFF
--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -23,7 +23,6 @@
 
 import sys
 import re
-import matplotlib
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 import yt
@@ -101,6 +100,19 @@ assert(error_rel < tolerance)
 # Plot Ez
 E_sim = data['Ez'].to_ndarray()[:,:,0]
 
+def set_axes_and_colorbar(ax, cb, title):
+    ax.set_xlabel(r'$z$')
+    ax.set_ylabel(r'$x$')
+    ax.xaxis.set_major_locator(plt.MaxNLocator(5))
+    ax.yaxis.set_major_locator(plt.MaxNLocator(5))
+    ax.set_title(title)
+    cb.ax.tick_params()
+    cb.ax.yaxis.get_offset_text().set()
+    cb.ax.yaxis.offsetText.set_ha('center')
+    cb.ax.yaxis.offsetText.set_va('bottom')
+    cb.formatter.set_powerlimits((0,0))
+    cb.update_ticks()
+
 fig, (ax1,ax2) = plt.subplots(1,2, dpi=100)
 # Absolute min and max field values
 vmin = min(E_sim.min(), E_th.min())
@@ -109,32 +121,12 @@ vmax = max(E_sim.max(), E_th.max())
 cax1 = make_axes_locatable(ax1).append_axes('right', size='5%', pad='5%')
 im1 = ax1.imshow(E_sim, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
 cb1 = fig.colorbar(im1, cax = cax1)
-ax1.set_xlabel(r'$z$')
-ax1.set_ylabel(r'$x$')
-ax1.xaxis.set_major_locator(plt.MaxNLocator(5))
-ax1.yaxis.set_major_locator(plt.MaxNLocator(5))
-ax1.set_title('Ez (sim)')
-cb1.ax.tick_params()
-cb1.ax.yaxis.get_offset_text().set()
-cb1.ax.yaxis.offsetText.set_ha('center')
-cb1.ax.yaxis.offsetText.set_va('bottom')
-cb1.formatter.set_powerlimits((0,0))
-cb1.update_ticks()
+set_axes_and_colorbar(ax1, cb1, 'Ez (sim)')
 # Second plot
 cax2 = make_axes_locatable(ax2).append_axes('right', size='5%', pad='5%')
 im2 = ax2.imshow(E_th, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
 cb2 = fig.colorbar(im2, cax = cax2)
-ax2.set_xlabel(r'$z$')
-ax2.set_ylabel(r'$x$')
-ax2.xaxis.set_major_locator(plt.MaxNLocator(5))
-ax2.yaxis.set_major_locator(plt.MaxNLocator(5))
-ax2.set_title('Ez (theory)')
-cb2.ax.tick_params()
-cb2.ax.yaxis.get_offset_text().set()
-cb2.ax.yaxis.offsetText.set_ha('center')
-cb2.ax.yaxis.offsetText.set_va('bottom')
-cb2.formatter.set_powerlimits((0,0))
-cb2.update_ticks()
+set_axes_and_colorbar(ax2, cb2, 'Ez (theory)')
 # Save figure
 fig.tight_layout()
 fig.savefig('analysis_langmuir_multi_2d.png', dpi=200)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -2,29 +2,23 @@
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #
+#
 # This file is part of WarpX.
 #
 # License: BSD-3-Clause-LBNL
 
-# This is a script that analyzes the simulation results of the following CI tests:
-# - Langmuir_multi_2d_nodal
-# - Langmuir_multi_2d_psatd
-# - Langmuir_multi_2d_psatd_nodal
-# - Langmuir_multi_2d_psatd_momentum_conserving
-# - Langmuir_multi_2d_psatd_current_correction
-# - Langmuir_multi_2d_psatd_current_correction_nodal
-# - Langmuir_multi_2d_psatd_Vay_deposition
-# - Langmuir_multi_2d_psatd_Vay_deposition_nodal
-# - Langmuir_multi_2d_MR
-# The tests simulate a 3D periodic plasma wave. The theoretical electric field is given by
-# E_x = epsilon \frac{me c2 k_x}{q_e} sin(kx x) cos(ky y) cos(kz z) sin(omega_p t)
-# E_y = epsilon \frac{me c2 k_y}{q_e} cos(kx x) sin(ky y) cos(kz z) sin(omega_p t)
-# E_z = epsilon \frac{me c2 k_z}{q_e} cos(kx x) cos(ky y) sin(kz z) sin(omega_p t)
 
+# This is a script that analyses the simulation results from
+# the script `inputs.multi.rt`. This simulates a 3D periodic plasma wave.
+# The electric field in the simulation is given (in theory) by:
+# $$ E_x = \epsilon \,\frac{m_e c^2 k_x}{q_e}\sin(k_x x)\cos(k_y y)\cos(k_z z)\sin( \omega_p t)$$
+# $$ E_y = \epsilon \,\frac{m_e c^2 k_y}{q_e}\cos(k_x x)\sin(k_y y)\cos(k_z z)\sin( \omega_p t)$$
+# $$ E_z = \epsilon \,\frac{m_e c^2 k_z}{q_e}\cos(k_x x)\cos(k_y y)\sin(k_z z)\sin( \omega_p t)$$
 import sys
 import re
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
@@ -32,7 +26,7 @@ from scipy.constants import e, m_e, epsilon_0, c
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
-# Name of the plotfile
+# this will be the name of the plot file
 fn = sys.argv[1]
 
 # Parse test name and check if current correction (psatd.current_correction=1) is applied
@@ -41,8 +35,7 @@ current_correction = True if re.search( 'current_correction', fn ) else False
 # Parse test name and check if Vay current deposition (algo.current_deposition=vay) is used
 vay_deposition = True if re.search( 'Vay_deposition', fn ) else False
 
-# Parameters (these parameters must match the parameters in the relevant input files as well as the
-# additional parameters specified as runtime_params for the relevant tests in Regression/WarpX-tests.ini)
+# Parameters (these parameters must match the parameters in `inputs.multi.rt`)
 epsilon = 0.01
 n = 4.e24
 n_osc_x = 2
@@ -50,86 +43,67 @@ n_osc_z = 2
 xmin = -20e-6; xmax = 20.e-6; Nx = 128
 zmin = -20e-6; zmax = 20.e-6; Nz = 128
 
-Lx = xmax - xmin
-Lz = zmax - zmin
-
-dx = Lx / Nx
-dz = Lz / Nz
-
-xarr = xmin + dx * (0.5 + np.arange(Nx))
-zarr = zmin + dz * (0.5 + np.arange(Nz))
-
 # Wave vector of the wave
-kx = 2. * np.pi * n_osc_x / Lx
-kz = 2. * np.pi * n_osc_z / Lz
+kx = 2.*np.pi*n_osc_x/(xmax-xmin)
+kz = 2.*np.pi*n_osc_z/(zmax-zmin)
 # Plasma frequency
-wp = np.sqrt((n * e**2) / (m_e * epsilon_0))
+wp = np.sqrt((n*e**2)/(m_e*epsilon_0))
 
-k = {'Ex': kx, 'Ez': kz}
-cos = {'Ex': (0,1,1), 'Ez': (1,1,0)}
+k = {'Ex':kx, 'Ez':kz}
+cos = {'Ex': (0,1,1), 'Ez':(1,1,0)}
 
-def get_theoretical_field(field, t):
-    amplitude = (epsilon * m_e * c**2 * k[field] / e) * np.sin(wp*t)
+def get_contribution( is_cos, k ):
+    du = (xmax-xmin)/Nx
+    u = xmin + du*( 0.5 + np.arange(Nx) )
+    if is_cos == 1:
+        return( np.cos(k*u) )
+    else:
+        return( np.sin(k*u) )
+
+def get_theoretical_field( field, t ):
+    amplitude = epsilon * (m_e*c**2*k[field])/e * np.sin(wp*t)
     cos_flag = cos[field]
-    x_contribution = np.cos(kx * xarr) if cos_flag[0] else np.sin(kx * xarr)
-    z_contribution = np.cos(kz * zarr) if cos_flag[2] else np.sin(kz * zarr)
-    E = amplitude * x_contribution[:,np.newaxis] * z_contribution[np.newaxis,:]
-    return E
+    x_contribution = get_contribution( cos_flag[0], kx )
+    z_contribution = get_contribution( cos_flag[2], kz )
 
-# Read the file and load data from main grid
+    E = amplitude * x_contribution[:, np.newaxis ] \
+                  * z_contribution[np.newaxis, :]
+
+    return( E )
+
+# Read the file
 ds = yt.load(fn)
-t  = ds.current_time.to_value()
-data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
-edge = np.array([np.array([(ds.domain_left_edge[1]).item(), (ds.domain_right_edge[1]).item(), \
-                           (ds.domain_left_edge[0]).item(), (ds.domain_right_edge[0]).item()])])
+t0 = ds.current_time.to_value()
+data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
+                                    dims=ds.domain_dimensions)
 
 # Check the validity of the fields
-error_rel = 0.
+error_rel = 0
 for field in ['Ex', 'Ez']:
     E_sim = data[field].to_ndarray()[:,:,0]
-    E_th = get_theoretical_field(field, t)
-    max_error = abs(E_sim - E_th).max() / abs(E_th).max()
-    print('{:s}: max error = {}'.format(field, max_error))
-    error_rel = max(error_rel, max_error)
+    E_th = get_theoretical_field(field, t0)
+    max_error = abs(E_sim-E_th).max()/abs(E_th).max()
+    print('%s: Max error: %.2e' %(field,max_error))
+    error_rel = max( error_rel, max_error )
 
-tolerance = 0.05
-print("error_rel = {}".format(error_rel))
-print("tolerance = {}".format(tolerance))
-assert(error_rel < tolerance)
+# Plot the last field from the loop (Ez at iteration 40)
+plt.subplot2grid( (1,2), (0,0) )
+plt.imshow( E_sim )
+plt.colorbar()
+plt.title('Ez, last iteration\n(simulation)')
+plt.subplot2grid( (1,2), (0,1) )
+plt.imshow( E_th )
+plt.colorbar()
+plt.title('Ez, last iteration\n(theory)')
+plt.tight_layout()
+plt.savefig('langmuir_multi_2d_analysis.png')
 
-# Plot Ez
-E_sim = data['Ez'].to_ndarray()[:,:,0]
+tolerance_rel = 0.05
 
-def set_axes_and_colorbar(ax, cb, title):
-    ax.set_xlabel(r'$z$')
-    ax.set_ylabel(r'$x$')
-    ax.xaxis.set_major_locator(plt.MaxNLocator(5))
-    ax.yaxis.set_major_locator(plt.MaxNLocator(5))
-    ax.set_title(title)
-    cb.ax.tick_params()
-    cb.ax.yaxis.get_offset_text().set()
-    cb.ax.yaxis.offsetText.set_ha('center')
-    cb.ax.yaxis.offsetText.set_va('bottom')
-    cb.formatter.set_powerlimits((0,0))
-    cb.update_ticks()
+print("error_rel    : " + str(error_rel))
+print("tolerance_rel: " + str(tolerance_rel))
 
-fig, (ax1,ax2) = plt.subplots(1,2, dpi=100)
-# Absolute min and max field values
-vmin = min(E_sim.min(), E_th.min())
-vmax = max(E_sim.max(), E_th.max())
-# First plot
-cax1 = make_axes_locatable(ax1).append_axes('right', size='5%', pad='5%')
-im1 = ax1.imshow(E_sim, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
-cb1 = fig.colorbar(im1, cax = cax1)
-set_axes_and_colorbar(ax1, cb1, 'Ez (sim)')
-# Second plot
-cax2 = make_axes_locatable(ax2).append_axes('right', size='5%', pad='5%')
-im2 = ax2.imshow(E_th, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
-cb2 = fig.colorbar(im2, cax = cax2)
-set_axes_and_colorbar(ax2, cb2, 'Ez (theory)')
-# Save figure
-fig.tight_layout()
-fig.savefig('analysis_langmuir_multi_2d.png', dpi=200)
+assert( error_rel < tolerance_rel )
 
 # Check relative L-infinity spatial norm of rho/epsilon_0 - div(E) when
 # current correction (psatd.do_current_correction=1) is applied or when
@@ -137,13 +111,12 @@ fig.savefig('analysis_langmuir_multi_2d.png', dpi=200)
 if current_correction or vay_deposition:
     rho  = data['rho' ].to_ndarray()
     divE = data['divE'].to_ndarray()
-    error_rel = np.amax(np.abs(divE - rho/epsilon_0)) / np.amax(np.abs(rho/epsilon_0))
+    error_rel = np.amax( np.abs( divE - rho/epsilon_0 ) ) / np.amax( np.abs( rho/epsilon_0 ) )
     tolerance = 1.e-9
     print("Check charge conservation:")
     print("error_rel = {}".format(error_rel))
     print("tolerance = {}".format(tolerance))
-    assert(error_rel < tolerance)
+    assert( error_rel < tolerance )
 
-# Regression analysis on checksum benchmark
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -2,23 +2,30 @@
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #
-#
 # This file is part of WarpX.
 #
 # License: BSD-3-Clause-LBNL
 
+# This is a script that analyzes the simulation results of the following CI tests:
+# - Langmuir_multi_2d_nodal
+# - Langmuir_multi_2d_psatd
+# - Langmuir_multi_2d_psatd_nodal
+# - Langmuir_multi_2d_psatd_momentum_conserving
+# - Langmuir_multi_2d_psatd_current_correction
+# - Langmuir_multi_2d_psatd_current_correction_nodal
+# - Langmuir_multi_2d_psatd_Vay_deposition
+# - Langmuir_multi_2d_psatd_Vay_deposition_nodal
+# - Langmuir_multi_2d_MR
+# The tests simulate a 3D periodic plasma wave. The theoretical electric field is given by
+# E_x = epsilon \frac{me c2 k_x}{q_e} sin(kx x) cos(ky y) cos(kz z) sin(omega_p t)
+# E_y = epsilon \frac{me c2 k_y}{q_e} cos(kx x) sin(ky y) cos(kz z) sin(omega_p t)
+# E_z = epsilon \frac{me c2 k_z}{q_e} cos(kx x) cos(ky y) sin(kz z) sin(omega_p t)
 
-# This is a script that analyses the simulation results from
-# the script `inputs.multi.rt`. This simulates a 3D periodic plasma wave.
-# The electric field in the simulation is given (in theory) by:
-# $$ E_x = \epsilon \,\frac{m_e c^2 k_x}{q_e}\sin(k_x x)\cos(k_y y)\cos(k_z z)\sin( \omega_p t)$$
-# $$ E_y = \epsilon \,\frac{m_e c^2 k_y}{q_e}\cos(k_x x)\sin(k_y y)\cos(k_z z)\sin( \omega_p t)$$
-# $$ E_z = \epsilon \,\frac{m_e c^2 k_z}{q_e}\cos(k_x x)\cos(k_y y)\sin(k_z z)\sin( \omega_p t)$$
 import sys
 import re
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
@@ -26,7 +33,7 @@ from scipy.constants import e, m_e, epsilon_0, c
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
-# this will be the name of the plot file
+# Name of the plotfile
 fn = sys.argv[1]
 
 # Parse test name and check if current correction (psatd.current_correction=1) is applied
@@ -35,7 +42,8 @@ current_correction = True if re.search( 'current_correction', fn ) else False
 # Parse test name and check if Vay current deposition (algo.current_deposition=vay) is used
 vay_deposition = True if re.search( 'Vay_deposition', fn ) else False
 
-# Parameters (these parameters must match the parameters in `inputs.multi.rt`)
+# Parameters (these parameters must match the parameters in the relevant input files as well as the
+# additional parameters specified as runtime_params for the relevant tests in Regression/WarpX-tests.ini)
 epsilon = 0.01
 n = 4.e24
 n_osc_x = 2
@@ -43,67 +51,93 @@ n_osc_z = 2
 xmin = -20e-6; xmax = 20.e-6; Nx = 128
 zmin = -20e-6; zmax = 20.e-6; Nz = 128
 
+Lx = xmax - xmin
+Lz = zmax - zmin
+
+dx = Lx / Nx
+dz = Lz / Nz
+
+xarr = xmin + dx * (0.5 + np.arange(Nx))
+zarr = zmin + dz * (0.5 + np.arange(Nz))
+
 # Wave vector of the wave
-kx = 2.*np.pi*n_osc_x/(xmax-xmin)
-kz = 2.*np.pi*n_osc_z/(zmax-zmin)
+kx = 2. * np.pi * n_osc_x / Lx
+kz = 2. * np.pi * n_osc_z / Lz
 # Plasma frequency
-wp = np.sqrt((n*e**2)/(m_e*epsilon_0))
+wp = np.sqrt((n * e**2) / (m_e * epsilon_0))
 
-k = {'Ex':kx, 'Ez':kz}
-cos = {'Ex': (0,1,1), 'Ez':(1,1,0)}
+k = {'Ex': kx, 'Ez': kz}
+cos = {'Ex': (0,1,1), 'Ez': (1,1,0)}
 
-def get_contribution( is_cos, k ):
-    du = (xmax-xmin)/Nx
-    u = xmin + du*( 0.5 + np.arange(Nx) )
-    if is_cos == 1:
-        return( np.cos(k*u) )
-    else:
-        return( np.sin(k*u) )
-
-def get_theoretical_field( field, t ):
-    amplitude = epsilon * (m_e*c**2*k[field])/e * np.sin(wp*t)
+def get_theoretical_field(field, t):
+    amplitude = (epsilon * m_e * c**2 * k[field] / e) * np.sin(wp*t)
     cos_flag = cos[field]
-    x_contribution = get_contribution( cos_flag[0], kx )
-    z_contribution = get_contribution( cos_flag[2], kz )
+    x_contribution = np.cos(kx * xarr) if cos_flag[0] else np.sin(kx * xarr)
+    z_contribution = np.cos(kz * zarr) if cos_flag[2] else np.sin(kz * zarr)
+    E = amplitude * x_contribution[:,np.newaxis] * z_contribution[np.newaxis,:]
+    return E
 
-    E = amplitude * x_contribution[:, np.newaxis ] \
-                  * z_contribution[np.newaxis, :]
-
-    return( E )
-
-# Read the file
+# Read the file and load data from main grid
 ds = yt.load(fn)
-t0 = ds.current_time.to_value()
-data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
-                                    dims=ds.domain_dimensions)
+t  = ds.current_time.to_value()
+data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
+edge = np.array([np.array([(ds.domain_left_edge[1]).item(), (ds.domain_right_edge[1]).item(), \
+                           (ds.domain_left_edge[0]).item(), (ds.domain_right_edge[0]).item()])])
 
 # Check the validity of the fields
-error_rel = 0
+error_rel = 0.
 for field in ['Ex', 'Ez']:
     E_sim = data[field].to_ndarray()[:,:,0]
-    E_th = get_theoretical_field(field, t0)
-    max_error = abs(E_sim-E_th).max()/abs(E_th).max()
-    print('%s: Max error: %.2e' %(field,max_error))
-    error_rel = max( error_rel, max_error )
+    E_th = get_theoretical_field(field, t)
+    max_error = abs(E_sim - E_th).max() / abs(E_th).max()
+    print('{:s}: max error = {}'.format(field, max_error))
+    error_rel = max(error_rel, max_error)
 
-# Plot the last field from the loop (Ez at iteration 40)
-plt.subplot2grid( (1,2), (0,0) )
-plt.imshow( E_sim )
-plt.colorbar()
-plt.title('Ez, last iteration\n(simulation)')
-plt.subplot2grid( (1,2), (0,1) )
-plt.imshow( E_th )
-plt.colorbar()
-plt.title('Ez, last iteration\n(theory)')
-plt.tight_layout()
-plt.savefig('langmuir_multi_2d_analysis.png')
+tolerance = 0.05
+print("error_rel = {}".format(error_rel))
+print("tolerance = {}".format(tolerance))
+assert(error_rel < tolerance)
 
-tolerance_rel = 0.05
+# Plot Ez
+E_sim = data['Ez'].to_ndarray()[:,:,0]
 
-print("error_rel    : " + str(error_rel))
-print("tolerance_rel: " + str(tolerance_rel))
-
-assert( error_rel < tolerance_rel )
+fig, (ax1,ax2) = plt.subplots(1,2, dpi=100)
+# Absolute min and max field values
+vmin = min(E_sim.min(), E_th.min())
+vmax = max(E_sim.max(), E_th.max())
+# First plot
+cax1 = make_axes_locatable(ax1).append_axes('right', size='5%', pad='5%')
+im1 = ax1.imshow(E_sim, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
+cb1 = fig.colorbar(im1, cax = cax1)
+ax1.set_xlabel(r'$z$')
+ax1.set_ylabel(r'$x$')
+ax1.xaxis.set_major_locator(plt.MaxNLocator(5))
+ax1.yaxis.set_major_locator(plt.MaxNLocator(5))
+ax1.set_title('Ez (sim)')
+cb1.ax.tick_params()
+cb1.ax.yaxis.get_offset_text().set()
+cb1.ax.yaxis.offsetText.set_ha('center')
+cb1.ax.yaxis.offsetText.set_va('bottom')
+cb1.formatter.set_powerlimits((0,0))
+cb1.update_ticks()
+# Second plot
+cax2 = make_axes_locatable(ax2).append_axes('right', size='5%', pad='5%')
+im2 = ax2.imshow(E_th, origin = 'lower', extent = edge[0], vmin = vmin, vmax = vmax)
+cb2 = fig.colorbar(im2, cax = cax2)
+ax2.set_xlabel(r'$z$')
+ax2.set_ylabel(r'$x$')
+ax2.xaxis.set_major_locator(plt.MaxNLocator(5))
+ax2.yaxis.set_major_locator(plt.MaxNLocator(5))
+ax2.set_title('Ez (theory)')
+cb2.ax.tick_params()
+cb2.ax.yaxis.get_offset_text().set()
+cb2.ax.yaxis.offsetText.set_ha('center')
+cb2.ax.yaxis.offsetText.set_va('bottom')
+cb2.formatter.set_powerlimits((0,0))
+cb2.update_ticks()
+# Save figure
+fig.tight_layout()
+fig.savefig('analysis_langmuir_multi_2d.png', dpi=200)
 
 # Check relative L-infinity spatial norm of rho/epsilon_0 - div(E) when
 # current correction (psatd.do_current_correction=1) is applied or when
@@ -111,12 +145,13 @@ assert( error_rel < tolerance_rel )
 if current_correction or vay_deposition:
     rho  = data['rho' ].to_ndarray()
     divE = data['divE'].to_ndarray()
-    error_rel = np.amax( np.abs( divE - rho/epsilon_0 ) ) / np.amax( np.abs( rho/epsilon_0 ) )
+    error_rel = np.amax(np.abs(divE - rho/epsilon_0)) / np.amax(np.abs(rho/epsilon_0))
     tolerance = 1.e-9
     print("Check charge conservation:")
     print("error_rel = {}".format(error_rel))
     print("tolerance = {}".format(tolerance))
-    assert( error_rel < tolerance )
+    assert(error_rel < tolerance)
 
+# Regression analysis on checksum benchmark
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, fn)

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR.json
@@ -2,43 +2,43 @@
   "electrons": {
     "particle_cpu": 32768.0,
     "particle_id": 1123057664.0,
-    "particle_momentum_x": 4.276090718497629e-20,
+    "particle_momentum_x": 4.241495334522421e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 4.2760907184976306e-20,
-    "particle_position_x": 0.6553628040570301,
-    "particle_position_y": 0.6553628040570301,
+    "particle_momentum_z": 4.241495334522413e-20,
+    "particle_position_x": 0.6553605577217855,
+    "particle_position_y": 0.6553605577217853,
     "particle_weight": 3200000000000000.5
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 221.42236128302574,
+    "By": 32.88376813880145,
     "Bz": 0.0,
-    "Ex": 7504684227111.061,
+    "Ex": 7572926260078.977,
     "Ey": 0.0,
-    "Ez": 7504684227111.084,
-    "jx": 7359106068851068.0,
+    "Ez": 7572926260078.995,
+    "jx": 7298077411371068.0,
     "jy": 0.0,
-    "jz": 7359106068851218.0
+    "jz": 7298077411371252.0
   },
   "lev=1": {
     "Bx": 0.0,
-    "By": 697.1533197692002,
+    "By": 565.8504447463731,
     "Bz": 0.0,
-    "Ex": 7619120391393.9,
+    "Ex": 7546287967911.542,
     "Ey": 0.0,
-    "Ez": 7619120391393.923,
-    "jx": 7472295105027076.0,
+    "Ez": 7546287967911.541,
+    "jx": 7199765368042636.0,
     "jy": 0.0,
-    "jz": 7472295105027004.0
+    "jz": 7199765368042662.0
   },
   "positrons": {
     "particle_cpu": 32768.0,
     "particle_id": 3371204608.0,
-    "particle_momentum_x": 4.2764337014921225e-20,
+    "particle_momentum_x": 4.2413987484133116e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 4.276433701492124e-20,
-    "particle_position_x": 0.6553573847487077,
-    "particle_position_y": 0.6553573847487079,
+    "particle_momentum_z": 4.241398748413304e-20,
+    "particle_position_x": 0.6553600696643818,
+    "particle_position_y": 0.6553600696643818,
     "particle_weight": 3200000000000000.5
   }
 }

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR.json
@@ -1,0 +1,44 @@
+{
+  "electrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 1123057664.0,
+    "particle_momentum_x": 4.276090718497629e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.2760907184976306e-20,
+    "particle_position_x": 0.6553628040570301,
+    "particle_position_y": 0.6553628040570301,
+    "particle_weight": 3200000000000000.5
+  },
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 221.42236128302574,
+    "Bz": 0.0,
+    "Ex": 7504684227111.061,
+    "Ey": 0.0,
+    "Ez": 7504684227111.084,
+    "jx": 7359106068851068.0,
+    "jy": 0.0,
+    "jz": 7359106068851218.0
+  },
+  "lev=1": {
+    "Bx": 0.0,
+    "By": 697.1533197692002,
+    "Bz": 0.0,
+    "Ex": 7619120391393.9,
+    "Ey": 0.0,
+    "Ez": 7619120391393.923,
+    "jx": 7472295105027076.0,
+    "jy": 0.0,
+    "jz": 7472295105027004.0
+  },
+  "positrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 3371204608.0,
+    "particle_momentum_x": 4.2764337014921225e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.276433701492124e-20,
+    "particle_position_x": 0.6553573847487077,
+    "particle_position_y": 0.6553573847487079,
+    "particle_weight": 3200000000000000.5
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -537,6 +537,25 @@ analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 tolerance = 1.e-14
 
+[Langmuir_multi_2d_MR]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+runtime_params = algo.maxwell_solver = ckc  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
+dim = 2
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = Langmuir_multi_2d_MR.png
+tolerance = 1.e-14
+
 [Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
@@ -1125,7 +1144,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 tolerance = 1.e-14
-
 
 [particles_in_pml_2d_MR]
 buildDir = .

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1145,6 +1145,7 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 tolerance = 1.e-14
 
+
 [particles_in_pml_2d_MR]
 buildDir = .
 inputFile = Examples/Tests/particles_in_PML/inputs_mr_2d


### PR DESCRIPTION
This adds a first 2D Langmuir test with mesh refinement ratio 4 and FDTD (CKC) solver. The Python analysis comparing the output fields with their theoretical predictions passes.

I believe that increasing the refinement ratio will cause problems, which I will report in a separate issue once the test is merged and it's easy to tune its input parameters.