### PR TITLE
Use queryWithParser for more real input values

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -221,7 +221,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         parseMomentum(pp_species_name);
     } else if (part_pos_s == "nfluxpercell") {
         surface_flux = true;
-        pp_species_name.query("num_particles_per_cell", num_particles_per_cell_real);
+        queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell_real);
 #ifdef WARPX_DIM_RZ
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             num_particles_per_cell_real>=2*WarpX::n_rz_azimuthal_modes,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -553,7 +553,7 @@ WarpX::ReadParameters ()
         }
 
         pp_warpx.query("n_buffer", n_buffer);
-        pp_warpx.query("const_dt", const_dt);
+        queryWithParser(pp_warpx, "const_dt", const_dt);
 
         // Read filter and fill IntVect filter_npass_each_dir with
         // proper size for AMREX_SPACEDIM


### PR DESCRIPTION
This PR uses `queryWithParser` for two more real input quantities, `const_dt` and `num_particles_per_cell` (when adding a surface flux emission).