### PR TITLE
Class `PsatdAlgorithm`: Simplify Initialization of Coefficients

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -96,7 +96,6 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients T2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
-        SpectralRealCoefficients C1_coef, C3_coef, S1_coef, S3_coef;
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Psi3_coef, Psi4_coef,
                                     A1_coef, A2_coef, Rhoold_coef, Rhonew_coef, Jcoef_coef;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -96,8 +96,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients T2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
-        SpectralComplexCoefficients Psi1_coef, Psi2_coef, Psi3_coef, Psi4_coef,
-                                    A1_coef, A2_coef, Rhoold_coef, Rhonew_coef, Jcoef_coef;
+        SpectralComplexCoefficients Psi1_coef, Psi2_coef, A1_coef, Cold_coef, Cnew_coef, J_coef;
 
         // Centered modified finite-order k vectors
         KVectorComponent modified_kx_vec_centered;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -96,7 +96,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients T2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
-        SpectralComplexCoefficients Psi1_coef, Psi2_coef, A1_coef, Cold_coef, Cnew_coef, J_coef;
+        SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;
 
         // Centered modified finite-order k vectors
         KVectorComponent modified_kx_vec_centered;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -49,6 +49,12 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const amrex::DistributionMapping& dm,
             const amrex::Real dt);
 
+        // TODO Add Doxygen docs
+        void InitializeSpectralCoefficientsAveraging (
+            const SpectralKSpace& spectral_kspace,
+            const amrex::DistributionMapping& dm,
+            const amrex::Real dt);
+
         /**
          * \brief Virtual function for current correction in Fourier space
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -17,7 +17,20 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
 {
     public:
 
-        // TODO Add Doxygen docs
+        /**
+         * \brief Constructor of the class PsatdAlgorithm
+         *
+         * \param[in] spectral_kspace spectral space
+         * \param[in] dm distribution mapping
+         * \param[in] norder_x order of the spectral solver along x
+         * \param[in] norder_y order of the spectral solver along y
+         * \param[in] norder_z order of the spectral solver along z
+         * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
+         * \param[in] v_galilean Galilean velocity (three-dimensional array)
+         * \param[in] dt time step of the simulation
+         * \param[in] update_with_rho whether the update equation for E uses rho or not
+         * \param[in] time_averaging whether to use time averaging for large time steps
+         */
         PsatdAlgorithm (
             const SpectralKSpace& spectral_kspace,
             const amrex::DistributionMapping& dm,
@@ -30,10 +43,16 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const bool update_with_rho,
             const bool time_averaging);
 
-        // TODO Add Doxygen docs
+        /**
+         * \brief Updates the E and B fields in spectral space, according to the relevant PSATD equations
+         *
+         * \param[in,out] f all the fields in spectral space
+         */
         virtual void pushSpectralFields (SpectralFieldData& f) const override final;
 
-        // TODO Add Doxygen docs
+        /**
+         * \brief Returns the number of fields stored in spectral space
+         */
         virtual int getRequiredNumberOfFields () const override final
         {
             if (m_time_averaging) {
@@ -43,13 +62,26 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             }
         }
 
-        // TODO Add Doxygen docs
+        /**
+         * \brief Initializes the coefficients used in \c pushSpectralFields to update the E and B fields
+         *
+         * \param[in] spectral_kspace spectral space
+         * \param[in] dm distribution mapping
+         * \param[in] dt time step of the simulation
+         */
         void InitializeSpectralCoefficients (
             const SpectralKSpace& spectral_kspace,
             const amrex::DistributionMapping& dm,
             const amrex::Real dt);
 
