### PR TITLE
CI: BLAS++/LAPACK++ Only in Py/RZ

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -58,10 +58,12 @@ jobs:
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
         python -m pip install --upgrade openpmd-api
       fi
-      cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
-        -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-      cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
-        -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
+      if [[ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" || "${WARPX_CI_PYTHON_MAIN:-FALSE}" == "TRUE" ]]; then
+        cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
+          -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
+        cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
+          -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
+      fi
     displayName: 'Install dependencies'
 
   - script: |


### PR DESCRIPTION
Install BLAS++/LAPACK++ only for the Python main and RZ tests, which both build & perform RZ tests with PSATD support.

Save a minute in download & build for the other test matrix entries.