### PR TITLE
RZ PSATD: Compute dt as min(dr,dz)/c

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -37,14 +37,10 @@ WarpX::ComputeDt ()
 
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
-#if (defined WARPX_DIM_RZ)
-        // - In RZ geometry: dz/c
-        deltat = cfl * dx[1]/PhysConst::c;
-#elif (defined WARPX_DIM_XZ)
-        // - In Cartesian 2D geometry: determined by the minimum cell size in all direction
-        deltat = cfl * std::min( dx[0], dx[1] )/PhysConst::c;
+        // (determined by the minimum cell size in all directions)
+#if (AMREX_SPACEDIM == 2)
+        deltat = cfl * std::min(dx[0], dx[1]) / PhysConst::c;
 #else
-        // - In Cartesian 3D geometry: determined by the minimum cell size in all direction
         deltat = cfl * std::min(dx[0], std::min(dx[1], dx[2])) / PhysConst::c;
 #endif
     } else {


### PR DESCRIPTION
With the RZ spectral solver we were computing the time step always as `dz / c` (multiplied by the CFL coefficient), without taking into account situations where `dr < dz` (more likely in a boosted frame). With this PR the computation takes into account the minimum of the ratio given by cell size over speed of light among all directions, as in the Cartesian case.