### PR TITLE
Boundary Condition : Interface with existing PML

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -186,7 +186,7 @@ Domain Boundary Conditions
     Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``. If not set, the default value for the fields at the domain boundary will be set to pml.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
-    * ``pml``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
+    * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -186,7 +186,7 @@ Domain Boundary Conditions
     Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
-    * ``PML``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
+    * ``pml``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -183,11 +183,11 @@ Domain Boundary Conditions
 --------------------------
 
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
-    Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for `geometry.is_periodic` will be set, overriding the user-input for the input parameter, `geometry.is_periodic`.
+    Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
     * ``PML``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
-    Additional pml algorithms can be explored using the parameters `warpx.do_pml_in_domain`, `warpx.do_particles_in_pml`, and `warpx.do_pml_j_damping`.
+    Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -186,7 +186,7 @@ Domain Boundary Conditions
     Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``. If not set, the default value for the fields at the domain boundary will be set to pml.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
-    * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
+    * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for ``warpx.do_pml``. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -183,9 +183,11 @@ Domain Boundary Conditions
 --------------------------
 
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
-    Boundary conditions applied to field at the lower and upper domain boundaries.
+    Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for `geometry.is_periodic` will be set, overriding the user-input for the input parameter, `geometry.is_periodic`.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
+    * ``PML``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.
+    Additional pml algorithms can be explored using the parameters `warpx.do_pml_in_domain`, `warpx.do_particles_in_pml`, and `warpx.do_pml_j_damping`.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -183,7 +183,7 @@ Domain Boundary Conditions
 --------------------------
 
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
-    Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``.
+    Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``. If not set, the default value for the fields at the domain boundary will be set to pml.
     Options are:
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
     * ``pml``: This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for `do_pml`. See the :ref:`PML theory section <theory-bc>` for more details.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -185,6 +185,7 @@ Domain Boundary Conditions
 * ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``. If not set, the default value for the fields at the domain boundary will be set to pml.
     Options are:
