### PR TITLE
Fix libEnsemble: optimizer selection

### DIFF
--- a/Tools/LibEnsemble/run_libensemble_on_warpx.py
+++ b/Tools/LibEnsemble/run_libensemble_on_warpx.py
@@ -32,7 +32,7 @@ if generator_type == 'random':
         import give_sim_work_first as alloc_f
 elif generator_type == 'aposmm':
     import libensemble.gen_funcs
-    libensemble.gen_funcs.rc.aposmm_optimizer = 'nlopt'
+    libensemble.gen_funcs.rc.aposmm_optimizers = 'nlopt'
     from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
     from libensemble.alloc_funcs.persistent_aposmm_alloc \
         import persistent_aposmm_alloc as alloc_f


### PR DESCRIPTION
This PR fixes a bug in `Tools/LibEnsemble/run_libensemble_on_warpx.py` which resulted in `libensemble` trying to load all the possible solvers (`PETSc`, `scipy` ...) instead of just `nlopt`. This is an issue since some of these solvers (such as `PETSc`) have several additional dependencies.