### PR TITLE
Fix readability-container-size-empty warning raised by clang-tidy

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -482,7 +482,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
     const BoxArray& ba = (do_pml_in_domain)?
           MakeBoxArray(*geom, grid_ba_reduced, ncell, do_pml_in_domain, do_pml_Lo, do_pml_Hi) :
           MakeBoxArray(*geom, grid_ba, ncell, do_pml_in_domain, do_pml_Lo, do_pml_Hi);
-    if (ba.size() == 0) {
+    if (ba.empty()) {
         m_ok = false;
         return;
     } else {

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -920,7 +920,7 @@ writeLabFrameData(const MultiFab* cell_centered_data,
         if (WarpX::do_back_transformed_particles) {
 
             if (lf_diags->m_t_lab != prev_t_lab ) {
-               if (tmp_particle_buffer.size()>0)
+               if (!tmp_particle_buffer.empty())
                {
                   tmp_particle_buffer.clear();
                   tmp_particle_buffer.shrink_to_fit();

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -54,7 +54,7 @@ FullDiagnostics::InitializeParticleBuffer ()
 
     const MultiParticleContainer& mpc = warpx.GetPartContainer();
     // If not specified, dump all species
-    if (!m_output_species_names.empty()) m_output_species_names = mpc.GetSpeciesNames();
+    if (m_output_species_names.empty()) m_output_species_names = mpc.GetSpeciesNames();
     // Initialize one ParticleDiag per species requested
     for (auto const& species : m_output_species_names){
         const int idx = mpc.getSpeciesID(species);

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -54,7 +54,7 @@ FullDiagnostics::InitializeParticleBuffer ()
 
     const MultiParticleContainer& mpc = warpx.GetPartContainer();
     // If not specified, dump all species
-    if (m_output_species_names.size() == 0) m_output_species_names = mpc.GetSpeciesNames();
+    if (!m_output_species_names.empty()) m_output_species_names = mpc.GetSpeciesNames();
     // Initialize one ParticleDiag per species requested
     for (auto const& species : m_output_species_names){
         const int idx = mpc.getSpeciesID(species);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -59,12 +59,12 @@ namespace detail
 
         std::string op_parameters;
         for (const auto& kv : operator_parameters) {
-            if (op_parameters.size() > 0u) op_parameters.append(",\n");
+            if (!op_parameters.empty()) op_parameters.append(",\n");
             op_parameters.append(std::string(12, ' '))         /* just pretty alignment */
                     .append("\"").append(kv.first).append("\": ")    /* key */
                     .append("\"").append(kv.second).append("\""); /* value (as string) */
         }
-        if (operator_type.size() > 0u) {
+        if (!operator_type.empty()) {
             options = R"END(
 {
   "adios2": {
@@ -74,13 +74,13 @@ namespace detail
           "type": ")END";
             options += operator_type + "\"";
         }
-        if (operator_type.size() > 0u && op_parameters.size() > 0u) {
+        if (!operator_type.empty() && !op_parameters.empty()) {
             options += R"END(
          ,"parameters": {
 )END";
             options += op_parameters + "}";
         }
-        if (operator_type.size() > 0u)
+        if (!operator_type.empty())
             options += R"END(
         }
       ]
@@ -88,7 +88,7 @@ namespace detail
   }
 }
 )END";
-        if (options.size() == 0u) options = "{}";
+        if (options.empty()) options = "{}";
         return options;
     }
 
@@ -395,7 +395,7 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
     m_Series->setIterationEncoding( m_Encoding );
 
     // input file / simulation setup author
-    if( WarpX::authors.size() > 0u )
+    if( !WarpX::authors.empty())
         m_Series->setAuthor( WarpX::authors );
     // more natural naming for PIC
     m_Series->setMeshesPath( "fields" );

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -117,7 +117,7 @@ SpectralFieldData::SpectralFieldData( const int lev,
 
 SpectralFieldData::~SpectralFieldData()
 {
-    if (tmpRealField.size() > 0){
+    if (!tmpRealField.empty()){
         for ( MFIter mfi(tmpRealField); mfi.isValid(); ++mfi ){
             AnyFFT::DestroyPlan(forward_plan[mfi]);
             AnyFFT::DestroyPlan(backward_plan[mfi]);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -490,7 +490,7 @@ MultiParticleContainer::DepositCharge (
 std::unique_ptr<MultiFab>
 MultiParticleContainer::GetChargeDensity (int lev, bool local)
 {
-    if (allcontainers.size() == 0)
+    if (!allcontainers.empty())
     {
         std::unique_ptr<MultiFab> rho = GetZeroChargeDensity(lev);
         return rho;
@@ -562,7 +562,7 @@ MultiParticleContainer::GetZeroParticlesInGrid (const int lev) const
 Vector<Long>
 MultiParticleContainer::NumberOfParticlesInGrid (int lev) const
 {
-    if (allcontainers.size() == 0)
+    if (allcontainers.empty())
     {
         const Vector<Long> r = GetZeroParticlesInGrid(lev);
         return r;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -490,7 +490,7 @@ MultiParticleContainer::DepositCharge (
 std::unique_ptr<MultiFab>
 MultiParticleContainer::GetChargeDensity (int lev, bool local)
 {
-    if (!allcontainers.empty())
+    if (allcontainers.empty())
     {
         std::unique_ptr<MultiFab> rho = GetZeroChargeDensity(lev);
         return rho;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -869,7 +869,7 @@ WarpX::ReadParameters ()
         std::vector<std::string> lasers_names;
         pp_lasers.queryarr("names", lasers_names);
 
-        if (species_names.size() > 0 || lasers_names.size() > 0) {
+        if (!species_names.empty() || !lasers_names.empty()) {
             int particle_shape;
             if (pp_algo.query("particle_shape", particle_shape) == false)
             {


### PR DESCRIPTION
I've run the `clang-tidy` tool on WarpX.  One of the suggestions was to use `container.empty()` or `!container.empty()` to check whether a container is empty or not, rather then `container.size() == 0` or `container.size() > 0` . It seems to me that using `.empty()` is more readable, so I would like to propose to do that in WarpX.