### PR TITLE
Backtransformed Diags with openPMD

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -105,8 +105,8 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     if ( !HeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
 
     HeaderFile.precision(17);
-    
-    // Generic Plotfile type name   
+
+    // Generic Plotfile type name
     HeaderFile << m_file_version << '\n';
     // number of components
     HeaderFile << m_varnames.size() << '\n';

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -143,7 +143,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << '\n';
     // coordinate system (Cartesian)
     HeaderFile << m_coordsys << '\n';
-    // 
+    //
     HeaderFile << m_bwidth << '\n';
     // current level, number of Fabs, current time -- for a single level (m_level = 0)
     HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
@@ -153,11 +153,11 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     for (int iFab = 0; iFab < m_numFabs; ++iFab) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
-        }       
+        }
     }
     // MultiFabHeaderPath
     HeaderFile << m_CellPath << '\n';
-   
+
 }
 
 

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -105,8 +105,8 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     if ( !HeaderFile.good()) amrex::FileOpenFailed(m_Header_path);
 
     HeaderFile.precision(17);
-
-    // Genetic Plotfile type name
+    
+    // Generic Plotfile type name   
     HeaderFile << m_file_version << '\n';
     // number of components
     HeaderFile << m_varnames.size() << '\n';
@@ -143,7 +143,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << '\n';
     // coordinate system (Cartesian)
     HeaderFile << m_coordsys << '\n';
-    //
+    // 
     HeaderFile << m_bwidth << '\n';
     // current level, number of Fabs, current time -- for a single level (m_level = 0)
     HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
@@ -153,11 +153,11 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     for (int iFab = 0; iFab < m_numFabs; ++iFab) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
-        }
+        }       
     }
     // MultiFabHeaderPath
     HeaderFile << m_CellPath << '\n';
-
+   
 }
 
 

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -164,7 +164,7 @@ private:
      *  stored in the buffer multifab is flushed out and the counter is reset is zero.
      */
     amrex::Vector<int> m_buffer_counter;
-    /** Vector of maximum number of buffer multifabs that need to be flushed to 
+    /** Vector of maximum number of buffer multifabs that need to be flushed to
      *  generate each lab-frame snapshot. At the final flush, m_buffer_flush_counter
      *  will be equal to the predicted m_max_buffer_multifabs for each snapshot.
      */

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -164,6 +164,11 @@ private:
      *  stored in the buffer multifab is flushed out and the counter is reset is zero.
      */
     amrex::Vector<int> m_buffer_counter;
+    /** Vector of maximum number of buffer multifabs that need to be flushed to 
+     *  generate each lab-frame snapshot. At the final flush, m_buffer_flush_counter
+     *  will be equal to the predicted m_max_buffer_multifabs for each snapshot.
+     */
+    amrex::Vector<int> m_max_buffer_multifabs;
     /** Vector of counters tracking number of times the buffer of multifab is
      *  flushed out and emptied before being refilled again for each snapshot */
     amrex::Vector<int> m_buffer_flush_counter;

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -297,7 +297,7 @@ private:
                                                           "jx", "jy", "jz", "rho"};
 
     /** Temporarily clear species output for BTD until particle buffer is added */
-    void TMP_ClearSpeciesDataForBTD();
+    void TMP_ClearSpeciesDataForBTD() override;
 
     void MergeBuffersForPlotfile (int i_snapshot);
     void InterleaveBufferAndSnapshotHeader ( std::string buffer_Header,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -855,3 +855,130 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     snapshot_FabHeader.WriteMultiFabHeader();
     
 }
