### PR TITLE
[WIP] Summit Power9: SMT Packed

### DIFF
--- a/Tools/BatchScripts/batch_summit_power9.sh
+++ b/Tools/BatchScripts/batch_summit_power9.sh
@@ -8,15 +8,17 @@
 #
 # Refs.:
 #   https://jsrunvisualizer.olcf.ornl.gov/?s1f0o121n2c21g0r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#hardware-threads
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#hardware-threads-multiple-threads-per-core
 
 #BSUB -P <allocation ID>
 #BSUB -W 00:10
 #BSUB -nnodes 1
-#BSUB -alloc_flags "smt1"
+#BSUB -alloc_flags "smt4"
 #BSUB -J WarpX
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
 
-export OMP_NUM_THREADS=21
-jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt
+export OMP_NUM_THREADS=84
+jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -bpacked:4 <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
Last time that we evaluated SMT (hyperthreading) on Summit's Power9 CPUs, we did not run with `-bpacked:<N>` as well.

## Measure

### SMT1
todo

### SMT2
todo

### SMT4
todo