### PR TITLE
Remove Temporary Custom Output for Reformatted BTD

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -44,22 +44,12 @@ public:
      */
     amrex::Real probhi (int dim) const noexcept {return m_prob_hi[dim]; }
 
-    //amrex::Array<amrex::Real, AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; }
-    //amrex::Array<amrex::Real, AMREX_SPACEDIM> probHo () const noexcept { return m_prob_hi; }
-    //amrex::Array<amrex::Real, AMREX_SPACEDIM> cellsize () const noexcept {return m_cell_size; }
     /** Returns the bounding box of the domain spanned in the plotfile */
     amrex::Box probDomain () const noexcept {return m_prob_domain; }
     /** Returns timestep at which the plotfile was written */
     int timestep () const noexcept {return m_timestep; }
-    ///** Returns the type of coordinate system */
-    //int coordsys () const noexcept {return m_coordsys; }
-
-    //int bwidth () const noexcept {return m_bwidth; }
-    //int cur_level () const noexcept {return m_cur_level; }
     int numFabs () const noexcept {return m_numFabs; }
 
-   // const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& glo () const noexcept {return m_glo; }
-   // const amrex::Vector<amrex::Array<amrex::Real, AMREX_SPACEDIM> >& ghi () const noexcept {return m_ghi; }
     /** Returns physical co-ordinates of the lower-corner for the i-th Fab.
      *  \param[in] iFab, id of the ith Fab in the list of Multifabs
      *  \param[out] Array of lower-corner physical co-ordinates corresponding to the ith Fab

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -143,7 +143,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << '\n';
     // coordinate system (Cartesian)
     HeaderFile << m_coordsys << '\n';
-    // 
+    //
     HeaderFile << m_bwidth << '\n';
     // current level, number of Fabs, current time -- for a single level (m_level = 0)
     HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
@@ -153,11 +153,11 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     for (int iFab = 0; iFab < m_numFabs; ++iFab) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
-        }       
+        }
     }
     // MultiFabHeaderPath
     HeaderFile << m_CellPath << '\n';
-   
+
 }
 
 

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -143,7 +143,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     HeaderFile << '\n';
     // coordinate system (Cartesian)
     HeaderFile << m_coordsys << '\n';
-    //
+    // 
     HeaderFile << m_bwidth << '\n';
     // current level, number of Fabs, current time -- for a single level (m_level = 0)
     HeaderFile << m_cur_level << ' ' << m_numFabs << ' ' << m_time << '\n';
@@ -153,11 +153,11 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     for (int iFab = 0; iFab < m_numFabs; ++iFab) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             HeaderFile << m_glo[iFab][idim] << ' ' << m_ghi[iFab][idim] << '\n';
-        }
+        }       
     }
     // MultiFabHeaderPath
     HeaderFile << m_CellPath << '\n';
-
+   
 }
 
 

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -179,35 +179,10 @@ private:
      *  z slice location.
      */
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > m_cell_centered_data;
-    /** Name of the output directories where the lab-frame data
-     *  is dumped out in a custom format.
-     *  This is a TMP variable, which may not be required after including
-     *  OpenPMD and plotfile formats.
-     */
-    std::vector<std::string> m_file_name;
     /** Vector of pointers to compute cell-centered data, per level, per component
      *  using the coarsening-ratio provided by the user.
      */
     amrex::Vector< amrex::Vector <std::unique_ptr<ComputeDiagFunctor const> > > m_cell_center_functors;
-    /** Customized (temporary) function to flush out back-transformed data */
-    void TMP_writeMetaData ();
-    /** Customized (temporary) functions creating lab-frame directories
-     *  to flush out back-transformed data
-     * \param[in] i_buffer, index of the buffer data that is being flushed out
-     * \param[in] lev, level of the buffer data.
-     *  (Currently only single-level data is supported.)
-     */
-    void TMP_createLabFrameDirectories (int i_buffer, int lev);
-    /** Customized (temporary) functions creating header files
-     *  to flush out back-transformed data for the ith buffer
-     * \param[in] i_buffer, ith buffer storing data for the ith snapshot
-     */
-    void TMP_writeLabFrameHeader (int i_buffer);
-    /** Customized (temporary) output format for flushing out lab-frame data stored in
-     *  the output buffer, m_mf_output.
-     * \param[in] i_buffer, ith buffer for which the lab-farme data is flushed out.
-     */
-    void TMP_FlushLabFrameData ( int i_buffer );
     /** Define the cell-centered multi-component MultiFab at level, lev.
      *  This function is called when the buffer counter for a snapshot is zero,
      *  or when the buffer is empty. Checked using `buffer_empty(i_buffer)`
@@ -299,9 +274,18 @@ private:
     /** Temporarily clear species output for BTD until particle buffer is added */
     void TMP_ClearSpeciesDataForBTD() override;
 
