### PR TITLE
Remove embedded boundary test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2002,19 +2002,3 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/resampling/analysis_leveling_thinning.py
-
-[embedded_boundary_cube]
-buildDir = .
-inputFile = Examples/Modules/embedded_boundary_cube/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString = USE_EB=TRUE
-restartTest = 0
-useMPI = 1
-numprocs = 4
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0s
-analysisRoutine = Examples/Modules/embedded_boundary_cube/analysis_fields.py


### PR DESCRIPTION
This removes the CI embedded boundary test, in order to fix a time-out issue.

This test will be added again in #1921.