### PR TITLE
Add "." to libwarpx Aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,27 @@ install(TARGETS ${WarpX_INSTALL_TARGET_NAMES}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+# simplified library alias
+# this is currently expected by Python bindings
+if(WarpX_LIB)
+    if(WarpX_DIMS STREQUAL 3)
+        set(lib_suffix "3d")
+    elseif(WarpX_DIMS STREQUAL 2)
+        set(lib_suffix "2d")
+    elseif(WarpX_DIMS STREQUAL RZ)
+        set(lib_suffix "rz")
+    endif()
+    if(WIN32)
+        set(mod_ext "dll")
+    else()
+        set(mod_ext "so")
+    endif()
+    install(CODE "file(CREATE_LINK
+        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libwarpx.3d.MPI.OMP.DP.QED.so
+        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
+        COPY_ON_ERROR SYMBOLIC)")
+endif()
+
 # CMake package file for find_package(WarpX::WarpX) in depending projects
 #install(EXPORT WarpXTargets
 #    FILE WarpXTargets.cmake

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -59,13 +59,12 @@ else:
 
 _libc = ctypes.CDLL(_find_library('c'))
 
-# macOS/Linux use .so, Windows uses .pyd
-# https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll
+# this is a plain C/C++ shared library, not a Python module
 if os.name == 'nt':
-    mod_ext = "pyd"
+    mod_ext = "dll"
 else:
     mod_ext = "so"
-libname = "libwarpx{0}.{1}".format(geometry_dim, mod_ext)
+libname = "libwarpx.{0}.{1}".format(geometry_dim, mod_ext)
 
 try:
     libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), libname))

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -34,7 +34,7 @@ if args.with_libwarpx:
     # GNUmake
     if args.with_libwarpx not in allowed_dims:
         print("WARNING: '%s' is not an allowed WarpX DIM" % args.with_libwarpx)
-    package_data = {'pywarpx' : ['libwarpx%s.so' % args.with_libwarpx]}
+    package_data = {'pywarpx' : ['libwarpx.%s.so' % args.with_libwarpx]}
     data_files = []
 elif args.with_lib_dir or PYWARPX_LIB_DIR:
     # CMake and Package Managers
@@ -42,7 +42,7 @@ elif args.with_lib_dir or PYWARPX_LIB_DIR:
     lib_dir = args.with_lib_dir if args.with_lib_dir else PYWARPX_LIB_DIR
     my_path = os.path.dirname(os.path.realpath(__file__))
     for dim in allowed_dims:
-        lib_name = 'libwarpx%s.so' % dim
+        lib_name = 'libwarpx.%s.so' % dim
         lib_path = os.path.join(lib_dir, lib_name)
         link_name = os.path.join(my_path, "pywarpx", lib_name)
         if os.path.isfile(link_name):

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -230,17 +230,17 @@ else
   PYDIM = $(DIM)d
 endif
 
-installwarpx: libwarpx$(PYDIM).so
-	mv libwarpx$(PYDIM).so Python/pywarpx
+installwarpx: libwarpx.$(PYDIM).so
+	mv libwarpx.$(PYDIM).so Python/pywarpx
 	cd Python; python setup.py install --with-libwarpx $(PYDIM) $(PYINSTALLOPTIONS)
 
-libwarpx$(PYDIM).a: $(objForExecs)
+libwarpx.$(PYDIM).a: $(objForExecs)
 	@echo Making static library $@ ...
 	$(SILENT) $(AR) -crv $@ $^
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 	@echo SUCCESS
 
-libwarpx$(PYDIM).so: $(objForExecs)
+libwarpx.$(PYDIM).so: $(objForExecs)
 	@echo Making dynamic library $@ ...
 ifeq ($(USE_CUDA),TRUE)
 	$(SILENT) $(CXX) $(LINKFLAGS) $(SHARED_OPTION) -Xlinker=$(SHARED_OPTION) -Xlinker=-fPIC -o $@ $^ $(LDFLAGS) $(libraries)
@@ -252,9 +252,9 @@ endif
 
 clean::
 	$(SILENT) $(RM) -rf build
-	$(SILENT) $(RM) -f libwarpx?d.a
-	$(SILENT) $(RM) -f libwarpx?d.so
-	$(SILENT) $(RM) -f pywarpx/libwarpx?d.so
+	$(SILENT) $(RM) -f libwarpx.?d.a
+	$(SILENT) $(RM) -f libwarpx.?d.so
+	$(SILENT) $(RM) -f pywarpx/libwarpx.?d.so
 
 else
 

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -209,14 +209,14 @@ function(set_warpx_binary_name)
             set(lib_suffix "rz")
         endif()
         if(WIN32)
-            set(mod_ext "pyd")
+            set(mod_ext "dll")
         else()
             set(mod_ext "so")
         endif()
         add_custom_command(TARGET shared POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E create_symlink
                 $<TARGET_FILE:shared>
-                ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwarpx${lib_suffix}.${mod_ext}
+                ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwarpx.${lib_suffix}.${mod_ext}
         )
     endif()
 endfunction()

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ class CopyPreBuild(build):
     def run(self):
         build.run(self)
 
-        # matches: libwarpx(2d|3d|rz).(so|pyd)
-        re_libprefix = re.compile(r"libwarpx..\.(?:so|pyd)")
+        # matches: libwarpx.(2d|3d|rz).(so|pyd)
+        re_libprefix = re.compile(r"libwarpx\...\.(?:so|pyd)")
         libs_found = []
         for lib_name in os.listdir(PYWARPX_LIB_DIR):
             if re_libprefix.match(lib_name):


### PR DESCRIPTION
Add a "." to the suffix of the short-hand `libwarpx.<DIM>.<so|dll>` libs. This unifies the suffix with the structure in executables and makes it easier to find a "long" version of the library (not in this PR).

Also fixes the suffix naming on Windows to ".dll", since this is a true C/C++ library, not a Python module (aka not a shared library following Python entry points and conventions).

For CMake, this also adds the expected library alias in CMake install prefixes.