### PR TITLE
Fix Warning: PlasmaInjector

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -160,12 +160,12 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         pp.getarr("multiple_particles_vel_z", multiple_particles_vel_z);
         pp.getarr("multiple_particles_weight", multiple_particles_weight);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (multiple_particles_pos_x.size() == multiple_particles_pos_y.size() &
-             multiple_particles_pos_x.size() == multiple_particles_pos_z.size() &
-             multiple_particles_pos_x.size() == multiple_particles_vel_x.size() &
-             multiple_particles_pos_x.size() == multiple_particles_vel_y.size() &
-             multiple_particles_pos_x.size() == multiple_particles_vel_z.size() &
-             multiple_particles_pos_x.size() == multiple_particles_weight.size()),
+            ((multiple_particles_pos_x.size() == multiple_particles_pos_y.size()) &
+             (multiple_particles_pos_x.size() == multiple_particles_pos_z.size()) &
+             (multiple_particles_pos_x.size() == multiple_particles_vel_x.size()) &
+             (multiple_particles_pos_x.size() == multiple_particles_vel_y.size()) &
+             (multiple_particles_pos_x.size() == multiple_particles_vel_z.size()) &
+             (multiple_particles_pos_x.size() == multiple_particles_weight.size())),
             "Error: The multiple particles source quantities must all have the same number of elements");
         for (auto& vx : multiple_particles_vel_x) { vx *= PhysConst::c; }
         for (auto& vy : multiple_particles_vel_y) { vy *= PhysConst::c; }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -160,11 +160,11 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         pp.getarr("multiple_particles_vel_z", multiple_particles_vel_z);
         pp.getarr("multiple_particles_weight", multiple_particles_weight);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            ((multiple_particles_pos_x.size() == multiple_particles_pos_y.size()) &
-             (multiple_particles_pos_x.size() == multiple_particles_pos_z.size()) &
-             (multiple_particles_pos_x.size() == multiple_particles_vel_x.size()) &
-             (multiple_particles_pos_x.size() == multiple_particles_vel_y.size()) &
-             (multiple_particles_pos_x.size() == multiple_particles_vel_z.size()) &
+            ((multiple_particles_pos_x.size() == multiple_particles_pos_y.size()) &&
+             (multiple_particles_pos_x.size() == multiple_particles_pos_z.size()) &&
+             (multiple_particles_pos_x.size() == multiple_particles_vel_x.size()) &&
+             (multiple_particles_pos_x.size() == multiple_particles_vel_y.size()) &&
+             (multiple_particles_pos_x.size() == multiple_particles_vel_z.size()) &&
              (multiple_particles_pos_x.size() == multiple_particles_weight.size())),
             "Error: The multiple particles source quantities must all have the same number of elements");
         for (auto& vx : multiple_particles_vel_x) { vx *= PhysConst::c; }


### PR DESCRIPTION
This fixes a few instances of the warning 
"**warning:** suggest parentheses around comparison in operand of ‘&’ [**-Wparentheses**]"
in Source/Initialization/PlasmaInjector.cpp.

The PR also replaces `&` with `&&`, as suggested in the comment below.