### PR TITLE
Update Monte Carlo Collisions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,6 +78,7 @@ jobs:
           -DWarpX_openpmd_internal=OFF \
           -DWarpX_PRECISION=SINGLE     \
           -DWarpX_PSATD=ON             \
+          -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
           -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
         cmake --build build_sp -j 2
 

--- a/Source/Particles/Collision/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCCCollision.H
@@ -12,20 +12,21 @@
 #include "MCCProcess.H"
 
 #include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
 #include <AMReX_GpuContainers.H>
 
+#include <memory>
 #include <string>
 
-class BackgroundMCCCollision
+class BackgroundMCCCollision final
     : public CollisionBase
 {
 public:
-    template <typename T>
-    using VectorType = amrex::Gpu::ManagedVector<T>;
-
     BackgroundMCCCollision (std::string collision_name);
 
-    amrex::Real get_nu_max ( VectorType<MCCProcess*> const& mcc_processes );
+    virtual ~BackgroundMCCCollision () = default;
+
+    amrex::Real get_nu_max (amrex::Vector<MCCProcess const*> const& mcc_processes);
 
     /** Perform the collisions
      *
@@ -57,8 +58,10 @@ public:
 
 private:
 
-    VectorType< MCCProcess* > m_scattering_processes;
-    VectorType< MCCProcess* > m_ionization_processes;
+    amrex::Vector<std::unique_ptr<MCCProcess> > m_scattering_processes;
+    amrex::Vector<std::unique_ptr<MCCProcess> > m_ionization_processes;
+    amrex::Gpu::DeviceVector<MCCProcess::Executor> m_scattering_processes_exe;
+    amrex::Gpu::DeviceVector<MCCProcess::Executor> m_ionization_processes_exe;
 
     bool init_flag = false;
     bool ionization_flag = false;

--- a/Source/Particles/Collision/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCCCollision.H
@@ -26,7 +26,7 @@ public:
 
     virtual ~BackgroundMCCCollision () = default;
 
-    amrex::Real get_nu_max (amrex::Vector<MCCProcess const*> const& mcc_processes);
+    amrex::Real get_nu_max (amrex::Vector<MCCProcess> const& mcc_processes);
 
     /** Perform the collisions
      *
@@ -58,8 +58,8 @@ public:
 
 private:
 
-    amrex::Vector<std::unique_ptr<MCCProcess> > m_scattering_processes;
-    amrex::Vector<std::unique_ptr<MCCProcess> > m_ionization_processes;
+    amrex::Vector<MCCProcess> m_scattering_processes;
+    amrex::Vector<MCCProcess> m_ionization_processes;
     amrex::Gpu::DeviceVector<MCCProcess::Executor> m_scattering_processes_exe;
     amrex::Gpu::DeviceVector<MCCProcess::Executor> m_ionization_processes_exe;
 

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -253,7 +253,7 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
 
     // get collision parameters
     auto scattering_processes = m_scattering_processes_exe.data();
-    auto process_count        = m_scattering_processes_exe.size();
+    int const process_count   = m_scattering_processes_exe.size();
 
     amrex::Real total_collision_prob = m_total_collision_prob;
     amrex::Real nu_max = m_nu_max;

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -58,9 +58,9 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
             pp.get(kw_energy.c_str(), energy);
         }
 
-        auto process = new MCCProcess(scattering_process, cross_section_file, energy);
+        auto process = std::make_unique<MCCProcess>(scattering_process, cross_section_file, energy);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(process->m_type != MCCProcessType::INVALID,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(process->type() != MCCProcessType::INVALID,
                                          "Cannot add an unknown MCC process type");
 
         // if the scattering process is ionization get the secondary species
@@ -68,7 +68,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
         // m_ionization_processes is only used to make it simple to calculate
         // the maximum collision frequency with the same function used for
         // particle conserving processes
-        if (process->m_type == MCCProcessType::IONIZATION) {
+        if (process->type() == MCCProcessType::IONIZATION) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!ionization_flag,
                                              "Background MCC only supports a single ionization process");
             ionization_flag = true;
@@ -77,20 +77,43 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
             pp.get("ionization_species", secondary_species);
             m_species_names.push_back(secondary_species);
 
-            m_ionization_processes.push_back(process);
+            m_ionization_processes.push_back(std::move(process));
         } else {
-            m_scattering_processes.push_back(process);
+            m_scattering_processes.push_back(std::move(process));
         }
-
-        amrex::Gpu::synchronize();
     }
+
+#ifdef AMREX_USE_GPU
+    amrex::Gpu::HostVector<MCCProcess::Executor> h_scattering_processes_exe;
+    amrex::Gpu::HostVector<MCCProcess::Executor> h_ionization_processes_exe;
+    for (auto const& p : m_scattering_processes) {
+        h_scattering_processes_exe.push_back(p->executor());
+    }
+    for (auto const& p : m_ionization_processes) {
+        h_ionization_processes_exe.push_back(p->executor());
+    }
+    m_scattering_processes_exe.resize(h_scattering_processes_exe.size());
+    m_ionization_processes_exe.resize(h_ionization_processes_exe.size());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, h_scattering_processes_exe.begin(),
+                          h_scattering_processes_exe.end(), m_scattering_processes_exe.begin());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, h_ionization_processes_exe.begin(),
+                          h_ionization_processes_exe.end(), m_ionization_processes_exe.begin());
+    amrex::Gpu::streamSynchronize();
+#else
+    for (auto const& p : m_scattering_processes) {
+        m_scattering_processes_exe.push_back(p->executor());
+    }
+    for (auto const& p : m_ionization_processes) {
+        m_ionization_processes_exe.push_back(p->executor());
+    }
+#endif
 }
 
 /** Calculate the maximum collision frequency using a fixed energy grid that
  *  ranges from 1e-4 to 5000 eV in 0.2 eV increments
  */
 amrex::Real
-BackgroundMCCCollision::get_nu_max(amrex::Gpu::ManagedVector<MCCProcess*> const& mcc_processes)
+BackgroundMCCCollision::get_nu_max(amrex::Vector<MCCProcess const*> const& mcc_processes)
 {
     using namespace amrex::literals;
     amrex::Real nu, nu_max = 0.0;
@@ -138,7 +161,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
         m_mass1 = species1.getMass();
 
         // calculate maximum collision frequency without ionization
-        m_nu_max = get_nu_max(m_scattering_processes);
+        m_nu_max = get_nu_max(amrex::GetVecOfConstPtrs(m_scattering_processes));
 
         // calculate total collision probability
         auto coll_n = m_nu_max * dt;
@@ -153,7 +176,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
 
         if (ionization_flag) {
             // calculate maximum collision frequency for ionization
-            m_nu_max_ioniz = get_nu_max(m_ionization_processes);
+            m_nu_max_ioniz = get_nu_max(amrex::GetVecOfConstPtrs(m_ionization_processes));
 
             // calculate total ionization probability
             auto coll_n_ioniz = m_nu_max_ioniz * dt;
@@ -229,8 +252,8 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
     amrex::Real vel_std = sqrt(PhysConst::kb * T_a / mass_a);
 
     // get collision parameters
-    auto scattering_processes = m_scattering_processes.data();
-    auto process_count = m_scattering_processes.size();
+    auto scattering_processes = m_scattering_processes_exe.data();
+    auto process_count        = m_scattering_processes_exe.size();
 
     amrex::Real total_collision_prob = m_total_collision_prob;
     amrex::Real nu_max = m_nu_max;
@@ -288,8 +311,8 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
                               v_coll = sqrt(v_coll2);
 
                               // loop through all collision pathways
-                              for (size_t i = 0; i < process_count; i++) {
-                                  auto const& scattering_process = **(scattering_processes + i);
+                              for (int i = 0; i < process_count; i++) {
+                                  auto const& scattering_process = *(scattering_processes + i);
 
                                   // get collision cross-section
                                   sigma_E = scattering_process.getCrossSection(E_coll);
@@ -368,7 +391,7 @@ void BackgroundMCCCollision::doBackgroundIonization
         const auto np_ion = ion_tile.numParticles();
 
         auto Transform = ImpactIonizationTransformFunc(
-                                                       m_ionization_processes[0]->m_energy_penalty, m_mass1, vel_std
+                                                       m_ionization_processes[0]->getEnergyPenalty(), m_mass1, vel_std
                                                        );
 
         const auto num_added = filterCopyTransformParticles<1>(

--- a/Source/Particles/Collision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision.H
@@ -54,7 +54,7 @@
  *
  */
 template <typename FunctorType>
-class BinaryCollision
+class BinaryCollision final
     : public CollisionBase
 {
     // Define shortcuts for frequently-used type names
@@ -84,6 +84,8 @@ public:
             m_isSameSpecies = false;
     }
 
+    virtual ~BinaryCollision () = default;
+
     /** Perform the collisions
      *
      * @param lev AMR level of the tile
@@ -109,10 +111,10 @@ public:
         amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
             // Loop over all grids/tiles at this level
-    #ifdef AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
             info.SetDynamic(true);
-    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-    #endif
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
             for (amrex::MFIter mfi = species1.MakeMFIter(lev, info); mfi.isValid(); ++mfi){
                 if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
                 {
@@ -178,18 +180,18 @@ public:
 
             const amrex::Real dt = WarpX::GetInstance().getdt(lev);
             amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
-    #if defined WARPX_DIM_XZ
+#if defined WARPX_DIM_XZ
             auto dV = geom.CellSize(0) * geom.CellSize(1);
-    #elif defined WARPX_DIM_RZ
+#elif defined WARPX_DIM_RZ
             amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
             const auto lo = lbound(cbx);
             const auto hi = ubound(cbx);
             int const nz = hi.y-lo.y+1;
             auto dr = geom.CellSize(0);
             auto dz = geom.CellSize(1);
-    #elif (AMREX_SPACEDIM == 3)
+#elif (AMREX_SPACEDIM == 3)
             auto dV = geom.CellSize(0) * geom.CellSize(1) * geom.CellSize(2);
-    #endif
+#endif
 
             // Loop over cells
             amrex::ParallelForRNG( n_cells,
@@ -207,10 +209,10 @@ public:
                     // shuffle
                     ShuffleFisherYates(
                         indices_1, cell_start_1, cell_half_1, engine );
-    #if defined WARPX_DIM_RZ
+#if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
                     auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
-    #endif
+#endif
                     // Call the function in order to perform collisions
                     binary_collision_functor(
                         cell_start_1, cell_half_1,
@@ -262,18 +264,18 @@ public:
 
             const amrex::Real dt = WarpX::GetInstance().getdt(lev);
             amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
-    #if defined WARPX_DIM_XZ
+#if defined WARPX_DIM_XZ
             auto dV = geom.CellSize(0) * geom.CellSize(1);
-    #elif defined WARPX_DIM_RZ
+#elif defined WARPX_DIM_RZ
             amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
             const auto lo = lbound(cbx);
             const auto hi = ubound(cbx);
             int nz = hi.y-lo.y+1;
             auto dr = geom.CellSize(0);
             auto dz = geom.CellSize(1);
-    #elif (AMREX_SPACEDIM == 3)
+#elif (AMREX_SPACEDIM == 3)
             auto dV = geom.CellSize(0) * geom.CellSize(1) * geom.CellSize(2);
-    #endif
+#endif
 
             // Loop over cells
             amrex::ParallelForRNG( n_cells,
@@ -298,10 +300,10 @@ public:
                     // shuffle
                     ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
                     ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-    #if defined WARPX_DIM_RZ
+#if defined WARPX_DIM_RZ
                     int ri = (i_cell - i_cell%nz) / nz;
                     auto dV = MathConst::pi*(2.0_rt*ri+1.0_rt)*dr*dr*dz;
-    #endif
+#endif
                     // Call the function in order to perform collisions
                     binary_collision_functor(
                         cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,

--- a/Source/Particles/Collision/MCCProcess.H
+++ b/Source/Particles/Collision/MCCProcess.H
@@ -88,7 +88,7 @@ public:
             }
         }
 
-        amrex::Real* m_sigmas_data;
+        amrex::Real* m_sigmas_data = nullptr;
         amrex::Real m_energy_lo, m_energy_hi, m_sigma_lo, m_sigma_hi, m_dE;
         amrex::Real m_energy_penalty;
         MCCProcessType m_type;

--- a/Source/Particles/Collision/MCCProcess.H
+++ b/Source/Particles/Collision/MCCProcess.H
@@ -38,6 +38,12 @@ public:
                 const amrex::Real energy
                 );
 
+    MCCProcess (MCCProcess const&) = delete;
+    MCCProcess& operator= (MCCProcess const&) = delete;
+
+    MCCProcess (MCCProcess &&) = default;
+    MCCProcess& operator= (MCCProcess &&) = default;
+
     /** Read the given cross-section data file to memory.
      *
      * @param cross_section_file the path to the file containing the cross-

--- a/Source/Particles/Collision/MCCProcess.H
+++ b/Source/Particles/Collision/MCCProcess.H
@@ -7,6 +7,7 @@
 #ifndef WARPX_PARTICLES_COLLISION_MCCPROCESS_H_
 #define WARPX_PARTICLES_COLLISION_MCCPROCESS_H_
 
+#include <AMReX_Math.H>
 #include <AMReX_Vector.H>
 #include <AMReX_RandomEngine.H>
 #include <AMReX_GpuContainers.H>
@@ -23,9 +24,6 @@ enum class MCCProcessType {
 class MCCProcess
 {
 public:
-    template <typename T>
-    using VectorType = amrex::Gpu::ManagedVector<T>;
-
     MCCProcess (
                 const std::string& scattering_process,
                 const std::string& cross_section_file,
@@ -40,39 +38,6 @@ public:
                 const amrex::Real energy
                 );
 
-    void* operator new  ( std::size_t count );
-    void operator delete (void* ptr);
-
-    /** Get the collision cross-section using a simple linear interpolator. If
-     * the energy value is lower (higher) than the given energy range the
-     * first (last) cross-section value is used.
-     *
-     * @param E_coll collision energy in eV
-     *
-     */
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real getCrossSection (amrex::Real E_coll) const
-    {
-        if (E_coll < m_energy_lo) {
-            return m_sigma_lo;
-        } else if (E_coll > m_energy_hi) {
-            return m_sigma_hi;
-        } else {
-            using std::floor;
-            using std::ceil;
-            // calculate index of bounding energy pairs
-            amrex::Real temp = (E_coll - m_energy_lo) / m_dE;
-            int idx_1 = floor(temp);
-            int idx_2 = ceil(temp);
-
-            // linearly interpolate to the given energy value
-            temp -= idx_1;
-            return (
-                    m_sigmas_data[idx_1] + (m_sigmas_data[idx_2] - m_sigmas_data[idx_1]) * temp
-                    );
-        }
-    }
-
     /** Read the given cross-section data file to memory.
      *
      * @param cross_section_file the path to the file containing the cross-
@@ -84,33 +49,85 @@ public:
     static
     void readCrossSectionFile (
                                const std::string cross_section_file,
-                               VectorType<amrex::Real>& energies,
-                               VectorType<amrex::Real>& sigmas
+                               amrex::Vector<amrex::Real>& energies,
+                               amrex::Gpu::HostVector<amrex::Real>& sigmas
                                );
 
     static
     void sanityCheckEnergyGrid (
-                                const VectorType<amrex::Real>& energies,
+                                const amrex::Vector<amrex::Real>& energies,
                                 amrex::Real dE
                                 );
 
-    MCCProcessType m_type;
-    amrex::Real m_energy_penalty;
+    struct Executor {
+        /** Get the collision cross-section using a simple linear interpolator. If
+         * the energy value is lower (higher) than the given energy range the
+         * first (last) cross-section value is used.
+         *
+         * @param E_coll collision energy in eV
+         *
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::Real getCrossSection (amrex::Real E_coll) const
+        {
+            if (E_coll < m_energy_lo) {
+                return m_sigma_lo;
+            } else if (E_coll > m_energy_hi) {
+                return m_sigma_hi;
+            } else {
+                using amrex::Math::floor;
+                using amrex::Math::ceil;
+                // calculate index of bounding energy pairs
+                amrex::Real temp = (E_coll - m_energy_lo) / m_dE;
+                int idx_1 = static_cast<int>(floor(temp));
+                int idx_2 = static_cast<int>(ceil(temp));
+
+                // linearly interpolate to the given energy value
+                temp -= idx_1;
+                return m_sigmas_data[idx_1] + (m_sigmas_data[idx_2] - m_sigmas_data[idx_1]) * temp;
+            }
+        }
+
+        amrex::Real* m_sigmas_data;
+        amrex::Real m_energy_lo, m_energy_hi, m_sigma_lo, m_sigma_hi, m_dE;
+        amrex::Real m_energy_penalty;
+        MCCProcessType m_type;
+    };
+
+    Executor const& executor () const {
+#ifdef AMREX_USE_GPU
+        return m_exe_d;
+#else
+        return m_exe_h;
+#endif
+    }
+
+    amrex::Real getCrossSection (amrex::Real E_coll) const
+    {
+        return m_exe_h.getCrossSection(E_coll);
+    }
+
+    amrex::Real getEnergyPenalty () const { return m_exe_h.m_energy_penalty; }
+
+    MCCProcessType type () const { return m_exe_h.m_type; }
 
 private:
 
     static
     MCCProcessType parseProcessType(const std::string& process);
 
-    void init();
+    void init (const std::string& scattering_process, const amrex::Real energy);
 
-    VectorType<amrex::Real> m_energies;
-    amrex::Real* m_energies_data;
-    VectorType<amrex::Real> m_sigmas;
-    amrex::Real* m_sigmas_data;
+    amrex::Vector<amrex::Real> m_energies;
+
+#ifdef AMREX_USE_GPU
+    amrex::Gpu::DeviceVector<amrex::Real> m_sigmas_d;
+    Executor m_exe_d;
+#endif
+    amrex::Gpu::HostVector<amrex::Real> m_sigmas_h;
+    Executor m_exe_h;
 
     int m_grid_size;
-    amrex::Real m_energy_lo, m_energy_hi, m_sigma_lo, m_sigma_hi, m_dE;
 };
 
 #endif // WARPX_PARTICLES_COLLISION_MCCPROCESS_H_

--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -11,16 +11,14 @@ MCCProcess::MCCProcess (
                         const std::string& scattering_process,
                         const std::string& cross_section_file,
                         const amrex::Real energy )
-    : m_type(parseProcessType(scattering_process))
-    , m_energy_penalty(energy)
 {
     amrex::Print() << "Reading file " << cross_section_file << " for "
                    << scattering_process << " scattering cross-sections.\n";
 
     // read the cross-section data file into memory
-    readCrossSectionFile(cross_section_file, m_energies, m_sigmas);
+    readCrossSectionFile(cross_section_file, m_energies, m_sigmas_h);
 
-    init();
+    init(scattering_process, energy);
 }
 
 template <typename InputVector>
@@ -29,55 +27,48 @@ MCCProcess::MCCProcess (
                         const InputVector&& energies,
                         const InputVector&& sigmas,
                         const amrex::Real energy )
-    : m_type(parseProcessType(scattering_process))
-    , m_energy_penalty(energy)
 {
-    using std::begin;
-    using std::end;
-    m_energies.insert(m_energies.begin(), begin(energies), end(energies));
-    m_sigmas  .insert(m_sigmas.begin(),   begin(sigmas),   end(sigmas));
+    m_energies.insert(m_energies.begin(), std::begin(energies), std::end(energies));
+    m_sigmas_h.insert(m_sigmas_h.begin(), std::begin(sigmas),   std::end(sigmas));
 
-    init();
-}
-
-void*
-MCCProcess::operator new ( std::size_t count )
-{
-    return amrex::The_Managed_Arena()->alloc(count);
+    init(scattering_process, energy);
 }
 
 void
-MCCProcess::operator delete ( void* ptr )
+MCCProcess::init (const std::string& scattering_process, const amrex::Real energy)
 {
-    amrex::The_Managed_Arena()->free(ptr);
-}
-
-void
-MCCProcess::init()
-{
-    m_energies_data = m_energies.data();
-    m_sigmas_data = m_sigmas.data();
+    m_exe_h.m_sigmas_data = m_sigmas_h.data();
 
     // save energy grid parameters for easy use
     m_grid_size = m_energies.size();
-    m_energy_lo = m_energies[0];
-    m_energy_hi = m_energies[m_grid_size-1];
-    m_sigma_lo = m_sigmas[0];
-    m_sigma_hi = m_sigmas[m_grid_size-1];
-    m_dE = (m_energy_hi - m_energy_lo)/(m_grid_size - 1.);
+    m_exe_h.m_energy_lo = m_energies[0];
+    m_exe_h.m_energy_hi = m_energies[m_grid_size-1];
+    m_exe_h.m_sigma_lo = m_sigmas_h[0];
+    m_exe_h.m_sigma_hi = m_sigmas_h[m_grid_size-1];
+    m_exe_h.m_dE = (m_exe_h.m_energy_hi - m_exe_h.m_energy_lo)/(m_grid_size - 1.);
+    m_exe_h.m_energy_penalty = energy;
+    m_exe_h.m_type = parseProcessType(scattering_process);
 
     // sanity check cross-section energy grid
-    sanityCheckEnergyGrid(m_energies, m_dE);
+    sanityCheckEnergyGrid(m_energies, m_exe_h.m_dE);
 
     // check that the cross-section is 0 at the energy cost if the energy
     // cost is > 0 - this is to prevent the possibility of negative left
     // over energy after a collision event
-    if (m_energy_penalty > 0) {
+    if (m_exe_h.m_energy_penalty > 0) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (getCrossSection(m_energy_penalty) == 0),
+            (getCrossSection(m_exe_h.m_energy_penalty) == 0),
             "Cross-section > 0 at energy cost for collision."
         );
     }
+
+#ifdef AMREX_USE_GPU
+    m_exe_d = m_exe_h;
+    m_sigmas_d.resize(m_sigmas_h.size());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, m_sigmas_h.begin(), m_sigmas_h.end(),
+                          m_sigmas_d.begin());
+    amrex::Gpu::streamSynchronize();
+#endif
 }
 
 MCCProcessType
@@ -101,8 +92,8 @@ MCCProcess::parseProcessType(const std::string& scattering_process)
 void
 MCCProcess::readCrossSectionFile (
                                   const std::string cross_section_file,
-                                  MCCProcess::VectorType<amrex::Real>& energies,
-                                  MCCProcess::VectorType<amrex::Real>& sigmas )
+                                  amrex::Vector<amrex::Real>& energies,
+                                  amrex::Gpu::HostVector<amrex::Real>& sigmas )
 {
     std::ifstream infile(cross_section_file);
     double energy, sigma;
@@ -114,7 +105,7 @@ MCCProcess::readCrossSectionFile (
 
 void
 MCCProcess::sanityCheckEnergyGrid (
-                                   const VectorType<amrex::Real>& energies,
+                                   const amrex::Vector<amrex::Real>& energies,
                                    amrex::Real dE
                                    )
 {

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -160,11 +160,11 @@ public:
     *            by the neutral density.
     */
     ImpactIonizationFilterFunc(
-        MCCProcess mcc_process,
+        MCCProcess const& mcc_process,
         amrex::Real const mass,
         amrex::Real const total_collision_prob,
         amrex::Real const nu_max_norm
-    ) : m_mcc_process(mcc_process), m_mass(mass),
+    ) : m_mcc_process(mcc_process.executor()), m_mass(mass),
         m_total_collision_prob(total_collision_prob),
         m_nu_max_norm(nu_max_norm){ }
 
@@ -209,7 +209,7 @@ public:
     }
 
 private:
-    MCCProcess m_mcc_process;
+    MCCProcess::Executor m_mcc_process;
     amrex::Real m_mass;
     amrex::Real m_total_collision_prob = 0;
     amrex::Real m_nu_max_norm;


### PR DESCRIPTION
This addresses a number of issues in the Monte Carlo collision code.

* `MCCProcess` is not trivially copyable because it contains
  `ManagedVector`.  Therefore, it cannot be captured by GPU device lambda.

* The use of managed memory may have performance issues.

* There are memory leaks because some raw pointers allocated by `new` are
  not `delete`d.

* `BackgroundMCCCollision` derives from a virtual base class, but the
  compiler generated destructor is not automatically virtual.

Follow-up to #1857