### PR TITLE
Feature pass MPI comm from Python script to AMReX during initialization

### DIFF
--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -1,6 +1,6 @@
 # --- Test if MPI_communicator is correctly passed from Python to CPP
 # --- This test should be run with MPI enabled
-# --- Inputs taken from langmuir_2d. Runs 1 step, and will check
+# --- Inputs taken from langmuir_2d. Runs 10 steps, and will check
 # --- if the correct amount of processors are initialized in AMReX.
 
 from mpi4py import MPI
@@ -10,10 +10,6 @@ constants = picmi.constants
 ##########################
 # MPI communicator setup
 ##########################
-
-# must initialize everything separately on separate processors
-# so we need to create comm first before setting params,
-# and importing packages
 
 # split processor 0 into separate communicator from others
 comm_world = MPI.COMM_WORLD
@@ -107,13 +103,11 @@ sim.add_species(electrons,
 sim.add_diagnostic(field_diag)
 sim.add_diagnostic(part_diag)
 
-
 ##########################
 # simulation run
 ##########################
 
 sim.step(max_steps, mpi_comm=new_comm)
-
 
 ##########################
 # test

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -1,0 +1,145 @@
+# --- Test if MPI_communicator is correctly passed from Python to CPP
+# --- This test should be run with MPI enabled
+# --- Inputs taken from langmuir_2d. Runs 1 step, and will check
+# --- if the correct amount of processors are initialized in AMReX.
+
+from mpi4py import MPI
+from pywarpx import picmi
+from pywarpx import geometry
+# need to set geometry before importing _libwarpx
+geometry.coord_sys = 0
+geometry.prob_lo = [0]*2
+constants = picmi.constants
+
+##########################
+# MPI communicator setup
+##########################
+
+# must initialize everything separately on separate processors
+# so we need to create comm first before setting params,
+# and importing packages
+
+# split processor 0 into separate communicator from others
+comm_world = MPI.COMM_WORLD
+rank = comm_world.Get_rank()
+if rank == 0:
+    color = 0
+else:
+    color = 1
+new_comm = comm_world.Split(color)
+
+if color == 1:
+    # only import libwarpx after splitting up processors otherwise
+    # throws a segmentation fault. Don't know why this happens.
+    from pywarpx import _libwarpx
+
+    ##########################
+    # physics parameters
+    ##########################
+
+    plasma_density = 1.e25
+    plasma_xmin = 0.
+    plasma_x_velocity = 0.1*constants.c
+
+    ##########################
+    # numerics parameters
+    ##########################
+
+    # --- Number of time steps
+    max_steps = 10
+    diagnostic_intervals = "::10"
+
+    # --- Grid
+    nx = 64
+    ny = 64
+
+    xmin = -20.e-6
+    ymin = -20.e-6
+    xmax = +20.e-6
+    ymax = +20.e-6
+
+    number_per_cell_each_dim = [2,2]
+
+    ##########################
+    # physics components
+    ##########################
+
+    uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+                                            upper_bound = [0., None, None],
+                                            directed_velocity = [0.1*constants.c, 0., 0.])
+
+    electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
+
+    ##########################
+    # numerics components
+    ##########################
+
+    grid = picmi.Cartesian2DGrid(number_of_cells = [nx, ny],
+                                lower_bound = [xmin, ymin],
+                                upper_bound = [xmax, ymax],
+                                lower_boundary_conditions = ['periodic', 'periodic'],
+                                upper_boundary_conditions = ['periodic', 'periodic'],
+                                moving_window_velocity = [0., 0., 0.],
+                                warpx_max_grid_size = 32)
+
+    solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
+
+    ##########################
+    # diagnostics
+    ##########################
+
+    field_diag1 = picmi.FieldDiagnostic(name = 'diag1',
+                                        grid = grid,
+                                        period = diagnostic_intervals,
+                                        data_list = ['Ex', 'Jx'],
+                                        write_dir = '.',
+                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt')
+
+    part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
+                                        period = diagnostic_intervals,
+                                        species = [electrons],
+                                        data_list = ['weighting', 'ux'])
+
+    ##########################
+    # simulation setup
+    ##########################
+
+    sim = picmi.Simulation(solver = solver,
+                        max_steps = max_steps,
+                        verbose = 1,
+                        warpx_current_deposition_algo = 'direct')
+
+    sim.add_species(electrons,
+                    layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))
+
+    sim.add_diagnostic(field_diag1)
+    sim.add_diagnostic(part_diag1)
+
+    ##########################
+    # simulation run and test
+    ##########################
+
+    # NOTE: All tests are done in this input PICMI file, in this section
+    # the analysis file is only there to satisfy the test script
+    # requirements. The test will crash if any asserts fail.
+
+    # write_inputs will create an inputs file that can be used to run
+    # with the compiled version.
+    sim.write_input_file(file_name = 'inputs2d_from_PICMI')
+
+    # pass communicators to amrex
+    # Manually initialize inputs and warpx, to pass mpi communicator
+    sim.initialize_inputs()
+    sim.initialize_warpx(mpi_comm=new_comm)
+    sim.step(max_steps)
+
+    # verify that amrex initialized with 1 fewer proc than comm world
+    comm_world_size = comm_world.size
+    new_comm_size = new_comm.size
+
+    assert _libwarpx.libwarpx.warpx_getNProcs() == comm_world_size - 1
+    assert _libwarpx.libwarpx.warpx_getNProcs() == new_comm_size
+
+    # verify that amrex proc ranks are offset by -1 from
+    # world comm proc ranks
+    assert _libwarpx.libwarpx.warpx_getMyProc() == rank - 1

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -6,11 +6,6 @@
 from mpi4py import MPI
 from pywarpx import picmi
 constants = picmi.constants
