### PR TITLE
pyproject.toml: build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
-requires = ["setuptools>38.6", "wheel", "cmake>=3.15.0,<4.0.0"]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "cmake>=3.15.0,<4.0.0"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
"Never make a pyproject.toml without `build-backend = "setuptools.build_meta"`, this causes issues if missing for (at least) PyPI-Build."

Ref.:
  https://github.com/pybind/cmake_example/commit/11a644072b12ad78352b6e6649db9dfe7f406676#commitcomment-43964684