+
+void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
+{
+    auto & warpx = WarpX::GetInstance();
+    const amrex::Vector<int> iteration = warpx.getistep();
+    if (amrex::ParallelContext::IOProcessorSub()) {
+
+        // Path to final snapshot plotfiles
+        std::string snapshot_path = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_snapshot,5);
+        std::string snapshot_Level0_path = snapshot_path + "/Level_0";
+        std::string snapshot_Header_filename = snapshot_path + "/Header";
+        if (m_buffer_flush_counter[i_snapshot] == 0 ) {
+            // Create Level_0 directory to store all Cell_D and Cell_H files
+            amrex::UtilCreateDirectory(snapshot_Level0_path, 0755);
+        }
+
+        // Path of the buffer recently flushed 
+        std::string BufferPath_prefix = snapshot_path + "/buffer";
+        const std::string recent_Buffer_filepath = amrex::Concatenate(BufferPath_prefix,iteration[0]);
+    
+        // Header file of the recently flushed buffer
+        std::string recent_Header_filename = recent_Buffer_filepath+"/Header";
+        std::string recent_Buffer_Level0_path = recent_Buffer_filepath + "/Level_0";
+        std::string recent_Buffer_FabHeaderFilename = recent_Buffer_Level0_path + "/Cell_H";
+        std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/Cell_D_00000";
+        std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
+        std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
+        std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], 5);
+        
+
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {
+            std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
+            std::rename(recent_Buffer_FabHeaderFilename.c_str(),
+                        snapshot_FabHeaderFilename.c_str());
+            std::rename(recent_Buffer_FabFilename.c_str(),
+                        snapshot_FabFilename.c_str());
+        } else {
+            // 0 Interleave Header file
+            // look at PlotFileDataImpl::PlotFileDataImpl ()
+            InterleaveBufferAndSnapshotHeader(recent_Header_filename,
+                                              snapshot_Header_filename);
+            //1. Copy Cell_D_00000 to snapshot_Level0/Cell_D_00001
+            InterleaveFabArrayHeader(recent_Buffer_FabHeaderFilename,
+                                     snapshot_FabHeaderFilename,
+                                     new_snapshotFabFilename);
+            std::rename(recent_Buffer_FabFilename.c_str(),
+                        snapshot_FabFilename.c_str());
+            // Check if buffer*istep file is present
+        }
+        amrex::Print() << " I am destroying " << recent_Buffer_filepath << "\n";
+        amrex::FileSystem::RemoveAll(recent_Buffer_filepath);        
+
+    } // ParallelContext if ends
+    amrex::ParallelDescriptor::Barrier();
+}  
+
+void
+BTDiagnostics::InterleaveBufferAndSnapshotHeader ( std::string buffer_Header_path,
+                                                   std::string snapshot_Header_path)
+{
+    BTDPlotfileHeaderImpl snapshot_HeaderImpl(snapshot_Header_path);
+    snapshot_HeaderImpl.ReadHeaderData();
+
+    BTDPlotfileHeaderImpl buffer_HeaderImpl(buffer_Header_path);
+    buffer_HeaderImpl.ReadHeaderData();
+
+    // Update timestamp of snapshot with recently flushed buffer
+    snapshot_HeaderImpl.set_time( buffer_HeaderImpl.time() );
+    snapshot_HeaderImpl.set_timestep( buffer_HeaderImpl.timestep() );
+
+    amrex::Box snapshot_Box = snapshot_HeaderImpl.probDomain();
+    amrex::Box buffer_Box = buffer_HeaderImpl.probDomain();
+    amrex::IntVect box_lo(0);
+    amrex::IntVect box_hi(1);
+    // Update prob_lo with min of buffer and snapshot
+    for (int idim = 0; idim < snapshot_HeaderImpl.spaceDim(); ++idim) {
+        amrex::Real min_prob_lo = amrex::min(buffer_HeaderImpl.problo(idim),
+                                             snapshot_HeaderImpl.problo(idim));
+        amrex::Real max_prob_hi = amrex::max(buffer_HeaderImpl.probhi(idim),
+                                             snapshot_HeaderImpl.probhi(idim));
+        snapshot_HeaderImpl.set_problo(idim, min_prob_lo);
+        snapshot_HeaderImpl.set_probhi(idim, max_prob_hi);
+        // Update prob_hi with max of buffer and snapshot
+        box_lo[idim] = amrex::min(buffer_Box.smallEnd(idim),
+                                  snapshot_Box.smallEnd(idim));
+        box_hi[idim] = amrex::max(buffer_Box.bigEnd(idim),
+                                  snapshot_Box.bigEnd(idim));
+    }
+    amrex::Box domain_box(box_lo, box_hi);
+    snapshot_HeaderImpl.set_probDomain(domain_box);    
+
+    // Increment numFabs
+    snapshot_HeaderImpl.IncrementNumFabs(); 
+    snapshot_HeaderImpl.AppendNewFabLo( buffer_HeaderImpl.FabLo(0));
+    snapshot_HeaderImpl.AppendNewFabHi( buffer_HeaderImpl.FabHi(0));
+
+    snapshot_HeaderImpl.WriteHeader();
+}
+
+
+void
+BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
+                                        std::string snapshot_FabHeader_path,
+                                        std::string newsnapshot_FabFilename)
+{
+    BTDMultiFabHeaderImpl snapshot_FabHeader(snapshot_FabHeader_path);
+    snapshot_FabHeader.ReadMultiFabHeader();
+
+    BTDMultiFabHeaderImpl Buffer_FabHeader(Buffer_FabHeader_path);
+    Buffer_FabHeader.ReadMultiFabHeader();
+
+    // Increment existing fabs in snapshot with the number of fabs in the buffer
+    snapshot_FabHeader.IncreaseMultiFabSize( Buffer_FabHeader.ba_size() );
+    snapshot_FabHeader.ResizeFabData();
+    
+    for (int ifab = 0; ifab < Buffer_FabHeader.ba_size(); ++ifab) {
+        int new_ifab = snapshot_FabHeader.ba_size() - 1 + ifab;
+        snapshot_FabHeader.SetBox(new_ifab, Buffer_FabHeader.ba_box(ifab) );
+        snapshot_FabHeader.SetFabName(new_ifab, Buffer_FabHeader.fodPrefix(ifab),
+                                                newsnapshot_FabFilename,
+                                                Buffer_FabHeader.FabHead(ifab) );
+        snapshot_FabHeader.SetMinVal(new_ifab, Buffer_FabHeader.minval(ifab));
+        snapshot_FabHeader.SetMaxVal(new_ifab, Buffer_FabHeader.maxval(ifab));
+    }
+
+    snapshot_FabHeader.WriteMultiFabHeader();
+}

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -211,7 +211,7 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
         diag_dom.setLo(idim, std::max(m_lo[idim],warpx.Geom(lev).ProbLo(idim)) );
         // Setting hi-coordinate for the diag domain by taking the max of user-defined
         // hi-cordinate and hi-coordinate of the simulation domain at level, lev
