### PR TITLE
[mini-PR] Add unified atomic mass unit (Dalton) to WarpX constants

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -350,6 +350,7 @@ WarpX provides a few pre-defined constants, that can be used for any parameter t
 q_e      elementary charge
 m_e      electron mass
 m_p      proton mass
+m_u      unified atomic mass unit (Dalton)
 epsilon0 vacuum permittivity
 mu0      vacuum permeability
 clight   speed of light

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -204,6 +204,8 @@ Diagnostics::InitData ()
         // the particle-diag vector to zero.
         // This is a temporary fix until particle_buffer is supported in diagnostics.
         m_output_species.clear();
+
+        auto& wpx = WarpX::GetInstance();
         amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
     }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -12,6 +12,8 @@
 #   include "FlushFormats/FlushFormatOpenPMD.H"
 #endif
 #include "WarpX.H"
+#include "Utils/MsgLogger.H"
+
 #include "Utils/WarpXUtil.H"
 #include <AMReX_Vector.H>
 #include <string>
@@ -205,8 +207,11 @@ Diagnostics::InitData ()
         // This is a temporary fix until particle_buffer is supported in diagnostics.
         m_output_species.clear();
 
-        auto& wpx = WarpX::GetInstance();
-        amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+        auto& logger = WarpX::GetInstance().get_logger();
+        logger.record_entry(
+            MsgLogger::Type::warning, MsgLogger::Importance::medium, "Diagnostics",
+            "For full diagnostics on a reduced domain, particle io is not supported, yet! \n" +
+            MsgLogger::new_line_skip + "Therefore, particle-io is disabled for this diag " + m_diag_name);
     }
 
     // default for writing species output is 1

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -271,6 +271,13 @@ WarpX::Evolve (int numsteps)
         }
         multi_diags->FilterComputePackFlush( step );
 
+        if(step < 1)
+        {
+            std::stringstream ss;
+            m_logger.print_warnings(ss);
+            amrex::Print() << ss.str();
+        }
+
         if (cur_time >= stop_time - 1.e-3*dt[0]) {
             break;
         }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -11,6 +11,7 @@
 #include "Particles/SpeciesPhysicalProperties.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
+#include "Utils/MsgLogger.H"
 #include "WarpX.H"
 
 #include <AMReX.H>
