### PR TITLE
RigidInjectedParticleContainer: clean duplicated code

### DIFF
--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -486,28 +486,23 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                                nox, galerkin_interpolation);
                 getExternalE(ip, Exp, Eyp, Ezp);
                 getExternalB(ip, Bxp, Byp, Bzp);
+                
+                amrex::Real qp = q;
+                if (ion_lev != nullptr) { qp *= ion_lev[ip]; }
 
                 if (do_crr) {
-                    amrex::Real qp = q;
-                    if (ion_lev) { qp *= ion_lev[ip]; }
                     UpdateMomentumBorisWithRadiationReaction(uxpp[ip], uypp[ip], uzpp[ip],
                                                              Exp, Eyp, Ezp, Bxp,
                                                              Byp, Bzp, qp, m, dt);
                 } else if (pusher_algo == ParticlePusherAlgo::Boris) {
-                    amrex::Real qp = q;
-                    if (ion_lev) { qp *= ion_lev[ip]; }
                     UpdateMomentumBoris( uxpp[ip], uypp[ip], uzpp[ip],
                                          Exp, Eyp, Ezp, Bxp,
                                          Byp, Bzp, qp, m, dt);
                 } else if (pusher_algo == ParticlePusherAlgo::Vay) {
-                    amrex::Real qp = q;
-                    if (ion_lev){ qp *= ion_lev[ip]; }
                     UpdateMomentumVay( uxpp[ip], uypp[ip], uzpp[ip],
                                        Exp, Eyp, Ezp, Bxp,
                                        Byp, Bzp, qp, m, dt);
                 } else if (pusher_algo == ParticlePusherAlgo::HigueraCary) {
-                    amrex::Real qp = q;
-                    if (ion_lev){ qp *= ion_lev[ip]; }
                     UpdateMomentumHigueraCary( uxpp[ip], uypp[ip], uzpp[ip],
                                                Exp, Eyp, Ezp, Bxp,
                                                Byp, Bzp, qp, m, dt);

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -486,9 +486,9 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                                nox, galerkin_interpolation);
                 getExternalE(ip, Exp, Eyp, Ezp);
                 getExternalB(ip, Bxp, Byp, Bzp);
-                
+
                 amrex::Real qp = q;
-                if (ion_lev != nullptr) { qp *= ion_lev[ip]; }
+                if (ion_lev) { qp *= ion_lev[ip]; }
 
                 if (do_crr) {
                     UpdateMomentumBorisWithRadiationReaction(uxpp[ip], uypp[ip], uzpp[ip],


### PR DESCRIPTION
This PR eliminates some duplicated code.

Note that `clang-tidy` raises a readability warning for these lines, although this is the recommended way to test if a pointer is null in the [C++ core guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#S-gsl).

```
warpx_dir/WarpX/Source/Particles/RigidInjectedParticleContainer.cpp:492:25: warning: implicit conversion 'int *' -> bool [readability-implicit-bool-conversion]
                    if (ion_lev) { qp *= ion_lev[ip]; }
                        ^
                                != nullptr
```