### PR TITLE
CI: IntelLLVM known to CMake

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -158,12 +158,6 @@ jobs:
         export CC=$(which icx)
 
         cmake -S . -B build_sp         \
-          -DCMAKE_C_COMPILER_ID="Clang"                  \
-          -DCMAKE_C_COMPILER_VERSION=12.0                \
-          -DCMAKE_C_STANDARD_COMPUTED_DEFAULT="11"       \
-          -DCMAKE_CXX_COMPILER_ID="Clang"                \
-          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
@@ -175,9 +169,6 @@ jobs:
         python3 -m pip install --upgrade setuptools wheel
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel -v .
         python3 -m pip install *.whl
-     # note: setting the CXX compiler ID is a work-around for
-     # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
-     # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
     - name: run pywarpx
       run: |
@@ -207,9 +198,6 @@ jobs:
 
         cmake -S . -B build_sp         \
           -DBUILD_SHARED_LIBS=ON       \
-          -DCMAKE_CXX_COMPILER_ID="Clang"                \
-          -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-          -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
           -DWarpX_LIB=ON               \
@@ -223,9 +211,6 @@ jobs:
      #   python3 -m pip install --upgrade setuptools wheel
      #   PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
      #   python3 -m pip install *.whl
-     # note: setting the CXX compiler ID is a work-around for
-     # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
-     # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
   build_hip:
     name: HIP SP [Linux]


### PR DESCRIPTION
`IntelLLVM` is now a recognized CMake compiler, so we don't need to add a Clang-ish identification anymore.