### PR TITLE
[WIP] GH Action: Run Compilers After Source

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,10 @@
 name: macOS build
 
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: ["source"]
+    types:
+      - completed
 
 jobs:
   build_gcc9:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,10 @@
 name: Ubuntu build
 
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: ["source"]
+    types:
+      - completed
 
 jobs:
   build_cxxminimal:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,10 @@
 name: windows
 
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: ["source"]
+    types:
+      - completed
 
 jobs:
   build_win_msvc:


### PR DESCRIPTION
Only run GH Actions that do compiler coverage tests after the source checks have passed.

Does not yet trigger Azure actions on the same dependency.