### PR TITLE
README: License Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,23 @@ To contact the developers, feel free to open an issue on this repo, or visit our
 ## Contributing
 
 Our workflow is described in [CONTRIBUTING.rst](CONTRIBUTING.rst).
+
+## License
+
+WarpX Copyright (c) 2018-2021, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+If you have questions about your rights to use or distribute this software,
+please contact Berkeley Lab's Innovation & Partnerships Office at
+IPO@lbl.gov.
+
+NOTICE.  This Software was developed under funding from the U.S. Department
+of Energy and the U.S. Government consequently retains certain rights. As
+such, the U.S. Government has been granted for itself and others acting on
+its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+Software to reproduce, distribute copies to the public, prepare derivative
+works, and perform publicly and display publicly, and to permit other to do
+so.
+
+License for WarpX can be found at [LICENSE.txt](LICENSE.txt).

--- a/Tools/Release/newVersion.sh
+++ b/Tools/Release/newVersion.sh
@@ -132,6 +132,13 @@ sed -i -E "s/"\
 "\1${VERSION_STR_NOSUFFIX}\3$(date +%Y)\5/g" \
     ${REPO_DIR}/LICENSE.txt
 
+# README.md
+#   README.md: WarpX Copyright (c) 2018-2021, The Regents of ...
+sed -i -E "s/"\
+"(WarpX Copyright \(c\) 2018-)(.*)(, The Regents of.*)/"\
+"\1$(date +%Y)\3/g" \
+    ${REPO_DIR}/README.md
+
 
 # Epilog ######################################################################
 


### PR DESCRIPTION
Add a license block in the README. This is best practice recommended from our IPO.