### PR TITLE
Abort If More Guard Cells Than Valid Cells

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -109,25 +109,9 @@ WarpX::InitData ()
         printGridSummary(std::cout, 0, finestLevel());
     }
 
-    // Abort if the number of guard cells is larger than or equal to the number of valid cells
-    // (example: box with 16 valid cells and 32 guard cells in z).
-    // Note that we use Ex on level 0 and use the AMReX function IntVect::allGT to check this.
-    for (amrex::MFIter mfi(*Efield_fp[0][0]); mfi.isValid(); ++mfi)
-    {
-        const amrex::IntVect vc = mfi.validbox().enclosedCells().size();
-        const amrex::IntVect gc = Efield_fp[0][0]->nGrowVect();
-        if (vc.allGT(gc) == false)
-        {
-            std::stringstream ss;
-            ss << "\nThe number of guard cells "
-               << gc
-               << " is larger than or equal to the number of valid cells "
-               << vc
-               << ":\nplease reduce the number of guard cells"
-               << " or increase the grid size by changing domain decomposition";
-            amrex::Abort(ss.str());
-        }
-    }
+    // Check that the number of guard cells is smaller than the number of valid cells for all MultiFabs
+    // (example: a box with 16 valid cells and 32 guard cells in z will not be considered valid)
+    CheckGuardCells();
 
     if (restart_chkfile.empty())
     {
@@ -596,4 +580,82 @@ WarpX::PerformanceHints ()
     // TODO: check MPI-rank to GPU ratio (should be 1:1)
     // TODO: check memory per MPI rank, especially if GPUs are underutilized
     // TODO: CPU tiling hints with OpenMP
+}
+
+void WarpX::CheckGuardCells()
+{
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        for (int dim = 0; dim < 3; ++dim)
+        {
+            CheckGuardCells(*Efield_fp[lev][dim]);
+            CheckGuardCells(*Bfield_fp[lev][dim]);
+            CheckGuardCells(*current_fp[lev][dim]);
+
+            if (WarpX::fft_do_time_averaging)
+            {
+                CheckGuardCells(*Efield_avg_fp[lev][dim]);
+                CheckGuardCells(*Bfield_avg_fp[lev][dim]);
+            }
+        }
+
+        if (rho_fp[lev])
+        {
+            CheckGuardCells(*rho_fp[lev]);
+        }
+
+        if (F_fp[lev])
+        {
+            CheckGuardCells(*F_fp[lev]);
+        }
+
+        // MultiFabs on coarse patch
+        if (lev > 0)
+        {
+            for (int dim = 0; dim < 3; ++dim)
+            {
+                CheckGuardCells(*Efield_cp[lev][dim]);
+                CheckGuardCells(*Bfield_cp[lev][dim]);
+                CheckGuardCells(*current_cp[lev][dim]);
+
+                if (WarpX::fft_do_time_averaging)
+                {
+                    CheckGuardCells(*Efield_avg_cp[lev][dim]);
+                    CheckGuardCells(*Bfield_avg_cp[lev][dim]);
+                }
+            }
+
+            if (rho_cp[lev])
+            {
+                CheckGuardCells(*rho_cp[lev]);
+            }
+
+            if (F_cp[lev])
+            {
+                CheckGuardCells(*F_cp[lev]);
+            }
+        }
+    }
+}
+
+void WarpX::CheckGuardCells(amrex::MultiFab const& mf)
+{
+    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi)
+    {
+        const amrex::IntVect vc = mfi.validbox().enclosedCells().size();
+        const amrex::IntVect gc = mf.nGrowVect();
+        if (vc.allGT(gc) == false)
+        {
+            std::stringstream ss;
+            ss << "\nMultiFab "
+               << mf.tags()[1]
+               << ":\nthe number of guard cells "
+               << gc
+               << " is larger than or equal to the number of valid cells "
+               << vc
+               << ",\nplease reduce the number of guard cells"
+               << " or increase the grid size by changing domain decomposition";
+            amrex::Abort(ss.str());
+        }
+    }
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -767,6 +767,18 @@ private:
 
     void InitNCICorrector ();
 
+    /**
+     * \brief Check that the number of guard cells is smaller than the number of valid cells,
+     * for all available MultiFabs, and abort otherwise.
+     */
+    void CheckGuardCells();
+
+    /**
+     * \brief Check that the number of guard cells is smaller than the number of valid cells,
+     * for a given MultiFab, and abort otherwise.
+     */
+    void CheckGuardCells(amrex::MultiFab const& mf);
+
     /** Check the requested resources and write performance hints */
     void PerformanceHints ();
 


### PR DESCRIPTION
This PR closes #1844.

I implemented the check in `WarpX::InitData`, instead of `WarpX::AllocLevelMFs`, after the printout of the grids summary, so that the user can match the information printed in the abort message with the information printed in the grids summary.

Notes:
- I currently perform the check only using the Ex MultiFab on level 0. I think this should be enough.
- The code will abort also in the limit case where the number of guard cells equals the number of valid cells, say, 16 valid cells and 16 guard cells. I think that this is a case that should be avoided too, to play safe.
- Regarding the issue of implementing the same check after regridding for load balancing, I understand that I could probably implement this in `WarpX::RemakeLevel`, but I'm not sure if we should wait to see where exactly the regridding will be implemented in the future, before implementing the check that should follow it. Let me know what you think.

Please let me know if you have suggestions or would like to do anything differently.

In the meantime, here's an example of how the abort message currently looks like:
```sh
amrex::Abort::0::
MultiFab Efield_fp[x][l=0]:
the number of guard cells (16,32) is larger than or equal to the number of valid cells (128,16),
please reduce the number of guard cells or increase the grid size by changing domain decomposition !!!
```