### PR TITLE
Docs: Spock (OLCF)

### DIFF
--- a/Docs/source/install/hpc.rst
+++ b/Docs/source/install/hpc.rst
@@ -26,6 +26,7 @@ HPC Systems
 
    hpc/cori
    hpc/summit
+   hpc/spock
    hpc/juwels
    hpc/lassen
    hpc/quartz

--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -58,7 +58,7 @@ We use the following modules and environments on the system (``$HOME/warpx_spock
    # compiler environment hints
    export CC=$(which clang)
    export CXX=$(which hipcc)
-   export LDFLAGS="-L/opt/cray/pe/cce/11.0.4/cce/x86_64/lib/ $(CC --cray-print-opts=libs) -lmpi"
+   export LDFLAGS="-L${CRAYLIBS_X86_64} $(CC --cray-print-opts=libs) -lmpi"
    # GPU aware MPI: ${PE_MPICH_GTL_DIR_gfx908} -lmpi_gtl_hsa
 
 

--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -1,0 +1,106 @@
+.. _building-spock:
+
+Spock (OLCF)
+=============
+
+The `Spock cluster <https://docs.olcf.ornl.gov/systems/spock_quick_start_guide.html>`_ is located at OLCF.
+
+If you are new to this system, please see the following resources:
+
+* `Spock user guide <https://docs.olcf.ornl.gov/systems/spock_quick_start_guide.html>`_
+* Batch system: `Slurm <https://docs.olcf.ornl.gov/systems/spock_quick_start_guide.html#running-jobs>`_
+* `Production directories <https://docs.olcf.ornl.gov/data/storage_overview.html>`_:
+
+  * ``$PROJWORK/$proj/``: shared with all members of a project (recommended)
+  * ``$MEMBERWORK/$proj/``: single user (usually smaller quota)
+  * ``$WORLDWORK/$proj/``: shared with all users
+  * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
+    That means you cannot run in your ``$HOME``.
+
+
+Installation
+------------
+
+Use the following commands to download the WarpX source code and switch to the correct branch:
+
+.. code-block:: bash
+
+   git clone https://github.com/ECP-WarpX/WarpX.git $HOME/src/warpx
+
+We use the following modules and environments on the system (``$HOME/warpx_spock.profile``).
+
+.. code-block:: bash
+
+   # please set your project account
+   export proj=<yourProject>
+
+   # required dependencies
+   module load cmake
+   module load craype-accel-amd-gfx908
+   module load rocm/4.1.0
+
+   # optional: faster builds
+   module load ccache
+   module load ninja
+
+   # optional: just an additional text editor
+   module load nano
+
+   # optional: an alias to request an interactive node for one hour
+   alias getNode="salloc -A $proj -J warpx -t 01:00:00 -p ecp -N 1"
+
+   # fix system defaults: do not escape $ with a \ on tab completion
+   shopt -s direxpand
+
+   # optimize CUDA compilation for MI100
+   export AMREX_AMD_ARCH=gfx908
+
+   # compiler environment hints
+   export CC=$(which clang)
+   export CXX=$(which hipcc)
+   export LDFLAGS="-L/opt/cray/pe/cce/11.0.4/cce/x86_64/lib/ $(CC --cray-print-opts=libs) -lmpi"
+   # GPU aware MPI: ${PE_MPICH_GTL_DIR_gfx908} -lmpi_gtl_hsa
+
+
+We recommend to store the above lines in a file, such as ``$HOME/warpx_spock.profile``, and load it into your shell after a login:
+
+.. code-block:: bash
+
+   source $HOME/warpx_spock.profile
+
+
+Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+
+.. code-block:: bash
+
+   cd $HOME/src/warpx
+   rm -rf build
+
+   cmake -S . -B build -DWarpX_OPENPMD=ON -DWarpX_DIMS=3 -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
+   cmake --build build -j 10
+
+The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
+
+
+.. _running-cpp-spock:
+
+Running
+-------
+
+.. _running-cpp-spock-MI100-GPUs:
+
+MI100 GPUs
+^^^^^^^^^^
+
+After requesting an interactive node with the ``getNode`` alias above, run a simulation like this, here using 4 MPI ranks:
+
+.. code-block:: bash
+
+   srun -n 4 -c 2 --ntasks-per-node=4 ./warpx inputs
+
+Or in non-interactive runs:
+
+.. literalinclude:: ../../../../Tools/BatchScripts/batch_spock.sh
+   :language: bash
+
+We can currently use up to ``4`` nodes with ``4`` GPUs each (maximum: ``-N 4 -n 16``).

--- a/Tools/BatchScripts/batch_spock.sh
+++ b/Tools/BatchScripts/batch_spock.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#SBATCH -A <project id>
+#SBATCH -J warpx
+#SBATCH -o %x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p ecp
+#SBATCH -N 1
+
+export OMP_NUM_THREADS=1
+srun -n 4 -c 2 --ntasks-per-node=4 ./warpx inputs > output.txt


### PR DESCRIPTION
Add an initial instruction on how to build on Spock (OLCF) for AMD rocm GPUs (HIP).

This works around the missing Cray `PrgEnv-hip` that could be used with the compiler wrappers.