### PR TITLE
Fix Electrostatic Init & Filter

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -163,6 +163,11 @@ WarpX::InitData ()
 
     if (restart_chkfile.empty())
     {
+        // Loop through species and calculate their space-charge field
+        bool const reset_fields = false; // Do not erase previous user-specified values on the grid
+        ComputeSpaceChargeField(reset_fields);
+
+        // Write full diagnostics before the first iteration.
         multi_diags->FilterComputePackFlush( -1 );
 
         // Write reduced diagnostics before the first iteration.
@@ -211,10 +216,6 @@ WarpX::InitFromScratch ()
 
     mypc->AllocData();
     mypc->InitData();
-
-    // Loop through species and calculate their space-charge field
-    bool const reset_fields = false; // Do not erase previous user-specified values on the grid
-    ComputeSpaceChargeField(reset_fields);
 
     InitPML();
 }


### PR DESCRIPTION
Move the calculation of initial space charge fields further down in `WarpX::InitData` and out of `InitFromScratch`.

This call runs already MLMG routines that rely on a filtered rho, whose stencils are not initialized if called  to early.

Seen as sporadic crash after enabling filters by default for all tests: #2031

Thanks to @RemiLehe for debugging this with me.