-# from pywarpx import geometry
-# # need to set geometry before importing _libwarpx
-# geometry.coord_sys = 0
-# geometry.prob_lo = [0]*2
-
 
 ##########################
 # MPI communicator setup
@@ -29,221 +24,123 @@ else:
     color = 1
 new_comm = comm_world.Split(color)
 
+##########################
+# physics parameters
+##########################
+
+# different communicators will be passed different plasma density
+plasma_density = [1.e18, 1.e19]
+plasma_xmin = 0.
+plasma_x_velocity = 0.1*constants.c
+
+##########################
+# numerics parameters
+##########################
+
+# --- Number of time steps
+max_steps = 10
+diagnostic_intervals = "::10"
+
+# --- Grid
+nx = 64
+ny = 64
+
+xmin = -20.e-6
+ymin = -20.e-6
+xmax = +20.e-6
+ymax = +20.e-6
+
+number_per_cell_each_dim = [2,2]
+
+##########################
+# physics components
+##########################
+
+uniform_plasma = picmi.UniformDistribution(density = plasma_density[color],
+                                        upper_bound = [0., None, None],
+                                        directed_velocity = [0.1*constants.c, 0., 0.])
+
+electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
+
+##########################
+# numerics components
+##########################
+
+grid = picmi.Cartesian2DGrid(number_of_cells = [nx, ny],
+                            lower_bound = [xmin, ymin],
+                            upper_bound = [xmax, ymax],
+                            lower_boundary_conditions = ['periodic', 'periodic'],
+                            upper_boundary_conditions = ['periodic', 'periodic'],
+                            moving_window_velocity = [0., 0., 0.],
+                            warpx_max_grid_size = 32)
+
+solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
+
+##########################
+# diagnostics
+##########################
+
+field_diag = picmi.FieldDiagnostic(name = f'diag{color + 1}',
+                                    grid = grid,
+                                    period = diagnostic_intervals,
+                                    data_list = ['Ex', 'Jx'],
+                                    write_dir = '.',
+                                    warpx_file_prefix = f'Python_pass_mpi_comm_plt{color + 1}_')
+
+part_diag = picmi.ParticleDiagnostic(name = f'diag{color + 1}',
+                                    period = diagnostic_intervals,
+                                    species = [electrons],
+                                    data_list = ['weighting', 'ux'])
+
+##########################
+# simulation setup
+##########################
+
+sim = picmi.Simulation(solver = solver,
+                    max_steps = max_steps,
+                    verbose = 1,
+                    warpx_current_deposition_algo = 'direct')
+
+sim.add_species(electrons,
+                layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))
+
+sim.add_diagnostic(field_diag)
+sim.add_diagnostic(part_diag)
+
+
+##########################
+# simulation run
+##########################
+
+sim.step(max_steps, mpi_comm=new_comm)
+
+
+##########################
+# test
+##########################
+
+comm_world_size = comm_world.size
+new_comm_size = new_comm.size
+
+from pywarpx import wx
+
 if color == 0:
