### PR TITLE
Quick bugfix: changed species to self.species in picmi.py

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -999,7 +999,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic):
         if np.iterable(self.species):
             species_list = self.species
         else:
-            species_list = [species]
+            species_list = [self.species]
 
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this distribution


### PR DESCRIPTION
Just a quick fix to a bug I found. When I tried running a particle diagnostic with only one particle species, the program threw an error saying that `[species]` was undefined. Changing `[species]` to `[self.species]` seemed to fix the issue though.