### PR TITLE
[mini-PR] Update AMReX version to fix EB+single precision bug

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -192,7 +192,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "1796dd911bae1ae0b58ae92e4e023bdb00a0f44a"
+set(WarpX_amrex_branch "e6833a86ebf35861017cfd5f16ca66ac9dc8b7ae"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 


### PR DESCRIPTION
In order to compiler WarpX in single precision with EB support we need to update the AMReX version fetched by cmake (it must include  https://github.com/AMReX-Codes/amrex/pull/1972 )