### PR TITLE
More Output In `checksum.py` When Checksum Benchmarks Fail

### DIFF
--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -130,10 +130,18 @@ class Checksum:
                 if not passed:
                     print("ERROR: Benchmark and plotfile checksum have "
                           "different value for key [%s,%s]" % (key1, key2))
-                    print("Benchmark: [%s,%s] %.40f"
+                    print("Benchmark: [%s,%s] %.15e"
                           % (key1, key2, ref_benchmark.data[key1][key2]))
-                    print("Plotfile : [%s,%s] %.40f"
+                    print("Plotfile : [%s,%s] %.15e"
                           % (key1, key2, self.data[key1][key2]))
                     checksums_differ = True
+                    # Print absolute and relative error for each failing key
+                    x = ref_benchmark.data[key1][key2]
+                    y = self.data[key1][key2]
+                    abs_err = np.abs(x - y)
+                    print("Absolute error: {:.2e}".format(abs_err))
+                    if (np.abs(x) != 0.):
+                        rel_err = abs_err / np.abs(x)
+                        print("Relative error: {:.2e}".format(rel_err))
         if checksums_differ:
             sys.exit(1)


### PR DESCRIPTION
I added a printout of absolute and relative errors when the checksum benchmarks fail.

I think it is quite useful to be able to see, at a glance, the orders of magnitude of the errors for the various failing keys.

Especially for PRs where many benchmarks fail, it should make it easier for the developer to identify the tests where changes are relatively small (machine precision) and those where more significant differences are playing out.

I also changed the format of the numbers printed, now they should be shown with scientific notation and 15 decimal digits (while the absolute and relative errors will be shown with 2 decimal digits only). Please let me know if you are aware of cases where this would not be convenient.

Here's a screenshot to show what the new output would look like:
<p align="center">
    <img src="https://user-images.githubusercontent.com/59625522/112907246-62b40a00-90a2-11eb-8419-ed8f590f5719.png" width="600">
</p>

Here's a screenshot to show what the old output (current) looks like:
<p align="center">
    <img src="https://user-images.githubusercontent.com/59625522/112907386-9a22b680-90a2-11eb-8320-8802336a0145.png" width="600">
</p>
