### PR TITLE
Input parameter for AMReX MLMG verbosity

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -94,6 +94,11 @@ Overall simulation parameters
     ``self_fields_required_precision``, this parameter may be increased.
     This only applies when warpx.do_electrostatic = labframe.
 
+* ``warpx.self_fields_verbosity`` (`integer`, default: 2)
+    The vebosity used for MLMG solver for space-charge fields calculation. Currently
+    MLMG solver looks for verbosity levels from 0-5. A higher number results in more
+    verbose output. This only applies when warpx.do_electrostatic = labframe.
+
 * ``amrex.abort_on_out_of_gpu_memory``  (``0`` or ``1``; default is ``1`` for true)
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
     This will cause severe performance drops.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -97,7 +97,7 @@ Overall simulation parameters
 * ``warpx.self_fields_verbosity`` (`integer`, default: 2)
     The vebosity used for MLMG solver for space-charge fields calculation. Currently
     MLMG solver looks for verbosity levels from 0-5. A higher number results in more
-    verbose output. This only applies when warpx.do_electrostatic = labframe.
+    verbose output.
 
 * ``amrex.abort_on_out_of_gpu_memory``  (``0`` or ``1``; default is ``1`` for true)
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -524,7 +524,6 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 
         self.do_pml = kw.pop('warpx_do_pml', None)
         self.pml_ncell = kw.pop('warpx_pml_ncell', None)
-
         if self.method == 'PSATD':
             self.psatd_periodic_single_box_fft = kw.pop('warpx_periodic_single_box_fft', None)
             self.psatd_fftw_plan_measure = kw.pop('warpx_fftw_plan_measure', None)
@@ -579,11 +578,11 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     def init(self, kw):
         self.relativistic = kw.pop('warpx_relativistic', False)
-
+        self.solver_verbosity = kw.pop('warpx_solver_verbosity', 2)
     def initialize_inputs(self):
 
         self.grid.initialize_inputs()
-
+        pywarpx.warpx.solver_verbosity = self.solver_verbosity
         if self.relativistic:
             pywarpx.warpx.do_electrostatic = 'relativistic'
         else:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -579,7 +579,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     def init(self, kw):
         self.relativistic = kw.pop('warpx_relativistic', False)
-        self.solver_verbosity = kw.pop('warpx_solver_verbosity', 2)
+        self.solver_verbosity = kw.pop('warpx_solver_verbosity', None)
     def initialize_inputs(self):
 
         self.grid.initialize_inputs()

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -585,6 +585,7 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     def initialize_inputs(self):
 
         self.grid.initialize_inputs()
+
         if self.relativistic:
             pywarpx.warpx.do_electrostatic = 'relativistic'
         else:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -81,6 +81,7 @@ class Species(picmistandard.PICMI_Species):
         # For the relativistic electrostatic solver
         self.self_fields_required_precision = kw.pop('warpx_self_fields_required_precision', None)
         self.self_fields_max_iters = kw.pop('warpx_self_fields_max_iters', None)
+        self.self_fields_verbosity = kw.pop('warpx_self_fields_verbosity', None)
 
     def initialize_inputs(self, layout,
                           initialize_self_fields = False,
@@ -103,7 +104,8 @@ class Species(picmistandard.PICMI_Species):
                                              initialize_self_fields = int(initialize_self_fields),
                                              boost_adjust_transverse_positions = self.boost_adjust_transverse_positions,
                                              self_fields_required_precision = self.self_fields_required_precision,
-                                             self_fields_max_iters = self.self_fields_max_iters)
+                                             self_fields_max_iters = self.self_fields_max_iters,
+                                             self_fields_verbosity = self.self_fields_verbosity)
         pywarpx.Particles.particles_list.append(self.species)
 
         if self.initial_distribution is not None:
@@ -579,17 +581,17 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     def init(self, kw):
         self.relativistic = kw.pop('warpx_relativistic', False)
-        self.solver_verbosity = kw.pop('warpx_solver_verbosity', None)
+        self.self_fields_verbosity = kw.pop('warpx_self_fields_verbosity', None)
     def initialize_inputs(self):
 
         self.grid.initialize_inputs()
