### PR TITLE
Initialize BTD buffer with 0 values

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -462,6 +462,7 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
         int ngrow = 0;
         m_mf_output[i_buffer][lev] = amrex::MultiFab ( buffer_ba, buffer_dmap,
                                                   m_varnames.size(), ngrow ) ;
+        m_mf_output[i_buffer][lev].setVal(0.);
 
         amrex::IntVect ref_ratio = amrex::IntVect(1);
         if (lev > 0 ) ref_ratio = WarpX::RefRatio(lev-1);


### PR DESCRIPTION
In this PR, the BTD buffer multifab is initialized with zero as soon as it is created. This buffer will then be filled in the lab-frame.. If the simulation terminates before filling the multifab fully, the unfilled regions are padded with 0 (from initialization), instead of having undefined values. 

(this branch was created on top of PR #1858 and has commits from that PR)
