### PR TITLE
Split Cartesian tests across 2 CI workers

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,8 +15,10 @@ jobs:
 
   strategy:
     matrix:
-      cartesian:
-        WARPX_CI_REGULAR_CARTESIAN: 'TRUE'
+      cartesian2d:
+        WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
+      cartesian3d:
+        WARPX_CI_REGULAR_CARTESIAN_3D: 'TRUE'
       psatd:
         WARPX_CI_PSATD: 'TRUE'
       python:

--- a/.github/workflows/source/test_travis_matrix.sh
+++ b/.github/workflows/source/test_travis_matrix.sh
@@ -10,8 +10,10 @@ python prepare_file_travis.py
 grep "\[" travis-tests.ini > travis_all_tests.txt
 
 # Concatenate the names of all elements in Travis matrix into another test file
-WARPX_CI_REGULAR_CARTESIAN=TRUE python prepare_file_travis.py
+WARPX_CI_REGULAR_CARTESIAN_2D=TRUE python prepare_file_travis.py
 grep "\[" travis-tests.ini >  travis_matrix_elements.txt
+WARPX_CI_REGULAR_CARTESIAN_3D=TRUE python prepare_file_travis.py
+grep "\[" travis-tests.ini >>  travis_matrix_elements.txt
 WARPX_CI_PSATD=TRUE             python prepare_file_travis.py
 grep "\[" travis-tests.ini >> travis_matrix_elements.txt
 WARPX_CI_PYTHON_MAIN=TRUE       python prepare_file_travis.py

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -15,7 +15,8 @@ import os
 # Get relevant environment variables
 arch = os.environ.get('WARPX_TEST_ARCH', 'CPU')
 
-ci_regular_cartesian = os.environ.get('WARPX_CI_REGULAR_CARTESIAN') == 'TRUE'
+ci_regular_cartesian_2d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_2D') == 'TRUE'
+ci_regular_cartesian_3d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_3D') == 'TRUE'
 ci_psatd = os.environ.get('WARPX_CI_PSATD') == 'TRUE'
 ci_python_main = os.environ.get('WARPX_CI_PYTHON_MAIN') == 'TRUE'
 ci_single_precision = os.environ.get('WARPX_CI_SINGLE_PRECISION') == 'TRUE'
@@ -98,7 +99,17 @@ def select_tests(blocks, match_string_list, do_test):
             blocks = [ block for block in blocks if match_string in block ]
     return blocks
 
-if ci_regular_cartesian:
+if ci_regular_cartesian_2d:
+    test_blocks = select_tests(test_blocks, ['dim = 2'], True)
+    test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
+    test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], False)
+    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
+    test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
+    test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
+    test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
+
+if ci_regular_cartesian_3d:
+    test_blocks = select_tests(test_blocks, ['dim = 2'], False)
     test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['USE_PSATD=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)


### PR DESCRIPTION
This should allow the CI to complete without a time-out.
Each 2D and 3D Cartesian contain one `make` build.

Check
- [ ] before this PR in `Cartesian`: ... runs
- [ ] after this PR in 2D: ... and 3D: ... runs