### PR TITLE
Add option to specify a0 instead of e_max for the laser

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -765,11 +765,16 @@ Laser initialization
 
     .. math::
 
-        E_{max} = a_0 \frac{2 \pi m_e c}{e\lambda} = a_0 \times (4.0 \cdot 10^{12} \;V.m^{-1})
+        E_{max} = a_0 \frac{2 \pi m_e c^2}{e\lambda} = a_0 \times (4.0 \cdot 10^{12} \;V.m^{-1})
 
     When running a **boosted-frame simulation**, provide the value of ``<laser_name>.e_max``
     in the laboratory frame, and use ``warpx.gamma_boost`` to automatically
     perform the conversion to the boosted frame.
+
+* ``<laser_name>.a0`` (`float` ; dimensionless)
+    Peak normalized amplitude of the laser field (given in the lab frame, just as ``e_max`` above).
+    See the description of ``<laser_name>.e_max`` for the conversion between ``a0`` and ``e_max``.
+    Exactly one of ``a0`` and ``e_max`` must be specified.
 
 * ``<laser_name>.wavelength`` (`float`; in meters)
     The wavelength of the laser in vacuum.

--- a/Examples/Modules/ionization/inputs_2d_bf_rt
+++ b/Examples/Modules/ionization/inputs_2d_bf_rt
@@ -50,7 +50,7 @@ laser1.profile      = Gaussian
 laser1.position     = 0. 0. -1.e-6
 laser1.direction    = 0. 0. 1.
 laser1.polarization = 1. 0. 0.
-laser1.e_max        = 7.224e12 # a0=1.8
+laser1.a0           = 1.8
 laser1.profile_waist = 1.e10
 laser1.profile_duration = 26.685e-15
 laser1.profile_t_peak = 60.e-15

--- a/Examples/Modules/ionization/inputs_2d_rt
+++ b/Examples/Modules/ionization/inputs_2d_rt
@@ -43,7 +43,7 @@ laser1.profile      = Gaussian
 laser1.position     = 0. 0. 3.e-6
 laser1.direction    = 0. 0. 1.
 laser1.polarization = 1. 0. 0.
-laser1.e_max        = 7.224e12 # a0=1.8
+laser1.a0           = 1.8
 laser1.profile_waist = 1.e10
 laser1.profile_duration = 26.685e-15
 laser1.profile_t_peak = 60.e-15

--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -167,7 +167,7 @@ lasers.names        = laser1
 laser1.position     = 0. 0. -4.0e-6     # point the laser plane (antenna)
 laser1.direction    = 0. 0. 1.          # the plane's (antenna's) normal direction
 laser1.polarization = 1. 0. 0.          # the main polarization vector
-laser1.e_max        = 64.e12            # maximum amplitude of the laser field [V/m]
+laser1.a0           = 16.0              # maximum amplitude of the laser field [V/m]
 laser1.wavelength   = 0.8e-6            # central wavelength of the laser pulse [m]
 laser1.profile      = Gaussian
 laser1.profile_waist = 4.e-6            # beam waist (E(w_0)=E_0/e) [m]
@@ -175,8 +175,8 @@ laser1.profile_duration = 30.e-15       # pulse length (E(tau)=E_0/e; tau=tau_E=
 laser1.profile_t_peak = 50.e-15         # time until peak intensity reached at the laser plane [s]
 laser1.profile_focal_distance = 4.0e-6  # focal distance from the antenna [m]
 
-# E_0 = a_0 * 3.211e12 / lambda_0[mu]
-#   a_0 = 16, lambda_0 = 0.8mu -> E_0 = 64.22 TV/m
+# e_max = a0 * 3.211e12 / lambda_0[mu]
+#   a0 = 16, lambda_0 = 0.8mu -> e_max = 64.22 TV/m
 
 
 #################################

--- a/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
+++ b/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
@@ -1,36 +1,36 @@
 {
   "electrons": {
     "particle_cpu": 0.0,
-    "particle_id": 2100770663.0,
-    "particle_momentum_x": 3.6171938780852974e-19,
+    "particle_id": 2101654260.0,
+    "particle_momentum_x": 3.819006669880345e-19,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.6311514862164977e-18,
-    "particle_position_x": 0.008132465063060472,
-    "particle_position_y": 0.03052543530299656,
-    "particle_weight": 2.639604043928779e+17
+    "particle_momentum_z": 1.6442919544438796e-18,
+    "particle_position_x": 0.008132686129387588,
+    "particle_position_y": 0.030529759891592873,
+    "particle_weight": 2.641331189632942e+17
   },
   "hydrogen": {
     "particle_cpu": 0.0,
-    "particle_id": 8665433085.0,
-    "particle_momentum_x": 2.2382541035986144e-18,
+    "particle_id": 8663540542.0,
+    "particle_momentum_x": 2.2442931423587623e-18,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.0813049491770702e-18,
-    "particle_position_x": 0.008258418949038466,
-    "particle_position_y": 0.03669703064170578,
-    "particle_weight": 2.7025048365676528e+17
+    "particle_momentum_z": 1.0841108905602765e-18,
+    "particle_position_x": 0.008258183385250792,
+    "particle_position_y": 0.03668783554832863,
+    "particle_weight": 2.701906737218416e+17
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 11356841.408736344,
+    "By": 11393535.83414041,
     "Bz": 0.0,
-    "Ex": 2027017677607943.5,
+    "Ex": 2033400456620381.5,
     "Ey": 0.0,
-    "Ez": 315120773358047.5,
-    "jx": 1.6296835325234199e+19,
+    "Ez": 316047264778828.4,
+    "jx": 1.6346708216210751e+19,
     "jy": 0.0,
-    "jz": 8.845130014069639e+18,
-    "rho": 61585701576.20557,
-    "rho_electrons": 17451938595941.123,
-    "rho_hydrogen": 17441818166866.402
+    "jz": 8.884557953651988e+18,
+    "rho": 61729754758.60603,
+    "rho_electrons": 17451988255188.39,
+    "rho_hydrogen": 17441820007046.848
   }
 }

