### PR TITLE
CI: HIP w/o MPI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -220,6 +220,9 @@ jobs:
      # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
      # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
+  # MPI_C is broken since HIP 4.1
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/21968
+  # https://github.com/ROCm-Developer-Tools/HIP/issues/2246
   build_hip:
     name: HIP SP [Linux]
     runs-on: ubuntu-20.04
@@ -241,12 +244,12 @@ jobs:
           -DAMReX_AMD_ARCH=gfx900     \
           -DWarpX_COMPUTE=HIP         \
           -DWarpX_LIB=ON              \
-          -DWarpX_MPI=ON              \
+          -DWarpX_MPI=OFF             \
           -DWarpX_OPENPMD=ON          \
           -DWarpX_PRECISION=SINGLE    \
           -DWarpX_PSATD=ON
         cmake --build build_sp -j 2
 
-        export WarpX_MPI=ON
+        export WarpX_MPI=OFF
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl


### PR DESCRIPTION
HIP 4.1 introduces issues with C targets which break the MPI feature test in CMake's `FindMPI.cmake` for C.

https://github.com/ROCm-Developer-Tools/HIP/issues/2246
https://gitlab.kitware.com/cmake/cmake/-/issues/21968

### Underlying issue

`hipcc` 4.1.0 forgot that `-I/-isystem <path>` allows a space in between the flag and argument...