-
-    ##########################
-    # physics parameters
-    ##########################
-
-    plasma_density = 1.e18
-    plasma_xmin = 0.
-    plasma_x_velocity = 0.1*constants.c
-
-    ##########################
-    # numerics parameters
-    ##########################
-
-    # --- Number of time steps
-    max_steps = 10
-    diagnostic_intervals = "::10"
-
-    # --- Grid
-    nx = 64
-    ny = 64
-
-    xmin = -20.e-6
-    ymin = -20.e-6
-    xmax = +20.e-6
-    ymax = +20.e-6
-
-    number_per_cell_each_dim = [2,2]
-
-    ##########################
-    # physics components
-    ##########################
-
-    uniform_plasma = picmi.UniformDistribution(density = plasma_density,
-                                            upper_bound = [0., None, None],
-                                            directed_velocity = [0.1*constants.c, 0., 0.])
-
-    electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
-
-    ##########################
-    # numerics components
-    ##########################
-
-    grid = picmi.Cartesian2DGrid(number_of_cells = [nx, ny],
-                                lower_bound = [xmin, ymin],
-                                upper_bound = [xmax, ymax],
-                                lower_boundary_conditions = ['periodic', 'periodic'],
-                                upper_boundary_conditions = ['periodic', 'periodic'],
-                                moving_window_velocity = [0., 0., 0.],
-                                warpx_max_grid_size = 32)
-
-    solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
-
-    ##########################
-    # diagnostics
-    ##########################
-
-    field_diag1 = picmi.FieldDiagnostic(name = 'diag1',
-                                        grid = grid,
-                                        period = diagnostic_intervals,
-                                        data_list = ['Ex', 'Jx'],
-                                        write_dir = '.',
-                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt1_')
-
-    part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
-                                        period = diagnostic_intervals,
-                                        species = [electrons],
-                                        data_list = ['weighting', 'ux'])
-
-    ##########################
-    # simulation setup
-    ##########################
-
-    sim = picmi.Simulation(solver = solver,
-                        max_steps = max_steps,
-                        verbose = 1,
-                        warpx_current_deposition_algo = 'direct')
-
-    sim.add_species(electrons,
-                    layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))
-
-    sim.add_diagnostic(field_diag1)
-    sim.add_diagnostic(part_diag1)
-
-    ##########################
-    # simulation run and test
-    ##########################
-
     # NOTE: Some tests are done in this input PICMI file. These tests
     # check that amrex initialized the correct amount of procs and
     # that the procs ranks in amrex are correct.
     # If any of these tests fail, the terminal will print that the
     # program crashed.
 
-    # pass communicators to amrex
-    # Manually initialize inputs and warpx, to pass mpi communicator
-    sim.step(max_steps, mpi_comm=new_comm)
-
-    comm_world_size = comm_world.size
-    new_comm_size = new_comm.size
-
-    # only import wx after splitting up processors otherwise
-    # throws a segmentation fault. Don't know why this happens.
-    from pywarpx import wx
-
     # verify that communicator contains correct number of procs (1)
     assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 2
     assert wx.libwarpx.warpx_getNProcs() == new_comm_size
 
-
 else:
-
-    ##########################
-    # physics parameters
-    ##########################
-
-    plasma_density = 1.e19
-    plasma_xmin = 0.
-    plasma_x_velocity = 0.1*constants.c
-
-    ##########################
-    # numerics parameters
-    ##########################
-
-    # --- Number of time steps
-    max_steps = 10
-    diagnostic_intervals = "::10"
-
-    # --- Grid
-    nx = 64
-    ny = 64
-
-    xmin = -20.e-6
-    ymin = -20.e-6
-    xmax = +20.e-6
-    ymax = +20.e-6
-
-    number_per_cell_each_dim = [2,2]
-
-    ##########################
-    # physics components
-    ##########################
-
-    uniform_plasma = picmi.UniformDistribution(density = plasma_density,
-                                            upper_bound = [0., None, None],
-                                            directed_velocity = [0.1*constants.c, 0., 0.])
-
-    electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
-
-    ##########################
-    # numerics components
-    ##########################
-
-    grid = picmi.Cartesian2DGrid(number_of_cells = [nx, ny],
-                                lower_bound = [xmin, ymin],
-                                upper_bound = [xmax, ymax],
-                                lower_boundary_conditions = ['periodic', 'periodic'],
-                                upper_boundary_conditions = ['periodic', 'periodic'],
-                                moving_window_velocity = [0., 0., 0.],
-                                warpx_max_grid_size = 32)
-
-    solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
-
-    ##########################
-    # diagnostics
-    ##########################
-
-    field_diag2 = picmi.FieldDiagnostic(name = 'diag2',
-                                        grid = grid,
-                                        period = diagnostic_intervals,
-                                        data_list = ['Ex', 'Jx'],
-                                        write_dir = '.',
-                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt2_')
-
-    part_diag2 = picmi.ParticleDiagnostic(name = 'diag2',
-                                        period = diagnostic_intervals,
-                                        species = [electrons],
-                                        data_list = ['weighting', 'ux'])
-
-    ##########################
-    # simulation setup
-    ##########################
-
-    sim = picmi.Simulation(solver = solver,
-                        max_steps = max_steps,
-                        verbose = 1,
-                        warpx_current_deposition_algo = 'direct')
-
-    sim.add_species(electrons,
-                    layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))
-
-    sim.add_diagnostic(field_diag2)
-    sim.add_diagnostic(part_diag2)
-
-    ##########################
-    # simulation run and test
-    ##########################
-
-    # NOTE: Some tests are done in this input PICMI file to verify
-    # that the communicators were passed correctly to the
-    # , in this section
-    # the analysis file is only there to satisfy the test script
-    # requirements. The test will crash if any asserts fail.
-
-    # pass communicators to amrex
-    # Manually initialize inputs and warpx, to pass mpi communicator
-    sim.step(max_steps, mpi_comm=new_comm)
-
-
-    comm_world_size = comm_world.size
-    new_comm_size = new_comm.size
-
-    # only import wx after splitting up processors otherwise
-    # throws a segmentation fault. Don't know why this happens.
-    from pywarpx import wx
+    # NOTE: Some tests are done in this input PICMI file. These tests
+    # check that amrex initialized the correct amount of procs and
+    # that the procs ranks in amrex are correct.
+    # If any of these tests fail, the terminal will print that the
+    # program crashed.
 
     # verify that amrex initialized with 1 fewer proc than comm world
     assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 1

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -5,11 +5,12 @@
 
 from mpi4py import MPI
 from pywarpx import picmi
