### PR TITLE
replace copy with FabArray::ParallelCopy() in BTD

### DIFF
--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -728,7 +728,7 @@ void BackTransformedDiagnostic::Flush(const Geometry& /*geom*/)
 
                 MultiFab tmp(buff_ba, buff_dm, ncomp, 0);
 
-                tmp.copy(*lf_diags->m_data_buffer_, 0, 0, ncomp);
+                tmp.ParallelCopy(*lf_diags->m_data_buffer_, 0, 0, ncomp);
 
 #ifdef WARPX_USE_HDF5
                 for (int comp = 0; comp < ncomp; ++comp) {
@@ -881,7 +881,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
              // which has the dmap of the domain to
              // tmp_slice_ptr which has the dmap of the
              // data_buffer that stores the back-transformed data.
-             tmp_slice_ptr->copy(*slice, 0, 0, ncomp);
+             tmp_slice_ptr->ParallelCopy(*slice, 0, 0, ncomp);
              lf_diags->AddDataToBuffer(*tmp_slice_ptr, i_lab,
                                                map_actual_fields_to_dump);
              tmp_slice_ptr = nullptr;

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -59,7 +59,7 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         // Parallel copy the lab-frame data from "slice" MultiFab with
         // ncomp=10 and boosted-frame dmap to "tmp_slice_ptr" MultiFab with
         // ncomp=10 and dmap of the destination Multifab, which will store the final data
-        tmp_slice_ptr->copy( *slice, 0, 0, slice->nComp() );
+        tmp_slice_ptr->ParallelCopy( *slice, 0, 0, slice->nComp() );
         // Now we will cherry pick only the user-defined fields from
         // tmp_slice_ptr to dst_mf
         const int k_lab = m_k_index_zlab[i_buffer];


### PR DESCRIPTION
Replaced `mf.copy()` with `mf.ParallelCopy()` as AMReX added a deprecation message for those calls.
Thank you @ax3l for catching this.