### PR TITLE
BC : Interface for damping EB fields in guard cells in z-direction

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -210,7 +210,7 @@ Domain Boundary Conditions
     * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for ``warpx.do_pml``. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
 
-    * ``damped``: This option can be set when using the spectral solver with moving window. This boundary condition applies a damping factor to the electric and magnetic fields in the guard cells along z that extend beyond the edge of the domain. The damping profile is a sine squared and is applied to the fields on the outer half of the guard cell region. This damping is useful for damping high frequency numerical artifacts that occur at the boundary when using moving window condition for the spectral solver. Note that this boundary is only valid for the spectral solve. Since no such high frequency numerical artifacts are present for FDTD solver with moving window, this boundary condition is not valid for FDTD and can be used only for PSATD and only in the direction of the moving window.
+    * ``damped``: This is the recommended option in the moving direction when using the spectral solver with moving window (currently only supported along z). This boundary condition applies a damping factor to the electric and magnetic fields in the outer half of the guard cells, using a sine squared profile. As the spectral solver is by nature periodic, the damping prevents fields from wrapping around to the other end of the domain when the periodicity is not desired. This boundary condition is only valid when using the spectral solver.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:
@@ -1141,18 +1141,6 @@ Numerics and algorithms
 * ``warpx.use_filter_compensation`` (`0` or `1`; default: `0`)
     Whether to add compensation when applying filtering.
     This is only supported with the RZ spectral solver.
-
-* ``warpx.use_damp_fields_in_z_guard`` (`0` or `1`)
-    When using the RZ spectrol solver, specifies whether to apply a
-    damping factor to the E and B fields in the guard cells
-    along z that extend beyond the edge of the domain.
-    When the boundary conditions along z are not periodic, this defaults to
-    true, otherwise false. The damping profile is
-    a sine squared and is applied to the fields on the outer half of the guards.
-    This damping is useful for damping high frequency numerical artifacts that
-    occur when there is parallel decomposition along z with non-periodic boundary
-    conditions. Note that this input parameter will be deprecated soon and the capability
-    will be supported using ``boundary.field_lo=damped`` and ``boundary.field_hi=damped``.
 
 * ``algo.current_deposition`` (`string`, optional)
     This parameter selects the algorithm for the deposition of the current density.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -199,14 +199,18 @@ Setting up the field mesh
 Domain Boundary Conditions
 --------------------------
 
-* ``boundary.field_lo`` and ``boundary_field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
+* ``boundary.field_lo`` and ``boundary.field_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Boundary conditions applied to field at the lower and upper domain boundaries. Depending on the type of boundary condition, the value for ``geometry.is_periodic`` will be set, overriding the user-input for the input parameter, ``geometry.is_periodic``. If not set, the default value for the fields at the domain boundary will be set to pml.
     Options are:
 
     * ``Periodic``: This option can be used to set periodic domain boundaries. Note that if the fields for lo in a certain dimension are set to periodic, then the corresponding upper boundary must also be set to periodic. If particle boundaries are not specified in the input file, then particles boundaries by default will be set to periodic. If particles boundaries are specified, then they must be set to periodic corresponding to the periodic field boundaries.
+
     * ``pec``: This option can be used to add a Perfect Electric Conductor at the simulation boundary. If an electrostatic field solve is used the boundary potentials can also be set through ``boundary.potential_lo_x/y/z`` and ``boundary.potential_hi_x/y/z`` (default `0`).
+
     * ``pml`` (default): This option can be used to add Perfectly Matched Layers (PML) around the simulation domain. It will override the user-defined value provided for ``warpx.do_pml``. See the :ref:`PML theory section <theory-bc>` for more details.
     Additional pml algorithms can be explored using the parameters ``warpx.do_pml_in_domain``, ``warpx.do_particles_in_pml``, and ``warpx.do_pml_j_damping``.
+
+    * ``damped``: This option can be set when using the spectral solver with moving window. This boundary condition applies a damping factor to the electric and magnetic fields in the guard cells along z that extend beyond the edge of the domain. The damping profile is a sine squared and is applied to the fields on the outer half of the guard cell region. This damping is useful for damping high frequency numerical artifacts that occur at the boundary when using moving window condition for the spectral solver. Note that this boundary is only valid for the spectral solve. Since no such high frequency numerical artifacts are present for FDTD solver with moving window, this boundary condition is not valid for FDTD and can be used only for PSATD and only in the direction of the moving window.
 
 * ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:
@@ -1147,7 +1151,8 @@ Numerics and algorithms
     a sine squared and is applied to the fields on the outer half of the guards.
     This damping is useful for damping high frequency numerical artifacts that
     occur when there is parallel decomposition along z with non-periodic boundary
