### PR TITLE
Use only species name in libwarpx

### DIFF
--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -220,13 +220,16 @@ extern "C"
         warpx.Evolve(numsteps);
     }
 
-    void warpx_addNParticles(int speciesnumber, int lenx,
-                             amrex::ParticleReal const * x, amrex::ParticleReal const * y, amrex::ParticleReal const * z,
-                             amrex::ParticleReal const * vx, amrex::ParticleReal const * vy, amrex::ParticleReal const * vz,
-                             int nattr, amrex::ParticleReal const * attr, int uniqueparticles)
+    void warpx_addNParticles(
+        const char* char_species_name, int lenx, amrex::ParticleReal const * x,
+        amrex::ParticleReal const * y, amrex::ParticleReal const * z,
+        amrex::ParticleReal const * vx, amrex::ParticleReal const * vy,
+        amrex::ParticleReal const * vz, int nattr,
+        amrex::ParticleReal const * attr, int uniqueparticles)
     {
         auto & mypc = WarpX::GetInstance().GetPartContainer();
-        auto & myspc = mypc.GetParticleContainer(speciesnumber);
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
         const int lev = 0;
         myspc.AddNParticles(lev, lenx, x, y, z, vx, vy, vz, nattr, attr, uniqueparticles);
     }
@@ -265,9 +268,10 @@ extern "C"
         return dx[dir];
     }
 
-    long warpx_getNumParticles(int speciesnumber) {
+    long warpx_getNumParticles(const char* char_species_name) {
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
-        const auto & myspc = mypc.GetParticleContainer(speciesnumber);
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
         return myspc.TotalNumberOfParticles();
     }
 
@@ -377,10 +381,12 @@ extern "C"
     WARPX_GET_LOVECTS_PML(warpx_getCurrentDensityCPLoVects_PML, Getj_cp)
     WARPX_GET_LOVECTS_PML(warpx_getCurrentDensityFPLoVects_PML, Getj_fp)
 
-    amrex::ParticleReal** warpx_getParticleStructs(int speciesnumber, int lev,
-                                      int* num_tiles, int** particles_per_tile) {
+    amrex::ParticleReal** warpx_getParticleStructs(
+            const char* char_species_name, int lev,
+            int* num_tiles, int** particles_per_tile) {
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
-        auto & myspc = mypc.GetParticleContainer(speciesnumber);
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
 
         int i = 0;
         for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti, ++i) {}
@@ -399,17 +405,7 @@ extern "C"
         return data;
     }
 
-    amrex::ParticleReal** warpx_getParticleArrays(int speciesnumber, int comp, int lev,
-                                     int* num_tiles, int** particles_per_tile) {
-        const auto & mypc = WarpX::GetInstance().GetPartContainer();
-        auto & myspc = mypc.GetParticleContainer(speciesnumber);
-
-        return warpx_getParticleArraysUsingPC(
-            myspc, comp, lev, num_tiles, particles_per_tile
-        );
-    }
-
-    amrex::ParticleReal** warpx_getParticleArraysFromCompName (
+    amrex::ParticleReal** warpx_getParticleArrays (
             const char* char_species_name, const char* char_comp_name,
             int lev, int* num_tiles, int** particles_per_tile ) {
 
@@ -417,16 +413,8 @@ extern "C"
         const std::string species_name(char_species_name);
         auto & myspc = mypc.GetParticleContainerFromName(species_name);
 
-        return warpx_getParticleArraysUsingPC(
-            myspc,
-            warpx_getParticleCompIndex(char_species_name, char_comp_name), lev,
-            num_tiles, particles_per_tile
-        );
-    }
+        int comp = warpx_getParticleCompIndex(char_species_name, char_comp_name);
 
-    amrex::ParticleReal** warpx_getParticleArraysUsingPC (
-            WarpXParticleContainer& myspc, int comp,
-            int lev, int* num_tiles, int** particles_per_tile ) {
         int i = 0;
         for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti, ++i) {}
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -95,10 +95,6 @@ extern "C" {
         const char* char_species_name, const char* char_comp_name, int lev,
         int* num_tiles, int** particles_per_tile);
 
-    amrex::ParticleReal** warpx_getParticleArraysUsingPC(
-        WarpXParticleContainer& myspc, int comp,
-        int lev, int* num_tiles, int** particles_per_tile);
-
     int warpx_getParticleCompIndex(
         const char* char_species_name, const char* char_comp_name);
 

--- a/Source/Python/WarpXWrappers.h
+++ b/Source/Python/WarpXWrappers.h
@@ -63,7 +63,7 @@ extern "C" {
 
     void warpx_evolve (int numsteps);  // -1 means the inputs parameter will be used.
 
-    void warpx_addNParticles(int speciesnumber,
+    void warpx_addNParticles(const char* char_species_name,
                              int lenx,
                              amrex::ParticleReal const * x,
                              amrex::ParticleReal const * y,
@@ -85,15 +85,13 @@ extern "C" {
 
     amrex::Real warpx_getProbHi(int dir);
 
-    long warpx_getNumParticles(int speciesnumber);
+    long warpx_getNumParticles(const char* char_species_name);
 
-    amrex::ParticleReal** warpx_getParticleStructs(int speciesnumber, int lev,
-                                                   int* num_tiles, int** particles_per_tile);
+    amrex::ParticleReal** warpx_getParticleStructs(
+        const char* char_species_name, int lev, int* num_tiles,
+        int** particles_per_tile);
 
-    amrex::ParticleReal** warpx_getParticleArrays(int speciesnumber, int comp, int lev,
-                                                  int* num_tiles, int** particles_per_tile);
-
-    amrex::ParticleReal** warpx_getParticleArraysFromCompName(
+    amrex::ParticleReal** warpx_getParticleArrays(
         const char* char_species_name, const char* char_comp_name, int lev,
         int* num_tiles, int** particles_per_tile);
 


### PR DESCRIPTION
The libwarpx functions that interact with particle data has been changed to take the species name as input parameter rather than the species ID.
This is a follow-up to PR #2112 and should be merged before PR #2115.