### PR TITLE
CI: Checksums for yt 4.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
       sudo update-alternatives --set python /usr/bin/python3
       python -m pip install --upgrade pip
       python -m pip install --upgrade wheel
-      python -m pip install --upgrade cmake matplotlib==3.2.2 mpi4py numpy scipy yt
+      python -m pip install --upgrade cmake matplotlib==3.2.2 mpi4py numpy scipy yt==3.6.1
       export CEI_CMAKE="$HOME/.local/bin/cmake"
       export CEI_SUDO="sudo"
       sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -51,7 +51,8 @@ class Checksum:
         ds = yt.load(self.plotfile)
         grid_fields = [item for item in ds.field_list if item[0] == 'boxlib']
         species_list = set([item[0] for item in ds.field_list if
-                            item[1][:9] == 'particle_' and item[0] != 'all'])
+                            item[1][:9] == 'particle_' and item[0] != 'all' and
+                            item[0] != 'nbody'])
 
         data = {}
 


### PR DESCRIPTION
The latest yt release (4.0.0) adds a new unconditional `nbody` key, which breaks our test checksums.

Fix #1917

X-ref: https://github.com/yt-project/yt/issues/3279