### PR TITLE
Python - add new particle attributes at runtime

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -145,6 +145,7 @@ libwarpx.amrex_init.argtypes = (ctypes.c_int, _LP_LP_c_char)
 libwarpx.amrex_init_with_inited_mpi.argtypes = (ctypes.c_int, _LP_LP_c_char, _MPI_Comm_type)
 libwarpx.warpx_getParticleStructs.restype = _LP_particle_p
 libwarpx.warpx_getParticleArrays.restype = _LP_LP_c_particlereal
+libwarpx.warpx_getParticleArraysFromCompName.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getEfield.restype = _LP_LP_c_real
 libwarpx.warpx_getEfieldLoVects.restype = _LP_c_int
 libwarpx.warpx_getEfieldCP.restype = _LP_LP_c_real
@@ -503,6 +504,50 @@ def get_particle_arrays(species_number, comp, level):
     return particle_data
 
 
+def get_particle_arrays_from_comp_name(species_number, comp_name, level):
+    '''
+
+    This returns a list of numpy arrays containing the particle array data
+    on each tile for this process.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        species_number : the species id that the data will be returned for
+        comp_name      : the component of the array data that will be returned.
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+
+    particles_per_tile = _LP_c_int()
+    num_tiles = ctypes.c_int(0)
+    data = libwarpx.warpx_getParticleArraysFromCompName(
+        species_number, ctypes.c_char_p(comp_name.encode('utf-8')),
+        level, ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
+    )
+
+    particle_data = []
+    for i in range(num_tiles.value):
+        arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
+        try:
+            # This fails on some versions of numpy
+            arr.setflags(write=1)
+        except ValueError:
+            pass
+        particle_data.append(arr)
+
+    _libc.free(particles_per_tile)
+    _libc.free(data)
+    return particle_data
+
+
 def get_particle_x(species_number, level=0):
     '''
 
@@ -641,6 +686,22 @@ def get_particle_theta(species_number, level=0):
         return [np.arctan2(struct['y'], struct['x']) for struct in structs]
     elif geometry_dim == '2d':
         raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
+
+
+def add_real_comp(pid_name, comm=True):
+    '''
+
+    Add a real component to the particle data array. The new component is
+    added to all Particle Containers in the simulation.
+
+    Parameters
+    ----------
+
+        pid_name       : string that is used to identify the new component
+        comm           : should the component be communicated
+
+    '''
+    libwarpx.warpx_addRealComp(ctypes.c_char_p(pid_name.encode('utf-8')), comm)
 
 
 def _get_mesh_field_list(warpx_func, level, direction, include_ghosts):

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -146,6 +146,7 @@ libwarpx.amrex_init_with_inited_mpi.argtypes = (ctypes.c_int, _LP_LP_c_char, _MP
 libwarpx.warpx_getParticleStructs.restype = _LP_particle_p
 libwarpx.warpx_getParticleArrays.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getParticleArraysFromCompName.restype = _LP_LP_c_particlereal
+libwarpx.warpx_getParticleCompIndex.restype = ctypes.c_int
 libwarpx.warpx_getEfield.restype = _LP_LP_c_real
 libwarpx.warpx_getEfieldLoVects.restype = _LP_c_int
 libwarpx.warpx_getEfieldCP.restype = _LP_LP_c_real
@@ -686,6 +687,30 @@ def get_particle_theta(species_number, level=0):
         return [np.arctan2(struct['y'], struct['x']) for struct in structs]
     elif geometry_dim == '2d':
         raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
+
+
+def get_particle_comp_index(species_number, pid_name):
+    '''
+
+    Get the component index for a given particle attribute. This is useful
+    to get the corrent ordering of attributes when adding new particles using
+    `add_particles()`.
+
+    Parameters
+    ----------
+
+        species_number : id for the species of interest
+        pid_name       : string that is used to identify the new component
+
+    Returns
+    -------
+
+        Integer corresponding to the index of the requested attribute
+
+    '''
+    return libwarpx.warpx_getParticleCompIndex(
+        species_number, ctypes.c_char_p(pid_name.encode('utf-8'))
+    )
 
 
 def add_real_comp(pid_name, comm=True):

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -715,20 +715,23 @@ def get_particle_comp_index(species_name, pid_name):
     )
 
 
