### PR TITLE
Fix Warning in 2D/3D Cartesian Builds

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -845,7 +845,9 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         // The invalid ones are given negative ID and are deleted during the
         // next redistribute.
         const auto poffset = offset.data();
+#ifdef WARPX_DIM_RZ
         const bool rz_random_theta = m_rz_random_theta;
+#endif
         amrex::ParallelForRNG(overlap_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::RandomEngine const& engine) noexcept
         {


### PR DESCRIPTION
Fix one warning in the 2D/3D Cartesian builds (`rz_random_theta` used only in RZ code), introduced in #2029.