### PR TITLE
Remove extra ghost cell used with momentum-conserving gathering

### DIFF
--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -450,8 +450,8 @@ FullDiagnostics::PrepareFieldDataForOutput ()
     // First, make sure all guard cells are properly filled
     // Probably overkill/unnecessary, but safe and shouldn't happen often !!
     auto & warpx = WarpX::GetInstance();
-    warpx.FillBoundaryE(warpx.getngE(), warpx.getngExtra());
-    warpx.FillBoundaryB(warpx.getngE(), warpx.getngExtra());
+    warpx.FillBoundaryE(warpx.getngE());
+    warpx.FillBoundaryB(warpx.getngE());
     warpx.UpdateAuxilaryData();
     warpx.FillBoundaryAux(warpx.getngUpdateAux());
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -90,8 +90,8 @@ WarpX::Evolve (int numsteps)
         if (is_synchronized) {
             if (do_electrostatic == ElectrostaticSolverAlgo::None) {
                 // Not called at each iteration, so exchange all guard cells
-                FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-                FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+                FillBoundaryE(guard_cells.ng_alloc_EB);
+                FillBoundaryB(guard_cells.ng_alloc_EB);
                 UpdateAuxilaryData();
                 FillBoundaryAux(guard_cells.ng_UpdateAux);
             }
@@ -109,14 +109,14 @@ WarpX::Evolve (int numsteps)
                 // Particles have p^{n-1/2} and x^{n}.
 
                 // E and B are up-to-date inside the domain only
-                FillBoundaryE(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
-                FillBoundaryB(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
+                FillBoundaryE(guard_cells.ng_FieldGather);
+                FillBoundaryB(guard_cells.ng_FieldGather);
                 // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
                 // Need to update Aux on lower levels, to interpolate to higher levels.
                 if (fft_do_time_averaging)
                 {
-                    FillBoundaryE_avg(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
-                    FillBoundaryB_avg(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
+                    FillBoundaryE_avg(guard_cells.ng_FieldGather);
+                    FillBoundaryB_avg(guard_cells.ng_FieldGather);
                 }
                 // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
                 if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD)
@@ -348,16 +348,16 @@ WarpX::OneStep_nosub (Real cur_time)
             if (use_hybrid_QED)
             {
                 WarpX::Hybrid_QED_Push(dt);
-                FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+                FillBoundaryE(guard_cells.ng_alloc_EB);
             }
             PushPSATD(dt[0]);
-            FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-            FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+            FillBoundaryE(guard_cells.ng_alloc_EB);
+            FillBoundaryB(guard_cells.ng_alloc_EB);
 
             if (use_hybrid_QED)
             {
                 WarpX::Hybrid_QED_Push(dt);
-                FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+                FillBoundaryE(guard_cells.ng_alloc_EB);
             }
             if (do_pml) {
                 DampPML();
@@ -368,7 +368,7 @@ WarpX::OneStep_nosub (Real cur_time)
             FillBoundaryF(guard_cells.ng_FieldSolverF);
             EvolveB(0.5_rt * dt[0]); // We now have B^{n+1/2}
 
-            FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+            FillBoundaryB(guard_cells.ng_FieldSolver);
             if (WarpX::em_solver_medium == MediumForEM::Vacuum) {
                 // vacuum medium
                 EvolveE(dt[0]); // We now have E^{n+1}
@@ -379,21 +379,21 @@ WarpX::OneStep_nosub (Real cur_time)
                 amrex::Abort(" Medium for EM is unknown \n");
             }
 
-            FillBoundaryE(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+            FillBoundaryE(guard_cells.ng_FieldSolver);
             EvolveF(0.5_rt * dt[0], DtType::SecondHalf);
             EvolveB(0.5_rt * dt[0]); // We now have B^{n+1}
             if (do_pml) {
                 FillBoundaryF(guard_cells.ng_alloc_F);
                 DampPML();
                 NodalSyncPML();
-                FillBoundaryE(guard_cells.ng_MovingWindow, IntVect::TheZeroVector());
+                FillBoundaryE(guard_cells.ng_MovingWindow);
                 FillBoundaryF(guard_cells.ng_MovingWindow);
-                FillBoundaryB(guard_cells.ng_MovingWindow, IntVect::TheZeroVector());
+                FillBoundaryB(guard_cells.ng_MovingWindow);
             }
             // E and B are up-to-date in the domain, but all guard cells are
             // outdated.
             if (safe_guard_cells)
-                FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+                FillBoundaryB(guard_cells.ng_alloc_EB);
         } // !PSATD
     } // !do_electrostatic
 }
@@ -486,11 +486,11 @@ WarpX::OneStep_sub1 (Real curtime)
 
     EvolveB(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev]);
     EvolveF(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], DtType::FirstHalf);
-    FillBoundaryB(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather + guard_cells.ng_Extra);
+    FillBoundaryB(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather);
     FillBoundaryF(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolverF);
 
     EvolveE(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev]);
