### PR TITLE
Test Scripts: +PSATD

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -12,7 +12,6 @@ jobs:
     WARPX_CI_NUM_MAKE_JOBS: 2
     WARPX_CI_CCACHE: 'TRUE'
     WARPX_CI_OPENPMD: 'TRUE'
-    WARPX_CI_PSATD: 'TRUE'
     FFTW_HOME: '/usr/'
     BLASPP_HOME: '/usr/local/'
     LAPACKPP_HOME: '/usr/local/'

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -18,6 +18,7 @@ Optional dependencies include:
 - `CUDA Toolkit 9.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
 - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution (currently not fully accelerated)
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
+- `BLAS++ <https://bitbucket.org/icl/blaspp>`_ and `LAPACK++ <https://bitbucket.org/icl/lapackpp>`_: for spectral solver (PSATD) support in RZ geometry
 - `Boost 1.66.0+ <https://www.boost.org/>`__: for QED lookup tables generation support
 - `openPMD-api 0.12.0+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
@@ -38,11 +39,13 @@ Spack (macOS/Linux)
 
    spack env create warpx-dev
    spack env activate warpx-dev
-   spack add adios2
+   spack add adios2     # for openPMD
+   spack add blaspp     # for PSATD in RZ
    spack add ccache
    spack add cmake
    spack add fftw
-   spack add hdf5
+   spack add hdf5       # for openPMD
+   spack add lapackpp   # for PSATD in RZ
    spack add mpi
    spack add pkgconfig  # for fftw
    # optional:
@@ -53,7 +56,7 @@ Spack (macOS/Linux)
 
 (in new terminals, re-activate the environment with ``spack env activate warpx-dev`` again)
 
-If you also want to run runtime tests and added Python (``spack add python``) above, install also these additional Python packages in the active Spack environment:
+If you also want to run runtime tests and added Python (``spack add python`` and ``spack add py-pip``) above, install also these additional Python packages in the active Spack environment:
 
 .. code-block:: bash
 
@@ -84,7 +87,7 @@ Without MPI:
 
 .. code-block:: bash
 
-   conda create -n warpx-dev -c conda-forge ccache cmake compilers git openpmd-api python numpy scipy yt fftw matplotlib mamba ninja
+   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp openpmd-api python numpy scipy yt fftw matplotlib mamba ninja
    conda activate warpx-dev
 
    # compile WarpX with -DWarpX_MPI=OFF
@@ -93,7 +96,7 @@ With MPI (only Linux/macOS):
 
 .. code-block:: bash
 
-   conda create -n warpx-dev -c conda-forge ccache cmake compilers git openpmd-api=*=mpi_openmpi* python numpy scipy yt fftw=*=mpi_openmpi* matplotlib mamba ninja openmpi
+   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp openpmd-api=*=mpi_openmpi* python numpy scipy yt fftw=*=mpi_openmpi* matplotlib mamba ninja openmpi
    conda activate warpx-dev
 
 

--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -17,7 +17,7 @@ arch = os.environ.get('WARPX_TEST_ARCH', 'CPU')
 
 ci_regular_cartesian_2d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_2D') == 'TRUE'
 ci_regular_cartesian_3d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_3D') == 'TRUE'
-ci_psatd = os.environ.get('WARPX_CI_PSATD') == 'TRUE'
+ci_psatd = os.environ.get('WARPX_CI_PSATD', 'TRUE') == 'TRUE'
 ci_python_main = os.environ.get('WARPX_CI_PYTHON_MAIN') == 'TRUE'
 ci_single_precision = os.environ.get('WARPX_CI_SINGLE_PRECISION') == 'TRUE'
 ci_rz_or_nompi = os.environ.get('WARPX_CI_RZ_OR_NOMPI') == 'TRUE'


### PR DESCRIPTION
Unless the `run_test.sh` are run with `export WARPX_CI_PSATD=FALSE`, build by default using also FFT libraries.

This continues to ensure that we can disable FFT features on new platforms but reduced the confusion that can occur between the Azure and local tests.

This now requires that people have either FFTW or the respective accelerated compute FFTW library installed locally when running the full `./run_tests.sh` locally. We document how to get those libs, so this should be fine.

**Update:** For full tests, this also means that one has to install BLAS++ and LAPACK++ (because we perform RZ+PSATD tests).

I have not yet changed the same default for openPMD until we change the regression test scripts to use CMake (need to merge with mainline).