### PR TITLE
openPMD-api: 0.13.4 (internal)

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -81,7 +81,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "0.13.2"
+    set(WarpX_openpmd_branch "0.13.4"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 


### PR DESCRIPTION
Build the latest release, which fixes AppleClang and DPC++ compilation problems.

https://github.com/openPMD/openPMD-api/blob/0.13.4/CHANGELOG.rst