-def add_real_comp(pid_name, comm=True):
+def add_real_comp(species_name, pid_name, comm=True):
     '''
 
-    Add a real component to the particle data array. The new component is
-    added to all Particle Containers in the simulation.
+    Add a real component to the particle data array.
 
     Parameters
     ----------
 
+        species_name   : the species name for which the new component will be added
         pid_name       : string that is used to identify the new component
         comm           : should the component be communicated
 
     '''
-    libwarpx.warpx_addRealComp(ctypes.c_char_p(pid_name.encode('utf-8')), comm)
+    libwarpx.warpx_addRealComp(
+        ctypes.c_char_p(species_name.encode('utf-8')),
+        ctypes.c_char_p(pid_name.encode('utf-8')), comm
+    )
 
 
 def _get_mesh_field_list(warpx_func, level, direction, include_ghosts):

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -505,7 +505,7 @@ def get_particle_arrays(species_number, comp, level):
     return particle_data
 
 
-def get_particle_arrays_from_comp_name(species_number, comp_name, level):
+def get_particle_arrays_from_comp_name(species_name, comp_name, level):
     '''
 
     This returns a list of numpy arrays containing the particle array data
@@ -517,7 +517,7 @@ def get_particle_arrays_from_comp_name(species_number, comp_name, level):
     Parameters
     ----------
 
-        species_number : the species id that the data will be returned for
+        species_name   : the species name that the data will be returned for
         comp_name      : the component of the array data that will be returned.
 
     Returns
@@ -530,7 +530,8 @@ def get_particle_arrays_from_comp_name(species_number, comp_name, level):
     particles_per_tile = _LP_c_int()
     num_tiles = ctypes.c_int(0)
     data = libwarpx.warpx_getParticleArraysFromCompName(
-        species_number, ctypes.c_char_p(comp_name.encode('utf-8')),
+        ctypes.c_char_p(species_name.encode('utf-8')),
+        ctypes.c_char_p(comp_name.encode('utf-8')),
         level, ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
     )
 
@@ -689,7 +690,7 @@ def get_particle_theta(species_number, level=0):
         raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
 
 
-def get_particle_comp_index(species_number, pid_name):
+def get_particle_comp_index(species_name, pid_name):
     '''
 
     Get the component index for a given particle attribute. This is useful
@@ -699,7 +700,7 @@ def get_particle_comp_index(species_number, pid_name):
     Parameters
     ----------
 
-        species_number : id for the species of interest
+        species_name   : the species name that the data will be returned for
         pid_name       : string that is used to identify the new component
 
     Returns