+
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
     * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for ``warpx.do_pml``. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -31,6 +31,7 @@ grid = picmi.Cartesian3DGrid(number_of_cells = [nx, ny, nz],
 
 solver = picmi.ElectromagneticSolver(grid = grid,
                                      cfl = 1.,
+                                     warpx_do_pml = True,
                                      stencil_order=[em_order,em_order,em_order])
 
 electron_beam = picmi.GaussianBunchDistribution(n_physical_particles = total_charge/constants.q_e,

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -31,7 +31,6 @@ grid = picmi.Cartesian3DGrid(number_of_cells = [nx, ny, nz],
 
 solver = picmi.ElectromagneticSolver(grid = grid,
                                      cfl = 1.,
-                                     warpx_do_pml = True,
                                      stencil_order=[em_order,em_order,em_order])
 
 electron_beam = picmi.GaussianBunchDistribution(n_physical_particles = total_charge/constants.q_e,
@@ -73,4 +72,3 @@ sim.add_diagnostic(part_diag1)
 
 # Alternatively, sim.step will run WarpX, controlling it from Python
 sim.step()
-

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -25,7 +25,8 @@ amr.n_cell = 2688 3712
 amr.max_level = 0
 geometry.prob_lo = -7.5e-6 -5.e-6
 geometry.prob_hi =  7.5e-6 25.e-6
-geometry.is_periodic = 0 0 0  # non-periodic (default)
+geometry.is_periodic = 0 0  # non-periodic (default)
+warpx.do_pml = 1
 
 # macro-particle shape
 interpolation.nox = 3

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -26,7 +26,6 @@ amr.max_level = 0
 geometry.prob_lo = -7.5e-6 -5.e-6
 geometry.prob_hi =  7.5e-6 25.e-6
 geometry.is_periodic = 0 0  # non-periodic (default)
-warpx.do_pml = 1
 
 # macro-particle shape
 interpolation.nox = 3

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
@@ -28,7 +28,7 @@ grid = picmi.Cartesian3DGrid(number_of_cells = [nx, ny, nz],
                              moving_window_velocity = moving_window_velocity,
                              warpx_max_grid_size=32)
 
-solver = picmi.ElectromagneticSolver(grid=grid, cfl=1, warpx_do_pml = True)
+solver = picmi.ElectromagneticSolver(grid=grid, cfl=1)
 
 beam_distribution = picmi.UniformDistribution(density = 1.e23,
                                               lower_bound = [-20.e-6, -20.e-6, -150.e-6],
@@ -72,4 +72,3 @@ sim.add_diagnostic(part_diag)
 
 # Alternatively, sim.step will run WarpX, controlling it from Python
 sim.step()
-

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
@@ -28,7 +28,7 @@ grid = picmi.Cartesian3DGrid(number_of_cells = [nx, ny, nz],
                              moving_window_velocity = moving_window_velocity,
                              warpx_max_grid_size=32)
 
-solver = picmi.ElectromagneticSolver(grid=grid, cfl=1)
+solver = picmi.ElectromagneticSolver(grid=grid, cfl=1, warpx_do_pml = True)
 
 beam_distribution = picmi.UniformDistribution(density = 1.e23,
                                               lower_bound = [-20.e-6, -20.e-6, -150.e-6],

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -28,7 +28,6 @@ my_constants.zc2   = 24.05545177444479562e-6
 warpx.cfl = 1.0
 warpx.use_filter = 1
 algo.load_balance_intervals = 66
-warpx.do_pml = 1
 
 #################################
 ############ PLASMA #############

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -7,7 +7,7 @@ amr.max_grid_size = 128
 amr.blocking_factor = 32
 amr.max_level = 0
 geometry.coord_sys   = 0                  # 0: Cartesian
-geometry.is_periodic = 0 0 0     # Is periodic?
+geometry.is_periodic = 0 0     # Is periodic?
 geometry.prob_lo     = -100.e-6   0.     # physical domain
 geometry.prob_hi     =  100.e-6   100.e-6
 warpx.verbose = 1
@@ -28,6 +28,7 @@ my_constants.zc2   = 24.05545177444479562e-6
 warpx.cfl = 1.0
 warpx.use_filter = 1
 algo.load_balance_intervals = 66
+warpx.do_pml = 1
 
 #################################
 ############ PLASMA #############

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -585,12 +585,12 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (do_pml_Lo[idim]){
                 // ncell is divided by refinement ratio to ensure that the
-                // physical width of the PML region is equal is fine and coarse patch
+                // physical width of the PML region is equal in fine and coarse patch
                 domain1.growLo(idim, -ncell/ref_ratio[idim]);
             }
             if (do_pml_Hi[idim]){
                 // ncell is divided by refinement ratio to ensure that the
-                // physical width of the PML region is equal is fine and coarse patch
+                // physical width of the PML region is equal in fine and coarse patch
                 domain1.growHi(idim, -ncell/ref_ratio[idim]);
             }
         }

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -446,15 +446,12 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
     // with same [min,max]. But it does not support multiple disjoint refinement patches.
     Box domain0 = grid_ba.minimalBox();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        //if ( ! geom->isPeriodic(idim)) {
-            if (do_pml_Lo[idim]){
-                domain0.growLo(idim, -ncell);
-            }
-            if (do_pml_Hi[idim]){
-                domain0.growHi(idim, -ncell);
-            }
-
-        //}
+        if (do_pml_Lo[idim]){
+            domain0.growLo(idim, -ncell);
+        }
+        if (do_pml_Hi[idim]){
+            domain0.growHi(idim, -ncell);
+        }
     }
     const BoxArray grid_ba_reduced = BoxArray(grid_ba.boxList().intersect(domain0));
 
@@ -586,18 +583,16 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
         // assuming that the bounding box around grid_cba is a single patch, and not disjoint patches, similar to fine patch.
         amrex::Box domain1 = grid_cba.minimalBox();
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            //if ( ! cgeom->isPeriodic(idim)) {
-                if (do_pml_Lo[idim]){
-                    // ncell is divided by refinement ratio to ensure that the
-                    // physical width of the PML region is equal is fine and coarse patch
-                    domain1.growLo(idim, -ncell/ref_ratio[idim]);
-                }
-                if (do_pml_Hi[idim]){
-                    // ncell is divided by refinement ratio to ensure that the
-                    // physical width of the PML region is equal is fine and coarse patch
-                    domain1.growHi(idim, -ncell/ref_ratio[idim]);
-                }
-            //}
+            if (do_pml_Lo[idim]){
+                // ncell is divided by refinement ratio to ensure that the
+                // physical width of the PML region is equal is fine and coarse patch
+                domain1.growLo(idim, -ncell/ref_ratio[idim]);
+            }
+            if (do_pml_Hi[idim]){
+                // ncell is divided by refinement ratio to ensure that the
+                // physical width of the PML region is equal is fine and coarse patch
+                domain1.growHi(idim, -ncell/ref_ratio[idim]);
+            }
         }
         const BoxArray grid_cba_reduced = BoxArray(grid_cba.boxList().intersect(domain1));
 
@@ -681,14 +676,12 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
 {
     Box domain = geom.Domain();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        //if ( ! geom.isPeriodic(idim) ) {
-            if (do_pml_Lo[idim]){
-                domain.growLo(idim, ncell);
-            }
-            if (do_pml_Hi[idim]){
-                domain.growHi(idim, ncell);
-            }
-        //}
+        if (do_pml_Lo[idim]){
+            domain.growLo(idim, ncell);
+        }
+        if (do_pml_Hi[idim]){
+            domain.growHi(idim, ncell);
+        }
     }
     BoxList bl;
     for (int i = 0, N = grid_ba.size(); i < N; ++i)
@@ -701,13 +694,11 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
             //  the PML cells surrounding these patches cannot overlap
             // The check is only needed along the axis where PMLs are being used.
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                //if (! geom.isPeriodic(idim)) {
-                    if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
-                        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                            grid_bx.length(idim) > ncell,
-                            "Consider using larger amr.blocking_factor with PMLs");
-                    }
-                //}
+                if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                        grid_bx.length(idim) > ncell,
+                        "Consider using larger amr.blocking_factor with PMLs");
+                }
             }
         }
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -446,7 +446,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
     // with same [min,max]. But it does not support multiple disjoint refinement patches.
     Box domain0 = grid_ba.minimalBox();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if ( ! geom->isPeriodic(idim)) {
+        //if ( ! geom->isPeriodic(idim)) {
             if (do_pml_Lo[idim]){
                 domain0.growLo(idim, -ncell);
             }
@@ -454,7 +454,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
                 domain0.growHi(idim, -ncell);
             }
 