-        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) );
+        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) ); 
     }
     // Initializing the m_buffer_box for the i^th snapshot.
     // At initialization, the Box has the same index space as the boosted-frame
@@ -244,18 +244,6 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
     amrex::Box diag_box( lo, hi );
     m_buffer_box[i_buffer] = diag_box;
     m_snapshot_box[i_buffer] = diag_box;
-    // Define box array
-    amrex::BoxArray diag_ba(diag_box);
-    diag_ba.maxSize( warpx.maxGridSize( lev ) );
-    // Update the physical co-ordinates m_lo and m_hi using the final index values
-    // from the coarsenable, cell-centered BoxArray, ba.
-    for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
-            diag_ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
-        diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-            (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
-    }
-
     // Define box array
     amrex::BoxArray diag_ba(diag_box);
     diag_ba.maxSize( warpx.maxGridSize( lev ) );
@@ -465,7 +453,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                 m_current_z_lab[i_buffer] = UpdateCurrentZLabCoordinate(m_t_lab[i_buffer],
                                                                       warpx.gett_new(lev) );
                 // Check if the zslice is in domain
-                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
+                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);                
                 // Initialize and define field buffer multifab if buffer is empty
                 if (ZSliceInDomain) {
                     if ( buffer_empty(i_buffer) ) {
@@ -473,7 +461,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                             // Compute the geometry, snapshot lab-domain extent
                             // and box-indices
                             DefineSnapshotGeometry(i_buffer, lev);
-                        }
+                        }                        
                         DefineFieldBufferMultiFab(i_buffer, lev);
                     }
                 }
@@ -727,7 +715,6 @@ void BTDiagnostics::TMP_ClearSpeciesDataForBTD ()
 {
     m_output_species.clear();
     m_output_species_names.clear();
-
 }
 
 void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
@@ -866,4 +853,5 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     }
 
     snapshot_FabHeader.WriteMultiFabHeader();
