### PR TITLE
Docs: Dev git Notes

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -8,6 +8,7 @@ Please see installation instructions below.
 
 - a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 5, Clang 3.6 or newer
 - `CMake 3.15.0+ <https://cmake.org>`__
+- `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `PICSAR <https://github.com/ECP-WarpX/picsar>`__: we automatically download and compile a copy of PICSAR
 
@@ -69,6 +70,7 @@ Brew (macOS/Linux)
    brew install ccache
    brew install cmake
    brew install fftw
+   brew install git
    brew install hdf5-mpi
    brew install libomp
    brew install pkg-config  # for fftw
@@ -101,5 +103,5 @@ Apt (Debian/Ubuntu)
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install build-essential ccache cmake g++ libfftw3-mpi-dev libfftw3-dev libhdf5-openmpi-dev libopenmpi-dev pkg-config python3 python3-matplotlib python3-numpy python3-scipy
+   sudo apt install build-essential ccache cmake g++ git libfftw3-mpi-dev libfftw3-dev libhdf5-openmpi-dev libopenmpi-dev pkg-config python3 python3-matplotlib python3-numpy python3-scipy
 


### PR DESCRIPTION
Add `git` installation instructions where missing.
Minimal version: as required by GitHub these days.

Not added in Spack: because Spack already requires `git` to run.

Related to #1935