### PR TITLE
Added new option <diag>.openpmd_encoding

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1591,10 +1591,10 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     ``json`` only works with serial/single-rank jobs.
     When WarpX is compiled with openPMD support, the first available backend in the order given above is taken.
 
-* ``<diag_name>.openpmd_encoding`` (optional, ``v`` (default, variable based), ``f`` (file based) or ``g`` (group based) ) only read if ``<diag_name>.format = openpmd``.
+* ``<diag_name>.openpmd_encoding`` (optional, ``v`` (variable based), ``f`` (file based) or ``g`` (group based) ) only read if ``<diag_name>.format = openpmd``.
      openPMD file output encoding (file based will write one file per timestep).
      `variable based` is not supported for back-transformed diagnostics.
-     Default: ``v`` (full diagnostics) or ``g`` (back-transformed diagnostics).
+     Default: ``f`` (full diagnostics)
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1593,6 +1593,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.openpmd_encoding`` (optional, ``v`` (default, variable based), ``f`` (file based) or ``g`` (group based) ) only read if ``<diag_name>.format = openpmd``.
      openPMD file output encoding (file based will write one file per timestep).
+     `variable based` is not supported for back-transformed diagnostics.
+     Default: ``v`` (full diagnostics) or ``g`` (back-transformed diagnostics).
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1591,8 +1591,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     ``json`` only works with serial/single-rank jobs.
     When WarpX is compiled with openPMD support, the first available backend in the order given above is taken.
 
-* ``<diag_name>.openpmd_tspf`` (`bool`, optional, default ``true``) only read if ``<diag_name>.format = openpmd``.
-    Whether to write one file per timestep.
+* ``<diag_name>.openpmd_encoding`` (optional, ``v`` (default, variable based), ``f`` (file based) or ``g`` (group based) ) only read if ``<diag_name>.format = openpmd``.
+     openPMD file output encoding (file based will write one file per timestep).
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -12,7 +12,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
     // Which backend to use (ADIOS, ADIOS2 or HDF5). Default depends on what is available
     std::string openpmd_backend {"default"};
     // one file per timestep (or one file for all steps)
-    std::string  openpmd_encoding {"v"};
+    std::string  openpmd_encoding {"f"};
     pp_diag_name.query("openpmd_backend", openpmd_backend);
     bool encodingDefined = pp_diag_name.query("openpmd_encoding", openpmd_encoding);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -25,7 +25,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 #endif
     else if ( 0 == openpmd_encoding.compare("f") )
       encoding = openPMD::IterationEncoding::fileBased;
-      
+
   //
   // if no encoding is defined, then check to see if tspf is defined.
   // (backward compatibility)

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -25,7 +25,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 #endif
     else if ( 0 == openpmd_encoding.compare("f") )
       encoding = openPMD::IterationEncoding::fileBased;
-
+      
   //
   // if no encoding is defined, then check to see if tspf is defined.
   // (backward compatibility)

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -35,12 +35,12 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
       bool openpmd_tspf = false;
       bool tspfDefined = pp_diag_name.query("openpmd_tspf", openpmd_tspf);
       if ( tspfDefined && openpmd_tspf )
-	encoding = openPMD::IterationEncoding::fileBased;
+    encoding = openPMD::IterationEncoding::fileBased;
     }
   auto & warpx = WarpX::GetInstance();
   m_OpenPMDPlotWriter = std::make_unique<WarpXOpenPMDPlot>(
-							   encoding, openpmd_backend, warpx.getPMLdirections()
-							   );
+                               encoding, openpmd_backend, warpx.getPMLdirections()
+                               );
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -93,11 +93,11 @@ public:
 
   /** Initialize openPMD I/O routines
    *
-   * @param oneFilePerTS write one file per timestep
+   * @param ie  iteration encoding from openPMD: "group, file, variable"
    * @param filetype file backend, e.g. "bp" or "h5"
    * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
    */
-  WarpXOpenPMDPlot (bool oneFilePerTS, std::string filetype, std::vector<bool> fieldPMLdirections);
+  WarpXOpenPMDPlot (openPMD::IterationEncoding ie, std::string filetype, std::vector<bool> fieldPMLdirections);
 
   ~WarpXOpenPMDPlot ();
 
@@ -243,7 +243,7 @@ private:
   //int m_NumSoAIntAttributes = PIdx::nattribs; //! WarpX' additional int particle attributes in SoA
   int m_NumAoSIntAttributes = 0; //! WarpX definition: no additional int attributes in particle AoS
 
-  bool m_OneFilePerTS = true;  //! write in openPMD fileBased manner for individual time steps
+  openPMD::IterationEncoding m_Encoding = openPMD::IterationEncoding::groupBased;
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5
   int m_CurrentStep  = -1;
 

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -129,6 +129,23 @@ public:
 private:
   void Init (openPMD::Access access, bool isBTD);
 
