### PR TITLE
Applied boost to single and multiple particle input

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -192,7 +192,8 @@ public:
     */
     void AddPlasma (int lev, amrex::RealBox part_realbox = amrex::RealBox());
 
-    void MapParticletoBoostedFrame (amrex::Real& x, amrex::Real& y, amrex::Real& z, std::array<amrex::Real, 3>& u);
+    void MapParticletoBoostedFrame (amrex::Real& x, amrex::Real& y, amrex::Real& z,
+                                    amrex::Real& ux, amrex::Real& uy, amrex::Real& uz);
 
     void AddGaussianBeam (
         const amrex::Real x_m, const amrex::Real y_m, const amrex::Real z_m,
@@ -209,7 +210,7 @@ public:
 
     void CheckAndAddParticle (
         amrex::Real x, amrex::Real y, amrex::Real z,
-        std::array<amrex::Real, 3> u,
+        amrex::Real ux, amrex::Real uy, amrex::Real uz,
         amrex::Real weight,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_x,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_y,


### PR DESCRIPTION
This change applies the boost to the single and multiple particle injection code, so that the particles can be specified in the lab frame.

Along the way, this also simplifies the `MapParticletoBoostedFrame` and `CheckAndAddParticle` routines, explicitly using the velocity coordinates instead of a std::array.

An aside - does the documentation state anywhere that input parameters should be in the lab frame and that it will be mapped to the boosted frame automatically? I couldn't find a statement like that.