### PR TITLE
Use Python Indexing in Reduced Diags Headers

### DIFF
--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -22,7 +22,6 @@ using namespace amrex;
 BeamRelevant::BeamRelevant (std::string rd_name)
 : ReducedDiags{rd_name}
 {
-
     // read beam name
     ParmParse pp_rd_name(rd_name);
     pp_rd_name.get("species",m_beam_name);
@@ -59,58 +58,56 @@ BeamRelevant::BeamRelevant (std::string rd_name)
             // write header row
 #if (defined WARPX_DIM_3D || defined WARPX_DIM_RZ)
             ofs << "#";
-            ofs << "[1]step()";           ofs << m_sep;
-            ofs << "[2]time(s)";          ofs << m_sep;
-            ofs << "[3]x_mean(m)";        ofs << m_sep;
-            ofs << "[4]y_mean(m)";        ofs << m_sep;
-            ofs << "[5]z_mean(m)";        ofs << m_sep;
-            ofs << "[6]px_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[7]py_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[8]pz_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[9]gamma_mean()";     ofs << m_sep;
-            ofs << "[10]x_rms(m)";        ofs << m_sep;
-            ofs << "[11]y_rms(m)";        ofs << m_sep;
-            ofs << "[12]z_rms(m)";        ofs << m_sep;
-            ofs << "[13]px_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[14]py_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[15]pz_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[16]gamma_rms()";     ofs << m_sep;
-            ofs << "[17]emittance_x(m)";  ofs << m_sep;
-            ofs << "[18]emittance_y(m)";  ofs << m_sep;
-            ofs << "[19]emittance_z(m)";  ofs << m_sep;
-            ofs << "[20]charge(C)";       ofs << std::endl;
-#elif (defined WARPX_DIM_XZ)
-            ofs << "#";
-            ofs << "[1]step()";           ofs << m_sep;
-            ofs << "[2]time(s)";          ofs << m_sep;
-            ofs << "[3]x_mean(m)";        ofs << m_sep;
+            ofs << "[0]step()";           ofs << m_sep;
+            ofs << "[1]time(s)";          ofs << m_sep;
+            ofs << "[2]x_mean(m)";        ofs << m_sep;
+            ofs << "[3]y_mean(m)";        ofs << m_sep;
             ofs << "[4]z_mean(m)";        ofs << m_sep;
             ofs << "[5]px_mean(kg*m/s)";  ofs << m_sep;
             ofs << "[6]py_mean(kg*m/s)";  ofs << m_sep;
             ofs << "[7]pz_mean(kg*m/s)";  ofs << m_sep;
             ofs << "[8]gamma_mean()";     ofs << m_sep;
             ofs << "[9]x_rms(m)";         ofs << m_sep;
-            ofs << "[10]z_rms(m)";        ofs << m_sep;
-            ofs << "[11]px_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[12]py_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[13]pz_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[14]gamma_rms()";     ofs << m_sep;
-            ofs << "[15]emittance_x(m)";  ofs << m_sep;
-            ofs << "[16]emittance_z(m)";  ofs << m_sep;
-            ofs << "[17]charge(C)";       ofs << std::endl;
+            ofs << "[10]y_rms(m)";        ofs << m_sep;
+            ofs << "[11]z_rms(m)";        ofs << m_sep;
+            ofs << "[12]px_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[13]py_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[14]pz_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[15]gamma_rms()";     ofs << m_sep;
+            ofs << "[16]emittance_x(m)";  ofs << m_sep;
+            ofs << "[17]emittance_y(m)";  ofs << m_sep;
+            ofs << "[18]emittance_z(m)";  ofs << m_sep;
+            ofs << "[19]charge(C)";       ofs << std::endl;
+#elif (defined WARPX_DIM_XZ)
+            ofs << "#";
+            ofs << "[0]step()";           ofs << m_sep;
+            ofs << "[1]time(s)";          ofs << m_sep;
+            ofs << "[2]x_mean(m)";        ofs << m_sep;
+            ofs << "[3]z_mean(m)";        ofs << m_sep;
+            ofs << "[4]px_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[5]py_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[6]pz_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[7]gamma_mean()";     ofs << m_sep;
+            ofs << "[8]x_rms(m)";         ofs << m_sep;
+            ofs << "[9]z_rms(m)";         ofs << m_sep;
+            ofs << "[10]px_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[11]py_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[12]pz_rms(kg*m/s)";  ofs << m_sep;
+            ofs << "[13]gamma_rms()";     ofs << m_sep;
+            ofs << "[14]emittance_x(m)";  ofs << m_sep;
+            ofs << "[15]emittance_z(m)";  ofs << m_sep;
+            ofs << "[16]charge(C)";       ofs << std::endl;
 #endif
             // close file
             ofs.close();
         }
     }
-
 }
 // end constructor
 
 // function that compute beam relevant quantities
 void BeamRelevant::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) { return; }
 
@@ -449,6 +446,5 @@ void BeamRelevant::ComputeDiags (int step)
 
     }
     // end loop over species