-        }
+        //}
     }
     const BoxArray grid_ba_reduced = BoxArray(grid_ba.boxList().intersect(domain0));
 
@@ -586,7 +586,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
         // assuming that the bounding box around grid_cba is a single patch, and not disjoint patches, similar to fine patch.
         amrex::Box domain1 = grid_cba.minimalBox();
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if ( ! cgeom->isPeriodic(idim)) {
+            //if ( ! cgeom->isPeriodic(idim)) {
                 if (do_pml_Lo[idim]){
                     // ncell is divided by refinement ratio to ensure that the
                     // physical width of the PML region is equal is fine and coarse patch
@@ -597,7 +597,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
                     // physical width of the PML region is equal is fine and coarse patch
                     domain1.growHi(idim, -ncell/ref_ratio[idim]);
                 }
-            }
+            //}
         }
         const BoxArray grid_cba_reduced = BoxArray(grid_cba.boxList().intersect(domain1));
 
@@ -681,14 +681,14 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
 {
     Box domain = geom.Domain();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if ( ! geom.isPeriodic(idim) ) {
+        //if ( ! geom.isPeriodic(idim) ) {
             if (do_pml_Lo[idim]){
                 domain.growLo(idim, ncell);
             }
             if (do_pml_Hi[idim]){
                 domain.growHi(idim, ncell);
             }
-        }
+        //}
     }
     BoxList bl;
     for (int i = 0, N = grid_ba.size(); i < N; ++i)
@@ -701,13 +701,13 @@ PML::MakeBoxArray (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
             //  the PML cells surrounding these patches cannot overlap
             // The check is only needed along the axis where PMLs are being used.
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                if (! geom.isPeriodic(idim)) {
+                //if (! geom.isPeriodic(idim)) {
                     if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                             grid_bx.length(idim) > ncell,
                             "Consider using larger amr.blocking_factor with PMLs");
                     }
