### PR TITLE
paraview.pmd: write on close

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -106,7 +106,7 @@ public:
    * @note If an iteration has been written, then it will give a warning
    *
    */
-  void SetStep (int ts, const std::string& filePrefix,
+  void SetStep (int ts, const std::string& dirPrefix,
                 bool isBTD=false);
 
   /** Close the step
@@ -127,7 +127,7 @@ public:
 
 
 private:
-  void Init (openPMD::Access access, const std::string& filePrefix, bool isBTD);
+  void Init (openPMD::Access access, bool isBTD);
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *
@@ -209,6 +209,14 @@ private:
   std::string GetFileName (std::string& filepath);
 
   std::unique_ptr<openPMD::Series> m_Series;
+
+  /** This is the output directory
+   *
+   * This usually does not yet end in a `/`.
+   * It does not yet include the file prefix of the openPMD series, which will
+   * be appended by the GetFileName function.
+   */
+  std::string m_dirPrefix;
 
   int m_MPIRank = 0;
   int m_MPISize = 1;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -239,10 +239,12 @@ WarpXOpenPMDPlot::GetFileName (std::string& filepath)
   return filename;
 }
 
-void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix,
+void WarpXOpenPMDPlot::SetStep (int ts, const std::string& dirPrefix,
                                 bool isBTD)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
+
+    m_dirPrefix = dirPrefix;
 
     if( ! isBTD ) {
         if (m_CurrentStep >= ts) {
@@ -255,7 +257,7 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& filePrefix,
         }
     }
     m_CurrentStep = ts;
-    Init(openPMD::Access::CREATE, filePrefix, isBTD);
+    Init(openPMD::Access::CREATE, isBTD);
 }
 
 void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
@@ -267,19 +269,31 @@ void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
     if (callClose) {
         if (m_Series)
             m_Series->iterations[m_CurrentStep].close();
+
+        // create a little helper file for ParaView 5.9+
+        if (amrex::ParallelDescriptor::IOProcessor())
+        {
+            // see Init()
+            std::string filepath = m_dirPrefix;
+            std::string const filename = GetFileName(filepath);
+
+            std::ofstream pv_helper_file(m_dirPrefix + "/paraview.pmd");
+            pv_helper_file << filename << std::endl;
+            pv_helper_file.close();
+        }
     }
 }
 
 void
-WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, bool isBTD)
+WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
 {
     if( isBTD && m_Series != nullptr )
         return; // already open for this snapshot (aka timestep in lab frame)
 
     // either for the next ts file,
     // or init a single file for all ts
-    std::string filepath = filePrefix;
-    std::string const filename = GetFileName(filepath);
+    std::string filepath = m_dirPrefix;
+    GetFileName(filepath);
 
     // close a previously open series before creating a new one
     // see ADIOS1 limitation: https://github.com/openPMD/openPMD-api/pull/686
@@ -300,14 +314,6 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, const std::string& filePrefix, b
         m_Series = std::make_unique<openPMD::Series>(filepath, access);
         m_MPISize = 1;
         m_MPIRank = 1;
-    }
-
-    // create a little helper file for ParaView 5.9+
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        std::ofstream pv_helper_file(filePrefix + "/paraview.pmd");
-        pv_helper_file << filename << std::endl;
-        pv_helper_file.close();
     }
 
     // input file / simulation setup author


### PR DESCRIPTION
Initially we wrote those on open. The problem was that writing this file depends on an existing directory structure, which is first created on earlierst on the first `flush()` and in case of extensive ADIOS buffering actually latest on `close()`.

Since in backtransformed diagnostics (BTD) this flush happens very late. The directory did not exist and thus the creation of the helper file early on did fail (silently).

- [x] tested on Summit

Follow-up to #1802