### PR TITLE
Use Clear Naming Standard for ParmParse Variables

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -104,21 +104,21 @@ BTDiagnostics::ReadParameters ()
         );
 
     // Read list of back-transform diag parameters requested by the user //
-    amrex::ParmParse pp(m_diag_name);
+    amrex::ParmParse pp_diag_name(m_diag_name);
 
     m_file_prefix = "diags/" + m_diag_name;
-    pp.query("file_prefix", m_file_prefix);
-    pp.query("do_back_transformed_fields", m_do_back_transformed_fields);
-    pp.query("do_back_transformed_particles", m_do_back_transformed_particles);
+    pp_diag_name.query("file_prefix", m_file_prefix);
+    pp_diag_name.query("do_back_transformed_fields", m_do_back_transformed_fields);
+    pp_diag_name.query("do_back_transformed_particles", m_do_back_transformed_particles);
     AMREX_ALWAYS_ASSERT(m_do_back_transformed_fields or m_do_back_transformed_particles);
 
-    pp.get("num_snapshots_lab", m_num_snapshots_lab);
+    pp_diag_name.get("num_snapshots_lab", m_num_snapshots_lab);
     m_num_buffers = m_num_snapshots_lab;
 
     // Read either dz_snapshots_lab or dt_snapshots_lab
     bool snapshot_interval_is_specified = false;