-                }
+                //}
             }
         }
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -197,6 +197,7 @@ WarpX::InitPML ()
         for (int lev = 1; lev <= finest_level; ++lev)
         {
             amrex::IntVect do_pml_Lo_MR = amrex::IntVect::TheUnitVector();
+            amrex::IntVect do_pml_Hi_MR = amrex::IntVect::TheUnitVector();
 #ifdef WARPX_DIM_RZ
             //In cylindrical geometry, if the edge of the patch is at r=0, do not add PML
             if ((max_level > 0) && (fine_tag_lo[0]==0.)) {
@@ -209,7 +210,7 @@ WarpX::InitPML ()
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
                                    do_dive_cleaning, do_moving_window,
                                    pml_has_particles, do_pml_in_domain,
-                                   do_pml_Lo_MR, amrex::IntVect::TheUnitVector());
+                                   do_pml_Lo_MR, do_pml_Hi_MR);
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -198,6 +198,17 @@ WarpX::InitPML ()
         {
             amrex::IntVect do_pml_Lo_MR = amrex::IntVect::TheUnitVector();
             amrex::IntVect do_pml_Hi_MR = amrex::IntVect::TheUnitVector();
+            // check if fine patch edges co-incide with domain boundary
+            amrex::Box levelBox = boxArray(lev).minimalBox();
+            // Domain box at level, lev
+            amrex::Box DomainBox = Geom(lev).Domain();
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (levelBox.smallEnd(idim) == DomainBox.smallEnd(idim))
+                    do_pml_Lo_MR[idim] = do_pml_Lo[idim];
+                if (levelBox.bigEnd(idim) == DomainBox.bigEnd(idim))
+                    do_pml_Hi_MR[idim] = do_pml_Hi[idim];
+            }
+
 #ifdef WARPX_DIM_RZ
             //In cylindrical geometry, if the edge of the patch is at r=0, do not add PML
             if ((max_level > 0) && (fine_tag_lo[0]==0.)) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -184,7 +184,7 @@ WarpX::InitPML ()
     } else {
         // setting do_pml = 0 as default and turning it on only when user-input is set to PML.
         do_pml = 0;
-        do_pml_Lo = amrex::IntVect::TheZeroVector(); 
+        do_pml_Lo = amrex::IntVect::TheZeroVector();
         do_pml_Hi = amrex::IntVect::TheZeroVector();
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -180,6 +180,7 @@ WarpX::InitPML ()
             do_pml_Hi[idim] = 1;
         }
     }
