### PR TITLE
Remove Wrong Parser Query in MultiParticleContainer.cpp

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -241,7 +241,6 @@ MultiParticleContainer::ReadParameters ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
                             "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
-        pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 
         std::string boundary_conditions = "none";
         pp.query("boundary_conditions", boundary_conditions);


### PR DESCRIPTION
It seems to me that we were querying a parameter called `galerkin_interpolation` from the parser `ParmParse pp("particles");` in Source/Particles/MultiParticleContainer.cpp.

However, the correct parameter is called `galerkin_scheme` and it is already parsed from the parser `ParmParse pp("interpolation");` in Source/WarpX.cpp:
https://github.com/ECP-WarpX/WarpX/blob/93cdd24708e8e975409daebce758ddbcaaac9325/Source/WarpX.cpp#L759

So I think we can safely remove the query of the wrong parameter `galerkin_interpolation`.