### PR TITLE
Parser: Fix Operator Issues; Field Energy: Cleanups

### DIFF
--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -90,7 +90,7 @@ FR_Min.reduction_type = Minimum
 FR_Integral.type = FieldReduction
 FR_Integral.intervals = 200
 FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) =
-    "if(y > 0, if(z < 0, 0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0), 0), 0)"
+    "if(y > 0 and z < 0, 0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0), 0)"
 FR_Integral.reduction_type = Integral
 
 # Diagnostics

--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -89,8 +89,8 @@ FR_Min.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = x*Ey*Bz
 FR_Min.reduction_type = Minimum
 FR_Integral.type = FieldReduction
 FR_Integral.intervals = 200
-FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = "((y > 0)*(z < 0)) *
-                              (0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0))"
+FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) =
+    "if(y > 0, if(z < 0, 0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0), 0), 0)"
 FR_Integral.reduction_type = Integral
 
 # Diagnostics

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.H
@@ -26,12 +26,11 @@ public:
     FieldEnergy(std::string rd_name);
 
     /**
-     * This function computes the field energy (EF).
-     * EF = E eps / 2 + B / mu / 2,
-     * where E is the electric field,
-     * B is the magnetic field,
-     * eps is the vacuum permittivity,
-     * mu is the vacuum permeability.
+     * This function computes the field energy (EF):
+     * EF = sum( 1/2 * (|E|^2 * eps0 + |B|^2 / mu0) * dV ),
+     * where E is the electric field, B is the magnetic field,
+     * eps0 is the vacuum permittivity, mu0 is the vacuum permeability,
+     * dV is the cell volume (area, in 2D) and the sum is over all cells.
      *
      * @param[in] step current time step
      */

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -38,13 +38,6 @@ FieldReduction::FieldReduction (std::string rd_name)
     std::string parser_string = "";
     Store_parserString(pp_rd_name,"reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz)",
                        parser_string);
-    // Remove newlines and spaces in the parser string. This is because this string is written in
-    // the header of the reduced diag output file so this should prevent weird formatting from
-    // occuring.
-    parser_string.erase(std::remove(parser_string.begin(), parser_string.end(), '\n'),
-                        parser_string.end());
-    parser_string.erase(std::remove(parser_string.begin(), parser_string.end(), ' '),
-                        parser_string.end());
     m_parser = std::make_unique<ParserWrapper<m_nvars>>(
         makeParser(parser_string,{"x","y","z","Ex","Ey","Ez","Bx","By","Bz"}));
 


### PR DESCRIPTION
Two late suggestions on #1944 had been left out:
- use new `if` capability of math parser (see #1976) in input file
- fix comment in Source/Diagnostics/ReducedDiags/FieldEnergy.H

In the meantime we also fix a small bug in WarpX/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
(do not remove `\n` or white spaces from strings passed to the parser, see https://github.com/ECP-WarpX/WarpX/pull/1987#discussion_r639306492 below).