@@ -709,7 +710,8 @@ def get_particle_comp_index(species_number, pid_name):
 
     '''
     return libwarpx.warpx_getParticleCompIndex(
-        species_number, ctypes.c_char_p(pid_name.encode('utf-8'))
+        ctypes.c_char_p(species_name.encode('utf-8')),
+        ctypes.c_char_p(pid_name.encode('utf-8'))
     )
 
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -421,6 +421,33 @@ extern "C"
         return data;
     }
 
+    amrex::ParticleReal** warpx_getParticleArraysFromCompName (
+            int speciesnumber, const char* char_comp_name,
+            int lev, int* num_tiles, int** particles_per_tile ) {
+
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
+        auto & myspc = mypc.GetParticleContainer(speciesnumber);
+
+        const std::string comp_name(char_comp_name);
+        auto particle_comps = myspc.getParticleComps();
+        auto comp = particle_comps.at(comp_name);
+
+        return warpx_getParticleArrays(
+            speciesnumber, comp, lev, num_tiles, particles_per_tile
+        );
+    }
+
+    void warpx_addRealComp(const char* char_comp_name, bool comm=true)
+    {
+        const std::string comp_name(char_comp_name);
+        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        for (int ii = 0; ii < warpx_nSpecies(); ii++) {
+            auto & myspc = mypc.GetParticleContainer(ii);
+            myspc.AddRealComp(comp_name, comm);
+        }
+        mypc.defineAllParticleTiles();
+    }
+
     void warpx_ComputeDt () {
         WarpX& warpx = WarpX::GetInstance();
         warpx.ComputeDt ();

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -404,6 +404,29 @@ extern "C"
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
         auto & myspc = mypc.GetParticleContainer(speciesnumber);
 
+        return warpx_getParticleArraysUsingPC(
+            myspc, comp, lev, num_tiles, particles_per_tile
+        );
+    }
+
+    amrex::ParticleReal** warpx_getParticleArraysFromCompName (
+            const char* char_species_name, const char* char_comp_name,
+            int lev, int* num_tiles, int** particles_per_tile ) {
+
+        const auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
+
+        return warpx_getParticleArraysUsingPC(
+            myspc,
+            warpx_getParticleCompIndex(char_species_name, char_comp_name), lev,
+            num_tiles, particles_per_tile
+        );
+    }
+
+    amrex::ParticleReal** warpx_getParticleArraysUsingPC (
+            WarpXParticleContainer& myspc, int comp,
+            int lev, int* num_tiles, int** particles_per_tile ) {
         int i = 0;
         for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti, ++i) {}
 
@@ -421,25 +444,16 @@ extern "C"
         return data;
     }
 
-    amrex::ParticleReal** warpx_getParticleArraysFromCompName (
-            int speciesnumber, const char* char_comp_name,
-            int lev, int* num_tiles, int** particles_per_tile ) {
-
-        return warpx_getParticleArrays(
-            speciesnumber,
-            warpx_getParticleCompIndex(speciesnumber, char_comp_name), lev,
-            num_tiles, particles_per_tile
-        );
-    }
-
     int warpx_getParticleCompIndex (
-        int speciesnumber, const char* char_comp_name ) {
-
+         const char* char_species_name, const char* char_comp_name ) {
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
-        auto & myspc = mypc.GetParticleContainer(speciesnumber);
+
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
 
         const std::string comp_name(char_comp_name);
         auto particle_comps = myspc.getParticleComps();
+
         return particle_comps.at(comp_name);
     }
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -425,16 +425,22 @@ extern "C"
             int speciesnumber, const char* char_comp_name,
             int lev, int* num_tiles, int** particles_per_tile ) {
 
+        return warpx_getParticleArrays(
+            speciesnumber,
+            warpx_getParticleCompIndex(speciesnumber, char_comp_name), lev,
+            num_tiles, particles_per_tile
+        );
+    }
+
+    int warpx_getParticleCompIndex (
+        int speciesnumber, const char* char_comp_name ) {
+
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
         auto & myspc = mypc.GetParticleContainer(speciesnumber);
 
         const std::string comp_name(char_comp_name);
         auto particle_comps = myspc.getParticleComps();
-        auto comp = particle_comps.at(comp_name);
-
-        return warpx_getParticleArrays(
-            speciesnumber, comp, lev, num_tiles, particles_per_tile
-        );
+        return particle_comps.at(comp_name);
     }
 
     void warpx_addRealComp(const char* char_comp_name, bool comm=true)

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -445,7 +445,8 @@ extern "C"
     }
 
     int warpx_getParticleCompIndex (
-         const char* char_species_name, const char* char_comp_name ) {
+         const char* char_species_name, const char* char_comp_name )
+    {
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
 
         const std::string species_name(char_species_name);
@@ -457,14 +458,16 @@ extern "C"
         return particle_comps.at(comp_name);
     }
 
-    void warpx_addRealComp(const char* char_comp_name, bool comm=true)
+    void warpx_addRealComp(const char* char_species_name,
+        const char* char_comp_name, bool comm=true)
     {
-        const std::string comp_name(char_comp_name);
         auto & mypc = WarpX::GetInstance().GetPartContainer();
-        for (int ii = 0; ii < warpx_nSpecies(); ii++) {
-            auto & myspc = mypc.GetParticleContainer(ii);
-            myspc.AddRealComp(comp_name, comm);
-        }
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
+
+        const std::string comp_name(char_comp_name);
+        myspc.AddRealComp(comp_name, comm);
+
         mypc.defineAllParticleTiles();
     }
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -8,6 +8,7 @@
 #ifndef WARPX_WRAPPERS_H_
 #define WARPX_WRAPPERS_H_
 
+#include "Particles/WarpXParticleContainer.H"
 #include "Evolve/WarpXDtType.H"
 #include <AMReX_Config.H>
 #include <AMReX_REAL.H>
@@ -93,11 +94,15 @@ extern "C" {
                                                   int* num_tiles, int** particles_per_tile);
 
     amrex::ParticleReal** warpx_getParticleArraysFromCompName(
-        int speciesnumber, const char* char_comp_name, int lev,
+        const char* char_species_name, const char* char_comp_name, int lev,
         int* num_tiles, int** particles_per_tile);
 
+    amrex::ParticleReal** warpx_getParticleArraysUsingPC(
+        WarpXParticleContainer& myspc, int comp,
+        int lev, int* num_tiles, int** particles_per_tile);
+
     int warpx_getParticleCompIndex(
-        int speciesnumber, const char* char_comp_name);
+        const char* char_species_name, const char* char_comp_name);
 
     void warpx_addRealComp(const char* char_comp_name, bool comm);
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -104,7 +104,8 @@ extern "C" {
     int warpx_getParticleCompIndex(
         const char* char_species_name, const char* char_comp_name);
 
-    void warpx_addRealComp(const char* char_comp_name, bool comm);
+    void warpx_addRealComp(
+        const char* char_species_name, const char* char_comp_name, bool comm);
 
   void warpx_ComputeDt ();
   void warpx_MoveWindow (int step, bool move_j);

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -92,6 +92,12 @@ extern "C" {
     amrex::ParticleReal** warpx_getParticleArrays(int speciesnumber, int comp, int lev,
                                                   int* num_tiles, int** particles_per_tile);
 
+    amrex::ParticleReal** warpx_getParticleArraysFromCompName(
+        int speciesnumber, const char* char_comp_name, int lev,
+        int* num_tiles, int** particles_per_tile);
+
+    void warpx_addRealComp(const char* char_comp_name, bool comm);
+
   void warpx_ComputeDt ();
   void warpx_MoveWindow (int step, bool move_j);
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -96,6 +96,9 @@ extern "C" {
         int speciesnumber, const char* char_comp_name, int lev,
         int* num_tiles, int** particles_per_tile);
 
+    int warpx_getParticleCompIndex(
+        int speciesnumber, const char* char_comp_name);
+
     void warpx_addRealComp(const char* char_comp_name, bool comm);
 
   void warpx_ComputeDt ();


### PR DESCRIPTION
A wrapper has been added for the `AddRealComp` function used to add particle attributes at runtime (addresses issue #1902).

Also a function `warpx_getParticleArraysFromCompName` has been added to grab particle array data using the component name as a string instead of the index of the array. This is convenient in order to avoid passing incorrect indices when grabbing particle data. The old functionality has been preserved but if desired we can remove `warpx_getParticleArrays` and only keep the new function that uses the component names. This would require further (but simple) changes to `_libwarpx.py`'s functions such as `get_particle_weight`, `get_particle_ux`, etc.