### PR TITLE
using amrex::Math::abs for EB init

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -110,7 +110,8 @@ WarpX::ComputeEdgeLengths () {
                         edge_lengths_dim(i, j, k) = 1.;
                     } else {
                         // This edge is cut.
-                        edge_lengths_dim(i, j, k) = 1 - abs(amrex::Real(2.0)*edge_cent(i, j, k));
+                        edge_lengths_dim(i, j, k) = 1 - amrex::Math::abs(amrex::Real(2.0)
+                                                                        * edge_cent(i, j, k));
                     }
                 });
             }


### PR DESCRIPTION
When compiling with USE_EB=TRUE on summit, the code failed with the amrex disabled error message for `abs`.
In this PR, this is fixed by using `amrex::Math::abs`