### PR TITLE
AMReX: Skip AMRLEVEL

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -62,6 +62,7 @@ macro(find_amrex)
         endif()
 
         set(AMReX_INSTALL ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
+        set(AMReX_AMRLEVEL OFF CACHE INTERNAL "")
         set(AMReX_ENABLE_TESTS OFF CACHE INTERNAL "")
         set(AMReX_FORTRAN OFF CACHE INTERNAL "")
         set(AMReX_FORTRAN_INTERFACES OFF CACHE INTERNAL "")


### PR DESCRIPTION
We don't use AMRLEVEL components in AMReX since we implement the `AmrCore` class.

This solves AMReX dynamic library issues on macOS and Windows.
It also saves compile-time for a component that we don't use.

Introduced in https://github.com/AMReX-Codes/amrex/pull/1714