### PR TITLE
Docs: Update Release Git

### DIFF
--- a/Docs/source/maintenance/release.rst
+++ b/Docs/source/maintenance/release.rst
@@ -50,6 +50,6 @@ In order to create a GitHub release, you need to:
 
     .. code-block:: sh
 
-       git log --since=<last-release-tag> | grep -A 3 "Author: " | grep -B 1 "\-\-" | sed '/--/d' | sed -e 's/^    /- /'
+       git log <last-release-tag>.. | grep -A 3 "Author: " | grep -B 1 "\-\-" | sed '/--/d' | sed -e 's/^    /- /'
 
  3. Optional/future: create a ``release-<version>`` branch, write a changelog, and backport bug-fixes for a few days.


### PR DESCRIPTION
I noticed a few releases back that the old git command did not work well with our current squash commits and/or forgot commits already before. This one fixes the recommended string in the docs.
(The releases already mention the new command for a while.)