### PR TITLE
[WIP] Azure: Always with EB

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
     WARPX_CI_CCACHE: 'TRUE'
     WARPX_CI_OPENPMD: 'TRUE'
     WARPX_CI_PSATD: 'TRUE'
+    WARPX_CI_EB: 'TRUE'
     FFTW_HOME: '/usr/'
     BLASPP_HOME: '/usr/local/'
     LAPACKPP_HOME: '/usr/local/'
@@ -32,8 +33,6 @@ jobs:
         WARPX_CI_RZ_OR_NOMPI: 'TRUE'
       qed:
         WARPX_CI_QED: 'TRUE'
-      embedded_boundary:
-        WARPX_CI_EB: 'TRUE'
 
   # default: 60; maximum: 360
   timeoutInMinutes: 90

--- a/.github/workflows/source/test_travis_matrix.sh
+++ b/.github/workflows/source/test_travis_matrix.sh
@@ -25,8 +25,6 @@ WARPX_CI_RZ_OR_NOMPI=TRUE      python prepare_file_travis.py
 grep "\[" travis-tests.ini >> travis_matrix_elements.txt
 WARPX_CI_QED=TRUE               python prepare_file_travis.py
 grep "\[" travis-tests.ini >> travis_matrix_elements.txt
-WARPX_CI_EB=TRUE               python prepare_file_travis.py
-grep "\[" travis-tests.ini >> travis_matrix_elements.txt
 
 # Check that the resulting lists are equal
 {

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -68,6 +68,7 @@ jobs:
           -DWarpX_COMPUTE=CUDA         \
           -DWarpX_LIB=ON               \
           -DAMReX_CUDA_ARCH=6.0        \
+          -DWarpX_EB=ON                \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \
           -DWarpX_PRECISION=SINGLE     \
@@ -158,6 +159,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_VERSION=12.0              \
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
@@ -205,6 +207,7 @@ jobs:
           -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
@@ -240,6 +243,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DAMReX_AMD_ARCH=gfx900     \
           -DWarpX_COMPUTE=HIP         \
+          -DWarpX_EB=ON               \
           -DWarpX_LIB=ON              \
           -DWarpX_MPI=ON              \
           -DWarpX_OPENPMD=ON          \

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -62,6 +62,13 @@ if ci_psatd:
     text = re.sub('USE_PSATD=FALSE',
                   '', text)
 
+# always build with EB support (runtime controlled if used)
+if ci_eb:
+    text = re.sub('addToCompileString =',
+                  'addToCompileString = USE_EB=TRUE ', text)
+    text = re.sub('USE_EB=FALSE',
+                  '', text)
+
 # Ccache
 if ci_ccache:
     text = re.sub('addToCompileString =',
@@ -116,7 +123,6 @@ if ci_regular_cartesian_2d:
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['USE_EB=TRUE'], False)
 
 if ci_regular_cartesian_3d:
     test_blocks = select_tests(test_blocks, ['dim = 2'], False)
@@ -125,7 +131,6 @@ if ci_regular_cartesian_3d:
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['USE_EB=TRUE'], False)
 
 if ci_python_main:
     test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], True)
@@ -141,9 +146,6 @@ if ci_rz_or_nompi:
 
 if ci_qed:
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], True)
-
-if ci_eb:
-    test_blocks = select_tests(test_blocks, ['USE_EB=TRUE'], True)
 
 # - Add the selected test blocks to the text
 text = text + '\n' + '\n'.join(test_blocks)


### PR DESCRIPTION
Always compile with EB in Azure. Since EB shall be an opt-in, non-exclusive option we can also just compile with it to make sure we cover all geometries & cases. (Note: that does not mean we implemented all those combinations - we just make sure that we do not fail to compile and that we do not introduce runtime issues with other parts of the code base just by enabling it.)

Also compiles EB with all compilers in GitHub actions, besides one entry (minimal build) to make sure we can continue to build without it.

Rebase after:
- [ ] #1919 
- [ ] #2170

Follow up to:
- https://github.com/ECP-WarpX/WarpX/pull/1929#issuecomment-837008983
- #1982