### PR TITLE
Add reference to WarpX slides in the acknowledge us section

### DIFF
--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -32,7 +32,7 @@ Please add the following sentence to your publications, it helps contributors ke
 
 Main WarpX reference
 ********************
-  
+
 .. raw:: html
 
     <div id="ref-VayNIM2018">

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -1,7 +1,23 @@
 Acknowledge WarpX
 =================
 
-Please acknowledge the role that WarpX played in your research by adding the following sentence to your publications, it helps contributors keep in touch with the community and promote the project.
+Please acknowledge the role that WarpX played in your research.
+
+In presentations
+****************
+
+For your presentations, you can find WarpX slides `here <https://drive.google.com/file/d/1Ye2YuQ9ezqpL8vCiooMF1PBVwL5pnAOE/view?usp=sharing>`__. Several flavors are available:
+
+  - full slide
+  - half-slide (portrait or landscape format)
+  - small inset.
+
+Feel free to use the one that fits into your presentation and adequately acknowledges the part that WarpX played in your research.
+
+In publications
+***************
+
+Please add the following sentence to your publications, it helps contributors keep in touch with the community and promote the project.
 
 **Plain text:**
 
@@ -14,8 +30,9 @@ Please acknowledge the role that WarpX played in your research by adding the fol
   \usepackage{hyperref}
   This research used the open-source particle-in-cell code WarpX \url{https://github.com/ECP-WarpX/WarpX}, primarily funded by the US DOE Exascale Computing Project. We acknowledge all WarpX contributors.
 
-**Main WarpX reference:**
-
+Main WarpX reference
+********************
+  
 .. raw:: html
 
     <div id="ref-VayNIM2018">

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -37,4 +37,4 @@ Main WarpX reference
 
     <div id="ref-VayNIM2018">
 
-Vay JL, Almgren A, Bell J, Ge L, Grote DP, Hogan M, Kononenko O, Lehe R, Myers A, Ng C, Park J. **Warp-X: A new exascale computing platform for beam–plasma simulations**. *Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment*. 2018, 909, pp.476-479. https://doi.org/10.1016/j.nima.2018.01.035
+Vay JL, Huebl A, Almgren A, Amorim LD, Bell J, Fedeli L, Ge L, Gott K, Grote DP, Hogan M, Jambunathan R. **Modeling of a chain of three plasma accelerator stages with the WarpX electromagnetic PIC code on GPUs**. *Physics of Plasmas*. 2021 Feb 9;28(2):023105. https://doi.org/10.1063/5.0028512


### PR DESCRIPTION
This PR proposes to add a link to the WarpX slides in the "acknowledge us" section of our documentation. Here is how the page looks:
![Screenshot 2021-03-16 at 18 05 08](https://user-images.githubusercontent.com/26292713/111350266-394ab580-8682-11eb-9e77-6f68432999e2.png)
