### PR TITLE
Don't use RealVector in laser particle initialization.

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -350,7 +350,7 @@ LaserParticleContainer::InitData (int lev)
     BoxArray plane_ba { Box {IntVect(plane_lo[0],0), IntVect(plane_hi[0],0)} };
 #endif
 
-    RealVector particle_x, particle_y, particle_z, particle_w;
+    amrex::Vector<amrex::Real> particle_x, particle_y, particle_z, particle_w;
 
     const DistributionMapping plane_dm {plane_ba, nprocs};
     const Vector<int>& procmap = plane_dm.ProcessorMap();
@@ -397,9 +397,9 @@ LaserParticleContainer::InitData (int lev)
         }
     }
     const int np = particle_z.size();
-    RealVector particle_ux(np, 0.0);
-    RealVector particle_uy(np, 0.0);
-    RealVector particle_uz(np, 0.0);
+    amrex::Vector<amrex::Real> particle_ux(np, 0.0);
+    amrex::Vector<amrex::Real> particle_uy(np, 0.0);
+    amrex::Vector<amrex::Real> particle_uz(np, 0.0);
 
     if (Verbose()) amrex::Print() << "Adding laser particles\n";
     // Add particles on level 0. They will be redistributed afterwards


### PR DESCRIPTION
This relies on managed memory because these particles are created on the host.