### PR TITLE
ChecksumAPI: yt 4+ ds.force_periodicity()

### DIFF
--- a/Examples/Modules/dive_cleaning/analysis.py
+++ b/Examples/Modules/dive_cleaning/analysis.py
@@ -34,7 +34,7 @@ ds = yt.load( filename )
 # yt 4.0+ has rounding issues with our domain data:
 # RuntimeError: yt attempted to read outside the boundaries
 #               of a non-periodic domain along dimension 0.
-ds.force_periodicity()
+if 'force_periodicity' in dir(ds): ds.force_periodicity()
 
 # Extract data
 ad0 = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)

--- a/Examples/Modules/dive_cleaning/analysis.py
+++ b/Examples/Modules/dive_cleaning/analysis.py
@@ -31,17 +31,22 @@ r0 = 2.e-6
 # Open data file
 filename = sys.argv[1]
 ds = yt.load( filename )
+# yt 4.0+ has rounding issues with our domain data:
+# RuntimeError: yt attempted to read outside the boundaries
+#               of a non-periodic domain along dimension 0.
+ds.force_periodicity()
+
 # Extract data
 ad0 = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
-Ex_array = ad0['Ex'].to_ndarray().squeeze()
+Ex_array = ad0[("mesh", "Ex")].to_ndarray().squeeze()
 if ds.dimensionality == 2:
     # Rename the z dimension as y, so as to make this script work for 2d and 3d
-    Ey_array = ad0['Ez'].to_ndarray().squeeze()
+    Ey_array = ad0[("mesh", "Ez")].to_ndarray().squeeze()
     E_array = ( Ex_array**2 + Ey_array**2 )**.5
     relative_tolerance = 0.1
 elif ds.dimensionality == 3:
-    Ey_array = ad0['Ey'].to_ndarray()
-    Ez_array = ad0['Ez'].to_ndarray()
+    Ey_array = ad0[("mesh", "Ey")].to_ndarray()
+    Ez_array = ad0[("mesh", "Ez")].to_ndarray()
     E_array = ( Ex_array**2 + Ey_array**2 + Ez_array**2 )**.5
     relative_tolerance = 0.15
 

--- a/Examples/Modules/laser_injection/analysis_2d.py
+++ b/Examples/Modules/laser_injection/analysis_2d.py
@@ -150,6 +150,11 @@ def check_component(data, component, t_env_theory, coeff, X,Z,dx,dz):
 def check_laser(filename):
     ds = yt.load(filename)
 
