### PR TITLE
Fix QED Build (CUDA 10.0.130)

### DIFF
--- a/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
+++ b/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
@@ -24,7 +24,7 @@ struct SchwingerFilterFunc
      *
      * \tparam FABs the src array of Array4 type
      *
-     * @param[in] src_FABs Array of 6 Array4 that contain the EM field in the tile.
+     * @param[in] src_FABs A class with 6 named Array4 that contain the EM field in the tile.
      * @param[in] i index of the cell in the first direction.
      * @param[in] j index of the cell in the second direction.
      * @param[in] k index of the cell in the third direction.
@@ -35,12 +35,12 @@ struct SchwingerFilterFunc
                             const int i, const int j, const int k,
                             amrex::RandomEngine const& engine) const noexcept
     {
-        const auto& arrEx = src_FABs[0];
-        const auto& arrEy = src_FABs[1];
-        const auto& arrEz = src_FABs[2];
-        const auto& arrBx = src_FABs[3];
-        const auto& arrBy = src_FABs[4];
-        const auto& arrBz = src_FABs[5];
+        const auto& arrEx = src_FABs.Ex;
+        const auto& arrEy = src_FABs.Ey;
+        const auto& arrEz = src_FABs.Ez;
+        const auto& arrBx = src_FABs.Bx;
+        const auto& arrBy = src_FABs.By;
+        const auto& arrBz = src_FABs.Bz;
 
         return getSchwingerProductionNumber( m_dV, m_dt,
                     arrEx(i,j,k),arrEy(i,j,k),arrEz(i,j,k),

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -27,6 +27,15 @@
 
 using namespace amrex;
 
+namespace
+{
+    /** A little collection to transport six Array4 that point to the EM fields */
+    struct MyFieldList
+    {
+        Array4< amrex::Real const > const Ex, Ey, Ez, Bx, By, Bz;
+    };
+}
+
 MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 {
 
@@ -1138,15 +1147,9 @@ MultiParticleContainer::doQEDSchwinger ()
         if (!box.intersects(global_schwinger_box)) {continue;}
         box &= global_schwinger_box;
 
-        const auto& arrEx = Ex[mfi].array();
-        const auto& arrEy = Ey[mfi].array();
-        const auto& arrEz = Ez[mfi].array();
-        const auto& arrBx = Bx[mfi].array();
-        const auto& arrBy = By[mfi].array();
-        const auto& arrBz = Bz[mfi].array();
-
-        const Array4<const amrex::Real> array_EMFAB [] = {arrEx,arrEy,arrEz,
-                                           arrBx,arrBy,arrBz};
+        const MyFieldList fieldsEB = {
+            Ex[mfi].array(), Ey[mfi].array(), Ez[mfi].array(),
+            Bx[mfi].array(), By[mfi].array(), Bz[mfi].array()};
 
         auto& dst_ele_tile = pc_product_ele->ParticlesAt(level_0, mfi);
         auto& dst_pos_tile = pc_product_pos->ParticlesAt(level_0, mfi);
@@ -1167,9 +1170,9 @@ MultiParticleContainer::doQEDSchwinger ()
                             ParticleStringNames::to_index.find("w")->second};
 
         const auto num_added = filterCreateTransformFromFAB<1>( dst_ele_tile,
-                              dst_pos_tile, box, array_EMFAB, np_ele_dst,
+                               dst_pos_tile, box, fieldsEB, np_ele_dst,
                                np_pos_dst,Filter, CreateEle, CreatePos,
-                                Transform);
+                               Transform);
 
         setNewParticleIDs(dst_ele_tile, np_ele_dst, num_added);
         setNewParticleIDs(dst_pos_tile, np_pos_dst, num_added);

--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -132,8 +132,8 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
  * \param[in,out] dst1 the first destination tile
  * \param[in,out] dst2 the second destination tile
  * \param[in] box the box where the particles are created
- * \param[in] src_FABs An Array of Array4 (e.g. EM fields) defined on box on which
- *            the filter operation is applied/
+ * \param[in] src_FABs A collection of source data, e.g. a class with Array4 to the EM fields,
+ *            defined on box on which the filter operation is applied
  * \param[in] dst1_index the location at which to starting writing the result to dst1
  * \param[in] dst2_index the location at which to starting writing the result to dst2
  * \param[in] filter a callable returning a value > 0 if particles are to be created


### PR DESCRIPTION
Replace capture of a host-side array with unnamed members for E & B field transport with a nicely named struct that transports the Array4's as members.

This is harder to mix up and thus more self-documenting and solves an issue with NVCC 10.0.130 of the form:
```
nvcc_internal_extended_lambda_implementation: In instantiation of '__nv_dl_wrapper_t<Tag, F1, F2, F3, F4, F5>::__nv_dl_wrapper_t(F1, F2, F3, F4, F5) [with Tag = __nv_dl_tag<int (*)(amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&, amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&, amrex::Box, const amrex::Array4<const double> (&)[6], int, int, const SchwingerFilterFunc&, const SmartCreate&, const SmartCreate&, const SchwingerTransformFunc&), filterCreateTransformFromFAB<1, amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>, amrex::Array4<const double> [6], int, const SchwingerFilterFunc&, const SmartCreate&, const SmartCreate&, const SchwingerTransformFunc&>, 1>; F1 = amrex::Array4<double>; F2 = const SchwingerFilterFunc; F3 = const amrex::Array4<const double> [6]; F4 = const amrex::Box; F5 = int*]':
/home/ubuntu/repos/WarpX/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H:174:28:   required from 'Index filterCreateTransformFromFAB(DstTile&, DstTile&, amrex::Box, const FABs&, Index, Index, FilterFunc&&, CreateFunc1&&, CreateFunc2&&, TransFunc&&) [with int N = 1; DstTile = amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>; FABs = amrex::Array4<const double> [6]; Index = int; FilterFunc = const SchwingerFilterFunc&; CreateFunc1 = const SmartCreate&; CreateFunc2 = const SmartCreate&; TransFunc = const SchwingerTransformFunc&]'
/home/ubuntu/repos/WarpX/Source/Particles/MultiParticleContainer.cpp:1169:167:   required from here
nvcc_internal_extended_lambda_implementation:70:103: error: invalid initializer for array member 'const amrex::Array4<const double> __nv_dl_wrapper_t<__nv_dl_tag<int (*)(amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&, amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&, amrex::Box, const amrex::Array4<const double> (&)[6], int, int, const SchwingerFilterFunc&, const SmartCreate&, const SmartCreate&, const SchwingerTransformFunc&), filterCreateTransformFromFAB<1, amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>, amrex::Array4<const double> [6], int, const SchwingerFilterFunc&, const SmartCreate&, const SmartCreate&, const SchwingerTransformFunc&>, 1>, amrex::Array4<double>, const SchwingerFilterFunc, const amrex::Array4<const double> [6], const amrex::Box, int*>::f3 [6]'
```

Thanks to Phil Miller for the report!