-    FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather + guard_cells.ng_Extra);
+    FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather);
 
     // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
     FillBoundaryAux(guard_cells.ng_UpdateAux);

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -42,7 +42,6 @@ public:
         const bool do_fdtd_nci_corr,
         const bool do_nodal,
         const bool do_moving_window,
-        const bool aux_is_nodal,
         const int moving_window_dir,
         const int nox,
         const int nox_fft, const int noy_fft, const int noz_fft,
@@ -75,12 +74,6 @@ public:
     amrex::IntVect ng_UpdateAux = amrex::IntVect::TheZeroVector();
     // Number of guard cells of all MultiFabs that must exchanged before moving window
     amrex::IntVect ng_MovingWindow = amrex::IntVect::TheZeroVector();
-
-    // When the auxiliary grid is nodal but the field solver is staggered
-    // (typically with momentum-conserving gather with FDTD Yee solver),
-    // An extra guard cell is needed on the fine grid to do the interpolation
-    // for E and B.
-    amrex::IntVect ng_Extra = amrex::IntVect::TheZeroVector();
 
     // Number of guard cells for local deposition of J and rho
     amrex::IntVect ng_depos_J   = amrex::IntVect::TheZeroVector();

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -22,7 +22,6 @@ guardCellManager::Init (
     const bool do_fdtd_nci_corr,
     const bool do_nodal,
     const bool do_moving_window,
-    const bool aux_is_nodal,
     const int moving_window_dir,
     const int nox,
     const int nox_fft, const int noy_fft, const int noz_fft,
@@ -161,8 +160,6 @@ guardCellManager::Init (
         ng_alloc_F = IntVect(AMREX_D_DECL(ng_alloc_F_int, ng_alloc_F_int, ng_alloc_F_int));
     }
 
-    ng_Extra = IntVect(static_cast<int>(aux_is_nodal and !do_nodal));
-
     // Compute number of cells required for Field Solver
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         ng_FieldSolver = ng_alloc_EB;
@@ -189,10 +186,6 @@ guardCellManager::Init (
         // Compute number of cells required for Field Gather
         int FGcell[4] = {0,1,1,2}; // Index is nox
         IntVect ng_FieldGather_noNCI = IntVect(AMREX_D_DECL(FGcell[nox],FGcell[nox],FGcell[nox]));
-        // Add one cell if momentum_conserving gather in a staggered-field simulation
-        ng_FieldGather_noNCI += ng_Extra;
-        // Not sure why, but need one extra guard cell when using MR
-        if (max_level >= 1) ng_FieldGather_noNCI += ng_Extra;
         ng_FieldGather_noNCI = ng_FieldGather_noNCI.min(ng_alloc_EB);
         // If NCI filter, add guard cells in the z direction
         IntVect ng_NCIFilter = IntVect::TheZeroVector();

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -356,20 +356,20 @@ WarpX::UpdateAuxilaryDataSameType ()
 }
 
 void
-WarpX::FillBoundaryB (IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryB (IntVect ng)
 {
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        FillBoundaryB(lev, ng, ng_extra_fine);
+        FillBoundaryB(lev, ng);
     }
 }
 
 void
-WarpX::FillBoundaryE (IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryE (IntVect ng)
 {
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        FillBoundaryE(lev, ng, ng_extra_fine);
+        FillBoundaryE(lev, ng);
     }
 }
 
@@ -383,28 +383,28 @@ WarpX::FillBoundaryF (IntVect ng)
 }
 
 void
