### PR TITLE
openPMD: QED Attributes as scalars

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -349,14 +349,14 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     }
 
 #ifdef WARPX_QED
-      if( pc->has_breit_wheeler() ) {
-            real_names.push_back("optical_depth_BW");
-            tmp.AddRealComp(false);
-        }
-        if( pc->has_quantum_sync() ) {
-            real_names.push_back("optical_depth_QSR");
-            tmp.AddRealComp(false);
-        }
+    if( pc->has_breit_wheeler() ) {
+        real_names.push_back("opticalDepthBW");
+        tmp.AddRealComp(false);
+    }
+    if( pc->has_quantum_sync() ) {
+        real_names.push_back("opticalDepthQSR");
+        tmp.AddRealComp(false);
+    }
 #endif
 
       pc->ConvertUnits(ConvertDirection::WarpX_to_SI);


### PR DESCRIPTION
Avoid writing QED particle attributes as scalars.

- [ ] needs runtime testing
- [ ] needs CI test reading back a written QED test case
- [ ] I/O naming logic: consider using a more robust separator for components in naming conventions, e.g. `---` or so that is less likely to be picked

Trying to address reading issue:
```
[ADIOS2] Requested attribute (/data/0/particles/ele/optical_depth/QSR/value) not found in backend.
```