### PR TITLE
[mini-PR] replaced "query" with "get" to read reduced diag type from inputfile

### DIFF
--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -62,7 +62,7 @@ MultiReducedDiags::MultiReducedDiags ()
 
             // read reduced diags type
             std::string rd_type;
-            pp_rd_name.query("type", rd_type);
+            pp_rd_name.get("type", rd_type);
 
             if(reduced_diags_dictionary.count(rd_type) == 0)
                 Abort("No matching reduced diagnostics type found.");


### PR DESCRIPTION
The user must always write the type of a reduced diag in the inputfile. Therefore, I think that we can replace `query` with `get` in this case.