### PR TITLE
Fix kernel timer: use after free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,13 @@ set_default_install_dirs()
 
 # Options and Variants ########################################################
 #
+include(CMakeDependentOption)
 option(WarpX_APP           "Build the WarpX executable application"     ON)
 option(WarpX_ASCENT        "Ascent in situ diagnostics"                 OFF)
 option(WarpX_EB            "Embedded boundary support"                  OFF)
-option(WarpX_GPUCLOCK      "Add GPU kernel timers (cost function)"      ON)
+cmake_dependent_option(WarpX_GPUCLOCK
+                           "Add GPU kernel timers (cost function)"      ON
+                           "WarpX_COMPUTE STREQUAL CUDA OR WarpX_COMPUTE STREQUAL HIP" OFF)
 option(WarpX_LIB           "Build WarpX as a shared library"            OFF)
 option(WarpX_MPI           "Multi-node support (message-passing)"       ON)
 option(WarpX_OPENPMD       "openPMD I/O (HDF5, ADIOS)"                  OFF)

--- a/Source/Parallelization/KernelTimer.H
+++ b/Source/Parallelization/KernelTimer.H
@@ -28,26 +28,27 @@ public:
     KernelTimer
 #if (defined AMREX_USE_GPU)
     (const bool do_timing, amrex::Real* cost)
-        : m_do_timing(do_timing), m_cost(cost)
+        : m_do_timing(do_timing)
 #else
     (const bool, amrex::Real*)
 #endif
     {
 #if (defined AMREX_USE_GPU)
+        m_cost = cost;
 #   if (defined WARPX_USE_GPUCLOCK)
-        if (do_timing && cost) {
+        if (m_do_timing && cost) {
 #       if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
             // Start the timer
             m_wt = clock64();
 
 #       elif defined(AMREX_USE_DPCPP)
             // To be updated
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( do_timing == false,
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_do_timing == false,
                                               "KernelTimer not yet supported for this hardware." );
 #       endif
         }
 #   else // WARPX_USE_GPUCLOCK
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( do_timing == false,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_do_timing == false,
                                           "`algo.load_balance_costs_update = gpuclock` requires to compile with `-DWarpX_GPUCLOCK=ON`.");
 #   endif // WARPX_USE_GPUCLOCK
 #endif // AMREX_USE_GPU
@@ -74,7 +75,7 @@ private:
     bool m_do_timing;
 
     //! Location in which to accumulate costs from all threads.
-    amrex::Real* m_cost;
+    amrex::Real* m_cost = nullptr;
 
     //! Store the time difference (cost) from a single thread.
     long long int m_wt;

--- a/Source/Parallelization/KernelTimer.H
+++ b/Source/Parallelization/KernelTimer.H
@@ -34,9 +34,9 @@ public:
 #endif
     {
 #if (defined AMREX_USE_GPU)
-        m_cost = cost;
 #   if (defined WARPX_USE_GPUCLOCK)
         if (m_do_timing && cost) {
+            m_cost = cost;
 #       if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
             // Start the timer
             m_wt = clock64();

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -76,13 +76,18 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
     constexpr int CELL = amrex::IndexType::CELL;
 
     // Loop over particles and deposit into rho_fab
-    amrex::Real* cost_real = (amrex::Real*) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
-    *cost_real = 0.;
+#if defined(WARPX_USE_GPUCLOCK)
+    amrex::Real* cost_real = nullptr;
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        cost_real = (amrex::Real *) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
+        *cost_real = 0.;
+    }
+#endif
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
-#if (defined AMREX_USE_GPU)
-            KernelTimer KnlTimer(cost && load_balance_costs_update_algo
+#if defined(WARPX_USE_GPUCLOCK)
+            KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 #endif
             // --- Get particle quantities
@@ -177,7 +182,12 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
 #endif
         }
         );
-        amrex::The_Managed_Arena()->free(cost_real);
+#if defined(WARPX_USE_GPUCLOCK)
+        if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+            amrex::Gpu::synchronize();
+            amrex::The_Managed_Arena()->free(cost_real);
+        }
+#endif
 
 #ifndef WARPX_DIM_RZ
         amrex::ignore_unused(n_rz_azimuthal_modes);

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -184,7 +184,7 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
         );
 #if defined(WARPX_USE_GPUCLOCK)
         if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
-            amrex::Gpu::synchronize();
+            amrex::Gpu::streamSynchronize();
             *cost += *cost_real;
             amrex::The_Managed_Arena()->free(cost_real);
         }

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -185,6 +185,7 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
 #if defined(WARPX_USE_GPUCLOCK)
         if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
             amrex::Gpu::synchronize();
