### PR TITLE
[mini-PR] [PR # 2000 :-)]  Remove superfluous semicolon

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -150,7 +150,7 @@ private:
         openPMD::Iteration& it = iterations[iteration];
         return it;
     }
-  };
+  }
 
 
   /** This function does initial setup for the fields when interation is newly created


### PR DESCRIPTION
This PR fixes the warning:

```
/home/luca/Projects/warpx_directory/WarpX/Source/Diagnostics/WarpXOpenPMD.H:153:4: warning: extra ';' after member function definition [-Wextra-semi]
  };
   ^

```