### PR TITLE
Avoid calling `AddPlasma` when using `AddPlasmaFlux`

### DIFF
--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -62,7 +62,8 @@ public:
     amrex::Real getMass () {return mass;}
     PhysicalSpecies getPhysicalSpecies() const {return physical_species;}
 
-    bool doInjection () const noexcept { return h_inj_pos != nullptr;}
+    // bool: whether the initial injection of particles should be done
+    bool doInjection () const noexcept { return h_inj_pos != nullptr && !surface_flux;}
 
     bool add_single_particle = false;
     amrex::Vector<amrex::ParticleReal> single_particle_pos;

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -63,6 +63,8 @@ public:
     PhysicalSpecies getPhysicalSpecies() const {return physical_species;}
 
     // bool: whether the initial injection of particles should be done
+    // This routine is called during initialization of the plasma. When injecting
+    // a surface flux, no injection is done doing initialization so return false.
     bool doInjection () const noexcept { return h_inj_pos != nullptr && !surface_flux;}
 
     bool add_single_particle = false;


### PR DESCRIPTION
This is a small fix. Both normal plasma injection and flux injection use the `h_inj_pos` variable. During initialization of the particle containers, the `AddParticle` routine is called and if `h_inj_pos` is defined, it calls `AddPlasma`. This PR makes the change that the call to `AddPlasma` is only done if `surface_flux` is also false. This fixes a lock up that I was seeing when trying to run on Cori.