### PR TITLE
openPMD: Expose ADIOS2 Operators (Compressors)

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1602,6 +1602,27 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
      `variable based` is not supported for back-transformed diagnostics.
      Default: ``f`` (full diagnostics)
 
+* ``<diag_name>.openpmd_operator.type`` (``zfp``, ``blosc``) optional,
+    `ADIOS2 I/O operator type <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
+
+* ``<diag_name>.openpmd_operator.parameters.*`` optional,
+    `ADIOS2 I/O operator parameters <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
+
+    A typical example for `ADIOS2 output using lossless compression <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ with ``blosc`` using the ``zstd`` compressor and 6 CPU treads per MPI Rank (e.g. for a `GPU run with spare CPU resources <https://arxiv.org/abs/1706.00522>`__):
+    ```
+        <diag_name>.openpmd_operator.type = blosc
+        <diag_name>.openpmd_operator.parameters.compressor = zstd
+        <diag_name>.openpmd_operator.parameters.clevel = 1
+        <diag_name>.openpmd_operator.parameters.doshuffle = BLOSC_BITSHUFFLE
+        <diag_name>.openpmd_operator.parameters.threshold = 2048
+        <diag_name>.openpmd_operator.parameters.nthreads = 6  # per MPI rank (and thus per GPU)
+    ```
+    or for the lossy ZFP compressor using very strong compression per scalar:
+    ```
+        <diag_name>.openpmd_operator.type = zfp
+        <diag_name>.openpmd_operator.parameters.precision = 3
+    ```
+
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
     Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1602,25 +1602,25 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
      `variable based` is not supported for back-transformed diagnostics.
      Default: ``f`` (full diagnostics)
 
-* ``<diag_name>.openpmd_operator.type`` (``zfp``, ``blosc``) optional,
+* ``<diag_name>.adios2_operator.type`` (``zfp``, ``blosc``) optional,
     `ADIOS2 I/O operator type <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
 
-* ``<diag_name>.openpmd_operator.parameters.*`` optional,
+* ``<diag_name>.adios2_operator.parameters.*`` optional,
     `ADIOS2 I/O operator parameters <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
 
     A typical example for `ADIOS2 output using lossless compression <https://openpmd-api.readthedocs.io/en/0.13.3/details/backendconfig.html#adios2>`__ with ``blosc`` using the ``zstd`` compressor and 6 CPU treads per MPI Rank (e.g. for a `GPU run with spare CPU resources <https://arxiv.org/abs/1706.00522>`__):
     ```
-        <diag_name>.openpmd_operator.type = blosc
-        <diag_name>.openpmd_operator.parameters.compressor = zstd
-        <diag_name>.openpmd_operator.parameters.clevel = 1
-        <diag_name>.openpmd_operator.parameters.doshuffle = BLOSC_BITSHUFFLE
-        <diag_name>.openpmd_operator.parameters.threshold = 2048
-        <diag_name>.openpmd_operator.parameters.nthreads = 6  # per MPI rank (and thus per GPU)
+        <diag_name>.adios2_operator.type = blosc
+        <diag_name>.adios2_operator.parameters.compressor = zstd
+        <diag_name>.adios2_operator.parameters.clevel = 1
+        <diag_name>.adios2_operator.parameters.doshuffle = BLOSC_BITSHUFFLE
+        <diag_name>.adios2_operator.parameters.threshold = 2048
+        <diag_name>.adios2_operator.parameters.nthreads = 6  # per MPI rank (and thus per GPU)
     ```
     or for the lossy ZFP compressor using very strong compression per scalar:
     ```
-        <diag_name>.openpmd_operator.type = zfp
-        <diag_name>.openpmd_operator.parameters.precision = 3
+        <diag_name>.adios2_operator.type = zfp
+        <diag_name>.adios2_operator.parameters.precision = 3
     ```
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -58,8 +58,8 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 
   // ADIOS2 operator type & parameters
   std::string operator_type;
