### PR TITLE
Remove outdated abort and add LB PSATD regression test

### DIFF
--- a/Regression/Checksum/benchmarks_json/reduced_diags_loadbalancecosts_timers_psatd.json
+++ b/Regression/Checksum/benchmarks_json/reduced_diags_loadbalancecosts_timers_psatd.json
@@ -1,0 +1,24 @@
+{
+  "electrons": {
+    "particle_cpu": 0.0,
+    "particle_id": 8590000128.0,
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
+    "particle_position_x": 262144.0,
+    "particle_position_y": 262144.0,
+    "particle_position_z": 65536.0,
+    "particle_weight": 1600000000000000.0
+  },
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 0.0,
+    "Bz": 0.0,
+    "Ex": 0.0,
+    "Ey": 0.0,
+    "Ez": 0.0,
+    "jx": 0.0,
+    "jy": 0.0,
+    "jz": 0.0
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1654,6 +1654,23 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
+[reduced_diags_loadbalancecosts_timers_psatd]
+buildDir = .
+inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
+tolerance = 1e-12
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+
 [reduced_diags_loadbalancecosts_heuristic]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -57,8 +57,6 @@ WarpX::Evolve (int numsteps)
 
         amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(0);
         if (cost) {
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
-                amrex::Abort("LoadBalance for PSATD: TODO");
             if (step > 0 && load_balance_intervals.contains(step+1))
             {
                 LoadBalance();


### PR DESCRIPTION
This PR removes an outdated abort when using load balancing with PSATD, and also adds a regression test.  The test shows the expected improvement to load balancing on the regression test:
```
('load balance efficiency (before load balance): ', 0.5810276395352503)
('load balance efficiency (after load balance): ', 0.9961872159095969)
```