### PR TITLE
[WIP] CI: Test hipcc

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,7 +19,7 @@ jobs:
         hipcc --version
         which clang
         which clang++
-        export CXX=$(which clang++)
+        export CXX=$(which hipcc)
         export CC=$(which clang)
 
         cmake -S . -B build_sp \


### PR DESCRIPTION
*Do not merge.*

Investigate if the `std=c++17` flags are truly not forwarded from AMReX for `hipcc` as compiler.