+    if (finest_level > 0) do_pml = 1;
     if (do_pml)
     {
         amrex::IntVect do_pml_Lo_corrected = do_pml_Lo;

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -170,14 +170,31 @@ WarpX::InitFromScratch ()
 void
 WarpX::InitPML ()
 {
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {
-            do_pml = 1;
-            do_pml_Lo[idim] = 1;
+
+    // if periodicity defined in input, use existing pml interface
+    amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
+    ParmParse pp_geometry("geometry");
+    if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (geom_periodicity[idim] == 1) {
+                do_pml_Lo[idim] = 0;
+                do_pml_Hi[idim] = 0;
+            }
         }
-        if (WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) {
-            do_pml = 1;
-            do_pml_Hi[idim] = 1;
+    } else {
+        // setting do_pml = 0 as default and turning it on only when user-input is set to PML.
+        do_pml = 0;
+        do_pml_Lo = amrex::IntVect::TheZeroVector(); 
+        do_pml_Hi = amrex::IntVect::TheZeroVector();
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {
+                do_pml = 1;
+                do_pml_Lo[idim] = 1;
+            }
+            if (WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) {
+                do_pml = 1;
+                do_pml_Hi[idim] = 1;
+            }
         }
     }
     if (finest_level > 0) do_pml = 1;

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -170,6 +170,16 @@ WarpX::InitFromScratch ()
 void
 WarpX::InitPML ()
 {
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {
+            do_pml = 1;
+            do_pml_Lo[idim] = 1;
+        }
+        if (WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) {
+            do_pml = 1;
+            do_pml_Hi[idim] = 1;
+        }
+    }
     if (do_pml)
     {
         amrex::IntVect do_pml_Lo_corrected = do_pml_Lo;

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -96,9 +96,9 @@ struct LoadBalanceCostsUpdateAlgo {
  */
 struct FieldBoundaryType {
     enum {
-        PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
+        PML = 0,
         Periodic = 1,
-        PML = 2,
+        PEC = 2,     //!< perfect electric conductor (PEC) with E_tangential=0
         PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
     };
 };

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -114,28 +114,6 @@ struct ParticleBoundaryType {
     };
 };
 
-/** Field boundary conditions at the domain boundary
- */
-struct FieldBoundaryType {
-    enum {
-        PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
-        Periodic = 1,
-        PML = 2,
-        PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
-    };
-};
-
-/** Particle boundary conditions at the domain boundary
- */
-struct ParticleBoundaryType {
-    enum {
-        Absorbing = 0,     //!< particles crossing domain boundary are removed
-        Open = 1,          //!< particles cross domain boundary leave with damped j
-        Reflecting = 2,     //!< particles are reflected
-        Periodic = 3
-    };
-};
-
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -125,7 +125,7 @@ struct FieldBoundaryType {
     };
 };
 
-/** Field boundary conditions at the domain boundary
+/** Particle boundary conditions at the domain boundary
  */
 struct ParticleBoundaryType {
     enum {

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -114,6 +114,16 @@ struct ParticleBoundaryType {
     };
 };
 
+
+struct BoundaryType {
+    enum {
+        PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
+        Periodic = 1,
+        PML = 2,
+        PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
+    };
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -114,13 +114,25 @@ struct ParticleBoundaryType {
     };
 };
 
-
-struct BoundaryType {
+/** Field boundary conditions at the domain boundary
+ */
+struct FieldBoundaryType {
     enum {
         PEC = 0,     //!< perfect electric conductor (PEC) with E_tangential=0
         Periodic = 1,
         PML = 2,
         PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
+    };
+};
+
+/** Field boundary conditions at the domain boundary
+ */
+struct ParticleBoundaryType {
+    enum {
+        Absorbing = 0,     //!< particles crossing domain boundary are removed
+        Open = 1,          //!< particles cross domain boundary leave with damped j
+        Reflecting = 2,     //!< particles are reflected
+        Periodic = 3
     };
 };
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -76,11 +76,11 @@ const std::map<std::string, int> MacroscopicSolver_algo_to_int = {
 };
 
 const std::map<std::string, int> FieldBCType_algo_to_int = {
-    {"pec",      FieldBoundaryType::PEC},
-    {"periodic", FieldBoundaryType::Periodic},
     {"pml",      FieldBoundaryType::PML},
+    {"periodic", FieldBoundaryType::Periodic},
+    {"pec",      FieldBoundaryType::PEC},
     {"pmc",      FieldBoundaryType::PMC},
-    {"default",  FieldBoundaryType::PEC}
+    {"default",  FieldBoundaryType::PML}
 };
 
 const std::map<std::string, int> ParticleBCType_algo_to_int = {

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -363,10 +363,10 @@ void ReadBCParams ()
         // set default field and particle boundary appropriately
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (geom_periodicity[idim] == 1) {
-                field_BC_lo[idim] = 1;
-                field_BC_hi[idim] = 1;
-                particle_BC_lo[idim] = 1;
-                particle_BC_hi[idim] = 1;
+                WarpX::field_boundary_lo[idim] = 1;
+                WarpX::field_boundary_hi[idim] = 1;
+                WarpX::particle_boundary_lo[idim] = 1;
+                WarpX::particle_boundary_hi[idim] = 1;
             }
         }
         return;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -405,6 +405,10 @@ void ReadBCParams ()
                 // set particle boundary to periodic
                 WarpX::particle_boundary_lo[idim] = ParticleBoundaryType::Periodic;
                 WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
+<<<<<<< HEAD
+=======
+                amrex::Warning("Particle boundary is set to periodic to be consistent with the fields.");
+>>>>>>> 77e70c05... separate particle and field boudnary structs
             }
 
         }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -412,6 +412,7 @@ void ReadBCParams ()
             }
 
         }
+ 
     }
 
     pp_geometry.addarr("is_periodic", geom_periodicity);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -412,7 +412,7 @@ void ReadBCParams ()
             }
 
         }
- 
+
     }
 
     pp_geometry.addarr("is_periodic", geom_periodicity);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -360,6 +360,15 @@ void ReadBCParams ()
     amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
     ParmParse pp_geometry("geometry");
     if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