-  pp_diag_name.query("openpmd_operator.type", operator_type);
-  std::string const prefix = diag_name + ".openpmd_operator.parameters";
+  pp_diag_name.query("adios2_operator.type", operator_type);
+  std::string const prefix = diag_name + ".adios2_operator.parameters";
   ParmParse pp;
   auto entr = pp.getEntries(prefix);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -1,7 +1,11 @@
 #include "FlushFormatOpenPMD.H"
 #include "WarpX.H"
 
+#include <AMReX_ParmParse.H>
+
+#include <map>
 #include <memory>
+#include <string>
 
 using namespace amrex;
 
@@ -11,6 +15,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
     ParmParse pp_diag_name(diag_name);
     // Which backend to use (ADIOS, ADIOS2 or HDF5). Default depends on what is available
     std::string openpmd_backend {"default"};
+
     // one file per timestep (or one file for all steps)
     std::string  openpmd_encoding {"f"};
     pp_diag_name.query("openpmd_backend", openpmd_backend);
@@ -51,10 +56,28 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
           encoding = openPMD::IterationEncoding::fileBased;
     }
 
+  // ADIOS2 operator type & parameters
+  std::string operator_type;
+  pp_diag_name.query("openpmd_operator.type", operator_type);
+  std::string const prefix = diag_name + ".openpmd_operator.parameters";
+  ParmParse pp;
+  auto entr = pp.getEntries(prefix);
+
+  std::map< std::string, std::string > operator_parameters;
+  auto const prefix_len = prefix.size() + 1;
+  for (std::string k : entr) {
+    std::string v;
+    pp.get(k.c_str(), v);
+    k.erase(0, prefix_len);
+    operator_parameters.insert({k, v});
+  }
+
   auto & warpx = WarpX::GetInstance();
   m_OpenPMDPlotWriter = std::make_unique<WarpXOpenPMDPlot>(
-                               encoding, openpmd_backend, warpx.getPMLdirections()
-                               );
+    encoding, openpmd_backend,
+    operator_type, operator_parameters,
+    warpx.getPMLdirections()
+  );
 }
 
 void

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -24,6 +24,7 @@
 #endif
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -95,9 +96,15 @@ public:
    *
    * @param ie  iteration encoding from openPMD: "group, file, variable"
    * @param filetype file backend, e.g. "bp" or "h5"
+   * @param operator_type openPMD-api backend operator (compressor) for ADIOS2
+   * @param operator_parameters openPMD-api backend operator parameters for ADIOS2
    * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
    */
-  WarpXOpenPMDPlot (openPMD::IterationEncoding ie, std::string filetype, std::vector<bool> fieldPMLdirections);
+  WarpXOpenPMDPlot (openPMD::IterationEncoding ie,
+                    std::string filetype,
+                    std::string operator_type,
+                    std::map< std::string, std::string > operator_parameters,
+                    std::vector<bool> fieldPMLdirections);
 
   ~WarpXOpenPMDPlot ();
 
@@ -262,6 +269,7 @@ private:
 
   openPMD::IterationEncoding m_Encoding = openPMD::IterationEncoding::fileBased;
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5
+  std::string m_OpenPMDoptions = "{}"; //! JSON option string for openPMD::Series constructor
   int m_CurrentStep  = -1;
 
   // meta data


### PR DESCRIPTION
Expose ADIOS2 Operators (at the moment: one operator max) in WarpX inputs. This allows the user to select ZFP or Blosc (e.g. with ZSTD) compression without changing the input file.

We can later on define short-hand notions for this. For now we give the parameters control out for the expert user and document good examples.

## Background

This provides functionality as in our ISC17 / DRBSD-1 paper: https://arxiv.org/abs/1706.00522

## Tests

In my tests, the documented options work and make a difference. I am not sure if the blosc threading works (problem noted, debugged and moved upstream) - if that is a problem it will be fixed with a later release of ADIOS2.