-        pywarpx.warpx.solver_verbosity = self.solver_verbosity
         if self.relativistic:
             pywarpx.warpx.do_electrostatic = 'relativistic'
         else:
             pywarpx.warpx.do_electrostatic = 'labframe'
             pywarpx.warpx.self_fields_required_precision = self.required_precision
             pywarpx.warpx.self_fields_max_iters = self.maximum_iterations
+            pywarpx.warpx.self_fields_verbosity = self.self_fields_verbosity
             pywarpx.boundary.potential_lo_x = self.grid.potential_xmin
             pywarpx.boundary.potential_lo_y = self.grid.potential_ymin
             pywarpx.boundary.potential_lo_z = self.grid.potential_zmin

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -524,6 +524,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
 
         self.do_pml = kw.pop('warpx_do_pml', None)
         self.pml_ncell = kw.pop('warpx_pml_ncell', None)
+
         if self.method == 'PSATD':
             self.psatd_periodic_single_box_fft = kw.pop('warpx_periodic_single_box_fft', None)
             self.psatd_fftw_plan_measure = kw.pop('warpx_fftw_plan_measure', None)

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -333,10 +333,14 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
         rho[lev]->mult(-1._rt/PhysConst::ep0);
     }
 
+    int verbosity = 2;
+    ParmParse pp_warpx("warpx");
+    pp_warpx.query("solver_verbosity", verbosity);
+
     // Solve the Poisson equation
     linop.setDomainBC( lobc, hibc );
     MLMG mlmg(linop);
-    mlmg.setVerbose(2);
+    mlmg.setVerbose(verbosity);
     mlmg.setMaxIter(max_iters);
     mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho), required_precision, 0.0);
 }
@@ -415,9 +419,12 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     for (int lev=0; lev < rho.size(); lev++){
         rho[lev]->mult(-1._rt/PhysConst::ep0);
     }
+    int verbosity;
+    ParmParse pp_warpx("warpx");
+    pp_warpx.query("solver_verbosity", verbosity);
 
     MLMG mlmg(linop);
-    mlmg.setVerbose(2);
+    mlmg.setVerbose(verbosity);
     mlmg.setMaxIter(max_iters);
     mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho), required_precision, 0.0);
 }

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -193,7 +193,7 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    int const verbosity) const
 {
 #ifdef WARPX_DIM_RZ
-    computePhiRZ( rho, phi, beta, required_precision, max_iters );
+    computePhiRZ( rho, phi, beta, required_precision, max_iters, verbosity );
 #else
     computePhiCartesian( rho, phi, beta, required_precision, max_iters, verbosity );
 #endif

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -117,7 +117,7 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     for (Real& beta_comp : beta) beta_comp /= PhysConst::c; // Normalize
 
     // Compute the potential phi, by solving the Poisson equation
-    computePhi( rho, phi, beta, pc.self_fields_required_precision, pc.self_fields_max_iters );
+    computePhi( rho, phi, beta, pc.self_fields_required_precision, pc.self_fields_max_iters, pc.self_fields_verbosity );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
     computeE( Efield_fp, phi, beta );
@@ -168,7 +168,7 @@ WarpX::AddSpaceChargeFieldLabFrame ()
     std::array<Real, 3> beta = {0._rt};
 
     // Compute the potential phi, by solving the Poisson equation
-    computePhi( rho, phi_fp, beta, self_fields_required_precision, self_fields_max_iters );
+    computePhi( rho, phi_fp, beta, self_fields_required_precision, self_fields_max_iters, self_fields_verbosity );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
     computeE( Efield_fp, phi_fp, beta );
@@ -189,12 +189,13 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
-                   int const max_iters) const
+                   int const max_iters,
+                   int const verbosity) const
 {
 #ifdef WARPX_DIM_RZ
     computePhiRZ( rho, phi, beta, required_precision, max_iters );
 #else
-    computePhiCartesian( rho, phi, beta, required_precision, max_iters );
+    computePhiCartesian( rho, phi, beta, required_precision, max_iters, verbosity );
 #endif
 
 }
@@ -219,7 +220,8 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
-                   int const max_iters) const
+                   int const max_iters
+                   int const verbosity) const
 {
     // Create a new geometry with the z coordinate scaled by gamma
     amrex::Real const gamma = std::sqrt(1._rt/(1. - beta[2]*beta[2]));
@@ -333,10 +335,6 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
         rho[lev]->mult(-1._rt/PhysConst::ep0);
     }
 