-from pywarpx import geometry
-# need to set geometry before importing _libwarpx
-geometry.coord_sys = 0
-geometry.prob_lo = [0]*2
 constants = picmi.constants
+# from pywarpx import geometry
+# # need to set geometry before importing _libwarpx
+# geometry.coord_sys = 0
+# geometry.prob_lo = [0]*2
+
 
 ##########################
 # MPI communicator setup
@@ -28,16 +29,13 @@ else:
     color = 1
 new_comm = comm_world.Split(color)
 
-if color == 1:
-    # only import libwarpx after splitting up processors otherwise
-    # throws a segmentation fault. Don't know why this happens.
-    from pywarpx import _libwarpx
+if color == 0:
 
     ##########################
     # physics parameters
     ##########################
 
-    plasma_density = 1.e25
+    plasma_density = 1.e18
     plasma_xmin = 0.
     plasma_x_velocity = 0.1*constants.c
 
@@ -64,7 +62,7 @@ if color == 1:
     # physics components
     ##########################
 
-    uniform_plasma = picmi.UniformDistribution(density = 1.e25,
+    uniform_plasma = picmi.UniformDistribution(density = plasma_density,
                                             upper_bound = [0., None, None],
                                             directed_velocity = [0.1*constants.c, 0., 0.])
 
@@ -93,7 +91,7 @@ if color == 1:
                                         period = diagnostic_intervals,
                                         data_list = ['Ex', 'Jx'],
                                         write_dir = '.',
-                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt')
+                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt1_')
 
     part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
                                         period = diagnostic_intervals,
@@ -119,27 +117,138 @@ if color == 1:
     # simulation run and test
     ##########################
 
-    # NOTE: All tests are done in this input PICMI file, in this section
-    # the analysis file is only there to satisfy the test script
-    # requirements. The test will crash if any asserts fail.
-
-    # write_inputs will create an inputs file that can be used to run
-    # with the compiled version.
-    sim.write_input_file(file_name = 'inputs2d_from_PICMI')
+    # NOTE: Some tests are done in this input PICMI file. These tests
+    # check that amrex initialized the correct amount of procs and
+    # that the procs ranks in amrex are correct.
+    # If any of these tests fail, the terminal will print that the
+    # program crashed.
 
     # pass communicators to amrex
     # Manually initialize inputs and warpx, to pass mpi communicator
-    sim.initialize_inputs()
-    sim.initialize_warpx(mpi_comm=new_comm)
-    sim.step(max_steps)
+    sim.step(max_steps, mpi_comm=new_comm)
 
-    # verify that amrex initialized with 1 fewer proc than comm world
     comm_world_size = comm_world.size
     new_comm_size = new_comm.size
 
-    assert _libwarpx.libwarpx.warpx_getNProcs() == comm_world_size - 1
-    assert _libwarpx.libwarpx.warpx_getNProcs() == new_comm_size
+    # only import wx after splitting up processors otherwise
+    # throws a segmentation fault. Don't know why this happens.
+    from pywarpx import wx
+
+    # verify that communicator contains correct number of procs (1)
+    assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 2
+    assert wx.libwarpx.warpx_getNProcs() == new_comm_size
+
+
+else:
+
+    ##########################
+    # physics parameters
+    ##########################
+
+    plasma_density = 1.e19
+    plasma_xmin = 0.
+    plasma_x_velocity = 0.1*constants.c
+
+    ##########################
+    # numerics parameters
+    ##########################
+
+    # --- Number of time steps
+    max_steps = 10
+    diagnostic_intervals = "::10"
+
+    # --- Grid
+    nx = 64
+    ny = 64
+
+    xmin = -20.e-6
+    ymin = -20.e-6
+    xmax = +20.e-6
+    ymax = +20.e-6
+
+    number_per_cell_each_dim = [2,2]
+
+    ##########################
+    # physics components
+    ##########################
+
+    uniform_plasma = picmi.UniformDistribution(density = plasma_density,
+                                            upper_bound = [0., None, None],
+                                            directed_velocity = [0.1*constants.c, 0., 0.])
+
+    electrons = picmi.Species(particle_type='electron', name='electrons', initial_distribution=uniform_plasma)
+
+    ##########################
+    # numerics components
+    ##########################
+
+    grid = picmi.Cartesian2DGrid(number_of_cells = [nx, ny],
+                                lower_bound = [xmin, ymin],
+                                upper_bound = [xmax, ymax],
+                                lower_boundary_conditions = ['periodic', 'periodic'],
+                                upper_boundary_conditions = ['periodic', 'periodic'],
+                                moving_window_velocity = [0., 0., 0.],
+                                warpx_max_grid_size = 32)
+
+    solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)
+
+    ##########################
+    # diagnostics
+    ##########################
+
+    field_diag2 = picmi.FieldDiagnostic(name = 'diag2',
+                                        grid = grid,
+                                        period = diagnostic_intervals,
+                                        data_list = ['Ex', 'Jx'],
+                                        write_dir = '.',
+                                        warpx_file_prefix = 'Python_pass_mpi_comm_plt2_')
+
+    part_diag2 = picmi.ParticleDiagnostic(name = 'diag2',
+                                        period = diagnostic_intervals,
+                                        species = [electrons],
+                                        data_list = ['weighting', 'ux'])
+
+    ##########################
+    # simulation setup
+    ##########################
+
+    sim = picmi.Simulation(solver = solver,
+                        max_steps = max_steps,
+                        verbose = 1,
+                        warpx_current_deposition_algo = 'direct')
+
+    sim.add_species(electrons,
+                    layout = picmi.GriddedLayout(n_macroparticle_per_cell=number_per_cell_each_dim, grid=grid))
+
+    sim.add_diagnostic(field_diag2)
+    sim.add_diagnostic(part_diag2)
+
+    ##########################
+    # simulation run and test
+    ##########################
+
+    # NOTE: Some tests are done in this input PICMI file to verify
+    # that the communicators were passed correctly to the
+    # , in this section
+    # the analysis file is only there to satisfy the test script
+    # requirements. The test will crash if any asserts fail.
+
+    # pass communicators to amrex
+    # Manually initialize inputs and warpx, to pass mpi communicator
+    sim.step(max_steps, mpi_comm=new_comm)
+
+
+    comm_world_size = comm_world.size
+    new_comm_size = new_comm.size
+
+    # only import wx after splitting up processors otherwise
+    # throws a segmentation fault. Don't know why this happens.
+    from pywarpx import wx
+
+    # verify that amrex initialized with 1 fewer proc than comm world
+    assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 1
+    assert wx.libwarpx.warpx_getNProcs() == new_comm_size
 
     # verify that amrex proc ranks are offset by -1 from
     # world comm proc ranks
