### PR TITLE
Add empty runtime_params = in WarpX-tests.ini

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -111,6 +111,7 @@ tolerance = 1e-9
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
+runtime_params =
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -127,6 +128,7 @@ tolerance = 1e-12
 [RigidInjection_boost_backtransformed]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+runtime_params =
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -179,6 +181,7 @@ tolerance = 1.e-14
 # [ionization_lab]
 # buildDir = .
 # inputFile = Examples/Modules/ionization/inputs_2d_rt
+# runtime_params =
 # dim = 2
 # addToCompileString = USE_GPU=TRUE
 # restartTest = 0
@@ -194,6 +197,7 @@ tolerance = 1.e-14
 # [ionization_boost]
 # buildDir = .
 # inputFile = Examples/Modules/ionization/inputs_2d_bf_rt
+# runtime_params =
 # dim = 2
 # addToCompileString = USE_GPU=TRUE
 # restartTest = 0
@@ -492,6 +496,7 @@ tolerance = 5e-11
 # buildDir = .
 # inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
 # customRunCmd = python PICMI_inputs_langmuir_rz_multimode_analyze.py
+# runtime_params =
 # dim = 2
 # addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE USE_GPU=TRUE PYINSTALLOPTIONS="--user --prefix="
 # restartTest = 0
@@ -612,6 +617,7 @@ tolerance = 5e-11
 buildDir = .
 inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
 customRunCmd = python PICMI_inputs_langmuir_rt.py
+runtime_params =
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_GPU=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
@@ -647,6 +653,7 @@ tolerance = 1.e-12
 [particles_in_pml_2d]
 buildDir = .
 inputFile = Examples/Tests/particles_in_PML/inputs_2d
+runtime_params =
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -663,6 +670,7 @@ tolerance = 1e-12
 [particles_in_pml]
 buildDir = .
 inputFile = Examples/Tests/particles_in_PML/inputs_3d
+runtime_params =
 dim = 3
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -679,6 +687,7 @@ tolerance = 1e-10
 [photon_pusher]
 buildDir = .
 inputFile = Examples/Tests/photon_pusher/inputs_3d
+runtime_params =
 dim = 3
 addToCompileString = USE_GPU=TRUE
 restartTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1206,6 +1206,7 @@ tolerance = 1.e-14
 buildDir = .
 inputFile = Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
 customRunCmd = python PICMI_inputs_gaussian_beam.py
+runtime_params =
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
@@ -1431,6 +1432,7 @@ tolerance = 1.e-12
 [Uniform_2d]
 buildDir = .
 inputFile = Examples/Physics_applications/uniform_plasma/inputs_2d
+runtime_params =
 dim = 2
 addToCompileString =
 restartTest = 0
@@ -1464,6 +1466,7 @@ buildDir = .
 inputFile = Examples/Modules/laser_injection_from_file/analysis.py
 aux1File = Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
 customRunCmd = ./analysis.py
+runtime_params =
 dim = 2
 addToCompileString = USE_OPENPMD=FALSE
 restartTest = 0
@@ -1760,6 +1763,7 @@ tolerance = 1e-4
 [ElectrostaticSphere]
 buildDir = .
 inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d
+runtime_params =
 dim = 3
 addToCompileString =
 restartTest = 0


### PR DESCRIPTION
This small PR adds the line `runtime_params =` in all test entries of `WarpX-tests.ini` and `WarpX-GPU-tests.ini` that do not yet have this parameter.

The reason for doing this comes from these lines:
https://github.com/ECP-WarpX/WarpX/blob/faf15f02c2af254224f23e92cd413a7c5349d9f0/Regression/prepare_file_travis.py#L61-L64

Basically adding this line adds a check for unused parameters in CI so I figured it'd be best practice to always have it.