-WarpX::FillBoundaryB_avg (IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryB_avg (IntVect ng)
 {
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        FillBoundaryB_avg(lev, ng, ng_extra_fine);
+        FillBoundaryB_avg(lev, ng);
     }
 }
 
 void
-WarpX::FillBoundaryE_avg (IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryE_avg (IntVect ng)
 {
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        FillBoundaryE_avg(lev, ng, ng_extra_fine);
+        FillBoundaryE_avg(lev, ng);
     }
 }
 
 
 void
-WarpX::FillBoundaryE(int lev, IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryE(int lev, IntVect ng)
 {
-    FillBoundaryE(lev, PatchType::fine, ng+ng_extra_fine);
+    FillBoundaryE(lev, PatchType::fine, ng);
     if (lev > 0) FillBoundaryE(lev, PatchType::coarse, ng);
 }
 
@@ -464,9 +464,9 @@ WarpX::FillBoundaryE (int lev, PatchType patch_type, IntVect ng)
 }
 
 void
-WarpX::FillBoundaryB (int lev, IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryB (int lev, IntVect ng)
 {
-    FillBoundaryB(lev, PatchType::fine, ng + ng_extra_fine);
+    FillBoundaryB(lev, PatchType::fine, ng);
     if (lev > 0) FillBoundaryB(lev, PatchType::coarse, ng);
 }
 
@@ -524,9 +524,9 @@ WarpX::FillBoundaryB (int lev, PatchType patch_type, IntVect ng)
 }
 
 void
