### PR TITLE
User input for buffer size

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -124,6 +124,11 @@ BTDiagnostics::ReadParameters ()
         "For back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab");
     // For BTD, we always need rho to perform Lorentz Transform of current-density
     if (WarpXUtilStr::is_in(m_cellcenter_varnames, "rho")) warpx.setplot_rho(true);
+
+    if (pp_diag_name.query("buffer_size", m_buffer_size)) {
+        if(m_max_box_size < m_buffer_size) m_max_box_size = m_buffer_size;
+    }
+
 }
 
 bool
@@ -411,7 +416,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                                              i_buffer, ZSliceInDomain,
                                              m_current_z_boost[i_buffer],
                                              m_buffer_box[i_buffer],
-                                             k_index_zlab(i_buffer, lev) );
+                                             k_index_zlab(i_buffer, lev), m_max_box_size );
 
                 if (ZSliceInDomain) ++m_buffer_counter[i_buffer];
             }
@@ -741,4 +746,3 @@ BTDiagnostics::InterleaveFabArrayHeader(std::string Buffer_FabHeader_path,
     snapshot_FabHeader.WriteMultiFabHeader();
 
 }
-

--- a/Source/Diagnostics/BackTransformedDiagnostic.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic.H
@@ -122,7 +122,8 @@ class LabFrameSnapShot : public LabFrameDiag {
                      amrex::IntVect prob_ncells_lab, int ncomp_to_dump,
                      std::vector<std::string> mesh_field_names,
                      amrex::RealBox diag_domain_lab,
-                     amrex::Box diag_box, int file_num_in);
+                     amrex::Box diag_box, int file_num_in, const int max_box_size,
+                     const int buffer_size);
     void AddDataToBuffer( amrex::MultiFab& tmp_slice, int k_lab,
          amrex::Vector<int> const& map_actual_fields_to_dump) override;
     void AddPartDataToParticleBuffer(
@@ -149,7 +150,9 @@ class LabFrameSlice : public LabFrameDiag {
                      std::vector<std::string> mesh_field_names,
                      amrex::RealBox diag_domain_lab,
                      amrex::Box diag_box, int file_num_in,
-                     amrex::Real particle_slice_dx_lab);
+                     amrex::Real particle_slice_dx_lab,
+                     const int max_box_size,
+                     const int buffer_size);
     void AddDataToBuffer( amrex::MultiFab& tmp_slice_ptr, int i_lab,
          amrex::Vector<int> const& map_actual_fields_to_dump) override;
     void AddPartDataToParticleBuffer(

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -568,6 +568,9 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
     ParmParse pp_warpx("warpx");
     bool do_user_fields;
     do_user_fields = pp_warpx.queryarr("back_transformed_diag_fields", user_fields_to_dump);
+    if (pp_warpx.query("buffer_size", m_num_buffer_)) {
+        if (m_max_box_size_ < m_num_buffer_) m_max_box_size_ = m_num_buffer_;
+    }
     // If user specifies fields to dump, overwrite ncomp_to_dump,
     // map_actual_fields_to_dump and mesh_field_names.
     for (int i = 0; i < 10; ++i)
@@ -600,7 +603,7 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
                                 m_inv_gamma_boost_, m_inv_beta_boost_, m_dz_lab_,
                                 prob_domain_lab, prob_ncells_lab,
                                 m_ncomp_to_dump, m_mesh_field_names, prob_domain_lab,
-                                diag_box, i);
+                                diag_box, i, m_max_box_size_, m_num_buffer_);
     }
 
 
@@ -680,7 +683,8 @@ BackTransformedDiagnostic(Real zmin_lab, Real zmax_lab, Real v_window_lab,
                                 m_inv_gamma_boost_, m_inv_beta_boost_, m_dz_lab_,
                                 prob_domain_lab, slice_ncells_lab,
                                 m_ncomp_to_dump, m_mesh_field_names, slice_dom_lab,
-                                slicediag_box, i, m_particle_slice_width_lab_);
+                                slicediag_box, i, m_particle_slice_width_lab_,
+                                m_max_box_size_, m_num_buffer_);
     }
     // sort diags based on their respective t_lab
     std::stable_sort(m_LabFrameDiags_.begin(), m_LabFrameDiags_.end(), compare_tlab_uptr);
