### PR TITLE
[mini-PR] fix some unused variable warnings when WarpX is compiled with DIM=RZ

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -457,6 +457,7 @@ void
 WarpX::OneStep_multiJ (const amrex::Real cur_time)
 {
 #ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(cur_time);
     amrex::Abort("multi-J algorithm not implemented for RZ geometry");
 #else
 #ifdef WARPX_USE_PSATD

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -55,9 +55,8 @@ void FiniteDifferenceSolver::EvolveB (
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
     if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
-
+        ignore_unused(Gfield, face_areas);
         EvolveBCylindrical <CylindricalYeeAlgorithm> ( Bfield, Efield, lev, dt );
-
 #else
     if (m_do_nodal) {
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -56,9 +56,8 @@ void FiniteDifferenceSolver::EvolveE (
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
     if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
-
+        ignore_unused(edge_lengths);
         EvolveECylindrical <CylindricalYeeAlgorithm> ( Efield, Bfield, Jfield, Ffield, lev, dt );
-
 #else
     if (m_do_nodal) {
 


### PR DESCRIPTION
This PR fixes some unused variable warnings. 