### PR TITLE
ion_map_ids: static & const access

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2324,7 +2324,7 @@ PhysicalParticleContainer::InitIonizationModule ()
     // Add runtime integer component for ionization level
     AddIntComp("ionization_level");
     // Get atomic number and ionization energies from file
-    int ion_element_id = ion_map_ids[physical_element];
+    int const ion_element_id = ion_map_ids.at(physical_element);
     ion_atomic_number = ion_atomic_numbers[ion_element_id];
     Vector<Real> h_ionization_energies(ion_atomic_number);
     int offset = ion_energy_offsets[ion_element_id];

--- a/Source/Utils/IonizationEnergiesTable.H
+++ b/Source/Utils/IonizationEnergiesTable.H
@@ -11,9 +11,11 @@
 
 #include <AMReX_AmrCore.H>
 #include <AMReX_REAL.H>
-#include <map>
 
-std::map<std::string, int> ion_map_ids = {
+#include <map>
+#include <string>
+
+static std::map<std::string, int> const ion_map_ids = {
     {"H", 0},
     {"He", 1},
     {"Li", 2},

--- a/Source/Utils/write_atomic_data_cpp.py
+++ b/Source/Utils/write_atomic_data_cpp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2019-2020 Axel Huebl, Luca Fedeli, Maxence Thevenet
+# Copyright 2019-2021 Axel Huebl, Luca Fedeli, Maxence Thevenet
 #
 #
 # This file is part of WarpX.
@@ -34,11 +34,12 @@ cpp_string += '// Edit dev/Source/Utils/write_atomic_data_cpp.py instead!\n'
 cpp_string += '#ifndef WARPX_IONIZATION_TABLE_H_\n'
 cpp_string += '#define WARPX_IONIZATION_TABLE_H_\n\n'
 cpp_string += '#include <AMReX_AmrCore.H>\n'
-cpp_string += '#include <AMReX_REAL.H>\n'
-cpp_string += '#include <map>\n\n'
+cpp_string += '#include <AMReX_REAL.H>\n\n'
+cpp_string += '#include <map>\n'
+cpp_string += '#include <string>\n\n'
 
 # Map each element to ID in table
-cpp_string += 'std::map<std::string, int> ion_map_ids = {'
+cpp_string += 'static std::map<std::string, int> const ion_map_ids = {'
 for count, name in enumerate(ion_names):
     cpp_string += '\n    {"' + name + '", ' + str(count) + '},'
 cpp_string = cpp_string[:-1]


### PR DESCRIPTION
This fixes the `ion_map_ids` atom-to-number object:
- declare static, so the file can be included in multiple translation units
- use `.at()`:
  - missing entries do not cause an insertion
  - missing entries will throw
  - access is `const`, so we can declare the whole object `static const` as well.