### PR TITLE
callbacks.py: Fix bound method py2 -> py3 syntax

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -148,7 +148,7 @@ class CallbackFunctions(object):
         if isinstance(f,types.MethodType):
             # --- If the function is a method of a class instance, then save a full
             # --- reference to that instance and the method name.
-            finstance = f.im_self
+            finstance = f.__self__
             fname = f.__name__
             self.funcs.append([finstance,fname])
         elif callable(f):


### PR DESCRIPTION
`im_self` is a reference to the instance only in python2. In python3 it is `__self__`