-
 }
 // end void BeamRelevant::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -15,7 +15,6 @@
 #include <cmath>
 #include <limits>
 
-
 using namespace amrex;
 
 // constructor
@@ -57,46 +56,48 @@ BeamRelevant::BeamRelevant (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
 #if (defined WARPX_DIM_3D || defined WARPX_DIM_RZ)
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";           ofs << m_sep;
-            ofs << "[1]time(s)";          ofs << m_sep;
-            ofs << "[2]x_mean(m)";        ofs << m_sep;
-            ofs << "[3]y_mean(m)";        ofs << m_sep;
-            ofs << "[4]z_mean(m)";        ofs << m_sep;
-            ofs << "[5]px_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[6]py_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[7]pz_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[8]gamma_mean()";     ofs << m_sep;
-            ofs << "[9]x_rms(m)";         ofs << m_sep;
-            ofs << "[10]y_rms(m)";        ofs << m_sep;
-            ofs << "[11]z_rms(m)";        ofs << m_sep;
-            ofs << "[12]px_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[13]py_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[14]pz_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[15]gamma_rms()";     ofs << m_sep;
-            ofs << "[16]emittance_x(m)";  ofs << m_sep;
-            ofs << "[17]emittance_y(m)";  ofs << m_sep;
-            ofs << "[18]emittance_z(m)";  ofs << m_sep;
-            ofs << "[19]charge(C)";       ofs << std::endl;
+            ofs << "[" << c++ << "]step()";           ofs << m_sep;
+            ofs << "[" << c++ << "]time(s)";          ofs << m_sep;
+            ofs << "[" << c++ << "]x_mean(m)";        ofs << m_sep;
+            ofs << "[" << c++ << "]y_mean(m)";        ofs << m_sep;
+            ofs << "[" << c++ << "]z_mean(m)";        ofs << m_sep;
+            ofs << "[" << c++ << "]px_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]py_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]pz_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]gamma_mean()";     ofs << m_sep;
+            ofs << "[" << c++ << "]x_rms(m)";         ofs << m_sep;
+            ofs << "[" << c++ << "]y_rms(m)";         ofs << m_sep;
+            ofs << "[" << c++ << "]z_rms(m)";         ofs << m_sep;
+            ofs << "[" << c++ << "]px_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]py_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]pz_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]gamma_rms()";      ofs << m_sep;
+            ofs << "[" << c++ << "]emittance_x(m)";   ofs << m_sep;
+            ofs << "[" << c++ << "]emittance_y(m)";   ofs << m_sep;
+            ofs << "[" << c++ << "]emittance_z(m)";   ofs << m_sep;
+            ofs << "[" << c++ << "]charge(C)";        ofs << std::endl;
 #elif (defined WARPX_DIM_XZ)
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";           ofs << m_sep;
-            ofs << "[1]time(s)";          ofs << m_sep;
-            ofs << "[2]x_mean(m)";        ofs << m_sep;
-            ofs << "[3]z_mean(m)";        ofs << m_sep;
-            ofs << "[4]px_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[5]py_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[6]pz_mean(kg*m/s)";  ofs << m_sep;
-            ofs << "[7]gamma_mean()";     ofs << m_sep;
-            ofs << "[8]x_rms(m)";         ofs << m_sep;
-            ofs << "[9]z_rms(m)";         ofs << m_sep;
-            ofs << "[10]px_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[11]py_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[12]pz_rms(kg*m/s)";  ofs << m_sep;
-            ofs << "[13]gamma_rms()";     ofs << m_sep;
-            ofs << "[14]emittance_x(m)";  ofs << m_sep;
-            ofs << "[15]emittance_z(m)";  ofs << m_sep;
-            ofs << "[16]charge(C)";       ofs << std::endl;
+            ofs << "[" << c++ << "]step()";           ofs << m_sep;
+            ofs << "[" << c++ << "]time(s)";          ofs << m_sep;
+            ofs << "[" << c++ << "]x_mean(m)";        ofs << m_sep;
+            ofs << "[" << c++ << "]z_mean(m)";        ofs << m_sep;
+            ofs << "[" << c++ << "]px_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]py_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]pz_mean(kg*m/s)";  ofs << m_sep;
+            ofs << "[" << c++ << "]gamma_mean()";     ofs << m_sep;
+            ofs << "[" << c++ << "]x_rms(m)";         ofs << m_sep;
+            ofs << "[" << c++ << "]z_rms(m)";         ofs << m_sep;
+            ofs << "[" << c++ << "]px_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]py_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]pz_rms(kg*m/s)";   ofs << m_sep;
+            ofs << "[" << c++ << "]gamma_rms()";      ofs << m_sep;
+            ofs << "[" << c++ << "]emittance_x(m)";   ofs << m_sep;
+            ofs << "[" << c++ << "]emittance_z(m)";   ofs << m_sep;
+            ofs << "[" << c++ << "]charge(C)";        ofs << std::endl;
 #endif
             // close file
             ofs.close();
@@ -133,7 +134,6 @@ void BeamRelevant::ComputeDiags (int step)
     // loop over species
     for (int i_s = 0; i_s < nSpecies; ++i_s)
     {
-
         // only beam species does
         if (species_names[i_s] != m_beam_name) { continue; }
 
@@ -443,7 +443,6 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[13] = std::sqrt(z_ms*uz_ms-zuz*zuz) / PhysConst::c;
         m_data[14] = charge;
 #endif
-
     }
     // end loop over species
 }

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -45,24 +45,19 @@ FieldEnergy::FieldEnergy (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
-            constexpr int shift_total = 2;
-            constexpr int shift_E = 3;
-            constexpr int shift_B = 4;
+            ofs << "[" << c++ << "]time(s)";
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_total+noutputs*lev) + "]";
-                ofs << "total_lev"+std::to_string(lev)+"(J)";
+                ofs << "[" << c++ << "]total_lev" + std::to_string(lev) + "(J)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_E+noutputs*lev) + "]";
-                ofs << "E_lev"+std::to_string(lev)+"(J)";
+                ofs << "[" << c++ << "]E_lev" + std::to_string(lev) + "(J)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_B+noutputs*lev) + "]";
-                ofs << "B_lev"+std::to_string(lev)+"(J)";
+                ofs << "[" << c++ << "]B_lev" + std::to_string(lev) + "(J)";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -22,7 +22,6 @@ using namespace amrex;
 FieldEnergy::FieldEnergy (std::string rd_name)
 : ReducedDiags{rd_name}
 {
-
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
@@ -47,12 +46,12 @@ FieldEnergy::FieldEnergy (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
-            constexpr int shift_total = 3;
-            constexpr int shift_E = 4;
-            constexpr int shift_B = 5;
+            ofs << "[1]time(s)";
+            constexpr int shift_total = 2;
+            constexpr int shift_E = 3;
+            constexpr int shift_B = 4;
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
@@ -70,14 +69,12 @@ FieldEnergy::FieldEnergy (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
 // function that computes field energy
 void FieldEnergy::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) { return; }
 
@@ -90,7 +87,6 @@ void FieldEnergy::ComputeDiags (int step)
     // loop over refinement levels
     for (int lev = 0; lev < nLevel; ++lev)
     {
-
         // get MultiFab data at lev
         const MultiFab & Ex = warpx.getEfield(lev,0);
         const MultiFab & Ey = warpx.getEfield(lev,1);
@@ -129,7 +125,6 @@ void FieldEnergy::ComputeDiags (int step)
         m_data[lev*noutputs+index_B] = 0.5_rt * Bs / PhysConst::mu0 * dV;
         m_data[lev*noutputs+index_total] = m_data[lev*noutputs+index_E] +
                                            m_data[lev*noutputs+index_B];
-
     }
     // end loop over refinement levels
 
@@ -141,6 +136,5 @@ void FieldEnergy::ComputeDiags (int step)
      *   electric field energy at level 1,
      *   magnetic field energy at level 1,
      *   ......] */
-
 }
 // end void FieldEnergy::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -15,7 +15,6 @@ using namespace amrex;
 FieldMaximum::FieldMaximum (std::string rd_name)
 : ReducedDiags{rd_name}
 {
-
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
@@ -40,17 +39,17 @@ FieldMaximum::FieldMaximum (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
-            constexpr int shift_Ex = 3;
-            constexpr int shift_Ey = 4;
-            constexpr int shift_Ez = 5;
-            constexpr int shift_absE = 6;
-            constexpr int shift_Bx = 7;
-            constexpr int shift_By = 8;
-            constexpr int shift_Bz = 9;
-            constexpr int shift_absB = 10;
+            ofs << "[1]time(s)";
+            constexpr int shift_Ex = 2;
+            constexpr int shift_Ey = 3;
+            constexpr int shift_Ez = 4;
+            constexpr int shift_absE = 5;
+            constexpr int shift_Bx = 6;
+            constexpr int shift_By = 7;
+            constexpr int shift_Bz = 8;
+            constexpr int shift_absB = 9;
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
@@ -83,7 +82,6 @@ FieldMaximum::FieldMaximum (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
@@ -102,7 +100,6 @@ void FieldMaximum::ComputeDiags (int step)
     // loop over refinement levels
     for (int lev = 0; lev < nLevel; ++lev)
     {
-
         // get MultiFab data at lev
         const MultiFab & Ex = warpx.getEfield(lev,0);
         const MultiFab & Ey = warpx.getEfield(lev,1);
@@ -280,6 +277,5 @@ void FieldMaximum::ComputeDiags (int step)
     /* m_data now contains up-to-date values for:
      *  [max(Ex),max(Ey),max(Ez),max(|E|),
      *   max(Bx),max(By),max(Bz),max(|B|)] */
-
 }
 // end void FieldMaximum::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -38,44 +38,29 @@ FieldMaximum::FieldMaximum (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
-            constexpr int shift_Ex = 2;
-            constexpr int shift_Ey = 3;
-            constexpr int shift_Ez = 4;
-            constexpr int shift_absE = 5;
-            constexpr int shift_Bx = 6;
-            constexpr int shift_By = 7;
-            constexpr int shift_Bz = 8;
-            constexpr int shift_absB = 9;
+            ofs << "[" << c++ << "]time(s)";
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_Ex+noutputs*lev) + "]";
-                ofs << "max_Ex_lev"+std::to_string(lev)+" (V/m)";
+                ofs << "[" << c++ << "]max_Ex_lev" + std::to_string(lev) + " (V/m)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_Ey+noutputs*lev) + "]";
-                ofs << "max_Ey_lev"+std::to_string(lev)+" (V/m)";
+                ofs << "[" << c++ << "]max_Ey_lev" + std::to_string(lev) + " (V/m)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_Ez+noutputs*lev) + "]";
-                ofs << "max_Ez_lev"+std::to_string(lev)+" (V/m)";
+                ofs << "[" << c++ << "]max_Ez_lev" + std::to_string(lev) + " (V/m)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_absE+noutputs*lev) + "]";
-                ofs << "max_|E|_lev"+std::to_string(lev)+" (V/m)";
+                ofs << "[" << c++ << "]max_|E|_lev" + std::to_string(lev) + " (V/m)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_Bx+noutputs*lev) + "]";
-                ofs << "max_Bx_lev"+std::to_string(lev)+" (T)";
+                ofs << "[" << c++ << "]max_Bx_lev" + std::to_string(lev) + " (T)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_By+noutputs*lev) + "]";
-                ofs << "max_By_lev"+std::to_string(lev)+" (T)";
+                ofs << "[" << c++ << "]max_By_lev" + std::to_string(lev) + " (T)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_Bz+noutputs*lev) + "]";
-                ofs << "max_Bz_lev"+std::to_string(lev)+" (T)";
+                ofs << "[" << c++ << "]max_Bz_lev" + std::to_string(lev) + " (T)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_absB+noutputs*lev) + "]";
-                ofs << "max_|B|_lev"+std::to_string(lev)+" (T)";
+                ofs << "[" << c++ << "]max_|B|_lev" + std::to_string(lev) + " (T)";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -54,18 +54,17 @@ FieldReduction::FieldReduction (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
+            ofs << "[1]time(s)";
             ofs << m_sep;
-            ofs << "[3]" + reduction_type_string + " of " + parser_string + " (SI units)";
+            ofs << "[2]" + reduction_type_string + " of " + parser_string + " (SI units)";
 
             ofs << std::endl;
             // close file
             ofs.close();
         }
     }
