### PR TITLE
Update AMReX: Install (Regression)

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -186,7 +186,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "dd2ec76a5cc5db01caa17bdf51efb603c019346d"
+set(WarpX_amrex_branch "2fb82bf64838aba949f7a641988a0c58774e5a88"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR and AMReX
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout dd2ec76a5cc5db01caa17bdf51efb603c019346d && cd -
+cd amrex && git checkout 2fb82bf64838aba949f7a641988a0c58774e5a88 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout b35f07243c51ac35d47857fe36f0aafb6b517955 && cd -


### PR DESCRIPTION
Update AMReX to the latest `development` branch. Fix a regression introduced in #1755.

This includes https://github.com/AMReX-Codes/amrex/pull/1840 which makes sure `AMReX_Config.H` is installed.