-    conditions.
+    conditions. Note that this input parameter will be deprecated soon and the capability
+    will be supported using ``boundary.field_lo=damped`` and ``boundary.field_hi=damped``.
 
 * ``algo.current_deposition`` (`string`, optional)
     This parameter selects the algorithm for the deposition of the current density.

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -164,7 +164,9 @@ WarpX::PushPSATD (int lev, amrex::Real /* dt */) {
     }
 
     // Damp the fields in the guard cells along z
-    if (use_damp_fields_in_z_guard)
+    constexpr int zdir = AMREX_SPACEDIM - 1;
+    if (WarpX::field_boundary_lo[zdir] == FieldBoundaryType::Damped &&
+        WarpX::field_boundary_hi[zdir] == FieldBoundaryType::Damped)
     {
         DampFieldsInGuards(Efield_fp[lev], Bfield_fp[lev]);
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -99,7 +99,9 @@ struct FieldBoundaryType {
         PML = 0,
         Periodic = 1,
         PEC = 2,     //!< perfect electric conductor (PEC) with E_tangential=0
-        PMC = 3      //!< perfect magnetic conductor (PMC) with B_tangential=0
+        PMC = 3,      //!< perfect magnetic conductor (PMC) with B_tangential=0
+        Damped = 4   // Fields in the guard cells are damped for PSATD
+                     //in the moving window direction
     };
 };
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -80,6 +80,7 @@ const std::map<std::string, int> FieldBCType_algo_to_int = {
     {"periodic", FieldBoundaryType::Periodic},
     {"pec",      FieldBoundaryType::PEC},
     {"pmc",      FieldBoundaryType::PMC},
+    {"damped",   FieldBoundaryType::Damped},
     {"default",  FieldBoundaryType::PML}
 };
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -399,28 +399,6 @@ void ReadBCParams ()
                 }
             }
         }
-#ifdef WARPX_USE_PSATD
-        int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
-        if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
-            ParmParse pp_psatd("psatd");
-            int do_moving_window = 0;
-            pp_warpx.query("do_moving_window", do_moving_window);
-            if (do_moving_window == 1) {
-                std::string s;
-                pp_warpx.get("moving_window_dir", s);
-                int zdir;
-                if (s == "z" || s == "Z") zdir = AMREX_SPACEDIM-1;
-                bool damp_fields_in_z_guard = true;
-                if (pp_psatd.query("use_damp_fields_in_z_guard", damp_fields_in_z_guard) ) {
-                    amrex::Warning("WARNING : the input parameter ``use_damp_fields_in_z_guard`` will be deprecated soon. Please use boundary.field_lo=Damped and boundary.field_hi=Damped instead.");
-                }
-                if (damp_fields_in_z_guard == true) {
-                    WarpX::field_boundary_lo[zdir] = FieldBoundaryType::Damped;
-                    WarpX::field_boundary_hi[zdir] = FieldBoundaryType::Damped;
-                }
-            }
-        }
-#endif
         return;
         // When all boundary conditions are supported, the abort statement below will be introduced
         //amrex::Abort("geometry.is_periodic is not supported. Please use `boundary.field_lo`, `boundary.field_hi` to specifiy field boundary conditions and 'boundary.particle_lo', 'boundary.particle_hi'  to specify particle boundary conditions.");
@@ -471,18 +449,10 @@ void ReadBCParams ()
         }
         if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::Damped ||
             WarpX::field_boundary_hi[idim] == FieldBoundaryType::Damped ) {
-#ifdef WARPX_USE_PSATD
             int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
-            if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                    WarpX::field_boundary_lo[idim] == WarpX::field_boundary_hi[idim],
-                    "field boundary in both lo and high must be set to Damped for PSATD");}
-            else {
+            if (maxwell_solver_id != MaxwellSolverAlgo::PSATD) {
                 amrex::Abort("FieldBoundaryType::Damped is only supported for PSATD");
             }
-#else
-            amrex::Abort("FieldBoundaryType::Damped is only supported for PSATD");
-#endif
         }
     }
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -379,6 +379,7 @@ void ReadBCParams ()
     amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
     ParmParse pp_geometry("geometry");
     ParmParse pp_warpx("warpx");
+    ParmParse pp_algo("algo");
     if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
         // set default field and particle boundary appropriately
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -395,6 +396,23 @@ void ReadBCParams ()
                 if (pml_input == 0) {
                     WarpX::field_boundary_lo[idim] = FieldBoundaryType::PEC;
                     WarpX::field_boundary_hi[idim] = FieldBoundaryType::PEC;
+                }
+            }
+        }
+        // Temporarily setting default boundary to Damped until PEC Boundary Type is enabled
+        int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+        if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+            ParmParse pp_psatd("psatd");
+            int do_moving_window = 0;
+            pp_warpx.query("do_moving_window", do_moving_window);
+            if (do_moving_window == 1) {
+                std::string s;
+                pp_warpx.get("moving_window_dir", s);
+                int zdir;
+                if (s == "z" || s == "Z") {
+                    zdir = AMREX_SPACEDIM-1;
+                    WarpX::field_boundary_lo[zdir] = FieldBoundaryType::Damped;
+                    WarpX::field_boundary_hi[zdir] = FieldBoundaryType::Damped;
                 }
             }
         }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -403,9 +403,9 @@ void ReadBCParams ()
         int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
         if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
             ParmParse pp_psatd("psatd");
