### PR TITLE
CI: Disable HIP SP Temporarily

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -222,6 +222,7 @@ jobs:
 
   build_hip:
     name: HIP SP [Linux]
+    if: false # skip this for now because of the VOP bug in ROCm 4.2
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
ROCm 4.2 has a bug that causes the HIP SP build to fail. See https://github.com/AMReX-Codes/amrex/pull/2011.