-        // TODO Add Doxygen docs
+        /**
+         * \brief Initializes additional coefficients used in \c pushSpectralFields to update the E and B fields,
+         *        required only when using time averaging with large time steps
+         *
+         * \param[in] spectral_kspace spectral space
+         * \param[in] dm distribution mapping
+         * \param[in] dt time step of the simulation
+         */
         void InitializeSpectralCoefficientsAveraging (
             const SpectralKSpace& spectral_kspace,
             const amrex::DistributionMapping& dm,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -160,7 +160,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
             const     amrex::Real kz = modified_kz_arr[j];
 #endif
             // Physical constants and imaginary unit
-            constexpr amrex::Real c2 = std::pow(PhysConst::c, 2);
+            const amrex::Real c2 = std::pow(PhysConst::c, 2);
             constexpr Complex I = Complex{0._rt, 1._rt};
 
             // These coefficients are initialized in the function InitializeSpectralCoefficients
@@ -326,11 +326,10 @@ void PsatdAlgorithm::InitializeSpectralCoefficients (
 #endif
             // Physical constants and imaginary unit
             constexpr amrex::Real c = PhysConst::c;
-            constexpr amrex::Real c2 = std::pow(c, 2);
             constexpr amrex::Real ep0 = PhysConst::ep0;
             constexpr Complex I = Complex{0._rt, 1._rt};
 
-            // Auxiliary coefficients used when update_with_rho=false
+            const amrex::Real c2 = std::pow(c, 2);
             const amrex::Real dt2 = std::pow(dt, 2);
             const amrex::Real dt3 = std::pow(dt, 3);
 
@@ -491,10 +490,6 @@ void PsatdAlgorithm::InitializeSpectralCoefficientsAveraging (
         const amrex::Real* kz_s = modified_kz_vec[mfi].dataPtr();
         const amrex::Real* kz_c = modified_kz_vec_centered[mfi].dataPtr();
 
-        // Coefficients always allocated
-        amrex::Array4<amrex::Real> C = C_coef[mfi].array();
-        amrex::Array4<amrex::Real> S_ck = S_ck_coef[mfi].array();
-
         // Coefficients allocated only with averaged Galilean PSATD
         amrex::Array4<Complex> Psi1 = Psi1_coef[mfi].array();
         amrex::Array4<Complex> Psi2 = Psi2_coef[mfi].array();
@@ -523,11 +518,10 @@ void PsatdAlgorithm::InitializeSpectralCoefficientsAveraging (
 #endif
             // Physical constants and imaginary unit
             constexpr amrex::Real c = PhysConst::c;
-            constexpr amrex::Real c2 = std::pow(c, 2);
             constexpr amrex::Real ep0 = PhysConst::ep0;
             constexpr Complex I = Complex{0._rt, 1._rt};
 
-            // Auxiliary coefficients used when update_with_rho=false
+            const amrex::Real c2 = std::pow(c, 2);
             const amrex::Real dt2 = std::pow(dt, 2);
 
             // Calculate the dot product of the k vector with the Galilean velocity.
@@ -550,7 +544,6 @@ void PsatdAlgorithm::InitializeSpectralCoefficientsAveraging (
             const Complex theta_c  = amrex::exp(I * w_c * dt * 0.5_rt);
             const Complex theta2_c = amrex::exp(I * w_c * dt);
             const Complex theta3_c = amrex::exp(I * w_c * dt * 1.5_rt);
-            const Complex theta4_c = amrex::exp(I * w_c * dt * 2.0_rt);
             const Complex theta5_c = amrex::exp(I * w_c * dt * 2.5_rt);
 
             // C1,C3

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -20,15 +20,15 @@ PsatdAlgorithm::PsatdAlgorithm(
     const int norder_y,
     const int norder_z,
     const bool nodal,
-    const Array<Real,3>& v_galilean,
-    const Real dt,
+    const amrex::Array<amrex::Real,3>& v_galilean,
+    const amrex::Real dt,
     const bool update_with_rho,
     const bool time_averaging)
     // Initializer list
     : SpectralBaseAlgorithm(spectral_kspace, dm, norder_x, norder_y, norder_z, nodal),
-    // Initialize the centered finite-order modified k vectors: these are computed
-    // always with the assumption of centered grids (argument nodal = true),
-    // for both nodal and staggered simulations
+    // Initialize the centered finite-order modified k vectors:
+    // these are computed always with the assumption of centered grids
+    // (argument nodal = true), for both nodal and staggered simulations
     modified_kx_vec_centered(spectral_kspace.getModifiedKComponent(dm, 0, norder_x, true)),
 #if (AMREX_SPACEDIM == 3)
     modified_ky_vec_centered(spectral_kspace.getModifiedKComponent(dm, 1, norder_y, true)),
@@ -41,7 +41,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     m_update_with_rho(update_with_rho),
     m_time_averaging(time_averaging)
 {
-    const BoxArray& ba = spectral_kspace.spectralspace_ba;
+    const amrex::BoxArray& ba = spectral_kspace.spectralspace_ba;
 
     m_is_galilean = (v_galilean[0] != 0.) || (v_galilean[1] != 0.) || (v_galilean[2] != 0.);
 
@@ -84,20 +84,20 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
     // Loop over boxes
     for (amrex::MFIter mfi(f.fields); mfi.isValid(); ++mfi)
     {
-        const Box& bx = f.fields[mfi].box();
+        const amrex::Box& bx = f.fields[mfi].box();
 
         // Extract arrays for the fields to be updated
-        Array4<Complex> fields = f.fields[mfi].array();
+        amrex::Array4<Complex> fields = f.fields[mfi].array();
 
         // These coefficients are always allocated
-        Array4<const Real> C_arr = C_coef[mfi].array();
-        Array4<const Real> S_ck_arr = S_ck_coef[mfi].array();
-        Array4<const Complex> X1_arr = X1_coef[mfi].array();
-        Array4<const Complex> X2_arr = X2_coef[mfi].array();
-        Array4<const Complex> X3_arr = X3_coef[mfi].array();
+        amrex::Array4<const amrex::Real> C_arr = C_coef[mfi].array();
+        amrex::Array4<const amrex::Real> S_ck_arr = S_ck_coef[mfi].array();
+        amrex::Array4<const Complex> X1_arr = X1_coef[mfi].array();
+        amrex::Array4<const Complex> X2_arr = X2_coef[mfi].array();
+        amrex::Array4<const Complex> X3_arr = X3_coef[mfi].array();
 
-        Array4<const Complex> X4_arr;
-        Array4<const Complex> T2_arr;
+        amrex::Array4<const Complex> X4_arr;
+        amrex::Array4<const Complex> T2_arr;
         if (is_galilean)
         {
             X4_arr = X4_coef[mfi].array();
@@ -105,12 +105,12 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
         }
 
         // These coefficients are allocated only with averaged Galilean PSATD
-        Array4<const Complex> Psi1_arr;
-        Array4<const Complex> Psi2_arr;
-        Array4<const Complex> A1_arr;
-        Array4<const Complex> Cnew_arr;
-        Array4<const Complex> Cold_arr;
-        Array4<const Complex> J_arr;
+        amrex::Array4<const Complex> Psi1_arr;
+        amrex::Array4<const Complex> Psi2_arr;
+        amrex::Array4<const Complex> A1_arr;
+        amrex::Array4<const Complex> Cnew_arr;
+        amrex::Array4<const Complex> Cold_arr;
+        amrex::Array4<const Complex> J_arr;
 
         if (time_averaging)
         {
@@ -123,11 +123,11 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
         }
 
         // Extract pointers for the k vectors
-        const Real* modified_kx_arr = modified_kx_vec[mfi].dataPtr();
+        const amrex::Real* modified_kx_arr = modified_kx_vec[mfi].dataPtr();
 #if (AMREX_SPACEDIM == 3)
-        const Real* modified_ky_arr = modified_ky_vec[mfi].dataPtr();
+        const amrex::Real* modified_ky_arr = modified_ky_vec[mfi].dataPtr();
 #endif
-        const Real* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
+        const amrex::Real* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
 
         // Loop over indices within one box
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -151,22 +151,22 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
             const Complex rho_new = fields(i,j,k,Idx::rho_new);
 
             // k vector values
-            const Real kx = modified_kx_arr[i];
+            const amrex::Real kx = modified_kx_arr[i];
 #if (AMREX_SPACEDIM == 3)
-            const Real ky = modified_ky_arr[j];
-            const Real kz = modified_kz_arr[k];
+            const amrex::Real ky = modified_ky_arr[j];
+            const amrex::Real kz = modified_kz_arr[k];
 #else
-            constexpr Real ky = 0._rt;
-            const     Real kz = modified_kz_arr[j];
+            constexpr amrex::Real ky = 0._rt;
+            const     amrex::Real kz = modified_kz_arr[j];
 #endif
             // Physical constants and imaginary unit
-            constexpr Real c2 = PhysConst::c * PhysConst::c;
-            constexpr Real inv_ep0 = 1._rt / PhysConst::ep0;
+            constexpr amrex::Real c2 = PhysConst::c * PhysConst::c;
+            constexpr amrex::Real inv_ep0 = 1._rt / PhysConst::ep0;
             constexpr Complex I = Complex{0._rt, 1._rt};
 
             // These coefficients are initialized in the function InitializeSpectralCoefficients
-            const Real C = C_arr(i,j,k);
-            const Real S_ck = S_ck_arr(i,j,k);
+            const amrex::Real C = C_arr(i,j,k);
+            const amrex::Real S_ck = S_ck_arr(i,j,k);
             const Complex X1 = X1_arr(i,j,k);
             const Complex X2 = X2_arr(i,j,k);
             const Complex X3 = X3_arr(i,j,k);


### PR DESCRIPTION
To-do:
- [x] Split initialization functions of coefficients without/with averaging
- [x] **Do not store** coefficients `C1`, `S1`, `C3`, `S3`, `A2`, `Psi3` with averaging
- [x] Simplify limits of coefficients without averaging
- [x] Simplify limits of coefficients with averaging
- [x] Add `amrex::` prefix following WarpX style guidelines
- [x] Match names of coefficients without/with averaging (`X<1234>` to `Y<1234>`)
- [x] Update Doxygen