### PR TITLE
Make FieldReduction more robust with respect to multiline parser inputs

### DIFF
--- a/Examples/Tests/reduced_diags/inputs
+++ b/Examples/Tests/reduced_diags/inputs
@@ -93,8 +93,8 @@ FR_Min.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = x*Ey*Bz
 FR_Min.reduction_type = Minimum
 FR_Integral.type = FieldReduction
 FR_Integral.intervals = 200
-FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) =
-    "if(y > 0 and z < 0, 0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0), 0)"
+FR_Integral.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = "if(y > 0 and z < 0,
+                            0.5*((Ex**2 + Ey**2 + Ez**2)*epsilon0+(Bx**2 + By**2 + Bz**2)/mu0), 0)"
 FR_Integral.reduction_type = Integral
 
 # Diagnostics

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -45,7 +45,7 @@ FieldReduction::FieldReduction (std::string rd_name)
 
     // Replace all newlines and possible following whitespaces with a single whitespace. This
     // should avoid weird formatting when the string is written in the header of the output file.
-    parser_string = std::regex_replace(parser_string, std::regex(("\n\\s*")), " ");
+    parser_string = std::regex_replace(parser_string, std::regex("\n\\s*"), " ");
 
     // read reduction type
     std::string reduction_type_string;

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -9,6 +9,8 @@
 #include "WarpX.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
+#include <regex>
+
 // constructor
 FieldReduction::FieldReduction (std::string rd_name)
 : ReducedDiags{rd_name}
@@ -40,6 +42,10 @@ FieldReduction::FieldReduction (std::string rd_name)
                        parser_string);
     m_parser = std::make_unique<ParserWrapper<m_nvars>>(
         makeParser(parser_string,{"x","y","z","Ex","Ey","Ez","Bx","By","Bz"}));
+
+    // Replace all newlines and possible following whitespaces with a single whitespace. This
+    // should avoid weird formatting when the string is written in the header of the output file.
+    parser_string = std::regex_replace(parser_string, std::regex(("\n\\s*")), " ");
 
     // read reduction type
     std::string reduction_type_string;


### PR DESCRIPTION
I think that using multi-line parser inputs in the `FieldReduction` diag should break our integrated tests so in this PR I'll try to make this more robust.

In the first commit, I've just added a multiline string in the input file to make sure that this indeed breaks CI.

Edit: As expected, CI was broken by a multiline input string (because of `np.genfromtext()`).
I've used a regex command to replace newlines + possible following whitespaces by a single whitespace. It looks like it is working now and it should look good on the headers. Also the regex command is now called after `makeParser` and so in any case it shouldn't affect the parser itself.