### PR TITLE
MCC user friendliness improvement

### DIFF
--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -102,6 +102,9 @@ MCCProcess::readCrossSectionFile (
         energies.push_back(energy);
         sigmas.push_back(sigma);
     }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(energies.size() > 1,
+        "Failed to read cross-section data from file."
+    );
 }
 
 void


### PR DESCRIPTION
Currently if a user passes an invalid (non-existent) cross-section file to the MCC setup routine the program crashes without a clear indication of what the problem is. In this PR I added an error message for invalid cross-section files.