+        // set default field and particle boundary appropriately
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (geom_periodicity[idim] == 1) {
+                field_BC_lo[idim] = 1;
+                field_BC_hi[idim] = 1;
+                particle_BC_lo[idim] = 1;
+                particle_BC_hi[idim] = 1;
+            }
+        }
         return;
         // When all boundary conditions are supported, the abort statement below will be introduced
         //amrex::Abort("geometry.is_periodic is not supported. Please use `boundary.field_lo`, `boundary.field_hi` to specifiy field boundary conditions and 'boundary.particle_lo', 'boundary.particle_hi'  to specify particle boundary conditions.");

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -405,10 +405,6 @@ void ReadBCParams ()
                 // set particle boundary to periodic
                 WarpX::particle_boundary_lo[idim] = ParticleBoundaryType::Periodic;
                 WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
-<<<<<<< HEAD
-=======
-                amrex::Warning("Particle boundary is set to periodic to be consistent with the fields.");
->>>>>>> 77e70c05... separate particle and field boudnary structs
             }
 
         }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -359,14 +359,24 @@ void ReadBCParams ()
     amrex::Vector<std::string> particle_BC_hi(AMREX_SPACEDIM,"default");
     amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
     ParmParse pp_geometry("geometry");
+    ParmParse pp_warpx("warpx");
     if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
         // set default field and particle boundary appropriately
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (geom_periodicity[idim] == 1) {
-                WarpX::field_boundary_lo[idim] = 1;
-                WarpX::field_boundary_hi[idim] = 1;
-                WarpX::particle_boundary_lo[idim] = 1;
-                WarpX::particle_boundary_hi[idim] = 1;
+                // set boundary to periodic based on user-defined periodicity
+                WarpX::field_boundary_lo[idim] = FieldBoundaryType::Periodic;
+                WarpX::field_boundary_hi[idim] = FieldBoundaryType::Periodic;
+                WarpX::particle_boundary_lo[idim] = ParticleBoundaryType::Periodic;
+                WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
+            } else {
+                // if non-periodic and do_pml=0, then set default boundary to PEC
+                int pml_input;
+                pp_warpx.query("do_pml", temp_pml_input);
+                if (pml_input == 0) {
+                    WarpX::field_boundary_lo[idim] = FieldBoundaryType::PEC;
+                    WarpX::field_boundary_hi[idim] = FieldBoundaryType::PEC;
+                }
             }
         }
         return;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -408,7 +408,6 @@ void ReadBCParams ()
             }
 
         }
-
     }
 
     pp_geometry.addarr("is_periodic", geom_periodicity);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -371,8 +371,8 @@ void ReadBCParams ()
                 WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
             } else {
                 // if non-periodic and do_pml=0, then set default boundary to PEC
-                int pml_input;
-                pp_warpx.query("do_pml", temp_pml_input);
+                int pml_input = 1;
+                pp_warpx.query("do_pml", pml_input);
                 if (pml_input == 0) {
                     WarpX::field_boundary_lo[idim] = FieldBoundaryType::PEC;
                     WarpX::field_boundary_hi[idim] = FieldBoundaryType::PEC;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -890,15 +890,15 @@ private:
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > charge_buf;
 
     // PML
-    int do_pml = 0;
+    int do_pml = 1;
     int do_silver_mueller = 0;
     int pml_ncell = 10;
     int pml_delta = 10;
     int pml_has_particles = 0;
     int do_pml_j_damping = 0;
     int do_pml_in_domain = 0;
-    amrex::IntVect do_pml_Lo = amrex::IntVect::TheZeroVector();
-    amrex::IntVect do_pml_Hi = amrex::IntVect::TheZeroVector();
+    amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector();
+    amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector();
     amrex::Vector<std::unique_ptr<PML> > pml;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -890,15 +890,15 @@ private:
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > charge_buf;
 
     // PML
-    int do_pml = 1;
+    int do_pml = 0;
     int do_silver_mueller = 0;
     int pml_ncell = 10;
     int pml_delta = 10;
     int pml_has_particles = 0;
     int do_pml_j_damping = 0;
     int do_pml_in_domain = 0;
-    amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector();
-    amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector();
+    amrex::IntVect do_pml_Lo = amrex::IntVect::TheZeroVector();
+    amrex::IntVect do_pml_Hi = amrex::IntVect::TheZeroVector();
     amrex::Vector<std::unique_ptr<PML> > pml;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -584,10 +584,11 @@ WarpX::ReadParameters ()
 #endif
         // setting default to 0
         Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,0);
-        // Switching pml lo to 1 when do_pml = 1
+        // Switching pml lo to 1 when do_pml = 1 and if domain is non-periodic
+        // Note to remove this code when new BC API is fully functional
         if (do_pml == 1) {
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                parse_do_pml_Lo[idim] = 1;
+                if ( Geom(0).isPeriodic(idim) == 0) parse_do_pml_Lo[idim] = 1;
             }
         }
         pp_warpx.queryarr("do_pml_Lo", parse_do_pml_Lo);
