### PR TITLE
Filter Always ON by Default

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1156,7 +1156,7 @@ Numerics and algorithms
     and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for `warpx.cfl=1`,
     the timestep will be exactly equal to the CFL limit.)
 
-* ``warpx.use_filter`` (`0 or 1`)
+* ``warpx.use_filter`` (`0` or `1`; default: `1`)
     Whether to smooth the charge and currents on the mesh, after depositing
     them from the macroparticles. This uses a bilinear filter
     (see the :ref:`filtering section <theory-pic-filter>`).

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1156,11 +1156,15 @@ Numerics and algorithms
     and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for `warpx.cfl=1`,
     the timestep will be exactly equal to the CFL limit.)
 
-* ``warpx.use_filter`` (`0` or `1`; default: `1`)
-    Whether to smooth the charge and currents on the mesh, after depositing
-    them from the macroparticles. This uses a bilinear filter
-    (see the :ref:`filtering section <theory-pic-filter>`).
-    When using the RZ spectral solver, the filtering is done in k-space.
+* ``warpx.use_filter`` (`0` or `1`; default: `1`, except for RZ FDTD)
+    Whether to smooth the charge and currents on the mesh, after depositing them from the macro-particles.
+    This uses a bilinear filter (see the :ref:`filtering section <theory-pic-filter>`).
+    The default is `1` in all cases, except for simulations in RZ geometry using the FDTD solver.
+    With the RZ PSATD solver, the filtering is done in :math:`k`-space.
+
+    .. warning::
+
+       Known bug: filter currently not working with FDTD solver in RZ geometry (see https://github.com/ECP-WarpX/WarpX/issues/1943).
 
 * ``warpx.filter_npass_each_dir`` (`3 int`) optional (default `1 1 1`)
     Number of passes along each direction for the bilinear filter.

--- a/Examples/Modules/RigidInjection/inputs_2d_LabFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_LabFrame
@@ -13,6 +13,7 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
 warpx.serialize_ics = 1
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Modules/dive_cleaning/inputs_3d
+++ b/Examples/Modules/dive_cleaning/inputs_3d
@@ -10,6 +10,7 @@ geometry.prob_hi     =  50.e-6    50.e-6   50.e-6
 
 warpx.do_dive_cleaning = 1
 warpx.do_pml = 1
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -60,7 +60,8 @@ part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
 sim = picmi.Simulation(solver = solver,
                        max_steps = 10,
                        verbose = 1,
-                       warpx_current_deposition_algo = 'direct')
+                       warpx_current_deposition_algo = 'direct',
+                       warpx_use_filter = 0)
 
 sim.add_species(electrons, layout=picmi.PseudoRandomLayout(n_macroparticles=number_sim_particles))
 sim.add_species(protons, layout=picmi.PseudoRandomLayout(n_macroparticles=number_sim_particles))

--- a/Examples/Modules/ionization/inputs_2d_bf_rt
+++ b/Examples/Modules/ionization/inputs_2d_bf_rt
@@ -16,6 +16,7 @@ warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0
 warpx.gamma_boost = 2.
 warpx.boost_direction = z
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Modules/ionization/inputs_2d_rt
+++ b/Examples/Modules/ionization/inputs_2d_rt
@@ -11,6 +11,7 @@ amr.max_level = 0
 algo.maxwell_solver = ckc
 warpx.do_pml = 1
 warpx.cfl = .999
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Modules/laser_injection/inputs_2d_rt
+++ b/Examples/Modules/laser_injection/inputs_2d_rt
@@ -24,6 +24,7 @@ warpx.verbose = 1
 
 # Algorithms
 algo.current_deposition = esirkepov
+warpx.use_filter = 0
 
 # CFL
 warpx.cfl = 1.0

--- a/Examples/Modules/laser_injection/inputs_3d_rt
+++ b/Examples/Modules/laser_injection/inputs_3d_rt
@@ -24,6 +24,7 @@ warpx.verbose = 1
 
 # Algorithms
 warpx.do_pml = 0
+warpx.use_filter = 0
 
 # CFL
 warpx.cfl = 1.0

