### PR TITLE
Add generic field reduction reduced diag

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1812,6 +1812,9 @@ Reduced Diagnostics
         :math:`E` field energy,
         :math:`B` field energy, at mesh refinement levels from 0 to :math:`n`.
 
+        Note that the fields are *not* averaged on the cell centers before their energy is
+        computed.
+
     * ``FieldMaximum``
         This type computes the maximum value of each component of the electric and magnetic fields
         and of the norm of the electric and magnetic field vectors.
@@ -1844,6 +1847,25 @@ Reduced Diagnostics
 
         Note that the charge densities are averaged on the cell centers before their maximum values
         are computed.
+
+    * ``FieldReduction``
+        This type computes an arbitrary reduction of the positions and the electromagnetic fields.
+
+        * ``<reduced_diags_name>.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz)`` (`string`)
+            An analytic function to be reduced must be provided, using the math parser.
+
+        * ``<reduced_diags_name>.reduction_type`` (`string`)
+            The type of reduction to be performed. It must be either ``Maximum``, ``Minimum`` or
+            ``Sum``.
+            Note that if ``Sum`` is used, the quantity to be reduced is multiplied by the volume of
+            a cell, so that the result is an integration over the simulation domain rather than
+            simply a sum of the values on the grid points.
+            Please be also aware that measuring maximum quantities might be very noisy in PIC
+            simulations.
+
+        The only output column is the reduced value.
+
+        Note that the fields are averaged on the cell centers before the reduction is performed.
 
     * ``ParticleNumber``
         This type computes the total number of macroparticles and of physical particles (i.e. the

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -343,6 +343,7 @@ q_e      elementary charge
 m_e      electron mass
 m_p      proton mass
 epsilon0 vacuum permittivity
+mu0      vacuum permeability
 clight   speed of light
 pi       math constant pi
 ======== ===================
@@ -1856,10 +1857,10 @@ Reduced Diagnostics
 
         * ``<reduced_diags_name>.reduction_type`` (`string`)
             The type of reduction to be performed. It must be either ``Maximum``, ``Minimum`` or
-            ``Sum``.
-            Note that if ``Sum`` is used, the quantity to be reduced is multiplied by the volume of
-            a cell, so that the result is an integration over the simulation domain rather than
-            simply a sum of the values on the grid points.
+            ``Integral``.
+            ``Integral`` computes the spatial integral of the function defined in the parser by
+            summing its value on all grid points and multiplying the result by the volume of a
+            cell.
             Please be also aware that measuring maximum quantities might be very noisy in PIC
             simulations.
 

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -91,6 +91,9 @@ Bz = ad['Bz'].to_ndarray()
 rho = ad['rho'].to_ndarray()
 rho_electrons = ad['rho_electrons'].to_ndarray()
 rho_protons = ad['rho_protons'].to_ndarray()
+x = ad['x'].to_ndarray()
+y = ad['y'].to_ndarray()
+z = ad['z'].to_ndarray()
 
 # Field energy
 E2 = np.sum(Ex**2) + np.sum(Ey**2) + np.sum(Ez**2)
@@ -99,19 +102,26 @@ N  = np.array(ds.domain_width / ds.domain_dimensions)
 dV = N[0] * N[1] * N[2]
 values_yt['field energy'] = 0.5 * dV * (E2 * eps0 + B2 / mu0)
 
+# Field energy in quarter of simulation domain
+E2 = np.sum((Ex**2 + Ey**2 + Ez**2)*(y > 0)*(z < 0))
+B2 = np.sum((Bx**2 + By**2 + Bz**2)*(y > 0)*(z < 0))
+values_yt['field energy in quarter of simulation domain'] = 0.5 * dV * (E2 * eps0 + B2 / mu0)
+
 # Max/min values of various grid quantities
-values_yt['maximum of Ex'] = np.amax(np.abs(Ex))
-values_yt['maximum of Ey'] = np.amax(np.abs(Ey))
-values_yt['maximum of Ez'] = np.amax(np.abs(Ez))
-values_yt['maximum of Bx'] = np.amax(np.abs(Bx))
-values_yt['maximum of By'] = np.amax(np.abs(By))
-values_yt['maximum of Bz'] = np.amax(np.abs(Bz))
+values_yt['maximum of |Ex|'] = np.amax(np.abs(Ex))
+values_yt['maximum of |Ey|'] = np.amax(np.abs(Ey))
+values_yt['maximum of |Ez|'] = np.amax(np.abs(Ez))
+values_yt['maximum of |Bx|'] = np.amax(np.abs(Bx))
+values_yt['maximum of |By|'] = np.amax(np.abs(By))
+values_yt['maximum of |Bz|'] = np.amax(np.abs(Bz))
 values_yt['maximum of |E|'] = np.amax(np.sqrt(Ex**2 + Ey**2 + Ez**2))
 values_yt['maximum of |B|'] = np.amax(np.sqrt(Bx**2 + By**2 + Bz**2))
 values_yt['maximum of rho'] = np.amax(rho)
 values_yt['minimum of rho'] = np.amin(rho)
 values_yt['electrons: maximum of |rho|'] = np.amax(np.abs(rho_electrons))
 values_yt['protons: maximum of |rho|'] = np.amax(np.abs(rho_protons))
+values_yt['maximum of |B| from generic field reduction'] = np.amax(np.sqrt(Bx**2 + By**2 + Bz**2))
+values_yt['minimum of x*Ey*Bz'] = np.amin(x*Ey*Bz)
 
 #--------------------------------------------------------------------------------------------------
 # Part 2: get results from reduced diagnostics (label '_rd')
@@ -126,17 +136,21 @@ EPdata = np.genfromtxt('./diags/reducedfiles/EP.txt')  # Particle energy
 MFdata = np.genfromtxt('./diags/reducedfiles/MF.txt')  # Field maximum
 MRdata = np.genfromtxt('./diags/reducedfiles/MR.txt')  # Rho maximum
 NPdata = np.genfromtxt('./diags/reducedfiles/NP.txt')  # Particle number
+FR_Maxdata = np.genfromtxt('./diags/reducedfiles/FR_Max.txt')  # Field Reduction using maximum
+FR_Mindata = np.genfromtxt('./diags/reducedfiles/FR_Min.txt')  # Field Reduction using minimum
+FR_Sumdata = np.genfromtxt('./diags/reducedfiles/FR_Sum.txt')  # Field Reduction using sum
 
 # First index "1" points to the values written at the last time step
 values_rd['field energy'] = EFdata[1][2]
+values_rd['field energy in quarter of simulation domain'] = FR_Sumdata[1][2]
 values_rd['particle energy'] = EPdata[1][2]
-values_rd['maximum of Ex'] = MFdata[1][2]
-values_rd['maximum of Ey'] = MFdata[1][3]
-values_rd['maximum of Ez'] = MFdata[1][4]
+values_rd['maximum of |Ex|'] = MFdata[1][2]
+values_rd['maximum of |Ey|'] = MFdata[1][3]
+values_rd['maximum of |Ez|'] = MFdata[1][4]
 values_rd['maximum of |E|'] = MFdata[1][5]
-values_rd['maximum of Bx'] = MFdata[1][6]
-values_rd['maximum of By'] = MFdata[1][7]
-values_rd['maximum of Bz'] = MFdata[1][8]
+values_rd['maximum of |Bx|'] = MFdata[1][6]
+values_rd['maximum of |By|'] = MFdata[1][7]
+values_rd['maximum of |Bz|'] = MFdata[1][8]
 values_rd['maximum of |B|'] = MFdata[1][9]
 values_rd['maximum of rho'] = MRdata[1][2]
 values_rd['minimum of rho'] = MRdata[1][3]
@@ -150,6 +164,8 @@ values_rd['sum of weights'] = NPdata[1][6]
 values_rd['electrons: sum of weights'] = NPdata[1][7]
 values_rd['protons: sum of weights'] = NPdata[1][8]
 values_rd['photons: sum of weights'] = NPdata[1][9]
+values_rd['maximum of |B| from generic field reduction'] = FR_Maxdata[1][2]
+values_rd['minimum of x*Ey*Bz'] = FR_Mindata[1][2]
 
 #--------------------------------------------------------------------------------------------------
 # Part 3: compare values from plotfiles and reduced diagnostics and print output
@@ -160,7 +176,7 @@ tolerance = 1e-12
 field_energy_tolerance = 0.3
 
 # The comparison of field energies requires a large tolerance,
-# possibly because the field energy from the plotfiles is computed from cell-centered data,
+# because the field energy from the plotfiles is computed from cell-centered data,
 # while the field energy from the reduced diagnostics is computed from (Yee) staggered data.
 for k in values_yt.keys():
     print()

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -138,11 +138,11 @@ MRdata = np.genfromtxt('./diags/reducedfiles/MR.txt')  # Rho maximum
 NPdata = np.genfromtxt('./diags/reducedfiles/NP.txt')  # Particle number
 FR_Maxdata = np.genfromtxt('./diags/reducedfiles/FR_Max.txt')  # Field Reduction using maximum
 FR_Mindata = np.genfromtxt('./diags/reducedfiles/FR_Min.txt')  # Field Reduction using minimum
-FR_Sumdata = np.genfromtxt('./diags/reducedfiles/FR_Sum.txt')  # Field Reduction using sum
+FR_Integraldata = np.genfromtxt('./diags/reducedfiles/FR_Integral.txt')  # Field Reduction using integral
 
 # First index "1" points to the values written at the last time step
 values_rd['field energy'] = EFdata[1][2]
-values_rd['field energy in quarter of simulation domain'] = FR_Sumdata[1][2]
+values_rd['field energy in quarter of simulation domain'] = FR_Integraldata[1][2]
 values_rd['particle energy'] = EPdata[1][2]
 values_rd['maximum of |Ex|'] = MFdata[1][2]
 values_rd['maximum of |Ey|'] = MFdata[1][3]

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -68,7 +68,7 @@ photons.uz_th = 0.2
 #################################
 ###### REDUCED DIAGS ############
 #################################
-warpx.reduced_diags_names = EP NP EF MF MR
+warpx.reduced_diags_names = EP NP EF MF MR FR_Max FR_Min FR_Sum
 EP.type = ParticleEnergy
 EP.intervals = 200
 EF.type = FieldEnergy
@@ -79,6 +79,21 @@ MR.type = RhoMaximum
 MR.intervals = 200
 NP.type = ParticleNumber
 NP.intervals = 200
+FR_Max.type = FieldReduction
+FR_Max.intervals = 200
+FR_Max.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = sqrt(Bx**2 + By**2 + Bz**2)
+FR_Max.reduction_type = Maximum
+FR_Min.type = FieldReduction
+FR_Min.intervals = 200
+FR_Min.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = x*Ey*Bz
+FR_Min.reduction_type = Minimum
+FR_Sum.type = FieldReduction
+FR_Sum.intervals = 200
+FR_Sum.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = "((y > 0)*(z < 0)) *
+                              (0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0))"
+FR_Sum.reduction_type = Sum
+
+my_constants.mu0 = 1.25663706212e-06
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -68,7 +68,7 @@ photons.uz_th = 0.2
 #################################
 ###### REDUCED DIAGS ############
 #################################
