### PR TITLE
Performance: Preserve the electrostatic potential from step to step

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -106,7 +106,6 @@ WarpX::AddSpaceChargeFieldLabFrame ()
 #endif
 
     // Allocate fields for charge
-    // Also, zero out the phi data
     const int num_levels = max_level + 1;
     Vector<std::unique_ptr<MultiFab> > rho(num_levels);
     // Use number of guard cells used for local deposition of rho
@@ -116,7 +115,6 @@ WarpX::AddSpaceChargeFieldLabFrame ()
         nba.surroundingNodes();
         rho[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, ng);
         rho[lev]->setVal(0.);
-        phi_fp[lev]->setVal(0.);
     }
 
     // Deposit particle charge density (source of Poisson solver)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1401,6 +1401,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     {
         IntVect ngPhi = IntVect( AMREX_D_DECL(1,1,1) );
         phi_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,phi_nodal_flag),dm,ncomps,ngPhi,tag("phi_fp"));
+        phi_fp[lev]->setVal(0.);
     }
 
     if (do_subcycling == 1 && lev == 0)


### PR DESCRIPTION
@dpgrote as we've discussed before this change is to preserve `phi` between simulation steps so that the potential of the previous step is used as a starting guess for the solution of the Poisson equation. These changes shouldn't interfere with any simulation that doesn't use the electrostatic solver in the lab frame. 
In a specific test case I've been running this results in a ~25% speed-up for the field solve, mainly by decreasing the number of iterations needed to reach convergence. As an example, here is the output from a single field solve step before the change:
```
MLMG: # of AMR levels: 1
      # of MG levels on the coarsest AMR level: 3
MLMG: Initial rhs               = 1689348.824
MLMG: Initial residual (resid0) = 1689348.824
MLMG: Iteration   1 Fine resid/bnorm = 0.2716172395
...
MLMG: Iteration  22 Fine resid/bnorm = 7.88474967e-07
MLMG: Final Iter. 22 resid, resid/bnorm = 1.332009258, 7.88474967e-07
MLMG: Timers: Solve = 0.023249422 Iter = 0.023105762 Bottom = 0.017562342
```
and here is the output with the change:
```
MLMG: # of AMR levels: 1
      # of MG levels on the coarsest AMR level: 3
MLMG: Initial rhs               = 1689348.314
MLMG: Initial residual (resid0) = 240063.9761
MLMG: Iteration   1 Fine resid/bnorm = 0.02256391458
...
MLMG: Iteration  18 Fine resid/bnorm = 7.326168992e-07
MLMG: Final Iter. 18 resid, resid/bnorm = 1.237645124, 7.326168992e-07
MLMG: Timers: Solve = 0.017365125 Iter = 0.017234262 Bottom = 0.012807491
```