-
 }
 // end constructor
 

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -53,12 +53,13 @@ FieldReduction::FieldReduction (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
+            ofs << "[" << c++ << "]time(s)";
             ofs << m_sep;
-            ofs << "[2]" + reduction_type_string + " of " + parser_string + " (SI units)";
+            ofs << "[" << c++ << "]" + reduction_type_string + " of " + parser_string + " (SI units)";
 
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -17,7 +17,6 @@ using namespace amrex;
 LoadBalanceCosts::LoadBalanceCosts (std::string rd_name)
     : ReducedDiags{rd_name}
 {
-
 }
 
 // function that gathers costs
@@ -225,7 +224,6 @@ void LoadBalanceCosts::WriteToFile (int step) const
     // close file
     ofs.close();
 
-
     // get a reference to WarpX instance
     auto& warpx = WarpX::GetInstance();
 
@@ -244,40 +242,40 @@ void LoadBalanceCosts::WriteToFile (int step) const
         int nDataFieldsToWrite = m_nDataFields + 1;
 
         ofstmp << "#";
-        ofstmp << "[1]step()";
+        ofstmp << "[0]step()";
         ofstmp << m_sep;
-        ofstmp << "[2]time(s)";
+        ofstmp << "[1]time(s)";
 
         for (int boxNumber=0; boxNumber<m_nBoxesMax; ++boxNumber)
         {
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(3 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(2 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "cost_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(4 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(3 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "proc_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(5 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(4 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "lev_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(6 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(5 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "i_low_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(7 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(6 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "j_low_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(8 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(7 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "k_low_box_"+std::to_string(boxNumber)+"()";
 #ifdef AMREX_USE_GPU
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(9 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(8 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "gpu_ID_box_"+std::to_string(boxNumber)+"()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(10 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(9 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "hostname_box_"+std::to_string(boxNumber)+"()";
 #else
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(9 + nDataFieldsToWrite*boxNumber) + "]";
+            ofstmp << "[" + std::to_string(8 + nDataFieldsToWrite*boxNumber) + "]";
             ofstmp << "hostname_box_"+std::to_string(boxNumber)+"()";
 #endif
         }

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -241,42 +241,34 @@ void LoadBalanceCosts::WriteToFile (int step) const
         // nDataFieldsToWrite = below accounts for the Real data fields (m_nDataFields), then 1 string output to write
         int nDataFieldsToWrite = m_nDataFields + 1;
 
+        int c = 0;
         ofstmp << "#";
-        ofstmp << "[0]step()";
+        ofstmp << "[" << c++ << "]step()";
         ofstmp << m_sep;
-        ofstmp << "[1]time(s)";
+        ofstmp << "[" << c++ << "]time(s)";
 
         for (int boxNumber=0; boxNumber<m_nBoxesMax; ++boxNumber)
         {
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(2 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "cost_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]cost_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(3 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "proc_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]proc_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(4 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "lev_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]lev_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(5 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "i_low_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]i_low_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(6 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "j_low_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]j_low_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(7 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "k_low_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]k_low_box_" + std::to_string(boxNumber) + "()";
 #ifdef AMREX_USE_GPU
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(8 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "gpu_ID_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]gpu_ID_box_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(9 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "hostname_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]hostname_box_" + std::to_string(boxNumber) + "()";
 #else
             ofstmp << m_sep;
-            ofstmp << "[" + std::to_string(8 + nDataFieldsToWrite*boxNumber) + "]";
-            ofstmp << "hostname_box_"+std::to_string(boxNumber)+"()";
+            ofstmp << "[" << c++ << "]hostname_box_" + std::to_string(boxNumber) + "()";
 #endif
         }
         ofstmp << std::endl;

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -31,16 +31,15 @@ LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
 
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
-            constexpr int shift = 2;
+            ofs << "[" << c++ << "]time(s)";
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift+lev) + "]";
-                ofs << "lev"+std::to_string(lev);
+                ofs << "[" << c++ << "]lev" + std::to_string(lev);
             }
             ofs << std::endl;
 

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -32,10 +32,10 @@ LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
 
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
-            constexpr int shift = 3;
+            ofs << "[1]time(s)";
+            constexpr int shift = 2;
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -32,7 +32,6 @@ using namespace amrex;
 // constructor
 MultiReducedDiags::MultiReducedDiags ()
 {
-
     // read reduced diags names
     ParmParse pp_warpx("warpx");
     m_plot_rd = pp_warpx.queryarr("reduced_diags_names", m_rd_names);
@@ -70,7 +69,6 @@ MultiReducedDiags::MultiReducedDiags ()
             return reduced_diags_dictionary.at(rd_type)(rd_name);
         });
     // end loop over all reduced diags
-
 }
 // end constructor
 
@@ -89,7 +87,6 @@ void MultiReducedDiags::ComputeDiags (int step)
 // function to write data
 void MultiReducedDiags::WriteToFile (int step)
 {
-
     // Only the I/O rank does
     if ( !ParallelDescriptor::IOProcessor() ) { return; }
 
@@ -101,7 +98,6 @@ void MultiReducedDiags::WriteToFile (int step)
 
         // call the write to file function
         m_multi_rd[i_rd]->WriteToFile(step);
-
     }
     // end loop over all reduced diags
 }

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -46,24 +46,24 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
+            ofs << "[1]time(s)";
             ofs << m_sep;
-            ofs << "[3]total(J)";
+            ofs << "[2]total(J)";
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(4+i) + "]";
+                ofs << "[" + std::to_string(3+i) + "]";
                 ofs << species_names[i]+"(J)";
             }
             ofs << m_sep;
-            ofs << "[" + std::to_string(4+nSpecies) + "]";
+            ofs << "[" + std::to_string(3+nSpecies) + "]";
             ofs << "total_mean(J)";
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(5+nSpecies+i) + "]";
+                ofs << "[" + std::to_string(4+nSpecies+i) + "]";
                 ofs << species_names[i]+"_mean(J)";
             }
             ofs << std::endl;
@@ -71,14 +71,12 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
 // function that computes kinetic energy
 void ParticleEnergy::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) { return; }
 
@@ -156,7 +154,6 @@ void ParticleEnergy::ComputeDiags (int step)
         { m_data[nSpecies+2+i_s] = Etot / Wtot; }
         else
         { m_data[nSpecies+2+i_s] = 0.0; }
-
     }
     // end loop over species
 
