### PR TITLE
Spectral: Missing Include

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.H
@@ -12,6 +12,8 @@
 
 #include <AMReX_BoxArray.H>
 #include <AMReX_LayoutData.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RealVect.H>
 
 
 // `KVectorComponent` and `SpectralShiftFactor` hold one 1D array


### PR DESCRIPTION
Fix a build error with the latest AMReX version due to a missing include of `AMReX_RealVect.H`.
```
./Source/FieldSolver/SpectralSolver/SpectralKSpace.H:45:38:
error: ‘RealVect’ in namespace ‘amrex’ does not name a type
       const amrex::RealVect realspace_dx );
```

Seen in #1999