-    int verbosity = 2;
-    ParmParse pp_warpx("warpx");
-    pp_warpx.query("solver_verbosity", verbosity);
-
     // Solve the Poisson equation
     linop.setDomainBC( lobc, hibc );
     MLMG mlmg(linop);
@@ -366,7 +364,8 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
                             amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                             std::array<Real, 3> const beta,
                             Real const required_precision,
-                            int const max_iters) const
+                            int const max_iters,
+                            int const verbosity) const
 {
 
     // Define the boundary conditions
@@ -419,9 +418,6 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     for (int lev=0; lev < rho.size(); lev++){
         rho[lev]->mult(-1._rt/PhysConst::ep0);
     }
-    int verbosity = 2;
-    ParmParse pp_warpx("warpx");
-    pp_warpx.query("solver_verbosity", verbosity);
 
     MLMG mlmg(linop);
     mlmg.setVerbose(verbosity);

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -419,7 +419,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     for (int lev=0; lev < rho.size(); lev++){
         rho[lev]->mult(-1._rt/PhysConst::ep0);
     }
-    int verbosity;
+    int verbosity = 2;
     ParmParse pp_warpx("warpx");
     pp_warpx.query("solver_verbosity", verbosity);
 

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -220,7 +220,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
-                   int const max_iters
+                   int const max_iters,
                    int const verbosity) const
 {
     // Create a new geometry with the z coordinate scaled by gamma

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -185,6 +185,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp_species_name.query("initialize_self_fields", initialize_self_fields);
     queryWithParser(pp_species_name, "self_fields_required_precision", self_fields_required_precision);
     pp_species_name.query("self_fields_max_iters", self_fields_max_iters);
+    pp_species_name.query("self_fields_verbosity", self_fields_verbosity);
     // Whether to plot back-transformed (lab-frame) diagnostics
     // for this species.
     pp_species_name.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -290,6 +290,7 @@ public:
     amrex::Real self_fields_required_precision =
         amrex::Real(1.e-11);
     int self_fields_max_iters = 200;
+    int self_fields_verbosity = 2;
 
     // split along diagonals (0) or axes (1)
     int split_type = 0;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -545,6 +545,7 @@ public:
     // Parameters for lab frame electrostatic
     static amrex::Real self_fields_required_precision;
     static int self_fields_max_iters;
+    static int self_fields_verbosity;
 
     static int do_moving_window;
     static int moving_window_dir;
@@ -590,17 +591,20 @@ public:
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
                      amrex::Real const required_precision=amrex::Real(1.e-11),
-                     const int max_iters=200) const;
+                     const int max_iters=200,
+                     const int verbosity=2) const;
     void computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                        amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                        std::array<amrex::Real, 3> const beta,
                        amrex::Real const required_precision,
-                       int const max_iters) const;
+                       int const max_iters,
+                       int const verbosity) const;
     void computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                        amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                        std::array<amrex::Real, 3> const beta,
                        amrex::Real const required_precision,
-                       int const max_iters) const;
+                       int const max_iters,
+                       int const verbosity) const;
 
     void setPhiBC (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<bool,AMREX_SPACEDIM> dirichlet_flag,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -169,6 +169,7 @@ bool WarpX::do_dynamic_scheduling = true;
 int WarpX::do_electrostatic;
 Real WarpX::self_fields_required_precision = 1.e-11_rt;
 int WarpX::self_fields_max_iters = 200;
+int WarpX::self_fields_verbosity = 2;
 
 int WarpX::do_subcycling = 0;
 bool WarpX::safe_guard_cells = 0;
@@ -540,6 +541,7 @@ WarpX::ReadParameters ()
         if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
             queryWithParser(pp_warpx, "self_fields_required_precision", self_fields_required_precision);
             pp_warpx.query("self_fields_max_iters", self_fields_max_iters);
+            pp_warpx.query("self_fields_verbosity", self_fields_verbosity);
             // Note that with the relativistic version, these parameters would be
             // input for each species.
         }


### PR DESCRIPTION
Currently the verbosity level for the AMReX `MLMG` used in the electrostatic solver is hard-coded to a value of 2. However `MLMG` checks for verbosity values from 0-5. Now a verbosity parameter called `warpx.self_fields_verbosity` can be passed in when creating an electrostatic solver or through a particle species, in the same way that `warpx.self_fields_max_iters` is.