@@ -180,6 +177,5 @@ void ParticleEnergy::ComputeDiags (int step)
      *   mean energy (species 1),
      *   ...,
      *   mean energy (species n)] */
-
 }
 // end void ParticleEnergy::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -45,26 +45,24 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
+            ofs << "[" << c++ << "]time(s)";
             ofs << m_sep;
-            ofs << "[2]total(J)";
+            ofs << "[" << c++ << "]total(J)";
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(3+i) + "]";
-                ofs << species_names[i]+"(J)";
+                ofs << "[" << c++ << "]" << species_names[i] + "(J)";
             }
             ofs << m_sep;
-            ofs << "[" + std::to_string(3+nSpecies) + "]";
-            ofs << "total_mean(J)";
+            ofs << "[" << c++ << "]total_mean(J)";
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(4+nSpecies+i) + "]";
-                ofs << species_names[i]+"_mean(J)";
+                ofs << "[" << c++ << "]" << species_names[i] + "_mean(J)";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -72,54 +72,55 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
                 ofs.open(m_path + m_rd_name + "." + m_extension,
                     std::ofstream::out | std::ofstream::app);
                 // write header row
+                int c = 0;
                 ofs << "#";
-                ofs << "[0]step()";
+                ofs << "[" << c++ << "]step()";
                 ofs << m_sep;
