### PR TITLE
CI (Nightly): Spack py-warpx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,9 +248,11 @@ jobs:
       git clone https://github.com/spack/spack.git
       . spack/share/spack/setup-env.sh
       spack compiler find
-      spack install -v --fail-fast warpx %gcc@9.3.0
+      spack install -v --fail-fast py-warpx %gcc@9.3.0
+      spack install -v --fail-fast py-warpx %gcc@9.3.0 ^warpx dims=2
+      spack install -v --fail-fast py-warpx %gcc@9.3.0 ^warpx dims=rz
 
-      spack load -r warpx
+      spack load -r py-warpx ^warpx dims=rz
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
 #      warpx.3d.MPI.OMP.DP.OPMD.QED
 #      warpx.RZ.MPI.OMP.DP.OPMD.QED
@@ -266,9 +268,10 @@ jobs:
       git clone https://github.com/spack/spack.git
       . spack/share/spack/setup-env.sh
       spack compiler find
-      spack install -v --fail-fast warpx -mpi
+      spack install -v --fail-fast py-warpx -mpi
+      spack install -v --fail-fast py-warpx -mpi ^warpx dims=rz
 
-      spack load -r pywarpx
+      spack load -r py-warpx ^warpx dims=rz
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
 #      warpx.3d.MPI.OMP.DP.OPMD.QED
 #      warpx.RZ.MPI.OMP.DP.OPMD.QED
@@ -289,7 +292,7 @@ jobs:
 #      spack compiler find
 #      spack bootstrap
 #      . spack/share/spack/setup-env.sh
-#      spack install -v --fail-fast warpx +qed +openpmd %gcc@9.3.0
+#      spack install -v --fail-fast py-warpx ^warpx +qed +openpmd %gcc@9.3.0
 #
 #      spack load -r warpx
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
@@ -656,8 +659,10 @@ jobs:
       git clone https://github.com/spack/spack.git
       . spack/share/spack/setup-env.sh
       spack compiler find
-      spack install -v --fail-fast warpx
-      spack load warpx
+      spack install -v --fail-fast py-warpx
+      spack install -v --fail-fast py-warpx ^warpx dims=2
+      spack install -v --fail-fast py-warpx ^warpx dims=rz
+      spack load py-warpx ^warpx dims=rz
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
 #      warpx.3d.MPI.OMP.DP.OPMD.QED
 #      warpx.RZ.MPI.OMP.DP.OPMD.QED
@@ -673,8 +678,9 @@ jobs:
       git clone https://github.com/spack/spack.git
       . spack/share/spack/setup-env.sh
       spack compiler find
-      spack install -v --fail-fast warpx@develop -mpi
-      spack load -r warpx
+      spack install -v --fail-fast py-warpx@develop -mpi
+      spack install -v --fail-fast py-warpx@develop -mpi ^warpx dims=rz
+      spack load -r py-warpx ^warpx dims=rz
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
 #      warpx.3d.MPI.OMP.DP.OPMD.QED
 #      warpx.RZ.MPI.OMP.DP.OPMD.QED
@@ -691,7 +697,7 @@ jobs:
 #      git clone https://github.com/spack/spack.git
 #      . spack/share/spack/setup-env.sh
 #      spack compiler find
-#      spack install -v --fail-fast warpx +qed +openpmd
+#      spack install -v --fail-fast py-warpx ^warpx +qed +openpmd
 #      spack load -r warpx
 #      warpx.2d.MPI.OMP.DP.OPMD.QED
 #      warpx.3d.MPI.OMP.DP.OPMD.QED


### PR DESCRIPTION
We now have a
- `warpx` and
- `py-warpx`

package in Spack.

Installing the latter will test basically all functionality.

- [x] @dpgrote @RemiLehe please approve https://github.com/spack/spack/pull/21787 first, then it gets merged, and then we can merge this PR.