### PR TITLE
Fix: CMake Library Alias (Install)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ if(WarpX_LIB)
         set(mod_ext "so")
     endif()
     install(CODE "file(CREATE_LINK
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libwarpx.3d.MPI.OMP.DP.QED.so
+        $<TARGET_FILE_NAME:shared>
         ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
         COPY_ON_ERROR SYMBOLIC)")
 endif()

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -195,7 +195,7 @@ function(set_warpx_binary_name)
         # alias to the latest build, because using the full name is often confusing
         add_custom_command(TARGET app POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E create_symlink
-                $<TARGET_FILE:app>
+                $<TARGET_FILE_NAME:app>
                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/warpx
         )
     endif()
@@ -215,7 +215,7 @@ function(set_warpx_binary_name)
         endif()
         add_custom_command(TARGET shared POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E create_symlink
-                $<TARGET_FILE:shared>
+                $<TARGET_FILE_NAME:shared>
                 ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwarpx.${lib_suffix}.${mod_ext}
         )
     endif()


### PR DESCRIPTION
Ups, forgot to remove a hard-coded test value with the generic library name in the last PR (#1720).

Also makes the links relative.