### PR TITLE
DepositCurrent: Const Arguments

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -340,7 +340,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                                   const amrex::ParticleReal * const uxp,
                                   const amrex::ParticleReal * const uyp,
                                   const amrex::ParticleReal * const uzp,
-                                  const int * ion_lev,
+                                  const int * const ion_lev,
                                   const amrex::Array4<amrex::Real>& Jx_arr,
                                   const amrex::Array4<amrex::Real>& Jy_arr,
                                   const amrex::Array4<amrex::Real>& Jz_arr,
@@ -351,7 +351,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                                   const amrex::Dim3 lo,
                                   const amrex::Real q,
                                   const int n_rz_azimuthal_modes,
-                                  amrex::Real* cost,
+                                  amrex::Real * const cost,
                                   const long load_balance_costs_update_algo)
 {
     using namespace amrex;

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -93,22 +93,22 @@ public:
                                 int /*depos_lev*/) override {}
 
     // DepositCurrent should do nothing for photons
-    virtual void DepositCurrent(WarpXParIter& /*pti*/,
-                                RealVector& /*wp*/,
-                                RealVector& /*uxp*/,
-                                RealVector& /*uyp*/,
-                                RealVector& /*uzp*/,
-                                const int * const /*ion_lev*/,
-                                amrex::MultiFab* /*jx*/,
-                                amrex::MultiFab* /*jy*/,
-                                amrex::MultiFab* /*jz*/,
-                                const long /*offset*/,
-                                const long /*np_to_depose*/,
-                                int /*thread_num*/,
-                                int /*lev*/,
-                                int /*depos_lev*/,
-                                amrex::Real /*dt*/,
-                                amrex::Real /*relative_time*/) override {}
+    virtual void DepositCurrent (WarpXParIter& /*pti*/,
+                                 RealVector const & /*wp*/,
+                                 RealVector const & /*uxp*/,
+                                 RealVector const & /*uyp*/,
+                                 RealVector const & /*uzp*/,
+                                 int const * const /*ion_lev*/,
+                                 amrex::MultiFab * const /*jx*/,
+                                 amrex::MultiFab * const /*jy*/,
+                                 amrex::MultiFab * const /*jz*/,
+                                 long const /*offset*/,
+                                 long const /*np_to_depose*/,
+                                 int const /*thread_num*/,
+                                 int const /*lev*/,
+                                 int const /*depos_lev*/,
+                                 amrex::Real const /*dt*/,
+                                 amrex::Real const /*relative_time*/) override {}
 };
 
 #endif // #ifndef WARPX_PhotonParticleContainer_H_

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -199,7 +199,7 @@ public:
                        bool do_rz_volume_scaling = false );
     std::unique_ptr<amrex::MultiFab> GetChargeDensity(int lev, bool local = false);
 
-    virtual void DepositCharge(WarpXParIter& pti,
+    virtual void DepositCharge (WarpXParIter& pti,
                                RealVector& wp,
                                const int * const ion_lev,
                                amrex::MultiFab* rho,
@@ -210,22 +210,22 @@ public:
                                int lev,
                                int depos_lev);
 
-    virtual void DepositCurrent(WarpXParIter& pti,
-                                RealVector& wp,
-                                RealVector& uxp,
-                                RealVector& uyp,
-                                RealVector& uzp,
-                                const int * const ion_lev,
-                                amrex::MultiFab* jx,
-                                amrex::MultiFab* jy,
-                                amrex::MultiFab* jz,
-                                const long offset,
-                                const long np_to_depose,
-                                int thread_num,
-                                int lev,
-                                int depos_lev,
-                                amrex::Real dt,
-                                amrex::Real relative_time);
+    virtual void DepositCurrent (WarpXParIter& pti,
+                                RealVector const & wp,
+                                RealVector const & uxp,
+                                RealVector const & uyp,
+                                RealVector const & uzp,
+                                int const * const ion_lev,
+                                amrex::MultiFab* const jx,
+                                amrex::MultiFab* const jy,
+                                amrex::MultiFab* const jz,
+                                long const offset,
+                                long const np_to_depose,
+                                int const thread_num,
+                                int const lev,
+                                int const depos_lev,
+                                amrex::Real const dt,
+                                amrex::Real const relative_time);
 
     // If particles start outside of the domain, ContinuousInjection
     // makes sure that they are initialized when they enter the domain, and

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -234,8 +234,8 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
  */
 void
 WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
-                                        RealVector const & wp, const RealVector const & uxp,
-                                        RealVector const & uyp, const RealVector const & uzp,
+                                        RealVector const & wp, RealVector const & uxp,
+                                        RealVector const & uyp, RealVector const & uzp,
                                         int const * const ion_lev,
                                         MultiFab * const jx, MultiFab * const jy, MultiFab * const jz,
                                         long const offset, long const np_to_depose,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -213,7 +213,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
 /* \brief Current Deposition for thread thread_num
  * \param pti         : Particle iterator
  * \param wp          : Array of particle weights
- * \param uxp uyp uzp : Array of particle
+ * \param uxp uyp uzp : Array of particle momenta
  * \param ion_lev      : Pointer to array of particle ionization level. This is
                          required to have the charge of each macroparticle
                          since q is a scalar. For non-ionizable species,
@@ -233,14 +233,14 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
  *                       time of the deposition.
  */
 void
-WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
-                                       RealVector& wp, RealVector& uxp,
-                                       RealVector& uyp, RealVector& uzp,
-                                       const int * const ion_lev,
-                                       MultiFab* jx, MultiFab* jy, MultiFab* jz,
-                                       const long offset, const long np_to_depose,
-                                       int thread_num, int lev, int depos_lev,
-                                       Real dt, Real relative_time)
+WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
+                                        RealVector const & wp, const RealVector const & uxp,
+                                        RealVector const & uyp, const RealVector const & uzp,
+                                        int const * const ion_lev,
+                                        MultiFab * const jx, MultiFab * const jy, MultiFab * const jz,
+                                        long const offset, long const np_to_depose,
+                                        int const thread_num, const int lev, int const depos_lev,
+                                        Real const dt, Real const relative_time)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev==(lev-1)) ||
                                      (depos_lev==(lev  )),
@@ -376,8 +376,8 @@ WarpXParticleContainer::DepositCurrent(WarpXParIter& pti,
     }
 
     WARPX_PROFILE_VAR_START(blp_deposit);
-    amrex::LayoutData<amrex::Real>* costs = WarpX::getCosts(lev);
-    amrex::Real* cost = costs ? &((*costs)[pti.index()]) : nullptr;
+    amrex::LayoutData<amrex::Real> * const costs = WarpX::getCosts(lev);
+    amrex::Real * const cost = costs ? &((*costs)[pti.index()]) : nullptr;
 
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov) {
         if        (WarpX::nox == 1){


### PR DESCRIPTION
Improve const correctness of the `DepositCurrent` interface, esp. for momentum arguments.

No influence on kernels, which already accept by const.