-WarpX::FillBoundaryE_avg(int lev, IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryE_avg(int lev, IntVect ng)
 {
-    FillBoundaryE_avg(lev, PatchType::fine, ng+ng_extra_fine);
+    FillBoundaryE_avg(lev, PatchType::fine, ng);
     if (lev > 0) FillBoundaryE_avg(lev, PatchType::coarse, ng);
 }
 
@@ -578,9 +578,9 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
 
 
 void
-WarpX::FillBoundaryB_avg (int lev, IntVect ng, IntVect ng_extra_fine)
+WarpX::FillBoundaryB_avg (int lev, IntVect ng)
 {
-    FillBoundaryB_avg(lev, PatchType::fine, ng + ng_extra_fine);
+    FillBoundaryB_avg(lev, PatchType::fine, ng);
     if (lev > 0) FillBoundaryB_avg(lev, PatchType::coarse, ng);
 }
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -39,9 +39,6 @@ WarpX::MoveWindow (bool move_j)
 {
     if (do_moving_window == 0) return 0;
 
-    IntVect ng_extra = guard_cells.ng_Extra;
-    IntVect ng_zero  = IntVect::TheZeroVector();
-
     // Update the continuous position of the moving window,
     // and of the plasma injection
     moving_window_x += (moving_window_v - WarpX::beta_boost * PhysConst::c)/(1 - moving_window_v * WarpX::beta_boost / PhysConst::c) * dt[0];
@@ -128,42 +125,42 @@ WarpX::MoveWindow (bool move_j)
                 if (dim == 1) Efield_parser = getParser(Eyfield_parser);
                 if (dim == 2) Efield_parser = getParser(Ezfield_parser);
             }
-            shiftMF(*Bfield_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, B_external_grid[dim], use_Bparser, Bfield_parser);
-            shiftMF(*Efield_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, E_external_grid[dim], use_Eparser, Efield_parser);
+            shiftMF(*Bfield_fp[lev][dim], geom[lev], num_shift, dir, B_external_grid[dim], use_Bparser, Bfield_parser);
+            shiftMF(*Efield_fp[lev][dim], geom[lev], num_shift, dir, E_external_grid[dim], use_Eparser, Efield_parser);
             if (fft_do_time_averaging) {
-                shiftMF(*Bfield_avg_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, B_external_grid[dim], use_Bparser, Bfield_parser);
-                shiftMF(*Efield_avg_fp[lev][dim], geom[lev], num_shift, dir, ng_extra, E_external_grid[dim], use_Eparser, Efield_parser);
+                shiftMF(*Bfield_avg_fp[lev][dim], geom[lev], num_shift, dir, B_external_grid[dim], use_Bparser, Bfield_parser);
+                shiftMF(*Efield_avg_fp[lev][dim], geom[lev], num_shift, dir, E_external_grid[dim], use_Eparser, Efield_parser);
             }
             if (move_j) {
-                shiftMF(*current_fp[lev][dim], geom[lev], num_shift, dir, ng_zero);
+                shiftMF(*current_fp[lev][dim], geom[lev], num_shift, dir);
             }
             if (do_pml && pml[lev]->ok()) {
                 const std::array<MultiFab*, 3>& pml_B = pml[lev]->GetB_fp();
                 const std::array<MultiFab*, 3>& pml_E = pml[lev]->GetE_fp();
-                shiftMF(*pml_B[dim], geom[lev], num_shift, dir, ng_extra);
-                shiftMF(*pml_E[dim], geom[lev], num_shift, dir, ng_extra);
+                shiftMF(*pml_B[dim], geom[lev], num_shift, dir);
+                shiftMF(*pml_E[dim], geom[lev], num_shift, dir);
             }
 
             if (lev > 0) {
                 // coarse grid
-                shiftMF(*Bfield_cp[lev][dim], geom[lev-1], num_shift_crse, dir, ng_zero, B_external_grid[dim], use_Bparser, Bfield_parser);
-                shiftMF(*Efield_cp[lev][dim], geom[lev-1], num_shift_crse, dir, ng_zero, E_external_grid[dim], use_Eparser, Efield_parser);
-                shiftMF(*Bfield_aux[lev][dim], geom[lev], num_shift, dir, ng_zero);
-                shiftMF(*Efield_aux[lev][dim], geom[lev], num_shift, dir, ng_zero);
+                shiftMF(*Bfield_cp[lev][dim], geom[lev-1], num_shift_crse, dir, B_external_grid[dim], use_Bparser, Bfield_parser);
+                shiftMF(*Efield_cp[lev][dim], geom[lev-1], num_shift_crse, dir, E_external_grid[dim], use_Eparser, Efield_parser);
+                shiftMF(*Bfield_aux[lev][dim], geom[lev], num_shift, dir);
+                shiftMF(*Efield_aux[lev][dim], geom[lev], num_shift, dir);
                 if (fft_do_time_averaging) {
-                    shiftMF(*Bfield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, ng_zero, B_external_grid[dim], use_Bparser, Bfield_parser);
-                    shiftMF(*Efield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, ng_zero, E_external_grid[dim], use_Eparser, Efield_parser);
-                    shiftMF(*Bfield_avg_aux[lev][dim], geom[lev], num_shift, dir, ng_zero);
-                    shiftMF(*Efield_avg_aux[lev][dim], geom[lev], num_shift, dir, ng_zero);
+                    shiftMF(*Bfield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, B_external_grid[dim], use_Bparser, Bfield_parser);
+                    shiftMF(*Efield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, E_external_grid[dim], use_Eparser, Efield_parser);
+                    shiftMF(*Bfield_avg_aux[lev][dim], geom[lev], num_shift, dir);
+                    shiftMF(*Efield_avg_aux[lev][dim], geom[lev], num_shift, dir);
                 }
                 if (move_j) {
-                    shiftMF(*current_cp[lev][dim], geom[lev-1], num_shift_crse, dir, ng_zero);
+                    shiftMF(*current_cp[lev][dim], geom[lev-1], num_shift_crse, dir);
                 }
                 if (do_pml && pml[lev]->ok()) {
                     const std::array<MultiFab*, 3>& pml_B = pml[lev]->GetB_cp();
                     const std::array<MultiFab*, 3>& pml_E = pml[lev]->GetE_cp();
-                    shiftMF(*pml_B[dim], geom[lev-1], num_shift_crse, dir, ng_extra);
-                    shiftMF(*pml_E[dim], geom[lev-1], num_shift_crse, dir, ng_extra);
+                    shiftMF(*pml_B[dim], geom[lev-1], num_shift_crse, dir);
+                    shiftMF(*pml_E[dim], geom[lev-1], num_shift_crse, dir);
                 }
             }
         }
