### PR TITLE
check if nspecies>0 before parsing particle_shape

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1200,7 +1200,7 @@ Numerics and algorithms
     Low-order shape factors result in faster simulations, but may lead to more noisy results.
     High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results. For production runs it is generally safer to use high-order shape factors, such as cubic order.
 
-    Note that this input parameter is not optional and must always be set in all input files (provided that there is at least one particle species in the simulation). No default value is provided automatically.
+    Note that this input parameter is not optional and must always be set in all input files provided that there is at least one particle species (set in input as ``particles.species_names``) or one laser species (set in input as ``lasers.names``) in the simulation. No default value is provided automatically.
 
 * ``algo.maxwell_solver`` (`string`, optional)
     The algorithm for the Maxwell field solver.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1200,8 +1200,7 @@ Numerics and algorithms
     Low-order shape factors result in faster simulations, but may lead to more noisy results.
     High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results. For production runs it is generally safer to use high-order shape factors, such as cubic order.
 
-    Note that this input parameter is not optional and must always be set in all input files.
-    No default value is provided automatically.
+    Note that this input parameter is not optional and must always be set in all input files (provided that there is at least one particle species in the simulation). No default value is provided automatically.
 
 * ``algo.maxwell_solver`` (`string`, optional)
     The algorithm for the Maxwell field solver.

--- a/Examples/Modules/embedded_boundary_cube/inputs_3d
+++ b/Examples/Modules/embedded_boundary_cube/inputs_3d
@@ -11,9 +11,6 @@ warpx.do_pml = 0
 warpx.const_dt = 1e-6
 warpx.cfl = 1
 
-# Order of particle shape factors
-algo.particle_shape = 1
-
 eb2.geom_type = box
 eb2.box_lo = -0.5 -0.5 -0.5
 eb2.box_hi = 0.5 0.5 0.5

--- a/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
+++ b/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
@@ -15,7 +15,6 @@ boundary.field_hi = pec periodic
 boundary.potential_lo_x = 150.0*sin(2*pi*6.78e+06*t)
 boundary.potential_hi_x = 450.0*sin(2*pi*13.56e+06*t)
 
-algo.particle_shape = 1
 diagnostics.diags_names = diag1
 diag1.diag_type = Full
 diag1.intervals = ::4

--- a/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
+++ b/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
@@ -23,9 +23,6 @@ warpx.cfl = 1.
 warpx.do_pml = 0
 warpx.use_hybrid_QED = 1
 
-# Order of particle shape factors
-algo.particle_shape = 1
-
 #################################
 ############ FIELDS #############
 #################################

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -791,7 +791,7 @@ WarpX::ReadParameters ()
         queryWithParser(pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
 
         // Parse algo.particle_shape and check that input is acceptable
-        // (do this only if there is at least one particle species)
+        // (do this only if there is at least one particle or laser species)
         ParmParse pp_particles("particles");
         std::vector<std::string> species_names;
         pp_particles.queryarr("species_names", species_names);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -790,23 +790,29 @@ WarpX::ReadParameters ()
         queryWithParser(pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
         queryWithParser(pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
 
-        int particle_shape;
-        if (pp_algo.query("particle_shape", particle_shape) == false)
-        {
-            amrex::Abort("\nalgo.particle_shape must be set in the input file:"
-                         "\nplease set algo.particle_shape to 1, 2, or 3");
-        }
-        else
-        {
-            if (particle_shape < 1 || particle_shape > 3)
+        // check if any nspecies > 0 before testing entry for algo.particle_shape
+        ParmParse pp_particles("particles");
+        std::vector<std::string> species_names;
+        pp_particles.queryarr("species_names", species_names);
+        if (species_names.size() > 0) {
+            int particle_shape;
+            if (pp_algo.query("particle_shape", particle_shape) == false)
             {
-                amrex::Abort("\nalgo.particle_shape can be only 1, 2, or 3");
+                amrex::Abort("\nalgo.particle_shape must be set in the input file:"
+                             "\nplease set algo.particle_shape to 1, 2, or 3");
             }
             else
             {
-                nox = particle_shape;
-                noy = particle_shape;
-                noz = particle_shape;
+                if (particle_shape < 1 || particle_shape > 3)
+                {
+                    amrex::Abort("\nalgo.particle_shape can be only 1, 2, or 3");
+                }
+                else
+                {
+                    nox = particle_shape;
+                    noy = particle_shape;
+                    noz = particle_shape;
+                }
             }
         }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -790,7 +790,8 @@ WarpX::ReadParameters ()
         queryWithParser(pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
         queryWithParser(pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
 
-        // check if any nspecies > 0 before testing entry for algo.particle_shape
+        // Parse algo.particle_shape and check that input is acceptable
+        // (do this only if there is at least one particle species)
         ParmParse pp_particles("particles");
         std::vector<std::string> species_names;
         pp_particles.queryarr("species_names", species_names);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -814,13 +814,13 @@ WarpX::ReadParameters ()
                     noz = particle_shape;
                 }
             }
-        }
 
-        if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))
-        {
-            amrex::Warning("\nWARNING: When algo.particle_shape > 1,"
-                           " some numerical artifact will be present at the interface between coarse and fine patch."
-                           "\nWe recommend setting algo.particle_shape = 1 in order to avoid this issue");
+            if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))
+            {
+                amrex::Warning("\nWARNING: When algo.particle_shape > 1,"
+                               " some numerical artifact will be present at the interface between coarse and fine patch."
+                               "\nWe recommend setting algo.particle_shape = 1 in order to avoid this issue");
+            }
         }
     }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -795,7 +795,12 @@ WarpX::ReadParameters ()
         ParmParse pp_particles("particles");
         std::vector<std::string> species_names;
         pp_particles.queryarr("species_names", species_names);
-        if (species_names.size() > 0) {
+
+        ParmParse pp_lasers("lasers");
+        std::vector<std::string> lasers_names;
+        pp_lasers.queryarr("names", lasers_names);
+
+        if (species_names.size() > 0 || lasers_names.size() > 0) {
             int particle_shape;
             if (pp_algo.query("particle_shape", particle_shape) == false)
             {


### PR DESCRIPTION
New input parameter `algo.particle_shape` is mandatory only if there is at least one particle species or one laser species.