+    /** Merge the lab-frame buffer multifabs so it can be visualized as
+     *  a single plotfile
+     */
     void MergeBuffersForPlotfile (int i_snapshot);
+    /** Interleave lab-frame meta-data of the buffers to be consistent
+     *  with the merged plotfile lab-frame data.
+     */
     void InterleaveBufferAndSnapshotHeader ( std::string buffer_Header,
                                              std::string snapshot_Header);
+    /** Interleave meta-data of the buffer multifabs to be consistent
+     *  with the merged plotfile lab-frame data.
+     */
     void InterleaveFabArrayHeader( std::string Buffer_FabHeaderFilename,
                                    std::string snapshot_FabHeaderFilename,
                                    std::string newsnapshot_FabFilename);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -786,10 +786,10 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
         if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-	    Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
-			                new_snapshotFabFilename,
-					Buffer_FabHeader.FabHead(0));
-	    Buffer_FabHeader.WriteMultiFabHeader();
+        Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
+                            new_snapshotFabFilename,
+                    Buffer_FabHeader.FabHead(0));
+        Buffer_FabHeader.WriteMultiFabHeader();
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());
             std::rename(recent_Buffer_FabFilename.c_str(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -260,6 +260,18 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
             (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
     }
 
+    // Define box array
+    amrex::BoxArray diag_ba(diag_box);
+    diag_ba.maxSize( warpx.maxGridSize( lev ) );
+    // Update the physical co-ordinates m_lo and m_hi using the final index values
+    // from the coarsenable, cell-centered BoxArray, ba.
+    for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
+            diag_ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
+        diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
+            (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+    }
+
     // Define buffer_domain in lab-frame for the i^th snapshot.
     // Replace z-dimension with lab-frame co-ordinates.
     amrex::Real zmin_buffer_lab = diag_dom.lo(m_moving_window_dir)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -784,7 +784,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         // Name of the newly appended fab in the snapshot
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
 
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {            
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
         Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
                             new_snapshotFabFilename,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -784,12 +784,12 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         // Name of the newly appended fab in the snapshot
         std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
 
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {            
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {
             std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-        Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
-                            new_snapshotFabFilename,
-                    Buffer_FabHeader.FabHead(0));
-        Buffer_FabHeader.WriteMultiFabHeader();
+	    Buffer_FabHeader.SetFabName(0, Buffer_FabHeader.fodPrefix(0),
+			                new_snapshotFabFilename,
+					Buffer_FabHeader.FabHead(0));
+	    Buffer_FabHeader.WriteMultiFabHeader();
             std::rename(recent_Buffer_FabHeaderFilename.c_str(),
                         snapshot_FabHeaderFilename.c_str());
             std::rename(recent_Buffer_FabFilename.c_str(),

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -215,7 +215,7 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
         diag_dom.setLo(idim, std::max(m_lo[idim],warpx.Geom(lev).ProbLo(idim)) );
         // Setting hi-coordinate for the diag domain by taking the max of user-defined
         // hi-cordinate and hi-coordinate of the simulation domain at level, lev
-        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) ); 
+        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) );
     }
     // Initializing the m_buffer_box for the i^th snapshot.
     // At initialization, the Box has the same index space as the boosted-frame
@@ -457,7 +457,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                 m_current_z_lab[i_buffer] = UpdateCurrentZLabCoordinate(m_t_lab[i_buffer],
                                                                       warpx.gett_new(lev) );
                 // Check if the zslice is in domain
-                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);                
+                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
                 // Initialize and define field buffer multifab if buffer is empty
                 if (ZSliceInDomain) {
                     if ( buffer_empty(i_buffer) ) {
@@ -465,7 +465,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                             // Compute the geometry, snapshot lab-domain extent
                             // and box-indices
                             DefineSnapshotGeometry(i_buffer, lev);
-                        }                        
+                        }
                         DefineFieldBufferMultiFab(i_buffer, lev);
                     }
                 }
