### PR TITLE
Add USE_OPENPMD=TRUE To Run Test `LaserIonAcc2d` Locally

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1347,7 +1347,7 @@ buildDir = .
 inputFile = Examples/Physics_applications/laser_ion/inputs
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=384 512 max_step=100
 dim = 2
-addToCompileString =
+addToCompileString = USE_OPENPMD=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2


### PR DESCRIPTION
I think we need to add the compile string `USE_OPENPMD=TRUE` for the CI test `LaserIonAcc2d`, in case someone wants to run that single test locally with `./run_test.sh LaserIonAcc2d`. Otherwise the openPMD format is requested for the diagnostics in the input file, but the executable is built without the flag and the test crashes (which I guess doesn't happen for some reason when we run the test together with all the other tests in the suite on Azure, because probably the openPMD executable is already built when we get to this test).