+
+  inline openPMD::Iteration& GetIteration(int iteration) const
+  {
+    // so BTD will be able to revisit previous steps, so we do not use steps with these two encodings,
+    if (  (openPMD::IterationEncoding::fileBased == m_Encoding ) ||
+          (openPMD::IterationEncoding::groupBased == m_Encoding )  )
+    {
+        openPMD::Iteration& it = m_Series->iterations[iteration];
+        return it;
+    } else {
+        auto iterations = m_Series->writeIterations();
+        openPMD::Iteration& it = iterations[iteration];
+        return it;
+    }
+  };
+
+
   /** This function does initial setup for the fields when interation is newly created
    *  @param[in] meshes   The meshes in a series
    *  @param[in] full_geom The geometry

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -260,7 +260,7 @@ private:
   //int m_NumSoAIntAttributes = PIdx::nattribs; //! WarpX' additional int particle attributes in SoA
   int m_NumAoSIntAttributes = 0; //! WarpX definition: no additional int attributes in particle AoS
 
-  openPMD::IterationEncoding m_Encoding = openPMD::IterationEncoding::groupBased;
+  openPMD::IterationEncoding m_Encoding = openPMD::IterationEncoding::fileBased;
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5
   int m_CurrentStep  = -1;
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -290,7 +290,7 @@ void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
     if (isBTD and !isLastBTDFlush) callClose = false;
     if (callClose) {
         if (m_Series) {
-      lf_iterationClose();    
+      lf_iterationClose();
         }
 
         // create a little helper file for ParaView 5.9+
@@ -341,7 +341,7 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
         m_MPISize = 1;
         m_MPIRank = 1;
     }
-   
+
     m_Series->setIterationEncoding( m_Encoding );
 
     // input file / simulation setup author
@@ -457,7 +457,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD: series must be initialized");
 
   WarpXParticleCounter counter(pc);
-  
+
   auto  lfs_test =[&] () -> openPMD::Iteration&
   {
     if ( m_Encoding != openPMD::IterationEncoding::variableBased ) {
@@ -469,9 +469,9 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
         return it;
     }
   };
- 
+
   openPMD::Iteration& currIteration = lfs_test();
-  
+
   openPMD::ParticleSpecies currSpecies = currIteration.particles[name];
   // meta data for ED-PIC extension
   currSpecies.setAttribute( "particleShape", double( WarpX::noz ) );

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -263,7 +263,7 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& dirPrefix,
       {
         std::string warnMsg = "Unable to support BTD with streaming. Using GroupBased ";
         amrex::Warning(warnMsg);
-	m_Encoding = openPMD::IterationEncoding::groupBased;
+    m_Encoding = openPMD::IterationEncoding::groupBased;
       }
     }
     m_CurrentStep = ts;
@@ -290,7 +290,7 @@ void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
     if (isBTD and !isLastBTDFlush) callClose = false;
     if (callClose) {
         if (m_Series) {
-	  lf_iterationClose();	
+      lf_iterationClose();    
         }
 
         // create a little helper file for ParaView 5.9+

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -465,7 +465,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
     if (  (openPMD::IterationEncoding::fileBased == m_Encoding ) ||
           (openPMD::IterationEncoding::groupBased == m_Encoding )  )
     {
-        openPMD::Iteration& it = m_Series->iterations[iteration]; 
+        openPMD::Iteration& it = m_Series->iterations[iteration];
         return it;
     } else {
         auto iterations = m_Series->writeIterations();
@@ -985,7 +985,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
     {
         openPMD::Iteration& it = m_Series->iterations[m_CurrentStep];
         return it;
-    } else { 
+    } else {
         auto iterations = m_Series->writeIterations();
         openPMD::Iteration& it = iterations[m_CurrentStep];
         return it;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -259,11 +259,12 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& dirPrefix,
 
     if ( isBTD )
     {
-      if ( m_Encoding == openPMD::IterationEncoding::variableBased )xs
+      if ( ( openPMD::IterationEncoding::fileBased != m_Encoding ) &&
+           ( openPMD::IterationEncoding::groupBased != m_Encoding ) )
       {
         std::string warnMsg = "Unable to support BTD with streaming. Using GroupBased ";
         amrex::Warning(warnMsg);
-    m_Encoding = openPMD::IterationEncoding::groupBased;
+        m_Encoding = openPMD::IterationEncoding::groupBased;
       }
     }
     m_CurrentStep = ts;
@@ -460,8 +461,11 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
 
   auto  lfs_test =[&] () -> openPMD::Iteration&
   {
-    if ( m_Encoding != openPMD::IterationEncoding::variableBased ) {
-        openPMD::Iteration& it = m_Series->iterations[iteration];
+    // do not use steps with these two encodings, so BTD will be able to revisit previous steps
+    if (  (openPMD::IterationEncoding::fileBased == m_Encoding ) ||
+          (openPMD::IterationEncoding::groupBased == m_Encoding )  )
+    {
+        openPMD::Iteration& it = m_Series->iterations[iteration]; 
         return it;
     } else {
         auto iterations = m_Series->writeIterations();
@@ -975,10 +979,13 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
 
   auto  lfs_test =[&] () -> openPMD::Iteration&
   {
-    if ( m_Encoding != openPMD::IterationEncoding::variableBased ) {
+    // do not use steps with these two encodings, so BTD will be able to revisit previous steps
+    if (  (openPMD::IterationEncoding::fileBased == m_Encoding ) ||
+          (openPMD::IterationEncoding::groupBased == m_Encoding )  )
+    {
         openPMD::Iteration& it = m_Series->iterations[m_CurrentStep];
         return it;
-    } else {
+    } else { 
         auto iterations = m_Series->writeIterations();
         openPMD::Iteration& it = iterations[m_CurrentStep];
         return it;


### PR DESCRIPTION
which can be either f/g/v for  file/group/variable

With the encoding being either "group" or "variable",  one file will be generated for all
iterations.  While if the encoding value is "file",  each iteration will generate its own file.