### PR TITLE
openPMD: Support for mesh refinement

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -50,8 +50,8 @@ FlushFormatOpenPMD::WriteToFile (
     m_OpenPMDPlotWriter->SetStep(output_iteration, prefix, isBTD);
 
     // fields: only dumped for coarse level
-    m_OpenPMDPlotWriter->WriteOpenPMDFields(
-        varnames, mf[0], geom[0], output_iteration, time, isBTD, full_BTD_snapshot);
+    m_OpenPMDPlotWriter->WriteOpenPMDFieldsAll(
+        varnames, mf, geom, output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
     m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -117,10 +117,10 @@ public:
 
   void WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags);
 
-  void WriteOpenPMDFields (
+  void WriteOpenPMDFieldsAll (
               const std::vector<std::string>& varnames,
-              const amrex::MultiFab& mf,
-              const amrex::Geometry& geom,
+              const amrex::Vector<amrex::MultiFab>& mf,
+              amrex::Vector<amrex::Geometry>& geom,
               const int iteration, const double time,
               bool isBTD = false,
               const amrex::Geometry& full_BTD_snapshot=amrex::Geometry() ) const;
@@ -128,6 +128,22 @@ public:
 
 private:
   void Init (openPMD::Access access, bool isBTD);
+
+  /** This function does initial setup for the fields when interation is newly created
+   *  @param[in] meshes   The meshes in a series
+   *  @param[in] full_geom The geometry
+   */
+  void SetupFields(  openPMD::Container< openPMD::Mesh >& meshes, amrex::Geometry& full_geom  ) const;
+
+  void SetupMeshComp( openPMD::Mesh& mesh,
+                      amrex::Geometry& full_geom,
+                      openPMD::MeshRecordComponent& mesh_comp
+                     ) const;
+
+  void GetMeshCompNames( int meshLevel,
+                         const std::string& varname,
+                         std::string& field_name,
+                         std::string& comp_name ) const;
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *


### PR DESCRIPTION
Implements the openPMD mesh-refinement extension: https://github.com/openPMD/openPMD-standard/pull/252

- [x] Field naming structure (ADIOS2):
```
 double  /data/1000/fields/j/x              {2048, 2048, 2048}
 double  /data/1000/fields/j/y              {2048, 2048, 2048}
 double  /data/1000/fields/j/z              {2048, 2048, 2048}
 double  /data/1000/fields/j_lvl1/x         {4096, 4096, 4096}
 double  /data/1000/fields/j_lvl1/y         {4096, 4096, 4096}
 double  /data/1000/fields/j_lvl1/z         {4096, 4096, 4096}
 double  /data/1000/fields/rho              {2048, 2048, 2048}
 double  /data/1000/fields/rho_lvl1         {4096, 4096, 4096}
```
(future: `_<P>` patch number for HDF5 as a fallback)

- [x] particles live on the finest level of each patch but get by default initialized on the coarse mesh