@@ -886,129 +886,3 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
 
 }
 
-void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
-{
-    auto & warpx = WarpX::GetInstance();
-    const amrex::Vector<int> iteration = warpx.getistep();
-    if (amrex::ParallelContext::IOProcessorSub()) {
-
-        // Path to final snapshot plotfiles
-        std::string snapshot_path = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_snapshot,5);
-        std::string snapshot_Level0_path = snapshot_path + "/Level_0";
-        std::string snapshot_Header_filename = snapshot_path + "/Header";
-        if (m_buffer_flush_counter[i_snapshot] == 0 ) {
-            // Create Level_0 directory to store all Cell_D and Cell_H files
-            amrex::UtilCreateDirectory(snapshot_Level0_path, 0755);
-        }
-
-        // Path of the buffer recently flushed 
-        std::string BufferPath_prefix = snapshot_path + "/buffer";
-        const std::string recent_Buffer_filepath = amrex::Concatenate(BufferPath_prefix,iteration[0]);
-    
-        // Header file of the recently flushed buffer
-        std::string recent_Header_filename = recent_Buffer_filepath+"/Header";
-        std::string recent_Buffer_Level0_path = recent_Buffer_filepath + "/Level_0";
-        std::string recent_Buffer_FabHeaderFilename = recent_Buffer_Level0_path + "/Cell_H";
-        std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/Cell_D_00000";
-        std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
-        std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
-        std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], 5);
-        
-
-        if ( m_buffer_flush_counter[i_snapshot] == 0) {
-            std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
-            std::rename(recent_Buffer_FabHeaderFilename.c_str(),
-                        snapshot_FabHeaderFilename.c_str());
-            std::rename(recent_Buffer_FabFilename.c_str(),
-                        snapshot_FabFilename.c_str());
-        } else {
-            // 0 Interleave Header file
-            // look at PlotFileDataImpl::PlotFileDataImpl ()
-            InterleaveBufferAndSnapshotHeader(recent_Header_filename,
-                                              snapshot_Header_filename);
-            //1. Copy Cell_D_00000 to snapshot_Level0/Cell_D_00001
-            InterleaveFabArrayHeader(recent_Buffer_FabHeaderFilename,
-                                     snapshot_FabHeaderFilename,
-                                     new_snapshotFabFilename);
-            std::rename(recent_Buffer_FabFilename.c_str(),
-                        snapshot_FabFilename.c_str());
-            // Check if buffer*istep file is present
-        }
-        amrex::Print() << " I am destroying " << recent_Buffer_filepath << "\n";
-        amrex::FileSystem::RemoveAll(recent_Buffer_filepath);        
-
-    } // ParallelContext if ends
-    amrex::ParallelDescriptor::Barrier();
-}  
-
-void
-BTDiagnostics::InterleaveBufferAndSnapshotHeader ( std::string buffer_Header_path,
-                                                   std::string snapshot_Header_path)
-{
-    BTDPlotfileHeaderImpl snapshot_HeaderImpl(snapshot_Header_path);
-    snapshot_HeaderImpl.ReadHeaderData();
-
-    BTDPlotfileHeaderImpl buffer_HeaderImpl(buffer_Header_path);
-    buffer_HeaderImpl.ReadHeaderData();
-
-    // Update timestamp of snapshot with recently flushed buffer
-    snapshot_HeaderImpl.set_time( buffer_HeaderImpl.time() );
-    snapshot_HeaderImpl.set_timestep( buffer_HeaderImpl.timestep() );
-
-    amrex::Box snapshot_Box = snapshot_HeaderImpl.probDomain();
-    amrex::Box buffer_Box = buffer_HeaderImpl.probDomain();
-    amrex::IntVect box_lo(0);
-    amrex::IntVect box_hi(1);
-    // Update prob_lo with min of buffer and snapshot
-    for (int idim = 0; idim < snapshot_HeaderImpl.spaceDim(); ++idim) {
-        amrex::Real min_prob_lo = amrex::min(buffer_HeaderImpl.problo(idim),
-                                             snapshot_HeaderImpl.problo(idim));
-        amrex::Real max_prob_hi = amrex::max(buffer_HeaderImpl.probhi(idim),
-                                             snapshot_HeaderImpl.probhi(idim));
-        snapshot_HeaderImpl.set_problo(idim, min_prob_lo);
-        snapshot_HeaderImpl.set_probhi(idim, max_prob_hi);
-        // Update prob_hi with max of buffer and snapshot
-        box_lo[idim] = amrex::min(buffer_Box.smallEnd(idim),
-                                  snapshot_Box.smallEnd(idim));
-        box_hi[idim] = amrex::max(buffer_Box.bigEnd(idim),
-                                  snapshot_Box.bigEnd(idim));
-    }
-    amrex::Box domain_box(box_lo, box_hi);
-    snapshot_HeaderImpl.set_probDomain(domain_box);    
-
-    // Increment numFabs
-    snapshot_HeaderImpl.IncrementNumFabs(); 
-    snapshot_HeaderImpl.AppendNewFabLo( buffer_HeaderImpl.FabLo(0));
-    snapshot_HeaderImpl.AppendNewFabHi( buffer_HeaderImpl.FabHi(0));
-
-    snapshot_HeaderImpl.WriteHeader();
-}
-
-
-void
-BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
-                                        std::string snapshot_FabHeader_path,
-                                        std::string newsnapshot_FabFilename)
-{
-    BTDMultiFabHeaderImpl snapshot_FabHeader(snapshot_FabHeader_path);
-    snapshot_FabHeader.ReadMultiFabHeader();
-
-    BTDMultiFabHeaderImpl Buffer_FabHeader(Buffer_FabHeader_path);
-    Buffer_FabHeader.ReadMultiFabHeader();
-
-    // Increment existing fabs in snapshot with the number of fabs in the buffer
-    snapshot_FabHeader.IncreaseMultiFabSize( Buffer_FabHeader.ba_size() );
-    snapshot_FabHeader.ResizeFabData();
-    
-    for (int ifab = 0; ifab < Buffer_FabHeader.ba_size(); ++ifab) {
-        int new_ifab = snapshot_FabHeader.ba_size() - 1 + ifab;
-        snapshot_FabHeader.SetBox(new_ifab, Buffer_FabHeader.ba_box(ifab) );
-        snapshot_FabHeader.SetFabName(new_ifab, Buffer_FabHeader.fodPrefix(ifab),
-                                                newsnapshot_FabFilename,
-                                                Buffer_FabHeader.FabHead(ifab) );
-        snapshot_FabHeader.SetMinVal(new_ifab, Buffer_FabHeader.minval(ifab));
-        snapshot_FabHeader.SetMaxVal(new_ifab, Buffer_FabHeader.maxval(ifab));
-    }
-
-    snapshot_FabHeader.WriteMultiFabHeader();
-}

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -34,8 +34,6 @@ void BTDiagnostics::DerivedInitData ()
     // and then sliced+back-transformed+filled_to_buffer.
     // The number of levels to be output is nlev_output.
     nlev_output = 1;