-warpx.reduced_diags_names = EP NP EF MF MR FR_Max FR_Min FR_Sum
+warpx.reduced_diags_names = EP NP EF MF MR FR_Max FR_Min FR_Integral
 EP.type = ParticleEnergy
 EP.intervals = 200
 EF.type = FieldEnergy

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -87,13 +87,11 @@ FR_Min.type = FieldReduction
 FR_Min.intervals = 200
 FR_Min.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = x*Ey*Bz
 FR_Min.reduction_type = Minimum
-FR_Sum.type = FieldReduction
-FR_Sum.intervals = 200
-FR_Sum.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = "((y > 0)*(z < 0)) *
+FR_Integral.type = FieldReduction
+FR_Integral.intervals = 200
+FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = "((y > 0)*(z < 0)) *
                               (0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0))"
-FR_Sum.reduction_type = Sum
-
-my_constants.mu0 = 1.25663706212e-06
+FR_Integral.reduction_type = Integral
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.H
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.H
@@ -18,15 +18,19 @@ class BeamRelevant : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     BeamRelevant(std::string rd_name);
 
     /// name of beam species
     std::string m_beam_name;
 
-    /** This function computes beam relevant quantites.
-     *  \param [in] step current time step
+    /**
+     * This function computes beam relevant quantites.
+     *
+     * @param[in] step current time step
      */
     virtual void ComputeDiags(int step) override final;
 

