### PR TITLE
Update picmi.py for new injection_style default

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -100,7 +100,7 @@ class Species(picmistandard.PICMI_Species):
         self.species = pywarpx.Bucket.Bucket(self.name,
                                              mass = self.mass,
                                              charge = self.charge,
-                                             injection_style = 'python',
+                                             injection_style = 'none',
                                              initialize_self_fields = int(initialize_self_fields),
                                              boost_adjust_transverse_positions = self.boost_adjust_transverse_positions,
                                              self_fields_required_precision = self.self_fields_required_precision,

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -100,7 +100,7 @@ class Species(picmistandard.PICMI_Species):
         self.species = pywarpx.Bucket.Bucket(self.name,
                                              mass = self.mass,
                                              charge = self.charge,
-                                             injection_style = 'none',
+                                             injection_style = None,
                                              initialize_self_fields = int(initialize_self_fields),
                                              boost_adjust_transverse_positions = self.boost_adjust_transverse_positions,
                                              self_fields_required_precision = self.self_fields_required_precision,


### PR DESCRIPTION
The 'null' injection_style was changed from 'python' to 'none' in PR
#2081, but the associated call in picmi.py was not.