### PR TITLE
openPMD: Add ParaView .pmd Helper File

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -198,8 +198,15 @@ private:
             amrex::ParticleReal const charge,
             amrex::ParticleReal const mass) const;
 
-  // no need for ts in the name, openPMD  handles it
-  void GetFileName (std::string& filename);
+  /** Get the openPMD-api filename for openPMD::Series
+   *
+   * No need for ts in the file name, openPMD handles steps (iterations).
+   *
+   * @param[inout] filepath the path and filename for openPMD::Series
+   *               passes a prefix path in and appends the filename
+   * @return pure filename w/o path
+   */
+  std::string GetFileName (std::string& filepath);
 
   std::unique_ptr<openPMD::Series> m_Series;
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -12,6 +12,7 @@
 #include "Utils/WarpXUtil.H"
 
 #include <AMReX_AmrParticles.H>
+#include <AMReX_ParallelDescriptor.H>
 
 #include <algorithm>
 #include <cstdint>
@@ -21,6 +22,7 @@
 #include <tuple>
 #include <utility>
 #include <iostream>
+#include <fstream>
 
 
 namespace detail
@@ -222,21 +224,20 @@ WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
   }
 }
 
-
-//
-//
-//
-void WarpXOpenPMDPlot::GetFileName(std::string& filename)
+std::string
+WarpXOpenPMDPlot::GetFileName (std::string& filepath)
 {
-  filename.append("/openpmd");
+  filepath.append("/");
+  std::string filename = "openpmd";
   //
   // OpenPMD supports timestepped names
   //
   if (m_OneFilePerTS)
       filename = filename.append("_%06T");
   filename.append(".").append(m_OpenPMDFileType);
+  filepath.append(filename);
+  return filename;
 }
-
 
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix,
                                 bool isBTD)
@@ -277,8 +278,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
 
     // either for the next ts file,
     // or init a single file for all ts
-    std::string filename = filePrefix;
-    GetFileName(filename);
+    std::string filepath = filePrefix;
+    std::string const filename = GetFileName(filepath);
 
     // close a previously open series before creating a new one
     // see ADIOS1 limitation: https://github.com/openPMD/openPMD-api/pull/686
@@ -287,7 +288,7 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
     if (amrex::ParallelDescriptor::NProcs() > 1) {
 #if defined(AMREX_USE_MPI)
         m_Series = std::make_unique<openPMD::Series>(
-                filename, access,
+                filepath, access,
                 amrex::ParallelDescriptor::Communicator()
         );
         m_MPISize = amrex::ParallelDescriptor::NProcs();
@@ -296,9 +297,17 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
         amrex::Abort("openPMD-api not built with MPI support!");
 #endif
     } else {
-        m_Series = std::make_unique<openPMD::Series>(filename, access);
+        m_Series = std::make_unique<openPMD::Series>(filepath, access);
         m_MPISize = 1;
         m_MPIRank = 1;
+    }
+
+    // create a little helper file for ParaView 5.9+
+    if (amrex::ParallelDescriptor::IOProcessor())
+    {
+        std::ofstream pv_helper_file(filePrefix + "/paraview.pmd");
+        pv_helper_file << filename << std::endl;
+        pv_helper_file.close();
     }
 
     // input file / simulation setup author


### PR DESCRIPTION
ParaView 5.9+ adds initial support for openPMD files.
We need the filename passed to the `openPMD::Series` constructor as a little text helper file to open the files properly, this adds this.