-                ofs << "[1]time(s)";
+                ofs << "[" << c++ << "]time(s)";
                 ofs << m_sep;
-                ofs << "[2]xmin(m)";
+                ofs << "[" << c++ << "]xmin(m)";
                 ofs << m_sep;
-                ofs << "[3]xmax(m)";
+                ofs << "[" << c++ << "]xmax(m)";
                 ofs << m_sep;
-                ofs << "[4]ymin(m)";
+                ofs << "[" << c++ << "]ymin(m)";
                 ofs << m_sep;
-                ofs << "[5]ymax(m)";
+                ofs << "[" << c++ << "]ymax(m)";
                 ofs << m_sep;
-                ofs << "[6]zmin(m)";
+                ofs << "[" << c++ << "]zmin(m)";
                 ofs << m_sep;
-                ofs << "[7]zmax(m)";
+                ofs << "[" << c++ << "]zmax(m)";
                 ofs << m_sep;
-                ofs << "[8]pxmin(kg*m/s)";
+                ofs << "[" << c++ << "]pxmin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[9]pxmax(kg*m/s)";
+                ofs << "[" << c++ << "]pxmax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[10]pymin(kg*m/s)";
+                ofs << "[" << c++ << "]pymin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[11]pymax(kg*m/s)";
+                ofs << "[" << c++ << "]pymax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[12]pzmin(kg*m/s)";
+                ofs << "[" << c++ << "]pzmin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[13]pzmax(kg*m/s)";
+                ofs << "[" << c++ << "]pzmax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[14]gmin()";
+                ofs << "[" << c++ << "]gmin()";
                 ofs << m_sep;
