### PR TITLE
FlushFormatOpenPMD: Cleanup

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -4,20 +4,23 @@
 #include "FlushFormat.H"
 #include "Diagnostics/WarpXOpenPMD.H"
 
+#include <memory>
+
+
 /**
- * \brief This class aims at dumping diags data to disk using the OpenPMD standard.
+ * \brief This class aims at dumping diags data to disk using the openPMD standard.
  * In particular, function WriteToFile takes fields and particles as input arguments,
  * and writes data to file.
  */
-class FlushFormatOpenPMD : public FlushFormat
+class FlushFormatOpenPMD final : public FlushFormat
 {
 public:
 
     /** Constructor takes name of diagnostics to set the output directory */
-    FlushFormatOpenPMD (const std::string& diag_name);
+    explicit FlushFormatOpenPMD (const std::string& diag_name);
 
     /** Flush fields and particles to plotfile */
-    virtual void WriteToFile (
+    void WriteToFile (
         const amrex::Vector<std::string> varnames,
         const amrex::Vector<amrex::MultiFab>& mf,
         amrex::Vector<amrex::Geometry>& geom,
@@ -28,13 +31,13 @@ public:
         bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false) const override final;
+        bool isLastBTDFlush = false) const override;
 
-    ~FlushFormatOpenPMD ();
+    ~FlushFormatOpenPMD () override = default;
 
 private:
     /** This is responsible for dumping to file */
-    WarpXOpenPMDPlot* m_OpenPMDPlotWriter = nullptr;
+    std::unique_ptr< WarpXOpenPMDPlot > m_OpenPMDPlotWriter;
 };
 
 #endif // WARPX_FLUSHFORMATOPENPMD_H_

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -1,10 +1,10 @@
 #include "FlushFormatOpenPMD.H"
 #include "WarpX.H"
-#include "Utils/Interpolate.H"
 
-#include <AMReX_buildInfo.H>
+#include <memory>
 
 using namespace amrex;
+
 
 FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 {
@@ -16,9 +16,9 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
     pp_diag_name.query("openpmd_backend", openpmd_backend);
     pp_diag_name.query("openpmd_tspf", openpmd_tspf);
     auto & warpx = WarpX::GetInstance();
-    m_OpenPMDPlotWriter = new WarpXOpenPMDPlot(
+    m_OpenPMDPlotWriter = std::make_unique<WarpXOpenPMDPlot>(
         openpmd_tspf, openpmd_backend, warpx.getPMLdirections()
-        );
+    );
 }
 
 void
@@ -58,8 +58,4 @@ FlushFormatOpenPMD::WriteToFile (
 
     // signal that no further updates will be written to this iteration
     m_OpenPMDPlotWriter->CloseStep(isBTD, isLastBTDFlush);
-}
-
-FlushFormatOpenPMD::~FlushFormatOpenPMD (){
-    delete m_OpenPMDPlotWriter;
 }


### PR DESCRIPTION
- avoid raw pointers
- proper override/final
- explicit in single-argument constructor