@@ -598,10 +599,11 @@ WarpX::ReadParameters ()
 #endif
         // setting default to 0
         Vector<int> parse_do_pml_Hi(AMREX_SPACEDIM,0);
-        // Switching pml hi to 1 when do_pml = 1
+        // Switching pml hi to 1 when do_pml = 1 and if domain is non-periodic
+        // Note to remove this code when new BC API is fully functional
         if (do_pml == 1) {
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                parse_do_pml_Hi[idim] = 1;
+                if ( Geom(0).isPeriodic(idim) == 0) parse_do_pml_Hi[idim] = 1;
             }
         }
         pp_warpx.queryarr("do_pml_Hi", parse_do_pml_Hi);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -582,15 +582,28 @@ WarpX::ReadParameters ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( do_pml==0,
             "PML are not implemented in RZ geometry ; please set `warpx.do_pml=0`");
 #endif
-
-        Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,1);
+        // setting default to 0
+        Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,0);
+        // Switching pml lo to 1 when do_pml = 1
+        if (do_pml == 1) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                parse_do_pml_Lo[idim] = 1;
+            }
+        }
         pp_warpx.queryarr("do_pml_Lo", parse_do_pml_Lo);
         do_pml_Lo[0] = parse_do_pml_Lo[0];
         do_pml_Lo[1] = parse_do_pml_Lo[1];
 #if (AMREX_SPACEDIM == 3)
         do_pml_Lo[2] = parse_do_pml_Lo[2];
 #endif
-        Vector<int> parse_do_pml_Hi(AMREX_SPACEDIM,1);
+        // setting default to 0
+        Vector<int> parse_do_pml_Hi(AMREX_SPACEDIM,0);
+        // Switching pml hi to 1 when do_pml = 1
+        if (do_pml == 1) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                parse_do_pml_Hi[idim] = 1;
+            }
+        }
         pp_warpx.queryarr("do_pml_Hi", parse_do_pml_Hi);
         do_pml_Hi[0] = parse_do_pml_Hi[0];
         do_pml_Hi[1] = parse_do_pml_Hi[1];


### PR DESCRIPTION
This PR interfaces the new boundary input, `field.boundary_lo = PML` and `field.boundary_hi = PML` with the pml implementation the code, by setting `do_pml`, `do_pml_Lo` and `do_pml_Hi` accordingly.

Additionally, if `num_levels > 0`, then `do_pml = 1` and `do_pml_Lo_MR` and `do_pml_Hi_MR` are set to 1 in each direction.

However, if the fine patch co-incides with the domain boundary, then the domain boundary condition will be applied and the pml flag for the level1 and higher patches will be set to the value of the pml flag consistent with the domain boundary.
That is, if the domain boundary is pml, then the pml flags for MR patches will be set to 1 in that direction.
If domain boundary is pec, periodic, or pmc, then the pml flag for the MR patches will be set to 0.


I have tested this with the test in `Examples/Tests/particles_in_PML/` using the input parameters
```
boundary.field_lo = pml pml pml
boundary.field_hi = pml pml pml
```
The particles in this test-case are still treated based on the input parameters, `warpx.do_pml_j_damping=1`

Note that, `geometric.is_periodic` and `warpx.do_pml` are not used, since the field boundary condition will override those parameters.

[inputs_mr_3d_BC.txt](https://github.com/ECP-WarpX/WarpX/files/6224879/inputs_mr_3d_BC.txt)

![Screenshot from 2021-03-29 16-43-46](https://user-images.githubusercontent.com/41089244/112913170-0951d800-90ae-11eb-927f-c3624831fcdf.png)





To be merged after PR #1730 