-                ofs << "[15]gmax()";
+                ofs << "[" << c++ << "]gmax()";
                 ofs << m_sep;
 #if (defined WARPX_DIM_3D)
-                ofs << "[16]wmin()";
+                ofs << "[" << c++ << "]wmin()";
                 ofs << m_sep;
-                ofs << "[17]wmax()";
+                ofs << "[" << c++ << "]wmax()";
 #else
-                ofs << "[16]wmin(1/m)";
+                ofs << "[" << c++ << "]wmin(1/m)";
                 ofs << m_sep;
-                ofs << "[17]wmax(1/m)";
+                ofs << "[" << c++ << "]wmax(1/m)";
 #endif
                 if (myspc.DoQED())
                 {
                     ofs << m_sep;
-                    ofs << "[18]chimin()";
+                    ofs << "[" << c++ << "]chimin()";
                     ofs << m_sep;
-                    ofs << "[19]chimax()";
+                    ofs << "[" << c++ << "]chimax()";
                 }
                 ofs << std::endl;
                 // close file

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -73,53 +73,53 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
                     std::ofstream::out | std::ofstream::app);
                 // write header row
                 ofs << "#";
-                ofs << "[1]step()";
+                ofs << "[0]step()";
                 ofs << m_sep;
-                ofs << "[2]time(s)";
+                ofs << "[1]time(s)";
                 ofs << m_sep;
-                ofs << "[3]xmin(m)";
+                ofs << "[2]xmin(m)";
                 ofs << m_sep;
-                ofs << "[4]xmax(m)";
+                ofs << "[3]xmax(m)";
                 ofs << m_sep;
-                ofs << "[5]ymin(m)";
+                ofs << "[4]ymin(m)";
                 ofs << m_sep;
-                ofs << "[6]ymax(m)";
+                ofs << "[5]ymax(m)";
                 ofs << m_sep;
-                ofs << "[7]zmin(m)";
+                ofs << "[6]zmin(m)";
                 ofs << m_sep;
-                ofs << "[8]zmax(m)";
+                ofs << "[7]zmax(m)";
                 ofs << m_sep;
-                ofs << "[9]pxmin(kg*m/s)";
+                ofs << "[8]pxmin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[10]pxmax(kg*m/s)";
+                ofs << "[9]pxmax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[11]pymin(kg*m/s)";
+                ofs << "[10]pymin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[12]pymax(kg*m/s)";
+                ofs << "[11]pymax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[13]pzmin(kg*m/s)";
+                ofs << "[12]pzmin(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[14]pzmax(kg*m/s)";
+                ofs << "[13]pzmax(kg*m/s)";
                 ofs << m_sep;
-                ofs << "[15]gmin()";
+                ofs << "[14]gmin()";
                 ofs << m_sep;
-                ofs << "[16]gmax()";
+                ofs << "[15]gmax()";
                 ofs << m_sep;
 #if (defined WARPX_DIM_3D)
-                ofs << "[17]wmin()";
+                ofs << "[16]wmin()";
                 ofs << m_sep;
-                ofs << "[18]wmax()";
+                ofs << "[17]wmax()";
 #else
-                ofs << "[17]wmin(1/m)";
+                ofs << "[16]wmin(1/m)";
                 ofs << m_sep;
