### PR TITLE
 [mini-PR] Add unified atomic mass unit (Dalton) to WarpX constants

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -350,6 +350,7 @@ WarpX provides a few pre-defined constants, that can be used for any parameter t
 q_e      elementary charge
 m_e      electron mass
 m_p      proton mass
+m_u      unified atomic mass unit (Dalton)
 epsilon0 vacuum permittivity
 mu0      vacuum permeability
 clight   speed of light

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -27,6 +27,7 @@ namespace PhysConst
     static constexpr auto q_e   = static_cast<amrex::Real>( 1.602176634e-19 );
     static constexpr auto m_e   = static_cast<amrex::Real>( 9.1093837015e-31 );
     static constexpr auto m_p   = static_cast<amrex::Real>( 1.67262192369e-27 );
+    static constexpr auto m_u   = static_cast<amrex::Real>( 1.66053906660e-27 );
     static constexpr auto hbar  = static_cast<amrex::Real>( 1.054571817e-34 );
     static constexpr auto alpha = static_cast<amrex::Real>( 0.007297352573748943 );//mu0/(4*MathConst::pi)*q_e*q_e*c/hbar;
     static constexpr auto r_e   = static_cast<amrex::Real>( 2.817940326204929e-15 );//1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -238,6 +238,9 @@ WarpXParser makeParser (std::string const& parse_function, std::vector<std::stri
         } else if (std::strcmp(it->c_str(), "m_p") == 0) {
             parser.setConstant(*it, PhysConst::m_p);
             it = symbols.erase(it);
+        } else if (std::strcmp(it->c_str(), "m_u") == 0) {
+            parser.setConstant(*it, PhysConst::m_u);
+            it = symbols.erase(it);
         } else if (std::strcmp(it->c_str(), "epsilon0") == 0) {
             parser.setConstant(*it, PhysConst::ep0);
             it = symbols.erase(it);


### PR DESCRIPTION
This PR adds unified atomic mass unit (a.k.a. Dalton) to WarpX constants. It also adds it to the list of constants that can be used in the parser. The documentation is updated accordingly.
