### PR TITLE
[WIP] Move calls to UpdateAuxilaryData and FillBoundary immediatly before diagnostics

### DIFF
--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -454,6 +454,14 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
 void
 FullDiagnostics::PrepareFieldDataForOutput ()
 {
+    // First, make sure all guard cells are properly filled
+    // Probably overkill/unnecessary, but safe and shouldn't happen often !!
+    auto & warpx = WarpX::GetInstance();
+    warpx.FillBoundaryE(warpx.getngE());
+    warpx.FillBoundaryB(warpx.getngE());
+    warpx.UpdateAuxilaryData();
+    warpx.FillBoundaryAux(warpx.getngUpdateAux());
+
     // Update the RealBox used for the geometry filter in particle diags
     for (int i = 0; i < m_output_species.size(); ++i) {
         m_output_species[i].m_diag_domain = m_geom_output[0][0].ProbDomain();

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -454,14 +454,6 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
 void
 FullDiagnostics::PrepareFieldDataForOutput ()
 {
-    // First, make sure all guard cells are properly filled
-    // Probably overkill/unnecessary, but safe and shouldn't happen often !!
-    auto & warpx = WarpX::GetInstance();
-    warpx.FillBoundaryE(warpx.getngE());
-    warpx.FillBoundaryB(warpx.getngE());
-    warpx.UpdateAuxilaryData();
-    warpx.FillBoundaryAux(warpx.getngUpdateAux());
-
     // Update the RealBox used for the geometry filter in particle diags
     for (int i = 0; i < m_output_species.size(); ++i) {
         m_output_species[i].m_diag_domain = m_geom_output[0][0].ProbDomain();


### PR DESCRIPTION
This should ensure that the fields are always up-to-date in the diagnostics. (currently if we have an auxiliary grid, e.g. with momentum conserving field gathering, we use the fields of the previous timestep in the reduced diagostic).

I've also removed the calls to `FillBoundary` and `UpdateAuxilaryData` which are done in the regular diagnostics, and which should now be unnecessary. Let's see if this breaks CI. Edit: I've added these calls again, otherwise it breaks CI (see comment below).

Follow-up to #1954