-    // temporary function related to customized output from previous BTD to verify accuracy
-    TMP_writeMetaData();
 
     // allocate vector of m_t_lab with m_num_buffers;
     m_t_lab.resize(m_num_buffers);
@@ -57,8 +55,6 @@ void BTDiagnostics::DerivedInitData ()
     m_buffer_counter.resize(m_num_buffers);
     // allocate vector of num_Cells in the lab-frame
     m_snapshot_ncells_lab.resize(m_num_buffers);
-    // allocate vector of file names for each buffer
-    m_file_name.resize(m_num_buffers);
     // allocate vector of cell centered multifabs for nlevels
     m_cell_centered_data.resize(nmax_lev);
     // allocate vector of cell-center functors for nlevels
@@ -75,10 +71,6 @@ void BTDiagnostics::DerivedInitData ()
         m_geom_snapshot[i].resize(nmax_lev);
     }
 
-    for (int i = 0; i < m_num_buffers; ++i) {
-        // TMP variable name for customized BTD output to verify accuracy
-        m_file_name[i] = amrex::Concatenate(m_file_prefix +"/snapshots/snapshot",i,5);
-    }
     for (int lev = 0; lev < nmax_lev; ++lev) {
         // Define cell-centered multifab over the whole domain with
         // user-defined crse_ratio for nlevels
@@ -134,36 +126,6 @@ BTDiagnostics::ReadParameters ()
         "For back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab");
     // For BTD, we always need rho to perform Lorentz Transform of current-density
     if (WarpXUtilStr::is_in(m_cellcenter_varnames, "rho")) warpx.setplot_rho(true);
