### PR TITLE
fix bx used in amrexParallelFor

### DIFF
--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -1373,13 +1373,10 @@ AddDataToBuffer( MultiFab& tmp, int k_lab,
 #endif
     for (MFIter mfi(tmp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-       Box& bx = m_buff_box_;
        const Box& bx_bf = mfi.tilebox();
-       bx.setSmall(AMREX_SPACEDIM-1,bx_bf.smallEnd(AMREX_SPACEDIM-1));
-       bx.setBig(AMREX_SPACEDIM-1,bx_bf.bigEnd(AMREX_SPACEDIM-1));
        Array4<Real> tmp_arr = tmp[mfi].array();
        Array4<Real> buf_arr = buf[mfi].array();
-       ParallelFor(bx, ncomp_to_dump,
+       ParallelFor(bx_bf, ncomp_to_dump,
            [=] AMREX_GPU_DEVICE(int i, int j, int k, int n)
            {
               const int icomp = field_map_ptr[n];

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -77,17 +77,10 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
 #endif
         for (amrex::MFIter mfi(tmp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            // Box spanning the user-defined index-space for diagnostic, mf_dst
-            amrex::Box bx = m_buffer_box[i_buffer];
-            // Box of tmp_slice_ptr spanning full domain in x,y and z_boost
-            // of the respective buffer , i_buffer
             const Box& tbx = mfi.tilebox();
-            // Modify bx, such that the z-index is equal to the sliced tmp_mf
-            bx.setSmall( moving_window_dir, tbx.smallEnd( moving_window_dir ) );
-            bx.setBig( moving_window_dir, tbx.bigEnd( moving_window_dir ) );
             amrex::Array4<amrex::Real> src_arr = tmp[mfi].array();
             amrex::Array4<amrex::Real> dst_arr = mf_dst[mfi].array();
-            amrex::ParallelFor( bx, ncomp_dst,
+            amrex::ParallelFor( tbx, ncomp_dst,
                 [=] AMREX_GPU_DEVICE(int i, int j, int k, int n)
                 {
                     const int icomp = field_map_ptr[n];


### PR DESCRIPTION
Fixing the box used to loop over (i,j,k) in old and new BTD.

Was not captured by CI because all our tests have only one box in X and Y.