### PR TITLE
Generalize the way we handle runtime components when writing diagnostics

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -333,7 +333,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // get the names of the real comps
         real_names.resize(pc->NumRealComps());
         auto runtime_rnames = pc->getParticleRuntimeComps();
-        for (auto const& x : runtime_rnames) { real_names[x.second] = x.first; }
+        for (auto const& x : runtime_rnames) { real_names[x.second+PIdx::nattribs] = x.first; }
 
         // plot any "extra" fields by default
         real_flags = particle_diags[i].plot_flags;
@@ -345,7 +345,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // and the names
         int_names.resize(pc->NumIntComps());
         auto runtime_inames = pc->getParticleRuntimeiComps();
-        for (auto const& x : runtime_inames) { int_names[x.second] = x.first; }
+        for (auto const& x : runtime_inames) { int_names[x.second+0] = x.first; }
 
         // plot by default
         int_flags.resize(pc->NumIntComps(), 1);

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -315,6 +315,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         Vector<std::string> real_names;
         Vector<std::string> int_names;
         Vector<int> int_flags;
+        Vector<int> real_flags;
 
         real_names.push_back("weight");
 
@@ -326,26 +327,28 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         real_names.push_back("theta");
 #endif
 
-        if(pc->DoFieldIonization()){
-            int_names.push_back("ionization_level");
-            // int_flags specifies, for each integer attribs, whether it is
-            // dumped to plotfiles. So far, ionization_level is the only
-            // integer attribs, and it is automatically dumped to plotfiles
-            // when ionization is on.
-            int_flags.resize(1, 1);
-            tmp.AddIntComp(false);
-        }
+        // add runtime real comps to tmp
+        for (int ic = 0; ic < pc->NumRuntimeRealComps(); ++ic) { tmp.AddRealComp(false); }
 
-#ifdef WARPX_QED
-        if( pc->has_breit_wheeler() ) {
-            real_names.push_back("optical_depth_BW");
-            tmp.AddRealComp(false);
-        }
-        if( pc->has_quantum_sync() ) {
-            real_names.push_back("optical_depth_QSR");
-            tmp.AddRealComp(false);
-        }
-#endif
+        // get the names of the real comps
+        real_names.resize(pc->NumRealComps());
+        auto runtime_rnames = pc->getParticleRuntimeComps();
+        for (auto const& x : runtime_rnames) { real_names[x.second] = x.first; }
+
+        // plot any "extra" fields by default
+        real_flags = particle_diags[i].plot_flags;
+        real_flags.resize(pc->NumRealComps(), 1);
+
+        // add runtime int comps to tmp
+        for (int ic = 0; ic < pc->NumRuntimeIntComps(); ++ic) { tmp.AddIntComp(false); }
+
+        // and the names
+        int_names.resize(pc->NumIntComps());
+        auto runtime_inames = pc->getParticleRuntimeiComps();
+        for (auto const& x : runtime_inames) { int_names[x.second] = x.first; }
+
+        // plot by default
+        int_flags.resize(pc->NumIntComps(), 1);
 
         pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -377,7 +377,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
             dir, particle_diags[i].getSpeciesName(),
-            particle_diags[i].plot_flags, int_flags,
+            real_flags, int_flags,
             real_names, int_names);
 
         pc->ConvertUnits(ConvertDirection::SI_to_WarpX);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -488,7 +488,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
       DumpToFile(&tmp,
          particle_diags[i].getSpeciesName(),
          m_CurrentStep,
-         particle_diags[i].plot_flags,
+         real_flags,
          int_flags,
          real_names, int_names,
          pc->getCharge(), pc->getMass()

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -441,7 +441,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     // get the names of the real comps
     real_names.resize(pc->NumRealComps());
     auto runtime_rnames = pc->getParticleRuntimeComps();
-    for (auto const& x : runtime_rnames) { real_names[x.second] = x.first; }
+    for (auto const& x : runtime_rnames) { real_names[x.second+PIdx::nattribs] = x.first; }
 
     // plot any "extra" fields by default
     real_flags = particle_diags[i].plot_flags;
@@ -453,7 +453,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     // and the names
     int_names.resize(pc->NumIntComps());
     auto runtime_inames = pc->getParticleRuntimeiComps();
-    for (auto const& x : runtime_inames) { int_names[x.second] = x.first; }
+    for (auto const& x : runtime_inames) { int_names[x.second+0] = x.first; }
 
     // plot by default
     int_flags.resize(pc->NumIntComps(), 1);
@@ -482,7 +482,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
       }, true);
 
     // real_names contains a list of all real particle attributes.
-    // particle_diags[i].plot_flags is 1 or 0, whether quantity is dumped or not.
+    // real_flags is 1 or 0, whether quantity is dumped or not.
 
     {
       DumpToFile(&tmp,

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -433,26 +433,29 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
 #ifdef WARPX_DIM_RZ
     real_names.push_back("theta");
 #endif
-    if(pc->DoFieldIonization()){
-       int_names.push_back("ionizationLevel");
-       // int_flags specifies, for each integer attribs, whether it is
-       // dumped as particle record in a plotfile. So far, ionization_level is the only
-       // integer attribs, and it is automatically dumped as particle record
-       // when ionization is on.
-       int_flags.resize(1, 1);
-       tmp.AddIntComp(false);
-    }
 
-#ifdef WARPX_QED
-    if( pc->has_breit_wheeler() ) {
-        real_names.push_back("opticalDepthBW");
-        tmp.AddRealComp(false);
-    }
-    if( pc->has_quantum_sync() ) {
-        real_names.push_back("opticalDepthQSR");
-        tmp.AddRealComp(false);
-    }
-#endif
+    // add runtime real comps to tmp
+    for (int ic = 0; ic < pc->NumRuntimeRealComps(); ++ic) { tmp.AddRealComp(false); }
+
+    // get the names of the real comps
+    real_names.resize(pc->NumRealComps());
+    auto runtime_rnames = pc->getParticleRuntimeComps();
+    for (auto const& x : runtime_rnames) { real_names[x.second] = x.first; }
+
+    // plot any "extra" fields by default
+    real_flags = particle_diags[i].plot_flags;
+    real_flags.resize(pc->NumRealComps(), 1);
+
+    // add runtime int comps to tmp
+    for (int ic = 0; ic < pc->NumRuntimeIntComps(); ++ic) { tmp.AddIntComp(false); }
+
+    // and the names
+    int_names.resize(pc->NumIntComps());
+    auto runtime_inames = pc->getParticleRuntimeiComps();
+    for (auto const& x : runtime_inames) { int_names[x.second] = x.first; }
+
+    // plot by default
+    int_flags.resize(pc->NumIntComps(), 1);
 
       pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -420,6 +420,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     amrex::Vector<std::string> real_names;
     amrex::Vector<std::string> int_names;
     amrex::Vector<int> int_flags;
+    amrex::Vector<int> real_flags;
 
     // see openPMD ED-PIC extension for namings
     // note: an underscore separates the record name from its component


### PR DESCRIPTION
Right now, there is some hard coding about what comps to expect based on whether we are running with QED, ionization, etc...

This changes this to just ask the source `pc` what components and names to use.