### PR TITLE
[mini-PR] remove superfluous semicolon

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -84,7 +84,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
                     return SpectralFieldIndex::n_fields;
                 }
             }
-        };
+        }
 
         /**
          * \brief Initializes the coefficients used in \c pushSpectralFields to update the E and B fields


### PR DESCRIPTION
This PR fixes the warning:
```
In file included from WarpX/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp:7:
WarpX/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H:87:10: warning: extra ';' after member function definition [-Wextra-semi]
        };
         ^
```