### PR TITLE
CMake: Print Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,12 @@ set_warpx_binary_name()
 
 # Defines #####################################################################
 #
+get_source_version(WarpX ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(WarpX PUBLIC WARPX_GIT_VERSION="${WarpX_GIT_VERSION}")
+if(WarpX_QED)
+    target_compile_definitions(WarpX PUBLIC PICSAR_GIT_VERSION="${PXRMP_QED_GIT_VERSION}")
+endif()
+
 if(WarpX_DIMS STREQUAL 3)
     target_compile_definitions(WarpX PUBLIC WARPX_DIM_3D)
 elseif(WarpX_DIMS STREQUAL 2)

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -48,7 +48,6 @@ MultiDiagnostics::ReadParameters ()
     if (enable_diags == 1) {
         pp_diagnostics.queryarr("diags_names", diags_names);
         ndiags = diags_names.size();
-        Print()<<"ndiags "<<ndiags<<'\n';
     }
 
     diags_types.resize( ndiags );

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -67,6 +67,10 @@ void
 WarpX::InitData ()
 {
     WARPX_PROFILE("WarpX::InitData()");
+    Print() << "WarpX (" << WarpX::Version() << ")\n";
+#ifdef WARPX_QED
+    Print() << "PICSAR (" << WarpX::PicsarVersion() << ")\n";
+#endif
 
     if (restart_chkfile.empty())
     {

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -52,13 +52,10 @@ int main(int argc, char* argv[])
 
         warpx.Evolve();
 
-        auto end_total = static_cast<Real>(amrex::second()) - strt_total;
-
-        ParallelDescriptor::ReduceRealMax(end_total, ParallelDescriptor::IOProcessorNumber());
         if (warpx.Verbose()) {
+            auto end_total = static_cast<Real>(amrex::second()) - strt_total;
+            ParallelDescriptor::ReduceRealMax(end_total, ParallelDescriptor::IOProcessorNumber());
             Print() << "Total Time                     : " << end_total << '\n';
-            Print() << "WarpX Version: " << WarpX::Version() << '\n';
-            Print() << "PICSAR Version: " << WarpX::PicsarVersion() << '\n';
         }
     }
 

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -133,7 +133,7 @@ endfunction()
 function(make_third_party_includes_system imported_target propagated_name)
     add_library(WarpX::thirdparty::${propagated_name} INTERFACE IMPORTED)
     target_link_libraries(WarpX::thirdparty::${propagated_name} INTERFACE ${imported_target})
-    
+
     if(TARGET ${imported_target})
         get_target_property(imported_target_type ${imported_target} TYPE)
         if(NOT imported_target_type STREQUAL INTERFACE_LIBRARY)
@@ -268,12 +268,40 @@ function(configure_mpiexec num_ranks)
 endfunction()
 
 
+# FUNCTION: get_source_version
+#
+# Retrieves source version info and sets internal cache variables
+# ${NAME}_GIT_VERSION and ${NAME}_PKG_VERSION
+#
+function(get_source_version NAME SOURCE_DIR)
+    find_package(Git QUIET)
+    set(_tmp "")
+
+    # Try to inquire software version from git
+    if(EXISTS ${SOURCE_DIR}/.git AND ${GIT_FOUND})
+        execute_process(COMMAND git describe --abbrev=12 --dirty --always --tags
+            WORKING_DIRECTORY ${SOURCE_DIR}
+            OUTPUT_VARIABLE _tmp)
+        string( STRIP ${_tmp} _tmp)
+    endif()
+
+    # Is there a CMake project version?
+    # For deployed releases that build from tarballs, this is what we want to pick
+    if(NOT _tmp AND ${NAME}_VERSION)
+        set(_tmp "${${NAME}_VERSION}-nogit")
+    endif()
+
+    set(${NAME}_GIT_VERSION "${_tmp}" CACHE INTERNAL "")
+    unset(_tmp)
+endfunction ()
+
+
 # Prints a summary of WarpX options at the end of the CMake configuration
 #
 function(warpx_print_summary)
     message("")
     message("WarpX build configuration:")
-    message("  Version: ${WarpX_VERSION}")
+    message("  Version: ${WarpX_VERSION} (${WarpX_GIT_VERSION})")
     message("  C++ Compiler: ${CMAKE_CXX_COMPILER_ID} "
                             "${CMAKE_CXX_COMPILER_VERSION} "
                             "${CMAKE_CXX_COMPILER_WRAPPER}")

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -28,7 +28,7 @@ function(find_picsar)
 
         # Always disable tests
         set (PXRMP_QED_TEST OFF CACHE INTERNAL "")
-        
+
         if(WarpX_COMPUTE STREQUAL SYCL)
             set (PXRMP_DPCPP_FIX ON CACHE INTERNAL "")
         endif()
@@ -38,6 +38,7 @@ function(find_picsar)
                 ${WarpX_picsar_src}/multi_physics/QED
                 _deps/localpicsar-build/
             )
+            get_source_version(PXRMP_QED ${WarpX_picsar_src})
         else()
             FetchContent_Declare(fetchedpicsar
                 GIT_REPOSITORY ${WarpX_picsar_repo}
@@ -52,6 +53,10 @@ function(find_picsar)
                     ${fetchedpicsar_SOURCE_DIR}/multi_physics/QED
                     ${fetchedpicsar_BINARY_DIR}
                 )
+            endif()
+            get_source_version(PXRMP_QED ${fetchedpicsar_SOURCE_DIR})
+            if(NOT PXRMP_QED_GIT_VERSION)
+                set(PXRMP_QED_GIT_VERSION "${WarpX_picsar_branch}" CACHE INTERNAL "")
             endif()
 
             # advanced fetch options


### PR DESCRIPTION
Print the WarpX and PICSAR version to the terminal. Fetched from `git` as usual. Will use a proper tag-prefixed description as soon as we add tags in the git history.