### PR TITLE
KernelTimer cleaning

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -713,7 +713,7 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
     *cost_real = 0.;
     amrex::ParallelFor(np_to_depose, [=] AMREX_GPU_DEVICE (long ip)
     {
-        KernelTimer KnlTimer(cost && load_balance_costs_update_algo
+        KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                              == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 
         // Inverse of Lorentz factor gamma

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -382,7 +382,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long const ip) {
-            KernelTimer KnlTimer(cost && load_balance_costs_update_algo
+            KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 
             // --- Get particle quantities

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -107,7 +107,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
-            KernelTimer KnlTimer(cost && load_balance_costs_update_algo
+            KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 
             // --- Get particle quantities

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -107,10 +107,9 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
-#if (defined AMREX_USE_GPU)
             KernelTimer KnlTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
-#endif
+
             // --- Get particle quantities
             const amrex::Real gaminv = 1.0/std::sqrt(1.0 + uxp[ip]*uxp[ip]*clightsq
                                                          + uyp[ip]*uyp[ip]*clightsq
@@ -383,10 +382,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long const ip) {
-#if (defined AMREX_USE_GPU)
             KernelTimer KnlTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
-#endif
+
             // --- Get particle quantities
             Real const gaminv = 1.0_rt/std::sqrt(1.0_rt + uxp[ip]*uxp[ip]*clightsq
                                                  + uyp[ip]*uyp[ip]*clightsq
@@ -715,10 +713,9 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
     *cost_real = 0.;
     amrex::ParallelFor(np_to_depose, [=] AMREX_GPU_DEVICE (long ip)
     {
-#if (defined AMREX_USE_GPU)
         KernelTimer KnlTimer(cost && load_balance_costs_update_algo
                              == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
-#endif
+
         // Inverse of Lorentz factor gamma
         const amrex::Real invgam = 1._rt / std::sqrt(1._rt + uxp[ip] * uxp[ip] * invcsq
                                                            + uyp[ip] * uyp[ip] * invcsq

--- a/Source/Utils/KernelTimer.H
+++ b/Source/Utils/KernelTimer.H
@@ -24,7 +24,7 @@ public:
     AMREX_GPU_DEVICE
     KernelTimer (const bool do_timing, amrex::Real* cost)
         : m_do_timing(do_timing), m_cost(cost) {
-#if (defined AMREX_USE_GPU
+#if (defined AMREX_USE_GPU)
     if (do_timing && cost) {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
             // Start the timer

--- a/Source/Utils/KernelTimer.H
+++ b/Source/Utils/KernelTimer.H
@@ -7,7 +7,6 @@
 #ifndef KERNELTIMER_H_
 #define KERNELTIMER_H_
 
-#ifdef AMREX_USE_GPU
 #include <limits.h>
 
 /**
@@ -65,5 +64,4 @@ private:
     long long int m_wt;
 };
 
-#endif
 #endif

--- a/Source/Utils/KernelTimer.H
+++ b/Source/Utils/KernelTimer.H
@@ -24,6 +24,7 @@ public:
     AMREX_GPU_DEVICE
     KernelTimer (const bool do_timing, amrex::Real* cost)
         : m_do_timing(do_timing), m_cost(cost) {
+#if (defined AMREX_USE_GPU
     if (do_timing && cost) {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
             // Start the timer
@@ -35,11 +36,13 @@ public:
                                               "KernelTimer not yet supported for this hardware." );
 #endif
     }
+#endif
     }
 
     //! Destructor.
     AMREX_GPU_DEVICE
     ~KernelTimer () {
+#if (defined AMREX_USE_GPU)
     if (m_do_timing && m_cost) {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
             m_wt = clock64() - m_wt;
@@ -48,6 +51,7 @@ public:
             // To be updated
 #endif
     }
+#endif
     }
 
 private:


### PR DESCRIPTION
This PR moves preprocessor directives inside `KernelTimer` ctr and dtr to clean up instrumentation.