### PR TITLE
[mini-PR] fix bug in libensemble script

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/AvgGalileanAlgorithm.H
@@ -19,7 +19,7 @@ class AvgGalileanAlgorithm : public SpectralBaseAlgorithm
         virtual void pushSpectralFields (SpectralFieldData& f) const override final;
         virtual int getRequiredNumberOfFields () const override final {
              return SpectralAvgFieldIndex::n_fields;
-        };
+        }
         void InitializeSpectralCoefficients(
            const SpectralKSpace& spectral_kspace,
            const amrex::DistributionMapping& dm,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/ComovingPsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/ComovingPsatdAlgorithm.H
@@ -33,7 +33,7 @@ class ComovingPsatdAlgorithm : public SpectralBaseAlgorithm
         virtual int getRequiredNumberOfFields () const override final
         {
             return SpectralFieldIndex::n_fields;
-        };
+        }
 
         /* \brief Initialize the coefficients needed in the update equations
          */

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanAlgorithm.H
@@ -21,7 +21,7 @@ class GalileanAlgorithm : public SpectralBaseAlgorithm
         virtual void pushSpectralFields (SpectralFieldData& f) const override final;
         virtual int getRequiredNumberOfFields () const override final {
             return SpectralFieldIndex::n_fields;
-        };
+        }
         void InitializeSpectralCoefficients (const SpectralKSpace& spectral_kspace,
                                              const amrex::DistributionMapping& dm,
                                              const amrex::Real dt);

--- a/Tools/LibEnsemble/run_libensemble_on_warpx.py
+++ b/Tools/LibEnsemble/run_libensemble_on_warpx.py
@@ -32,7 +32,7 @@ if generator_type == 'random':
         import give_sim_work_first as alloc_f
 elif generator_type == 'aposmm':
     import libensemble.gen_funcs
-    libensemble.gen_funcs.rc.aposmm_optimizer = 'nlopt'
+    libensemble.gen_funcs.rc.aposmm_optimizers = 'nlopt'
     from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
     from libensemble.alloc_funcs.persistent_aposmm_alloc \
         import persistent_aposmm_alloc as alloc_f


### PR DESCRIPTION
This PR fixes a bug in `Tools/LibEnsemble/run_libensemble_on_warpx.py` which resulted in `libensemble` trying to load all the possible solvers (`PETSc`, `scipy` ...) instead of just `nlopt`. This is an issue since some of these solvers (such as `PETSc`) have several additional dependencies.