-}
-
-void
-BTDiagnostics::TMP_writeMetaData ()
-{
-    // This function will have the same functionality as writeMetaData in
-    // previously used BackTransformedDiagnostics class to write
-    // back-transformed data in a customized format
-
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-        const std::string fullpath = m_file_prefix + "/snapshots";
-        if (!amrex::UtilCreateDirectory(fullpath, 0755)) amrex::CreateDirectoryFailed(fullpath);
-
-        amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::IO_Buffer_Size);
-        std::ofstream HeaderFile;
-        HeaderFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
-        std::string HeaderFileName(m_file_prefix + "/snapshots/Header");
-        HeaderFile.open(HeaderFileName.c_str(), std::ofstream::out   |
-                                                std::ofstream::trunc |
-                                                std::ofstream::binary);
-        if (!HeaderFile.good()) amrex::FileOpenFailed( HeaderFileName );
-
-        HeaderFile.precision(17);
-        HeaderFile << m_num_snapshots_lab << "\n";
-        HeaderFile << m_dt_snapshots_lab << "\n";
-        HeaderFile << m_gamma_boost << "\n";
-        HeaderFile << m_beta_boost << "\n";
-
-    }
-
 }
 
 bool
@@ -319,8 +281,6 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
 #else
     m_snapshot_ncells_lab[i_buffer] = {Nx_lab, Nz_lab};
 #endif
-    // Call funtion to create directories for customized output format
-    TMP_createLabFrameDirectories(i_buffer, lev);
 }
 
 void
@@ -391,26 +351,6 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
             m_cell_center_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio);
         }
     }
-
-}
-
-// Temporary function only to debug the current implementation.
-// Will be replaced with plotfile/OpenPMD functionality
-void
-BTDiagnostics::TMP_createLabFrameDirectories(int i_buffer, int lev)
-{
-    // This is a creates lab-frame directories for writing out customized BTD output.
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        if ( !amrex::UtilCreateDirectory (m_file_name[i_buffer], 0755) )
-            amrex::CreateDirectoryFailed(m_file_name[i_buffer]);
-
-        const std::string &fullpath = amrex::LevelFullPath(lev, m_file_name[i_buffer]);
-        if ( !amrex::UtilCreateDirectory(fullpath, 0755) )
-            amrex::CreateDirectoryFailed(fullpath);
-    }
-    amrex::ParallelDescriptor::Barrier();
-    TMP_writeLabFrameHeader(i_buffer);
 
 }
 
@@ -525,7 +465,6 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
         m_mf_output[i_buffer][lev] = amrex::MultiFab ( buffer_ba, buffer_dmap,
                                                   m_varnames.size(), ngrow ) ;
 
-        // TMP
         amrex::IntVect ref_ratio = amrex::IntVect(1);
         if (lev > 0 ) ref_ratio = WarpX::RefRatio(lev-1);
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -633,52 +572,6 @@ BTDiagnostics::GetZSliceInDomainFlag (const int i_buffer, const int lev)
 }
 
 void
-BTDiagnostics::TMP_writeLabFrameHeader (int i_buffer)
-{
-    if (amrex::ParallelDescriptor::IOProcessor() )
-    {
-        amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::IO_Buffer_Size);
-        std::ofstream HeaderFile;
-        HeaderFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
-        std::string HeaderFileName(m_file_name[i_buffer] + "/Header");
-        HeaderFile.open(HeaderFileName.c_str(), std::ofstream::out    |
-                                                std::ofstream::trunc  |
-                                                std::ofstream::binary );
-
-        if ( !HeaderFile.good() ) amrex::FileOpenFailed( HeaderFileName );
-
-        HeaderFile.precision(17);
-
-        HeaderFile << m_t_lab[i_buffer] << "\n";
-        // Write buffer number of cells
-        HeaderFile << m_snapshot_ncells_lab[i_buffer][0] << ' '
-#if ( AMREX_SPACEDIM==3 )
-                   << m_snapshot_ncells_lab[i_buffer][1] << ' '
-#endif
-                   << m_snapshot_ncells_lab[i_buffer][m_moving_window_dir] << "\n";
-        // Write physical boundary of the buffer
-        // Lower bound
-        HeaderFile << m_snapshot_domain_lab[i_buffer].lo(0) << ' '
-#if ( AMREX_SPACEDIM == 3 )
-                   << m_snapshot_domain_lab[i_buffer].lo(1) << ' '
-#endif
-                   << m_snapshot_domain_lab[i_buffer].lo(m_moving_window_dir) << "\n";
-        // Higher bound
-        HeaderFile << m_snapshot_domain_lab[i_buffer].hi(0) << ' '
-#if ( AMREX_SPACEDIM == 3 )
-                   << m_snapshot_domain_lab[i_buffer].hi(1) << ' '
-#endif
-                   << m_snapshot_domain_lab[i_buffer].hi(m_moving_window_dir) << "\n";
-        // List of fields to flush to file
-        for (int i = 0; i < m_varnames.size(); ++i)
-        {
-            HeaderFile << m_varnames[i] << ' ';
-        }
-        HeaderFile << "\n";
-    }
-}
-
-void
 BTDiagnostics::Flush (int i_buffer)
 {
     auto & warpx = WarpX::GetInstance();
@@ -701,44 +594,9 @@ BTDiagnostics::Flush (int i_buffer)
         MergeBuffersForPlotfile(i_buffer);
     }
 
