### PR TITLE
Remove coarse bounding box check from the BTD selection

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1558,10 +1558,6 @@ PhysicalParticleContainer::GetParticleSlice (
     const Real z_min = z_new - base_dx[direction];
     const Real z_max = z_old + base_dx[direction];
 
-    RealBox slice_box = Geom(0).ProbDomain();
-    slice_box.setLo(direction, z_min);
-    slice_box.setHi(direction, z_max);
-
     diagnostic_particles.resize(finestLevel()+1);
 
     for (int lev = 0; lev < nlevs; ++lev) {
@@ -1592,9 +1588,6 @@ PhysicalParticleContainer::GetParticleSlice (
             {
                 const Box& box = pti.validbox();
                 auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
-                const RealBox tile_real_box(box, dx, plo);
-
-                if ( !slice_box.intersects(tile_real_box) ) continue;
 
                 const auto GetPosition = GetParticlePosition(pti);
 


### PR DESCRIPTION
This check is incorrect in the case of the galilean algorithm, because it does not take into account the fact that the box locations are at different positions at different times. Removing the check results in the correct number of particles in the outputs for all snapshots and also doesn't slow the code down at all in my single-gpu test. However, it is probably worth testing to see if this is significantly slower on a bigger problem before merging this.

If we end up wanted to keep the short circuit, I think we need to figure out the superset of the two bounding boxes at the "old" and "new" times.  

EDIT: We may also need to grow the tile_box before we do this to account for the fact that the particles could have moved by 1 cell since the last time we redistributed them. But if there is not performance penalty the cleanest thing is just to remove the check.