### PR TITLE
Add option to deposit current at arbitrary time

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -33,10 +33,9 @@ using namespace amrex::literals;
  * \param jy_fab       : FArrayBox of current density, either full array or tile.
  * \param jz_fab       : FArrayBox of current density, either full array or tile.
  * \param np_to_depose : Number of particles for which current is deposited.
- * \param dt           : Time step for particle level
- * \param relative_time: Time at which to deposit J, relative to the time of
- *                       the current positions of the particles (expressed as
- *                       a fraction of dt). When different than 0, the particle
+ * \param relative_t   : Time at which to deposit J, relative to the time of
+ *                       the current positions of the particles (expressed in
+ *                       physical units). When different than 0, the particle
  *                       position will be temporarily modified to match the
  *                       time of the deposition.
  * \param dx           : 3D cell size
@@ -57,8 +56,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                         amrex::FArrayBox& jx_fab,
                         amrex::FArrayBox& jy_fab,
                         amrex::FArrayBox& jz_fab,
-                        const long np_to_depose, const amrex::Real dt,
-                        const amrex::Real relative_time,
+                        const long np_to_depose,
+                        const amrex::Real relative_t,
                         const std::array<amrex::Real,3>& dx,
                         const std::array<amrex::Real,3>& xyzmin,
                         const amrex::Dim3 lo,
@@ -80,15 +79,10 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     const bool do_ionization = ion_lev;
     const amrex::Real dxi = 1.0_rt/dx[0];
     const amrex::Real dzi = 1.0_rt/dx[2];
-#if !(defined WARPX_DIM_RZ)
-    const amrex::Real dtsdx = dt*dxi;
-#endif
-    const amrex::Real dtsdz = dt*dzi;
 #if (AMREX_SPACEDIM == 2)
     const amrex::Real invvol = dxi*dzi;
 #elif (defined WARPX_DIM_3D)
     const amrex::Real dyi = 1.0_rt/dx[1];
-    const amrex::Real dtsdy = dt*dyi;
     const amrex::Real invvol = dxi*dyi*dzi;
 #endif
 
@@ -139,8 +133,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_RZ)
             // In RZ, wqx is actually wqr, and wqy is wqtheta
             // Convert to cylinderical at the mid point
-            const amrex::Real xpmid = xp + relative_time*dt*vx;
-            const amrex::Real ypmid = yp + relative_time*dt*vy;
+            const amrex::Real xpmid = xp + relative_t*vx;
+            const amrex::Real ypmid = yp + relative_t*vy;
             const amrex::Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
             amrex::Real costheta;
             amrex::Real sintheta;
@@ -167,7 +161,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             // Keep these double to avoid bug in single precision
             const double xmid = (rpmid - xmin)*dxi;
 #else
-            const double xmid = (xp - xmin)*dxi + relative_time*dtsdx*vx;
+            const double xmid = ((xp - xmin) + relative_t*vx)*dxi;
 #endif
             // j_j[xyz] leftmost grid point in x that the particle touches for the centering of each current
             // sx_j[xyz] shape factor along x for the centering of each current
@@ -203,7 +197,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_3D)
             // y direction
             // Keep these double to avoid bug in single precision
-            const double ymid = (yp - ymin)*dyi + relative_time*dtsdy*vy;
+            const double ymid = ( (yp - ymin) + relative_t*vy )*dyi;
             double sy_node[depos_order + 1];
             double sy_cell[depos_order + 1];
             int k_node = 0;
@@ -230,7 +224,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 
             // z direction
             // Keep these double to avoid bug in single precision
-            const double zmid = (zp - zmin)*dzi + relative_time*dtsdz*vz;
+            const double zmid = ((zp - zmin) + relative_t*vz)*dzi;
             double sz_node[depos_order + 1];
             double sz_cell[depos_order + 1];
             int l_node = 0;

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -34,6 +34,11 @@ using namespace amrex::literals;
  * \param jz_fab       : FArrayBox of current density, either full array or tile.
  * \param np_to_depose : Number of particles for which current is deposited.
  * \param dt           : Time step for particle level
+ * \param relative_time: Time at which to deposit J, relative to the time of
+ *                       the current positions of the particles (expressed as
+ *                       a fraction of dt). When different than 0, the particle
+ *                       position will be temporarily modified to match the
+ *                       time of the deposition.
  * \param dx           : 3D cell size
  * \param xyzmin       : Physical lower bounds of domain.
  * \param lo           : Index lower bounds of domain.
@@ -52,7 +57,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                         amrex::FArrayBox& jx_fab,
                         amrex::FArrayBox& jy_fab,
                         amrex::FArrayBox& jz_fab,
