### PR TITLE
Check verbose parameter before printing out step info

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -280,15 +280,15 @@ WarpX::Evolve (int numsteps)
             ComputeSpaceChargeField( reset_fields );
         }
 
-        Real walltime_end_step = amrex::second();
-        walltime = walltime_end_step - walltime_start;
+        Real evolve_time_end_step = amrex::second();
+        evolve_time += evolve_time_end_step - evolve_time_beg_step;
 
         if (verbose) {
             amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
                         << " DT = " << dt[0] << "\n";
-            amrex::Print()<< "Walltime = " << walltime
-                        << " s; This step = " << walltime_end_step-walltime_beg_step
-                        << " s; Avg. per step = " << walltime/(step+1) << " s\n";
+            amrex::Print()<< "Evolve time = " << evolve_time
+                      << " s; This step = " << evolve_time_end_step-evolve_time_beg_step
+                      << " s; Avg. per step = " << evolve_time/(step+1) << " s\n";
         }
         // sync up time
         for (int i = 0; i <= max_level; ++i) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -48,8 +48,9 @@ WarpX::Evolve (int numsteps)
         multi_diags->NewIteration();
 
         // Start loop on time steps
-        amrex::Print() << "\nSTEP " << step+1 << " starts ...\n";
-
+        if (verbose) {
+            amrex::Print() << "\nSTEP " << step+1 << " starts ...\n";
+        }
         if (warpx_py_beforestep) warpx_py_beforestep();
 
         amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(0);
@@ -251,15 +252,15 @@ WarpX::Evolve (int numsteps)
             bool const reset_fields = true;
             ComputeSpaceChargeField( reset_fields );
         }
-
-        amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
-                      << " DT = " << dt[0] << "\n";
-        Real walltime_end_step = amrex::second();
-        walltime = walltime_end_step - walltime_start;
-        amrex::Print()<< "Walltime = " << walltime
-                      << " s; This step = " << walltime_end_step-walltime_beg_step
-                      << " s; Avg. per step = " << walltime/(step+1) << " s\n";
-
+        if (verbose) {
+            amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
+                        << " DT = " << dt[0] << "\n";
+            Real walltime_end_step = amrex::second();
+            walltime = walltime_end_step - walltime_start;
+            amrex::Print()<< "Walltime = " << walltime
+                        << " s; This step = " << walltime_end_step-walltime_beg_step
+                        << " s; Avg. per step = " << walltime/(step+1) << " s\n";
+        }
         // sync up time
         for (int i = 0; i <= max_level; ++i) {
             t_new[i] = cur_time;

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -252,11 +252,13 @@ WarpX::Evolve (int numsteps)
             bool const reset_fields = true;
             ComputeSpaceChargeField( reset_fields );
         }
+
+        Real walltime_end_step = amrex::second();
+        walltime = walltime_end_step - walltime_start;
+
         if (verbose) {
             amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
                         << " DT = " << dt[0] << "\n";
-            Real walltime_end_step = amrex::second();
-            walltime = walltime_end_step - walltime_start;
             amrex::Print()<< "Walltime = " << walltime
                         << " s; This step = " << walltime_end_step-walltime_beg_step
                         << " s; Avg. per step = " << walltime/(step+1) << " s\n";


### PR DESCRIPTION
Currently the `verbose` input parameter exists but does nothing. Now `verbose` is checked before printing information when a step starts and after a step ends.