### PR TITLE
[mini-PR] improve error message in case of wrong type of a reduced diag

### DIFF
--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -65,7 +65,7 @@ MultiReducedDiags::MultiReducedDiags ()
             pp_rd_name.query("type", rd_type);
 
             if(reduced_diags_dictionary.count(rd_type) == 0)
-                Abort("No matching reduced diagnostics type found.");
+                Abort(rd_type + " is not a valid type for reduced diagnostic " + rd_name + ".");
 
             return reduced_diags_dictionary.at(rd_type)(rd_name);
         });

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -65,7 +65,7 @@ MultiReducedDiags::MultiReducedDiags ()
             pp_rd_name.query("type", rd_type);
 
             if(reduced_diags_dictionary.count(rd_type) == 0)
-                Abort(rd_type + " is not a valid type for reduced diagnostic " + rd_name + ".");
+                Abort(rd_type + " is not a valid type for reduced diagnostic " + rd_name);
 
             return reduced_diags_dictionary.at(rd_type)(rd_name);
         });


### PR DESCRIPTION
This PR should improve the error message in the case of a non-matching type of a reduced diag.
In particular, the error message should change from
```
No matching reduced diagnostics type found. !!!
```
to a more informative message:
```
FFieldReduction is not a valid type for reduced diagnostic FR_Integral !!!
```