--- a/Regression/Checksum/benchmarks_json/ionization_boost.json
+++ b/Regression/Checksum/benchmarks_json/ionization_boost.json
@@ -2,33 +2,33 @@
   "electrons": {
     "particle_cpu": 184.0,
     "particle_id": 1300726794.0,
-    "particle_momentum_x": 2.098113570957052e-17,
+    "particle_momentum_x": 2.109735198203607e-17,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.7268821693904448e-17,
-    "particle_position_x": 0.11034569656973041,
-    "particle_position_y": 1.7106214131701365,
+    "particle_momentum_z": 1.7061960960279204e-17,
+    "particle_position_x": 0.11060117510075951,
+    "particle_position_y": 1.7038797728732886,
     "particle_weight": 3.0702532354579605e-09
   },
   "ions": {
     "particle_cpu": 0.0,
     "particle_id": 89142848.0,
     "particle_ionization_level": 52651.0,
-    "particle_momentum_x": 3.586036810957103e-18,
+    "particle_momentum_x": 3.586073239449067e-18,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.0432995298791402e-13,
-    "particle_position_x": 0.021439915568523423,
-    "particle_position_y": 0.47267670568729886,
+    "particle_momentum_z": 1.0432995298791797e-13,
+    "particle_position_x": 0.021439915608916116,
+    "particle_position_y": 0.4726767056871516,
     "particle_weight": 5.000948082142308e-10
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 18262991.064426593,
+    "By": 18263186.89822245,
     "Bz": 0.0,
-    "Ex": 5472952295140504.0,
+    "Ex": 5473010981530852.0,
     "Ey": 0.0,
-    "Ez": 923.6823445233051,
-    "jx": 12440722989281.025,
+    "Ez": 924.2093948096151,
+    "jx": 12440856390978.352,
     "jy": 0.0,
-    "jz": 166080.0000011085
+    "jz": 156080.00000114003
   }
 }

--- a/Regression/Checksum/benchmarks_json/ionization_lab.json
+++ b/Regression/Checksum/benchmarks_json/ionization_lab.json
@@ -1,34 +1,34 @@
 {
   "electrons": {
-    "particle_cpu": 21621.0,
-    "particle_id": 807671229.0,
-    "particle_momentum_x": 4.430889492774030e-18,
+    "particle_cpu": 21625.0,
+    "particle_id": 804501788.0,
+    "particle_momentum_x": 4.395709867927343e-18,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.666121148895218e-18,
-    "particle_position_x": 0.11023109550208991,
-    "particle_position_y": 0.6440160066398601,
-    "particle_weight": 3.454453125e-10
+    "particle_momentum_z": 2.6480766870985618e-18,
+    "particle_position_x": 0.10949403929812224,
+    "particle_position_y": 0.6411712856802138,
+    "particle_weight": 3.441640625e-10
   },
   "ions": {
     "particle_cpu": 5888.0,
     "particle_id": 42547456.0,
-    "particle_ionization_level": 72896.0,
-    "particle_momentum_x": 1.7611825794527892e-18,
+    "particle_ionization_level": 72897.0,
+    "particle_momentum_x": 1.761324005206226e-18,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 3.6184756635148216e-23,
-    "particle_position_x": 0.03199998869821981,
-    "particle_position_y": 0.1280000046215487,
+    "particle_momentum_z": 3.618696656380377e-23,
+    "particle_position_x": 0.03199998819289686,
+    "particle_position_y": 0.12800000462171646,
     "particle_weight": 9.999999999999999e-11
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 26296286.46016179,
+    "By": 26296568.43487075,
     "Bz": 0.0,
-    "Ex": 7878018647090106.0,
+    "Ex": 7878103122973058.0,
     "Ey": 0.0,
-    "Ez": 4192.9182796341565,
-    "jx": 1.2111228466502686e+16,
+    "Ez": 4193.202306476831,
+    "jx": 1.2111358333819302e+16,
     "jy": 0.0,
-    "jz": 1.361603066206671e-07
+    "jz": 1.3447249886563635e-07
   }
 }

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -52,7 +52,20 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 
     pp.query("pusher_algo", m_pusher_algo);
     getWithParser(pp, "wavelength", m_wavelength);
-    getWithParser(pp, "e_max", m_e_max);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_wavelength > 0, "The laser wavelength must be >0.");
+    const bool e_max_is_specified = queryWithParser(pp, "e_max", m_e_max);
+    Real a0;
+    const bool a0_is_specified = queryWithParser(pp, "a0", a0);
+    if (a0_is_specified){
+        Real omega = 2._rt*MathConst::pi*PhysConst::c/m_wavelength;
+        m_e_max = PhysConst::m_e * omega * PhysConst::c * a0 / PhysConst::q_e;
+    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        e_max_is_specified ^ a0_is_specified,
+        "Exactly one of e_max or a0 must be specified for the laser.\n"
+        );
+
     pp.query("do_continuous_injection", do_continuous_injection);
     pp.query("min_particles_per_mode", m_min_particles_per_mode);
 


### PR DESCRIPTION
This PR proposes to add the option to specify `a0` instead of `e_max`. If none is specified, an error is raised. If both are specified, a0 overrides with a warning.