### PR TITLE
Boundary input - Periodic

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -181,6 +181,29 @@ Setting up the field mesh
     When using the RZ version, this is the number of azimuthal modes.
 
 .. _running-cpp-parameters-parallelization:
+Domain Boundary Conditions
+--------------------------
+
+* ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
+    Boundary conditions applied to field at the lower and upper domain boundaries.
+    Options are:
+    * ``PEC``: This option can be used to simulate a perfect conductor or a metallic surface,
+               where, the tangential electric field is zero, and normal magnetic field is zero.
+               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``. This option is currently not supported through this interface. 
+    * ``PMC``: This option can be used to apply a perfect magnetic conductor or a symmetry boundary for the fields, where, the tangential magnetic field is zero and the normal electric field is zero.
+               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``.
+    * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input field, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
+    * ``PML``: This option can be used to absorb fields at the domain boundary. Note that, this will override the ``do_pml`` option. Additional pml parameters, such as ``do_pml_in_domain``, ``pml_ncell``, and ``pml_delta`` can be set by the user. Note that particles boundary must be consistent with the field, and set to absorbing/open. For particles, additional pml parameters include ``pml_has_particles`` and ``do_pml_j_damping``. This option is currently not supported through this interface.
+    
+* ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
+    Boundary conditions applied to particles at the lower and upper domain boundaries.
+    Options are:
+    * ``Reflecting``: Particles leaving the boundary will be reflected. This option is currently not supported.
+    * ``Periodic``: Particles leaving the boundary will re-enter from the opposite boundary. The field boundary condition must be consistenly set to periodic and both lower and upper boundaries must be periodic.
+    * ``Open``: Particles leaving the boundary will be deleted. This option is not supported through this interface currently.
+    * ``Absorbing``: Particles leaving the boundary will be absorbed. Additional pml parameters include ``pml_has_particles`` and ``do_pml_j_damping``. This option is currently not supported through this interface.
+
+.. _running-cpp-parameters-parallelization:
 
 Distribution across MPI ranks and parallelization
 -------------------------------------------------

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -187,7 +187,7 @@ Domain Boundary Conditions
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Boundary conditions applied to field at the lower and upper domain boundaries.
     Options are:
-    * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input field, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
+    * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -187,21 +187,11 @@ Domain Boundary Conditions
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Boundary conditions applied to field at the lower and upper domain boundaries.
     Options are:
-    * ``PEC``: This option can be used to simulate a perfect conductor or a metallic surface,
-               where, the tangential electric field is zero, and normal magnetic field is zero.
-               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``. This option is currently not supported through this interface.
-    * ``PMC``: This option can be used to apply a perfect magnetic conductor or a symmetry boundary for the fields, where, the tangential magnetic field is zero and the normal electric field is zero.
-               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``.
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input field, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
-    * ``PML``: This option can be used to absorb fields at the domain boundary. Note that, this will override the ``do_pml`` option. Additional pml parameters, such as ``do_pml_in_domain``, ``pml_ncell``, and ``pml_delta`` can be set by the user. Note that particles boundary must be consistent with the field, and set to absorbing/open. For particles, additional pml parameters include ``pml_has_particles`` and ``do_pml_j_damping``. This option is currently not supported through this interface.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
-    Boundary conditions applied to particles at the lower and upper domain boundaries.
     Options are:
-    * ``Reflecting``: Particles leaving the boundary will be reflected. This option is currently not supported.
     * ``Periodic``: Particles leaving the boundary will re-enter from the opposite boundary. The field boundary condition must be consistenly set to periodic and both lower and upper boundaries must be periodic.
-    * ``Open``: Particles leaving the boundary will be deleted. This option is not supported through this interface currently.
-    * ``Absorbing``: Particles leaving the boundary will be absorbed. Additional pml parameters include ``pml_has_particles`` and ``do_pml_j_damping``. This option is currently not supported through this interface.
 
 .. _running-cpp-parameters-parallelization:
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -189,12 +189,12 @@ Domain Boundary Conditions
     Options are:
     * ``PEC``: This option can be used to simulate a perfect conductor or a metallic surface,
                where, the tangential electric field is zero, and normal magnetic field is zero.
