### PR TITLE
Examples: Dynamic Scheduling

### DIFF
--- a/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
+++ b/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
@@ -20,7 +20,6 @@ interpolation.nox = 3
 interpolation.noy = 3
 interpolation.noz = 3
 warpx.cfl = 0.98
-warpx.do_dynamic_scheduling = 0
 warpx.use_filter = 0
 algo.maxwell_solver = ckc
 algo.load_balance_intervals = -1

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -42,7 +42,6 @@ warpx.use_filter = 1          # bilinear current/charge filter
 #
 amr.max_grid_size = 64
 amr.blocking_factor = 64
-warpx.do_dynamic_scheduling = 0
 
 # load balancing
 algo.load_balance_intervals = 10

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -26,7 +26,6 @@ my_constants.nc    = 1.74e27
 my_constants.zp2   = 24.e-6
 my_constants.zc2   = 24.05545177444479562e-6
 warpx.cfl = 1.0
-warpx.do_dynamic_scheduling = 0
 warpx.use_filter = 1
 algo.load_balance_intervals = 66
 

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1469,7 +1469,7 @@ buildDir = .
 inputFile = Examples/Modules/laser_injection_from_file/analysis.py
 aux1File = Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
 customRunCmd = ./analysis.py
-runtime_params =
+runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_OPENPMD=FALSE
 restartTest = 0


### PR DESCRIPTION
Remove the three locations where an input file sets `warpx.do_dynamic_scheduling=0`. This is only needed for CI `.ini` files to ensure determinism and should not be used in production (thanks for the details @MaxThevenet ! :) )