@@ -171,19 +168,19 @@ WarpX::MoveWindow (bool move_j)
         // Shift scalar component F for dive cleaning
         if (do_dive_cleaning) {
             // Fine grid
-            shiftMF(*F_fp[lev], geom[lev], num_shift, dir, ng_zero);
+            shiftMF(*F_fp[lev], geom[lev], num_shift, dir);
             if (do_pml && pml[lev]->ok()) {
                 MultiFab* pml_F = pml[lev]->GetF_fp();
-                shiftMF(*pml_F, geom[lev], num_shift, dir, ng_extra);
+                shiftMF(*pml_F, geom[lev], num_shift, dir);
             }
             if (lev > 0) {
                 // Coarse grid
-                shiftMF(*F_cp[lev], geom[lev-1], num_shift_crse, dir, ng_zero);
+                shiftMF(*F_cp[lev], geom[lev-1], num_shift_crse, dir);
                 if (do_pml && pml[lev]->ok()) {
                     MultiFab* pml_F = pml[lev]->GetF_cp();
-                    shiftMF(*pml_F, geom[lev-1], num_shift_crse, dir, ng_zero);
+                    shiftMF(*pml_F, geom[lev-1], num_shift_crse, dir);
                 }
-                shiftMF(*rho_cp[lev], geom[lev-1], num_shift_crse, dir, ng_zero);
+                shiftMF(*rho_cp[lev], geom[lev-1], num_shift_crse, dir);
             }
         }
 
@@ -191,10 +188,10 @@ WarpX::MoveWindow (bool move_j)
         if (move_j) {
             if (rho_fp[lev]){
                 // Fine grid
-                shiftMF(*rho_fp[lev],   geom[lev], num_shift, dir, ng_zero);
+                shiftMF(*rho_fp[lev],   geom[lev], num_shift, dir);
                 if (lev > 0){
                     // Coarse grid
-                    shiftMF(*rho_cp[lev], geom[lev-1], num_shift_crse, dir, ng_zero);
+                    shiftMF(*rho_cp[lev], geom[lev-1], num_shift_crse, dir);
                 }
             }
         }
@@ -243,7 +240,7 @@ WarpX::MoveWindow (bool move_j)
 
 void
 WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