-    assert _libwarpx.libwarpx.warpx_getMyProc() == rank - 1
+    assert wx.libwarpx.warpx_getMyProc() == rank - 1

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -119,29 +119,23 @@ sim.step(max_steps, mpi_comm=new_comm)
 # test
 ##########################
 
+# NOTE: Some tests are done in this input PICMI file. These tests
+# check that amrex initialized the correct amount of procs and
+# that the procs ranks in amrex are correct.
+# If any of these tests fail, the terminal will print that the
+# program crashed.
+
 comm_world_size = comm_world.size
 new_comm_size = new_comm.size
 
 from pywarpx import wx
 
 if color == 0:
-    # NOTE: Some tests are done in this input PICMI file. These tests
-    # check that amrex initialized the correct amount of procs and
-    # that the procs ranks in amrex are correct.
-    # If any of these tests fail, the terminal will print that the
-    # program crashed.
-
     # verify that communicator contains correct number of procs (1)
     assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 2
     assert wx.libwarpx.warpx_getNProcs() == new_comm_size
 
 else:
-    # NOTE: Some tests are done in this input PICMI file. These tests
-    # check that amrex initialized the correct amount of procs and
-    # that the procs ranks in amrex are correct.
-    # If any of these tests fail, the terminal will print that the
-    # program crashed.
-
     # verify that amrex initialized with 1 fewer proc than comm world
     assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 1
     assert wx.libwarpx.warpx_getNProcs() == new_comm_size

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -1,0 +1,7 @@
+#! /usr/bin/env python
+
+# This file is here to satisfy the requirements of the test
+# script. All tests are performed in the "simulation run
+# and test" section of the input PICMI file.
+
+assert True

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -1,7 +1,79 @@
 #! /usr/bin/env python
 
-# This file is here to satisfy the requirements of the test
-# script. All tests are performed in the "simulation run
-# and test" section of the input PICMI file.
+# This is a script that analyses the simulation results from
+# the script `PICMI_inputs_2d`.
 