-                ofs << "[18]wmax(1/m)";
+                ofs << "[17]wmax(1/m)";
 #endif
                 if (myspc.DoQED())
                 {
                     ofs << m_sep;
-                    ofs << "[19]chimin()";
+                    ofs << "[18]chimin()";
                     ofs << m_sep;
-                    ofs << "[20]chimax()";
+                    ofs << "[19]chimax()";
                 }
                 ofs << std::endl;
                 // close file
@@ -133,7 +133,6 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
 // function that computes extrema
 void ParticleExtrema::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) { return; }
 
@@ -159,7 +158,6 @@ void ParticleExtrema::ComputeDiags (int step)
     // loop over species
     for (int i_s = 0; i_s < nSpecies; ++i_s)
     {
-
         // only chosen species does
         if (species_names[i_s] != m_species_name) { continue; }
 
@@ -353,7 +351,6 @@ void ParticleExtrema::ComputeDiags (int step)
 
         if (myspc.DoQED())
         {
-
             // declare chi arrays
             std::vector<Real> chimin, chimax;
             chimin.resize(level_number+1,0.0_rt);
@@ -460,7 +457,6 @@ void ParticleExtrema::ComputeDiags (int step)
             ParallelDescriptor::ReduceRealMax(chimax_f);
         }
 #endif
-
         m_data[0]  = xmin;
         m_data[1]  = xmax;
         m_data[2]  = ymin;
@@ -484,9 +480,7 @@ void ParticleExtrema::ComputeDiags (int step)
             m_data[17] = chimax_f;
         }
 #endif
-
     }
     // end loop over species
-
 }
 // end void ParticleEnergy::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -108,16 +108,17 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
+            ofs << "[" << c++ << "]time(s)";
             for (int i = 0; i < m_bin_num; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(2+i) + "]";
+                ofs << "[" << c++ << "]";
                 Real b = m_bin_min + m_bin_size*(Real(i)+0.5_rt);
-                ofs << "bin" + std::to_string(0+i)
+                ofs << "bin" + std::to_string(1+i)
                              + "=" + std::to_string(b) + "()";
             }
             ofs << std::endl;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -36,7 +36,6 @@ struct NormalizationType {
 ParticleHistogram::ParticleHistogram (std::string rd_name)
 : ReducedDiags{rd_name}
 {
-
     ParmParse pp_rd_name(rd_name);
 
     // read species
@@ -110,15 +109,15 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
+            ofs << "[1]time(s)";
             for (int i = 0; i < m_bin_num; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(3+i) + "]";
+                ofs << "[" + std::to_string(2+i) + "]";
                 Real b = m_bin_min + m_bin_size*(Real(i)+0.5_rt);
-                ofs << "bin" + std::to_string(1+i)
+                ofs << "bin" + std::to_string(0+i)
                              + "=" + std::to_string(b) + "()";
             }
             ofs << std::endl;
@@ -126,14 +125,12 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
 // function that computes the histogram
 void ParticleHistogram::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) return;
 
@@ -260,6 +257,5 @@ void ParticleHistogram::ComputeDiags (int step)
         }
         return;
     }
-
 }
 // end void ParticleHistogram::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -37,32 +37,27 @@ ParticleNumber::ParticleNumber (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
+            ofs << "[" << c++ << "]time(s)";
             ofs << m_sep;
-            ofs << "[2]total macroparticles()";
+            ofs << "[" << c++ << "]total macroparticles()";
             // Column number of first species macroparticle number
-            constexpr int shift_first_species_macroparticles = 3;
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_first_species_macroparticles+i) + "]";
-                ofs << species_names[i]+" macroparticles()";
+                ofs << "[" << c++ << "]" << species_names[i] + " macroparticles()";
             }
             // Column number of total weight (summed over all species)
-            const int shift_total_sum_weight = shift_first_species_macroparticles + nSpecies;
             ofs << m_sep;
-            ofs << "[" + std::to_string(shift_total_sum_weight) + "]";
-            ofs << "total weight()";
+            ofs << "[" << c++ << "]total weight()";
             // Column number of first species weight