-                        const long np_to_depose, const amrex::Real dt, const amrex::Real relative_time,
+                        const long np_to_depose, const amrex::Real dt,
+                        const amrex::Real relative_time,
                         const std::array<amrex::Real,3>& dx,
                         const std::array<amrex::Real,3>& xyzmin,
                         const amrex::Dim3 lo,

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -52,7 +52,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
                         amrex::FArrayBox& jx_fab,
                         amrex::FArrayBox& jy_fab,
                         amrex::FArrayBox& jz_fab,
-                        const long np_to_depose, const amrex::Real dt,
+                        const long np_to_depose, const amrex::Real dt, const amrex::Real relative_time,
                         const std::array<amrex::Real,3>& dx,
                         const std::array<amrex::Real,3>& xyzmin,
                         const amrex::Dim3 lo,
@@ -75,14 +75,14 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     const amrex::Real dxi = 1.0_rt/dx[0];
     const amrex::Real dzi = 1.0_rt/dx[2];
 #if !(defined WARPX_DIM_RZ)
-    const amrex::Real dts2dx = 0.5_rt*dt*dxi;
+    const amrex::Real dtsdx = dt*dxi;
 #endif
-    const amrex::Real dts2dz = 0.5_rt*dt*dzi;
+    const amrex::Real dtsdz = dt*dzi;
 #if (AMREX_SPACEDIM == 2)
     const amrex::Real invvol = dxi*dzi;
 #elif (defined WARPX_DIM_3D)
     const amrex::Real dyi = 1.0_rt/dx[1];
-    const amrex::Real dts2dy = 0.5_rt*dt*dyi;
+    const amrex::Real dtsdy = dt*dyi;
     const amrex::Real invvol = dxi*dyi*dzi;
 #endif
 
@@ -133,8 +133,8 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_RZ)
             // In RZ, wqx is actually wqr, and wqy is wqtheta
             // Convert to cylinderical at the mid point
-            const amrex::Real xpmid = xp - 0.5_rt*dt*vx;
-            const amrex::Real ypmid = yp - 0.5_rt*dt*vy;
+            const amrex::Real xpmid = xp + relative_time*dt*vx;
+            const amrex::Real ypmid = yp + relative_time*dt*vy;
             const amrex::Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
             amrex::Real costheta;
             amrex::Real sintheta;
@@ -161,7 +161,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
             // Keep these double to avoid bug in single precision
             const double xmid = (rpmid - xmin)*dxi;
 #else
-            const double xmid = (xp - xmin)*dxi - dts2dx*vx;
+            const double xmid = (xp - xmin)*dxi + relative_time*dtsdx*vx;
 #endif
             // j_j[xyz] leftmost grid point in x that the particle touches for the centering of each current
             // sx_j[xyz] shape factor along x for the centering of each current
@@ -197,7 +197,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if (defined WARPX_DIM_3D)
             // y direction
             // Keep these double to avoid bug in single precision
-            const double ymid = (yp - ymin)*dyi - dts2dy*vy;
+            const double ymid = (yp - ymin)*dyi + relative_time*dtsdy*vy;
             double sy_node[depos_order + 1];
             double sy_cell[depos_order + 1];
             int k_node = 0;
@@ -224,7 +224,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 
             // z direction
             // Keep these double to avoid bug in single precision
-            const double zmid = (zp - zmin)*dzi - dts2dz*vz;
+            const double zmid = (zp - zmin)*dzi + relative_time*dtsdz*vz;
             double sz_node[depos_order + 1];
             double sz_cell[depos_order + 1];
             int l_node = 0;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -516,14 +516,14 @@ LaserParticleContainer::Evolve (int lev,
                 int* ion_lev = nullptr;
                 DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                0, np_current, thread_num,
-                               lev, lev, dt);
+                               lev, lev, dt, -0.5_rt); // Deposit current at t_{n+1/2}
 
                 bool has_buffer = cjx;
                 if (has_buffer){
                     // Deposit in buffers
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                    np_current, np-np_current, thread_num,
-                                   lev, lev-1, dt);
+                                   lev, lev-1, dt, -0.5_rt); // Deposit current at t_{n+1/2}
                 }
             }
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -100,7 +100,8 @@ public:
                                 int /*thread_num*/,
                                 int /*lev*/,
                                 int /*depos_lev*/,
-                                amrex::Real /*dt*/) override {}
+                                amrex::Real /*dt*/,
+                                amrex::Real /*relative_time*/) override {}
 };
 
 #endif // #ifndef WARPX_PhotonParticleContainer_H_

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1121,12 +1121,12 @@ PhysicalParticleContainer::Evolve (int lev,
                     // Deposit inside domains
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                    0, np_current, thread_num,
-                                   lev, lev, dt);
+                                   lev, lev, dt, -0.5_rt); // Deposit current at t_{n+1/2}
                     if (has_buffer){
                         // Deposit in buffers
                         DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                        np_current, np-np_current, thread_num,
-                                       lev, lev-1, dt);
+                                       lev, lev-1, dt, -0.5_rt);  // Deposit current at t_{n+1/2}
                     }
                 } // end of "if do_electrostatic == ElectrostaticSolverAlgo::None"
             } // end of "if do_not_push"

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -226,7 +226,8 @@ public:
                                 int thread_num,
                                 int lev,
                                 int depos_lev,