-assert True
+import sys
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import yt
+yt.funcs.mylog.setLevel(50)
+import numpy as np
+from scipy.constants import e, m_e, epsilon_0, c
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import checksum
+
+
+# this will be the name of the first plot file
+fn1 = "Python_pass_mpi_comm_plt1_00010"
+# second plot file
+fn2 = "Python_pass_mpi_comm_plt2_00010"
+
+test_name1 = fn1[:-9]
+test_name2 = fn2[:-9]
+
+
+checksum1 = checksum.Checksum(test_name1, fn1, do_fields=True,
+                             do_particles=True)
+
+checksum2 = checksum.Checksum(test_name2, fn2, do_fields=True,
+                             do_particles=True)
+
+rtol=1.e-9
+atol=1.e-40
+
+# Evaluate checksums against each other, adapted from
+# Checksum.evaluate() method
+
+# Dictionaries have same outer keys (levels, species)?
+if (checksum1.data.keys() != checksum2.data.keys()):
+    print("ERROR: plotfile 1 and plotfile 2 checksums "
+            "have different outer keys:")
+    print("Plot1: %s" % checksum1.data.keys())
+    print("Plot2: %s" % checksum2.data.keys())
+    sys.exit(1)
+
+# Dictionaries have same inner keys (field and particle quantities)?
+for key1 in checksum1.data.keys():
+    if (checksum1.data[key1].keys() != checksum2.data[key1].keys()):
+        print("ERROR: plotfile 1 and plotfile 2 checksums have "
+                "different inner keys:")
+        print("Common outer keys: %s" % checksum2.data.keys())
+        print("Plotfile 1 inner keys in %s: %s"
+                % (key1, checksum1.data[key1].keys()))
+        print("Plotfile 2 inner keys in %s: %s"
+                % (key1, checksum2.data[key1].keys()))
+        sys.exit(1)
+
+# Dictionaries have same values?
+checksums_same = False
+for key1 in checksum1.data.keys():
+    for key2 in checksum1.data[key1].keys():
+        passed = np.isclose(checksum2.data[key1][key2],
+                            checksum1.data[key1][key2],
+                            rtol=rtol, atol=atol)
+        # skip over these, since they will be the same if communicators
+        # have same number of procs
+        if key2 in ["particle_cpu", "particle_id", "particle_position_y"]:
+            continue
+        if passed:
+            print("ERROR: plotfile 1 and plotfile 2 checksums have "
+                    "same values for key [%s,%s]" % (key1, key2))
+            print("Plotfile 1: [%s,%s] %.15e"
+                    % (key1, key2, checksum1.data[key1][key2]))
+            print("Plotfile 2: [%s,%s] %.15e"
+                    % (key1, key2, checksum2.data[key1][key2]))
+            checksums_same = True
+if checksums_same:
+    sys.exit(1)

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -6,11 +6,9 @@
 import sys
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
-from scipy.constants import e, m_e, epsilon_0, c
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksum
 

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -68,10 +68,10 @@ class WarpX(Bucket):
 
         return argv
 
-    def init(self):
+    def init(self, mpi_comm=None):
         from . import wx
         argv = ['warpx'] + self.create_argv_list()
-        wx.initialize(argv)
+        wx.initialize(argv, mpi_comm=mpi_comm)
 
     def evolve(self, nsteps=-1):
         from . import wx

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -20,6 +20,10 @@ try:
     # --- If mpi4py is going to be used, this needs to be imported
     # --- before libwarpx is loaded (though don't know why)
     from mpi4py import MPI
+    if MPI.sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
+        MPI_Comm = ctypes.c_int
+    else:
+        MPI_Comm = ctypes.c_void_p
 except ImportError:
     pass
 
@@ -136,6 +140,7 @@ def _array1d_from_pointer(pointer, dtype, size):
 
 # set the arg and return types of the wrapped functions
 libwarpx.amrex_init.argtypes = (ctypes.c_int, _LP_LP_c_char)
+libwarpx.amrex_init_with_inited_mpi.argtypes = (ctypes.c_int, _LP_LP_c_char, MPI_Comm)
 libwarpx.warpx_getParticleStructs.restype = _LP_particle_p
 libwarpx.warpx_getParticleArrays.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getEfield.restype = _LP_LP_c_real
@@ -234,7 +239,7 @@ def get_nattr():
     # --- The -3 is because the comps include the velocites
     return libwarpx.warpx_nComps() - 3
 
-def amrex_init(argv):
+def amrex_init(argv, mpi_comm=None):
     # --- Construct the ctype list of strings to pass in
     argc = len(argv)
     argvC = (_LP_c_char * (argc+1))()
@@ -242,9 +247,14 @@ def amrex_init(argv):
         enc_arg = arg.encode('utf-8')
         argvC[i] = ctypes.create_string_buffer(enc_arg)
 