+    
 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -754,7 +754,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         // Name of the newly appended fab in the snapshot
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
 
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {            
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
         Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
                             new_snapshotFabFilename,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -754,12 +754,12 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         // Name of the newly appended fab in the snapshot
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
 
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {            
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-        Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
-                            new_snapshotFabFilename,
-                    Buffer_FabHeader.FabHead(0));
-        Buffer_FabHeader.WriteMultiFabHeader();
+	    Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
+			                new_snapshotFabFilename,
+					Buffer_FabHeader.FabHead(0));
+	    Buffer_FabHeader.WriteMultiFabHeader();
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());
             std::rename(recent_Buffer_FabFilename.c_str(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -66,7 +66,7 @@ void BTDiagnostics::DerivedInitData ()
     // allocate vector to estimate maximum number of buffer multifabs needed to
     // obtain the lab-frame snapshot.
     m_max_buffer_multifabs.resize(m_num_buffers);
-    // allocate vector to count number of times the buffer multifab 
+    // allocate vector to count number of times the buffer multifab
     // has been flushed and refilled
     m_buffer_flush_counter.resize(m_num_buffers);
     // allocate vector of geometry objects corresponding to each snapshot
@@ -581,14 +581,14 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
         // contains a minimum m_buffer_size=256 cells
         int num_z_cells_in_snapshot = m_max_buffer_multifabs[i_buffer] * m_buffer_size;
         // Modify the domain indices according to the buffers that are flushed out
-        m_snapshot_box[i_buffer].setSmall( m_moving_window_dir, 
+        m_snapshot_box[i_buffer].setSmall( m_moving_window_dir,
                                            k_lab - (num_z_cells_in_snapshot-1) );
         m_snapshot_box[i_buffer].setBig( m_moving_window_dir, k_lab);
 
         // Modifying the physical coordinates of the lab-frame snapshot to be
         // consistent with the above modified domain-indices in m_snapshot_box.
         amrex::IntVect ref_ratio = amrex::IntVect(1);
-        amrex::Real new_lo = m_snapshot_domain_lab[i_buffer].hi(m_moving_window_dir) - 
+        amrex::Real new_lo = m_snapshot_domain_lab[i_buffer].hi(m_moving_window_dir) -
                              num_z_cells_in_snapshot *
                              dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]);
         m_snapshot_domain_lab[i_buffer].setLo(m_moving_window_dir, new_lo);
@@ -684,7 +684,7 @@ BTDiagnostics::Flush (int i_buffer)
     auto & warpx = WarpX::GetInstance();
     std::string tmp_file_name = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_buffer,5);
     tmp_file_name = tmp_file_name+"/buffer";
-    bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer] 
+    bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
                                - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
     amrex::Print() << " is last buffer flush : " << isLastBTDFlush << "\n";
     bool isBTD = true;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -756,10 +756,10 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
         if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-	    Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
-			                new_snapshotFabFilename,
-					Buffer_FabHeader.FabHead(0));
-	    Buffer_FabHeader.WriteMultiFabHeader();
+        Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
+                            new_snapshotFabFilename,
+                    Buffer_FabHeader.FabHead(0));
+        Buffer_FabHeader.WriteMultiFabHeader();
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());
             std::rename(recent_Buffer_FabFilename.c_str(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -889,4 +889,3 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     snapshot_FabHeader.WriteMultiFabHeader();
 
 }
-

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -879,6 +879,6 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     }
 
     snapshot_FabHeader.WriteMultiFabHeader();
-    
+
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -686,7 +686,6 @@ BTDiagnostics::Flush (int i_buffer)
     tmp_file_name = tmp_file_name+"/buffer";
     bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
                                - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
-    amrex::Print() << " is last buffer flush : " << isLastBTDFlush << "\n";
     bool isBTD = true;
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -256,6 +256,18 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
             (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
     }
 
