### PR TITLE
QEDInternals: replace amrex::Real with amrex::ParticleReal where appropriate

### DIFF
--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -240,12 +240,12 @@ public:
         const auto chi_photon = QedUtils::chi_photon(
             px, py, pz, ex, ey, ez, bx, by, bz);
 
-        const auto momentum_photon = pxr_m::vec3<amrex::Real>{px, py, pz};
-        auto momentum_ele = pxr_m::vec3<amrex::Real>();
-        auto momentum_pos = pxr_m::vec3<amrex::Real>();
+        const auto momentum_photon = pxr_m::vec3<amrex::ParticleReal>{px, py, pz};
+        auto momentum_ele = pxr_m::vec3<amrex::ParticleReal>();
+        auto momentum_pos = pxr_m::vec3<amrex::ParticleReal>();
 
         const auto is_out = pxr_bw::generate_breit_wheeler_pairs<
-            amrex::Real,
+            amrex::ParticleReal,
             BW_pair_prod_table_view,
             pxr_p::unit_system::SI>(
                 chi_photon, momentum_photon,

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -110,7 +110,7 @@ public:
      */
     BreitWheelerEvolveOpticalDepth (
         const BW_dndt_table_view table_view,
-        const amrex::ParticleReal bw_minimum_chi_phot):
+        const amrex::Real bw_minimum_chi_phot):
         m_table_view{table_view}, m_bw_minimum_chi_phot{bw_minimum_chi_phot}{}
 
     /**
@@ -130,10 +130,12 @@ public:
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     int operator()(
-        const amrex::Real ux, const amrex::Real uy, const amrex::Real uz,
-        const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
-        const amrex::Real bx, const amrex::Real by, const amrex::Real bz,
-        const amrex::Real dt, amrex::Real& opt_depth) const noexcept
+        const amrex::ParticleReal ux, const amrex::ParticleReal uy,
+        const amrex::ParticleReal uz, const amrex::ParticleReal ex,
+        const amrex::ParticleReal ey, const amrex::ParticleReal ez,
+        const amrex::ParticleReal bx, const amrex::ParticleReal by,
+        const amrex::ParticleReal bz, const amrex::ParticleReal dt,
+        amrex::ParticleReal& opt_depth) const noexcept
     {
         namespace pxr_m = picsar::multi_physics::math;
         namespace pxr_p = picsar::multi_physics::phys;
@@ -165,7 +167,7 @@ public:
 
 private:
     BW_dndt_table_view m_table_view;
-    amrex::ParticleReal m_bw_minimum_chi_phot;
+    amrex::Real m_bw_minimum_chi_phot;
 };
 
 /**
@@ -209,11 +211,14 @@ public:
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     int operator()(
-    const amrex::Real ux, const amrex::Real uy, const amrex::Real uz,
-    const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
-    const amrex::Real bx, const amrex::Real by, const amrex::Real bz,
-    amrex::Real& e_ux, amrex::Real& e_uy, amrex::Real& e_uz,
-    amrex::Real& p_ux, amrex::Real& p_uy, amrex::Real& p_uz,
+    const amrex::ParticleReal ux, const amrex::ParticleReal uy,
+    const amrex::ParticleReal uz, const amrex::ParticleReal ex,
+    const amrex::ParticleReal ey, const amrex::ParticleReal ez,
+    const amrex::ParticleReal bx, const amrex::ParticleReal by,
+    const amrex::ParticleReal bz, amrex::ParticleReal& e_ux,
+    amrex::ParticleReal& e_uy, amrex::ParticleReal& e_uz,
+    amrex::ParticleReal& p_ux, amrex::ParticleReal& p_uy,
+    amrex::ParticleReal& p_uz,
     amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -134,7 +134,7 @@ public:
         const amrex::ParticleReal uz, const amrex::ParticleReal ex,
         const amrex::ParticleReal ey, const amrex::ParticleReal ez,
         const amrex::ParticleReal bx, const amrex::ParticleReal by,
-        const amrex::ParticleReal bz, const amrex::ParticleReal dt,
+        const amrex::ParticleReal bz, const amrex::Real dt,
         amrex::ParticleReal& opt_depth) const noexcept
     {
         namespace pxr_m = picsar::multi_physics::math;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -89,7 +89,7 @@ BreitWheelerEngine::init_lookup_tables_from_raw_data (
 }
 
 void BreitWheelerEngine::init_builtin_tables(
-    const amrex::ParticleReal bw_minimum_chi_phot)
+    const amrex::Real bw_minimum_chi_phot)
 {
     init_builtin_dndt_table();
     init_builtin_pair_prod_table();

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -123,8 +123,8 @@ BreitWheelerEngine::get_default_ctrl() const
 {
     namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
     return PicsarBreitWheelerCtrl{
-        pxr_bw::default_dndt_lookup_table_params<amrex::ParticleReal>,
-        pxr_bw::default_pair_prod_lookup_table_params<amrex::ParticleReal>
+        pxr_bw::default_dndt_lookup_table_params<amrex::Real>,
+        pxr_bw::default_pair_prod_lookup_table_params<amrex::Real>
     };
 }
 

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -61,7 +61,7 @@ bool BreitWheelerEngine::are_lookup_tables_initialized () const
 bool
 BreitWheelerEngine::init_lookup_tables_from_raw_data (
     const vector<char>& raw_data,
-    const amrex::Real bw_minimum_chi_phot)
+    const amrex::ParticleReal bw_minimum_chi_phot)
 {
     auto raw_iter = raw_data.begin();
     const auto size_first = pxr_sr::get_out<uint64_t>(raw_iter);
@@ -89,7 +89,7 @@ BreitWheelerEngine::init_lookup_tables_from_raw_data (
 }
 
 void BreitWheelerEngine::init_builtin_tables(
-    const amrex::Real bw_minimum_chi_phot)
+    const amrex::ParticleReal bw_minimum_chi_phot)
 {
     init_builtin_dndt_table();
     init_builtin_pair_prod_table();
@@ -123,8 +123,8 @@ BreitWheelerEngine::get_default_ctrl() const
 {
     namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
     return PicsarBreitWheelerCtrl{
-        pxr_bw::default_dndt_lookup_table_params<amrex::Real>,
-        pxr_bw::default_pair_prod_lookup_table_params<amrex::Real>
+        pxr_bw::default_dndt_lookup_table_params<amrex::ParticleReal>,
+        pxr_bw::default_pair_prod_lookup_table_params<amrex::ParticleReal>
     };
 }
 
@@ -192,7 +192,7 @@ void BreitWheelerEngine::init_builtin_pair_prod_table()
     pair_prod_params.chi_phot_how_many = 64;
     pair_prod_params.frac_how_many = 64;
 
-    const auto vals = amrex::Gpu::DeviceVector<amrex::Real>{
+    const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{
         0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt,
         0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt, 3.35120e-221_rt,
         1.13067e-188_rt, 2.14228e-163_rt, 3.39948e-143_rt, 1.09215e-126_rt,

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -192,7 +192,7 @@ void BreitWheelerEngine::init_builtin_pair_prod_table()
     pair_prod_params.chi_phot_how_many = 64;
     pair_prod_params.frac_how_many = 64;
 
-    const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{
+    const auto vals = amrex::Gpu::DeviceVector<amrex::Real>{
         0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt,
         0.00000e+00_rt, 0.00000e+00_rt, 0.00000e+00_rt, 3.35120e-221_rt,
         1.13067e-188_rt, 2.14228e-163_rt, 3.39948e-143_rt, 1.09215e-126_rt,

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -61,7 +61,7 @@ bool BreitWheelerEngine::are_lookup_tables_initialized () const
 bool
 BreitWheelerEngine::init_lookup_tables_from_raw_data (
     const vector<char>& raw_data,
-    const amrex::ParticleReal bw_minimum_chi_phot)
+    const amrex::Real bw_minimum_chi_phot)
 {
     auto raw_iter = raw_data.begin();
     const auto size_first = pxr_sr::get_out<uint64_t>(raw_iter);

--- a/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
@@ -33,7 +33,7 @@ namespace QedUtils{
         const amrex::ParticleReal pz, const amrex::ParticleReal ex,
         const amrex::ParticleReal ey, const amrex::ParticleReal ez,
         const amrex::ParticleReal bx, const amrex::ParticleReal by,
-        const amrex::RealParticleReal bz)
+        const amrex::ParticleReal bz)
     {
         namespace pxr_p = picsar::multi_physics::phys;
         return pxr_p::chi_photon<amrex::Real, pxr_p::unit_system::SI>(

--- a/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
@@ -29,9 +29,11 @@ namespace QedUtils{
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real chi_photon(
-        const amrex::Real px, const amrex::Real py, const amrex::Real pz,
-        const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
-        const amrex::Real bx, const amrex::Real by, const amrex::Real bz)
+        const amrex::ParticleReal px, const amrex::ParticleReal py,
+        const amrex::ParticleReal pz, const amrex::ParticleReal ex,
+        const amrex::ParticleReal ey, const amrex::ParticleReal ez,
+        const amrex::ParticleReal bx, const amrex::ParticleReal by,
+        const amrex::RealParticleReal bz)
     {
         namespace pxr_p = picsar::multi_physics::phys;
         return pxr_p::chi_photon<amrex::Real, pxr_p::unit_system::SI>(
@@ -49,9 +51,11 @@ namespace QedUtils{
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real chi_ele_pos(
-        const amrex::Real px, const amrex::Real py, const amrex::Real pz,
-        const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
-        const amrex::Real bx, const amrex::Real by, const amrex::Real bz)
+        const amrex::ParticleReal px, const amrex::ParticleReal py,
+        const amrex::ParticleReal pz, const amrex::ParticleReal ex,
+        const amrex::ParticleReal ey, const amrex::ParticleReal ez,
+        const amrex::ParticleReal bx, const amrex::ParticleReal by,
+        const amrex::ParticleReal bz)
     {
             namespace pxr_p = picsar::multi_physics::phys;
             return pxr_p::chi_ele_pos<amrex::Real, pxr_p::unit_system::SI>(

--- a/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
@@ -36,7 +36,7 @@ namespace QedUtils{
         const amrex::ParticleReal bz)
     {
         namespace pxr_p = picsar::multi_physics::phys;
-        return pxr_p::chi_photon<amrex::Real, pxr_p::unit_system::SI>(
+        return pxr_p::chi_photon<amrex::ParticleReal, pxr_p::unit_system::SI>(
             px, py, pz, ex, ey, ez, bx, by, bz);
     }
 

--- a/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
@@ -58,7 +58,7 @@ namespace QedUtils{
         const amrex::ParticleReal bz)
     {
             namespace pxr_p = picsar::multi_physics::phys;
-            return pxr_p::chi_ele_pos<amrex::Real, pxr_p::unit_system::SI>(
+            return pxr_p::chi_ele_pos<amrex::ParticleReal, pxr_p::unit_system::SI>(
                 px, py, pz, ex, ey, ez, bx, by, bz);
     }
     //_________

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
@@ -227,11 +227,11 @@ public:
         const auto chi_particle = QedUtils::chi_ele_pos(
             px, py, pz, ex, ey, ez, bx, by, bz);
 
-        auto momentum_particle = pxr_m::vec3<amrex::Real>{px, py, pz};
-        auto momentum_photon = pxr_m::vec3<amrex::Real>();
+        auto momentum_particle = pxr_m::vec3<amrex::ParticleReal>{px, py, pz};
+        auto momentum_photon = pxr_m::vec3<amrex::ParticleReal>();
 
         const auto is_out = pxr_qs::generate_photon_update_momentum<
-            amrex::Real,
+            amrex::ParticleReal,
             QS_phot_em_table_view,
             pxr_p::unit_system::SI>(
                 chi_particle, momentum_particle,

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
@@ -200,11 +200,13 @@ public:
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     bool operator()(
-    amrex::Real& ux, amrex::Real& uy, amrex::Real& uz,
-    const amrex::Real ex, const amrex::Real ey, const amrex::Real ez,
-    const amrex::Real bx, const amrex::Real by, const amrex::Real bz,
-    amrex::Real& g_ux, amrex::Real& g_uy, amrex::Real& g_uz,
-    amrex::RandomEngine const& engine) const noexcept
+    amrex::ParticleReal& ux, amrex::ParticleReal& uy,
+    amrex::ParticleReal& uz,
+    const amrex::ParticleReal ex, const amrex::ParticleReal ey,
+    const amrex::ParticleReal ez, const amrex::ParticleReal bx,
+    const amrex::ParticleReal by, const amrex::ParticleReal bz,
+    amrex::ParticleReal& g_ux, amrex::ParticleReal& g_uy,
+    amrex::ParticleReal& g_uz, amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
         namespace pxr_m = picsar::multi_physics::math;

--- a/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/SchwingerProcessWrapper.H
@@ -36,9 +36,9 @@
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real
 getSchwingerProductionNumber (const amrex::Real dV, const amrex::Real dt,
-              const amrex::Real Ex, const amrex::Real Ey, const amrex::Real Ez,
-              const amrex::Real Bx, const amrex::Real By, const amrex::Real Bz,
-              const amrex::Real PoissonToGaussianThreshold,
+              const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
+              const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
+              const amrex::ParticleReal PoissonToGaussianThreshold,
               amrex::RandomEngine const& engine)
 {
     using namespace amrex;

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -102,7 +102,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 
 #ifdef WARPX_QED
     BreitWheelerEvolveOpticalDepth evolve_opt;
-    amrex::Real* AMREX_RESTRICT p_optical_depth_BW = nullptr;
+    amrex::ParticleReal* AMREX_RESTRICT p_optical_depth_BW = nullptr;
     const bool local_has_breit_wheeler = has_breit_wheeler();
     if (local_has_breit_wheeler) {
         evolve_opt = m_shr_p_bw_engine->build_evolve_functor();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -720,8 +720,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
 #ifdef WARPX_QED
         //Pointer to the optical depth component
-        amrex::Real* p_optical_depth_QSR = nullptr;
-        amrex::Real* p_optical_depth_BW  = nullptr;
+        amrex::ParticleReal* p_optical_depth_QSR = nullptr;
+        amrex::ParticleReal* p_optical_depth_BW  = nullptr;
 
         // If a QED effect is enabled, the corresponding optical depth
         // has to be initialized


### PR DESCRIPTION
This PR replaces few amrex::Real with amrex::ParticleReal in the QED modules.