### PR TITLE
AMReX: CMake IntelLLVM

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -192,7 +192,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "0a50fded0df7539b5e8e32b2a88966d8d671e264"
+set(WarpX_amrex_branch "1796dd911bae1ae0b58ae92e4e023bdb00a0f44a"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR and AMReX
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout 0a50fded0df7539b5e8e32b2a88966d8d671e264 && cd -
+cd amrex && git checkout 1796dd911bae1ae0b58ae92e4e023bdb00a0f44a && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout 3a948c4eb74b5355727b27eb0a7b2a215be69610 && cd -


### PR DESCRIPTION
Just an update to support CMake 3.20+ that starts to define `IntelLLVM` for the ICX/DPC++ compiler from Intel's oneAPI.

https://github.com/AMReX-Codes/amrex/pull/1959

```
./Tools/Release/updateAMReX.py
```