-                IntVect ng_extra, amrex::Real external_field, bool useparser,
+                amrex::Real external_field, bool useparser,
                 HostDeviceParser<3> const& field_parser)
 {
     WARPX_PROFILE("WarpX::shiftMF()");
@@ -264,8 +261,6 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
         IntVect ng_mw = IntVect::TheUnitVector();
         // Enough guard cells in the MW direction
         ng_mw[dir] = num_shift;
-        // Add the extra cell (if momentum-conserving gather with staggered field solve)
-        ng_mw += ng_extra;
         // Make sure we don't exceed number of guard cells allocated
         ng_mw = ng_mw.min(ng);
         // Fill guard cells.

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -93,9 +93,8 @@ public:
     MultiParticleContainer& GetPartContainer () { return *mypc; }
 
     static void shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
-                         int num_shift, int dir, amrex::IntVect ng_extra,
-                         amrex::Real external_field=0.0, bool useparser = false,
-                         HostDeviceParser<3> const& field_parser={});
+                         int num_shift, int dir, amrex::Real external_field=0.0,
+                         bool useparser = false, HostDeviceParser<3> const& field_parser={});
 
     static void GotoNextLine (std::istream& is);
 
@@ -437,17 +436,17 @@ public:
     void UpdateAuxilaryDataSameType ();
 
     // Fill boundary cells including coarse/fine boundaries
-    void FillBoundaryB   (amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryE   (amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryB_avg   (amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryE_avg   (amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
+    void FillBoundaryB   (amrex::IntVect ng);
+    void FillBoundaryE   (amrex::IntVect ng);
+    void FillBoundaryB_avg   (amrex::IntVect ng);
+    void FillBoundaryE_avg   (amrex::IntVect ng);
 
     void FillBoundaryF   (amrex::IntVect ng);
     void FillBoundaryAux (amrex::IntVect ng);
-    void FillBoundaryE   (int lev, amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryB   (int lev, amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryE_avg   (int lev, amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
-    void FillBoundaryB_avg   (int lev, amrex::IntVect ng, amrex::IntVect ng_extra_fine=amrex::IntVect::TheZeroVector());
+    void FillBoundaryE   (int lev, amrex::IntVect ng);
+    void FillBoundaryB   (int lev, amrex::IntVect ng);
+    void FillBoundaryE_avg   (int lev, amrex::IntVect ng);
+    void FillBoundaryB_avg   (int lev, amrex::IntVect ng);
 
     void FillBoundaryF   (int lev, amrex::IntVect ng);
     void FillBoundaryAux (int lev, amrex::IntVect ng);
@@ -529,7 +528,6 @@ public:
 
     const amrex::IntVect getngE() const { return guard_cells.ng_alloc_EB; }
     const amrex::IntVect getngF() const { return guard_cells.ng_alloc_F; }
-    const amrex::IntVect getngExtra() const { return guard_cells.ng_Extra; }
     const amrex::IntVect getngUpdateAux() const { return guard_cells.ng_UpdateAux; }
     const amrex::IntVect get_ng_depos_J() const {return guard_cells.ng_depos_J;}
     const amrex::IntVect get_ng_depos_rho() const {return guard_cells.ng_depos_rho;}
@@ -763,7 +761,7 @@ private:
     void AllocLevelMFs (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
                         const amrex::IntVect& ngE, const amrex::IntVect& ngJ,
                         const amrex::IntVect& ngRho, const amrex::IntVect& ngF,
-                        const amrex::IntVect& ngextra, const bool aux_is_nodal);
+                        const bool aux_is_nodal);
 
     amrex::Vector<int> istep;      // which step?
     amrex::Vector<int> nsubsteps;  // how many substeps on each level?

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1046,7 +1046,6 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         WarpX::use_fdtd_nci_corr,
         do_nodal,
         do_moving_window,
-        aux_is_nodal,
         moving_window_dir,
         WarpX::nox,
         nox_fft, noy_fft, noz_fft,
@@ -1075,14 +1074,13 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
     }
 
     AllocLevelMFs(lev, ba, dm, guard_cells.ng_alloc_EB, guard_cells.ng_alloc_J,
-                  guard_cells.ng_alloc_Rho, guard_cells.ng_alloc_F,
-                  guard_cells.ng_Extra, aux_is_nodal);
+                  guard_cells.ng_alloc_Rho, guard_cells.ng_alloc_F, aux_is_nodal);
 }
 
 void
 WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm,
                       const IntVect& ngE, const IntVect& ngJ, const IntVect& ngRho,
-                      const IntVect& ngF, const IntVect& ngextra, const bool aux_is_nodal)
+                      const IntVect& ngF, const bool aux_is_nodal)
 {
     // Declare nodal flags
     IntVect Ex_nodal_flag, Ey_nodal_flag, Ez_nodal_flag;
@@ -1164,13 +1162,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     //
     std::array<Real,3> dx = CellSize(lev);
 
-    Bfield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Bx_nodal_flag),dm,ncomps,ngE+ngextra,tag("Bfield_fp[x]"));
-    Bfield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,By_nodal_flag),dm,ncomps,ngE+ngextra,tag("Bfield_fp[y]"));
-    Bfield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Bz_nodal_flag),dm,ncomps,ngE+ngextra,tag("Bfield_fp[z]"));
+    Bfield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Bx_nodal_flag),dm,ncomps,ngE,tag("Bfield_fp[x]"));
+    Bfield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,By_nodal_flag),dm,ncomps,ngE,tag("Bfield_fp[y]"));
+    Bfield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Bz_nodal_flag),dm,ncomps,ngE,tag("Bfield_fp[z]"));
 
