### PR TITLE
[WIP] macOS: MPI_HOME hint for brew

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -74,6 +74,14 @@ Brew (macOS/Linux)
    brew install pkg-config  # for fftw
    brew install open-mpi
 
+.. note::
+
+   On macOS, it is sometimes required to also set the following environment variable to hint the MPI installation location inside ``brew``'s prefix:
+
+   .. code-block:: bash
+
+      export MPI_HOME=/usr/local
+
 
 Conda (Linux/macOS/Windows)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It seems that some versions of macOS in combination with brew and at least CMake 3.18 need an additional hint to find MPI.

https://gitlab.kitware.com/cmake/cmake/-/issues/21955

Also seen on @dpgrote Mac with a similar setup.