### PR TITLE
Fix small issue when adding moving window upon restart

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -266,6 +266,8 @@ FlushFormatPlotfile::WriteWarpXHeader(
         }
         HeaderFile << "\n";
 
+        HeaderFile << warpx.getdo_moving_window() << "\n";
+
         HeaderFile << warpx.getmoving_window_x() << "\n";
 
         HeaderFile << warpx.getis_synchronized() << "\n";

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -266,8 +266,6 @@ FlushFormatPlotfile::WriteWarpXHeader(
         }
         HeaderFile << "\n";
 
-        HeaderFile << warpx.getdo_moving_window() << "\n";
-
         HeaderFile << warpx.getmoving_window_x() << "\n";
 
         HeaderFile << warpx.getis_synchronized() << "\n";
@@ -291,6 +289,8 @@ FlushFormatPlotfile::WriteWarpXHeader(
         WriteHeaderParticle(HeaderFile, particle_diags);
 
         HeaderFile << warpx.getcurrent_injection_position() << "\n";
+
+        HeaderFile << warpx.getdo_moving_window() << "\n";
     }
 }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -123,14 +123,8 @@ WarpX::InitFromCheckpoint ()
             }
         }
 
-        int do_moving_window_before_restart;
-
-        is >> do_moving_window_before_restart;
-        GotoNextLine(is);
-
-        if (do_moving_window_before_restart) {
-            is >> moving_window_x;
-        }
+        amrex::Real moving_window_x_checkpoint;
+        is >> moving_window_x_checkpoint;
         GotoNextLine(is);
 
         is >> is_synchronized;
@@ -171,6 +165,14 @@ WarpX::InitFromCheckpoint ()
         mypc->ReadHeader(is);
         is >> current_injection_position;
         GotoNextLine(is);
+
+        int do_moving_window_before_restart;
+        is >> do_moving_window_before_restart;
+        GotoNextLine(is);
+
+        if (do_moving_window_before_restart) {
+            moving_window_x = moving_window_x_checkpoint;
+        }
     }
 
     const int nlevs = finestLevel()+1;

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -123,7 +123,14 @@ WarpX::InitFromCheckpoint ()
             }
         }
 
-        is >> moving_window_x;
+        int do_moving_window_before_restart;
+
+        is >> do_moving_window_before_restart;
+        GotoNextLine(is);
+
+        if (do_moving_window_before_restart) {
+            is >> moving_window_x;
+        }
         GotoNextLine(is);
 
         is >> is_synchronized;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -517,6 +517,7 @@ public:
     void sett_new (int lev, amrex::Real time) {t_new[lev] = time;}
     amrex::Vector<amrex::Real> getdt () const {return dt;}
     amrex::Real getdt (int lev) const {return dt[lev];}
+    int getdo_moving_window() const {return do_moving_window;}
     amrex::Real getmoving_window_x() const {return moving_window_x;}
     amrex::Real getcurrent_injection_position () const {return current_injection_position;}
     bool getis_synchronized() const {return is_synchronized;}


### PR DESCRIPTION
@tmsclark has found that the code segfaults when adding a moving window upon restart. (i.e. the initial simulation is started with `warpx.do_moving_window = 0` and it is restarted with `warpx.do_moving_window = 1`). I'm not sure how much we want to support changing input file parameters when restarting and in any case what @tmsclark wanted to do can be achieved with #2027, so it's definitely not an urgent issue. Still, I thought it was worth opening a small PR so that we don't forget about it and to make restarting slightly more robust.

This is how the issue goes:
1. In the initial run, the parameter `WarpX::moving_window_x` is initialized to `std::numeric_limits<amrex::Real>::max();` https://github.com/ECP-WarpX/WarpX/blob/ca5652a1dd88343c2b6b6c8d67a12bd4e18bb609/Source/WarpX.H#L989 and is never updated afterwards because there is no moving window.
2. The value `std::numeric_limits<amrex::Real>::max();` is written to the checkpoint file. https://github.com/ECP-WarpX/WarpX/blob/ca5652a1dd88343c2b6b6c8d67a12bd4e18bb609/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp#L269
3. Upon restart, there is now a moving window so `WarpX::moving_window_x` is set to the lower bound of the box, as it should be.https://github.com/ECP-WarpX/WarpX/blob/ca5652a1dd88343c2b6b6c8d67a12bd4e18bb609/Source/WarpX.cpp#L502
4. When reading the checkpoint data, the value of `WarpX::moving_window_x` is overwritten with its value in the checkpoint file, i.e. `std::numeric_limits<amrex::Real>::max();`. https://github.com/ECP-WarpX/WarpX/blob/ca5652a1dd88343c2b6b6c8d67a12bd4e18bb609/Source/Diagnostics/WarpXIO.cpp#L126
5. Because of this value, we get an overflow when computing the number of cells by which the moving window should be moved, https://github.com/ECP-WarpX/WarpX/blob/ca5652a1dd88343c2b6b6c8d67a12bd4e18bb609/Source/Utils/WarpXMovingWindow.cpp#L95 and chaos ensues.

The fix proposed here only affects step 4. Now we only overwrite the value of `WarpX::moving_window_x` with the checkpoint value if there was a moving window in the initial run. To do this, I needed to also store `WarpX::do_moving_window` in the checkpoint. Does this fix sound reasonable?