-    Efield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Ex_nodal_flag),dm,ncomps,ngE+ngextra,tag("Efield_fp[x]"));
-    Efield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE+ngextra,tag("Efield_fp[y]"));
-    Efield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE+ngextra,tag("Efield_fp[z]"));
+    Efield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Ex_nodal_flag),dm,ncomps,ngE,tag("Efield_fp[x]"));
+    Efield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE,tag("Efield_fp[y]"));
+    Efield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE,tag("Efield_fp[z]"));
 
     current_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_fp[x]"));
     current_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_fp[y]"));


### PR DESCRIPTION
I think the initial reason for adding this extra ghost cell with momentum-conserving field gathering was that with the _old interpolation functions_, which did not have padding with zeros around the ghost cells of the input staggered arrays and which performed always linear interpolation only, we needed one extra point when interpolating from a staggered field to a nodal field, in order to properly fill the last nodal point in the output array (which otherwise would be filled with junk, like `NaN` or similar, without padding):

```
--o-----o-----o-----o     (this was the last nodal point)
-----x-----x-----x:::::x  (this was the extra ghost point)
```

However, with the _new interpolation functions_ implemented in recent PRs, where we now have _padding_ with zeros around the ghost cells of the input staggered arrays, we probably do not need this anymore.

Given that we are talking about the last ghost points, they should not matter at all in the end for the subsequent field gathering operations (at least with PSATD for sure, where we have many ghost cells which span a region larger than (half of) the support of the shape factors).

The current CI tests that use momentum-conserving field gathering do _not_ seem to be compromised:
- ElectrostaticSphere (3D, FDTD)
- ElectrostaticSphereLabFrame (3D, FDTD)
- momentum-conserving-gather (2D, FDTD)
- Langmuir_multi_2d_psatd_momentum_conserving (2D, PSATD)
- Langmuir_multi_psatd_momentum_conserving (3D, PSATD)
- galilean_hybrid_2d (2D, PSATD)
- comoving_hybrid_2d (2D, PSATD)
- qed_schwinger1 (3D, FDTD)
- qed_schwinger2 (3D, FDTD)
- qed_schwinger3 (3D, FDTD)
- qed_schwinger4 (3D, FDTD)

**Note**
Issues might come if some scenarios are not covered by CI. Do you think the tests above provide enough coverage? I mean, the rationale behind the PR to me seems to make sense, but I'm not sure how safe we want to play (an extra-safe way to implement this change would be to set by hand `ng_Extra = 0` in Source/Parallelization/GuardCellManager.cpp, which we could revert if we discovered that this an issue for some scenario that isn't covered by CI -- I wouldn't be too in favor of this solution, though). 