### PR TITLE
Replace `injection_style = python` with `injection_style = none`

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -452,7 +452,7 @@ Particle initialization
     When ``<species_name>.xmin`` and ``<species_name>.xmax`` are set, they delimit the region within which particles are injected.
     If periodic boundary conditions are used in direction ``i``, then the default (i.e. if the range is not specified) range will be the simulation box, ``[geometry.prob_hi[i], geometry.prob_lo[i]]``.
 
-* ``<species_name>.injection_style`` (`string`)
+* ``<species_name>.injection_style`` (`string`; default: ``none``)
     Determines how the (macro-)particles will be injected in the simulation.
     The number of particles per cell is always given with respect to the coarsest level (level 0/mother grid), even if particles are immediately assigned to a refined patch.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -511,6 +511,8 @@ Particle initialization
       ``<species_name>.flux_direction`` (`-1` or `+1`, direction of flux relative to the plane)
       ``<species_name>.num_particles_per_cell`` (`double`)
 
+    * ``none``: Do not inject macro-particles (for example, in a simulation that starts with neutral, ionizable atoms, one may want to create the electrons species -- where ionized electrons can be stored later on -- without injecting electron macro-particles).
+
 * ``<species_name>.num_particles_per_cell_each_dim`` (`3 integers in 3D and RZ, 2 integers in 2D`)
     With the NUniformPerCell injection style, this specifies the number of particles along each axis
     within a cell. Note that for RZ, the three axis are radius, theta, and z and that the recommended

--- a/Python/pywarpx/Particles.py
+++ b/Python/pywarpx/Particles.py
@@ -12,17 +12,17 @@ particles_list = []
 electrons = Bucket('electrons')
 electrons.charge = "-q_e"
 electrons.mass = "m_e"
-electrons.injection_style = "python"
+electrons.injection_style = "none"
 
 positrons = Bucket('positrons')
 positrons.charge = "q_e"
 positrons.mass = "m_e"
-positrons.injection_style = "python"
+positrons.injection_style = "none"
 
 protons = Bucket('protons')
 protons.charge = "q_e"
 protons.mass = "m_p"
-protons.injection_style = "python"
+protons.injection_style = "none"
 
 particle_dict = {'electrons':electrons,
                  'positrons':positrons,

--- a/Python/pywarpx/Particles.py
+++ b/Python/pywarpx/Particles.py
@@ -12,17 +12,17 @@ particles_list = []
 electrons = Bucket('electrons')
 electrons.charge = "-q_e"
 electrons.mass = "m_e"
-electrons.injection_style = "none"
+electrons.injection_style = None
 
 positrons = Bucket('positrons')
 positrons.charge = "q_e"
 positrons.mass = "m_e"
-positrons.injection_style = "none"
+positrons.injection_style = None
 
 protons = Bucket('protons')
 protons.charge = "q_e"
 protons.mass = "m_p"
-protons.injection_style = "none"
+protons.injection_style = None
 
 particle_dict = {'electrons':electrons,
                  'positrons':positrons,

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -119,7 +119,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     }
 
     // Parse injection style
-    std::string injection_style;
+    std::string injection_style = "none";
     pp_species_name.query("injection_style", injection_style);
     std::transform(injection_style.begin(),
                    injection_style.end(),
@@ -462,7 +462,7 @@ void PlasmaInjector::parseDensity (ParmParse& pp)
                                             makeParser(str_density_function,{"x","y","z"})));
     } else {
         //No need for profile definition if external file is used
-        std::string injection_style;
+        std::string injection_style = "none";
         pp.query("injection_style", injection_style);
         if (injection_style != "external_file") {
             StringParseAbortMessage("Density profile type", rho_prof_s);
@@ -611,7 +611,7 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
                                              makeParser(str_momentum_function_uz,{"x","y","z"})));
     } else {
         //No need for momentum definition if external file is used
-        std::string injection_style;
+        std::string injection_style = "none";
         pp.query("injection_style", injection_style);
         if (injection_style != "external_file") {
             StringParseAbortMessage("Momentum distribution type", mom_dist_s);

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -118,8 +118,13 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         mass = species::get_mass( physical_species );
     }
 
-    std::string s_inj_style;
-    pp_species_name.query("injection_style", s_inj_style);
+    // Parse injection style
+    std::string injection_style;
+    pp_species_name.query("injection_style", injection_style);
+    std::transform(injection_style.begin(),
+                   injection_style.end(),
+                   injection_style.begin(),
+                   ::tolower);
 
     // parse charge and mass
     bool charge_is_specified = queryWithParser(pp_species_name, "charge", charge);
@@ -130,7 +135,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
                 << species_name << ".species_type' are specified\n'"
                 << species_name << ".charge' will take precedence.\n";
     }
-    if (!charge_is_specified && !species_is_specified && s_inj_style != "external_file"){
+    if (!charge_is_specified && !species_is_specified && injection_style != "external_file"){
         // external file will throw own assertions below if charge cannot be found
         amrex::Abort("Need to specify at least one of species_type or charge");
     }
@@ -140,22 +145,16 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
                 << species_name << ".species_type' are specified\n'"
                 << species_name << ".mass' will take precedence.\n";
     }