--- a/Source/Diagnostics/ReducedDiags/CMakeLists.txt
+++ b/Source/Diagnostics/ReducedDiags/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(WarpX
     ParticleExtrema.cpp
     RhoMaximum.cpp
     ParticleNumber.cpp
+    FieldReduction.cpp
 )

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.H
@@ -19,16 +19,22 @@ class FieldEnergy : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     FieldEnergy(std::string rd_name);
 
-    /** This function computes the field energy (EF).
-     *  EF = E eps / 2 + B / mu / 2,
-     *  where E is the electric field,
-     *  B is the magnetic field,
-     *  eps is the vacuum permittivity,
-     *  mu is the vacuum permeability. */
+    /**
+     * This function computes the field energy (EF).
+     * EF = E eps / 2 + B / mu / 2,
+     * where E is the electric field,
+     * B is the magnetic field,
+     * eps is the vacuum permittivity,
+     * mu is the vacuum permeability.
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) override final;
 
 };

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.H
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.H
@@ -18,11 +18,17 @@ class FieldMaximum : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     FieldMaximum(std::string rd_name);
 
-    /** This function computes the maximum value of Ex, Ey, Ez, |E|, Bx, By, Bz and |B| */
+    /**
+     * This function computes the maximum value of Ex, Ey, Ez, |E|, Bx, By, Bz and |B|
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) override final;
 
 };

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -147,12 +147,14 @@ void FieldMaximum::ComputeDiags (int step)
         using ReduceTuple = typename decltype(reduceEx_data)::Type;
 
         // Prepare interpolation of field components to cell center
-        GpuArray<int,3> Extype;
-        GpuArray<int,3> Eytype;
-        GpuArray<int,3> Eztype;
-        GpuArray<int,3> Bxtype;
-        GpuArray<int,3> Bytype;
-        GpuArray<int,3> Bztype;
+        // The arrays below store the index type (staggering) of each MultiFab, with the third
+        // component set to zero in the two-dimensional case.
+        auto Extype = amrex::GpuArray<int,3>{0,0,0};
+        auto Eytype = amrex::GpuArray<int,3>{0,0,0};
+        auto Eztype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bxtype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bytype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bztype = amrex::GpuArray<int,3>{0,0,0};
         for (int i = 0; i < AMREX_SPACEDIM; ++i){
             Extype[i] = Ex.ixType()[i];
             Eytype[i] = Ey.ixType()[i];
@@ -161,14 +163,6 @@ void FieldMaximum::ComputeDiags (int step)
             Bytype[i] = By.ixType()[i];
             Bztype[i] = Bz.ixType()[i];
         }
-#if   (AMREX_SPACEDIM == 2)
-        Extype[2] = 0;
-        Eytype[2] = 0;
-        Eztype[2] = 0;
-        Bxtype[2] = 0;
-        Bytype[2] = 0;
-        Bztype[2] = 0;
-#endif
 
         // MFIter loop to interpolate fields to cell center and get maximum values
 #ifdef AMREX_USE_OMP
@@ -176,7 +170,8 @@ void FieldMaximum::ComputeDiags (int step)
 #endif
         for ( MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
-            // Make the box cell centered to avoid including ghost cells in the calculation
+            // Make the box cell centered in preparation for the interpolation (and to avoid
+            // including ghost cells in the calculation)
             const Box& box = enclosedCells(mfi.nodaltilebox());
             const auto& arrEx = Ex[mfi].array();
             const auto& arrEy = Ey[mfi].array();

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -28,9 +28,9 @@ FieldMaximum::FieldMaximum (std::string rd_name)
     pp_amr.query("max_level", nLevel);
     nLevel += 1;
 
-    constexpr int noutputs = 8; // total energy, E-field energy and B-field energy
+    constexpr int noutputs = 8;  // max of Ex,Ey,Ez,|E|,Bx,By,Bz and |B|
     // resize data array
-    m_data.resize(noutputs*nLevel, 0.0_rt); // max of Ex,Ey,Ez,|E|,Bx,By,Bz and |B|
+    m_data.resize(noutputs*nLevel, 0.0_rt);
 
     if (ParallelDescriptor::IOProcessor())
     {

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -39,6 +39,8 @@ private:
     // Type of reduction (e.g. Maximum, Minimum or Sum)
     int m_reduction_type;
 
+public:
+
     /** This function does the actual reduction computation. The fields are first interpolated on
      *  the cell centers and the reduction operation is then performed using amrex::ReduceOps.
      *

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -28,7 +28,7 @@ public:
     FieldReduction(std::string rd_name);
 
     /**
-     * This function is called at everytime step, and if necessary calls the templated function
+     * This function is called at every time step, and if necessary calls the templated function
      * ComputeFieldReduction(), which does the actual reduction computation.
      *
      * @param[in] step the timestep

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -21,12 +21,17 @@ class FieldReduction : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     *  constructor
+     *  @param[in] rd_name reduced diags names 
+     */
     FieldReduction(std::string rd_name);
 