-            const int shift_first_species_sum_weight = shift_total_sum_weight + 1;
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_first_species_sum_weight+i) + "]";
-                ofs << species_names[i]+" weight()";
+                ofs << "[" << c++ << "]" << species_names[i] + " weight()";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -38,13 +38,13 @@ ParticleNumber::ParticleNumber (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
+            ofs << "[1]time(s)";
             ofs << m_sep;
-            ofs << "[3]total macroparticles()";
+            ofs << "[2]total macroparticles()";
             // Column number of first species macroparticle number
-            constexpr int shift_first_species_macroparticles = 4;
+            constexpr int shift_first_species_macroparticles = 3;
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
@@ -69,14 +69,12 @@ ParticleNumber::ParticleNumber (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
 // function that computes total number of macroparticles and physical particles
 void ParticleNumber::ComputeDiags (int step)
 {
-
     // Judge if the diags should be done
     if (!m_intervals.contains(step+1)) { return; }
 
@@ -140,6 +138,5 @@ void ParticleNumber::ComputeDiags (int step)
      *   sum of particles weight (species 1),
      *   ...,
      *   sum of particles weight (species n)] */
-
 }
 // end void ParticleNumber::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -18,7 +18,6 @@ using namespace amrex;
 // constructor
 ReducedDiags::ReducedDiags (std::string rd_name)
 {
-
     m_rd_name = rd_name;
 
     BackwardCompatibility();
@@ -58,7 +57,6 @@ ReducedDiags::ReducedDiags (std::string rd_name)
 
     // read separator
     pp_rd_name.query("separator", m_sep);
-
 }
 // end constructor
 
@@ -75,7 +73,6 @@ void ReducedDiags::BackwardCompatibility ()
 // write to file function
 void ReducedDiags::WriteToFile (int step) const
 {
-
     // open file
     std::ofstream ofs{m_path + m_rd_name + "." + m_extension,
         std::ofstream::out | std::ofstream::app};
@@ -104,6 +101,5 @@ void ReducedDiags::WriteToFile (int step) const
 
     // close file
     ofs.close();
-
 }
 // end ReducedDiags::WriteToFile

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -78,27 +78,22 @@ RhoMaximum::RhoMaximum (std::string rd_name)
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
+            int c = 0;
             ofs << "#";
-            ofs << "[0]step()";
+            ofs << "[" << c++ << "]step()";
             ofs << m_sep;
-            ofs << "[1]time(s)";
-            constexpr int shift_max_rho = 2;
-            constexpr int shift_min_rho = 3;
-            constexpr int shift_first_species = 4;
+            ofs << "[" << c++ << "]time(s)";
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_max_rho+noutputs_per_level*lev) + "]";
-                ofs << "max_rho_lev"+std::to_string(lev)+" (C/m^3)";
+                ofs << "[" << c++ << "]max_rho_lev" + std::to_string(lev) + " (C/m^3)";
                 ofs << m_sep;
-                ofs << "[" + std::to_string(shift_min_rho+noutputs_per_level*lev) + "]";
-                ofs << "min_rho_lev"+std::to_string(lev)+" (C/m^3)";
+                ofs << "[" << c++ << "]min_rho_lev" + std::to_string(lev) + " (C/m^3)";
                 for (int i = 0; i < n_charged_species; ++i)
                 {
                     ofs << m_sep;
-                    ofs << "[" + std::to_string(shift_first_species+i+noutputs_per_level*lev) + "]";
-                    ofs << "max_" + species_names[indices_charged_species[i]]
-                                  + "_|rho|_lev"+std::to_string(lev)+" (C/m^3)";
+                    ofs << "[" << c++ << "]max_" + species_names[indices_charged_species[i]]
+                                         + "_|rho|_lev" + std::to_string(lev) + " (C/m^3)";
                 }
             }
             ofs << std::endl;

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -15,7 +15,6 @@ using namespace amrex::literals;
 RhoMaximum::RhoMaximum (std::string rd_name)
 : ReducedDiags{rd_name}
 {
-
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
@@ -80,12 +79,12 @@ RhoMaximum::RhoMaximum (std::string rd_name)
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};
             // write header row
             ofs << "#";
-            ofs << "[1]step()";
+            ofs << "[0]step()";
             ofs << m_sep;
-            ofs << "[2]time(s)";
-            constexpr int shift_max_rho = 3;
-            constexpr int shift_min_rho = 4;
-            constexpr int shift_first_species = 5;
+            ofs << "[1]time(s)";
+            constexpr int shift_max_rho = 2;
+            constexpr int shift_min_rho = 3;
+            constexpr int shift_first_species = 4;
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
@@ -107,7 +106,6 @@ RhoMaximum::RhoMaximum (std::string rd_name)
             ofs.close();
         }
     }
-
 }
 // end constructor
 
@@ -165,6 +163,5 @@ void RhoMaximum::ComputeDiags (int step)
 
     /* m_data now contains up-to-date values for:
      *  [max(rho), min(rho), max(|rho_charged_species1|), max(|rho_charged_species2|), ...] */
-
 }
 // end void RhoMaximum::ComputeDiags


### PR DESCRIPTION
As discussed in the thread following https://github.com/ECP-WarpX/WarpX/pull/1944#discussion_r628392904, it is easier to enumerate the columns in the headers of our reduced diagnostics files starting from `0` instead of `1`. The reason being that when we load the data from the files into some Python arrays, using for example `numpy.loadtxt` or `numpy.genfromtxt`, we typically access the columns with an indexing that starts with `0`.

So if we start from `1` in our headers, then if we see, for example, `[3] Sum of Ex*By (SI units)` in the header and load the data in some Python array `data`, we would have to access the reduced quantity through `data[row][2]`, with a shift of 1 in the column index.

This can become a bit annoying when there are many columns, because one has to remember to take the index displayed in our header and subtract 1 in order to access it correctly through Python.

I checked by hand the headers in the reduced diagnostics files of the following CI tests:
- reduced_diags
- reduced_diags_loadbalancecosts_timers
- reduced_diags_loadbalancecosts_timers_psatd
- reduced_diags_loadbalancecosts_heuristic

and they seemed correct. It would be worth anyways double-checking the changes in the PR, even if they are trivial.