-    if (!mass_is_specified && !species_is_specified && s_inj_style != "external_file"){
+    if (!mass_is_specified && !species_is_specified && injection_style != "external_file"){
         // external file will throw own assertions below if mass cannot be found
         amrex::Abort("Need to specify at least one of species_type or mass");
     }
 
-    // parse injection style
-    std::string part_pos_s;
-    pp_species_name.get("injection_style", part_pos_s);
-    std::transform(part_pos_s.begin(),
-                   part_pos_s.end(),
-                   part_pos_s.begin(),
-                   ::tolower);
     num_particles_per_cell_each_dim.assign(3, 0);
-    if (part_pos_s == "python") {
+
+    if (injection_style == "none") {
         return;
-    } else if (part_pos_s == "singleparticle") {
+    } else if (injection_style == "singleparticle") {
         getArrWithParser(pp_species_name, "single_particle_pos", single_particle_pos, 0, 3);
         getArrWithParser(pp_species_name, "single_particle_vel", single_particle_vel, 0, 3);
         for (auto& x : single_particle_vel) {
@@ -164,7 +163,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         getWithParser(pp_species_name, "single_particle_weight", single_particle_weight);
         add_single_particle = true;
         return;
-    } else if (part_pos_s == "multipleparticles") {
+    } else if (injection_style == "multipleparticles") {
         getArrWithParser(pp_species_name, "multiple_particles_pos_x", multiple_particles_pos_x);
         getArrWithParser(pp_species_name, "multiple_particles_pos_y", multiple_particles_pos_y);
         getArrWithParser(pp_species_name, "multiple_particles_pos_z", multiple_particles_pos_z);
@@ -185,7 +184,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         for (auto& vz : multiple_particles_vel_z) { vz *= PhysConst::c; }
         add_multiple_particles = true;
         return;
-    } else if (part_pos_s == "gaussian_beam") {
+    } else if (injection_style == "gaussian_beam") {
         getWithParser(pp_species_name, "x_m", x_m);
         getWithParser(pp_species_name, "y_m", y_m);
         getWithParser(pp_species_name, "z_m", z_m);
@@ -204,7 +203,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     // Depending on injection type at runtime, initialize inj_pos
     // so that inj_pos->getPositionUnitBox calls
     // InjectorPosition[Random or Regular].getPositionUnitBox.
-    else if (part_pos_s == "nrandompercell") {
+    else if (injection_style == "nrandompercell") {
         pp_species_name.query("num_particles_per_cell", num_particles_per_cell);
 #if WARPX_DIM_RZ
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -219,7 +218,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             xmin, xmax, ymin, ymax, zmin, zmax);
         parseDensity(pp_species_name);
         parseMomentum(pp_species_name);
-    } else if (part_pos_s == "nfluxpercell") {
+    } else if (injection_style == "nfluxpercell") {
         surface_flux = true;
         queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell_real);
 #ifdef WARPX_DIM_RZ
@@ -271,7 +270,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             flux_normal_axis);
         parseDensity(pp_species_name);
         parseMomentum(pp_species_name);
-    } else if (part_pos_s == "nuniformpercell") {
+    } else if (injection_style == "nuniformpercell") {
         // Note that for RZ, three numbers are expected, r, theta, and z.
         // For 2D, only two are expected. The third is overwritten with 1.
         num_particles_per_cell_each_dim.assign(3, 1);
@@ -298,7 +297,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
                                  num_particles_per_cell_each_dim[2];
         parseDensity(pp_species_name);
         parseMomentum(pp_species_name);
-    } else if (part_pos_s == "external_file") {
+    } else if (injection_style == "external_file") {
 #ifndef WARPX_USE_OPENPMD
         amrex::Abort("WarpX has to be compiled with USE_OPENPMD=TRUE to be able"
                      " to read the external openPMD file with species data");
@@ -385,7 +384,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 #endif  // WARPX_USE_OPENPMD
 
     } else {
-        StringParseAbortMessage("Injection style", part_pos_s);
+        StringParseAbortMessage("Injection style", injection_style);
     }
 
     if (h_inj_pos) {
@@ -463,9 +462,9 @@ void PlasmaInjector::parseDensity (ParmParse& pp)
                                             makeParser(str_density_function,{"x","y","z"})));
     } else {
         //No need for profile definition if external file is used
-        std::string s_inj_style;
-        pp.query("injection_style", s_inj_style);
-        if (s_inj_style != "external_file") {
+        std::string injection_style;
+        pp.query("injection_style", injection_style);
+        if (injection_style != "external_file") {
             StringParseAbortMessage("Density profile type", rho_prof_s);
         }
     }
@@ -612,9 +611,9 @@ void PlasmaInjector::parseMomentum (ParmParse& pp)
                                              makeParser(str_momentum_function_uz,{"x","y","z"})));
     } else {
         //No need for momentum definition if external file is used
-        std::string s_inj_style;
-        pp.query("injection_style", s_inj_style);
-        if (s_inj_style != "external_file") {
+        std::string injection_style;
+        pp.query("injection_style", injection_style);
+        if (injection_style != "external_file") {
             StringParseAbortMessage("Momentum distribution type", mom_dist_s);
         }
     }


### PR DESCRIPTION
Fix #1942 by replacing the option `injection_style = python` with `injection_style = none`. I also renamed the temporary variables used to parse `injection_style` with the same name of the input parameter, which I think makes the code easier to follow.