### PR TITLE
Parser: Abort on NaN/Inf Results

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -31,6 +31,7 @@ sudo apt-get install -y --no-install-recommends \
     openmpi-bin     \
     rocm-dev        \
     rocfft          \
+    rocprim         \
     rocrand
 
 # activate

--- a/Source/Parser/wp_parser_c.h
+++ b/Source/Parser/wp_parser_c.h
@@ -6,6 +6,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuPrint.H>
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>
 #include <AMReX.H>
@@ -282,7 +283,7 @@ wp_ast_eval (struct wp_node* node, amrex::Real const* x)
 #endif
     (Depth == 0)
     {
-        if (!std::isfinite(result))
+        if (!amrex::Math::isfinite(result))
         {
             constexpr char const * const err_msg =
                 "wp_ast_eval: function parser encountered an invalid result value (NaN or Inf)!";

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -192,7 +192,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "21.04"
+set(WarpX_amrex_branch "4cb1c5b79906fe566d1b80777315cf4817924b1a"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR and AMReX
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout 21.04 && cd -
+cd amrex && git checkout 4cb1c5b79906fe566d1b80777315cf4817924b1a && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout 348830b444c65ca305aa3f89cd72fef7c65abd7d && cd -


### PR DESCRIPTION
If individual terms in an expression passed to the parser result in Inf or NaN, this invalidates the whole expression result (as in usual C).
Since this happens often in user-proveided piecewise constructed functons, we throw an error now instead of working with the invalid results.

- [x] if `std::isfinite()` does not work with all compilers (:eye: SYCL/DPC++), add it to the AMReX math wrappers or implement our own https://github.com/AMReX-Codes/amrex/pull/1929
- [x] updates AMReX to include above PR (needs rocprim: https://github.com/AMReX-Codes/amrex/pull/1925)