### PR TITLE
RZ: Add ASSERT for Lower Bound of Radial Coordinate

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -49,8 +49,18 @@ void ParseGeometryInput()
     AMREX_ALWAYS_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
 
 #ifdef WARPX_DIM_RZ
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
-        "Lower bound of radial coordinate in RZ geometry (prob_lo[0]) must be non-negative");
+    ParmParse pp_algo("algo");
+    int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
+            "Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero");
+    }
+    else
+    {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
+            "Lower bound of radial coordinate (prob_lo[0]) with RZ FDTD solver must be non-negative");
+    }
 #endif
 
     pp_geometry.addarr("prob_lo", prob_lo);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -48,6 +48,11 @@ void ParseGeometryInput()
     getArrWithParser(pp_geometry, "prob_hi", prob_hi, 0, AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
 
+#ifdef WARPX_DIM_RZ
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
+        "Lower bound of radial coordinate in RZ geometry (prob_lo[0]) must be non-negative");
+#endif
+
     pp_geometry.addarr("prob_lo", prob_lo);
     pp_geometry.addarr("prob_hi", prob_hi);
 }


### PR DESCRIPTION
Fix #1941 by adding an `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` to check that the lower bound of the radial coordinate in RZ geometry (the first component of `geometry.prob_lo` in the input file) is non-negative.