-    libwarpx.amrex_init(argc, argvC)
+    if mpi_comm is None:
+        libwarpx.amrex_init(argc, argvC)
+    else:
+        comm_ptr = MPI._addressof(mpi_comm)
+        comm_val = MPI_Comm.from_address(comm_ptr)
+        libwarpx.amrex_init_with_inited_mpi(argc, argvC, comm_val)
 
-def initialize(argv=None):
+def initialize(argv=None, mpi_comm=None):
     '''
 
     Initialize WarpX and AMReX. Must be called before
@@ -253,7 +263,7 @@ def initialize(argv=None):
     '''
     if argv is None:
         argv = sys.argv
-    amrex_init(argv)
+    amrex_init(argv, mpi_comm)
     libwarpx.warpx_ConvertLabParamsToBoost()
     libwarpx.warpx_ReadBCParams()
     if geometry_dim == 'rz':

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -21,11 +21,11 @@ try:
     # --- before libwarpx is loaded (though don't know why)
     from mpi4py import MPI
     if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
-        MPI_Comm = ctypes.c_int
+        _MPI_Comm_type = ctypes.c_int
     else:
-        MPI_Comm = ctypes.c_void_p
+        _MPI_Comm_type = ctypes.c_void_p
 except ImportError:
-    pass
+    _MPI_Comm_type = ctypes.c_void_p
 
 # --- Is there a better way of handling constants?
 clight = 2.99792458e+8 # m/s
@@ -140,7 +140,7 @@ def _array1d_from_pointer(pointer, dtype, size):
 
 # set the arg and return types of the wrapped functions
 libwarpx.amrex_init.argtypes = (ctypes.c_int, _LP_LP_c_char)
-libwarpx.amrex_init_with_inited_mpi.argtypes = (ctypes.c_int, _LP_LP_c_char, MPI_Comm)
+libwarpx.amrex_init_with_inited_mpi.argtypes = (ctypes.c_int, _LP_LP_c_char, _MPI_Comm_type)
 libwarpx.warpx_getParticleStructs.restype = _LP_particle_p
 libwarpx.warpx_getParticleArrays.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getEfield.restype = _LP_LP_c_real
@@ -253,7 +253,7 @@ def amrex_init(argv, mpi_comm=None):
         libwarpx.amrex_init(argc, argvC)
     else:
         comm_ptr = MPI._addressof(mpi_comm)
-        comm_val = MPI_Comm.from_address(comm_ptr)
+        comm_val = _MPI_Comm_type.from_address(comm_ptr)
         libwarpx.amrex_init_with_inited_mpi(argc, argvC, comm_val)
 
 def initialize(argv=None, mpi_comm=None):

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -24,7 +24,9 @@ try:
         _MPI_Comm_type = ctypes.c_int
     else:
         _MPI_Comm_type = ctypes.c_void_p
+        MPI = None
 except ImportError:
+    MPI = None
     _MPI_Comm_type = ctypes.c_void_p
 
 # --- Is there a better way of handling constants?
@@ -249,7 +251,7 @@ def amrex_init(argv, mpi_comm=None):
         enc_arg = arg.encode('utf-8')
         argvC[i] = ctypes.create_string_buffer(enc_arg)
 
-    if mpi_comm is None:
+    if mpi_comm is None or MPI is None:
         libwarpx.amrex_init(argc, argvC)
     else:
         comm_ptr = MPI._addressof(mpi_comm)

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -18,7 +18,7 @@ from .Geometry import geometry
 
 try:
     # --- If mpi4py is going to be used, this needs to be imported
-    # --- before libwarpx is loaded (though don't know why)
+    # --- before libwarpx is loaded, because mpi4py calls MPI_Init
     from mpi4py import MPI
     if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
         _MPI_Comm_type = ctypes.c_int

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -20,7 +20,7 @@ try:
     # --- If mpi4py is going to be used, this needs to be imported
     # --- before libwarpx is loaded (though don't know why)
     from mpi4py import MPI
-    if MPI.sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
+    if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
         MPI_Comm = ctypes.c_int
     else:
         MPI_Comm = ctypes.c_void_p

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -213,6 +213,8 @@ libwarpx.warpx_getdt.restype = c_real
 libwarpx.warpx_maxStep.restype = ctypes.c_int
 libwarpx.warpx_stopTime.restype = c_real
 libwarpx.warpx_finestLevel.restype = ctypes.c_int
+libwarpx.warpx_getMyProc.restype = ctypes.c_int
+libwarpx.warpx_getNProcs.restype = ctypes.c_int
 
 libwarpx.warpx_EvolveE.argtypes = [c_real]
 libwarpx.warpx_EvolveB.argtypes = [c_real]

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -24,7 +24,6 @@ try:
         _MPI_Comm_type = ctypes.c_int
     else:
         _MPI_Comm_type = ctypes.c_void_p
