### PR TITLE
CI: Fix Broken Test, Disable HIP Temporarily

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -222,6 +222,7 @@ jobs:
 
   build_hip:
     name: HIP SP [Linux]
+    if: false # skip this for now because of the VOP bug in ROCm 4.2
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
+++ b/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
@@ -15,9 +15,7 @@ boundary.field_hi = pec periodic
 boundary.potential_lo_x = 150.0*sin(2*pi*6.78e+06*t)
 boundary.potential_hi_x = 450.0*sin(2*pi*13.56e+06*t)
 
-interpolation.nox = 1
-interpolation.noy = 1
-interpolation.noz = 1
+algo.particle_shape = 1
 diagnostics.diags_names = diag1
 diag1.diag_type = Full
 diag1.intervals = ::4


### PR DESCRIPTION
Two CI fixes, both required but independent:
- ROCm 4.2 has a bug that causes the HIP SP build to fail. See https://github.com/AMReX-Codes/amrex/pull/2011;
- PR #1934 was merged right after PR #1761. The former introduced a new input syntax for the order of the particle shape factors, while the latter introduced a new CI test called `dirichletbc`. Since #1934 had not been rebased after #1761 was merged, the new test introduced in #1761 does not use the new syntax introduced in #1934 and, thus, fails currently on our Azure workflow.