### PR TITLE
Minor cleanup of RZ in collisions

### DIFF
--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -140,24 +140,23 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
                 index_type const cell_half_1 = (cell_start_1+cell_stop_1)/2;
 
                 // Do not collide if there is only one particle in the cell
-                if ( cell_stop_1 - cell_start_1 >= 2 )
-                {
-                    // shuffle
-                    ShuffleFisherYates(
-                        indices_1, cell_start_1, cell_half_1, engine );
+                if ( cell_stop_1 - cell_start_1 <= 1 ) return;
+
+                // shuffle
+                ShuffleFisherYates(
+                    indices_1, cell_start_1, cell_half_1, engine );
 #if defined WARPX_DIM_RZ
-                    int ri = (i_cell - i_cell%nz) / nz;
-                    auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
+                int ri = (i_cell - i_cell%nz) / nz;
+                auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
 #endif
-                    // Call the function in order to perform collisions
-                    ElasticCollisionPerez(
-                        cell_start_1, cell_half_1,
-                        cell_half_1, cell_stop_1,
-                        indices_1, indices_1,
-                        ux_1, uy_1, uz_1, ux_1, uy_1, uz_1, w_1, w_1,
-                        q1, q1, m1, m1, amrex::Real(-1.0), amrex::Real(-1.0),
-                        dt*ndt, CoulombLog, dV, engine );
-                }
+                // Call the function in order to perform collisions
+                ElasticCollisionPerez(
+                    cell_start_1, cell_half_1,
+                    cell_half_1, cell_stop_1,
+                    indices_1, indices_1,
+                    ux_1, uy_1, uz_1, ux_1, uy_1, uz_1, w_1, w_1,
+                    q1, q1, m1, m1, amrex::Real(-1.0), amrex::Real(-1.0),
+                    dt*ndt, CoulombLog, dV, engine );
             }
         );
     }
@@ -232,24 +231,23 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
                 // cell_start_1 (inclusive) and cell_start_2 (exclusive)
 
                 // Do not collide if one species is missing in the cell
-                if ( cell_stop_1 - cell_start_1 >= 1 &&
-                     cell_stop_2 - cell_start_2 >= 1 )
-                {
-                    // shuffle
-                    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-                    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
+                if ( cell_stop_1 - cell_start_1 < 1 ||
+                     cell_stop_2 - cell_start_2 < 1 ) return;
+                
+                // shuffle
+                ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+                ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
 #if defined WARPX_DIM_RZ
-                    int ri = (i_cell - i_cell%nz) / nz;
-                    auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
+                int ri = (i_cell - i_cell%nz) / nz;
+                auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
 #endif
-                    // Call the function in order to perform collisions
-                    ElasticCollisionPerez(
-                        cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,
-                        indices_1, indices_2,
-                        ux_1, uy_1, uz_1, ux_2, uy_2, uz_2, w_1, w_2,
-                        q1, q2, m1, m2, amrex::Real(-1.0), amrex::Real(-1.0),
-                        dt*ndt, CoulombLog, dV, engine );
-                }
+                // Call the function in order to perform collisions
+                ElasticCollisionPerez(
+                    cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,
+                    indices_1, indices_2,
+                    ux_1, uy_1, uz_1, ux_2, uy_2, uz_2, w_1, w_2,
+                    q1, q2, m1, m2, amrex::Real(-1.0), amrex::Real(-1.0),
+                    dt*ndt, CoulombLog, dV, engine );
             }
         );
     } // end if ( m_isSameSpecies)

--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -233,7 +233,7 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
                 // Do not collide if one species is missing in the cell
                 if ( cell_stop_1 - cell_start_1 < 1 ||
                      cell_stop_2 - cell_start_2 < 1 ) return;
-                
+
                 // shuffle
                 ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
                 ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);

--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -119,10 +119,10 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
         amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
         const auto lo = lbound(cbx);
         const auto hi = ubound(cbx);
-        int nz = hi.y-lo.y+1;
 #if defined WARPX_DIM_XZ
         auto dV = geom.CellSize(0) * geom.CellSize(1);
 #elif defined WARPX_DIM_RZ
+        int const nz = hi.y-lo.y+1;
         auto dr = geom.CellSize(0);
         auto dz = geom.CellSize(1);
 #elif (AMREX_SPACEDIM == 3)
@@ -145,14 +145,10 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
                     // shuffle
                     ShuffleFisherYates(
                         indices_1, cell_start_1, cell_half_1, engine );
-
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
                     auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
-#else
-                    amrex::ignore_unused(nz);
 #endif
-
                     // Call the function in order to perform collisions
                     ElasticCollisionPerez(
                         cell_start_1, cell_half_1,
@@ -242,14 +238,10 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
                     // shuffle
                     ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
                     ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-
 #if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
                     auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
-#else
-                    amrex::ignore_unused(nz);
 #endif
-
                     // Call the function in order to perform collisions
                     ElasticCollisionPerez(
                         cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,

--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -117,11 +117,11 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
         const amrex::Real dt = WarpX::GetInstance().getdt(lev);
         amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
         amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
-        const auto lo = lbound(cbx);
-        const auto hi = ubound(cbx);
 #if defined WARPX_DIM_XZ
         auto dV = geom.CellSize(0) * geom.CellSize(1);
 #elif defined WARPX_DIM_RZ
+        const auto lo = lbound(cbx);
+        const auto hi = ubound(cbx);
         int const nz = hi.y-lo.y+1;
         auto dr = geom.CellSize(0);
         auto dz = geom.CellSize(1);
@@ -202,12 +202,12 @@ void PairWiseCoulombCollision::doCoulombCollisionsWithinTile
         const amrex::Real dt = WarpX::GetInstance().getdt(lev);
         amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
         amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
-        const auto lo = lbound(cbx);
-        const auto hi = ubound(cbx);
-        int nz = hi.y-lo.y+1;
 #if defined WARPX_DIM_XZ
         auto dV = geom.CellSize(0) * geom.CellSize(1);
 #elif defined WARPX_DIM_RZ
+        const auto lo = lbound(cbx);
+        const auto hi = ubound(cbx);
+        int nz = hi.y-lo.y+1;
         auto dr = geom.CellSize(0);
         auto dz = geom.CellSize(1);
 #elif (AMREX_SPACEDIM == 3)


### PR DESCRIPTION
This slightly simplifies the code by removing the need for a call to the `ignore_unused` function.

I also simplified the indentation, by using `return` statements in the `ParallelFor` construct.