+    # yt 4.0+ has rounding issues with our domain data:
+    # RuntimeError: yt attempted to read outside the boundaries
+    # of a non-periodic domain along dimension 0.
+    ds.force_periodicity()
+
     x = np.linspace(
         ds.domain_left_edge[0].v,
         ds.domain_right_edge[0].v,

--- a/Examples/Modules/laser_injection/analysis_2d.py
+++ b/Examples/Modules/laser_injection/analysis_2d.py
@@ -153,7 +153,7 @@ def check_laser(filename):
     # yt 4.0+ has rounding issues with our domain data:
     # RuntimeError: yt attempted to read outside the boundaries
     # of a non-periodic domain along dimension 0.
-    ds.force_periodicity()
+    if 'force_periodicity' in dir(ds): ds.force_periodicity()
 
     x = np.linspace(
         ds.domain_left_edge[0].v,

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -33,7 +33,7 @@ ds = yt.load( filename )
 # yt 4.0+ has rounding issues with our domain data:
 # RuntimeError: yt attempted to read outside the boundaries
 #               of a non-periodic domain along dimension 0.
-ds.force_periodicity()
+if 'force_periodicity' in dir(ds): ds.force_periodicity()
 
 # Extract data
 ad0 = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -30,15 +30,20 @@ r0 = 2.e-6
 # Open data file
 filename = sys.argv[1]
 ds = yt.load( filename )
+# yt 4.0+ has rounding issues with our domain data:
+# RuntimeError: yt attempted to read outside the boundaries
+#               of a non-periodic domain along dimension 0.
+ds.force_periodicity()
+
 # Extract data
 ad0 = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
-Ex_array = ad0['Ex'].to_ndarray().squeeze()
+Ex_array = ad0[("mesh", "Ex")].to_ndarray().squeeze()
 if ds.dimensionality == 2:
     # Rename the z dimension as y, so as to make this script work for 2d and 3d
-    Ey_array = ad0['Ez'].to_ndarray().squeeze()
+    Ey_array = ad0[("mesh", "Ez")].to_ndarray().squeeze()
 elif ds.dimensionality == 3:
-    Ey_array = ad0['Ey'].to_ndarray()
-    Ez_array = ad0['Ez'].to_ndarray()
+    Ey_array = ad0[("mesh", "Ey")].to_ndarray()
+    Ez_array = ad0[("mesh", "Ez")].to_ndarray()
 
 # Extract grid coordinates
 Nx, Ny, Nz =  ds.domain_dimensions

--- a/Examples/Tests/galilean/analysis_2d.py
+++ b/Examples/Tests/galilean/analysis_2d.py
@@ -31,6 +31,11 @@ dims_RZ  = True if re.search('rz', filename) else False
 
 ds = yt.load( filename )
 
+# yt 4.0+ has rounding issues with our domain data:
+# RuntimeError: yt attempted to read outside the boundaries
+# of a non-periodic domain along dimension 0.
+ds.force_periodicity()
+
 all_data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
 Ex = all_data['boxlib', 'Ex'].squeeze().v
 Ey = all_data['boxlib', 'Ey'].squeeze().v

--- a/Examples/Tests/galilean/analysis_2d.py
+++ b/Examples/Tests/galilean/analysis_2d.py
@@ -34,7 +34,7 @@ ds = yt.load( filename )
 # yt 4.0+ has rounding issues with our domain data:
 # RuntimeError: yt attempted to read outside the boundaries
 # of a non-periodic domain along dimension 0.
-ds.force_periodicity()
+if 'force_periodicity' in dir(ds): ds.force_periodicity()
 
 all_data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
 Ex = all_data['boxlib', 'Ex'].squeeze().v

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -49,6 +49,10 @@ class Checksum:
         '''
 
         ds = yt.load(self.plotfile)
+        # yt 4.0+ has rounding issues with our domain data:
+        # RuntimeError: yt attempted to read outside the boundaries
+        # of a non-periodic domain along dimension 0.
+        ds.force_periodicity()
         grid_fields = [item for item in ds.field_list if item[0] == 'boxlib']
         species_list = set([item[0] for item in ds.field_list if
                             item[1][:9] == 'particle_' and item[0] != 'all' and

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -52,7 +52,7 @@ class Checksum:
         # yt 4.0+ has rounding issues with our domain data:
         # RuntimeError: yt attempted to read outside the boundaries
         # of a non-periodic domain along dimension 0.
-        ds.force_periodicity()
+        if 'force_periodicity' in dir(ds): ds.force_periodicity()
         grid_fields = [item for item in ds.field_list if item[0] == 'boxlib']
         species_list = set([item[0] for item in ds.field_list if
                             item[1][:9] == 'particle_' and item[0] != 'all' and


### PR DESCRIPTION
Mitigate issues of the form
```
RuntimeError: yt attempted to read outside the boundaries of a non-periodic domain along dimension 0.
Region left edge = -7.5e-06 code_length, Region right edge = 7.500000000000002e-06 code_length
Dataset left edge = -7.5e-06 code_length, Dataset right edge = 7.5e-06 code_length

This commonly happens when trying to compute ghost cells up to the domain boundary. Two possible solutions are to select a smaller region that does not border domain edge (see https://yt-project.org/docs/analyzing/objects.html?highlight=region)
or override the periodicity with
ds.force_periodicity()
```

in yt 4.0+ without loosing compatibility to yt 3.

Moved out from #2066