-    snapshot_interval_is_specified = queryWithParser(pp, "dt_snapshots_lab", m_dt_snapshots_lab);
-    if ( queryWithParser(pp, "dz_snapshots_lab", m_dz_snapshots_lab) ) {
+    snapshot_interval_is_specified = queryWithParser(pp_diag_name, "dt_snapshots_lab", m_dt_snapshots_lab);
+    if ( queryWithParser(pp_diag_name, "dz_snapshots_lab", m_dz_snapshots_lab) ) {
         m_dt_snapshots_lab = m_dz_snapshots_lab/PhysConst::c;
         snapshot_interval_is_specified = true;
     }

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -565,10 +565,9 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
 
     // Query fields to dump
     std::vector<std::string> user_fields_to_dump;
-    ParmParse pp("warpx");
+    ParmParse pp_warpx("warpx");
     bool do_user_fields;
-    do_user_fields = pp.queryarr("back_transformed_diag_fields",
-                                 user_fields_to_dump);
+    do_user_fields = pp_warpx.queryarr("back_transformed_diag_fields", user_fields_to_dump);
     // If user specifies fields to dump, overwrite ncomp_to_dump,
     // map_actual_fields_to_dump and mesh_field_names.
     for (int i = 0; i < 10; ++i)

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -31,13 +31,13 @@ Diagnostics::BaseReadParameters ()
 {
     auto & warpx = WarpX::GetInstance();
 
-    amrex::ParmParse pp(m_diag_name);
+    amrex::ParmParse pp_diag_name(m_diag_name);
     m_file_prefix = "diags/" + m_diag_name;
-    pp.query("file_prefix", m_file_prefix);
-    pp.query("format", m_format);
+    pp_diag_name.query("file_prefix", m_file_prefix);
+    pp_diag_name.query("format", m_format);
 
     // Query list of grid fields to write to output
-    bool varnames_specified = pp.queryarr("fields_to_plot", m_varnames);
+    bool varnames_specified = pp_diag_name.queryarr("fields_to_plot", m_varnames);
     if (!varnames_specified){
         m_varnames = {"Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"};
     }
@@ -74,14 +74,14 @@ Diagnostics::BaseReadParameters ()
     m_lo.resize(AMREX_SPACEDIM);
     m_hi.resize(AMREX_SPACEDIM);
 
-    bool lo_specified = pp.queryarr("diag_lo", m_lo);
+    bool lo_specified = pp_diag_name.queryarr("diag_lo", m_lo);
 
     if (!lo_specified) {
        for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
             m_lo[idim] = warpx.Geom(0).ProbLo(idim);
        }
     }
-    bool hi_specified = pp.queryarr("diag_hi", m_hi);
+    bool hi_specified = pp_diag_name.queryarr("diag_hi", m_hi);
     if (!hi_specified) {
        for (int idim =0; idim < AMREX_SPACEDIM; ++idim) {
             m_hi[idim] = warpx.Geom(0).ProbHi(idim);
@@ -107,7 +107,7 @@ Diagnostics::BaseReadParameters ()
     // Initialize cr_ratio with default value of 1 for each dimension.
     amrex::Vector<int> cr_ratio(AMREX_SPACEDIM, 1);
     // Read user-defined coarsening ratio for the output MultiFab.
-    bool cr_specified = pp.queryarr("coarsening_ratio", cr_ratio);
+    bool cr_specified = pp_diag_name.queryarr("coarsening_ratio", cr_ratio);
     if (cr_specified) {
        for (int idim =0; idim < AMREX_SPACEDIM; ++idim) {
            m_crse_ratio[idim] = cr_ratio[idim];
@@ -115,7 +115,7 @@ Diagnostics::BaseReadParameters ()
     }
 
     // Names of species to write to output
-    bool species_specified = pp.queryarr("species", m_output_species_names);
+    bool species_specified = pp_diag_name.queryarr("species", m_output_species_names);
 
     // Names of all species in the simulation
     m_all_species_names = warpx.GetPartContainer().GetSpeciesNames();
@@ -184,9 +184,9 @@ Diagnostics::InitData ()
     // When particle buffers, m_particle_buffers are included, they will be initialized here
     InitializeParticleBuffer();
 
-    amrex::ParmParse pp(m_diag_name);
+    amrex::ParmParse pp_diag_name(m_diag_name);
     amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
-    if ( pp.queryarr("diag_lo", dummy_val) || pp.queryarr("diag_hi", dummy_val) ) {
+    if ( pp_diag_name.queryarr("diag_lo", dummy_val) || pp_diag_name.queryarr("diag_hi", dummy_val) ) {
         // set geometry filter for particle-diags to true when the diagnostic domain-extent
         // is specified by the user
         for (int i = 0; i < m_output_species.size(); ++i) {
@@ -201,7 +201,7 @@ Diagnostics::InitData ()
 
     // default for writing species output is 1
     int write_species = 1;
-    pp.query("write_species", write_species);
+    pp_diag_name.query("write_species", write_species);
     if (write_species == 0) {
         if (m_format == "checkpoint"){
             amrex::Abort("For checkpoint format, write_species flag must be 1.");

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -8,13 +8,13 @@ using namespace amrex;
 
 FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 {
-    ParmParse pp(diag_name);
+    ParmParse pp_diag_name(diag_name);
     // Which backend to use (ADIOS, ADIOS2 or HDF5). Default depends on what is available
     std::string openpmd_backend {"default"};
     // one file per timestep (or one file for all steps)
     bool openpmd_tspf = true;
-    pp.query("openpmd_backend", openpmd_backend);
-    pp.query("openpmd_tspf", openpmd_tspf);
+    pp_diag_name.query("openpmd_backend", openpmd_backend);
+    pp_diag_name.query("openpmd_tspf", openpmd_tspf);
     auto & warpx = WarpX::GetInstance();
     m_OpenPMDPlotWriter = new WarpXOpenPMDPlot(
         openpmd_tspf, openpmd_backend, warpx.getPMLdirections()

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -18,10 +18,10 @@ FlushFormatSensei::FlushFormatSensei (amrex::AmrMesh *amr_mesh,
 #ifndef BL_USE_SENSEI_INSITU
     amrex::ignore_unused(m_insitu_pin_mesh, m_insitu_bridge, m_amr_mesh, diag_name);
 #else
-    amrex::ParmParse pp(diag_name);
+    amrex::ParmParse pp_diag_name(diag_name);
 
-    pp.query("sensei_config", m_insitu_config);
-    pp.query("sensei_pin_mesh", m_insitu_pin_mesh);
+    pp_diag_name.query("sensei_config", m_insitu_config);
+    pp_diag_name.query("sensei_pin_mesh", m_insitu_pin_mesh);
 
     m_insitu_bridge = new amrex::AmrMeshInSituBridge;
     m_insitu_bridge->setEnabled(true);

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -49,21 +49,21 @@ FullDiagnostics::ReadParameters ()
 {
     // Read list of full diagnostics fields requested by the user.
     bool checkpoint_compatibility = BaseReadParameters();
-    amrex::ParmParse pp(m_diag_name);
+    amrex::ParmParse pp_diag_name(m_diag_name);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_format == "plotfile" || m_format == "openpmd" ||
         m_format == "checkpoint" || m_format == "ascent" ||
         m_format == "sensei",
         "<diag>.format must be plotfile or openpmd or checkpoint or ascent or sensei");
     std::vector<std::string> intervals_string_vec = {"0"};
-    pp.queryarr("intervals", intervals_string_vec);
+    pp_diag_name.queryarr("intervals", intervals_string_vec);
     m_intervals = IntervalsParser(intervals_string_vec);
-    bool raw_specified = pp.query("plot_raw_fields", m_plot_raw_fields);
-    raw_specified += pp.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
-    raw_specified += pp.query("plot_raw_rho", m_plot_raw_rho);
+    bool raw_specified = pp_diag_name.query("plot_raw_fields", m_plot_raw_fields);
+    raw_specified += pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
+    raw_specified += pp_diag_name.query("plot_raw_rho", m_plot_raw_rho);
 
 #ifdef WARPX_DIM_RZ
-    pp.query("dump_rz_modes", m_dump_rz_modes);
+    pp_diag_name.query("dump_rz_modes", m_dump_rz_modes);
 #else
     amrex::ignore_unused(m_dump_rz_modes);
 #endif
@@ -83,9 +83,9 @@ FullDiagnostics::ReadParameters ()
 void
 FullDiagnostics::BackwardCompatibility ()
 {
-    amrex::ParmParse pp(m_diag_name);
+    amrex::ParmParse pp_diag_name(m_diag_name);
     std::vector<std::string> backward_strings;
-    if (pp.queryarr("period", backward_strings)){
+    if (pp_diag_name.queryarr("period", backward_strings)){
         amrex::Abort("<diag_name>.period is no longer a valid option. "
                      "Please use the renamed option <diag_name>.intervals instead.");
     }

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -41,21 +41,21 @@ MultiDiagnostics::InitializeFieldFunctors ( int lev )
 void
 MultiDiagnostics::ReadParameters ()
 {
-    ParmParse pp("diagnostics");
+    ParmParse pp_diagnostics("diagnostics");
 
     int enable_diags = 1;
-    pp.query("enable", enable_diags);
+    pp_diagnostics.query("enable", enable_diags);
     if (enable_diags == 1) {
-        pp.queryarr("diags_names", diags_names);
+        pp_diagnostics.queryarr("diags_names", diags_names);
         ndiags = diags_names.size();
         Print()<<"ndiags "<<ndiags<<'\n';
     }
 
     diags_types.resize( ndiags );
     for (int i=0; i<ndiags; i++){
-        ParmParse ppd(diags_names[i]);
+        ParmParse pp_diag_name(diags_names[i]);
         std::string diag_type_str;
-        ppd.get("diag_type", diag_type_str);
+        pp_diag_name.get("diag_type", diag_type_str);
         if (diag_type_str == "Full") diags_types[i] = DiagTypes::Full;
         if (diag_type_str == "BackTransformed") diags_types[i] = DiagTypes::BackTransformed;
     }

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -24,8 +24,8 @@ BeamRelevant::BeamRelevant (std::string rd_name)
 {
 
     // read beam name
-    ParmParse pp(rd_name);
-    pp.get("species",m_beam_name);
+    ParmParse pp_rd_name(rd_name);
+    pp_rd_name.get("species",m_beam_name);
 
     // resize data array
 #if (defined WARPX_DIM_3D || defined WARPX_DIM_RZ)

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -31,8 +31,8 @@ FieldEnergy::FieldEnergy (std::string rd_name)
 
     // read number of levels
     int nLevel = 0;
-    ParmParse pp("amr");
-    pp.query("max_level", nLevel);
+    ParmParse pp_amr("amr");
+    pp_amr.query("max_level", nLevel);
     nLevel += 1;
 
     constexpr int noutputs = 3; // total energy, E-field energy and B-field energy

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -24,8 +24,8 @@ FieldMaximum::FieldMaximum (std::string rd_name)
 
     // read number of levels
     int nLevel = 0;
-    ParmParse pp("amr");
-    pp.query("max_level", nLevel);
+    ParmParse pp_amr("amr");
+    pp_amr.query("max_level", nLevel);
     nLevel += 1;
 
     constexpr int noutputs = 8; // total energy, E-field energy and B-field energy

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -16,8 +16,8 @@ LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
 {
     // read number of levels
     int nLevel = 0;
-    ParmParse pp("amr");
-    pp.query("max_level", nLevel);
+    ParmParse pp_amr("amr");
+    pp_amr.query("max_level", nLevel);
     nLevel += 1;
 
     // resize data array

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -29,8 +29,8 @@ MultiReducedDiags::MultiReducedDiags ()
 {
 
     // read reduced diags names
-    ParmParse pp("warpx");
-    m_plot_rd = pp.queryarr("reduced_diags_names", m_rd_names);
+    ParmParse pp_warpx("warpx");
+    m_plot_rd = pp_warpx.queryarr("reduced_diags_names", m_rd_names);
 
     // if names are not given, reduced diags will not be done
     if ( m_plot_rd == 0 ) { return; }
@@ -42,11 +42,11 @@ MultiReducedDiags::MultiReducedDiags ()
     for (int i_rd = 0; i_rd < static_cast<int>(m_rd_names.size()); ++i_rd)
     {
 
-        ParmParse pp_rd(m_rd_names[i_rd]);
+        ParmParse pp_rd_name(m_rd_names[i_rd]);
 
         // read reduced diags type
         std::string rd_type;
-        pp_rd.query("type", rd_type);
+        pp_rd_name.query("type", rd_type);
 
         // match diags
         if (rd_type.compare("ParticleEnergy") == 0)

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -27,8 +27,8 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
 : ReducedDiags{rd_name}
 {
     // read species name
-    ParmParse pp(rd_name);
-    pp.get("species",m_species_name);
+    ParmParse pp_rd_name(rd_name);
+    pp_rd_name.get("species",m_species_name);
 
     // get WarpX class object
     auto & warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -37,28 +37,28 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 : ReducedDiags{rd_name}
 {
 
-    ParmParse pp(rd_name);
+    ParmParse pp_rd_name(rd_name);
 
     // read species
     std::string selected_species_name;
-    pp.get("species",selected_species_name);
+    pp_rd_name.get("species",selected_species_name);
 
     // read bin parameters
-    pp.get("bin_number",m_bin_num);
-    getWithParser(pp, "bin_max",   m_bin_max);
-    getWithParser(pp, "bin_min",   m_bin_min);
+    pp_rd_name.get("bin_number",m_bin_num);
+    getWithParser(pp_rd_name, "bin_max",   m_bin_max);
+    getWithParser(pp_rd_name, "bin_min",   m_bin_min);
     m_bin_size = (m_bin_max - m_bin_min) / m_bin_num;
 
     // read histogram function
     std::string function_string = "";
-    Store_parserString(pp,"histogram_function(t,x,y,z,ux,uy,uz)",
+    Store_parserString(pp_rd_name,"histogram_function(t,x,y,z,ux,uy,uz)",
                        function_string);
     m_parser = std::make_unique<ParserWrapper<m_nvars>>(
         makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
 
     // read normalization type
     std::string norm_string = "default";
-    pp.query("normalization",norm_string);
+    pp_rd_name.query("normalization",norm_string);
 
     // set normalization type
     if ( norm_string == "default" ) {
@@ -91,10 +91,10 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // Read optional filter
     std::string buf;
-    m_do_parser_filter = pp.query("filter_function(t,x,y,z,ux,uy,uz)", buf);
+    m_do_parser_filter = pp_rd_name.query("filter_function(t,x,y,z,ux,uy,uz)", buf);
     if (m_do_parser_filter) {
         std::string filter_string = "";
-        Store_parserString(pp,"filter_function(t,x,y,z,ux,uy,uz)", filter_string);
+        Store_parserString(pp_rd_name,"filter_function(t,x,y,z,ux,uy,uz)", filter_string);
         m_parser_filter = std::make_unique<ParserWrapper<m_nvars>>(
                                      makeParser(filter_string,{"t","x","y","z","ux","uy","uz"}));
     }

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -23,13 +23,13 @@ ReducedDiags::ReducedDiags (std::string rd_name)
 
     BackwardCompatibility();
 
-    ParmParse pp(m_rd_name);
+    ParmParse pp_rd_name(m_rd_name);
 
     // read path
-    pp.query("path", m_path);
+    pp_rd_name.query("path", m_path);
 
     // read extension
-    pp.query("extension", m_extension);
+    pp_rd_name.query("extension", m_extension);
 
     // check if it is a restart run
     std::string restart_chkfile = "";
@@ -53,20 +53,20 @@ ReducedDiags::ReducedDiags (std::string rd_name)
 
     // read reduced diags intervals
     std::vector<std::string> intervals_string_vec = {"1"};
-    pp.queryarr("intervals", intervals_string_vec);
+    pp_rd_name.queryarr("intervals", intervals_string_vec);
     m_intervals = IntervalsParser(intervals_string_vec);
 
     // read separator
-    pp.query("separator", m_sep);
+    pp_rd_name.query("separator", m_sep);
 
 }
 // end constructor
 
 void ReducedDiags::BackwardCompatibility ()
 {
-    amrex::ParmParse pp(m_rd_name);
+    amrex::ParmParse pp_rd_name(m_rd_name);
     std::vector<std::string> backward_strings;
-    if (pp.queryarr("frequency", backward_strings)){
+    if (pp_rd_name.queryarr("frequency", backward_strings)){
         amrex::Abort("<reduced_diag_name>.frequency is no longer a valid option. "
                      "Please use the renamed option <reduced_diag_name>.intervals instead.");
     }

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -24,8 +24,8 @@ RhoMaximum::RhoMaximum (std::string rd_name)
 
     // read number of levels
     int nLevel = 0;
-    amrex::ParmParse pp("amr");
-    pp.query("max_level", nLevel);
+    amrex::ParmParse pp_amr("amr");
+    pp_amr.query("max_level", nLevel);
     nLevel += 1;
     m_rho_functors.resize(nLevel);
 

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -13,9 +13,9 @@ WarpX::InitEB ()
 #ifdef AMREX_USE_EB
     BL_PROFILE("InitEB");
 
-    amrex::ParmParse pp("eb2");
-    if (!pp.contains("geom_type")) {
-        pp.add("geom_type", "all_regular"); // use all_regular by default
+    amrex::ParmParse pp_eb2("eb2");
+    if (!pp_eb2.contains("geom_type")) {
+        pp_eb2.add("geom_type", "all_regular"); // use all_regular by default
     }
     amrex::EB2::Build(Geom(maxLevel()), maxLevel(), maxLevel());
 #endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -16,7 +16,7 @@ MacroscopicProperties::MacroscopicProperties ()
 void
 MacroscopicProperties::ReadParameters ()
 {
-    ParmParse pp("macroscopic");
+    ParmParse pp_macroscopic("macroscopic");
     // Since macroscopic maxwell solve is turned on,
     // user-defined sigma, mu, and epsilon are queried.
     // The vacuum values are used as default for the macroscopic parameters
@@ -24,11 +24,11 @@ MacroscopicProperties::ReadParameters ()
 
     // Query input for material conductivity, sigma.
     bool sigma_specified = false;
-    if (queryWithParser(pp, "sigma", m_sigma)) {
+    if (queryWithParser(pp_macroscopic, "sigma", m_sigma)) {
         m_sigma_s = "constant";
         sigma_specified = true;
     }
-    if (pp.query("sigma_function(x,y,z)", m_str_sigma_function) ) {
+    if (pp_macroscopic.query("sigma_function(x,y,z)", m_str_sigma_function) ) {
         m_sigma_s = "parse_sigma_function";
         sigma_specified = true;
     }
@@ -37,17 +37,17 @@ MacroscopicProperties::ReadParameters ()
     }
     // initialization of sigma (conductivity) with parser
     if (m_sigma_s == "parse_sigma_function") {
-        Store_parserString(pp, "sigma_function(x,y,z)", m_str_sigma_function);
+        Store_parserString(pp_macroscopic, "sigma_function(x,y,z)", m_str_sigma_function);
         m_sigma_parser = std::make_unique<ParserWrapper<3>>(
                                  makeParser(m_str_sigma_function,{"x","y","z"}));
     }
 
     bool epsilon_specified = false;
-    if (queryWithParser(pp, "epsilon", m_epsilon)) {
+    if (queryWithParser(pp_macroscopic, "epsilon", m_epsilon)) {
         m_epsilon_s = "constant";
         epsilon_specified = true;
     }
-    if (pp.query("epsilon_function(x,y,z)", m_str_epsilon_function) ) {
+    if (pp_macroscopic.query("epsilon_function(x,y,z)", m_str_epsilon_function) ) {
         m_epsilon_s = "parse_epsilon_function";
         epsilon_specified = true;
     }
@@ -57,18 +57,18 @@ MacroscopicProperties::ReadParameters ()
 
     // initialization of epsilon (permittivity) with parser
     if (m_epsilon_s == "parse_epsilon_function") {
-        Store_parserString(pp, "epsilon_function(x,y,z)", m_str_epsilon_function);
+        Store_parserString(pp_macroscopic, "epsilon_function(x,y,z)", m_str_epsilon_function);
         m_epsilon_parser = std::make_unique<ParserWrapper<3>>(
                                  makeParser(m_str_epsilon_function,{"x","y","z"}));
     }
 
     // Query input for material permittivity, epsilon.
     bool mu_specified = false;
-    if (queryWithParser(pp, "mu", m_mu)) {
+    if (queryWithParser(pp_macroscopic, "mu", m_mu)) {
         m_mu_s = "constant";
         mu_specified = true;
     }
-    if (pp.query("mu_function(x,y,z)", m_str_mu_function) ) {
+    if (pp_macroscopic.query("mu_function(x,y,z)", m_str_mu_function) ) {
         m_mu_s = "parse_mu_function";
         mu_specified = true;
     }
@@ -78,7 +78,7 @@ MacroscopicProperties::ReadParameters ()
 
     // initialization of mu (permeability) with parser
     if (m_mu_s == "parse_mu_function") {
-        Store_parserString(pp, "mu_function(x,y,z)", m_str_mu_function);
+        Store_parserString(pp_macroscopic, "mu_function(x,y,z)", m_str_mu_function);
         m_mu_parser = std::make_unique<ParserWrapper<3>>(
                                  makeParser(m_str_mu_function,{"x","y","z"}));
     }

--- a/Source/Initialization/CustomDensityProb.H
+++ b/Source/Initialization/CustomDensityProb.H
@@ -21,11 +21,11 @@ struct InjectorDensityCustom
     InjectorDensityCustom (std::string const& species_name)
     {
         // Read parameters for custom density profile from file
-        amrex::ParmParse pp(species_name);
+        amrex::ParmParse pp_species_name(species_name);
         std::vector<amrex::Real> v;
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
                                          "Too many parameters for InjectorDensityCustom");
-        pp.getarr("custom_profile_params", v);
+        pp_species_name.getarr("custom_profile_params", v);
         for (int i = 0; i < static_cast<int>(v.size()); ++i) {
             p[i] = v[i];
         }

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -39,11 +39,11 @@ InjectorDensityPredefined::InjectorDensityPredefined (
     std::string const& a_species_name) noexcept
     : profile(Profile::null)
 {
-    ParmParse pp(a_species_name);
+    ParmParse pp_species_name(a_species_name);
 
     std::vector<amrex::Real> v;
     // Read parameters for the predefined plasma profile.
-    pp.getarr("predefined_profile_params", v);
+    pp_species_name.getarr("predefined_profile_params", v);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
                                      "Too many parameters for InjectorDensityPredefined");
     for (int i = 0; i < static_cast<int>(v.size()); ++i) {
@@ -52,7 +52,7 @@ InjectorDensityPredefined::InjectorDensityPredefined (
 
     // Parse predefined profile name, and update member variable profile.
     std::string which_profile_s;
-    pp.query("predefined_profile_name", which_profile_s);
+    pp_species_name.query("predefined_profile_name", which_profile_s);
     std::transform(which_profile_s.begin(), which_profile_s.end(),
                    which_profile_s.begin(), ::tolower);
     if (which_profile_s == "parabolic_channel"){

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -18,12 +18,12 @@ namespace {
     void
     overwrite_amrex_parser_defaults()
     {
-        amrex::ParmParse pp("amrex");
+        amrex::ParmParse pp_amrex("amrex");
 
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
-        pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
-        pp.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        pp_amrex.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        pp_amrex.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
         // Work-around:
         // If warpx.numprocs is used for the domain decomposition, we will not use blocking factor

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -265,18 +265,18 @@ void
 WarpX::InitLevelData (int lev, Real /*time*/)
 {
 
-    ParmParse pp("warpx");
+    ParmParse pp_warpx("warpx");
 
     // default values of E_external_grid and B_external_grid
     // are used to set the E and B field when "constant" or
     // "parser" is not explicitly used in the input.
-    pp.query("B_ext_grid_init_style", B_ext_grid_s);
+    pp_warpx.query("B_ext_grid_init_style", B_ext_grid_s);
     std::transform(B_ext_grid_s.begin(),
                    B_ext_grid_s.end(),
                    B_ext_grid_s.begin(),
                    ::tolower);
 
-    pp.query("E_ext_grid_init_style", E_ext_grid_s);
+    pp_warpx.query("E_ext_grid_init_style", E_ext_grid_s);
     std::transform(E_ext_grid_s.begin(),
                    E_ext_grid_s.end(),
                    E_ext_grid_s.begin(),
@@ -285,17 +285,17 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // if the input string is "constant", the values for the
     // external grid must be provided in the input.
     if (B_ext_grid_s == "constant")
-        pp.getarr("B_external_grid", B_external_grid);
+        pp_warpx.getarr("B_external_grid", B_external_grid);
 
     // if the input string is "constant", the values for the
     // external grid must be provided in the input.
     if (E_ext_grid_s == "constant")
-        pp.getarr("E_external_grid", E_external_grid);
+        pp_warpx.getarr("E_external_grid", E_external_grid);
 
     // initialize the averaged fields only if the averaged algorithm
     // is activated ('psatd.do_time_averaging=1')
-    ParmParse ppsatd("psatd");
-    ppsatd.query("do_time_averaging", fft_do_time_averaging );
+    ParmParse pp_psatd("psatd");
+    pp_psatd.query("do_time_averaging", fft_do_time_averaging );
 
     for (int i = 0; i < 3; ++i) {
         current_fp[lev][i]->setVal(0.0);
@@ -352,11 +352,11 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 #ifdef WARPX_DIM_RZ
        amrex::Abort("E and B parser for external fields does not work with RZ -- TO DO");
 #endif
-       Store_parserString(pp, "Bx_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "Bx_external_grid_function(x,y,z)",
                                                     str_Bx_ext_grid_function);
-       Store_parserString(pp, "By_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "By_external_grid_function(x,y,z)",
                                                     str_By_ext_grid_function);
-       Store_parserString(pp, "Bz_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "Bz_external_grid_function(x,y,z)",
                                                     str_Bz_ext_grid_function);
        Bxfield_parser = std::make_unique<ParserWrapper<3>>(
                                 makeParser(str_Bx_ext_grid_function,{"x","y","z"}));
@@ -400,11 +400,11 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 #ifdef WARPX_DIM_RZ
        amrex::Abort("E and B parser for external fields does not work with RZ -- TO DO");
 #endif
-       Store_parserString(pp, "Ex_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "Ex_external_grid_function(x,y,z)",
                                                     str_Ex_ext_grid_function);
-       Store_parserString(pp, "Ey_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "Ey_external_grid_function(x,y,z)",
                                                     str_Ey_ext_grid_function);
-       Store_parserString(pp, "Ez_external_grid_function(x,y,z)",
+       Store_parserString(pp_warpx, "Ez_external_grid_function(x,y,z)",
                                                     str_Ez_ext_grid_function);
 
        Exfield_parser = std::make_unique<ParserWrapper<3>>(

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -132,10 +132,10 @@ guardCellManager::Init (
         int ngFFt_y = do_nodal ? noy_fft : noy_fft / 2;
         int ngFFt_z = do_nodal ? noz_fft : noz_fft / 2;
 
-        ParmParse pp("psatd");
-        pp.query("nx_guard", ngFFt_x);
-        pp.query("ny_guard", ngFFt_y);
-        pp.query("nz_guard", ngFFt_z);
+        ParmParse pp_psatd("psatd");
+        pp_psatd.query("nx_guard", ngFFt_x);
+        pp_psatd.query("ny_guard", ngFFt_y);
+        pp_psatd.query("nz_guard", ngFFt_z);
 
 #if (AMREX_SPACEDIM == 3)
         IntVect ngFFT = IntVect(ngFFt_x, ngFFt_y, ngFFt_z);

--- a/Source/Particles/Collision/CollisionBase.cpp
+++ b/Source/Particles/Collision/CollisionBase.cpp
@@ -10,12 +10,12 @@ CollisionBase::CollisionBase (std::string collision_name)
 {
 
     // read collision species
-    amrex::ParmParse pp(collision_name);
-    pp.getarr("species", m_species_names);
+    amrex::ParmParse pp_collision_name(collision_name);
+    pp_collision_name.getarr("species", m_species_names);
 
     // number of time steps between collisions
     m_ndt = 1;
-    pp.query("ndt", m_ndt);
+    pp_collision_name.query("ndt", m_ndt);
 
 }
 

--- a/Source/Particles/Collision/PairWiseCoulombCollision.cpp
+++ b/Source/Particles/Collision/PairWiseCoulombCollision.cpp
@@ -20,11 +20,11 @@ PairWiseCoulombCollision::PairWiseCoulombCollision (std::string const collision_
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_species_names.size() == 2,
                                      "Pair wise Coulomb must have exactly two species.");
 
-    amrex::ParmParse pp(collision_name);
+    amrex::ParmParse pp_collision_name(collision_name);
 
     // default Coulomb log, if < 0, will be computed automatically
     m_CoulombLog = -1.0_rt;
-    queryWithParser(pp, "CoulombLog", m_CoulombLog);
+    queryWithParser(pp_collision_name, "CoulombLog", m_CoulombLog);
 
     if (m_species_names[0] == m_species_names[1])
         m_isSameSpecies = true;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -38,25 +38,25 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     mass = std::numeric_limits<Real>::max();
     do_back_transformed_diagnostics = 0;
 
-    ParmParse pp(m_laser_name);
+    ParmParse pp_laser_name(m_laser_name);
 
     // Parse the type of laser profile and set the corresponding flag `profile`
     std::string laser_type_s;
-    pp.get("profile", laser_type_s);
+    pp_laser_name.get("profile", laser_type_s);
     std::transform(laser_type_s.begin(), laser_type_s.end(), laser_type_s.begin(), ::tolower);
 
     // Parse the properties of the antenna
-    pp.getarr("position", m_position);
-    pp.getarr("direction", m_nvec);
-    pp.getarr("polarization", m_p_X);
+    pp_laser_name.getarr("position", m_position);
+    pp_laser_name.getarr("direction", m_nvec);
+    pp_laser_name.getarr("polarization", m_p_X);
 
-    pp.query("pusher_algo", m_pusher_algo);
-    getWithParser(pp, "wavelength", m_wavelength);
+    pp_laser_name.query("pusher_algo", m_pusher_algo);
+    getWithParser(pp_laser_name, "wavelength", m_wavelength);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_wavelength > 0, "The laser wavelength must be >0.");
-    const bool e_max_is_specified = queryWithParser(pp, "e_max", m_e_max);
+    const bool e_max_is_specified = queryWithParser(pp_laser_name, "e_max", m_e_max);
     Real a0;
-    const bool a0_is_specified = queryWithParser(pp, "a0", a0);
+    const bool a0_is_specified = queryWithParser(pp_laser_name, "a0", a0);
     if (a0_is_specified){
         Real omega = 2._rt*MathConst::pi*PhysConst::c/m_wavelength;
         m_e_max = PhysConst::m_e * omega * PhysConst::c * a0 / PhysConst::q_e;
@@ -66,8 +66,8 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
         "Exactly one of e_max or a0 must be specified for the laser.\n"
         );
 
-    pp.query("do_continuous_injection", do_continuous_injection);
-    pp.query("min_particles_per_mode", m_min_particles_per_mode);
+    pp_laser_name.query("do_continuous_injection", do_continuous_injection);
+    pp_laser_name.query("min_particles_per_mode", m_min_particles_per_mode);
 
     if (m_e_max == amrex::Real(0.)){
         amrex::Print() << m_laser_name << " with zero amplitude disabled.\n";
@@ -127,10 +127,10 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     m_laser_injection_box= Geom(0).ProbDomain();
     {
         Vector<Real> lo, hi;
-        if (pp.queryarr("prob_lo", lo)) {
+        if (pp_laser_name.queryarr("prob_lo", lo)) {
             m_laser_injection_box.setLo(lo);
         }
-        if (pp.queryarr("prob_hi", hi)) {
+        if (pp_laser_name.queryarr("prob_hi", hi)) {
             m_laser_injection_box.setHi(hi);
         }
     }
@@ -175,7 +175,7 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     common_params.e_max = m_e_max;
     common_params.p_X = m_p_X;
     common_params.nvec = m_nvec;
-    m_up_laser_profile->init(pp, ParmParse{"my_constants"}, common_params);
+    m_up_laser_profile->init(pp_laser_name, ParmParse{"my_constants"}, common_params);
 }
 
 /* \brief Check if laser particles enter the box, and inject if necessary.

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -81,7 +81,7 @@ MultiParticleContainer::ReadParameters ()
     static bool initialized = false;
     if (!initialized)
     {
-        ParmParse pp("particles");
+        ParmParse pp_particles("particles");
 
         // allocating and initializing default values of external fields for particles
         m_E_external_particle.resize(3);
@@ -94,12 +94,12 @@ MultiParticleContainer::ReadParameters ()
         // default values of E_external_particle and B_external_particle
         // are used to set the E and B field when "constant" or "parser"
         // is not explicitly used in the input
-        pp.query("B_ext_particle_init_style", m_B_ext_particle_s);
+        pp_particles.query("B_ext_particle_init_style", m_B_ext_particle_s);
         std::transform(m_B_ext_particle_s.begin(),
                        m_B_ext_particle_s.end(),
                        m_B_ext_particle_s.begin(),
                        ::tolower);
-        pp.query("E_ext_particle_init_style", m_E_ext_particle_s);
+        pp_particles.query("E_ext_particle_init_style", m_E_ext_particle_s);
         std::transform(m_E_ext_particle_s.begin(),
                        m_E_ext_particle_s.end(),
                        m_E_ext_particle_s.begin(),
@@ -108,13 +108,13 @@ MultiParticleContainer::ReadParameters ()
         // then the values for the external B on particles must
         // be provided in the input file.
         if (m_B_ext_particle_s == "constant")
-            pp.getarr("B_external_particle", m_B_external_particle);
+            pp_particles.getarr("B_external_particle", m_B_external_particle);
 
         // if the input string for E_external on particles is "constant"
         // then the values for the external E on particles must
         // be provided in the input file.
         if (m_E_ext_particle_s == "constant")
-            pp.getarr("E_external_particle", m_E_external_particle);
+            pp_particles.getarr("E_external_particle", m_E_external_particle);
 
         // if the input string for B_ext_particle_s is
         // "parse_b_ext_particle_function" then the mathematical expression
@@ -125,11 +125,11 @@ MultiParticleContainer::ReadParameters ()
            std::string str_Bx_ext_particle_function;
            std::string str_By_ext_particle_function;
            std::string str_Bz_ext_particle_function;
-           Store_parserString(pp, "Bx_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "Bx_external_particle_function(x,y,z,t)",
                                       str_Bx_ext_particle_function);
-           Store_parserString(pp, "By_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "By_external_particle_function(x,y,z,t)",
                                       str_By_ext_particle_function);
-           Store_parserString(pp, "Bz_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "Bz_external_particle_function(x,y,z,t)",
                                       str_Bz_ext_particle_function);
 
            // Parser for B_external on the particle
@@ -151,11 +151,11 @@ MultiParticleContainer::ReadParameters ()
            std::string str_Ex_ext_particle_function;
            std::string str_Ey_ext_particle_function;
            std::string str_Ez_ext_particle_function;
-           Store_parserString(pp, "Ex_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "Ex_external_particle_function(x,y,z,t)",
                                       str_Ex_ext_particle_function);
-           Store_parserString(pp, "Ey_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "Ey_external_particle_function(x,y,z,t)",
                                       str_Ey_ext_particle_function);
-           Store_parserString(pp, "Ez_external_particle_function(x,y,z,t)",
+           Store_parserString(pp_particles, "Ez_external_particle_function(x,y,z,t)",
                                       str_Ez_ext_particle_function);
            // Parser for E_external on the particle
            m_Ex_particle_parser = std::make_unique<ParserWrapper<4>>(
@@ -169,14 +169,14 @@ MultiParticleContainer::ReadParameters ()
 
 
         // particle species
-        pp.queryarr("species_names", species_names);
+        pp_particles.queryarr("species_names", species_names);
         auto const nspecies = species_names.size();
 
         if (nspecies > 0) {
             // Get species to deposit on main grid
             m_deposit_on_main_grid.resize(nspecies, false);
             std::vector<std::string> tmp;
-            pp.queryarr("deposit_on_main_grid", tmp);
+            pp_particles.queryarr("deposit_on_main_grid", tmp);
             for (auto const& name : tmp) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
                 WarpXUtilMsg::AlwaysAssert(
@@ -190,7 +190,7 @@ MultiParticleContainer::ReadParameters ()
 
             m_gather_from_main_grid.resize(nspecies, false);
             std::vector<std::string> tmp_gather;
-            pp.queryarr("gather_from_main_grid", tmp_gather);
+            pp_particles.queryarr("gather_from_main_grid", tmp_gather);
             for (auto const& name : tmp_gather) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
                 WarpXUtilMsg::AlwaysAssert(
@@ -206,7 +206,7 @@ MultiParticleContainer::ReadParameters ()
 
             // Get rigid-injected species
             std::vector<std::string> rigid_injected_species;
-            pp.queryarr("rigid_injected_species", rigid_injected_species);
+            pp_particles.queryarr("rigid_injected_species", rigid_injected_species);
             if (!rigid_injected_species.empty()) {
                 for (auto const& name : rigid_injected_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
@@ -221,7 +221,7 @@ MultiParticleContainer::ReadParameters ()
             }
             // Get photon species
             std::vector<std::string> photon_species;
-            pp.queryarr("photon_species", photon_species);
+            pp_particles.queryarr("photon_species", photon_species);
             if (!photon_species.empty()) {
                 for (auto const& name : photon_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
@@ -236,15 +236,14 @@ MultiParticleContainer::ReadParameters ()
             }
 
         }
-        pp.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
+        pp_particles.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
 #ifdef WARPX_DIM_RZ
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
                             "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
-        pp.query("galerkin_interpolation", WarpX::galerkin_interpolation);
 
         std::string boundary_conditions = "none";
-        pp.query("boundary_conditions", boundary_conditions);
+        pp_particles.query("boundary_conditions", boundary_conditions);
         if        (boundary_conditions == "none"){
             m_boundary_conditions = ParticleBC::none;
         } else if (boundary_conditions == "absorbing"){
@@ -253,29 +252,29 @@ MultiParticleContainer::ReadParameters ()
             amrex::Abort("unknown particle BC type");
         }
 
-        ParmParse ppl("lasers");
-        ppl.queryarr("names", lasers_names);
+        ParmParse pp_lasers("lasers");
+        pp_lasers.queryarr("names", lasers_names);
 
 #ifdef WARPX_QED
-        ParmParse ppw("warpx");
-        ppw.query("do_qed_schwinger", m_do_qed_schwinger);
+        ParmParse pp_warpx("warpx");
+        pp_warpx.query("do_qed_schwinger", m_do_qed_schwinger);
 
         if (m_do_qed_schwinger) {
-            ParmParse ppq("qed_schwinger");
-            ppq.get("ele_product_species", m_qed_schwinger_ele_product_name);
-            ppq.get("pos_product_species", m_qed_schwinger_pos_product_name);
+            ParmParse pp_qed_schwinger("qed_schwinger");
+            pp_qed_schwinger.get("ele_product_species", m_qed_schwinger_ele_product_name);
+            pp_qed_schwinger.get("pos_product_species", m_qed_schwinger_pos_product_name);
 #if (AMREX_SPACEDIM == 2)
-            getWithParser(ppq, "y_size",m_qed_schwinger_y_size);
+            getWithParser(pp_qed_schwinger, "y_size",m_qed_schwinger_y_size);
 #endif
-            ppq.query("threshold_poisson_gaussian", m_qed_schwinger_threshold_poisson_gaussian);
-            queryWithParser(ppq, "xmin", m_qed_schwinger_xmin);
-            queryWithParser(ppq, "xmax", m_qed_schwinger_xmax);
+            pp_qed_schwinger.query("threshold_poisson_gaussian", m_qed_schwinger_threshold_poisson_gaussian);
+            queryWithParser(pp_qed_schwinger, "xmin", m_qed_schwinger_xmin);
+            queryWithParser(pp_qed_schwinger, "xmax", m_qed_schwinger_xmax);
 #if (AMREX_SPACEDIM == 3)
-            queryWithParser(ppq, "ymin", m_qed_schwinger_ymin);
-            queryWithParser(ppq, "ymax", m_qed_schwinger_ymax);
+            queryWithParser(pp_qed_schwinger, "ymin", m_qed_schwinger_ymin);
+            queryWithParser(pp_qed_schwinger, "ymax", m_qed_schwinger_ymax);
 #endif
-            queryWithParser(ppq, "zmin", m_qed_schwinger_zmin);
-            queryWithParser(ppq, "zmax", m_qed_schwinger_zmax);
+            queryWithParser(pp_qed_schwinger, "zmin", m_qed_schwinger_zmin);
+            queryWithParser(pp_qed_schwinger, "zmax", m_qed_schwinger_zmax);
         }
 #endif
         initialized = true;
@@ -804,12 +803,12 @@ void MultiParticleContainer::InitQED ()
 void MultiParticleContainer::InitQuantumSync ()
 {
     std::string lookup_table_mode;
-    ParmParse pp("qed_qs");
+    ParmParse pp_qed_qs("qed_qs");
 
     //If specified, use a user-defined energy threshold for photon creation
     ParticleReal temp;
     constexpr auto mec2 = PhysConst::c * PhysConst::c * PhysConst::m_e;
-    if(queryWithParser(pp, "photon_creation_energy_threshold", temp)){
+    if(queryWithParser(pp_qed_qs, "photon_creation_energy_threshold", temp)){
         temp *= mec2;
         m_quantum_sync_photon_creation_energy_threshold = temp;
     }
@@ -822,10 +821,10 @@ void MultiParticleContainer::InitQuantumSync ()
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real qs_minimum_chi_part;
-    getWithParser(pp, "chi_min", qs_minimum_chi_part);
+    getWithParser(pp_qed_qs, "chi_min", qs_minimum_chi_part);
 
 
-    pp.query("lookup_table_mode", lookup_table_mode);
+    pp_qed_qs.query("lookup_table_mode", lookup_table_mode);
     if(lookup_table_mode.empty()){
         amrex::Abort("Quantum Synchrotron table mode should be provided");
     }
@@ -841,7 +840,7 @@ void MultiParticleContainer::InitQuantumSync ()
     else if(lookup_table_mode == "load"){
         amrex::Print() << "Quantum Synchrotron table will be read from file. \n" ;
         std::string load_table_name;
-        pp.query("load_table_from", load_table_name);
+        pp_qed_qs.query("load_table_from", load_table_name);
         if(load_table_name.empty()){
             amrex::Abort("Quantum Synchrotron table name should be provided");
         }
@@ -867,16 +866,16 @@ void MultiParticleContainer::InitQuantumSync ()
 void MultiParticleContainer::InitBreitWheeler ()
 {
     std::string lookup_table_mode;
-    ParmParse pp("qed_bw");
+    ParmParse pp_qed_bw("qed_bw");
 
     // bw_minimum_chi_phot is the minimum chi parameter to be
     // considered for pair production. If a photon has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real bw_minimum_chi_part;
-    if(!queryWithParser(pp, "chi_min", bw_minimum_chi_part))
+    if(!queryWithParser(pp_qed_bw, "chi_min", bw_minimum_chi_part))
         amrex::Abort("qed_bw.chi_min should be provided!");
 
-    pp.query("lookup_table_mode", lookup_table_mode);
+    pp_qed_bw.query("lookup_table_mode", lookup_table_mode);
     if(lookup_table_mode.empty()){
         amrex::Abort("Breit Wheeler table mode should be provided");
     }
@@ -892,7 +891,7 @@ void MultiParticleContainer::InitBreitWheeler ()
     else if(lookup_table_mode == "load"){
         amrex::Print() << "Breit Wheeler table will be read from file. \n" ;
         std::string load_table_name;
-        pp.query("load_table_from", load_table_name);
+        pp_qed_bw.query("load_table_from", load_table_name);
         if(load_table_name.empty()){
             amrex::Abort("Breit Wheeler table name should be provided");
         }
@@ -918,9 +917,9 @@ void MultiParticleContainer::InitBreitWheeler ()
 void
 MultiParticleContainer::QuantumSyncGenerateTable ()
 {
-    ParmParse pp("qed_qs");
+    ParmParse pp_qed_qs("qed_qs");
     std::string table_name;
-    pp.query("save_table_in", table_name);
+    pp_qed_qs.query("save_table_in", table_name);
     if(table_name.empty())
         amrex::Abort("qed_qs.save_table_in should be provided!");
 
@@ -928,7 +927,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real qs_minimum_chi_part;
-    getWithParser(pp, "chi_min", qs_minimum_chi_part);
+    getWithParser(pp_qed_qs, "chi_min", qs_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){
         PicsarQuantumSyncCtrl ctrl;
@@ -941,14 +940,14 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         //Minimun chi for the table. If a lepton has chi < tab_dndt_chi_min,
         //chi is considered as if it were equal to tab_dndt_chi_min
-        getWithParser(pp, "tab_dndt_chi_min", ctrl.dndt_params.chi_part_min);
+        getWithParser(pp_qed_qs, "tab_dndt_chi_min", ctrl.dndt_params.chi_part_min);
 
         //Maximum chi for the table. If a lepton has chi > tab_dndt_chi_max,
         //chi is considered as if it were equal to tab_dndt_chi_max
-        getWithParser(pp, "tab_dndt_chi_max", ctrl.dndt_params.chi_part_max);
+        getWithParser(pp_qed_qs, "tab_dndt_chi_max", ctrl.dndt_params.chi_part_max);
 
         //How many points should be used for chi in the table
-        pp.get("tab_dndt_how_many", ctrl.dndt_params.chi_part_how_many);
+        pp_qed_qs.get("tab_dndt_how_many", ctrl.dndt_params.chi_part_how_many);
         //------
 
         //--- sub-table 2 (2D)
@@ -958,23 +957,23 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         //Minimun chi for the table. If a lepton has chi < tab_em_chi_min,
         //chi is considered as if it were equal to tab_em_chi_min
-        getWithParser(pp, "tab_em_chi_min", ctrl.phot_em_params.chi_part_min);
+        getWithParser(pp_qed_qs, "tab_em_chi_min", ctrl.phot_em_params.chi_part_min);
 
         //Maximum chi for the table. If a lepton has chi > tab_em_chi_max,
         //chi is considered as if it were equal to tab_em_chi_max
-        getWithParser(pp, "tab_em_chi_max", ctrl.phot_em_params.chi_part_max);
+        getWithParser(pp_qed_qs, "tab_em_chi_max", ctrl.phot_em_params.chi_part_max);
 
         //How many points should be used for chi in the table
-        pp.get("tab_em_chi_how_many", ctrl.phot_em_params.chi_part_how_many);
+        pp_qed_qs.get("tab_em_chi_how_many", ctrl.phot_em_params.chi_part_how_many);
 
         //The other axis of the table is the ratio between the quantum
         //parameter of the emitted photon and the quantum parameter of the
         //lepton. This parameter is the minimum ratio to consider for the table.
-        getWithParser(pp, "tab_em_frac_min", ctrl.phot_em_params.frac_min);
+        getWithParser(pp_qed_qs, "tab_em_frac_min", ctrl.phot_em_params.frac_min);
 
         //This parameter is the number of different points to consider for the second
         //axis
-        pp.get("tab_em_frac_how_many", ctrl.phot_em_params.frac_how_many);
+        pp_qed_qs.get("tab_em_frac_how_many", ctrl.phot_em_params.frac_how_many);
         //====================
 
         m_shr_p_qs_engine->compute_lookup_tables(ctrl, qs_minimum_chi_part);
@@ -999,9 +998,9 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 void
 MultiParticleContainer::BreitWheelerGenerateTable ()
 {
-    ParmParse pp("qed_bw");
+    ParmParse pp_qed_bw("qed_bw");
     std::string table_name;
-    pp.query("save_table_in", table_name);
+    pp_qed_bw.query("save_table_in", table_name);
     if(table_name.empty())
         amrex::Abort("qed_bw.save_table_in should be provided!");
 
@@ -1009,7 +1008,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
     // considered for pair production. If a photon has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
     amrex::Real bw_minimum_chi_part;
-    getWithParser(pp, "chi_min", bw_minimum_chi_part);
+    getWithParser(pp_qed_bw, "chi_min", bw_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){
         PicsarBreitWheelerCtrl ctrl;
@@ -1022,14 +1021,14 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         //Minimun chi for the table. If a photon has chi < tab_dndt_chi_min,
         //an analytical approximation is used.
-        getWithParser(pp, "tab_dndt_chi_min", ctrl.dndt_params.chi_phot_min);
+        getWithParser(pp_qed_bw, "tab_dndt_chi_min", ctrl.dndt_params.chi_phot_min);
 
         //Maximum chi for the table. If a photon has chi > tab_dndt_chi_max,
         //an analytical approximation is used.
-        getWithParser(pp, "tab_dndt_chi_max", ctrl.dndt_params.chi_phot_max);
+        getWithParser(pp_qed_bw, "tab_dndt_chi_max", ctrl.dndt_params.chi_phot_max);
 
         //How many points should be used for chi in the table
-        pp.get("tab_dndt_how_many", ctrl.dndt_params.chi_phot_how_many);
+        pp_qed_bw.get("tab_dndt_how_many", ctrl.dndt_params.chi_phot_how_many);
         //------
 
         //--- sub-table 2 (2D)
@@ -1039,19 +1038,19 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         //Minimun chi for the table. If a photon has chi < tab_pair_chi_min
         //chi is considered as it were equal to chi_phot_tpair_min
-        getWithParser(pp, "tab_pair_chi_min", ctrl.pair_prod_params.chi_phot_min);
+        getWithParser(pp_qed_bw, "tab_pair_chi_min", ctrl.pair_prod_params.chi_phot_min);
 
         //Maximum chi for the table. If a photon has chi > tab_pair_chi_max
         //chi is considered as it were equal to chi_phot_tpair_max
-        getWithParser(pp, "tab_pair_chi_max", ctrl.pair_prod_params.chi_phot_max);
+        getWithParser(pp_qed_bw, "tab_pair_chi_max", ctrl.pair_prod_params.chi_phot_max);
 
         //How many points should be used for chi in the table
-        pp.get("tab_pair_chi_how_many", ctrl.pair_prod_params.chi_phot_how_many);
+        pp_qed_bw.get("tab_pair_chi_how_many", ctrl.pair_prod_params.chi_phot_how_many);
 
         //The other axis of the table is the fraction of the initial energy
         //'taken away' by the most energetic particle of the pair.
         //This parameter is the number of different fractions to consider
-        pp.get("tab_pair_frac_how_many", ctrl.pair_prod_params.frac_how_many);
+        pp_qed_bw.get("tab_pair_frac_how_many", ctrl.pair_prod_params.frac_how_many);
         //====================
 
         m_shr_p_bw_engine->compute_lookup_tables(ctrl, bw_minimum_chi_part);

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -31,22 +31,22 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core, int ispecie
                                                   const std::string& name)
     : PhysicalParticleContainer(amr_core, ispecies, name)
 {
-    ParmParse pp(species_name);
+    ParmParse pp_species_name(species_name);
 
 #ifdef WARPX_QED
         //Find out if Breit Wheeler process is enabled
-        pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
+        pp_species_name.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
 
         //If Breit Wheeler process is enabled, look for the target electron and positron
         //species
         if(m_do_qed_breit_wheeler){
-            pp.get("qed_breit_wheeler_ele_product_species", m_qed_breit_wheeler_ele_product_name);
-            pp.get("qed_breit_wheeler_pos_product_species", m_qed_breit_wheeler_pos_product_name);
+            pp_species_name.get("qed_breit_wheeler_ele_product_species", m_qed_breit_wheeler_ele_product_name);
+            pp_species_name.get("qed_breit_wheeler_pos_product_species", m_qed_breit_wheeler_pos_product_name);
         }
 
         //Check for processes which do not make sense for photons
         bool test_quantum_sync = false;
-        pp.query("do_qed_quantum_sync", test_quantum_sync);
+        pp_species_name.query("do_qed_quantum_sync", test_quantum_sync);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         test_quantum_sync == 0,
         "ERROR: do_qed_quantum_sync can be 1 for species NOT listed in particles.photon_species only!");

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -102,33 +102,33 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     charge = plasma_injector->getCharge();
     mass = plasma_injector->getMass();
 
-    ParmParse pp(species_name);
+    ParmParse pp_species_name(species_name);
 
-    pp.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
-    pp.query("do_backward_propagation", do_backward_propagation);
+    pp_species_name.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
+    pp_species_name.query("do_backward_propagation", do_backward_propagation);
 
     // Initialize splitting
-    pp.query("do_splitting", do_splitting);
-    pp.query("split_type", split_type);
-    pp.query("do_not_deposit", do_not_deposit);
-    pp.query("do_not_gather", do_not_gather);
-    pp.query("do_not_push", do_not_push);
+    pp_species_name.query("do_splitting", do_splitting);
+    pp_species_name.query("split_type", split_type);
+    pp_species_name.query("do_not_deposit", do_not_deposit);
+    pp_species_name.query("do_not_gather", do_not_gather);
+    pp_species_name.query("do_not_push", do_not_push);
 
-    pp.query("do_continuous_injection", do_continuous_injection);
-    pp.query("initialize_self_fields", initialize_self_fields);
-    queryWithParser(pp, "self_fields_required_precision", self_fields_required_precision);
-    pp.query("self_fields_max_iters", self_fields_max_iters);
+    pp_species_name.query("do_continuous_injection", do_continuous_injection);
+    pp_species_name.query("initialize_self_fields", initialize_self_fields);
+    queryWithParser(pp_species_name, "self_fields_required_precision", self_fields_required_precision);
+    pp_species_name.query("self_fields_max_iters", self_fields_max_iters);
     // Whether to plot back-transformed (lab-frame) diagnostics
     // for this species.
-    pp.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);
+    pp_species_name.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);
 
-    pp.query("do_field_ionization", do_field_ionization);
+    pp_species_name.query("do_field_ionization", do_field_ionization);
 
-    pp.query("do_resampling", do_resampling);
+    pp_species_name.query("do_resampling", do_resampling);
     if (do_resampling) m_resampler = Resampling(species_name);
 
     //check if Radiation Reaction is enabled and do consistency checks
-    pp.query("do_classical_radiation_reaction", do_classical_radiation_reaction);
+    pp_species_name.query("do_classical_radiation_reaction", do_classical_radiation_reaction);
     //if the species is not a lepton, do_classical_radiation_reaction
     //should be false
     WarpXUtilMsg::AlwaysAssert(
@@ -147,16 +147,16 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     //_____________________________
 
 #ifdef WARPX_QED
-    pp.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
+    pp_species_name.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
     if (m_do_qed_quantum_sync)
         AddRealComp("optical_depth_QSR");
 
-    pp.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
+    pp_species_name.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
     if (m_do_qed_breit_wheeler)
         AddRealComp("optical_depth_BW");
 
     if(m_do_qed_quantum_sync){
-        pp.get("qed_quantum_sync_phot_product_species",
+        pp_species_name.get("qed_quantum_sync_phot_product_species",
             m_qed_quantum_sync_phot_product_name);
     }
 #endif
@@ -184,15 +184,15 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
 void
 PhysicalParticleContainer::BackwardCompatibility ()
 {
-    ParmParse pps(species_name);
+    ParmParse pp_species_name(species_name);
     std::vector<std::string> backward_strings;
-    if (pps.queryarr("plot_vars", backward_strings)){
+    if (pp_species_name.queryarr("plot_vars", backward_strings)){
         amrex::Abort("<species>.plot_vars is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
 
     int backward_int;
-    if (pps.query("plot_species", backward_int)){
+    if (pp_species_name.query("plot_species", backward_int)){
         amrex::Abort("<species>.plot_species is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
@@ -1903,15 +1903,15 @@ void
 PhysicalParticleContainer::InitIonizationModule ()
 {
     if (!do_field_ionization) return;
-    ParmParse pp(species_name);
+    ParmParse pp_species_name(species_name);
     if (charge != PhysConst::q_e){
         amrex::Warning(
             "charge != q_e for ionizable species: overriding user value and setting charge = q_e.");
         charge = PhysConst::q_e;
     }
-    pp.query("ionization_initial_level", ionization_initial_level);
-    pp.get("ionization_product_species", ionization_product_name);
-    pp.get("physical_element", physical_element);
+    pp_species_name.query("ionization_initial_level", ionization_initial_level);
+    pp_species_name.get("ionization_product_species", ionization_product_name);
+    pp_species_name.get("physical_element", physical_element);
     // Add runtime integer component for ionization level
     AddIntComp("ionization_level");
     // Get atomic number and ionization energies from file

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -14,8 +14,8 @@ LevelingThinning::LevelingThinning (const std::string species_name)
 {
     using namespace amrex::literals;
 
-    amrex::ParmParse pp(species_name);
-    queryWithParser(pp, "resampling_algorithm_target_ratio", m_target_ratio);
+    amrex::ParmParse pp_species_name(species_name);
+    queryWithParser(pp_species_name, "resampling_algorithm_target_ratio", m_target_ratio);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_target_ratio > 0._rt,
                                     "Resampling target ratio should be strictly greater than 0");
     if (m_target_ratio <= 1._rt)
@@ -24,7 +24,7 @@ LevelingThinning::LevelingThinning (const std::string species_name)
                        " It is possible that no particle will be removed during resampling");
     }
 
-    pp.query("resampling_algorithm_min_ppc", m_min_ppc);
+    pp_species_name.query("resampling_algorithm_min_ppc", m_min_ppc);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_min_ppc >= 1,
                                      "Resampling min_ppc should be greater than or equal to 1");
 }

--- a/Source/Particles/Resampling/Resampling.cpp
+++ b/Source/Particles/Resampling/Resampling.cpp
@@ -9,9 +9,9 @@
 
 Resampling::Resampling (const std::string species_name)
 {
-    amrex::ParmParse pp(species_name);
+    amrex::ParmParse pp_species_name(species_name);
     std::string resampling_algorithm_string = "leveling_thinning"; // default resampling algorithm
-    pp.query("resampling_algorithm", resampling_algorithm_string);
+    pp_species_name.query("resampling_algorithm", resampling_algorithm_string);
 
     if (resampling_algorithm_string.compare("leveling_thinning") == 0)
     {

--- a/Source/Particles/Resampling/ResamplingTrigger.cpp
+++ b/Source/Particles/Resampling/ResamplingTrigger.cpp
@@ -10,13 +10,13 @@
 
 ResamplingTrigger::ResamplingTrigger (const std::string species_name)
 {
-    amrex::ParmParse pprt(species_name);
+    amrex::ParmParse pp_species_name(species_name);
 
     std::vector<std::string> resampling_trigger_int_string_vec = {"0"};
-    pprt.queryarr("resampling_trigger_intervals", resampling_trigger_int_string_vec);
+    pp_species_name.queryarr("resampling_trigger_intervals", resampling_trigger_int_string_vec);
     m_resampling_intervals = IntervalsParser(resampling_trigger_int_string_vec);
 
-    queryWithParser(pprt, "resampling_trigger_max_avg_ppc", m_max_avg_ppc);
+    queryWithParser(pp_species_name, "resampling_trigger_max_avg_ppc", m_max_avg_ppc);
 }
 
 bool ResamplingTrigger::triggered (const int timestep, const amrex::Real global_numparts) const

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -37,12 +37,12 @@ RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_cor
     : PhysicalParticleContainer(amr_core, ispecies, name)
 {
 
-    ParmParse pp(species_name);
+    ParmParse pp_species_name(species_name);
 
-    getWithParser(pp, "zinject_plane", zinject_plane);
-    pp.query("projected", projected);
-    pp.query("focused", focused);
-    pp.query("rigid_advance", rigid_advance);
+    getWithParser(pp_species_name, "zinject_plane", zinject_plane);
+    pp_species_name.query("projected", projected);
+    pp_species_name.query("focused", focused);
+    pp_species_name.query("rigid_advance", rigid_advance);
 
 }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -73,14 +73,14 @@ WarpXParticleContainer::ReadParameters ()
     static bool initialized = false;
     if (!initialized)
     {
-        ParmParse pp("particles");
+        ParmParse pp_particles("particles");
 
 #ifdef AMREX_USE_GPU
         do_tiling = false; // By default, tiling is off on GPU
 #else
         do_tiling = true;
 #endif
-        pp.query("do_tiling",  do_tiling);
+        pp_particles.query("do_tiling", do_tiling);
 
         initialized = true;
     }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -21,12 +21,12 @@ using namespace amrex;
 void ReadBoostedFrameParameters(Real& gamma_boost, Real& beta_boost,
                                 Vector<int>& boost_direction)
 {
-    ParmParse pp("warpx");
-    queryWithParser(pp, "gamma_boost", gamma_boost);
+    ParmParse pp_warpx("warpx");
+    queryWithParser(pp_warpx, "gamma_boost", gamma_boost);
     if( gamma_boost > 1. ) {
         beta_boost = std::sqrt(1.-1./pow(gamma_boost,2));
         std::string s;
-        pp.get("boost_direction", s);
+        pp_warpx.get("boost_direction", s);
         if (s == "x" || s == "X") {
             boost_direction[0] = 1;
         }
@@ -65,14 +65,14 @@ void ConvertLabParamsToBoost()
     Vector<Real> slice_lo(AMREX_SPACEDIM);
     Vector<Real> slice_hi(AMREX_SPACEDIM);
 
-    ParmParse pp_geom("geometry");
-    ParmParse pp_wpx("warpx");
+    ParmParse pp_geometry("geometry");
+    ParmParse pp_warpx("warpx");
     ParmParse pp_amr("amr");
     ParmParse pp_slice("slice");
 
-    pp_geom.getarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
+    pp_geometry.getarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(prob_lo.size() == AMREX_SPACEDIM);
-    pp_geom.getarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
+    pp_geometry.getarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
 
     pp_slice.queryarr("dom_lo",slice_lo,0,AMREX_SPACEDIM);
@@ -83,8 +83,8 @@ void ConvertLabParamsToBoost()
 
     pp_amr.query("max_level", max_level);
     if (max_level > 0){
-      pp_wpx.getarr("fine_tag_lo", fine_tag_lo);
-      pp_wpx.getarr("fine_tag_hi", fine_tag_hi);
+      pp_warpx.getarr("fine_tag_lo", fine_tag_lo);
+      pp_warpx.getarr("fine_tag_hi", fine_tag_hi);
     }
 
 
@@ -112,11 +112,11 @@ void ConvertLabParamsToBoost()
         }
     }
 
-    pp_geom.addarr("prob_lo", prob_lo);
-    pp_geom.addarr("prob_hi", prob_hi);
+    pp_geometry.addarr("prob_lo", prob_lo);
+    pp_geometry.addarr("prob_hi", prob_hi);
     if (max_level > 0){
-      pp_wpx.addarr("fine_tag_lo", fine_tag_lo);
-      pp_wpx.addarr("fine_tag_hi", fine_tag_hi);
+      pp_warpx.addarr("fine_tag_lo", fine_tag_lo);
+      pp_warpx.addarr("fine_tag_hi", fine_tag_hi);
     }
 
     pp_slice.addarr("dom_lo",slice_lo);
@@ -195,12 +195,12 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
 {
     WarpXParser parser(parse_function);
     parser.registerVariables(varnames);
-    ParmParse pp("my_constants");
+    ParmParse pp_my_constants("my_constants");
     std::set<std::string> symbols = parser.symbols();
     for (auto const& v : varnames) symbols.erase(v.c_str());
     for (auto it = symbols.begin(); it != symbols.end(); ) {
         Real v;
-        if (pp.query(it->c_str(), v)) {
+        if (pp_my_constants.query(it->c_str(), v)) {
             parser.setConstant(*it, v);
             it = symbols.erase(it);
         } else if (std::strcmp(it->c_str(), "q_e") == 0) {
@@ -275,8 +275,8 @@ void CheckGriddingForRZSpectral ()
     amrex::Abort("CheckGriddingForRZSpectral: WarpX was not built with RZ geometry.");
 #else
 
-    ParmParse pp("algo");
-    int maxwell_solver_id = GetAlgorithmInteger(pp, "maxwell_solver");
+    ParmParse pp_algo("algo");
+    int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
 
     // only check for PSATD in RZ
     if (maxwell_solver_id != MaxwellSolverAlgo::PSATD)
@@ -358,20 +358,20 @@ void ReadBCParams ()
     amrex::Vector<std::string> particle_BC_lo(AMREX_SPACEDIM,"default");
     amrex::Vector<std::string> particle_BC_hi(AMREX_SPACEDIM,"default");
     amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
-    ParmParse pp_geom("geometry");
-    if (pp_geom.queryarr("is_periodic", geom_periodicity)) {
+    ParmParse pp_geometry("geometry");
+    if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
         return;
         // When all boundary conditions are supported, the abort statement below will be introduced
         amrex::Abort("geometry.is_periodic is not supported. Please use `boundary.field_lo`, `boundary.field_hi` to specifiy field boundary conditions and 'boundary.particle_lo', 'boundary.particle_hi'  to specify particle boundary conditions.");
     }
     // particle boundary may not be explicitly specified for some applications
     bool particle_boundary_specified = false;
-    ParmParse pp("boundary");
-    pp.queryarr("field_lo", field_BC_lo, 0, AMREX_SPACEDIM);
-    pp.queryarr("field_hi", field_BC_hi, 0, AMREX_SPACEDIM);
-    if (pp.queryarr("particle_lo", particle_BC_lo, 0, AMREX_SPACEDIM))
+    ParmParse pp_boundary("boundary");
+    pp_boundary.queryarr("field_lo", field_BC_lo, 0, AMREX_SPACEDIM);
+    pp_boundary.queryarr("field_hi", field_BC_hi, 0, AMREX_SPACEDIM);
+    if (pp_boundary.queryarr("particle_lo", particle_BC_lo, 0, AMREX_SPACEDIM))
         particle_boundary_specified = true;
-    if (pp.queryarr("particle_hi", particle_BC_hi, 0, AMREX_SPACEDIM))
+    if (pp_boundary.queryarr("particle_hi", particle_BC_hi, 0, AMREX_SPACEDIM))
         particle_boundary_specified = true;
     AMREX_ALWAYS_ASSERT(field_BC_lo.size() == AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(field_BC_hi.size() == AMREX_SPACEDIM);
@@ -410,7 +410,7 @@ void ReadBCParams ()
         }
     }
 
-    pp_geom.addarr("is_periodic", geom_periodicity);
+    pp_geometry.addarr("is_periodic", geom_periodicity);
 }
 
 namespace WarpXUtilMsg{

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -349,21 +349,21 @@ WarpX::ReadParameters ()
     }
 
     {
-        ParmParse pp("amr");// Traditionally, these have prefix, amr.
+        ParmParse pp_amr("amr");
 
-        pp.query("restart", restart_chkfile);
+        pp_amr.query("restart", restart_chkfile);
     }
 
     {
-        ParmParse pp("algo");
-        maxwell_solver_id = GetAlgorithmInteger(pp, "maxwell_solver");
+        ParmParse pp_algo("algo");
+        maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
     }
 
     {
-        ParmParse pp("warpx");
+        ParmParse pp_warpx("warpx");
 
         std::vector<int> numprocs_in;
-        pp.queryarr("numprocs", numprocs_in);
+        pp_warpx.queryarr("numprocs", numprocs_in);
         if (not numprocs_in.empty()) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE
                 (numprocs_in.size() == AMREX_SPACEDIM,
@@ -380,7 +380,7 @@ WarpX::ReadParameters ()
 
         // set random seed
         std::string random_seed = "default";
-        pp.query("random_seed", random_seed);
+        pp_warpx.query("random_seed", random_seed);
         if ( random_seed != "default" ) {
             unsigned long myproc_1 = ParallelDescriptor::MyProc() + 1;
             if ( random_seed == "random" ) {
@@ -396,14 +396,14 @@ WarpX::ReadParameters ()
             }
         }
 
-        queryWithParser(pp, "cfl", cfl);
-        pp.query("verbose", verbose);
-        pp.query("regrid_int", regrid_int);
-        pp.query("do_subcycling", do_subcycling);
-        pp.query("use_hybrid_QED", use_hybrid_QED);
-        pp.query("safe_guard_cells", safe_guard_cells);
+        queryWithParser(pp_warpx, "cfl", cfl);
+        pp_warpx.query("verbose", verbose);
+        pp_warpx.query("regrid_int", regrid_int);
+        pp_warpx.query("do_subcycling", do_subcycling);
+        pp_warpx.query("use_hybrid_QED", use_hybrid_QED);
+        pp_warpx.query("safe_guard_cells", safe_guard_cells);
         std::vector<std::string> override_sync_intervals_string_vec = {"1"};
-        pp.queryarr("override_sync_intervals", override_sync_intervals_string_vec);
+        pp_warpx.queryarr("override_sync_intervals", override_sync_intervals_string_vec);
         override_sync_intervals = IntervalsParser(override_sync_intervals_string_vec);
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycling != 1 || max_level <= 1,
@@ -411,19 +411,19 @@ WarpX::ReadParameters ()
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
 
-        pp.query("do_device_synchronize_before_profile", do_device_synchronize_before_profile);
+        pp_warpx.query("do_device_synchronize_before_profile", do_device_synchronize_before_profile);
 
         // pp.query returns 1 if argument zmax_plasma_to_compute_max_step is
         // specified by the user, 0 otherwise.
         do_compute_max_step_from_zmax =
-            queryWithParser(pp, "zmax_plasma_to_compute_max_step",
+            queryWithParser(pp_warpx, "zmax_plasma_to_compute_max_step",
                       zmax_plasma_to_compute_max_step);
 
-        pp.query("do_moving_window", do_moving_window);
+        pp_warpx.query("do_moving_window", do_moving_window);
         if (do_moving_window)
         {
             std::string s;
-            pp.get("moving_window_dir", s);
+            pp_warpx.get("moving_window_dir", s);
             if (s == "x" || s == "X") {
                 moving_window_dir = 0;
             }
@@ -445,30 +445,30 @@ WarpX::ReadParameters ()
 
             moving_window_x = geom[0].ProbLo(moving_window_dir);
 
-            pp.get("moving_window_v", moving_window_v);
+            pp_warpx.get("moving_window_v", moving_window_v);
             moving_window_v *= PhysConst::c;
         }
 
-        pp.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);
+        pp_warpx.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);
         if (do_back_transformed_diagnostics) {
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
                    "gamma_boost must be > 1 to use the boosted frame diagnostic.");
 
-            pp.query("lab_data_directory", lab_data_directory);
+            pp_warpx.query("lab_data_directory", lab_data_directory);
 
             std::string s;
-            pp.get("boost_direction", s);
+            pp_warpx.get("boost_direction", s);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
                    "The boosted frame diagnostic currently only works if the boost is in the z direction.");
 
-            pp.get("num_snapshots_lab", num_snapshots_lab);
+            pp_warpx.get("num_snapshots_lab", num_snapshots_lab);
 
             // Read either dz_snapshots_lab or dt_snapshots_lab
             bool snapshot_interval_is_specified = 0;
             Real dz_snapshots_lab = 0;
-            snapshot_interval_is_specified += queryWithParser(pp, "dt_snapshots_lab", dt_snapshots_lab);
-            if ( queryWithParser(pp, "dz_snapshots_lab", dz_snapshots_lab) ){
+            snapshot_interval_is_specified += queryWithParser(pp_warpx, "dt_snapshots_lab", dt_snapshots_lab);
+            if ( queryWithParser(pp_warpx, "dz_snapshots_lab", dz_snapshots_lab) ){
                 dt_snapshots_lab = dz_snapshots_lab/PhysConst::c;
                 snapshot_interval_is_specified = 1;
             }
@@ -476,36 +476,36 @@ WarpX::ReadParameters ()
                 snapshot_interval_is_specified,
                 "When using back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab.");
 
-            getWithParser(pp, "gamma_boost", gamma_boost);
+            getWithParser(pp_warpx, "gamma_boost", gamma_boost);
 
-            pp.query("do_back_transformed_fields", do_back_transformed_fields);
+            pp_warpx.query("do_back_transformed_fields", do_back_transformed_fields);
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window,
                    "The moving window should be on if using the boosted frame diagnostic.");
 
-            pp.get("moving_window_dir", s);
+            pp_warpx.get("moving_window_dir", s);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
                    "The boosted frame diagnostic currently only works if the moving window is in the z direction.");
         }
 
-        do_electrostatic = GetAlgorithmInteger(pp, "do_electrostatic");
+        do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
 
         if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
-            queryWithParser(pp, "self_fields_required_precision", self_fields_required_precision);
-            pp.query("self_fields_max_iters", self_fields_max_iters);
+            queryWithParser(pp_warpx, "self_fields_required_precision", self_fields_required_precision);
+            pp_warpx.query("self_fields_max_iters", self_fields_max_iters);
             // Note that with the relativistic version, these parameters would be
             // input for each species.
         }
 
-        pp.query("n_buffer", n_buffer);
-        pp.query("const_dt", const_dt);
+        pp_warpx.query("n_buffer", n_buffer);
+        pp_warpx.query("const_dt", const_dt);
 
         // Read filter and fill IntVect filter_npass_each_dir with
         // proper size for AMREX_SPACEDIM
-        pp.query("use_filter", use_filter);
-        pp.query("use_filter_compensation", use_filter_compensation);
+        pp_warpx.query("use_filter", use_filter);
+        pp_warpx.query("use_filter_compensation", use_filter_compensation);
         Vector<int> parse_filter_npass_each_dir(AMREX_SPACEDIM,1);
-        pp.queryarr("filter_npass_each_dir", parse_filter_npass_each_dir);
+        pp_warpx.queryarr("filter_npass_each_dir", parse_filter_npass_each_dir);
         filter_npass_each_dir[0] = parse_filter_npass_each_dir[0];
         filter_npass_each_dir[1] = parse_filter_npass_each_dir[1];
 #if (AMREX_SPACEDIM == 3)
@@ -520,67 +520,67 @@ WarpX::ReadParameters ()
         }
 #endif
 
-        pp.query("num_mirrors", num_mirrors);
+        pp_warpx.query("num_mirrors", num_mirrors);
         if (num_mirrors>0){
             mirror_z.resize(num_mirrors);
-            pp.getarr("mirror_z", mirror_z, 0, num_mirrors);
+            pp_warpx.getarr("mirror_z", mirror_z, 0, num_mirrors);
             mirror_z_width.resize(num_mirrors);
-            pp.getarr("mirror_z_width", mirror_z_width, 0, num_mirrors);
+            pp_warpx.getarr("mirror_z_width", mirror_z_width, 0, num_mirrors);
             mirror_z_npoints.resize(num_mirrors);
-            pp.getarr("mirror_z_npoints", mirror_z_npoints, 0, num_mirrors);
+            pp_warpx.getarr("mirror_z_npoints", mirror_z_npoints, 0, num_mirrors);
         }
 
-        pp.query("serialize_ics", serialize_ics);
-        pp.query("refine_plasma", refine_plasma);
-        pp.query("do_dive_cleaning", do_dive_cleaning);
-        pp.query("n_field_gather_buffer", n_field_gather_buffer);
-        pp.query("n_current_deposition_buffer", n_current_deposition_buffer);
+        pp_warpx.query("serialize_ics", serialize_ics);
+        pp_warpx.query("refine_plasma", refine_plasma);
+        pp_warpx.query("do_dive_cleaning", do_dive_cleaning);
+        pp_warpx.query("n_field_gather_buffer", n_field_gather_buffer);
+        pp_warpx.query("n_current_deposition_buffer", n_current_deposition_buffer);
 #ifdef AMREX_USE_GPU
         std::vector<std::string>sort_intervals_string_vec = {"4"};
 #else
         std::vector<std::string> sort_intervals_string_vec = {"-1"};
 #endif
-        pp.queryarr("sort_intervals", sort_intervals_string_vec);
+        pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
         sort_intervals = IntervalsParser(sort_intervals_string_vec);
 
         Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
-        bool sort_bin_size_is_specified = pp.queryarr("sort_bin_size", vect_sort_bin_size);
+        bool sort_bin_size_is_specified = pp_warpx.queryarr("sort_bin_size", vect_sort_bin_size);
         if (sort_bin_size_is_specified){
             for (int i=0; i<AMREX_SPACEDIM; i++)
                 sort_bin_size[i] = vect_sort_bin_size[i];
         }
 
         amrex::Real quantum_xi_tmp;
-        int quantum_xi_is_specified = queryWithParser(pp, "quantum_xi", quantum_xi_tmp);
+        int quantum_xi_is_specified = queryWithParser(pp_warpx, "quantum_xi", quantum_xi_tmp);
         if (quantum_xi_is_specified) {
             double const quantum_xi = quantum_xi_tmp;
             quantum_xi_c2 = static_cast<amrex::Real>(quantum_xi * PhysConst::c * PhysConst::c);
         }
 
-        pp.query("do_pml", do_pml);
-        pp.query("do_silver_mueller", do_silver_mueller);
+        pp_warpx.query("do_pml", do_pml);
+        pp_warpx.query("do_silver_mueller", do_silver_mueller);
         if ( (do_pml==1)&&(do_silver_mueller==1) ) {
             amrex::Abort("PML and Silver-Mueller boundary conditions cannot be activated at the same time.");
         }
-        pp.query("pml_ncell", pml_ncell);
-        pp.query("pml_delta", pml_delta);
-        pp.query("pml_has_particles", pml_has_particles);
-        pp.query("do_pml_j_damping", do_pml_j_damping);
-        pp.query("do_pml_in_domain", do_pml_in_domain);
+        pp_warpx.query("pml_ncell", pml_ncell);
+        pp_warpx.query("pml_delta", pml_delta);
+        pp_warpx.query("pml_has_particles", pml_has_particles);
+        pp_warpx.query("do_pml_j_damping", do_pml_j_damping);
+        pp_warpx.query("do_pml_in_domain", do_pml_in_domain);
 #ifdef WARPX_DIM_RZ
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( do_pml==0,
             "PML are not implemented in RZ geometry ; please set `warpx.do_pml=0`");
 #endif
 
         Vector<int> parse_do_pml_Lo(AMREX_SPACEDIM,1);
-        pp.queryarr("do_pml_Lo", parse_do_pml_Lo);
+        pp_warpx.queryarr("do_pml_Lo", parse_do_pml_Lo);
         do_pml_Lo[0] = parse_do_pml_Lo[0];
         do_pml_Lo[1] = parse_do_pml_Lo[1];
 #if (AMREX_SPACEDIM == 3)
         do_pml_Lo[2] = parse_do_pml_Lo[2];
 #endif
         Vector<int> parse_do_pml_Hi(AMREX_SPACEDIM,1);
-        pp.queryarr("do_pml_Hi", parse_do_pml_Hi);
+        pp_warpx.queryarr("do_pml_Hi", parse_do_pml_Hi);
         do_pml_Hi[0] = parse_do_pml_Hi[0];
         do_pml_Hi[1] = parse_do_pml_Hi[1];
 #if (AMREX_SPACEDIM == 3)
@@ -594,46 +594,46 @@ WarpX::ReadParameters ()
         {
             // Parameters below control all plotfile diagnostics
             bool plotfile_min_max = true;
-            pp.query("plotfile_min_max", plotfile_min_max);
+            pp_warpx.query("plotfile_min_max", plotfile_min_max);
             if (plotfile_min_max) {
                 plotfile_headerversion = amrex::VisMF::Header::Version_v1;
             } else {
                 plotfile_headerversion = amrex::VisMF::Header::NoFabHeader_v1;
             }
-            pp.query("usesingleread", use_single_read);
-            pp.query("usesinglewrite", use_single_write);
-            ParmParse ppv("vismf");
-            ppv.add("usesingleread", use_single_read);
-            ppv.add("usesinglewrite", use_single_write);
-            pp.query("mffile_nstreams", mffile_nstreams);
+            pp_warpx.query("usesingleread", use_single_read);
+            pp_warpx.query("usesinglewrite", use_single_write);
+            ParmParse pp_vismf("vismf");
+            pp_vismf.add("usesingleread", use_single_read);
+            pp_vismf.add("usesinglewrite", use_single_write);
+            pp_warpx.query("mffile_nstreams", mffile_nstreams);
             VisMF::SetMFFileInStreams(mffile_nstreams);
-            pp.query("field_io_nfiles", field_io_nfiles);
+            pp_warpx.query("field_io_nfiles", field_io_nfiles);
             VisMF::SetNOutFiles(field_io_nfiles);
-            pp.query("particle_io_nfiles", particle_io_nfiles);
-            ParmParse ppp("particles");
-            ppp.add("particles_nfiles", particle_io_nfiles);
+            pp_warpx.query("particle_io_nfiles", particle_io_nfiles);
+            ParmParse pp_particles("particles");
+            pp_particles.add("particles_nfiles", particle_io_nfiles);
         }
 
         if (maxLevel() > 0) {
             Vector<Real> lo, hi;
-            pp.getarr("fine_tag_lo", lo);
-            pp.getarr("fine_tag_hi", hi);
+            pp_warpx.getarr("fine_tag_lo", lo);
+            pp_warpx.getarr("fine_tag_hi", hi);
             fine_tag_lo = RealVect{lo};
             fine_tag_hi = RealVect{hi};
         }
 
-        pp.query("do_dynamic_scheduling", do_dynamic_scheduling);
+        pp_warpx.query("do_dynamic_scheduling", do_dynamic_scheduling);
 
-        pp.query("do_nodal", do_nodal);
+        pp_warpx.query("do_nodal", do_nodal);
         // Use same shape factors in all directions, for gathering
         if (do_nodal) galerkin_interpolation = false;
 
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
-        pp.query("n_rz_azimuthal_modes", n_rz_azimuthal_modes);
+        pp_warpx.query("n_rz_azimuthal_modes", n_rz_azimuthal_modes);
     }
 
     {
-        ParmParse pp("algo");
+        ParmParse pp_algo("algo");
 #ifdef WARPX_DIM_RZ
         if (maxwell_solver_id == MaxwellSolverAlgo::CKC) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
@@ -661,47 +661,47 @@ WarpX::ReadParameters ()
 
         // note: current_deposition must be set after maxwell_solver is already determined,
         //       because its default depends on the solver selection
-        current_deposition_algo = GetAlgorithmInteger(pp, "current_deposition");
-        charge_deposition_algo = GetAlgorithmInteger(pp, "charge_deposition");
-        particle_pusher_algo = GetAlgorithmInteger(pp, "particle_pusher");
+        current_deposition_algo = GetAlgorithmInteger(pp_algo, "current_deposition");
+        charge_deposition_algo = GetAlgorithmInteger(pp_algo, "charge_deposition");
+        particle_pusher_algo = GetAlgorithmInteger(pp_algo, "particle_pusher");
 
-        field_gathering_algo = GetAlgorithmInteger(pp, "field_gathering");
+        field_gathering_algo = GetAlgorithmInteger(pp_algo, "field_gathering");
         if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
             // Use same shape factors in all directions, for gathering
             galerkin_interpolation = false;
         }
 
-        em_solver_medium = GetAlgorithmInteger(pp, "em_solver_medium");
+        em_solver_medium = GetAlgorithmInteger(pp_algo, "em_solver_medium");
         if (em_solver_medium == MediumForEM::Macroscopic ) {
-            macroscopic_solver_algo = GetAlgorithmInteger(pp,"macroscopic_sigma_method");
+            macroscopic_solver_algo = GetAlgorithmInteger(pp_algo,"macroscopic_sigma_method");
         }
 
         // Load balancing parameters
         std::vector<std::string> load_balance_intervals_string_vec = {"0"};
-        pp.queryarr("load_balance_intervals", load_balance_intervals_string_vec);
+        pp_algo.queryarr("load_balance_intervals", load_balance_intervals_string_vec);
         load_balance_intervals = IntervalsParser(load_balance_intervals_string_vec);
-        pp.query("load_balance_with_sfc", load_balance_with_sfc);
-        pp.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
-        queryWithParser(pp, "load_balance_efficiency_ratio_threshold",
+        pp_algo.query("load_balance_with_sfc", load_balance_with_sfc);
+        pp_algo.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
+        queryWithParser(pp_algo, "load_balance_efficiency_ratio_threshold",
                         load_balance_efficiency_ratio_threshold);
-        load_balance_costs_update_algo = GetAlgorithmInteger(pp, "load_balance_costs_update");
-        queryWithParser(pp, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
-        queryWithParser(pp, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
+        load_balance_costs_update_algo = GetAlgorithmInteger(pp_algo, "load_balance_costs_update");
+        queryWithParser(pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
+        queryWithParser(pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
     }
     {
-        ParmParse pp("interpolation");
-        pp.query("nox", nox);
-        pp.query("noy", noy);
-        pp.query("noz", noz);
+        ParmParse pp_interpolation("interpolation");
+        pp_interpolation.query("nox", nox);
+        pp_interpolation.query("noy", noy);
+        pp_interpolation.query("noz", noz);
 
 #ifdef WARPX_USE_PSATD
         if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
             // For momentum-conserving field gathering, read from input the order of
             // interpolation from the staggered positions to the grid nodes
             if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
-                pp.query("field_gathering_nox", field_gathering_nox);
-                pp.query("field_gathering_noy", field_gathering_noy);
-                pp.query("field_gathering_noz", field_gathering_noz);
+                pp_interpolation.query("field_gathering_nox", field_gathering_nox);
+                pp_interpolation.query("field_gathering_noy", field_gathering_noy);
+                pp_interpolation.query("field_gathering_noz", field_gathering_noz);
             }
 
             if (maxLevel() > 0) {
@@ -756,7 +756,7 @@ WarpX::ReadParameters ()
         }
 #endif
 
-        pp.query("galerkin_scheme",galerkin_interpolation);
+        pp_interpolation.query("galerkin_scheme",galerkin_interpolation);
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nox == noy and nox == noz ,
             "warpx.nox, noy and noz must be equal");
@@ -770,32 +770,32 @@ WarpX::ReadParameters ()
 
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
     {
-        ParmParse pp("psatd");
-        pp.query("periodic_single_box_fft", fft_periodic_single_box);
-        pp.query("fftw_plan_measure", fftw_plan_measure);
+        ParmParse pp_psatd("psatd");
+        pp_psatd.query("periodic_single_box_fft", fft_periodic_single_box);
+        pp_psatd.query("fftw_plan_measure", fftw_plan_measure);
 
         std::string nox_str;
         std::string noy_str;
         std::string noz_str;
 
-        pp.query("nox", nox_str);
-        pp.query("noy", noy_str);
-        pp.query("noz", noz_str);
+        pp_psatd.query("nox", nox_str);
+        pp_psatd.query("noy", noy_str);
+        pp_psatd.query("noz", noz_str);
 
         if(nox_str == "inf"){
             nox_fft = -1;
         } else{
-            pp.query("nox", nox_fft);
+            pp_psatd.query("nox", nox_fft);
         }
         if(noy_str == "inf"){
             noy_fft = -1;
         } else{
-            pp.query("noy", noy_fft);
+            pp_psatd.query("noy", noy_fft);
         }
         if(noz_str == "inf"){
             noz_fft = -1;
         } else{
-            pp.query("noz", noz_fft);
+            pp_psatd.query("noz", noz_fft);
         }
 
 
@@ -805,9 +805,9 @@ WarpX::ReadParameters ()
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
         }
 
-        pp.query("current_correction", current_correction);
-        pp.query("v_comoving", m_v_comoving);
-        pp.query("do_time_averaging", fft_do_time_averaging);
+        pp_psatd.query("current_correction", current_correction);
+        pp_psatd.query("v_comoving", m_v_comoving);
+        pp_psatd.query("do_time_averaging", fft_do_time_averaging);
 
         if (!fft_periodic_single_box && current_correction)
             amrex::Abort(
@@ -820,11 +820,11 @@ WarpX::ReadParameters ()
 
         // Check whether the default Galilean velocity should be used
         bool use_default_v_galilean = false;
-        pp.query("use_default_v_galilean", use_default_v_galilean);
+        pp_psatd.query("use_default_v_galilean", use_default_v_galilean);
         if (use_default_v_galilean) {
             m_v_galilean[2] = -std::sqrt(1._rt - 1._rt / (gamma_boost * gamma_boost));
         } else {
-            pp.query("v_galilean", m_v_galilean);
+            pp_psatd.query("v_galilean", m_v_galilean);
         }
         // Scale the Galilean/comoving velocity by the speed of light
         for (int i=0; i<3; i++) m_v_galilean[i] *= PhysConst::c;
@@ -864,7 +864,7 @@ WarpX::ReadParameters ()
 #   endif
 
         // Overwrite update_with_rho with value set in input file
-        pp.query("update_with_rho", update_with_rho);
+        pp_psatd.query("update_with_rho", update_with_rho);
 
         if (m_v_comoving[0] != 0. || m_v_comoving[1] != 0. || m_v_comoving[2] != 0.) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
@@ -875,14 +875,14 @@ WarpX::ReadParameters ()
         if (!Geom(0).isPeriodic(1)) {
             use_damp_fields_in_z_guard = true;
         }
-        pp.query("use_damp_fields_in_z_guard", use_damp_fields_in_z_guard);
+        pp_psatd.query("use_damp_fields_in_z_guard", use_damp_fields_in_z_guard);
 #   endif
 
     }
 
     // for slice generation //
     {
-       ParmParse pp("slice");
+       ParmParse pp_slice("slice");
        amrex::Vector<Real> slice_lo(AMREX_SPACEDIM);
        amrex::Vector<Real> slice_hi(AMREX_SPACEDIM);
        Vector<int> slice_crse_ratio(AMREX_SPACEDIM);
@@ -891,10 +891,10 @@ WarpX::ReadParameters ()
        {
           slice_crse_ratio[idim] = 1;
        }
-       pp.queryarr("dom_lo",slice_lo,0,AMREX_SPACEDIM);
-       pp.queryarr("dom_hi",slice_hi,0,AMREX_SPACEDIM);
-       pp.queryarr("coarsening_ratio",slice_crse_ratio,0,AMREX_SPACEDIM);
-       pp.query("plot_int",slice_plot_int);
+       pp_slice.queryarr("dom_lo",slice_lo,0,AMREX_SPACEDIM);
+       pp_slice.queryarr("dom_hi",slice_hi,0,AMREX_SPACEDIM);
+       pp_slice.queryarr("coarsening_ratio",slice_crse_ratio,0,AMREX_SPACEDIM);
+       pp_slice.query("plot_int",slice_plot_int);
        slice_realbox.setLo(slice_lo);
        slice_realbox.setHi(slice_hi);
        slice_cr_ratio = IntVect(AMREX_D_DECL(1,1,1));
@@ -908,10 +908,10 @@ WarpX::ReadParameters ()
        if (do_back_transformed_diagnostics) {
           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
                  "gamma_boost must be > 1 to use the boost frame diagnostic");
-          pp.query("num_slice_snapshots_lab", num_slice_snapshots_lab);
+          pp_slice.query("num_slice_snapshots_lab", num_slice_snapshots_lab);
           if (num_slice_snapshots_lab > 0) {
-             getWithParser(pp, "dt_slice_snapshots_lab", dt_slice_snapshots_lab );
-             getWithParser(pp, "particle_slice_width_lab",particle_slice_width_lab);
+             getWithParser(pp_slice, "dt_slice_snapshots_lab", dt_slice_snapshots_lab );
+             getWithParser(pp_slice, "particle_slice_width_lab",particle_slice_width_lab);
           }
        }
 
@@ -921,9 +921,9 @@ WarpX::ReadParameters ()
 void
 WarpX::BackwardCompatibility ()
 {
-    ParmParse ppa("amr");
+    ParmParse pp_amr("amr");
     int backward_int;
-    if (ppa.query("plot_int", backward_int)){
+    if (pp_amr.query("plot_int", backward_int)){
         amrex::Abort("amr.plot_int is not supported anymore. Please use the new syntax for diagnostics:\n"
             "diagnostics.diags_names = my_diag\n"
             "my_diag.intervals = 10\n"
@@ -931,80 +931,80 @@ WarpX::BackwardCompatibility ()
     }
 
     std::string backward_str;
-    if (ppa.query("plot_file", backward_str)){
+    if (pp_amr.query("plot_file", backward_str)){
         amrex::Abort("amr.plot_file is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
 
-    ParmParse ppw("warpx");
+    ParmParse pp_warpx("warpx");
     std::vector<std::string> backward_strings;
-    if (ppw.queryarr("fields_to_plot", backward_strings)){
+    if (pp_warpx.queryarr("fields_to_plot", backward_strings)){
         amrex::Abort("warpx.fields_to_plot is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
-    if (ppw.query("plot_finepatch", backward_int)){
+    if (pp_warpx.query("plot_finepatch", backward_int)){
         amrex::Abort("warpx.plot_finepatch is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
-    if (ppw.query("plot_crsepatch", backward_int)){
+    if (pp_warpx.query("plot_crsepatch", backward_int)){
         amrex::Abort("warpx.plot_crsepatch is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
-    if (ppw.queryarr("load_balance_int", backward_strings)){
+    if (pp_warpx.queryarr("load_balance_int", backward_strings)){
         amrex::Abort("warpx.load_balance_int is no longer a valid option. "
                      "Please use the renamed option algo.load_balance_intervals instead.");
     }
-    if (ppw.queryarr("load_balance_intervals", backward_strings)){
+    if (pp_warpx.queryarr("load_balance_intervals", backward_strings)){
         amrex::Abort("warpx.load_balance_intervals is no longer a valid option. "
                      "Please use the renamed option algo.load_balance_intervals instead.");
     }
 
     amrex::Real backward_Real;
-    if (ppw.query("load_balance_efficiency_ratio_threshold", backward_Real)){
+    if (pp_warpx.query("load_balance_efficiency_ratio_threshold", backward_Real)){
         amrex::Abort("warpx.load_balance_efficiency_ratio_threshold is not supported anymore. "
                      "Please use the renamed option algo.load_balance_efficiency_ratio_threshold.");
     }
-    if (ppw.query("load_balance_with_sfc", backward_int)){
+    if (pp_warpx.query("load_balance_with_sfc", backward_int)){
         amrex::Abort("warpx.load_balance_with_sfc is not supported anymore. "
                      "Please use the renamed option algo.load_balance_with_sfc.");
     }
-    if (ppw.query("load_balance_knapsack_factor", backward_Real)){
+    if (pp_warpx.query("load_balance_knapsack_factor", backward_Real)){
         amrex::Abort("warpx.load_balance_knapsack_factor is not supported anymore. "
                      "Please use the renamed option algo.load_balance_knapsack_factor.");
     }
-    if (ppw.queryarr("override_sync_int", backward_strings)){
+    if (pp_warpx.queryarr("override_sync_int", backward_strings)){
         amrex::Abort("warpx.override_sync_int is no longer a valid option. "
                      "Please use the renamed option warpx.override_sync_intervals instead.");
     }
-    if (ppw.queryarr("sort_int", backward_strings)){
+    if (pp_warpx.queryarr("sort_int", backward_strings)){
         amrex::Abort("warpx.sort_int is no longer a valid option. "
                      "Please use the renamed option warpx.sort_intervals instead.");
     }
-    if (ppw.query("use_kspace_filter", backward_int)){
+    if (pp_warpx.query("use_kspace_filter", backward_int)){
         amrex::Abort("warpx.use_kspace_filter is not supported anymore. "
                      "Please use the flag use_filter, see documentation.");
     }
 
-    ParmParse ppalgo("algo");
+    ParmParse pp_algo("algo");
     int backward_mw_solver;
-    if (ppalgo.query("maxwell_fdtd_solver", backward_mw_solver)){
+    if (pp_algo.query("maxwell_fdtd_solver", backward_mw_solver)){
         amrex::Abort("algo.maxwell_fdtd_solver is not supported anymore. "
                      "Please use the renamed option algo.maxwell_solver");
     }
 
-    ParmParse pparticles("particles");
+    ParmParse pp_particles("particles");
     int nspecies;
-    if (pparticles.query("nspecies", nspecies)){
+    if (pp_particles.query("nspecies", nspecies)){
         amrex::Print()<<"particles.nspecies is ignored. Just use particles.species_names please.\n";
     }
-    ParmParse pcol("collisions");
+    ParmParse pp_collisions("collisions");
     int ncollisions;
-    if (pcol.query("ncollisions", ncollisions)){
+    if (pp_collisions.query("ncollisions", ncollisions)){
         amrex::Print()<<"collisions.ncollisions is ignored. Just use particles.collision_names please.\n";
     }
-    ParmParse plasers("lasers");
+    ParmParse pp_lasers("lasers");
     int nlasers;
-    if (plasers.query("nlasers", nlasers)){
+    if (pp_lasers.query("nlasers", nlasers)){
         amrex::Print()<<"lasers.nlasers is ignored. Just use lasers.names please.\n";
     }
 }


### PR DESCRIPTION
I implemented the suggestion of @dpgrote for a clearer and more manifest naming standard for `ParmParse` variables, which should be less error-prone. This PR closes #1733. I'll try to double-check the changes once more, before we merge.