### PR TITLE
Summit/PPC64le: Numpy 1.19.5

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -113,7 +113,7 @@ Optionally, download and install :ref:`libEnsemble <libensemble>` for dynamic en
    source $HOME/sw/venvs/warpx-libE/bin/activate
    python3 -m pip install --upgrade pip
    python3 -m pip install --upgrade cython
-   python3 -m pip install --upgrade numpy==1.19.0
+   python3 -m pip install --upgrade numpy==1.19.5
    python3 -m pip install --upgrade scipy
    python3 -m pip install --upgrade mpi4py --no-binary mpi4py
    python3 -m pip install --upgrade -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -113,7 +113,7 @@ Optionally, download and install :ref:`libEnsemble <libensemble>` for dynamic en
    source $HOME/sw/venvs/warpx-libE/bin/activate
    python3 -m pip install --upgrade pip
    python3 -m pip install --upgrade cython
-   python3 -m pip install --upgrade numpy
+   python3 -m pip install --upgrade numpy==1.19.0
    python3 -m pip install --upgrade scipy
    python3 -m pip install --upgrade mpi4py --no-binary mpi4py
    python3 -m pip install --upgrade -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt


### PR DESCRIPTION
The latest (default) numpy, release `1.20.3` fails to build with fancy compiler errors of the form
```
error: "AltiVec argument passed to unprototyped function"
```

Thus, recommend an older numpy release to user that actually builds: `1.19.5`

Upstream bug report in https://github.com/numpy/numpy/issues/19017