--- a/Examples/Modules/qed/schwinger/inputs_3d_schwinger
+++ b/Examples/Modules/qed/schwinger/inputs_3d_schwinger
@@ -22,6 +22,7 @@ warpx.verbose = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
 warpx.do_pml = 0 # use Perfectly Matched Layer as boundary condition
 warpx.serialize_ics = 1
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_laser_acceleration.py
@@ -123,7 +123,8 @@ part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
 sim = picmi.Simulation(solver = solver,
                        max_steps = max_steps,
                        verbose = 1,
-                       warpx_current_deposition_algo = 'esirkepov')
+                       warpx_current_deposition_algo = 'esirkepov',
+                       warpx_use_filter = 0)
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=number_per_cell_each_dim))
 

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
@@ -48,7 +48,8 @@ plasma = picmi.Species(particle_type='electron', name='plasma', initial_distribu
 sim = picmi.Simulation(solver = solver,
                        max_steps = max_steps,
                        verbose = 1,
-                       warpx_current_deposition_algo = 'esirkepov')
+                       warpx_current_deposition_algo = 'esirkepov',
+                       warpx_use_filter = 0)
 
 sim.add_species(beam, layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=number_per_cell_each_dim))
 sim.add_species(plasma, layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=number_per_cell_each_dim))

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
@@ -54,7 +54,8 @@ plasma = picmi.Species(particle_type='electron', name='plasma', initial_distribu
 sim = picmi.Simulation(solver = solver,
                        max_steps = 2,
                        verbose = 1,
-                       warpx_current_deposition_algo = 'esirkepov')
+                       warpx_current_deposition_algo = 'esirkepov',
+                       warpx_use_filter = 0)
 
 sim.add_species(beam, layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=number_per_cell_each_dim))
 sim.add_species(plasma, layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=number_per_cell_each_dim))

--- a/Examples/Physics_applications/uniform_plasma/inputs_2d
+++ b/Examples/Physics_applications/uniform_plasma/inputs_2d
@@ -17,6 +17,7 @@ geometry.prob_hi     =  20.e-6    20.e-6
 warpx.serialize_ics = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
+++ b/Examples/Tests/ElectrostaticDirichletBC/inputs_2d
@@ -3,6 +3,7 @@ warpx.verbose = 0
 warpx.const_dt = 7.5e-10
 warpx.do_electrostatic = labframe
 warpx.self_fields_required_precision = 1e-06
+warpx.use_filter = 0
 amr.n_cell = 64 8
 amr.max_grid_size = 32
 amr.max_level = 0

--- a/Examples/Tests/ElectrostaticSphere/inputs_rz
+++ b/Examples/Tests/ElectrostaticSphere/inputs_rz
@@ -10,6 +10,7 @@ geometry.prob_hi     =  0.5  0.5
 warpx.do_pml = 0
 warpx.const_dt = 1e-6
 warpx.do_electrostatic = labframe
+warpx.use_filter = 0
 
 particles.species_names = electron
 

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
@@ -79,7 +79,8 @@ part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
 sim = picmi.Simulation(solver = solver,
                        max_steps = max_steps,
                        verbose = 1,
-                       warpx_current_deposition_algo = 'direct')
+                       warpx_current_deposition_algo = 'direct',
+                       warpx_use_filter = 0)
 
 sim.add_species(electrons,
                 layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -118,7 +118,8 @@ sim = picmi.Simulation(solver = solver,
                        verbose = 1,
                        warpx_current_deposition_algo = 'esirkepov',
                        warpx_field_gathering_algo = 'energy-conserving',
-                       warpx_particle_pusher_algo = 'boris')
+                       warpx_particle_pusher_algo = 'boris',
+                       warpx_use_filter = 0)
 
 sim.add_species(electrons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,16,2], grid=grid))
 sim.add_species(protons, layout=picmi.GriddedLayout(n_macroparticle_per_cell=[2,16,2], grid=grid))

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rt
@@ -25,6 +25,7 @@ warpx.verbose = 1
 # Algorithms
 algo.field_gathering = energy-conserving
 warpx.do_pml = 0
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -27,6 +27,7 @@ warpx.verbose = 1
 warpx.do_pml = 0
 algo.field_gathering = energy-conserving
 algo.current_deposition = esirkepov
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/Langmuir/inputs_3d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -26,6 +26,7 @@ warpx.verbose = 1
 algo.current_deposition = esirkepov
 algo.field_gathering = energy-conserving
 warpx.do_pml = 0
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/Larmor/inputs_2d_mr
+++ b/Examples/Tests/Larmor/inputs_2d_mr
@@ -34,6 +34,7 @@ particles.B_external_particle = 0.0  0.00078110417851950768  0.0
 warpx.verbose = 1
 
 # Algorithms
+warpx.use_filter = 0
 
 # CFL
 warpx.cfl = 1.0

--- a/Examples/Tests/PML/inputs_2d
+++ b/Examples/Tests/PML/inputs_2d
@@ -21,9 +21,9 @@ geometry.prob_hi     =  30.e-6  120.e-6
 warpx.verbose = 1
 
 # Algorithms
