### PR TITLE
RZ Poisson solver

### DIFF
--- a/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# Copyright 2019-2020 David Bizzozero
+# Copyright 2019-2021 David Bizzozero, David Grote
 #
 #
 # This file is part of WarpX.
@@ -10,7 +10,7 @@
 """
 This script tests the expansion of a uniformly charged sphere of electrons.
 
-The input file inputs_3d/inputs is used: it defines a sphere of charge with
+An input file inputs_3d or inputs_rz is used: it defines a sphere of charge with
 given initial conditions. The sphere of charge starts at rest and will expand
 due to Coulomb interactions. The test will check if the sphere has expanded at
 the correct speed and that the electric field is accurately modeled against a
@@ -28,9 +28,29 @@ filename = sys.argv[1]
 ds = yt.load( filename )
 t_max = ds.current_time.item()  # time of simulation
 
-# Constants and initial conditions
-xmin = ymin = zmin = -0.5  #Box dimensions
-xmax = ymax = zmax = 0.5
+ndims = np.count_nonzero(ds.domain_dimensions > 1)
+
+if ndims == 2:
+    xmin, zmin = [float(x) for x in ds.parameters.get('geometry.prob_lo').split()]
+    xmax, zmax = [float(x) for x in ds.parameters.get('geometry.prob_hi').split()]
+    nx, nz = [int(n) for n in ds.parameters['amr.n_cell'].split()]
+    ymin, ymax = xmin, xmax
+    ny = nx
+else:
+    xmin, ymin, zmin = [float(x) for x in ds.parameters.get('geometry.prob_lo').split()]
+    xmax, ymax, zmax = [float(x) for x in ds.parameters.get('geometry.prob_hi').split()]
+    nx, ny, nz = [int(n) for n in ds.parameters['amr.n_cell'].split()]
+
+dx = (xmax - xmin)/nx
+dy = (ymax - ymin)/ny
+dz = (zmax - zmin)/nz
+
+# Grid location of the axis
+ix0 = round((0. - xmin)/dx)
+iy0 = round((0. - ymin)/dy)
+iz0 = round((0. - zmin)/dz)
+
+# Constants
 eps_0 = 8.8541878128e-12  #Vacuum Permittivity in C/(V*m)
 m_e = 9.10938356e-31  #Electron mass in kg
 q_e = -1.60217662e-19  #Electron charge in C
@@ -57,50 +77,51 @@ E_exact = lambda r: np.sign(r)*(q_tot/(4*pi*eps_0*r**2)*(abs(r)>=r_end) \
     + q_tot*abs(r)/(4*pi*eps_0*r_end**3)*(abs(r)<r_end))
 
 # Load data pertaining to fields
-data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge,
+data = ds.covering_grid(level=0,
+                        left_edge=ds.domain_left_edge,
                         dims=ds.domain_dimensions)
-Ex = data['Ex'].to_ndarray()
-Ey = data['Ey'].to_ndarray()
-Ez = data['Ez'].to_ndarray()
-nx, ny, nz = Ex.shape
 
-# Extract longitudinal fields along x-, y-, and z-axes
-Ex_axis = Ex[:,int(ny/2),int(nz/2)]
-Ey_axis = Ey[int(nx/2),:,int(nz/2)]
-Ez_axis = Ez[int(nx/2),int(ny/2),:]
+# Extract the E field along the axes
+if ndims == 2:
+    Ex = data['Ex'].to_ndarray()
+    Ex_axis = Ex[:,iz0,0]
+    Ey_axis = Ex_axis
+    Ez = data['Ez'].to_ndarray()
+    Ez_axis = Ez[ix0,:,0]
+else:
+    Ex = data['Ex'].to_ndarray()
+    Ex_axis = Ex[:,iy0,iz0]
+    Ey = data['Ey'].to_ndarray()
+    Ey_axis = Ey[ix0,:,iz0]
+    Ez = data['Ez'].to_ndarray()
+    Ez_axis = Ez[ix0,iy0,:]
 
-# Compute cell centers for grid
-x_cell_edges = np.linspace(xmin,xmax,nx+1)
-x_cell_centers = (x_cell_edges[1::]+x_cell_edges[0:-1])/2
-y_cell_edges = np.linspace(ymin,ymax,ny+1)
-y_cell_centers = (y_cell_edges[1::]+y_cell_edges[0:-1])/2
-z_cell_edges = np.linspace(zmin,zmax,nz+1)
-z_cell_centers = (z_cell_edges[1::]+z_cell_edges[0:-1])/2
+def calculate_error(E_axis, xmin, dx, nx):
+    # Compute cell centers for grid
+    x_cell_centers = np.linspace(xmin+dx/2.,xmax-dx/2.,nx)
 
-# Extract subgrid away from boundary (exact solution assumes infinite/open
-# domain but WarpX solution assumes perfect conducting walls)
-x_sub_grid = x_cell_centers[int(nx/4):int(3*nx/4)]
-y_sub_grid = y_cell_centers[int(ny/4):int(3*ny/4)]
-z_sub_grid = z_cell_centers[int(nz/4):int(3*nz/4)]
+    # Extract subgrid away from boundary (exact solution assumes infinite/open
+    # domain but WarpX solution assumes perfect conducting walls)
+    ix1 = round((xmin/2. - xmin)/dx)
+    ix2 = round((xmax/2. - xmin)/dx)
+    x_sub_grid = x_cell_centers[ix1:ix2]
 
-# Exact solution of field along Cartesian axes
-Ex_exact_grid = E_exact(x_sub_grid)
-Ey_exact_grid = E_exact(y_sub_grid)
-Ez_exact_grid = E_exact(z_sub_grid)
+    # Exact solution of field along Cartesian axes
+    E_exact_grid = E_exact(x_sub_grid)
 
-# WarpX solution of field along Cartesian axes
-Ex_grid = Ex_axis[int(nx/4):int(3*nx/4)]
-Ey_grid = Ey_axis[int(ny/4):int(3*nz/4)]
-Ez_grid = Ez_axis[int(ny/4):int(3*nz/4)]
+    # WarpX solution of field along Cartesian axes
+    E_grid = E_axis[ix1:ix2]
 
-# Define approximate L2 norm error between exact and numerical solutions
-L2_error_x = np.sqrt(sum((Ex_exact_grid-Ex_grid)**2)) \
-    / np.sqrt(sum((Ex_exact_grid)**2))
-L2_error_y = np.sqrt(sum((Ey_exact_grid-Ey_grid)**2)) \
-    / np.sqrt(sum((Ey_exact_grid)**2))
-L2_error_z = np.sqrt(sum((Ez_exact_grid-Ez_grid)**2)) \
-    / np.sqrt(sum((Ez_exact_grid)**2))
+    # Define approximate L2 norm error between exact and numerical solutions
+    L2_error = (np.sqrt(sum((E_exact_grid - E_grid)**2))
+              / np.sqrt(sum((E_exact_grid)**2)))
 
+    return L2_error
+
+
+L2_error_x = calculate_error(Ex_axis, xmin, dx, nx)
+L2_error_y = calculate_error(Ey_axis, ymin, dy, ny)
+L2_error_z = calculate_error(Ez_axis, zmin, dz, nz)
 print("L2 error along x-axis = %s" %L2_error_x)
 print("L2 error along y-axis = %s" %L2_error_y)
 print("L2 error along z-axis = %s" %L2_error_z)

--- a/Examples/Tests/ElectrostaticSphere/inputs_rz
+++ b/Examples/Tests/ElectrostaticSphere/inputs_rz
@@ -27,6 +27,6 @@ electron.density_function(x,y,z) = "(x*x + y*y + z*z < R0*R0)*n0"
 electron.momentum_distribution_type = constant
 
 diagnostics.diags_names = diag1
-diag1.intervals = 1
+diag1.intervals = 30
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez rho

--- a/Examples/Tests/ElectrostaticSphere/inputs_rz
+++ b/Examples/Tests/ElectrostaticSphere/inputs_rz
@@ -1,0 +1,32 @@
+max_step = 30
+amr.n_cell = 32 64
+amr.max_level = 0
+amr.blocking_factor = 8
+amr.max_grid_size = 128
+geometry.coord_sys   = 0
+geometry.is_periodic = 0 0 0
+geometry.prob_lo     =  0.  -0.5
+geometry.prob_hi     =  0.5  0.5
+warpx.do_pml = 0
+warpx.const_dt = 1e-6
+warpx.do_electrostatic = labframe
+
+particles.species_names = electron
+
+algo.field_gathering = momentum-conserving
+
+my_constants.n0 = 1.49e6
+my_constants.R0 = 0.1
+
+electron.charge = -q_e
+electron.mass = m_e
+electron.injection_style = "NUniformPerCell"
+electron.num_particles_per_cell_each_dim = 2 2 2
+electron.profile = parse_density_function
+electron.density_function(x,y,z) = "(x*x + y*y + z*z < R0*R0)*n0"
+electron.momentum_distribution_type = constant
+
+diagnostics.diags_names = diag1
+diag1.intervals = 1
+diag1.diag_type = Full
+diag1.fields_to_plot = Ex Ey Ez rho

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1773,6 +1773,22 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
 tolerance = 1.e-12
 
+[ElectrostaticSphereRZ]
+buildDir = .
+inputFile = Examples/Tests/ElectrostaticSphere/inputs_rz
+dim = 2
+addToCompileString = USE_RZ=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+tolerance = 1.e-12
+
 [ElectrostaticSphereLabFrame]
 buildDir = .
 inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -7,7 +7,11 @@
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_MLMG.H>
+#ifdef WARPX_DIM_RZ
+#include <AMReX_MLNodeLaplacian.H>
+#else
 #include <AMReX_MLNodeTensorLaplacian.H>
+#endif
 #include <AMReX_REAL.H>
 
 #include <WarpX.H>
@@ -54,7 +58,8 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
 {
 
 #ifdef WARPX_DIM_RZ
-    amrex::Abort("The initialization of space-charge field has not yet been implemented in RZ geometry.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
+                                     "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
     // Allocate fields for charge and potential
@@ -96,7 +101,8 @@ WarpX::AddSpaceChargeFieldLabFrame ()
 {
 
 #ifdef WARPX_DIM_RZ
-    amrex::Abort("The calculation of space-charge field has not yet been implemented in RZ geometry.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
+                                     "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
     // Allocate fields for charge
@@ -124,6 +130,11 @@ WarpX::AddSpaceChargeFieldLabFrame ()
     for (int lev = 0; lev <= max_level; lev++) {
         ApplyFilterandSumBoundaryRho (lev, lev, *rho[lev], 0, 1);
     }
+#ifdef WARPX_DIM_RZ
+    for (int lev = 0; lev <= max_level; lev++) {
+        ApplyInverseVolumeScalingToChargeDensity(rho[lev].get(), lev);
+    }
+#endif
 
     // beta is zero in lab frame
     // Todo: use simpler finite difference form with beta=0
@@ -158,6 +169,96 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    Real const required_precision,
                    int const max_iters) const
 {
+#ifdef WARPX_DIM_RZ
+
+    // Create a new geometry with the z coordinate scaled by gamma
+    amrex::Real const gamma = std::sqrt(1._rt/(1. - beta[2]*beta[2]));
+
+    amrex::Vector<amrex::Geometry> geom_scaled(max_level + 1);
+    for (int lev = 0; lev <= max_level; ++lev) {
+        const amrex::Geometry & geom_lev = Geom(lev);
+        const amrex::Real* current_lo = geom_lev.ProbLo();
+        const amrex::Real* current_hi = geom_lev.ProbHi();
+        amrex::Real scaled_lo[AMREX_SPACEDIM];
+        amrex::Real scaled_hi[AMREX_SPACEDIM];
+        scaled_lo[0] = current_lo[0];
+        scaled_hi[0] = current_hi[0];
+        scaled_lo[1] = current_lo[1]*gamma;
+        scaled_hi[1] = current_hi[1]*gamma;
+        amrex::RealBox rb = RealBox(scaled_lo, scaled_hi);
+        geom_scaled[lev].define(geom_lev.Domain(), &rb);
+    }
+
+    // Setup the sigma = radius
+    // sigma must be cell centered
+    amrex::Vector<std::unique_ptr<amrex::MultiFab> > sigma(max_level+1);
+    for (int lev = 0; lev <= max_level; ++lev) {
+        const amrex::Real * problo = geom_scaled[lev].ProbLo();
+        const amrex::Real * dx = geom_scaled[lev].CellSize();
+        const amrex::Real rmin = problo[0];
+        const amrex::Real dr = dx[0];
+
+        amrex::BoxArray nba = boxArray(lev);
+        nba.enclosedCells(); // Get cell centered array (correct?)
+        sigma[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, 0);
+        for ( MFIter mfi(*sigma[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            const amrex::Box& tbx = mfi.tilebox();
+            const amrex::Dim3 lo = amrex::lbound(tbx);
+            const int irmin = lo.x;
+            Array4<amrex::Real> const& sigma_arr = sigma[lev]->array(mfi);
+            amrex::ParallelFor( tbx,
+                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/) {
+                    sigma_arr(i,j,0) = rmin + (i - irmin + 0.5_rt)*dr;
+                }
+            );
+        }
+
+        // Also, multiply rho by radius (rho is node centered)
+        // Note that this multiplication is not undone since rho is
+        // a temporary array.
+        for ( MFIter mfi(*rho[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            const amrex::Box& tbx = mfi.tilebox();
+            const amrex::Dim3 lo = amrex::lbound(tbx);
+            const int irmin = lo.x;
+            int const ncomp = rho[lev]->nComp(); // This should be 1!
+            Array4<Real> const& rho_arr = rho[lev]->array(mfi);
+            amrex::ParallelFor(tbx, ncomp,
+            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int icomp)
+            {
+                amrex::Real r = rmin + (i - irmin)*dr;
+                if (r == 0.) {
+                    rho_arr(i,j,0,icomp) *= dr/3._rt;
+                } else {
+                    rho_arr(i,j,0,icomp) *= r;
+                }
+            });
+        }
+    }
+
+    // Define the boundary conditions
+    Array<LinOpBCType,AMREX_SPACEDIM> lobc, hibc;
+    lobc[0] = LinOpBCType::Neumann;
+    hibc[0] = LinOpBCType::Dirichlet;
+    if ( Geom(0).isPeriodic(1) ) {
+        lobc[1] = LinOpBCType::Periodic;
+        hibc[1] = LinOpBCType::Periodic;
+    } else {
+        // Use Dirichlet boundary condition by default.
+        // Ideally, we would often want open boundary conditions here.
+        lobc[1] = LinOpBCType::Dirichlet;
+        hibc[1] = LinOpBCType::Dirichlet;
+    }
+
+    // Define the linear operator (Poisson operator)
+    MLNodeLaplacian linop( geom_scaled, boxArray(), dmap );
+    for (int lev = 0; lev <= max_level; ++lev) {
+        linop.setSigma( lev, *sigma[lev] );
+    }
+
+#else
+
     // Define the boundary conditions
     Array<LinOpBCType,AMREX_SPACEDIM> lobc, hibc;
     for (int idim=0; idim<AMREX_SPACEDIM; idim++){
@@ -174,7 +275,6 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
 
     // Define the linear operator (Poisson operator)
     MLNodeTensorLaplacian linop( Geom(), boxArray(), DistributionMap() );
-    linop.setDomainBC( lobc, hibc );
     // Set the value of beta
     amrex::Array<amrex::Real,AMREX_SPACEDIM> beta_solver =
 #if (AMREX_SPACEDIM==2)
@@ -184,7 +284,10 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
 #endif
     linop.setBeta( beta_solver );
 
+#endif
+
     // Solve the Poisson equation
+    linop.setDomainBC( lobc, hibc );
     MLMG mlmg(linop);
     mlmg.setVerbose(2);
     mlmg.setMaxIter(max_iters);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -551,6 +551,17 @@ public:
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
                      amrex::Real const required_precision=amrex::Real(1.e-11),
                      const int max_iters=200) const;
+    void computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
+                       amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
+                       std::array<amrex::Real, 3> const beta,
+                       amrex::Real const required_precision,
+                       int const max_iters) const;
+    void computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
+                       amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
+                       std::array<amrex::Real, 3> const beta,
+                       amrex::Real const required_precision,
+                       int const max_iters) const;
+
     void computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E,
                    const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<amrex::Real, 3> const beta = {{0,0,0}} ) const;


### PR DESCRIPTION
This implements the RZ Poisson solver whose main use is allowing the RZ electrostatic mode. This version only allows the lowest mode.

It uses the expanding electrostatic sphere as the test case.