### PR TITLE
RZ spectral solver header to be called within PSATD ifdefs

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -15,9 +15,10 @@
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 #include "Evolve/WarpXDtType.H"
 #ifdef WARPX_USE_PSATD
-#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   ifdef WARPX_DIM_RZ
-#      include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#       include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   else
+#       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif
 #endif
 #include "Parallelization/GuardCellManager.H"

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -16,9 +16,9 @@
 #include "Evolve/WarpXDtType.H"
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralSolver.H"
-#endif
-#ifdef WARPX_DIM_RZ
-#   include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   ifdef WARPX_DIM_RZ
+#      include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   endif
 #endif
 #include "Parallelization/GuardCellManager.H"
 #include "Particles/MultiParticleContainer.H"

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -11,12 +11,11 @@
 #include "BoundaryConditions/PML.H"
 #include "Evolve/WarpXDtType.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
-#if defined(WARPX_DIM_RZ) || defined(WARPX_USE_PSATD)
+#if defined(WARPX_USE_PSATD)
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
+#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   ifdef WARPX_DIM_RZ
 #       include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
-#   elif defined(WARPX_USE_PSATD)
-#       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif
 #endif
 #include "Utils/WarpXAlgorithmSelection.H"

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -13,9 +13,10 @@
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #if defined(WARPX_USE_PSATD)
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
-#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   ifdef WARPX_DIM_RZ
 #       include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   else
+#       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif
 #endif
 #include "Utils/WarpXAlgorithmSelection.H"

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -18,10 +18,11 @@
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #ifdef WARPX_USE_PSATD
-#   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   include "FieldSolver/SpectralSolver/SpectralKSpace.H"
 #   ifdef WARPX_DIM_RZ
 #       include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   else
+#       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif // RZ ifdef
 #endif // use PSATD ifdef
 #include "FieldSolver/WarpX_FDTD.H"

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -20,10 +20,10 @@
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   include "FieldSolver/SpectralSolver/SpectralKSpace.H"
-#endif
-#ifdef WARPX_DIM_RZ
-#   include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
-#endif
+#   ifdef WARPX_DIM_RZ
+#       include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
+#   endif // RZ ifdef
+#endif // use PSATD ifdef
 #include "FieldSolver/WarpX_FDTD.H"
 #include "Filter/NCIGodfreyFilter.H"
 #include "Parser/WarpXParserWrapper.H"


### PR DESCRIPTION
RZ was not compiling for FDTD as it was looking for `fftw3.h` since the spectral_solver header files for RZ were called outside of PSATD ifdefs.
I am not sure how the CI tests were passing. In particular, silver_mueller_rz.