-                                amrex::Real dt);
+                                amrex::Real dt,
+                                amrex::Real relative_time=-0.5);
 
     // If particles start outside of the domain, ContinuousInjection
     // makes sure that they are initialized when they enter the domain, and

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -227,7 +227,7 @@ public:
                                 int lev,
                                 int depos_lev,
                                 amrex::Real dt,
-                                amrex::Real relative_time=-0.5);
+                                amrex::Real relative_time);
 
     // If particles start outside of the domain, ContinuousInjection
     // makes sure that they are initialized when they enter the domain, and

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -430,21 +430,21 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
             doDepositionShapeN<1>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt*relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         } else if (WarpX::nox == 2){
             doDepositionShapeN<2>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt*relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         } else if (WarpX::nox == 3){
             doDepositionShapeN<3>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt*relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -428,21 +428,21 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
             doDepositionShapeN<1>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         } else if (WarpX::nox == 2){
             doDepositionShapeN<2>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         } else if (WarpX::nox == 3){
             doDepositionShapeN<3>(
                 GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                 uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
-                jx_fab, jy_fab, jz_fab, np_to_depose, dt, dx,
+                jx_fab, jy_fab, jz_fab, np_to_depose, dt, relative_time, dx,
                 xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                 WarpX::load_balance_costs_update_algo);
         }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -226,6 +226,9 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
  * \param lev         : Level of box that contains particles
  * \param depos_lev   : Level on which particles deposit (if buffers are used)
  * \param dt          : Time step for particle level
+ * \param relative_time: Time at which to deposit J, relative to the time of the current positions 
+ *                       of the particles (expressed as a fraction of dt. When different than 0,
+ *                       the particle position will be modified to match the time of the deposition.
  */
 void
 WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
@@ -235,7 +238,7 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
                                        MultiFab* jx, MultiFab* jy, MultiFab* jz,
                                        const long offset, const long np_to_depose,
                                        int thread_num, int lev, int depos_lev,
-                                       Real dt)
+                                       Real dt, Real relative_time)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev==(lev-1)) ||
                                      (depos_lev==(lev  )),
@@ -360,8 +363,16 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
         if ( (m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)){
             amrex::Abort("The Esirkepov algorithm cannot be used with the Galilean algorithm.");
         }
+        if ( relative_time != -0.5_rt ) {
+            amrex::Abort("The Esirkepov deposition cannot be performed at another time then -0.5 dt.");
+        }
     }
-
+    if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) {
+        if ( relative_time != -0.5_rt ) {
+          amrex::Abort("The Esirkepov deposition cannot be performed at another time then -0.5 dt.");
+        }
+    }
+      
     WARPX_PROFILE_VAR_START(blp_deposit);
     amrex::LayoutData<amrex::Real>* costs = WarpX::getCosts(lev);
     amrex::Real* cost = costs ? &((*costs)[pti.index()]) : nullptr;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -226,9 +226,11 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
  * \param lev         : Level of box that contains particles
  * \param depos_lev   : Level on which particles deposit (if buffers are used)
  * \param dt          : Time step for particle level
- * \param relative_time: Time at which to deposit J, relative to the time of the current positions 
- *                       of the particles (expressed as a fraction of dt. When different than 0,
- *                       the particle position will be modified to match the time of the deposition.
+ * \param relative_time: Time at which to deposit J, relative to the time of
+ *                       the current positions of the particles (expressed as
+ *                       a fraction of dt). When different than 0, the particle
+ *                       position will be temporarily modified to match the
+ *                       time of the deposition.
  */
 void
 WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
@@ -372,7 +374,7 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
           amrex::Abort("The Esirkepov deposition cannot be performed at another time then -0.5 dt.");
         }
     }
-      
+
     WARPX_PROFILE_VAR_START(blp_deposit);
     amrex::LayoutData<amrex::Real>* costs = WarpX::getCosts(lev);
     amrex::Real* cost = costs ? &((*costs)[pti.index()]) : nullptr;


### PR DESCRIPTION
In WarpX, the current is typically deposited at `t=(n+1/2) dt` (using the position of the particles at `t=(n+1)dt`, which are then temporarily pushed back in time to `t=(n+1/2)dt` in the current deposition kernel).

For some advanced PIC schemes, it would be useful to be able to deposit the current at arbitrary time. This PR implements the corresponding option. (The default remains `t=(n+1/2)dt`.)