@@ -1121,7 +1125,8 @@ LabFrameSnapShot(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
                  Real inv_beta_boost_in, Real dz_lab_in, RealBox prob_domain_lab,
                  IntVect prob_ncells_lab, int ncomp_to_dump,
                  std::vector<std::string> mesh_field_names,
-                 amrex::RealBox diag_domain_lab, Box diag_box, int file_num_in)
+                 amrex::RealBox diag_domain_lab, Box diag_box, int file_num_in,
+                 const int max_box_size, const int num_buffer)
 {
    m_t_lab = t_lab_in;
    m_dz_lab_ = dz_lab_in;
@@ -1143,6 +1148,8 @@ LabFrameSnapShot(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
                            m_file_num, 5);
    createLabFrameDirectories();
    m_buff_counter_ = 0;
+   m_max_box_size = max_box_size;
+   m_num_buffer_ = num_buffer;
    if (WarpX::do_back_transformed_fields) m_data_buffer_.reset(nullptr);
 }
 
@@ -1290,7 +1297,8 @@ LabFrameSlice(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
                  IntVect prob_ncells_lab, int ncomp_to_dump,
                  std::vector<std::string> mesh_field_names,
                  RealBox diag_domain_lab, Box diag_box, int file_num_in,
-                 amrex::Real particle_slice_dx_lab)
+                 amrex::Real particle_slice_dx_lab, const int max_box_size,
+                 const int num_buffer)
 {
     m_t_lab = t_lab_in;
     m_dz_lab_ = dz_lab_in;
@@ -1312,6 +1320,8 @@ LabFrameSlice(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
     createLabFrameDirectories();
     m_buff_counter_ = 0;
     m_particle_slice_dx_lab_ = particle_slice_dx_lab;
+    m_max_box_size = max_box_size;
+    m_num_buffer_ = num_buffer;
 
     if (WarpX::do_back_transformed_fields) m_data_buffer_.reset(nullptr);
 }

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -55,10 +55,12 @@ public:
      * \param[in] buffer_box, Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab, k-index in the lab-frame corresponding to the
      *                          current z co-ordinate in the lab-frame for the ith buffer.
+     * \param[in] max_box_size, maximum box size for the multifab to generate box arrays
      */
     void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                               amrex::Real current_z_boost,
-                              amrex::Box buffer_box, const int k_index_zlab ) override;
+                              amrex::Box buffer_box, const int k_index_zlab,
+                              const int max_box_size ) override;
     /** Allocate and initialize member variables and arrays required to back-transform
      *  field-data from boosted-frame to lab-frame.
      */

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -102,13 +102,15 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
 void
 BackTransformFunctor::PrepareFunctorData (int i_buffer,
                           bool ZSliceInDomain, amrex::Real current_z_boost,
-                          amrex::Box buffer_box, const int k_index_zlab )
+                          amrex::Box buffer_box, const int k_index_zlab,
+                          const int max_box_size )
 {
     m_buffer_box[i_buffer] = buffer_box;
     m_current_z_boost[i_buffer] = current_z_boost;
     m_k_index_zlab[i_buffer] = k_index_zlab;
     m_perform_backtransform[i_buffer] = 0;
     if (ZSliceInDomain) m_perform_backtransform[i_buffer] = 1;
+    m_max_box_size = max_box_size;
 }
 
 void

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -30,11 +30,12 @@ public:
 
     virtual void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                                       amrex::Real current_z_boost,
-                                      amrex::Box buffer_box, const int k_index_zlab) {
+                                      amrex::Box buffer_box, const int k_index_zlab,
+                                      const int max_box_size) {
                                           amrex::ignore_unused(i_buffer,
-                                              ZSliceInDomain,
-                                              current_z_boost, buffer_box,
-                                            k_index_zlab);
+                                          ZSliceInDomain,
+                                          current_z_boost, buffer_box,
+                                          k_index_zlab, max_box_size);
                                       }
     virtual void InitData() {}
 private:


### PR DESCRIPTION
This PR allows users to specify buffer size for BTD diagnostics.
If the buffer size is small, the BTD would be flushed out more often, but it would alow for a large number of snapshots to be computed.
The default still remains 256.
We have tested this on the recent milestone test-cases on summit