+    // Define box array
+    amrex::BoxArray diag_ba(diag_box);
+    diag_ba.maxSize( warpx.maxGridSize( lev ) );
+    // Update the physical co-ordinates m_lo and m_hi using the final index values
+    // from the coarsenable, cell-centered BoxArray, ba.
+    for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
+            diag_ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
+        diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
+            (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+    }
+
     // Define buffer_domain in lab-frame for the i^th snapshot.
     // Replace z-dimension with lab-frame co-ordinates.
     amrex::Real zmin_buffer_lab = diag_dom.lo(m_moving_window_dir)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -686,7 +686,7 @@ void
 BTDiagnostics::Flush (int i_buffer)
 {
     auto & warpx = WarpX::GetInstance();
-    std::string file_name = m_file_prefix; 
+    std::string file_name = m_file_prefix;
     if (m_format=="plotfile") {
         file_name = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_buffer,5);
         file_name = file_name+"/buffer";

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -114,7 +114,11 @@ BTDiagnostics::ReadParameters ()
     // Read list of back-transform diag parameters requested by the user //
     amrex::ParmParse pp(m_diag_name);
 
-    m_file_prefix = "diags/lab_frame_data/" + m_diag_name;
+    if (m_format == "openpmd") {
+        m_file_prefix = "diags/" + m_diag_name;
+    } else {
+        m_file_prefix = "diags/lab_frame_data/" + m_diag_name;
+    }
     pp.query("file_prefix", m_file_prefix);
     pp.query("do_back_transformed_fields", m_do_back_transformed_fields);
     pp.query("do_back_transformed_particles", m_do_back_transformed_particles);
@@ -682,15 +686,18 @@ void
 BTDiagnostics::Flush (int i_buffer)
 {
     auto & warpx = WarpX::GetInstance();
-    std::string tmp_file_name = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_buffer,5);
-    tmp_file_name = tmp_file_name+"/buffer";
+    std::string file_name = m_file_prefix; 
+    if (m_format=="plotfile") {
+        file_name = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_buffer,5);
+        file_name = file_name+"/buffer";
+    }
     bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
                                - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
-        labtime, m_output_species, nlev_output, tmp_file_name,
+        labtime, m_output_species, nlev_output, file_name,
         m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F,
         isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush);
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -686,10 +686,11 @@ BTDiagnostics::Flush (int i_buffer)
     tmp_file_name = tmp_file_name+"/buffer";
     bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
                                - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
-    bool isBTD = true;
+    bool const isBTD = true;
+    double const labtime = m_t_lab[i_buffer];
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
-        warpx.gett_new(0), m_output_species, nlev_output, tmp_file_name,
+        labtime, m_output_species, nlev_output, tmp_file_name,
         m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F,
         isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -17,7 +17,10 @@ public:
         const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const = 0;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const = 0;
 
      virtual ~FlushFormat() {}
 };

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -26,7 +26,10 @@ public:
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const override;
 
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -13,7 +13,8 @@ FlushFormatAscent::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool /*plot_raw_rho*/, bool plot_raw_F) const
+    bool plot_raw_fields_guards, bool /*plot_raw_rho*/, bool plot_raw_F,
+    bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
 #ifdef AMREX_USE_ASCENT
     auto & warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -14,7 +14,10 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override final;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const override final;
 
     void CheckpointParticles(const std::string& dir,
                              const amrex::Vector<ParticleDiag>& particle_diags) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -21,7 +21,7 @@ FlushFormatCheckpoint::WriteToFile (
         bool /*plot_raw_fields*/,
         bool /*plot_raw_fields_guards*/,
         bool /*plot_raw_rho*/, bool /*plot_raw_F*/,
-        bool /*isBTD*/, int /*snapshotID*/, 
+        bool /*isBTD*/, int /*snapshotID*/,
         const amrex::Geometry& /*full_BTD_snapshot*/,
         bool /*isLastBTDFlush*/) const
 {

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -20,7 +20,10 @@ FlushFormatCheckpoint::WriteToFile (
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool /*plot_raw_fields*/,
         bool /*plot_raw_fields_guards*/,
-        bool /*plot_raw_rho*/, bool /*plot_raw_F*/) const
+        bool /*plot_raw_rho*/, bool /*plot_raw_F*/,
+        bool /*isBTD*/, int /*snapshotID*/, 
+        const amrex::Geometry& /*full_BTD_snapshot*/,
+        bool /*isLastBTDFlush*/) const
 {
     WARPX_PROFILE("FlushFormatCheckpoint::WriteToFile()");
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -25,7 +25,10 @@ public:
         const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override final;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const override final;
 
     ~FlushFormatOpenPMD ();
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -29,7 +29,9 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/,
     const std::string prefix, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
+    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F,
+    bool isBTD, int snapshotID, const amrex::Geometry& full_BTD_snapshot,
+    bool isLastBTDFlush) const
 {
     WARPX_PROFILE("FlushFormatOpenPMD::WriteToFile()");
 
@@ -38,17 +40,17 @@ FlushFormatOpenPMD::WriteToFile (
         "Cannot plot raw data with OpenPMD output format. Use plotfile instead.");
 
     // Set step and output directory name.
-    m_OpenPMDPlotWriter->SetStep(iteration[0], prefix);
+    m_OpenPMDPlotWriter->SetStep(iteration[0], prefix, isBTD, snapshotID);
 
     // fields: only dumped for coarse level
     m_OpenPMDPlotWriter->WriteOpenPMDFields(
-        varnames, mf[0], geom[0], iteration[0], time);
+        varnames, mf[0], geom[0], iteration[0], time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
     m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags);
 
     // signal that no further updates will be written to this iteration
