### PR TITLE
Docs: Particle Injection in MR

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -141,6 +141,12 @@ Setting up the field mesh
     This patch is rectangular, and thus its extent is given here by the coordinates
     of the lower corner (``warpx.fine_tag_lo``) and upper corner (``warpx.fine_tag_hi``).
 
+* ``warpx.refine_plasma`` (`integer`) optional (default `0`)
+
+    Increase the number of macro-particles that are injected "ahead" of a mesh refinement patch in a moving window simulation.
+
+    Note: in development; only works with static mesh-refinement, specific to moving window plasma injection, and requires a single refined level.
+
 * ``warpx.n_current_deposition_buffer`` (`integer`)
     When using mesh refinement: the particles that are located inside
     a refinement patch, but within ``n_current_deposition_buffer`` cells of
@@ -406,8 +412,8 @@ Particle initialization
     If periodic boundary conditions are used in direction ``i``, then the default (i.e. if the range is not specified) range will be the simulation box, ``[geometry.prob_hi[i], geometry.prob_lo[i]]``.
 
 * ``<species_name>.injection_style`` (`string`)
-    Determines how the particles will be injected in the simulation.
-    The number of macro-particles per cell is always given with respect to the coarsest level (level 0/mother grid), even if particles are then immediately moved to a refined path.
+    Determines how the (macro-)particles will be injected in the simulation.
+    The number of particles per cell is always given with respect to the coarsest level (level 0/mother grid), even if particles are immediately assigned to a refined patch.
 
     The options are:
 
@@ -465,7 +471,7 @@ Particle initialization
 * ``<species_name>.do_splitting`` (`bool`) optional (default `0`)
     Split particles of the species when crossing the boundary from a lower
     resolution domain to a higher resolution domain.
-    
+
     Currently implemented on CPU only.
 
 * ``<species_name>.do_continuous_injection`` (`0` or `1`)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -407,6 +407,8 @@ Particle initialization
 
 * ``<species_name>.injection_style`` (`string`)
     Determines how the particles will be injected in the simulation.
+    The number of macro-particles per cell is always given with respect to the coarsest level (level 0/mother grid), even if particles are then immediately moved to a refined path.
+
     The options are:
 
     * ``NUniformPerCell``: injection with a fixed number of evenly-spaced particles per cell.
@@ -459,6 +461,12 @@ Particle initialization
     within a cell. Note that for RZ, the three axis are radius, theta, and z and that the recommended
     number of particles per theta is at least two times the number of azimuthal modes requested.
     (It is recommended to do a convergence scan of the number of particles per theta)
+
+* ``<species_name>.do_splitting`` (`bool`) optional (default `0`)
+    Split particles of the species when crossing the boundary from a lower
+    resolution domain to a higher resolution domain.
+    
+    Currently implemented on CPU only.
 
 * ``<species_name>.do_continuous_injection`` (`0` or `1`)
     Whether to inject particles during the simulation, and not only at
@@ -613,10 +621,6 @@ Particle initialization
 * ``<species_name>.do_backward_propagation`` (`bool`)
     Inject a backward-propagating beam to reduce the effect of charge-separation
     fields when running in the boosted frame. See examples.
-
-* ``<species_name>.do_splitting`` (`bool`) optional (default `0`)
-    Split particles of the species when crossing the boundary from a lower
-    resolution domain to a higher resolution domain.
 
 * ``<species_name>.split_type`` (`int`) optional (default `0`)
     Splitting technique. When `0`, particles are split along the simulation


### PR DESCRIPTION
Documenting what particles per cell means for our injection methods. They all call `AddParticles(lev=0)` which injects on the coarsest level.

https://github.com/ECP-WarpX/WarpX/blob/f95329cf2eae659b785be722afeea5ec028a4c87/Source/Particles/PhysicalParticleContainer.cpp#L1754
https://github.com/ECP-WarpX/WarpX/blob/f95329cf2eae659b785be722afeea5ec028a4c87/Source/Particles/PhysicalParticleContainer.cpp#L206