-
 warpx.cfl = 1.0
 warpx.do_pml = 1
+warpx.use_filter = 0
 
 warpx.do_moving_window = 0
 # warpx.moving_window_dir = z

--- a/Examples/Tests/SilverMueller/inputs_2d_x
+++ b/Examples/Tests/SilverMueller/inputs_2d_x
@@ -21,10 +21,10 @@ geometry.prob_hi     =  20.e-6  40.e-6
 warpx.verbose = 1
 
 # Algorithms
-
 warpx.cfl = 1.0
 warpx.do_pml = 0
 warpx.do_silver_mueller = 1
+warpx.use_filter = 0
 
 warpx.do_moving_window = 0
 # warpx.moving_window_dir = z

--- a/Examples/Tests/SilverMueller/inputs_2d_z
+++ b/Examples/Tests/SilverMueller/inputs_2d_z
@@ -21,10 +21,10 @@ geometry.prob_hi     =  40.e-6  20.e-6
 warpx.verbose = 1
 
 # Algorithms
-
 warpx.cfl = 1.0
 warpx.do_pml = 0
 warpx.do_silver_mueller = 1
+warpx.use_filter = 0
 
 warpx.do_moving_window = 0
 # warpx.moving_window_dir = z

--- a/Examples/Tests/SilverMueller/inputs_rz_z
+++ b/Examples/Tests/SilverMueller/inputs_rz_z
@@ -22,10 +22,10 @@ warpx.verbose = 1
 warpx.n_rz_azimuthal_modes = 2
 
 # Algorithms
-
 warpx.cfl = 1.0
 warpx.do_pml = 0
 warpx.do_silver_mueller = 1
+warpx.use_filter = 0
 
 warpx.do_moving_window = 0
 

--- a/Examples/Tests/initial_distribution/inputs
+++ b/Examples/Tests/initial_distribution/inputs
@@ -17,6 +17,7 @@ warpx.do_pml         = 0
 #################################
 warpx.verbose = 1
 warpx.cfl     = 1.e-8
+warpx.use_filter = 0
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/laser_on_fine/inputs_2d
+++ b/Examples/Tests/laser_on_fine/inputs_2d
@@ -34,6 +34,7 @@ warpx.verbose = 1
 algo.current_deposition = esirkepov
 algo.charge_deposition = standard
 algo.field_gathering = energy-conserving
