### PR TITLE
CI: DPC++ Re-Enable

### DIFF
--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -16,10 +16,15 @@ echo "deb https://apt.repos.intel.com/oneapi all main" \
 
 sudo apt-get update
 
+# Install and reduce disk space
+# https://github.com/ECP-WarpX/WarpX/pull/1566#issuecomment-790934878
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     cmake           \
     intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
     g++ gfortran    \
     libopenmpi-dev  \
-    openmpi-bin
+    openmpi-bin     && \
+sudo rm -rf /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sycl.a \
+            /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga    \
+            /opt/intel/oneapi/compiler/latest/linux/lib/emu

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -180,9 +180,7 @@ jobs:
         export OMP_NUM_THREADS=2
         Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
 
-# disabled on 2020-02-25 because DPC++ got too large and we run out CI disk space
   build_dpcc:
-    if: false
     name: oneAPI DPC++ SP [Linux]
     runs-on: ubuntu-20.04
     steps:
@@ -212,10 +210,11 @@ jobs:
           -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade setuptools wheel
-        PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
-        python3 -m pip install *.whl
+     # Skip this as it will copy the binary artifacts and we are tight on disk space
+     #   python3 -m pip install --upgrade pip
+     #   python3 -m pip install --upgrade setuptools wheel
+     #   PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+     #   python3 -m pip install *.whl
      # note: setting the CXX compiler ID is a work-around for
      # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
      # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580


### PR DESCRIPTION
Try to re-enable DPC++ with less packages, so we do not run out of CI disk space.
We now manually remove some parts of the oneAPI package that we do not use in our tests.

Continuation of https://github.com/ECP-WarpX/WarpX/pull/1566#issuecomment-786274791