### PR TITLE
Add damped to picmi BC_map

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -19,7 +19,7 @@ picmistandard.register_codename(codename)
 
 # dictionary to map field boundary conditions from picmistandard to WarpX
 BC_map = {
-    'open':'pml', 'dirichlet':'pec', 'periodic':'periodic', 'none':'none'
+    'open':'pml', 'dirichlet':'pec', 'periodic':'periodic', 'damped':'damped', 'none':'none'
 }
 
 class constants:


### PR DESCRIPTION
This adds 'damped' to the boundary condition map in the PICMI interface. This is needed to allow moving frame simulations using PSATD using the PICMI interface.

Note that the PICMI standard documentation should probably be updated to state that alternative boundary condition types that are code dependent maybe specified.