### PR TITLE
Fix Offset: PushPX -> evolve_opt

### DIFF
--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -96,9 +96,9 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     auto& attribs = pti.GetAttribs();
 
     // Extract pointers to the different particle quantities
-    ParticleReal* const AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
-    ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
-    ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
+    ParticleReal* const AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr() + offset;
 
 #ifdef WARPX_QED
     BreitWheelerEvolveOpticalDepth evolve_opt;
@@ -106,7 +106,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     const bool local_has_breit_wheeler = has_breit_wheeler();
     if (local_has_breit_wheeler) {
         evolve_opt = m_shr_p_bw_engine->build_evolve_functor();
-        p_optical_depth_BW = pti.GetAttribs(particle_comps["optical_depth_BW"]).dataPtr();
+        p_optical_depth_BW = pti.GetAttribs(particle_comps["optical_depth_BW"]).dataPtr() + offset;
     }
 #endif
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2227,9 +2227,9 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     amrex::IndexType const bz_type = bzfab->box().ixType();
 
     auto& attribs = pti.GetAttribs();
-    ParticleReal* const AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
-    ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
-    ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
+    ParticleReal* const AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr() + offset;
 
     auto copyAttribs = CopyParticleAttribs(pti, tmp_particle_data, offset);
     int do_copy = (WarpX::do_back_transformed_diagnostics &&
@@ -2287,7 +2287,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
 
         doParticlePush(getPosition, setPosition, copyAttribs, ip,
-                       ux[ip+offset], uy[ip+offset], uz[ip+offset],
+                       ux[ip], uy[ip], uz[ip],
                        Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                        ion_lev ? ion_lev[ip] : 0,
                        m, q, pusher_algo, do_crr, do_copy,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -254,9 +254,9 @@ RigidInjectedParticleContainer::PushPX (WarpXParIter& pti,
     const auto GetPosition = GetParticlePosition(pti);
           auto SetPosition = SetParticlePosition(pti);
 
-    ParticleReal* const AMREX_RESTRICT ux = uxp.dataPtr();
-    ParticleReal* const AMREX_RESTRICT uy = uyp.dataPtr();
-    ParticleReal* const AMREX_RESTRICT uz = uzp.dataPtr();
+    ParticleReal* const AMREX_RESTRICT ux = uxp.dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uy = uyp.dataPtr() + offset;
+    ParticleReal* const AMREX_RESTRICT uz = uzp.dataPtr() + offset;
 
     if (!done_injecting_lev)
     {
@@ -271,13 +271,13 @@ RigidInjectedParticleContainer::PushPX (WarpXParIter& pti,
         uyp_save.resize(np);
         uzp_save.resize(np);
 
-        amrex::Real* const AMREX_RESTRICT xp_save_ptr = xp_save.dataPtr();
-        amrex::Real* const AMREX_RESTRICT yp_save_ptr = yp_save.dataPtr();
-        amrex::Real* const AMREX_RESTRICT zp_save_ptr = zp_save.dataPtr();
+        amrex::Real* const AMREX_RESTRICT xp_save_ptr = xp_save.dataPtr() + offset;
+        amrex::Real* const AMREX_RESTRICT yp_save_ptr = yp_save.dataPtr() + offset;
+        amrex::Real* const AMREX_RESTRICT zp_save_ptr = zp_save.dataPtr() + offset;
 
-        amrex::Real* const AMREX_RESTRICT uxp_save_ptr = uxp_save.dataPtr();
-        amrex::Real* const AMREX_RESTRICT uyp_save_ptr = uyp_save.dataPtr();
-        amrex::Real* const AMREX_RESTRICT uzp_save_ptr = uzp_save.dataPtr();
+        amrex::Real* const AMREX_RESTRICT uxp_save_ptr = uxp_save.dataPtr() + offset;
+        amrex::Real* const AMREX_RESTRICT uyp_save_ptr = uyp_save.dataPtr() + offset;
+        amrex::Real* const AMREX_RESTRICT uzp_save_ptr = uzp_save.dataPtr() + offset;
 
         amrex::ParallelFor( np,
                             [=] AMREX_GPU_DEVICE (long i) {
@@ -302,12 +302,12 @@ RigidInjectedParticleContainer::PushPX (WarpXParIter& pti,
 
     if (!done_injecting_lev) {
 
-        ParticleReal* AMREX_RESTRICT x_save = xp_save.dataPtr();
-        ParticleReal* AMREX_RESTRICT y_save = yp_save.dataPtr();
-        ParticleReal* AMREX_RESTRICT z_save = zp_save.dataPtr();
-        ParticleReal* AMREX_RESTRICT ux_save = uxp_save.dataPtr();
-        ParticleReal* AMREX_RESTRICT uy_save = uyp_save.dataPtr();
-        ParticleReal* AMREX_RESTRICT uz_save = uzp_save.dataPtr();
+        ParticleReal* AMREX_RESTRICT x_save = xp_save.dataPtr() + offset;
+        ParticleReal* AMREX_RESTRICT y_save = yp_save.dataPtr() + offset;
+        ParticleReal* AMREX_RESTRICT z_save = zp_save.dataPtr() + offset;
+        ParticleReal* AMREX_RESTRICT ux_save = uxp_save.dataPtr() + offset;
+        ParticleReal* AMREX_RESTRICT uy_save = uyp_save.dataPtr() + offset;
+        ParticleReal* AMREX_RESTRICT uz_save = uzp_save.dataPtr() + offset;
 
         // Undo the push for particles not injected yet.
         // The zp are advanced a fixed amount.


### PR DESCRIPTION
Comparing to the `doParticlePush()` above, the `ux`/`uy`/`uz` SoA attributes seem to lack the particle offset in `PushPX`.

Also simplifies the offset calculation to reside off-kernel, which saves 8 bytes cmem and some index indirection logic for the compiler.