+            *cost += *cost_real;
             amrex::The_Managed_Arena()->free(cost_real);
         }
 #endif

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -106,12 +106,17 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     constexpr int CELL = amrex::IndexType::CELL;
 
     // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::Real* cost_real = (amrex::Real*) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
-    *cost_real = 0.;
+#if defined(WARPX_USE_GPUCLOCK)
+    amrex::Real* cost_real = nullptr;
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        cost_real = (amrex::Real *) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
+        *cost_real = 0.;
+    }
+#endif
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long ip) {
-#if (defined WARPX_USE_GPUCLOCK)
+#if defined(WARPX_USE_GPUCLOCK)
             KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 #endif
@@ -297,7 +302,12 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #endif
         }
     );
-    amrex::The_Managed_Arena()->free(cost_real);
+#if defined(WARPX_USE_GPUCLOCK)
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        amrex::Gpu::synchronize();
+        amrex::The_Managed_Arena()->free(cost_real);
+    }
+#endif
 }
 
 /**
@@ -386,12 +396,17 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
     Real const clightsq = 1.0_rt / ( PhysConst::c * PhysConst::c );
 
     // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::Real* cost_real = (amrex::Real*) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
-    *cost_real = 0.;
+#if defined(WARPX_USE_GPUCLOCK)
+    amrex::Real* cost_real = nullptr;
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        cost_real = (amrex::Real *) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
+        *cost_real = 0.;
+    }
+#endif
     amrex::ParallelFor(
         np_to_depose,
         [=] AMREX_GPU_DEVICE (long const ip) {
-#if (defined WARPX_USE_GPUCLOCK)
+#if defined(WARPX_USE_GPUCLOCK)
             KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                                  == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 #endif
@@ -617,7 +632,12 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 #endif
         }
     );
-    amrex::The_Managed_Arena()->free(cost_real);
+#if defined(WARPX_USE_GPUCLOCK)
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        amrex::Gpu::synchronize();
+        amrex::The_Managed_Arena()->free(cost_real);
+    }
+#endif
 }
 
 /**
@@ -724,11 +744,16 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
     amrex::Array4<amrex::Real> const& jz_arr = jz_fab.array();
 
     // Loop over particles and deposit (Dx,Dy,Dz) into jx_fab, jy_fab and jz_fab
-    amrex::Real* cost_real = (amrex::Real*) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
-    *cost_real = 0.;
+#if defined(WARPX_USE_GPUCLOCK)
+    amrex::Real* cost_real = nullptr;
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        cost_real = (amrex::Real *) amrex::The_Managed_Arena()->alloc(sizeof(amrex::Real));
+        *cost_real = 0.;
+    }
+#endif
     amrex::ParallelFor(np_to_depose, [=] AMREX_GPU_DEVICE (long ip)
     {
-#if (defined WARPX_USE_GPUCLOCK)
+#if defined(WARPX_USE_GPUCLOCK)
         KernelTimer kernelTimer(cost && load_balance_costs_update_algo
                              == LoadBalanceCostsUpdateAlgo::GpuClock, cost_real);
 #endif
@@ -964,7 +989,12 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
         }
 #endif
     } );
-    amrex::The_Managed_Arena()->free(cost_real);
+#   if defined(WARPX_USE_GPUCLOCK)
+    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        amrex::Gpu::synchronize();
+        amrex::The_Managed_Arena()->free(cost_real);
+    }
+#   endif
 #endif // #if !(defined WARPX_DIM_RZ)
 }
 #endif // CURRENTDEPOSITION_H_

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -305,6 +305,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
 #if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
         amrex::Gpu::synchronize();
+        *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }
 #endif
@@ -635,6 +636,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 #if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
         amrex::Gpu::synchronize();
+        *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }
 #endif
@@ -992,6 +994,7 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
 #   if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
         amrex::Gpu::synchronize();
+        *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }
 #   endif

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -304,7 +304,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
     );
 #if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
-        amrex::Gpu::synchronize();
+        amrex::Gpu::streamSynchronize();
         *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }
@@ -635,7 +635,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
     );
 #if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
-        amrex::Gpu::synchronize();
+        amrex::Gpu::streamSynchronize();
         *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }
@@ -993,7 +993,7 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
     } );
 #   if defined(WARPX_USE_GPUCLOCK)
     if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
-        amrex::Gpu::synchronize();
+        amrex::Gpu::streamSynchronize();
         *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
     }


### PR DESCRIPTION
Fixing a bug spotted by @WeiqunZhang: the `amrex::ParallelFor` functions are async. Thus, the free after their call can lead to a use-after-free of the cost result in the still running kernels.

We think we see that at larger scale runs at the moment.

This also guards the allocation and sync to the use-cases when the GPUTimes are enabled.