### PR TITLE
Embedded Boundaries not Implemented in RZ

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -77,6 +77,10 @@ WarpX::InitEB ()
 #ifdef AMREX_USE_EB
     BL_PROFILE("InitEB");
 
+#ifdef WARPX_DIM_RZ
+    amrex::Abort("Embedded Boundaries not implemented in RZ geometry");
+#endif
+
     amrex::ParmParse pp_warpx("warpx");
     std::string impf;
     pp_warpx.query("eb_implicit_function", impf);


### PR DESCRIPTION
Fix #2099. This location for the abort message seemed appropriate to me, please feel free to suggest other locations, if necessary.