@@ -113,9 +114,11 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     bool mass_is_specified = queryWithParser(pp_species_name, "mass", mass);
 
     if ( charge_is_specified && species_is_specified ){
-        Print() << "WARNING: Both '" << species_name << ".charge' and "
-                << species_name << ".species_type' are specified\n'"
-                << species_name << ".charge' will take precedence.\n";
+        auto& logger = WarpX::GetInstance().get_logger();
+        logger.record_entry(
+            MsgLogger::Type::warning, MsgLogger::Importance::medium,
+            "Particles", "Both '" + species_name + ".charge' and '" + species_name + ".species_type' are specified.\n" +
+            MsgLogger::new_line_skip + "'" + species_name + ".charge' will take precedence.");
     }
     if (!charge_is_specified && !species_is_specified && s_inj_style != "external_file"){
         // external file will throw own assertions below if charge cannot be found
@@ -123,9 +126,11 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     }
 
     if ( mass_is_specified && species_is_specified ){
-        Print() << "WARNING: Both '" << species_name << ".mass' and "
-                << species_name << ".species_type' are specified\n'"
-                << species_name << ".mass' will take precedence.\n";
+        auto& logger = WarpX::GetInstance().get_logger();
+        logger.record_entry(
+            MsgLogger::Type::warning, MsgLogger::Importance::medium,
+            "Particles", "Both '" + species_name + ".mass' and '" + species_name + ".species_type' are specified.\n" +
+            MsgLogger::new_line_skip + "'" + species_name + ".mass' will take precedence.");
     }
     if (!mass_is_specified && !species_is_specified && s_inj_style != "external_file"){
         // external file will throw own assertions below if mass cannot be found

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -8,6 +8,8 @@
 #include "Utils/WarpX_Complex.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
+#include "Utils/MsgLogger.H"
+#include "WarpX.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -29,8 +31,14 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::init (
 {
     if (!std::numeric_limits< double >::is_iec559)
     {
-        Print() << R"(Warning: double does not comply with IEEE 754: bad
-            things will happen parsing the X, Y and T profiles for the laser!)";
+        auto& logger = WarpX::GetInstance().get_logger();
+
+        logger.record_entry(
+            MsgLogger::Type::warning, MsgLogger::Importance::high,
+            "Laser",
+            "double precision type does not comply with IEEE 754:\n" +
+            MsgLogger::new_line_skip + "bad things will happen parsing the X, Y and T profiles for the laser!"
+        );
     }
 
     // Parse the TXYE file

--- a/Source/Particles/Resampling/ResamplingTrigger.H
+++ b/Source/Particles/Resampling/ResamplingTrigger.H
@@ -10,6 +10,7 @@
 #include "Utils/IntervalsParser.H"
 
 #include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
 
 /**
  * \brief This class is used to determine if resampling should be done at a given timestep for

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(WarpX
     Interpolate.cpp
     IntervalsParser.cpp
     MPIInitHelpers.cpp
+    MsgLogger.cpp
     ParticleUtils.cpp
     RelativeCellPosition.cpp
     WarpXAlgorithmSelection.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -7,6 +7,7 @@ CEXE_sources += CoarsenMR.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += IntervalsParser.cpp
 CEXE_sources += MPIInitHelpers.cpp
+CEXE_sources += MsgLogger.cpp
 CEXE_sources += RelativeCellPosition.cpp
 CEXE_sources += ParticleUtils.cpp
 

--- a/Source/Utils/MsgLogger.H
+++ b/Source/Utils/MsgLogger.H
@@ -24,6 +24,8 @@ enum class Importance{
     high
 };
 
+const auto new_line_skip = std::string{"*      "};
+
 class Logger
 {
 

--- a/Source/Utils/MsgLogger.H
+++ b/Source/Utils/MsgLogger.H
@@ -1,0 +1,58 @@
+/* Copyright 2021 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_MSG_LOGGER_H_
+#define WARPX_MSG_LOGGER_H_
+
+#include <vector>
+#include <map>
+#include <string>
+#include <sstream>
+
+namespace MsgLogger{
+
+enum class Type{
+    warning
+};
+
+enum class Importance{
+    low,
+    medium,
+    high
+};
+
+class Logger
+{
+
+public:
+    Logger(){}
+
+    void record_entry(
+        Type type,
+        Importance importance,
+        std::string topic,
+        std::string text);
+
+    void print_warnings(std::stringstream& ss);
+
+private:
+
+    void
+    aux_print_entries(
+        const std::string& prefix,
+        const std::string& topic,
+        const std::vector<std::string>& entries,
+        std::stringstream& ss);
+
+    std::map<Type,
+        std::map<Importance,
+            std::map<std::string,
+                std::vector<std::string>>>> m_entries;
+};
+
+}
+
+#endif //WARPX_MSG_LOGGER_H_

--- a/Source/Utils/MsgLogger.cpp
+++ b/Source/Utils/MsgLogger.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2021 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "MsgLogger.H"
+
+#include <algorithm>
+
+using namespace MsgLogger;
+
+void Logger::record_entry(
+    Type type,
+    Importance importance,
+    std::string topic,
+    std::string text)
+{
+    m_entries[type][importance][topic].push_back(text);
+}
+
+void Logger::print_warnings(std::stringstream& ss)
+{
+
+    auto& all_warnings = m_entries[Type::warning];
+
+    const auto& low_prefix = "* [!  ]";
+    const auto& medium_prefix = "* [!! ]";
+    const auto& high_prefix = "* [!!!]";
+
+    ss << "******************* WARNINGS! ********************* \n";
+
+    for (auto& by_topic : all_warnings[Importance::high])
+        aux_print_entries(high_prefix, by_topic.first, by_topic.second, ss);
+
+    for (auto& by_topic : all_warnings[Importance::medium])
+        aux_print_entries(medium_prefix, by_topic.first, by_topic.second, ss);
+
+    for (auto& by_topic : all_warnings[Importance::low])
+        aux_print_entries(low_prefix, by_topic.first, by_topic.second, ss);
+
+    ss << "*************************************************** \n";
+}
+
+void
+Logger::aux_print_entries(
+    const std::string& prefix,
+    const std::string& topic,
+    const std::vector<std::string>& entries,
+    std::stringstream& ss)
+{
+    for(const auto& msg : entries){
+        ss << prefix
+            << " [ " << topic << " ] "
+            << msg << "\n";
+    }
+}

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -27,6 +27,7 @@ namespace PhysConst
     static constexpr auto q_e   = static_cast<amrex::Real>( 1.602176634e-19 );
     static constexpr auto m_e   = static_cast<amrex::Real>( 9.1093837015e-31 );
     static constexpr auto m_p   = static_cast<amrex::Real>( 1.67262192369e-27 );
+    static constexpr auto m_u   = static_cast<amrex::Real>( 1.66053906660e-27 );
     static constexpr auto hbar  = static_cast<amrex::Real>( 1.054571817e-34 );
     static constexpr auto alpha = static_cast<amrex::Real>( 0.007297352573748943 );//mu0/(4*MathConst::pi)*q_e*q_e*c/hbar;
     static constexpr auto r_e   = static_cast<amrex::Real>( 2.817940326204929e-15 );//1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -238,6 +238,9 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
         } else if (std::strcmp(it->c_str(), "m_p") == 0) {
             parser.setConstant(*it, PhysConst::m_p);
             it = symbols.erase(it);
+        } else if (std::strcmp(it->c_str(), "m_u") == 0) {
+            parser.setConstant(*it, PhysConst::m_u);
+            it = symbols.erase(it);
         } else if (std::strcmp(it->c_str(), "epsilon0") == 0) {
             parser.setConstant(*it, PhysConst::ep0);
             it = symbols.erase(it);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -24,6 +24,7 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/IntervalsParser.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
+#include "Utils/MsgLogger.H"
 
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #ifdef WARPX_USE_PSATD
@@ -719,6 +720,8 @@ protected:
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;
 
+    MsgLogger::Logger& get_logger(){return m_logger;}
+
 private:
 
     // Singleton is used when the code is run from python
@@ -1112,6 +1115,9 @@ private:
     void ScaleAreas ();
 
 private:
+
+    MsgLogger::Logger m_logger;
+
     // void EvolvePSATD (int numsteps);
     void PushPSATD (amrex::Real dt);
     void PushPSATD (int lev, amrex::Real dt);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -662,6 +662,8 @@ public:
     amrex::Gpu::DeviceVector<amrex::Real> device_current_centering_stencil_coeffs_z;
 #endif
 
+    MsgLogger::Logger& get_logger(){return m_logger;}
+
 protected:
 
     /**
@@ -719,8 +721,6 @@ protected:
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;
-
-    MsgLogger::Logger& get_logger(){return m_logger;}
 
 private:
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -823,9 +823,13 @@ WarpX::ReadParameters ()
 
             if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))
             {
-                amrex::Warning("\nWARNING: When algo.particle_shape > 1,"
-                               " some numerical artifact will be present at the interface between coarse and fine patch."
-                               "\nWe recommend setting algo.particle_shape = 1 in order to avoid this issue");
+                m_logger.record_entry(
+                    MsgLogger::Type::warning, MsgLogger::Importance::medium,
+                    "algorithms",
+                    "When algo.particle_shape > 1, some numerical artifact will be present\n"
+                    "    at the interface between coarse and fine patch.\n"
+                    "    We recommend setting algo.particle_shape = 1 in order to avoid this issue."
+                    );
             }
         }
     }


### PR DESCRIPTION
This PR adds unified atomic mass unit (a.k.a. Dalton) to WarpX constants. It also adds it to the list of constants that can be used in the parser. The documentation is updated accordingly.