### PR TITLE
ParticleContainer: Fix Unused Vars

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1563,20 +1563,9 @@ PhysicalParticleContainer::GetParticleSlice (
     AMREX_ALWAYS_ASSERT(do_back_transformed_diagnostics == 1);
 
     const int nlevs = std::max(0, finestLevel()+1);
-
-    // we figure out a box for coarse-grained rejection. If the RealBox corresponding to a
-    // given tile doesn't intersect with this, there is no need to check any particles.
-    const Real* base_dx = Geom(0).CellSize();
-    const Real z_min = z_new - base_dx[direction];
-    const Real z_max = z_old + base_dx[direction];
-
     diagnostic_particles.resize(finestLevel()+1);
 
     for (int lev = 0; lev < nlevs; ++lev) {
-
-        const Real* dx  = Geom(lev).CellSize();
-        const Real* plo = Geom(lev).ProbLo();
-
         // first we touch each map entry in serial
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
@@ -1598,7 +1587,6 @@ PhysicalParticleContainer::GetParticleSlice (
             amrex::Gpu::DeviceVector<int> IndexForPartCopy;
             for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
             {
-                const Box& box = pti.validbox();
                 auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
 
                 const auto GetPosition = GetParticlePosition(pti);


### PR DESCRIPTION
Fix unused variable warnings in `PhysicalParticleContainer`.

Follow-up to  #1742