### PR TITLE
openPMD: fix additional real components (e.g., optical depths)

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -699,7 +699,8 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
 
   // here we the save the SoA properties (real)
   {
-    for (auto idx=0; idx<m_NumSoARealAttributes; idx++) {
+    auto const real_counter = std::min(write_real_comp.size(), real_comp_names.size());
+    for (auto idx=0; idx<real_counter; idx++) {
       auto ii = m_NumAoSRealAttributes + idx;
       if (write_real_comp[ii]) {
         getComponentRecord(real_comp_names[ii]).storeChunk(openPMD::shareRaw(soa.GetRealData(idx)),


### PR DESCRIPTION
When using openPMD output, additional real components (such as optical depths used for QED particles) are initialized but not actually written on disk. This PR should fix the bug 🐛. 