-    /** This function is called at everytime step, and if necessary calls the templated function
+    /**
+     * This function is called at everytime step, and if necessary calls the templated function
      *  ComputeFieldReduction(), which does the actual reduction computation.
+     *
+     * @param[in] step the timestep
      */
     virtual void ComputeDiags(int step) override final;
 
@@ -41,7 +46,8 @@ private:
 
 public:
 
-    /** This function does the actual reduction computation. The fields are first interpolated on
+    /** 
+     * This function does the actual reduction computation. The fields are first interpolated on
      *  the cell centers and the reduction operation is then performed using amrex::ReduceOps.
      *
      * \tparam T the type of reduction that is performed. This is typically amrex::ReduceOpMax,
@@ -176,7 +182,7 @@ public:
         // Fill output array
         m_data[0] = reduce_value;
 
-        // m_data now contains an up to date value of the reduced field quantity
+        // m_data now contains an up-to-date value of the reduced field quantity
     }
 
 };

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -13,23 +13,23 @@
 #include "Utils/CoarsenIO.H"
 
 /**
- *  This class contains a function that computes an arbitrary reduction of the fields. The function
- *  used in the reduction is defined by an input file parser expression and the reduction operation
- *  can be either Maximum, Minimum, or Sum.
+ * This class contains a function that computes an arbitrary reduction of the fields. The function
+ * used in the reduction is defined by an input file parser expression and the reduction operation
+ * can be either Maximum, Minimum, or Integral (Sum multiplied by cell volume).
  */
 class FieldReduction : public ReducedDiags
 {
 public:
 
     /**
-     *  constructor
-     *  @param[in] rd_name reduced diags names 
+     * constructor
+     * @param[in] rd_name reduced diags names
      */
     FieldReduction(std::string rd_name);
 
     /**
      * This function is called at everytime step, and if necessary calls the templated function
-     *  ComputeFieldReduction(), which does the actual reduction computation.
+     * ComputeFieldReduction(), which does the actual reduction computation.
      *
      * @param[in] step the timestep
      */
@@ -46,14 +46,14 @@ private:
 
 public:
 
-    /** 
+    /**
      * This function does the actual reduction computation. The fields are first interpolated on
-     *  the cell centers and the reduction operation is then performed using amrex::ReduceOps.
+     * the cell centers and the reduction operation is then performed using amrex::ReduceOps.
      *
-     * \tparam T the type of reduction that is performed. This is typically amrex::ReduceOpMax,
-     *         amrex::ReduceOpMin or amrex::ReduceOpSum.
+     * \tparam ReduceOp the type of reduction that is performed. This is typically
+     *         amrex::ReduceOpMax, amrex::ReduceOpMin or amrex::ReduceOpSum.
      */
-    template<typename T>
+    template<typename ReduceOp>
     void ComputeFieldReduction()
     {
         using namespace amrex::literals;
@@ -80,17 +80,19 @@ public:
         const amrex::GpuArray<int,3> reduction_coarsening_ratio{1,1,1};
         constexpr int reduction_comp = 0;
 
-        amrex::ReduceOps<T> reduce_op;
+        amrex::ReduceOps<ReduceOp> reduce_op;
         amrex::ReduceData<amrex::Real> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
 
         // Prepare interpolation of field components to cell center
-        amrex::GpuArray<int,3> Extype;
-        amrex::GpuArray<int,3> Eytype;
-        amrex::GpuArray<int,3> Eztype;
-        amrex::GpuArray<int,3> Bxtype;
-        amrex::GpuArray<int,3> Bytype;
-        amrex::GpuArray<int,3> Bztype;
+        // The arrays below store the index type (staggering) of each MultiFab, with the third
+        // component set to zero in the two-dimensional case.
+        auto Extype = amrex::GpuArray<int,3>{0,0,0};
+        auto Eytype = amrex::GpuArray<int,3>{0,0,0};
+        auto Eztype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bxtype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bytype = amrex::GpuArray<int,3>{0,0,0};
+        auto Bztype = amrex::GpuArray<int,3>{0,0,0};
         for (int i = 0; i < AMREX_SPACEDIM; ++i){
             Extype[i] = Ex.ixType()[i];
             Eytype[i] = Ey.ixType()[i];
@@ -99,14 +101,6 @@ public:
             Bytype[i] = By.ixType()[i];
             Bztype[i] = Bz.ixType()[i];
         }
-#if   (AMREX_SPACEDIM == 2)
-        Extype[2] = 0;
-        Eytype[2] = 0;
-        Eztype[2] = 0;
-        Bxtype[2] = 0;
-        Bytype[2] = 0;
-        Bztype[2] = 0;
-#endif
 
         // get parser
         HostDeviceParser<m_nvars> reduction_function_parser = getParser(m_parser);
@@ -117,7 +111,8 @@ public:
 #endif
         for ( amrex::MFIter mfi(Ex, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
-            // Make the box cell centered to avoid including ghost cells in the calculation
+            // Make the box cell centered in preparation for the interpolation (and to avoid
+            // including ghost cells in the calculation)
             const amrex::Box& box = enclosedCells(mfi.nodaltilebox());
             const auto& arrEx = Ex[mfi].array();
             const auto& arrEy = Ey[mfi].array();
@@ -158,20 +153,19 @@ public:
         amrex::Real reduce_value = amrex::get<0>(reduce_data.value());
 
         // MPI reduce
-        if (std::is_same<T, amrex::ReduceOpMax>::value)
+        if (std::is_same<ReduceOp, amrex::ReduceOpMax>::value)
         {
             amrex::ParallelDescriptor::ReduceRealMax(reduce_value);
         }
-        if (std::is_same<T, amrex::ReduceOpMin>::value)
+        if (std::is_same<ReduceOp, amrex::ReduceOpMin>::value)
         {
             amrex::ParallelDescriptor::ReduceRealMin(reduce_value);
         }
-        if (std::is_same<T, amrex::ReduceOpSum>::value)
+        if (std::is_same<ReduceOp, amrex::ReduceOpSum>::value)
         {
             amrex::ParallelDescriptor::ReduceRealSum(reduce_value);
         // If reduction operation is a sum, multiply the value by the cell volume so that the
-        // result is an integration over the simulation domain rather than simply a sum of the
-        // values on the grid points.
+        // result is the integral of the function over the simulation domain.
 #if (AMREX_SPACEDIM==2)
             reduce_value *= dx[0]*dx[1];
 #else

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -1,0 +1,182 @@
+/* Copyright 2021 Neil Zaim
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_FIELDREDUCTION_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_FIELDREDUCTION_H_
+
+#include "ReducedDiags.H"
+#include "WarpX.H"
+#include "Utils/CoarsenIO.H"
+
+/**
+ *  This class contains a function that computes an arbitrary reduction of the fields. The function
+ *  used in the reduction is defined by an input file parser expression and the reduction operation
+ *  can be either Maximum, Minimum, or Sum.
+ */
+class FieldReduction : public ReducedDiags
+{
+public:
+
+    /** constructor
+     *  @param[in] rd_name reduced diags names */
+    FieldReduction(std::string rd_name);
+
+    /** This function is called at everytime step, and if necessary calls the templated function
+     *  ComputeFieldReduction(), which does the actual reduction computation.
+     */
+    virtual void ComputeDiags(int step) override final;
+
+private:
+    /// Parser to read expression to be reduced from the input file.
+    /// 9 elements are x, y, z, Ex, Ey, Ez, Bx, By, Bz
+    static constexpr int m_nvars = 9;
+    std::unique_ptr<ParserWrapper<m_nvars>> m_parser;
+
+    // Type of reduction (e.g. Maximum, Minimum or Sum)
+    int m_reduction_type;
+
+    /** This function does the actual reduction computation. The fields are first interpolated on
+     *  the cell centers and the reduction operation is then performed using amrex::ReduceOps.
+     *
+     * \tparam T the type of reduction that is performed. This is typically amrex::ReduceOpMax,
+     *         amrex::ReduceOpMin or amrex::ReduceOpSum.
+     */
+    template<typename T>
+    void ComputeFieldReduction()
+    {
+        using namespace amrex::literals;
+
+        // get a reference to WarpX instance
+        auto & warpx = WarpX::GetInstance();
+
+        constexpr int lev = 0; // This reduced diag currently does not work with mesh refinement
+
+        amrex::Geometry const & geom = warpx.Geom(lev);
+        const amrex::RealBox& real_box = geom.ProbDomain();
+        const auto dx = geom.CellSizeArray();
+
+        // get MultiFab data
+        const amrex::MultiFab & Ex = warpx.getEfield(lev,0);
+        const amrex::MultiFab & Ey = warpx.getEfield(lev,1);
+        const amrex::MultiFab & Ez = warpx.getEfield(lev,2);
+        const amrex::MultiFab & Bx = warpx.getBfield(lev,0);
+        const amrex::MultiFab & By = warpx.getBfield(lev,1);
+        const amrex::MultiFab & Bz = warpx.getBfield(lev,2);
+
+        // General preparation of interpolation and reduction operations
+        const amrex::GpuArray<int,3> cellCenteredtype{0,0,0};
+        const amrex::GpuArray<int,3> reduction_coarsening_ratio{1,1,1};
+        constexpr int reduction_comp = 0;
+
+        amrex::ReduceOps<T> reduce_op;
+        amrex::ReduceData<amrex::Real> reduce_data(reduce_op);
+        using ReduceTuple = typename decltype(reduce_data)::Type;
+
+        // Prepare interpolation of field components to cell center
+        amrex::GpuArray<int,3> Extype;
+        amrex::GpuArray<int,3> Eytype;
+        amrex::GpuArray<int,3> Eztype;
+        amrex::GpuArray<int,3> Bxtype;
+        amrex::GpuArray<int,3> Bytype;
+        amrex::GpuArray<int,3> Bztype;
+        for (int i = 0; i < AMREX_SPACEDIM; ++i){
+            Extype[i] = Ex.ixType()[i];
+            Eytype[i] = Ey.ixType()[i];
+            Eztype[i] = Ez.ixType()[i];
+            Bxtype[i] = Bx.ixType()[i];
+            Bytype[i] = By.ixType()[i];
+            Bztype[i] = Bz.ixType()[i];
+        }
+#if   (AMREX_SPACEDIM == 2)
+        Extype[2] = 0;
+        Eytype[2] = 0;
+        Eztype[2] = 0;
+        Bxtype[2] = 0;
+        Bytype[2] = 0;
+        Bztype[2] = 0;
+#endif
+
+        // get parser
+        HostDeviceParser<m_nvars> reduction_function_parser = getParser(m_parser);
+
+        // MFIter loop to interpolate fields to cell center and perform reduction
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for ( amrex::MFIter mfi(Ex, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            // Make the box cell centered to avoid including ghost cells in the calculation
+            const amrex::Box& box = enclosedCells(mfi.nodaltilebox());
+            const auto& arrEx = Ex[mfi].array();
+            const auto& arrEy = Ey[mfi].array();
+            const auto& arrEz = Ez[mfi].array();
+            const auto& arrBx = Bx[mfi].array();
+            const auto& arrBy = By[mfi].array();
+            const auto& arrBz = Bz[mfi].array();
+
+            reduce_op.eval(box, reduce_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                 // 0.5 is here because position are computed on the cell centers
+                const amrex::Real x = (i + 0.5_rt)*dx[0] + real_box.lo(0);
+#if (AMREX_SPACEDIM==2)
+                const amrex::Real y = 0._rt;
+                const amrex::Real z = (j + 0.5_rt)*dx[1] + real_box.lo(1);
+#else
+                const amrex::Real y = (j + 0.5_rt)*dx[1] + real_box.lo(1);
+                const amrex::Real z = (k + 0.5_rt)*dx[2] + real_box.lo(2);
+#endif
+                const amrex::Real Ex_interp = CoarsenIO::Interp(arrEx, Extype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real Ey_interp = CoarsenIO::Interp(arrEy, Eytype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real Ez_interp = CoarsenIO::Interp(arrEz, Eztype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real Bx_interp = CoarsenIO::Interp(arrBx, Bxtype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real By_interp = CoarsenIO::Interp(arrBy, Bytype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real Bz_interp = CoarsenIO::Interp(arrBz, Bztype, cellCenteredtype,
+                                        reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return reduction_function_parser(x, y, z, Ex_interp, Ey_interp, Ez_interp,
+                                                          Bx_interp, By_interp, Bz_interp);
+            });
+        }
+
+        amrex::Real reduce_value = amrex::get<0>(reduce_data.value());
+
+        // MPI reduce
+        if (std::is_same<T, amrex::ReduceOpMax>::value)
+        {
+            amrex::ParallelDescriptor::ReduceRealMax(reduce_value);
+        }
+        if (std::is_same<T, amrex::ReduceOpMin>::value)
+        {
+            amrex::ParallelDescriptor::ReduceRealMin(reduce_value);
+        }
+        if (std::is_same<T, amrex::ReduceOpSum>::value)
+        {
+            amrex::ParallelDescriptor::ReduceRealSum(reduce_value);
+        // If reduction operation is a sum, multiply the value by the cell volume so that the
+        // result is an integration over the simulation domain rather than simply a sum of the
+        // values on the grid points.
+#if (AMREX_SPACEDIM==2)
+            reduce_value *= dx[0]*dx[1];
+#else
+            reduce_value *= dx[0]*dx[1]*dx[2];
+#endif
+        }
+
+        // Fill output array
+        m_data[0] = reduce_value;
+
+        // m_data now contains an up to date value of the reduced field quantity
+    }
+
+};
+
+#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_FIELDREDUCTION_H_

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -1,0 +1,98 @@
+/* Copyright 2021 Neil Zaim
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "FieldReduction.H"
+#include "WarpX.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+
+// constructor
+FieldReduction::FieldReduction (std::string rd_name)
+: ReducedDiags{rd_name}
+{
+    using namespace amrex::literals;
+
+    // RZ coordinate is not working
+#if (defined WARPX_DIM_RZ)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+        "FieldReduction reduced diagnostics does not work for RZ coordinate.");
+#endif
+
+    // read number of levels
+    int nLevel = 0;
+    amrex::ParmParse pp_amr("amr");
+    pp_amr.query("max_level", nLevel);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nLevel == 0,
+        "FieldReduction reduced diagnostics does not work with mesh refinement.");
+
+    constexpr int noutputs = 1; // A single output in the Field reduction diagnostic
+    // resize data array
+    m_data.resize(noutputs, 0.0_rt);
+
+    amrex::ParmParse pp_rd_name(rd_name);
+
+    // read reduced function with parser
+    std::string parser_string = "";
+    Store_parserString(pp_rd_name,"reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz)",
+                       parser_string);
+    // Remove newlines and spaces in the parser string. This is because this string is written in
+    // the header of the reduced diag output file so this should prevent weird formatting from
+    // occuring.
+    parser_string.erase(std::remove(parser_string.begin(), parser_string.end(), '\n'),
+                        parser_string.end());
+    parser_string.erase(std::remove(parser_string.begin(), parser_string.end(), ' '),
+                        parser_string.end());
+    m_parser = std::make_unique<ParserWrapper<m_nvars>>(
+        makeParser(parser_string,{"x","y","z","Ex","Ey","Ez","Bx","By","Bz"}));
+
+    // read reduction type
+    std::string reduction_type_string;
+    pp_rd_name.get("reduction_type", reduction_type_string);
+    m_reduction_type = GetAlgorithmInteger (pp_rd_name, "reduction_type");
+
+    if (amrex::ParallelDescriptor::IOProcessor())
+    {
+        if ( m_IsNotRestart )
+        {
+            // open file
+            std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
+            // write header row
+            ofs << "#";
+            ofs << "[1]step()";
+            ofs << m_sep;
+            ofs << "[2]time(s)";
+            ofs << m_sep;
+            ofs << "[3]" + reduction_type_string + " of " + parser_string + " (SI units)";
+
+            ofs << std::endl;
+            // close file
+            ofs.close();
+        }
+    }
+
+}
+// end constructor
+
+// function that does an arbitrary reduction of the electromagnetic fields
+void FieldReduction::ComputeDiags (int step)
+{
+    // Judge if the diags should be done
+    if (!m_intervals.contains(step+1)) { return; }
+
+    if (m_reduction_type == ReductionType::Maximum)
+    {
+        ComputeFieldReduction<amrex::ReduceOpMax>();
+    }
+    else if (m_reduction_type == ReductionType::Minimum)
+    {
+        ComputeFieldReduction<amrex::ReduceOpMin>();
+    }
+    else if (m_reduction_type == ReductionType::Sum)
+    {
+        ComputeFieldReduction<amrex::ReduceOpSum>();
+    }
+}
+// end void FieldMaximum::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
@@ -46,18 +46,27 @@ public:
      *  rectangular one */
     int m_nBoxesMax = -1;
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     LoadBalanceCosts(std::string rd_name);
 
-    /** This function updates the costs, given the current distribution mapping,
-     *  according to the number of particles and cells on the box  */
+    /**
+     * This function updates the costs, given the current distribution mapping,
+     * according to the number of particles and cells on the box
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) override final;
 
-    /** write to file function for costs;  this differs from the base class
-     *  `ReducedDiags` in that it will fill in blank entries with NaN at the
-     *  final timestep, ensuring that the data array is not jagged
-     *  @param[in] step time step */
+    /**
+     * write to file function for costs;  this differs from the base class
+     * `ReducedDiags` in that it will fill in blank entries with NaN at the
+     * final timestep, ensuring that the data array is not jagged
+     *
+     * @param[in] step current time step
+     */
     virtual void WriteToFile(int step) const override final;
 
 };

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.H
@@ -20,11 +20,17 @@ class LoadBalanceEfficiency : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     LoadBalanceEfficiency(std::string rd_name);
 
-    /** This function gets the current load balance efficiency  */
+    /**
+     * This function gets the current load balance efficiency
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) override final;
 };
 

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -10,5 +10,6 @@ CEXE_sources += FieldMaximum.cpp
 CEXE_sources += ParticleExtrema.cpp
 CEXE_sources += RhoMaximum.cpp
 CEXE_sources += ParticleNumber.cpp
+CEXE_sources += FieldReduction.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -15,6 +15,7 @@
 #include "FieldMaximum.H"
 #include "RhoMaximum.H"
 #include "ParticleNumber.H"
+#include "FieldReduction.H"
 #include "MultiReducedDiags.H"
 
 #include <AMReX_ParmParse.H>
@@ -45,6 +46,7 @@ MultiReducedDiags::MultiReducedDiags ()
             {"ParticleEnergy",        [](CS s){return std::make_unique<ParticleEnergy>(s);}},
             {"FieldEnergy",           [](CS s){return std::make_unique<FieldEnergy>(s);}},
             {"FieldMaximum",          [](CS s){return std::make_unique<FieldMaximum>(s);}},
+            {"FieldReduction",        [](CS s){return std::make_unique<FieldReduction>(s);}},
             {"RhoMaximum",            [](CS s){return std::make_unique<RhoMaximum>(s);}},
             {"BeamRelevant",          [](CS s){return std::make_unique<BeamRelevant>(s);}},
             {"LoadBalanceCosts",      [](CS s){return std::make_unique<LoadBalanceCosts>(s);}},

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.H
@@ -20,16 +20,20 @@ class ParticleEnergy : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     ParticleEnergy(std::string rd_name);
 
-    /** This function computes the particle relativistic
-     *  kinetic energy (EP).
-     *  \param [in] step current time step
-     *  EP = sqrt( p^2 c^2 + m^2 c^4 ) - m c^2,
-     *  where p is the relativistic momentum,
-     *  m is the particle rest mass. */
+    /**
+     * This function computes the particle relativistic kinetic energy (EP).
+     * EP = sqrt( p^2 c^2 + m^2 c^4 ) - m c^2,
+     * where p is the relativistic momentum,
+     * m is the particle rest mass.
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) override final;
 
 };

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
@@ -19,14 +19,19 @@ class ParticleExtrema : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     ParticleExtrema(std::string rd_name);
 
     /// name of species
     std::string m_species_name;
 
-    /** This funciton computes the particle extrema
+    /**
+     * This funciton computes the particle extrema
+     *
+     * @param[in] step current time step
      */
     void ComputeDiags(int step) override final;
 

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
@@ -20,8 +20,10 @@ class ParticleHistogram : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     ParticleHistogram(std::string rd_name);
 
     /// normalization type
@@ -51,8 +53,10 @@ public:
     /// Whether the filter is activated
     bool m_do_parser_filter = false;
 
-    /** This function computes a histogram of user defined quantity.
-     *  \param [in] step current time step.
+    /**
+     * This function computes a histogram of user defined quantity.
+     *
+     * @param[in] step current time step
      */
     virtual void ComputeDiags(int step) override final;
 

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.H
@@ -18,13 +18,17 @@ class ParticleNumber : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     ParticleNumber(std::string rd_name);
 
-    /** This function computes the total number of macroparticles and physical particles of each
-     *  species.
-     *  @param [in] step current time step
+    /**
+     * This function computes the total number of macroparticles and physical particles of each
+     * species.
+     *
+     * @param[in] step current time step
      */
     virtual void ComputeDiags(int step) override final;
 

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.H
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.H
@@ -46,23 +46,34 @@ public:
     /// output data
     std::vector<amrex::Real> m_data;
 
-    /** constructor
-     *  @param[in] rd_name reduced diags name */
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
+     */
     ReducedDiags(std::string rd_name);
 
-    /** Virtual destructor for polymorphism
+    /**
+     * Virtual destructor for polymorphism
      */
     virtual ~ReducedDiags() = default;
 
-    /// function to compute diags
+    /**
+     * function to compute diags
+     *
+     * @param[in] step current time step
+     */
     virtual void ComputeDiags(int step) = 0;
 
-    /** write to file function
-     *  @param[in] step time step */
+    /**
+     * write to file function
+     *
+     * @param[in] step current time step
+     */
     virtual void WriteToFile(int step) const;
 
-    /** This function queries deprecated input parameters and abort
-     *  the run if one of them is specified.
+    /**
+     * This function queries deprecated input parameters and aborts
+     * the run if one of them is specified.
      */
     void BackwardCompatibility ();
 

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.H
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.H
@@ -19,13 +19,17 @@ class RhoMaximum : public ReducedDiags
 {
 public:
 
-    /** constructor
-     *  @param[in] rd_name reduced diags names
+    /**
+     * constructor
+     * @param[in] rd_name reduced diags names
      */
     RhoMaximum(std::string rd_name);
 
-    /** This function computes the maximum and minimum values of rho (summed over all species) and
+    /**
+     * This function computes the maximum and minimum values of rho (summed over all species) and
      * the maximum absolute value of rho for each species.
+     *
+     * @param[in] step current time step
      */
     virtual void ComputeDiags(int step) override final;
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -116,6 +116,16 @@ struct ParticleBoundaryType {
     };
 };
 
+/** MPI reductions
+ */
+struct ReductionType {
+    enum {
+        Maximum = 0,
+        Minimum = 1,
+        Sum = 2
+    };
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key );
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -93,9 +93,9 @@ const std::map<std::string, int> ParticleBCType_algo_to_int = {
 };
 
 const std::map<std::string, int> ReductionType_algo_to_int = {
-    {"maximum", ReductionType::Maximum},
-    {"minimum", ReductionType::Minimum},
-    {"sum",     ReductionType::Sum}
+    {"maximum",  ReductionType::Maximum},
+    {"minimum",  ReductionType::Minimum},
+    {"integral", ReductionType::Sum}
 };
 
 int

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -92,6 +92,12 @@ const std::map<std::string, int> ParticleBCType_algo_to_int = {
     {"default",    ParticleBoundaryType::Absorbing}
 };
 
+const std::map<std::string, int> ReductionType_algo_to_int = {
+    {"maximum", ReductionType::Maximum},
+    {"minimum", ReductionType::Minimum},
+    {"sum",     ReductionType::Sum}
+};
+
 int
 GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
 
@@ -123,6 +129,8 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
         algo_to_int = MaxwellSolver_medium_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "macroscopic_sigma_method")) {
         algo_to_int = MacroscopicSolver_algo_to_int;
+    } else if (0 == std::strcmp(pp_search_key, "reduction_type")) {
+        algo_to_int = ReductionType_algo_to_int;
     } else {
         std::string pp_search_string = pp_search_key;
         amrex::Abort("Unknown algorithm type: " + pp_search_string);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -241,7 +241,7 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
         } else if (std::strcmp(it->c_str(), "epsilon0") == 0) {
             parser.setConstant(*it, PhysConst::ep0);
             it = symbols.erase(it);
-          else if (std::strcmp(it->c_str(), "mu0") == 0) {
+        }  else if (std::strcmp(it->c_str(), "mu0") == 0) {
             parser.setConstant(*it, PhysConst::mu0);
             it = symbols.erase(it);
         } else if (std::strcmp(it->c_str(), "clight") == 0) {

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -241,6 +241,9 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
         } else if (std::strcmp(it->c_str(), "epsilon0") == 0) {
             parser.setConstant(*it, PhysConst::ep0);
             it = symbols.erase(it);
+          else if (std::strcmp(it->c_str(), "mu0") == 0) {
+            parser.setConstant(*it, PhysConst::mu0);
+            it = symbols.erase(it);
         } else if (std::strcmp(it->c_str(), "clight") == 0) {
             parser.setConstant(*it, PhysConst::c);
             it = symbols.erase(it);


### PR DESCRIPTION
This PR adds a reduced diagnostic that does a generic reduction of the electromagnetic fields (and the positions). The quantity to be reduced is given in the input using the math parser and depends on `x`, `y`, `z`, `Ex`, `Ey`, `Ez`, `Bx`, `By` and `Bz` (if needed it shouldn't be too hard to add other quantities like current density). The reduction operation is either `Maximum`, `Minimum` or `Sum`. If `Sum` is used, the quantity to be reduced is multiplied by the volume of a cell, so that the result is an integration over the simulation domain rather than simply a sum of the values on the grid points.

Edit: following @lucafedeli88's suggestion, I've renamed the `Sum` option to `Integral` to be more descriptive.