### PR TITLE
Fix: CUDA Host-Side -O3 with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ mark_as_advanced(WarpX_PARSER_DEPTH)
 option(WarpX_amrex_internal                    "Download & build AMReX" ON)
 
 # change the default build type to RelWithDebInfo (or Release) instead of Debug
-set_default_build_type("RelWithDebInfo")
+set_default_build_type("Release")
 
 # Option to enable interprocedural optimization
 # (also know as "link-time optimization" or "whole program optimization")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ mark_as_advanced(WarpX_PARSER_DEPTH)
 
 option(WarpX_amrex_internal                    "Download & build AMReX" ON)
 
-# change the default build type to RelWithDebInfo (or Release) instead of Debug
+# change the default build type to Release (or RelWithDebInfo) instead of Debug
 set_default_build_type("Release")
 
 # Option to enable interprocedural optimization

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -72,7 +72,7 @@ Build Options
 ============================= ============================================ =========================================================
 CMake Option                  Default & Values                             Description
 ============================= ============================================ =========================================================
-``CMAKE_BUILD_TYPE``          **RelWithDebInfo**/Release/Debug             Type of build, symbols & optimizations
+``CMAKE_BUILD_TYPE``          RelWithDebInfo/**Release**/Debug             Type of build, symbols & optimizations
 ``CMAKE_INSTALL_PREFIX``      system-dependent path                        Install path prefix
 ``CMAKE_VERBOSE_MAKEFILE``    ON/**OFF**                                   Print all compiler commands to the terminal during build
 ``WarpX_APP``                 **ON**/OFF                                   Build the WarpX executable application

--- a/Docs/source/usage/workflows/debugging.rst
+++ b/Docs/source/usage/workflows/debugging.rst
@@ -22,7 +22,7 @@ Try the following steps to debug a simulation:
    Do you spot numerical artifacts or instabilities that could point to missing resolution or unexpected/incompatible numerical parameters?
 #. Did the job output files indicate a crash? Check the ``Backtrace.<mpirank>`` files for the location of the code that triggered the crash.
    Backtraces are read from bottom (high-level) to top (most specific line that crashed).
-#. In case of a crash, Backtraces can be more detailed if you :ref:`re-compile <install-developers>` with debug flags: for example, try compiling with ``-DCMAKE_BUILD_TYPE=Debug`` (this will make the simulation slower) and rerun.
+#. In case of a crash, Backtraces can be more detailed if you :ref:`re-compile <install-developers>` with debug flags: for example, try compiling with ``-DCMAKE_BUILD_TYPE=RelWithDebInfo`` (some slowdown) or even ``-DCMAKE_BUILD_TYPE=Debug`` (this will make the simulation way slower) and rerun.
 #. If debug builds are too costly, try instead compiling with ``-DAMReX_ASSERTIONS=ON`` to activate more checks and rerun.
 #. If the problem looks like a memory violation, this could be from an invalid field or particle index access.
    Try compiling with ``-DAMReX_BOUND_CHECK=ON`` (this will make the simulation very slow), and rerun.

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -72,13 +72,6 @@ macro(set_default_build_type default_build_type)
             set_property(CACHE CMAKE_BUILD_TYPE
                 PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
         endif()
-
-        # RelWithDebInfo uses -O2 which is sub-ideal for how it is intended to be used
-        #   https://gitlab.kitware.com/cmake/cmake/-/merge_requests/591
-        list(TRANSFORM CMAKE_C_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
-        list(TRANSFORM CMAKE_CXX_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
-        # FIXME: due to the "AMReX inits CUDA first" logic we will first see this with -O2 in output
-        list(TRANSFORM CMAKE_CUDA_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
     endif()
 endmacro()
 


### PR DESCRIPTION
`-O3` was only set for CUDA if we ran CMake at least twice. This was an intialization logic bug and should be set from the beginning, but we initialized CUDA too late / applied the transform too early.

We now change the default build type to `Release` to avoid changing defaults and avoid further surprises.

Similar implications as in #1203: here the host-side default optimization was taken (GCC: `-O0` but NVCC device-side is still defaulting to `-O3`). We saw ~30% performance regressions for GPU runs with this unoptimized host code path for CUDA translation units.

Thanks to @NeilZaim for raising this! Thanks to @WeiqunZhang for debugging this with me!

### To Do

- [x] test again: chicken-egg problem with AMReX summary print on first pass and need-to-update after CUDA was initialized
- [x] change default build type to `Release` to avoid any future issues
- follow-up: add potentially an option that adds / controls `-g` explicitly for any build mode