### PR TITLE
AddPlasma: Avoid a calculation resulting in NaN when num_ppc is 0

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -542,8 +542,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     const auto problo = geom.ProbLoArray();
 
     Real scale_fac = 0.0_rt;
-    
-    if(num_ppc != 0){    
+
+    if(num_ppc != 0){
 #if AMREX_SPACEDIM==3
         scale_fac = dx[0]*dx[1]*dx[2]/num_ppc;
 #elif AMREX_SPACEDIM==2

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -541,12 +541,15 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     const auto dx = geom.CellSizeArray();
     const auto problo = geom.ProbLoArray();
 
-    Real scale_fac;
+    Real scale_fac = 0.0_rt;
+    
+    if(num_ppc != 0){    
 #if AMREX_SPACEDIM==3
-    scale_fac = dx[0]*dx[1]*dx[2]/num_ppc;
+        scale_fac = dx[0]*dx[1]*dx[2]/num_ppc;
 #elif AMREX_SPACEDIM==2
-    scale_fac = dx[0]*dx[1]/num_ppc;
+        scale_fac = dx[0]*dx[1]/num_ppc;
 #endif
+    }
 
     defineAllParticleTiles();
 


### PR DESCRIPTION
If `num_ppc` is zero `scale_fac` is NaN. This is not generally an issue since in this case `scale_fac` is never used. However, for debugging purposes, it may be useful to look for floating point exceptions (e.g., by adding `feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);` to `main.cpp`). `scale_fac = NaN` when `num_ppc` may thus represent a false positive.