### PR TITLE
DPC++ CI: openPMD-api@dev

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -209,7 +209,7 @@ jobs:
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_PRECISION=SINGLE     \
-          -DWarpX_openpmd_branch=dev
+          -DWarpX_openpmd_branch=0.13.4
         cmake --build build_sp -j 2
 
      # Skip this as it will copy the binary artifacts and we are tight on disk space

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -208,7 +208,8 @@ jobs:
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
-          -DWarpX_PRECISION=SINGLE
+          -DWarpX_PRECISION=SINGLE     \
+          -DWarpX_openpmd_branch=dev
         cmake --build build_sp -j 2
 
      # Skip this as it will copy the binary artifacts and we are tight on disk space


### PR DESCRIPTION
Fix a missing include by updating to the latest dev branch of openPMD-api.

Fixed via: https://github.com/openPMD/openPMD-api/pull/972

First seen with macOS by @dpgrote and in CI as of #1957