### PR TITLE
Assert that the NCI corrector is used with Esirkepov only

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -382,6 +382,12 @@ WarpX::WarpX ()
         AMREX_ALWAYS_ASSERT(use_fdtd_nci_corr == 0);
         AMREX_ALWAYS_ASSERT(do_subcycling == 0);
     }
+
+    if (WarpX::current_deposition_algo != CurrentDepositionAlgo::Esirkepov) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            use_fdtd_nci_corr == 0,
+            "The NCI corrector should only be used with Esirkepov deposition");
+    }
 }
 
 WarpX::~WarpX ()


### PR DESCRIPTION
This is just a suggestion: the FDTD NCI corrector is implemented for Esirkepov deposition only, so this PR proposes to assert that this is used properly.