### PR TITLE
[WIP] Async fill boundary

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -453,8 +453,8 @@ WarpX::FillBoundaryB (IntVect ng)
     WarpX::FillBoundary_nowait( Bfield_cp, ng, PatchType::coarse );
 
     // Finalize MPI communications
-    WarpX::FillBoundary_finish( Bfield_fp );
-    WarpX::FillBoundary_finish( Bfield_cp );
+    WarpX::FillBoundary_finish( Bfield_fp, PatchType::fine );
+    WarpX::FillBoundary_finish( Bfield_cp, PatchType::coarse );
 }
 
 void
@@ -481,8 +481,8 @@ WarpX::FillBoundaryE (IntVect ng)
     WarpX::FillBoundary_nowait( Efield_cp, ng, PatchType::coarse );
 
     // Finalize MPI communications
-    WarpX::FillBoundary_finish( Efield_fp );
-    WarpX::FillBoundary_finish( Efield_cp );
+    WarpX::FillBoundary_finish( Efield_fp, PatchType::fine );
+    WarpX::FillBoundary_finish( Efield_cp, PatchType::coarse );
 }
 
 void
@@ -498,7 +498,7 @@ WarpX::FillBoundary_nowait(
         // Loop over vector components
         for (int idim=0; idim < 3; ++idim) {
             // Check that MultiFab exists at this level
-            if (vector_mf[lev][idim]) {
+            if ( patch_type==PatchType::fine || lev > 0 ) {
                 // Launch asynchronous MPI communication
                 if ( safe_guard_cells ){
                     vector_mf[lev][idim]->FillBoundary_nowait(period);
@@ -514,14 +514,16 @@ WarpX::FillBoundary_nowait(
 }
 
 void
-WarpX::FillBoundary_finish( Vector<std::array< std::unique_ptr<MultiFab>, 3 > >& vector_mf )
+WarpX::FillBoundary_finish(
+    Vector<std::array< std::unique_ptr<MultiFab>, 3 > >& vector_mf,
+    PatchType patch_type )
 {
     // Loop through levels
     for (int lev = 0; lev <= finest_level; ++lev) {
         // Loop over vector components
         for (int idim=0; idim < 3; ++idim) {
             // Check that MultiFab exists at this level
-            if (vector_mf[lev][idim]) {
+            if ( patch_type==PatchType::fine || lev > 0 ) {
                 // Finalize asynchronous MPI communication
                 vector_mf[lev][idim]->FillBoundary_finish();
             }
@@ -546,8 +548,8 @@ WarpX::FillBoundaryB_avg (IntVect ng)
     WarpX::FillBoundary_nowait( Bfield_avg_cp, ng, PatchType::coarse );
 
     // Finalize MPI communications
-    WarpX::FillBoundary_finish( Bfield_avg_fp );
-    WarpX::FillBoundary_finish( Bfield_avg_cp );
+    WarpX::FillBoundary_finish( Bfield_avg_fp, PatchType::fine );
+    WarpX::FillBoundary_finish( Bfield_avg_cp, PatchType::coarse );
 }
 
 void
@@ -558,8 +560,8 @@ WarpX::FillBoundaryE_avg (IntVect ng)
     WarpX::FillBoundary_nowait( Efield_avg_cp, ng, PatchType::coarse );
 
     // Finalize MPI communications
-    WarpX::FillBoundary_finish( Efield_avg_fp );
-    WarpX::FillBoundary_finish( Efield_avg_cp );
+    WarpX::FillBoundary_finish( Efield_avg_fp, PatchType::fine );
+    WarpX::FillBoundary_finish( Efield_avg_cp, PatchType::coarse );
 }
 
 
@@ -743,8 +745,8 @@ WarpX::FillBoundaryAux (IntVect ng)
     WarpX::FillBoundary_nowait( Bfield_aux, ng, PatchType::fine );
 
     // Finalize MPI communications
-    WarpX::FillBoundary_finish( Efield_aux );
-    WarpX::FillBoundary_finish( Bfield_aux );
+    WarpX::FillBoundary_finish( Efield_aux, PatchType::fine );
+    WarpX::FillBoundary_finish( Bfield_aux, PatchType::fine );
 }
 
 void

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -738,22 +738,13 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng)
 void
 WarpX::FillBoundaryAux (IntVect ng)
 {
-    for (int lev = 0; lev <= finest_level-1; ++lev)
-    {
-        FillBoundaryAux(lev, ng);
-    }
-}
+    // Launch asynchronous MPI communications
+    WarpX::FillBoundary_nowait( Efield_aux, ng, PatchType::fine );
+    WarpX::FillBoundary_nowait( Bfield_aux, ng, PatchType::fine );
 
-void
-WarpX::FillBoundaryAux (int lev, IntVect ng)
-{
-    const auto& period = Geom(lev).periodicity();
-    Efield_aux[lev][0]->FillBoundary(ng, period);
-    Efield_aux[lev][1]->FillBoundary(ng, period);
-    Efield_aux[lev][2]->FillBoundary(ng, period);
-    Bfield_aux[lev][0]->FillBoundary(ng, period);
-    Bfield_aux[lev][1]->FillBoundary(ng, period);
-    Bfield_aux[lev][2]->FillBoundary(ng, period);
+    // Finalize MPI communications
+    WarpX::FillBoundary_finish( Efield_aux );
+    WarpX::FillBoundary_finish( Bfield_aux );
 }
 
 void

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -492,13 +492,13 @@ WarpX::FillBoundary_nowait(
 {
     // Loop through levels
     for (int lev = 0; lev <= finest_level; ++lev) {
-        // Extract periodicity
-        const auto& period = (patch_type==PatchType::coarse)?
-            Geom(lev-1).periodicity() :  Geom(lev).periodicity();
-        // Loop over vector components
-        for (int idim=0; idim < 3; ++idim) {
-            // Check that MultiFab exists at this level
-            if ( patch_type==PatchType::fine || lev > 0 ) {
+        // Check that MultiFab exists at this level
+        if ( patch_type==PatchType::fine || lev > 0 ) {
+            // Extract periodicity
+            const auto& period = (patch_type==PatchType::coarse)?
+                Geom(lev-1).periodicity() :  Geom(lev).periodicity();
+            // Loop over vector components
+            for (int idim=0; idim < 3; ++idim) {
                 // Launch asynchronous MPI communication
                 if ( safe_guard_cells ){
                     vector_mf[lev][idim]->FillBoundary_nowait(period);
@@ -520,10 +520,10 @@ WarpX::FillBoundary_finish(
 {
     // Loop through levels
     for (int lev = 0; lev <= finest_level; ++lev) {
-        // Loop over vector components
-        for (int idim=0; idim < 3; ++idim) {
-            // Check that MultiFab exists at this level
-            if ( patch_type==PatchType::fine || lev > 0 ) {
+        // Check that MultiFab exists at this level
+        if ( patch_type==PatchType::fine || lev > 0 ) {
+            // Loop over vector components
+            for (int idim=0; idim < 3; ++idim) {
                 // Finalize asynchronous MPI communication
                 vector_mf[lev][idim]->FillBoundary_finish();
             }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -472,7 +472,8 @@ public:
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& vector_mf,
         amrex::IntVect ng, PatchType patch_type );
     void FillBoundary_finish(
-        amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& vector_mf );
+        amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& vector_mf,
+        PatchType patch_type );
 
 
     void FillBoundaryF   (amrex::IntVect ng);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -468,6 +468,13 @@ public:
     void FillBoundaryB_avg   (amrex::IntVect ng);
     void FillBoundaryE_avg   (amrex::IntVect ng);
 
+    void FillBoundary_nowait(
+        amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& vector_mf,
+        amrex::IntVect ng, PatchType patch_type );
+    void FillBoundary_finish(
+        amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& vector_mf );
+
+
     void FillBoundaryF   (amrex::IntVect ng);
     void FillBoundaryAux (amrex::IntVect ng);
     void FillBoundaryE   (int lev, amrex::IntVect ng);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -479,11 +479,7 @@ public:
     void FillBoundaryAux (amrex::IntVect ng);
     void FillBoundaryE   (int lev, amrex::IntVect ng);
     void FillBoundaryB   (int lev, amrex::IntVect ng);
-    void FillBoundaryE_avg   (int lev, amrex::IntVect ng);
-    void FillBoundaryB_avg   (int lev, amrex::IntVect ng);
-
     void FillBoundaryF   (int lev, amrex::IntVect ng);
-    void FillBoundaryAux (int lev, amrex::IntVect ng);
 
     void SyncCurrent ();
     void SyncRho ();


### PR DESCRIPTION
This implements asynchronous FillBoundary for several fields, whereby the difference components of a vector (x, y, z) and the different refinement levels are all sent simultaneously with FillBoundary_nowait, and then all collected with FillBoundary_finish.