+warpx.use_filter = 0
 
 # CFL
 warpx.cfl = 1.0

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -4,6 +4,7 @@
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     #include "FieldSolver/SpectralSolver/SpectralFieldData.H"
     #include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+    #include "Utils/WarpXAlgorithmSelection.H"
 #endif
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -54,11 +55,15 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
 
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     using IdxAvg = SpectralFieldIndexTimeAveraging;
-    if (WarpX::use_kspace_filter) {
-        auto & solver = warpx.get_spectral_solver_fp(m_lev);
-        solver.ForwardTransform(m_lev, *rho, IdxAvg::rho_new);
-        solver.ApplyFilter(IdxAvg::rho_new);
-        solver.BackwardTransform(m_lev, *rho, IdxAvg::rho_new);
+    // Apply k-space filtering when using the PSATD solver
+    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    {
+        if (WarpX::use_kspace_filter) {
+            auto & solver = warpx.get_spectral_solver_fp(m_lev);
+            solver.ForwardTransform(m_lev, *rho, IdxAvg::rho_new);
+            solver.ApplyFilter(IdxAvg::rho_new);
+            solver.BackwardTransform(m_lev, *rho, IdxAvg::rho_new);
+        }
     }
 #endif
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -141,8 +141,8 @@ int WarpX::current_centering_noz = 2;
 bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
-bool WarpX::use_filter        = false;
-bool WarpX::use_kspace_filter       = false;
+bool WarpX::use_filter = true;
+bool WarpX::use_kspace_filter = false;
 bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_ics     = false;
@@ -567,8 +567,11 @@ WarpX::ReadParameters ()
         filter_npass_each_dir[2] = parse_filter_npass_each_dir[2];
 #endif
 
+        // TODO When k-space filtering will be implemented also for Cartesian geometries,
+        // this code block will have to be applied in all cases (remove #ifdef condition)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+        {
             // With RZ spectral, only use k-space filtering
             use_kspace_filter = use_filter;
             use_filter = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -141,14 +141,8 @@ int WarpX::current_centering_noz = 2;
 bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
-// In RZ geometry, when using the PSATD executable with a FDTD runtime solver,
-// the defaults are WarpX::use_filter = false (set later on in the code below)
-// and WarpX::use_kspace_filter = false (set here).
-// However, if warpx.use_filter = true is set in the input file, the default for
-// WarpX::use_kspace_filter = false set here makes sure to avoid runtime crashes
-// (which would occur if WarpX::use_kspace_filter = true was set here instead).
 bool WarpX::use_filter = true;
-bool WarpX::use_kspace_filter       = false;
+bool WarpX::use_kspace_filter       = true;
 bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_ics     = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -141,8 +141,14 @@ int WarpX::current_centering_noz = 2;
 bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
+// In RZ geometry, when using the PSATD executable with a FDTD runtime solver,
+// the defaults are WarpX::use_filter = false (set later on in the code below)
+// and WarpX::use_kspace_filter = false (set here).
+// However, if warpx.use_filter = true is set in the input file, the default for
+// WarpX::use_kspace_filter = false set here makes sure to avoid runtime crashes
+// (which would occur if WarpX::use_kspace_filter = true was set here instead).
 bool WarpX::use_filter = true;
-bool WarpX::use_kspace_filter = true;
+bool WarpX::use_kspace_filter       = false;
 bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_ics     = false;
@@ -576,8 +582,7 @@ WarpX::ReadParameters ()
         // TODO When k-space filtering will be implemented also for Cartesian geometries,
         // this code block will have to be applied in all cases (remove #ifdef condition)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
-        {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
             // With RZ spectral, only use k-space filtering
             use_kspace_filter = use_filter;
             use_filter = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -142,7 +142,7 @@ bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
 bool WarpX::use_filter = true;
-bool WarpX::use_kspace_filter       = false;
+bool WarpX::use_kspace_filter = true;
 bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_ics     = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -142,7 +142,7 @@ bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
 bool WarpX::use_filter = true;
-bool WarpX::use_kspace_filter = false;
+bool WarpX::use_kspace_filter       = false;
 bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_ics     = false;
@@ -570,8 +570,7 @@ WarpX::ReadParameters ()
         // TODO When k-space filtering will be implemented also for Cartesian geometries,
         // this code block will have to be applied in all cases (remove #ifdef condition)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
-        {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
             // With RZ spectral, only use k-space filtering
             use_kspace_filter = use_filter;
             use_filter = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -555,6 +555,12 @@ WarpX::ReadParameters ()
         pp_warpx.query("n_buffer", n_buffer);
         pp_warpx.query("const_dt", const_dt);
 
+        // Filter currently not working with FDTD solver in RZ geometry: turn OFF by default
+        // (see https://github.com/ECP-WarpX/WarpX/issues/1943)
+#ifdef WARPX_DIM_RZ
+        if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD) WarpX::use_filter = false;
+#endif
+
         // Read filter and fill IntVect filter_npass_each_dir with
         // proper size for AMREX_SPACEDIM
         pp_warpx.query("use_filter", use_filter);
@@ -570,10 +576,23 @@ WarpX::ReadParameters ()
         // TODO When k-space filtering will be implemented also for Cartesian geometries,
         // this code block will have to be applied in all cases (remove #ifdef condition)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+        {
             // With RZ spectral, only use k-space filtering
             use_kspace_filter = use_filter;
             use_filter = false;
+        }
+        else // FDTD
+        {
+            // Filter currently not working with FDTD solver in RZ geometry
+            // (see https://github.com/ECP-WarpX/WarpX/issues/1943)
+            if (use_filter)
+            {
+                amrex::Print() << "\nWARNING:"
+                               << "\nFilter currently not working with FDTD solver in RZ geometry:"
+                               << "\nwe recommend setting warpx.use_filter = 0 in the input file.\n"
+                               << std::endl;
+            }
         }
 #endif
 


### PR DESCRIPTION
This turns filtering ON by default, as requested by @jlvay (has been on my to-do list for a while).

I kept filtering OFF in all CI tests that were not using filtering before, by adding `warpx.use_filter = 0` or PICMI equivalent explicitly in their input files (since the new default is `1`), in order to avoid updating all benchmarks.

Due to #1943, we now set filter OFF by default for RZ FDTD and also issue this warning:
```

WARNING:
Filter currently not working with FDTD solver in RZ geometry:
we recommend setting warpx.use_filter = 0 in the input file.

```

**Note**
I modified the GitHub label "changes input script" to "changes input scripts / defaults", in order to make it more clear that this is the label that should be added to PRs that change input scripts and/or defaults.