-    m_OpenPMDPlotWriter->CloseStep();
+    m_OpenPMDPlotWriter->CloseStep(isBTD, isLastBTDFlush);
 }
 
 FlushFormatOpenPMD::~FlushFormatOpenPMD (){

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -39,12 +39,19 @@ FlushFormatOpenPMD::WriteToFile (
         !plot_raw_fields && !plot_raw_fields_guards && !plot_raw_rho && !plot_raw_F,
         "Cannot plot raw data with OpenPMD output format. Use plotfile instead.");
 
+    // we output at full steps of the coarsest level
+    int output_iteration = iteration[0];
+    // in backtransformed diagnostics (BTD), we dump into a series of labframe
+    // snapshots
+    if( isBTD )
+        output_iteration = snapshotID;
+
     // Set step and output directory name.
-    m_OpenPMDPlotWriter->SetStep(iteration[0], prefix, isBTD, snapshotID);
+    m_OpenPMDPlotWriter->SetStep(output_iteration, prefix, isBTD);
 
     // fields: only dumped for coarse level
     m_OpenPMDPlotWriter->WriteOpenPMDFields(
-        varnames, mf[0], geom[0], iteration[0], time, isBTD, full_BTD_snapshot);
+        varnames, mf[0], geom[0], output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
     m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags);

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -21,7 +21,10 @@ public:
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const override;
 
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -21,7 +21,9 @@ FlushFormatPlotfile::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
+    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F,
+    bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/,
+    bool /*isLastBTDFlush*/) const
 {
     WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -53,7 +53,10 @@ public:
         const amrex::Vector<ParticleDiag>& particle_diags, int nlev, const std::string prefix,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F) const override;
+        bool plot_raw_rho, bool plot_raw_F,
+        bool isBTD = false, int snapshotID = -1,
+        const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
+        bool isLastBTDFlush = false) const override;
 
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -53,7 +53,9 @@ FlushFormatSensei::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F) const
+    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F,
+    bool /*isBTD*/, int /*snapshotID*/,
+    const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
 #ifndef BL_USE_SENSEI_INSITU
     (void)varnames;

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -107,7 +107,7 @@ public:
    *
    */
   void SetStep (int ts, const std::string& filePrefix,
-                bool isBTD=false, int BTD_ts=-1);
+                bool isBTD=false);
 
   /** Close the step
    *
@@ -127,7 +127,7 @@ public:
 
 
 private:
-  void Init (openPMD::Access access, const std::string& filePrefix);
+  void Init (openPMD::Access access, const std::string& filePrefix, bool isBTD);
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -106,13 +106,14 @@ public:
    * @note If an iteration has been written, then it will give a warning
    *
    */
-  void SetStep (int ts, const std::string& filePrefix);
+  void SetStep (int ts, const std::string& filePrefix,
+                bool isBTD=false, int BTD_ts=-1);
 
   /** Close the step
    *
    * Signal that no further updates will be written for the step.
    */
-  void CloseStep ();
+  void CloseStep (bool isBTD = false, bool isLastBTDFlush = false);
 
   void WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags);
 
@@ -120,7 +121,9 @@ public:
               const std::vector<std::string>& varnames,
               const amrex::MultiFab& mf,
               const amrex::Geometry& geom,