-    TMP_FlushLabFrameData (i_buffer);
     // Reset the buffer counter to zero after flushing out data stored in the buffer.
     ResetBufferCounter(i_buffer);
     IncrementBufferFlushCounter(i_buffer);
-}
-
-void
-BTDiagnostics::TMP_FlushLabFrameData ( int i_buffer )
-{
-    // customized output format for writing data stored in buffers to the disk.
-    amrex::VisMF::Header::Version current_version = amrex::VisMF::GetHeaderVersion();
-    amrex::VisMF::SetHeaderVersion(amrex::VisMF::Header::NoFabHeader_v1);
-
-    if ( ! buffer_empty(i_buffer) ) {
-        for ( int lev = 0; lev < nlev_output; ++lev) {
-            const int k_lab = k_index_zlab (i_buffer, lev);
-            const amrex::BoxArray& ba = m_mf_output[i_buffer][lev].boxArray();
-            const int hi = ba[0].bigEnd(m_moving_window_dir);
-            const int lo = hi - m_buffer_counter[i_buffer] + 1;
-
-            amrex::Box buffer_box = m_buffer_box[i_buffer];
-            buffer_box.setSmall(m_moving_window_dir, lo);
-            buffer_box.setBig(m_moving_window_dir, hi);
-            amrex::BoxArray buffer_ba(buffer_box);
-            buffer_ba.maxSize(m_max_box_size);
-            amrex::DistributionMapping buffer_dm(buffer_ba);
-
-            amrex::MultiFab tmp (buffer_ba, buffer_dm, m_varnames.size(), 0);
-            tmp.copy(m_mf_output[i_buffer][lev], 0, 0, m_varnames.size());
-
-            std::stringstream ss;
-            ss << m_file_name[i_buffer] << "/Level_0/"
-               << amrex::Concatenate("buffer", k_lab, 5);
-            amrex::VisMF::Write(tmp, ss.str());
-
-       }
-    }
-    amrex::VisMF::SetHeaderVersion(current_version);
 }
 
 void BTDiagnostics::TMP_ClearSpeciesDataForBTD ()

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -215,7 +215,7 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
         diag_dom.setLo(idim, std::max(m_lo[idim],warpx.Geom(lev).ProbLo(idim)) );
         // Setting hi-coordinate for the diag domain by taking the max of user-defined
         // hi-cordinate and hi-coordinate of the simulation domain at level, lev
-        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) );
+        diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) ); 
     }
     // Initializing the m_buffer_box for the i^th snapshot.
     // At initialization, the Box has the same index space as the boosted-frame
@@ -248,18 +248,6 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
     amrex::Box diag_box( lo, hi );
     m_buffer_box[i_buffer] = diag_box;
     m_snapshot_box[i_buffer] = diag_box;
-    // Define box array
-    amrex::BoxArray diag_ba(diag_box);
-    diag_ba.maxSize( warpx.maxGridSize( lev ) );
-    // Update the physical co-ordinates m_lo and m_hi using the final index values
-    // from the coarsenable, cell-centered BoxArray, ba.
-    for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
-            diag_ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
-        diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-            (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
-    }
-
     // Define box array
     amrex::BoxArray diag_ba(diag_box);
     diag_ba.maxSize( warpx.maxGridSize( lev ) );