-            int do_moving_window_input = 0;
-            pp_warpx.query("do_moving_window", do_moving_window_input);
-            if (do_moving_window_input == 1) {
+            int do_moving_window = 0;
+            pp_warpx.query("do_moving_window", do_moving_window);
+            if (do_moving_window == 1) {
                 std::string s;
                 pp_warpx.get("moving_window_dir", s);
                 int zdir;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -447,13 +447,6 @@ void ReadBCParams ()
             }
 
         }
-        if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::Damped ||
-            WarpX::field_boundary_hi[idim] == FieldBoundaryType::Damped ) {
-            int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
-            if (maxwell_solver_id != MaxwellSolverAlgo::PSATD) {
-                amrex::Abort("FieldBoundaryType::Damped is only supported for PSATD");
-            }
-        }
     }
 
     pp_geometry.addarr("is_periodic", geom_periodicity);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -379,7 +379,6 @@ void ReadBCParams ()
     amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
     ParmParse pp_geometry("geometry");
     ParmParse pp_warpx("warpx");
-    ParmParse pp_algo("algo");
     if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
         // set default field and particle boundary appropriately
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -182,7 +182,6 @@ public:
     static bool use_filter;
     static bool use_kspace_filter;
     static bool use_filter_compensation;
-    static bool use_damp_fields_in_z_guard;
     static bool serialize_ics;
 
     // Back transformation diagnostic
@@ -392,7 +391,7 @@ public:
      * Applies a damping factor in the guards cells that extend
      * beyond the extent of the domain, reducing fluctuations that
      * can appear in parallel simulations. This will be called
-     * when use_damp_fields_in_z_guard is true.
+     * when FieldBoundaryType is set to damped.
      */
     void DampFieldsInGuards (std::array<std::unique_ptr<amrex::MultiFab>,3>& Efield,
                              std::array<std::unique_ptr<amrex::MultiFab>,3>& Bfield);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -983,6 +983,13 @@ WarpX::ReadParameters ()
                 "field boundary in both lo and high must be set to Damped for PSATD"
             );
         }
+    } else {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::Damped ||
+                WarpX::field_boundary_hi[idim] == FieldBoundaryType::Damped ) {
+                    amrex::Abort("FieldBoundaryType::Damped is only supported for PSATD");
+            }
+        }
     }
 
     // for slice generation //

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -983,7 +983,9 @@ WarpX::ReadParameters ()
                 "field boundary in both lo and high must be set to Damped for PSATD"
             );
         }
-    } else {
+    }
+
+    if (maxwell_solver_id != MaxwellSolverAlgo::PSATD ) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::Damped ||
                 WarpX::field_boundary_hi[idim] == FieldBoundaryType::Damped ) {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -110,7 +110,6 @@ bool WarpX::galerkin_interpolation = true;
 bool WarpX::use_filter        = false;
 bool WarpX::use_kspace_filter       = false;
 bool WarpX::use_filter_compensation = false;
-bool WarpX::use_damp_fields_in_z_guard = false;
 
 bool WarpX::serialize_ics     = false;
 bool WarpX::refine_plasma     = false;
@@ -976,12 +975,6 @@ WarpX::ReadParameters ()
                 "psatd.update_with_rho must be equal to 1 for comoving PSATD");
         }
 
-        constexpr int zdir = AMREX_SPACEDIM - 1;
-        if (!Geom(0).isPeriodic(zdir))
-        {
-            use_damp_fields_in_z_guard = true;
-        }
-        pp_psatd.query("use_damp_fields_in_z_guard", use_damp_fields_in_z_guard);
     }
 
     // for slice generation //

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -975,6 +975,14 @@ WarpX::ReadParameters ()
                 "psatd.update_with_rho must be equal to 1 for comoving PSATD");
         }
 
+        constexpr int zdir = AMREX_SPACEDIM - 1;
+        if (WarpX::field_boundary_lo[zdir] == FieldBoundaryType::Damped ||
+            WarpX::field_boundary_hi[zdir] == FieldBoundaryType::Damped ) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WarpX::field_boundary_lo[zdir] == WarpX::field_boundary_hi[zdir],
+                "field boundary in both lo and high must be set to Damped for PSATD"
+            );
+        }
     }
 
     // for slice generation //


### PR DESCRIPTION
This PR add a new boundary type called `damped` to use the field damping implemented in the guard-cells for PSATD when using moving window in the simulations.
Note that eventually, the input parameter `warpx.use_damp_fields_in_z_guard` will be deprecated.