### PR TITLE
Fix: run_test.sh - fail on error & fix clone

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -55,7 +55,6 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-      export WARPX_TEST_COMMIT=$BUILD_SOURCEVERSION
       ./run_test.sh
   timeoutInMinutes: 360
   displayName: 'Build & test'

--- a/Docs/source/developers/testing.rst
+++ b/Docs/source/developers/testing.rst
@@ -39,7 +39,6 @@ from WarpX root folder. It will compile all necessary executables and run all te
 
 * ``export WARPX_TEST_DIM=3``, ``export WARPX_TEST_DIM=2`` or ``export WARPX_TEST_DIM=RZ`` in order to select only the tests that correspond to this dimensionality
 * ``export WARPX_TEST_ARCH=CPU`` or ``export WARPX_TEST_ARCH=GPU`` in order to run the tests on CPU or GPU respectively.
-* ``export WARPX_TEST_COMMIT=...`` in order to test a specific commit.
 
 The command above (without command line arguments) runs all the tests defined in [Regression/WarpX-tests.ini](./Regression/WarpX-tests.ini). In order to run single tests, pass the test names as command line arguments:
 

--- a/Tools/Release/updateAMReX.py
+++ b/Tools/Release/updateAMReX.py
@@ -100,9 +100,9 @@ run_test_path = str(REPO_DIR.joinpath("run_test.sh"))
 with open(run_test_path, encoding='utf-8') as f:
     run_test_content = f.read()
     #   branch/commit/tag (git fetcher) version
-    #     git clone --branch development https://github.com/AMReX-Codes/amrex.git
+    #     cd amrex && git checkout COMMIT_TAG_OR_BRANCH && cd -
     run_test_content = re.sub(
-        r'(.*git\s+clone\s+\-\-branch\s+)(.+)(\s+https://github\.com/AMReX\-Codes/amrex\.git)',
+        r'(.*cd\s+amrex.+git checkout\s+)(.+)(\s+&&\s.*)',
         r'\g<1>{}\g<3>'.format(amrex_new_branch),
         run_test_content, flags = re.MULTILINE)
 

--- a/Tools/Release/updatePICSAR.py
+++ b/Tools/Release/updatePICSAR.py
@@ -100,9 +100,9 @@ run_test_path = str(REPO_DIR.joinpath("run_test.sh"))
 with open(run_test_path, encoding='utf-8') as f:
     run_test_content = f.read()
     #   branch/commit/tag (git fetcher) version
-    #     git clone --branch development https://github.com/PICSAR-Codes/PICSAR.git
+    #     cd picsar && git checkout COMMIT_TAG_OR_BRANCH && cd -
     run_test_content = re.sub(
-        r'(.*git\s+clone\s+\-\-branch\s+)(.+)(\s+https://github\.com/ECP\-WarpX/picsar\.git)',
+        r'(.*cd\s+picsar.+git checkout\s+)(.+)(\s+&&\s.*)',
         r'\g<1>{}\g<3>'.format(PICSAR_new_branch),
         run_test_content, flags = re.MULTILINE)
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -70,8 +70,8 @@ cd ../../regression_testing/
 echo "cd $PWD"
 # run only tests specified in variable tests_arg (single test or multiple tests)
 if [[ ! -z "${tests_arg}" ]]; then
-  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT} "${tests_run}"
+  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all "${tests_run}"
 # run all tests (variables tests_arg and tests_run are empty)
 else
-  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all --source_git_hash=${WARPX_TEST_COMMIT}
+  python regtest.py ../rt-WarpX/travis-tests.ini --no_update all
 fi

--- a/run_test.sh
+++ b/run_test.sh
@@ -21,6 +21,8 @@
 # Use `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order
 # to run the tests on CPU or GPU respectively.
 
+set -eu -o pipefail
+
 # Parse command line arguments: if test names are given as command line arguments,
 # store them in variable tests_arg and define new command line argument to call
 # regtest.py with option --tests (works also for single test)

--- a/run_test.sh
+++ b/run_test.sh
@@ -50,9 +50,11 @@ cd test_dir
 echo "cd $PWD"
 
 # Clone PICSAR and AMReX
-git clone --branch e611121acca7696320f3757982de857cbab74926 https://github.com/AMReX-Codes/amrex.git
+git clone https://github.com/AMReX-Codes/amrex.git
+cd amrex && git checkout e611121acca7696320f3757982de857cbab74926 && cd -
 # Use QED brach for QED tests
-git clone --branch b35f07243c51ac35d47857fe36f0aafb6b517955 https://github.com/ECP-WarpX/picsar.git
+git clone https://github.com/ECP-WarpX/picsar.git
+cd picsar && git checkout b35f07243c51ac35d47857fe36f0aafb6b517955 && cd -
 
 # Clone the AMReX regression test utility
 git clone https://github.com/ECP-WarpX/regression_testing.git


### PR DESCRIPTION
`run_test.sh`:
- [x] fail on error
- [x] remove unused / obfuscating commit parameters for `regtest.py` (also: unbound bash variables)
- [x] fix git clone of a `sha` (follow-up to #1710, fixing bug introduced therein)