-               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``. This option is currently not supported through this interface. 
+               Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``. This option is currently not supported through this interface.
     * ``PMC``: This option can be used to apply a perfect magnetic conductor or a symmetry boundary for the fields, where, the tangential magnetic field is zero and the normal electric field is zero.
                Note that the particle boundary must be selected to be consistent with this option using ``boundary.particle_lo`` and ``boundary.particle_hi``.
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input field, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
     * ``PML``: This option can be used to absorb fields at the domain boundary. Note that, this will override the ``do_pml`` option. Additional pml parameters, such as ``do_pml_in_domain``, ``pml_ncell``, and ``pml_delta`` can be set by the user. Note that particles boundary must be consistent with the field, and set to absorbing/open. For particles, additional pml parameters include ``pml_has_particles`` and ``do_pml_j_damping``. This option is currently not supported through this interface.
-    
+
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Boundary conditions applied to particles at the lower and upper domain boundaries.
     Options are:

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -91,8 +91,9 @@ struct LoadBalanceCostsUpdateAlgo {
     };
 };
 
-
-struct BoundaryType {
+/** Field boundary conditions at the domain boundary
+ */
+struct FieldBoundaryType {
     enum {
         PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
         Periodic = 1,
@@ -101,10 +102,24 @@ struct BoundaryType {
     };
 };
 
+/** Field boundary conditions at the domain boundary
+ */
+struct ParticleBoundaryType {
+    enum {
+        Absorbing = 0,     //!< particles crossing domain boundary are removed
+        Open = 1,          //!< particles cross domain boundary leave with damped j
+        Reflecting = 2,     //!< particles are reflected
+        Periodic = 3
+    };
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
 
+/** Select BC Type for fields, if field=true
+ *  else select BCType for particles.
+ */
 int
-GetBCTypeInteger( std::string BCType );
+GetBCTypeInteger( std::string BCType, bool field );
 
 #endif // UTILS_WARPXALGORITHMSELECTION_H_

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -102,7 +102,7 @@ struct FieldBoundaryType {
     };
 };
 
-/** Field boundary conditions at the domain boundary
+/** Particle boundary conditions at the domain boundary
  */
 struct ParticleBoundaryType {
     enum {

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -91,7 +91,20 @@ struct LoadBalanceCostsUpdateAlgo {
     };
 };
 
+
+struct BoundaryType {
+    enum {
+        PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
+        Periodic = 1,
+        PML = 2,
+        PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
+    };
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
+
+int
+GetBCTypeInteger( std::string BCType );
 
 #endif // UTILS_WARPXALGORITHMSELECTION_H_

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -154,7 +154,7 @@ GetBCTypeInteger( std::string BCType, bool field ){
     else BCType_to_int = ParticleBCType_algo_to_int; // set particle boundary
 
     if (BCType_to_int.count(BCType) == 0) {
-        std::string error_message = "Invalid string for Field BC. : " + BCType                         + "\nThe valid values are : \n";
+        std::string error_message = "Invalid string for field/particle BC. : " + BCType                         + "\nThe valid values are : \n";
         for (const auto &valid_pair : BCType_to_int) {
             if (valid_pair.first != "default"){
                 error_message += " - " + valid_pair.first + "\n";

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -74,12 +74,20 @@ const std::map<std::string, int> MacroscopicSolver_algo_to_int = {
     {"default", MacroscopicSolverAlgo::BackwardEuler}
 };
 
-const std::map<std::string, int> BCType_algo_to_int = {
-    {"pec",      BoundaryType::PEC},
-    {"periodic", BoundaryType::Periodic},
-    {"pml",      BoundaryType::PML},
-    {"pmc",      BoundaryType::PMC},
-    {"default",  BoundaryType::PEC}
+const std::map<std::string, int> FieldBCType_algo_to_int = {
+    {"pec",      FieldBoundaryType::PEC},
+    {"periodic", FieldBoundaryType::Periodic},
+    {"pml",      FieldBoundaryType::PML},
+    {"pmc",      FieldBoundaryType::PMC},
+    {"default",  FieldBoundaryType::PEC}
+};
+
+const std::map<std::string, int> ParticleBCType_algo_to_int = {
+    {"absorbing",  ParticleBoundaryType::Absorbing},
+    {"open",       ParticleBoundaryType::Open},
+    {"reflecting", ParticleBoundaryType::Reflecting},
+    {"periodic",   ParticleBoundaryType::Periodic},
+    {"default",    ParticleBoundaryType::Absorbing}
 };
 
 int
@@ -137,12 +145,13 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
 }
 
 int
-GetBCTypeInteger( std::string BCType ){
+GetBCTypeInteger( std::string BCType, bool field ){
     std::transform(BCType.begin(), BCType.end(), BCType.begin(), ::tolower);
 
     std::map<std::string, int> BCType_to_int;
 
-    BCType_to_int = BCType_algo_to_int;
+    if (field) BCType_to_int = FieldBCType_algo_to_int; // set field boundary
+    else BCType_to_int = ParticleBCType_algo_to_int; // set particle boundary
 
     if (BCType_to_int.count(BCType) == 0) {
         std::string error_message = "Invalid string for Field BC. : " + BCType                         + "\nThe valid values are : \n";

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -71,7 +71,15 @@ const std::map<std::string, int> MaxwellSolver_medium_algo_to_int = {
 const std::map<std::string, int> MacroscopicSolver_algo_to_int = {
     {"backwardeuler", MacroscopicSolverAlgo::BackwardEuler},
     {"laxwendroff", MacroscopicSolverAlgo::LaxWendroff},
-    {"default", MacroscopicSolverAlgo::BackwardEuler},
+    {"default", MacroscopicSolverAlgo::BackwardEuler}
+};
+
+const std::map<std::string, int> BCType_algo_to_int = {
+    {"pec",      BoundaryType::PEC},
+    {"periodic", BoundaryType::Periodic},
+    {"pml",      BoundaryType::PML},
+    {"pmc",      BoundaryType::PMC},
+    {"default",  BoundaryType::PEC}
 };
 
 int
@@ -126,4 +134,24 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
 
     // If the input is a valid key, return the value
     return algo_to_int[algo];
+}
+
+int
+GetBCTypeInteger( std::string BCType ){
+    std::transform(BCType.begin(), BCType.end(), BCType.begin(), ::tolower);
+
+    std::map<std::string, int> BCType_to_int;
+
+    BCType_to_int = BCType_algo_to_int;
+
+    if (BCType_to_int.count(BCType) == 0) {
+        std::string error_message = "Invalid string for Field BC. : " + BCType                         + "\nThe valid values are : \n";
+        for (const auto &valid_pair : BCType_to_int) {
+            if (valid_pair.first != "default"){
+                error_message += " - " + valid_pair.first + "\n";
+            }
+        }
+        amrex::Abort(error_message);
+    }
+    return BCType_to_int[BCType];
 }

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -26,6 +26,11 @@ void ReadBoostedFrameParameters(amrex::Real& gamma_boost, amrex::Real& beta_boos
 void ConvertLabParamsToBoost();
 
 /**
+ * Reads the user-defined field and particle boundary condition parameters
+ */
+void ReadBCParams ();
+
+/**
  * \brief Ensures that the blocks are setup correctly for the RZ spectral solver
  */
 void CheckGriddingForRZSpectral();

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -405,7 +405,6 @@ void ReadBCParams ()
                 // set particle boundary to periodic
                 WarpX::particle_boundary_lo[idim] = ParticleBoundaryType::Periodic;
                 WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
-                amrex::Warning("Particle boundary is set to periodic to be consistent with the fields.");
             }
 
         }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -379,11 +379,11 @@ void ReadBCParams ()
     AMREX_ALWAYS_ASSERT(particle_BC_hi.size() == AMREX_SPACEDIM);
 
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        WarpX::field_boundary_lo[idim] = GetBCTypeInteger(field_BC_lo[idim]); 
+        WarpX::field_boundary_lo[idim] = GetBCTypeInteger(field_BC_lo[idim]);
         WarpX::field_boundary_hi[idim] = GetBCTypeInteger(field_BC_hi[idim]);
-        WarpX::particle_boundary_lo[idim] = GetBCTypeInteger(particle_BC_lo[idim]); 
+        WarpX::particle_boundary_lo[idim] = GetBCTypeInteger(particle_BC_lo[idim]);
         WarpX::particle_boundary_hi[idim] = GetBCTypeInteger(particle_BC_hi[idim]);
-         
+
         if (WarpX::field_boundary_lo[idim] == BoundaryType::Periodic ||
             WarpX::field_boundary_hi[idim] == BoundaryType::Periodic) {
             geom_periodicity[idim] = 1;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -137,6 +137,11 @@ public:
     static long load_balance_costs_update_algo;
     static int em_solver_medium;
     static int macroscopic_solver_algo;
+    static amrex::Vector<int> field_boundary_lo;
+    static amrex::Vector<int> field_boundary_hi;
+    static amrex::Vector<int> particle_boundary_lo;
+    static amrex::Vector<int> particle_boundary_hi;
+
 
     // PSATD: If true (overwritten by the user in the input file), the current correction
     // defined in equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010 is applied

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -78,6 +78,10 @@ long WarpX::load_balance_costs_update_algo;
 int WarpX::do_dive_cleaning = 0;
 int WarpX::em_solver_medium;
 int WarpX::macroscopic_solver_algo;
+amrex::Vector<int> WarpX::field_boundary_lo(AMREX_SPACEDIM,0);
+amrex::Vector<int> WarpX::field_boundary_hi(AMREX_SPACEDIM,0);
+amrex::Vector<int> WarpX::particle_boundary_lo(AMREX_SPACEDIM,0);
+amrex::Vector<int> WarpX::particle_boundary_hi(AMREX_SPACEDIM,0);
 
 int WarpX::n_rz_azimuthal_modes = 1;
 int WarpX::ncomps = 1;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char* argv[])
 #endif
 
     ConvertLabParamsToBoost();
+    ReadBCParams();
 
 #ifdef WARPX_DIM_RZ
     CheckGriddingForRZSpectral();


### PR DESCRIPTION
This PR is a first in a series to follow to enhance boundary condition.
In this PR, a new user-defined input for field and particle boundary is introduced.
The idea is to support  (https://github.com/ECP-WarpX/WarpX/projects/14)
1. pec
2. pmc 
3. periodic
4. pml
The implementation will override `geometry.is_periodic`. 
Until all the above boundary condition support is added, if the user has specified 'geometry.is_periodic', then the `boundary.field_lo` and `boudnary.field_hi` will not be parsed.
Once, we have the pec,  pmc, pml all supported through the new `boundary.` interface, I will change the input scripts for all the CI-tests and expose the Abort added to the code, to ensure `is_periodic` is not used.

```
##########################################
###### Boundary Condition ################
##########################################
boundary.field_lo =periodic periodic periodic
boundary.field_hi =periodic periodic periodic
boundary.particle_lo = periodic periodic periodic
boundary.particle_hi = periodic periodic periodic
```

I have tested the PR for periodic boundaries for fields and particles

**Field periodicity test:
[test_field_periodicity.txt](https://github.com/ECP-WarpX/WarpX/files/6025010/test_field_periodicity.txt)


![periodic_BC_Ey](https://user-images.githubusercontent.com/41089244/108768147-2a9e3200-750c-11eb-8530-0dfb600e1e9f.gif)


**particle periodicity test
[inputs_test_particleAndField_periodicity.txt](https://github.com/ECP-WarpX/WarpX/files/6025017/inputs_test_particleAndField_periodicity.txt)
![particles_periodic](https://user-images.githubusercontent.com/41089244/108768194-3853b780-750c-11eb-8513-e3527c026432.gif)