-              const int iteration, const double time ) const;
+              const int iteration, const double time,
+              bool isBTD = false,
+              const amrex::Geometry& full_BTD_snapshot=amrex::Geometry() ) const;
 
 
 private:

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,7 +241,6 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
-  amrex::Print() << " m_CurrentStep : " << m_CurrentStep << " ts : " << ts << "\n";
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,7 +241,7 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
-
+  amrex::Print() << " m_CurrentStep : " << m_CurrentStep << " ts : " << ts << "\n";
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series
@@ -257,8 +257,8 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 
 void WarpXOpenPMDPlot::CloseStep ()
 {
-    if (m_Series)
-        m_Series->iterations[m_CurrentStep].close();
+    //if (m_Series)
+    //    m_Series->iterations[m_CurrentStep].close();
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -773,9 +773,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
 
   // is this either a regular write (true) or the first write in a
   // backtransformed diagnostic (BTD):
-  bool first_write_to_iteration = false;
-  if( isBTD )
-      first_write_to_iteration = ! m_Series->iterations.contains( iteration );
+  bool const first_write_to_iteration = ! m_Series->iterations.contains( iteration );
 
   int const ncomp = mf.nComp();
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -257,8 +257,8 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 
 void WarpXOpenPMDPlot::CloseStep ()
 {
-    //if (m_Series)
-    //    m_Series->iterations[m_CurrentStep].close();
+    if (m_Series)
+        m_Series->iterations[m_CurrentStep].close();
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -773,9 +773,9 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
 
   // is this either a regular write (true) or the first write in a
   // backtransformed diagnostic (BTD):
-  bool first_BTD_write = false;
+  bool first_write_to_iteration = false;
   if( isBTD )
-      first_BTD_write = ! m_Series->iterations.contains( iteration );
+      first_write_to_iteration = ! m_Series->iterations.contains( iteration );
 
   int const ncomp = mf.nComp();
 
@@ -799,7 +799,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
   // meta data
   auto series_iteration = m_Series->iterations[iteration];
   auto meshes = series_iteration.meshes;
-  if( first_BTD_write ) {
+  if( first_write_to_iteration ) {
       series_iteration.setTime( time );
 
       // meta data for ED-PIC extension
@@ -896,7 +896,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
     //   we invert (only) meta-data arrays to assign labels and offsets in the
     //   order: slowest to fastest varying index when accessing the mesh
     //   contiguously (as 1D flattened logical memory)
-    if( first_BTD_write ) {
+    if( first_write_to_iteration ) {
         mesh.setDataOrder(openPMD::Mesh::DataOrder::C);
         mesh.setAxisLabels(axis_labels);
         mesh.setGridSpacing(grid_spacing);
@@ -907,7 +907,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
 
     // Create a new mesh record component, and store the associated metadata
     auto mesh_comp = mesh[comp_name];
-    if( first_BTD_write ) {
+    if( first_write_to_iteration ) {
         mesh_comp.resetDataset(dataset);
 
         auto relative_cell_pos = utils::getRelativeCellPosition(mf);       // AMReX Fortran index order

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -287,8 +287,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
     if (amrex::ParallelDescriptor::NProcs() > 1) {
 #if defined(AMREX_USE_MPI)
         m_Series = std::make_unique<openPMD::Series>(
-                filename, access,
-                amrex::ParallelDescriptor::Communicator()
+            filename, access,
+            amrex::ParallelDescriptor::Communicator()
         );
         m_MPISize = amrex::ParallelDescriptor::NProcs();
         m_MPIRank = amrex::ParallelDescriptor::MyProc();
@@ -771,6 +771,8 @@ WarpXOpenPMDPlot::WriteOpenPMDFields ( //const std::string& filename,
   if( isBTD )
       full_geom = full_BTD_snapshot;
 
+  // is this either a regular write (true) or the first write in a
+  // backtransformed diagnostic (BTD):
   bool first_BTD_write = false;
   if( isBTD )
       first_BTD_write = ! m_Series->iterations.contains( iteration );

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -241,6 +241,7 @@ void WarpXOpenPMDPlot::GetFileName(std::string& filename)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix)
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
+
   if (m_CurrentStep >= ts) {
       // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
       // last written step in m_Series's life time, but not other earlier written steps by other m_Series


### PR DESCRIPTION
This PR adds functionality for BTD to be written in the openPMD format.
The input file used to test this case is attached below.
[inputs.txt](https://github.com/ECP-WarpX/WarpX/files/6007876/inputs.txt)

![Screenshot from 2021-02-18 21-38-17](https://user-images.githubusercontent.com/41089244/108462617-bfb1da00-7231-11eb-9328-082e11f287cf.png)

