### PR TITLE
AMReX: unpackRemotes Managed Mem 

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -231,7 +231,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "fc9bc1e3efdaead0253d0a55dcf1abb7abc06bd7"
+set(WarpX_amrex_branch "501626901f500b45fce5102c01d15cd8f74c7187"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR and AMReX
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout fc9bc1e3efdaead0253d0a55dcf1abb7abc06bd7 && cd -
+cd amrex && git checkout 501626901f500b45fce5102c01d15cd8f74c7187 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout c16b642e3dcf860480dd1dd21cefa3874f395773 && cd -


### PR DESCRIPTION
Update AMReX to https://github.com/AMReX-Codes/amrex/commit/501626901f500b45fce5102c01d15cd8f74c7187

```
./Tools/Release/updateAMReX.py
```

Updated to include https://github.com/AMReX-Codes/amrex/pull/2116

This PR mitigates:
- do no allocated managed memory for received buffers as managed
  (with preferred location on-device): they are used only on host
- this can be inefficient, since the data is host-only
- caused crashes in `amrex::unpackRemotes` with `amrex.the_arena_is_managed=0`:
  managed memory buffers become pure device buffers with this option, thus the host cannot access them
  (https://github.com/ECP-WarpX/WarpX/issues/2009#issuecomment-861993324)