### PR TITLE
Add Time-Averaged Fields To Raw Fields Output

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -514,6 +514,28 @@ FlushFormatPlotfile::WriteAllRawFields(
             WriteRawMF(warpx.getphi_fp(lev), dm, raw_pltname, default_level_prefix, "phi_fp", lev, plot_raw_fields_guards);
         }
 
+        // Averaged fields on fine patch
+        if (warpx.fft_do_time_averaging)
+        {
+            WriteRawMF(warpx.getEfield_avg_fp(lev, 0) , dm, raw_pltname, default_level_prefix,
+                       "Ex_avg_fp", lev, plot_raw_fields_guards);
+
+            WriteRawMF(warpx.getEfield_avg_fp(lev, 1) , dm, raw_pltname, default_level_prefix,
+                       "Ey_avg_fp", lev, plot_raw_fields_guards);
+
+            WriteRawMF(warpx.getEfield_avg_fp(lev, 2) , dm, raw_pltname, default_level_prefix,
+                       "Ez_avg_fp", lev, plot_raw_fields_guards);
+
+            WriteRawMF(warpx.getBfield_avg_fp(lev, 0) , dm, raw_pltname, default_level_prefix,
+                       "Bx_avg_fp", lev, plot_raw_fields_guards);
+
+            WriteRawMF(warpx.getBfield_avg_fp(lev, 1) , dm, raw_pltname, default_level_prefix,
+                       "By_avg_fp", lev, plot_raw_fields_guards);
+
+            WriteRawMF(warpx.getBfield_avg_fp(lev, 2) , dm, raw_pltname, default_level_prefix,
+                       "Bz_avg_fp", lev, plot_raw_fields_guards);
+        }
+
         // Coarse path
         if (lev > 0) {
             WriteCoarseVector( "E",

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -265,6 +265,10 @@ public:
     const amrex::MultiFab& getrho_fp (int lev) {return *rho_fp[lev];}
     const amrex::MultiFab& getphi_fp (int lev) {return *phi_fp[lev];}
     const amrex::MultiFab& getF_fp (int lev) {return *F_fp[lev];}
+
+    const amrex::MultiFab& getEfield_avg_fp (int lev, int direction) {return *Efield_avg_fp[lev][direction];}
+    const amrex::MultiFab& getBfield_avg_fp (int lev, int direction) {return *Bfield_avg_fp[lev][direction];}
+
     bool DoPML () const {return do_pml;}
 
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */


### PR DESCRIPTION
This PR adds the possibility to write the averaged raw fields on the fine patch (`avg_fp`), besides the corresponding non-averaged raw fields (`fp`), when time averaging is used. Mainly for development purposes.