@@ -469,7 +457,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                 m_current_z_lab[i_buffer] = UpdateCurrentZLabCoordinate(m_t_lab[i_buffer],
                                                                       warpx.gett_new(lev) );
                 // Check if the zslice is in domain
-                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
+                bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);                
                 // Initialize and define field buffer multifab if buffer is empty
                 if (ZSliceInDomain) {
                     if ( buffer_empty(i_buffer) ) {
@@ -477,7 +465,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                             // Compute the geometry, snapshot lab-domain extent
                             // and box-indices
                             DefineSnapshotGeometry(i_buffer, lev);
-                        }
+                        }                        
                         DefineFieldBufferMultiFab(i_buffer, lev);
                     }
                 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -885,3 +885,130 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     snapshot_FabHeader.WriteMultiFabHeader();
 
 }
+
+void BTDiagnostics::StitchBuffersForPlotfile (int i_snapshot)
+{
+    auto & warpx = WarpX::GetInstance();
+    const amrex::Vector<int> iteration = warpx.getistep();
+    if (amrex::ParallelContext::IOProcessorSub()) {
+
+        // Path to final snapshot plotfiles
+        std::string snapshot_path = amrex::Concatenate(m_file_prefix +"/snapshots_plotfile/snapshot",i_snapshot,5);
+        std::string snapshot_Level0_path = snapshot_path + "/Level_0";
+        std::string snapshot_Header_filename = snapshot_path + "/Header";
+        if (m_buffer_flush_counter[i_snapshot] == 0 ) {
+            // Create Level_0 directory to store all Cell_D and Cell_H files
+            amrex::UtilCreateDirectory(snapshot_Level0_path, 0755);
+        }
+
+        // Path of the buffer recently flushed 
+        std::string BufferPath_prefix = snapshot_path + "/buffer";
+        const std::string recent_Buffer_filepath = amrex::Concatenate(BufferPath_prefix,iteration[0]);
+    
+        // Header file of the recently flushed buffer
+        std::string recent_Header_filename = recent_Buffer_filepath+"/Header";
+        std::string recent_Buffer_Level0_path = recent_Buffer_filepath + "/Level_0";
+        std::string recent_Buffer_FabHeaderFilename = recent_Buffer_Level0_path + "/Cell_H";
+        std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/Cell_D_00000";
+        std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
+        std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],5);
+        std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], 5);
+        
+
+        if ( m_buffer_flush_counter[i_snapshot] == 0) {
+            std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
+            std::rename(recent_Buffer_FabHeaderFilename.c_str(),
+                        snapshot_FabHeaderFilename.c_str());
+            std::rename(recent_Buffer_FabFilename.c_str(),
+                        snapshot_FabFilename.c_str());
+        } else {
+            // 0 Interleave Header file
+            // look at PlotFileDataImpl::PlotFileDataImpl ()
+            InterleaveBufferAndSnapshotHeader(recent_Header_filename,
+                                              snapshot_Header_filename);
+            //1. Copy Cell_D_00000 to snapshot_Level0/Cell_D_00001
+            InterleaveFabArrayHeader(recent_Buffer_FabHeaderFilename,
+                                     snapshot_FabHeaderFilename,
+                                     new_snapshotFabFilename);
+            std::rename(recent_Buffer_FabFilename.c_str(),
+                        snapshot_FabFilename.c_str());
+            // Check if buffer*istep file is present
+        }
+        amrex::Print() << " I am destroying " << recent_Buffer_filepath << "\n";
+        amrex::FileSystem::RemoveAll(recent_Buffer_filepath);        
+
+    } // ParallelContext if ends
+    amrex::ParallelDescriptor::Barrier();
+}  
+
+void
+BTDiagnostics::InterleaveBufferAndSnapshotHeader ( std::string buffer_Header_path,
+                                                   std::string snapshot_Header_path)
+{
+    BTDPlotfileHeaderImpl snapshot_HeaderImpl(snapshot_Header_path);
+    snapshot_HeaderImpl.ReadHeaderData();
+
+    BTDPlotfileHeaderImpl buffer_HeaderImpl(buffer_Header_path);
+    buffer_HeaderImpl.ReadHeaderData();
+
+    // Update timestamp of snapshot with recently flushed buffer
+    snapshot_HeaderImpl.set_time( buffer_HeaderImpl.time() );
+    snapshot_HeaderImpl.set_timestep( buffer_HeaderImpl.timestep() );
+
+    amrex::Box snapshot_Box = snapshot_HeaderImpl.probDomain();
+    amrex::Box buffer_Box = buffer_HeaderImpl.probDomain();
+    amrex::IntVect box_lo(0);
+    amrex::IntVect box_hi(1);
+    // Update prob_lo with min of buffer and snapshot
+    for (int idim = 0; idim < snapshot_HeaderImpl.spaceDim(); ++idim) {
+        amrex::Real min_prob_lo = amrex::min(buffer_HeaderImpl.problo(idim),
+                                             snapshot_HeaderImpl.problo(idim));
+        amrex::Real max_prob_hi = amrex::max(buffer_HeaderImpl.probhi(idim),
+                                             snapshot_HeaderImpl.probhi(idim));
+        snapshot_HeaderImpl.set_problo(idim, min_prob_lo);
+        snapshot_HeaderImpl.set_probhi(idim, max_prob_hi);
+        // Update prob_hi with max of buffer and snapshot
+        box_lo[idim] = amrex::min(buffer_Box.smallEnd(idim),
+                                  snapshot_Box.smallEnd(idim));
+        box_hi[idim] = amrex::max(buffer_Box.bigEnd(idim),
+                                  snapshot_Box.bigEnd(idim));
+    }
+    amrex::Box domain_box(box_lo, box_hi);
+    snapshot_HeaderImpl.set_probDomain(domain_box);    
+
+    // Increment numFabs
+    snapshot_HeaderImpl.IncrementNumFabs(); 
+    snapshot_HeaderImpl.AppendNewFabLo( buffer_HeaderImpl.FabLo(0));
+    snapshot_HeaderImpl.AppendNewFabHi( buffer_HeaderImpl.FabHi(0));
+
+    snapshot_HeaderImpl.WriteHeader();
+}
+
+
+void
+BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
+                                        std::string snapshot_FabHeader_path,
+                                        std::string newsnapshot_FabFilename)
+{
+    BTDMultiFabHeaderImpl snapshot_FabHeader(snapshot_FabHeader_path);
+    snapshot_FabHeader.ReadMultiFabHeader();
+
+    BTDMultiFabHeaderImpl Buffer_FabHeader(Buffer_FabHeader_path);
+    Buffer_FabHeader.ReadMultiFabHeader();
+
+    // Increment existing fabs in snapshot with the number of fabs in the buffer
+    snapshot_FabHeader.IncreaseMultiFabSize( Buffer_FabHeader.ba_size() );
+    snapshot_FabHeader.ResizeFabData();
+    
+    for (int ifab = 0; ifab < Buffer_FabHeader.ba_size(); ++ifab) {
+        int new_ifab = snapshot_FabHeader.ba_size() - 1 + ifab;
+        snapshot_FabHeader.SetBox(new_ifab, Buffer_FabHeader.ba_box(ifab) );
+        snapshot_FabHeader.SetFabName(new_ifab, Buffer_FabHeader.fodPrefix(ifab),
+                                                newsnapshot_FabFilename,
+                                                Buffer_FabHeader.FabHead(ifab) );
+        snapshot_FabHeader.SetMinVal(new_ifab, Buffer_FabHeader.minval(ifab));
+        snapshot_FabHeader.SetMaxVal(new_ifab, Buffer_FabHeader.maxval(ifab));
+    }
+
+    snapshot_FabHeader.WriteMultiFabHeader();
+}

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -287,8 +287,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
     if (amrex::ParallelDescriptor::NProcs() > 1) {
 #if defined(AMREX_USE_MPI)
         m_Series = std::make_unique<openPMD::Series>(
-            filename, access,
-            amrex::ParallelDescriptor::Communicator()
+                filename, access,
+                amrex::ParallelDescriptor::Communicator()
         );
         m_MPISize = amrex::ParallelDescriptor::NProcs();
         m_MPIRank = amrex::ParallelDescriptor::MyProc();


### PR DESCRIPTION
This is a clean-up PR that removes temporary functions that supported customized output in the reformatted BTD.
With the plotfile and openPMD capability added in the reformatted diags, this is no longer needed.
Needs to be merged after #1717 and #1723 