### PR TITLE
Deactivate Python script for embedded boundary test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2033,5 +2033,4 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 0s
-analysisRoutine = Examples/Modules/embedded_boundary_cube/analysis_fields.py
+compareParticles = 0


### PR DESCRIPTION
As mentioned in #1921, it seems that the last line of the `WarpX-test.ini` was not properly parsed due to a missing end-of-line. This implies that the test itself was run, but the Python analysis at the end was skipped.

Unfortunately, when activating the Python script, the test fails (this will be fixed in #1921). This causes any new PR that adds a new test to this list to fail (because by adding a new line, the end-of-line issue is fixed, and the Python script is then run, but fails.) 

The current PR temporarily fixes this issue by deactivating the Python script.