### PR TITLE
Laser: warning antenna of a box; Allow zero amplitude

### DIFF
--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -111,13 +111,6 @@ private:
     // Update position of the antenna
     void UpdateContinuousInjectionPosition(amrex::Real dt) override;
 
-    /**
-    * Checks if the laser antenna intersects the simulation box
-    *
-    * @return true if laser antenna intersects the simulation box, false otherwise
-    */
-    bool antenna_intersects_sim_box();
-
     // Unique (smart) pointer to the laser profile
     std::unique_ptr<WarpXLaserProfiles::ILaserProfile> m_up_laser_profile;
 

--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -115,7 +115,7 @@ private:
     std::unique_ptr<WarpXLaserProfiles::ILaserProfile> m_up_laser_profile;
 
     // Flag to disable the laser (e.g., if e_max is 0)
-    bool m_enabled = false;
+    bool m_enabled = true;
 };
 
 #endif

--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -121,6 +121,8 @@ private:
     // Unique (smart) pointer to the laser profile
     std::unique_ptr<WarpXLaserProfiles::ILaserProfile> m_up_laser_profile;
 
+    // Flag to disable the laser (e.g., if e_max is 0)
+    bool m_enabled = false;
 };
 
 #endif

--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -111,6 +111,13 @@ private:
     // Update position of the antenna
     void UpdateContinuousInjectionPosition(amrex::Real dt) override;
 
+    /**
+    * Checks if the laser antenna intersects the simulation box
+    *
+    * @return true if laser antenna intersects the simulation box, false otherwise
+    */
+    bool antenna_intersects_sim_box();
+
     // Unique (smart) pointer to the laser profile
     std::unique_ptr<WarpXLaserProfiles::ILaserProfile> m_up_laser_profile;
 

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -769,7 +769,9 @@ bool LaserParticleContainer::antenna_intersects_sim_box()
 #ifdef WARPX_DIM_RZ
     // In RZ we only check that the antenna position is within [z_left, z_right]
     amrex::ignore_unused(x_l, x_h, x_p, x_n, z_n, t_corners);
-    return (z_p >= z_l) && (z_p <= z_r);
+    const auto& z_l = sim_box.lo(1);
+    const auto& z_h = sim_box.hi(1);
+    return (z_p >= z_l) && (z_p <= z_h);
 
 #elif (defined WARPX_DIM_3D)
     const auto& y_l = sim_box.lo(1);

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -216,6 +216,8 @@ LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
 void
 LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
 {
+    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+
     int dir = WarpX::moving_window_dir;
     if (do_continuous_injection and (WarpX::gamma_boost > 1)){
         // In boosted-frame simulations, the antenna has moved since the last

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -171,8 +171,6 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_wavelength > 0.,
         "Laser wavelength must be positive.");
 
-    m_enabled = true;
-
     CommonLaserParameters common_params;
     common_params.wavelength = m_wavelength;
     common_params.e_max = m_e_max;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <algorithm>
 #include <numeric>
-#include <vector>
 
 using namespace amrex;
 using namespace WarpXLaserProfiles;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -233,6 +233,9 @@ LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
 void
 LaserParticleContainer::InitData ()
 {
+
+    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+
     // Call InitData on max level to inject one laser particle per
     // finest cell.
     InitData(maxLevel());

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -560,7 +560,7 @@ LaserParticleContainer::Evolve (int lev,
 void
 LaserParticleContainer::PostRestart ()
 {
-    if (m_enabled) return;
+    if (!m_enabled) return;
 
     Real Sx, Sy;
     const int lev = finestLevel();

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -185,8 +185,7 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 void
 LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
 {
-
-    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+    if (!m_enabled) return;
 
     // Input parameter injection_box contains small box where injection
     // should occur.
@@ -216,7 +215,7 @@ LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
 void
 LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
 {
-    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+    if (!m_enabled) return;
 
     int dir = WarpX::moving_window_dir;
     if (do_continuous_injection and (WarpX::gamma_boost > 1)){
@@ -238,8 +237,7 @@ LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
 void
 LaserParticleContainer::InitData ()
 {
-
-    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+    if (!m_enabled) return;
 
     // Call InitData on max level to inject one laser particle per
     // finest cell.
@@ -254,6 +252,8 @@ LaserParticleContainer::InitData ()
 void
 LaserParticleContainer::InitData (int lev)
 {
+    if (!m_enabled) return;
+
     // spacing of laser particles in the laser plane.
     // has to be done after geometry is set up.
     Real S_X, S_Y;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -185,6 +185,9 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 void
 LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
 {
+
+    if (!m_enabled) return; // Laser might be disabled due to e_max == 0.0
+
     // Input parameter injection_box contains small box where injection
     // should occur.
     // So far, LaserParticleContainer::laser_injection_box contains the


### PR DESCRIPTION
This PR introduces a check on the initial position of a laser antenna. If at t=0 the antenna is completely out of the simulation box, WarpX writes a warning message (except in the case of  a simulation with continuous injection).
If the antenna is completely out of the simulation box, the laser is disabled, as in the case of `e_max = 0` (I've introduced a new private variable `m_enabled`).

Close #1971


~~In order to decide if an antenna  intersects the simulation box, I do the following:~~
- ~~for each corner of the simulation box I calculate  `C = (P - P_antenna)*N_antenna` where `P` is the corner position, `P_antenna` is one point of the antenna and `N_antenna` is the normal to the antenna.~~
- ~~I create a vector of these `C` quantities~~
- ~~I sort this vector~~
- ~~I calculate `C_min * C_max`, where these quantities are the first and the last element of the sorted vector~~
- ~~If this product is < 0, it means that the antenna intersects the simulation box~~
- ~~We have to accept also the case in which either `C_min` or `C_max` is zero: it means that a face or just a corner of the simulation box lies in the plane of the antenna~~

~~@NeilZaim  has proposed an alternative solution: we could simply check the number of laser particles generated during the initialization of the antenna. If this number is zero we could raise a warning. The advantages of this approach are that it requires much less code lines and that it is more readable. The (minor) disadvantage is that we would do more calculations (we would still try to initialize the laser particles, before figuring out that they are all out of the box). I don't have a strong opinion on that. What do you think?~~

In order to decide if an antenna  intersects the simulation box we simply check the total number of laser particles.