-        MPI = None
 except ImportError:
     MPI = None
     _MPI_Comm_type = ctypes.c_void_p

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -20,6 +20,7 @@ try:
     # --- If mpi4py is going to be used, this needs to be imported
     # --- before libwarpx is loaded, because mpi4py calls MPI_Init
     from mpi4py import MPI
+    # --- Change MPI Comm type depending on MPICH (int) or OpenMPI (void*)
     if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
         _MPI_Comm_type = ctypes.c_int
     else:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -801,12 +801,12 @@ class Simulation(picmistandard.PICMI_Simulation):
         for diagnostic in self.diagnostics:
             diagnostic.initialize_inputs()
 
-    def initialize_warpx(self):
+    def initialize_warpx(self, mpi_comm=None):
         if self.warpx_initialized:
             return
 
         self.warpx_initialized = True
-        pywarpx.warpx.init()
+        pywarpx.warpx.init(mpi_comm)
 
     def write_input_file(self, file_name='inputs'):
         self.initialize_inputs()

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -817,9 +817,9 @@ class Simulation(picmistandard.PICMI_Simulation):
             kw['stop_time'] = self.max_time
         pywarpx.warpx.write_inputs(file_name, **kw)
 
-    def step(self, nsteps=None):
+    def step(self, nsteps=None, mpi_comm=None):
         self.initialize_inputs()
-        self.initialize_warpx()
+        self.initialize_warpx(mpi_comm)
         if nsteps is None:
             if self.max_steps is not None:
                 nsteps = self.max_steps

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2132,4 +2132,7 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
+compareParticles = 1
+particleTypes = electrons
 analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
+tolerance = 1.e-14

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2118,3 +2118,18 @@ particleTypes = electron proton
 analysisRoutine = Examples/analysis_default_regression.py
 tolerance = 1.e-14
 
+[Python_pass_mpi_comm]
+buildDir = .
+inputFile = Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
+restartTest = 0
+useMPI = 1
+numprocs = 3
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -479,6 +479,14 @@ extern "C"
         return warpx.finestLevel ();
     }
 
+    int warpx_getMyProc () {
+        return amrex::ParallelDescriptor::MyProc();
+    }
+
+    int warpx_getNProcs () {
+        return amrex::ParallelDescriptor::NProcs();
+    }
+
     void mypc_Redistribute () {
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         mypc.Redistribute();

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -125,12 +125,10 @@ extern "C"
         warpx_amrex_init(argc, argv);
     }
 
-#ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
         warpx_amrex_init(argc, argv, true, mpicomm);
     }
-#endif
 
     void amrex_finalize (int /*finalize_mpi*/)
     {

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -125,19 +125,10 @@ extern "C"
         warpx_amrex_init(argc, argv);
     }
 
-#ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
         warpx_amrex_init(argc, argv, true, mpicomm);
     }
-#else
-    // This shouldn't be called, but is here just in case, since the 
-    // function needs to be clared
-    void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
-    {
-        warpx_amrex_init(argc, argv);
-    }
-#endif
 
     void amrex_finalize (int /*finalize_mpi*/)
     {

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -125,10 +125,19 @@ extern "C"
         warpx_amrex_init(argc, argv);
     }
 
+#ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
         warpx_amrex_init(argc, argv, true, mpicomm);
     }
+#else
+    // This shouldn't be called, but is here just in case, since the 
+    // function needs to be clared
+    void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
+    {
+        warpx_amrex_init(argc, argv);
+    }
+#endif
 
     void amrex_finalize (int /*finalize_mpi*/)
     {

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -37,7 +37,9 @@ extern "C" {
 
     void amrex_init (int argc, char* argv[]);
 
+    #ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm);
+    #endif
 
     void amrex_finalize (int finalize_mpi);
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -11,7 +11,7 @@
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
 
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
 #   include <mpi.h>
 #endif
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -37,9 +37,7 @@ extern "C" {
 
     void amrex_init (int argc, char* argv[]);
 
-#ifdef BL_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm);
-#endif
 
     void amrex_finalize (int finalize_mpi);
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -116,6 +116,10 @@ extern "C" {
 
   int warpx_finestLevel ();
 
+  int warpx_getMyProc ();
+  int warpx_getNProcs ();
+
+
   void mypc_Redistribute ();
 
 #ifdef __cplusplus

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -37,9 +37,9 @@ extern "C" {
 
     void amrex_init (int argc, char* argv[]);
 
-    #ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm);
-    #endif
+#endif
 
     void amrex_finalize (int finalize_mpi);
 


### PR DESCRIPTION
Added ability to pass MPI communicator from input Python script to AMReX when initializing WarpX. Passing the communicator is optional, and original functionality remains the same if no communicator is specified to be passed from the Python script.