### PR TITLE
[WIP] run_test.sh: mass-reset benchmarks

### DIFF
--- a/Docs/source/developers/checksum.rst
+++ b/Docs/source/developers/checksum.rst
@@ -61,3 +61,21 @@ Since this will automatically change the JSON file stored on the repo, make a se
 
    git add <test name>.json
    git commit -m "reset benchmark for <test name> because ..." --author="Tools <warpx@lbl.gov>"
+
+Automated reset of a list of test benchmarks
+--------------------------------------------
+
+You can set the environment variable ``export CHECKSUM_RESET=ON`` before running the ``run_test.sh`` script to reset a series of tests.
+
+Note that in CI, these tests are also additionally run with ``export OMP_NUM_THREADS=1``.
+A convenient way to reset a few selected tests could be:
+
+.. code-block:: bash
+
+   export OMP_NUM_THREADS=1
+   export WARPX_CI_CCACHE=TRUE
+   export CHECKSUM_RESET=ON
+
+   ./run_test.sh Langmuir_multi_2d_nodal Langmuir_multi_nodal Langmuir_multi_psatd Langmuir_multi_psatd_current_correction Langmuir_multi_psatd_current_correction_nodal Langmuir_multi_psatd_momentum_conserving Langmuir_multi_psatd_nodal Langmuir_multi Langmuir_multi_psatd_single_precision
+
+   # ... check and commit changes

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
@@ -20,6 +20,7 @@ case rigid injection is OFF (i.e., the beam starts expanding from -5 microns),
 in which case a warning is raised.
 '''
 
+import os
 import sys
 import yt
 import numpy as np
@@ -82,5 +83,13 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Modules/ionization/analysis_ionization.py
+++ b/Examples/Modules/ionization/analysis_ionization.py
@@ -18,6 +18,7 @@ checks that, after the laser went through the plasma, ~32% of Nitrogen
 ions are N5+, in agreement with theory from Chen's article.
 """
 
+import os
 import sys
 import yt
 import numpy as np
@@ -90,5 +91,13 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Modules/laser_injection/analysis_2d.py
+++ b/Examples/Modules/laser_injection/analysis_2d.py
@@ -18,6 +18,7 @@
 # central frequency of the Fourier transform is the expected one.
 
 import yt
+import os
 import sys
 import matplotlib
 matplotlib.use('Agg')
@@ -193,8 +194,16 @@ def main():
 
     check_laser(filename_end)
 
+    # Reset benchmark?
+    reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+              ['true', '1', 't', 'y', 'yes', 'on'] )
+
+    # Run checksum regression test or reset
     test_name = filename_end[:-9] # Could also be os.path.split(os.getcwd())[1]
-    checksumAPI.evaluate_checksum(test_name, filename_end)
+    if reset:
+        checksumAPI.reset_benchmark(test_name, filename_end)
+    else:
+        checksumAPI.evaluate_checksum(test_name, filename_end)
 
 if __name__ == "__main__":
     main()

--- a/Examples/Modules/laser_injection/analysis_laser.py
+++ b/Examples/Modules/laser_injection/analysis_laser.py
@@ -7,7 +7,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
-
+import os
 import sys
 import matplotlib
 matplotlib.use('Agg')
@@ -25,5 +25,13 @@ s = 1 + np.sin(2*np.pi*t)
 plt.plot(t, s)
 plt.savefig("laser_analysis.png")
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Modules/qed/breit_wheeler/analysis.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis.py
@@ -10,6 +10,7 @@
 
 import yt
 import numpy as np
+import os
 import sys
 import scipy.special as spe
 import scipy.integrate as integ
@@ -288,8 +289,16 @@ def check():
 
         print("*************\n")
 
+    # Reset benchmark?
+    reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+              ['true', '1', 't', 'y', 'yes', 'on'] )
+
+    # Run checksum regression test or reset
     test_name = filename_end[:-9] # Could also be os.path.split(os.getcwd())[1]
-    checksumAPI.evaluate_checksum(test_name, filename_end)
+    if reset:
+        checksumAPI.reset_benchmark(test_name, filename_end)
+    else:
+        checksumAPI.evaluate_checksum(test_name, filename_end)
 
 def main():
     check()

--- a/Examples/Modules/qed/quantum_synchrotron/analysis.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis.py
@@ -10,6 +10,7 @@
 
 import yt
 import numpy as np
+import os
 import sys
 import scipy.special as spe
 import scipy.integrate as integ
@@ -288,8 +289,16 @@ def check():
 
         print("*************\n")
 
+    # Reset benchmark?
+    reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+              ['true', '1', 't', 'y', 'yes', 'on'] )
+
+    # Run checksum regression test or reset
     test_name = filename_end[:-9] # Could also be os.path.split(os.getcwd())[1]
-    checksumAPI.evaluate_checksum(test_name, filename_end)
+    if reset:
+        checksumAPI.reset_benchmark(test_name, filename_end)
+    else:
+        checksumAPI.evaluate_checksum(test_name, filename_end)
 
 def main():
     check()

--- a/Examples/Modules/qed/schwinger/analysis_schwinger.py
+++ b/Examples/Modules/qed/schwinger/analysis_schwinger.py
@@ -13,6 +13,7 @@
 
 import yt
 import numpy as np
+import os
 import sys
 import re
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
@@ -120,5 +121,13 @@ def do_analysis(Ex,Ey,Ez,Bx,By,Bz):
 
 do_analysis(Ex_test, Ey_test, Ez_test, Bx_test, By_test, Bz_test)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Modules/relativistic_space_charge_initialization/analysis.py
+++ b/Examples/Modules/relativistic_space_charge_initialization/analysis.py
@@ -11,6 +11,7 @@ This script checks the space-charge initialization routine, by
 verifying that the space-charge field of a Gaussian beam corresponds to
 the expected theoretical field.
 """
+import os
 import sys
 import matplotlib
 matplotlib.use('Agg')
@@ -84,5 +85,13 @@ def check(E, E_th, label):
 
 check( Ex_array, Ex_th, 'Ex' )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename, do_particles=False)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename, do_particles=False)

--- a/Examples/Modules/resampling/analysis_leveling_thinning.py
+++ b/Examples/Modules/resampling/analysis_leveling_thinning.py
@@ -11,6 +11,7 @@
 
 import yt
 import numpy as np
+import os
 import sys
 from scipy.special import erf
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
@@ -134,5 +135,13 @@ assert(numparts_unaffected == numparts_unaffected_anticipated)
 # Check that particles with weight higher than level weight are unaffected by resampling.
 assert(np.all(w[-numparts_unaffected:] == w0[-numparts_unaffected:]))
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = fn_final[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn_final)
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn_final)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn_final)

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -11,6 +11,7 @@ This script checks the space-charge initialization routine, by
 verifying that the space-charge field of a Gaussian beam corresponds to
 the expected theoretical field.
 """
+import os
 import sys
 import matplotlib
 matplotlib.use('Agg')
@@ -101,5 +102,13 @@ check( Ey_array, Ey_th, 'Ey' )
 if ds.dimensionality == 3:
     check( Ez_array, Ez_th, 'Ez' )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename, do_particles=0)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename, do_particles=False)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -14,6 +14,7 @@
 # $$ E_x = \epsilon \,\frac{m_e c^2 k_x}{q_e}\sin(k_x x)\cos(k_y y)\cos(k_z z)\sin( \omega_p t)$$
 # $$ E_y = \epsilon \,\frac{m_e c^2 k_y}{q_e}\cos(k_x x)\sin(k_y y)\cos(k_z z)\sin( \omega_p t)$$
 # $$ E_z = \epsilon \,\frac{m_e c^2 k_z}{q_e}\cos(k_x x)\cos(k_y y)\sin(k_z z)\sin( \omega_p t)$$
+import os
 import sys
 import re
 import matplotlib
@@ -142,9 +143,15 @@ if current_correction or vay_deposition:
     print("tolerance = {}".format(tolerance))
     assert( error_rel < tolerance )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 
-if re.search( 'single_precision', fn ):
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+elif re.search( 'single_precision', fn ):
     checksumAPI.evaluate_checksum(test_name, fn, rtol=1.e-3)
 else:
     checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -14,6 +14,7 @@
 # $$ E_x = \epsilon \,\frac{m_e c^2 k_x}{q_e}\sin(k_x x)\cos(k_y y)\cos(k_z z)\sin( \omega_p t)$$
 # $$ E_y = \epsilon \,\frac{m_e c^2 k_y}{q_e}\cos(k_x x)\sin(k_y y)\cos(k_z z)\sin( \omega_p t)$$
 # $$ E_z = \epsilon \,\frac{m_e c^2 k_z}{q_e}\cos(k_x x)\cos(k_y y)\sin(k_z z)\sin( \omega_p t)$$
+import os
 import sys
 import re
 import matplotlib
@@ -118,5 +119,13 @@ if current_correction or vay_deposition:
     print("tolerance = {}".format(tolerance))
     assert( error_rel < tolerance )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -14,6 +14,7 @@
 # $$ E_z = -\partial_z \phi = - \epsilon \,\frac{mc^2}{e} k_0 \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \sin(\omega_p t)
 # Unrelated to the Langmuir waves, we also test the plotfile particle filter function in this
 # analysis script.
+import os
 import sys
 import re
 import matplotlib
@@ -153,4 +154,12 @@ random_fraction = 0.66
 post_processing_utils.check_random_filter(fn, random_filter_fn, random_fraction,
                                           dim, species_name)
 
-checksumAPI.evaluate_checksum(test_name, fn)
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/PML/analysis_pml_ckc.py
+++ b/Examples/Tests/PML/analysis_pml_ckc.py
@@ -7,7 +7,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
-
+import os
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np
@@ -51,5 +51,13 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -7,6 +7,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
+import os
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np
@@ -60,5 +61,13 @@ print("reflectivity_max = " + str(reflectivity_max))
 
 assert(reflectivity < reflectivity_max)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -8,6 +8,7 @@
 # License: BSD-3-Clause-LBNL
 
 
+import os
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np
@@ -51,5 +52,13 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/SilverMueller/analysis_silver_mueller.py
+++ b/Examples/Tests/SilverMueller/analysis_silver_mueller.py
@@ -11,6 +11,7 @@ A laser pulse is emitted and propagates towards the boundaries ; the
 test check that the reflected field at the boundary is negligible.
 """
 
+import os
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np
@@ -31,5 +32,13 @@ assert np.all( abs(Ex) < max_reflection_amplitude )
 assert np.all( abs(Ey) < max_reflection_amplitude )
 assert np.all( abs(Ez) < max_reflection_amplitude )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
+++ b/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
@@ -6,7 +6,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
-
+import os
 import sys
 import yt ; yt.funcs.mylog.setLevel(0)
 import numpy as np
@@ -58,5 +58,13 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -23,6 +23,7 @@
 # tolerance: 0.001
 # Possible running time: ~ 30.0 s
 
+import os
 import sys
 import yt
 import math
@@ -99,5 +100,13 @@ random_fraction = 0.77
 post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_fraction,
                                           dim, species_name)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -23,6 +23,7 @@
 # tolerance: 0.001
 # Possible running time: ~ 30.0 s
 
+import os
 import sys
 import yt
 import math
@@ -99,5 +100,13 @@ random_fraction = 0.88
 post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_fraction,
                                           dim, species_name)
 
-test_name = last_fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
+test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/galilean/analysis_2d.py
+++ b/Examples/Tests/galilean/analysis_2d.py
@@ -14,6 +14,7 @@ It compares the energy of the electric field with precalculated reference energy
          * if averaged Galilean PSATD is used ('psatd.do_time_averaging == 1) :
            NCI is suppressed => simulation is stable.
 """
+import os
 import sys
 import re
 import yt ; yt.funcs.mylog.setLevel(0)
@@ -77,5 +78,13 @@ if current_correction:
     print("tolerance = {}".format(tolerance))
     assert( error_rel < tolerance )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/galilean/analysis_3d.py
+++ b/Examples/Tests/galilean/analysis_3d.py
@@ -14,6 +14,7 @@ It compares the energy of the electric field with precalculated reference energy
          * if averaged Galilean PSATD is used ('psatd.do_time_averaging == 1) :
            NCI is suppressed => simulation is stable.
 """
+import os
 import sys
 import re
 import yt ; yt.funcs.mylog.setLevel(0)
@@ -68,5 +69,13 @@ if current_correction:
     print("tolerance = {}".format(tolerance))
     assert( error_rel < tolerance )
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/initial_distribution/analysis_distribution.py
+++ b/Examples/Tests/initial_distribution/analysis_distribution.py
@@ -14,6 +14,7 @@
 # The distribution is obtained through reduced diagnostic ParticleHistogram.
 
 import numpy as np
+import os
 import scipy.constants as scc
 import scipy.special as scs
 from read_raw_data import read_reduced_diags_histogram, read_reduced_diags
@@ -144,5 +145,13 @@ assert(f4_error < tolerance)
 print('Relative beam charge difference:', charge_error)
 assert(charge_error < tolerance)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/initial_plasma_profile/analysis.py
+++ b/Examples/Tests/initial_plasma_profile/analysis.py
@@ -6,7 +6,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
-
+import os
 import sys
 import yt
 yt.funcs.mylog.setLevel(50)
@@ -19,4 +19,12 @@ fn = sys.argv[1]
 
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 
-checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-4, do_particles=False)
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-4, do_particles=False)

--- a/Examples/Tests/particle_pusher/analysis_pusher.py
+++ b/Examples/Tests/particle_pusher/analysis_pusher.py
@@ -22,6 +22,7 @@
 # tolerance: 0.001
 # Possible running time: ~ 4.0 s
 
+import os
 import sys
 import yt
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
@@ -38,5 +39,13 @@ print('error = ', abs(x))
 print('tolerance = ', tolerance)
 assert(abs(x) < tolerance)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+++ b/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
@@ -17,6 +17,7 @@ is close to 0 once the particles have left. With regular
 PML, this test fails, since the particles leave a spurious
 charge, with associated fields, behind them.
 """
+import os
 import sys
 import yt
 yt.funcs.mylog.setLevel(0)
@@ -53,5 +54,13 @@ else:
 print("tolerance_abs: " + str(tolerance_abs))
 assert max_Efield < tolerance_abs
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/photon_pusher/analysis_photon_pusher.py
+++ b/Examples/Tests/photon_pusher/analysis_photon_pusher.py
@@ -9,6 +9,7 @@
 
 import yt
 import numpy as np
+import os
 import sys
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
@@ -104,8 +105,16 @@ def check():
 
     assert ((max(disc_pos) <= tol_pos) and (max(disc_mom) <= tol_mom))
 
+    # Reset benchmark?
+    reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+              ['true', '1', 't', 'y', 'yes', 'on'] )
+
+    # Run checksum regression test or reset
     test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-    checksumAPI.evaluate_checksum(test_name, filename)
+    if reset:
+        checksumAPI.reset_benchmark(test_name, filename)
+    else:
+        checksumAPI.evaluate_checksum(test_name, filename)
 
 # This function generates the input file to test the photon pusher.
 def generate():

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -31,6 +31,7 @@
 #   (Cambridge University Press, Cambridge, 2004)
 
 import numpy as np
+import os
 import sys
 import yt
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
@@ -148,8 +149,16 @@ def check():
 
         assert( error_rel < tolerance_rel )
 
+    # Reset benchmark?
+    reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+              ['true', '1', 't', 'y', 'yes', 'on'] )
+
+    # Run checksum regression test or reset
     test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-    checksumAPI.evaluate_checksum(test_name, filename)
+    if reset:
+        checksumAPI.reset_benchmark(test_name, filename)
+    else:
+        checksumAPI.evaluate_checksum(test_name, filename)
 
 def generate():
 

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -21,6 +21,7 @@
 
 # Possible running time: ~ 2 s
 
+import os
 import sys
 import yt
 import numpy as np
@@ -161,5 +162,13 @@ assert(max_diffrhomax < 1.0e-18)
 assert(max_diff_number < 0.5)
 assert(max_diff_sum_weight < 0.5)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
@@ -18,6 +18,7 @@
 # Possible running time: ~ 1 s
 
 import numpy as np
+import os
 import sys
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
@@ -68,5 +69,13 @@ print('load balance efficiency (after load balance): ', efficiency_after)
 # The load balanced case is expcted to be more efficient then non-load balanced case
 assert(efficiency_before < efficiency_after)
 
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import os
 import sys
 import yt
 import numpy as np
@@ -43,4 +44,13 @@ assert(np.max(abs(ze-ze0))<tolerance)
 
 filename = sys.argv[1]
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, filename)
+
+# Reset benchmark?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
+if reset:
+    checksumAPI.reset_benchmark(test_name, filename)
+else:
+    checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -2,6 +2,7 @@
 
 import sys
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import os
 import checksumAPI
 
 # this will be the name of the plot file
@@ -10,5 +11,12 @@ fn = sys.argv[1]
 # Get name of the test
 test_name = fn[:-9] # Could also be os.path.split(os.getcwd())[1]
 
-# Run checksum regression test
-checksumAPI.evaluate_checksum(test_name, fn)
+# Reset all benchmarks?
+reset = ( os.getenv('CHECKSUM_RESET', 'False').lower() in
+          ['true', '1', 't', 'y', 'yes', 'on'] )
+
+# Run checksum regression test or reset
+if reset:
+    checksumAPI.reset_benchmark(test_name, fn)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -71,7 +71,7 @@ text = re.sub('runtime_params =',
               text)
 
 # Use only 2 cores for compiling
-text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 2', text )
+text = re.sub( 'numMakeJobs = \d+', 'numMakeJobs = 6', text )
 # Use only 1 OMP thread for running
 text = re.sub( 'numthreads = \d+', 'numthreads = 1', text)
 # Prevent emails from being sent

--- a/run_test.sh
+++ b/run_test.sh
@@ -20,8 +20,14 @@
 # select only the tests that correspond to this dimension
 # Use `export WARPX_TEST_ARCH=CPU` or `export WARPX_TEST_ARCH=GPU` in order
 # to run the tests on CPU or GPU respectively.
+#
+# Another environment variable is CHECKSUM_RESET=TRUE to reset the checksums of
+# the tests that are executed.
 
 set -eu -o pipefail
+
+# WarpX source directory
+warpx_src_dir=$PWD
 
 # Parse command line arguments: if test names are given as command line arguments,
 # store them in variable tests_arg and define new command line argument to call
@@ -77,3 +83,7 @@ if [[ ! -z "${tests_arg}" ]]; then
 else
   python regtest.py ../rt-WarpX/travis-tests.ini --no_update all
 fi
+cd ..
+
+# Copy test checksums back: update if reset
+cp warpx/Regression/Checksum/benchmarks_json/*json ${warpx_src_dir}/Regression/Checksum/benchmarks_json/


### PR DESCRIPTION
Resetting benchmarks is too manual to be enjoyable. Workflow:
- Manual re-compile for 2D, 3D, RZ, SP, ...
- Fiddle out overwritten compile in .ini file
- Fiddle out OMP/MPI options from .ini file
- Fiddle out overwritten runtime options from .ini file over inputs file
- Run
- Reset
- Commit
- Repeat for all compile combinations & run tests that are affected

This adds functionality to reset a couple of tests via:

```bash
CHECKSUM_RESET=TRUE ./run_test.sh test1 test2 test3
```