### PR TITLE
Fix LoadBalance + MR: Rebuild Particle Masks

### DIFF
--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -349,7 +349,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 const IntVect& ng = current_buffer_masks[lev]->nGrowVect();
                 auto pmf = std::make_unique<iMultiFab>(current_buffer_masks[lev]->boxArray(),
                                                                     dm, current_buffer_masks[lev]->nComp(), ng);
-                // pmf->ParallelCopy(*current_buffer_masks[lev], 0, 0, current_buffer_masks[lev]->nComp(), ng, ng);
+                // we can avoid this since we immediately re-build the values via BuildBufferMasks()
+                // pmf->Redistribute(*current_buffer_masks[lev], 0, 0, current_buffer_masks[lev]->nComp(), ng);
                 current_buffer_masks[lev] = std::move(pmf);
             }
             if (gather_buffer_masks[lev])
@@ -357,9 +358,12 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 const IntVect& ng = gather_buffer_masks[lev]->nGrowVect();
                 auto pmf = std::make_unique<iMultiFab>(gather_buffer_masks[lev]->boxArray(),
                                                                     dm, gather_buffer_masks[lev]->nComp(), ng);
-                // pmf->ParallelCopy(*gather_buffer_masks[lev], 0, 0, gather_buffer_masks[lev]->nComp(), ng, ng);
+                // we can avoid this since we immediately re-build the values via BuildBufferMasks()
+                // pmf->Redistribute(*gather_buffer_masks[lev], 0, 0, gather_buffer_masks[lev]->nComp(), ng);
                 gather_buffer_masks[lev] = std::move(pmf);
             }
+            if (current_buffer_masks[lev] || gather_buffer_masks[lev])
+                BuildBufferMasks();
         }
 
         if (costs[lev] != nullptr)


### PR DESCRIPTION
In MR simulations, particle masks are used to determine if a fine-patch particle is in the field gather and/or current deposition buffer regions near the coarse/fine boundaries. This is needed because some particles deposit to / gather from the coarse level, since they are near the level boundaries.

On regriding during load-balancing, we can avoid to communicate the `MultiFab`s for those masks (gather and deposit) if we locally re-build the mask in the new distribution mapping. We forgot to trigger the rebuild, which caused illegal memory accesses in the particle evolve (partition) down the road.