### PR TITLE
Fix: CUDA C++17 Builds (ParticleBins)

### DIFF
--- a/Source/Utils/ParticleUtils.cpp
+++ b/Source/Utils/ParticleUtils.cpp
@@ -53,7 +53,7 @@ namespace ParticleUtils {
         ParticleBins bins;
         bins.build(np, particle_ptr, cbx,
             // Pass lambda function that returns the cell index
-            [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) noexcept -> IntVect
+            [=] AMREX_GPU_DEVICE (const ParticleType& p) noexcept -> IntVect
             {
                 return IntVect(AMREX_D_DECL(
                                    static_cast<int>((p.pos(0)-plo[0])*dxi[0] - lo.x),


### PR DESCRIPTION
Seen with CUDA 11.2.0 in C++17 build:
```
nvcc_internal_extended_lambda_implementation: In instantiation of ‘struct __nv_hdl_helper_trait_outer<false, false, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_helper_trait<__nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>, amrex::IntVect (ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)::<lambda(const ParticleType&)>::*)(const amrex::Particle<0, 0>&) const noexcept>’:
nvcc_internal_extended_lambda_implementation:677:8:   required from ‘struct __nv_hdl_helper_trait_outer<false, false, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_helper_trait<__nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>, ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)::<lambda(const ParticleType&)> >’
nvcc_internal_extended_lambda_implementation:696:204:   required by substitution of ‘template<class Lambda> static decltype (__nv_hdl_helper_trait_outer<false, false, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_helper_trait<__nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>, Lambda>::get(lam, args#0, args#1, args#2)) __nv_hdl_create_wrapper_t<false, false, __nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_create_wrapper<Lambda>(Lambda&&, amrex::GpuArray<double, 3>, amrex::GpuArray<double, 3>, amrex::Dim3) [with Lambda = ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)::<lambda(const ParticleType&)>]’
/home/axel/src/warpx/Source/Utils/ParticleUtils.cpp:62:17:   required from here
nvcc_internal_extended_lambda_implementation:677:77: error: ‘operator()’ is not a member of ‘amrex::IntVect (ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)::<lambda(const ParticleType&)>::*)(const amrex::Particle<0, 0>&) const noexcept’
/home/axel/src/warpx/Source/Utils/ParticleUtils.cpp: In function ‘ParticleUtils::ParticleBins ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)’:
/home/axel/src/warpx/Source/Utils/ParticleUtils.cpp:62:17: error: no matching function for call to ‘__nv_hdl_create_wrapper_t<false, false, __nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_create_wrapper(ParticleUtils::findParticlesInEachCell(int, const amrex::MFIter&, const ParticleTileType&)::<lambda(const ParticleType&)>, const amrex::GpuArray<double, 3>&, const amrex::GpuArray<double, 3>&, const amrex::Dim3&)’
   62 |             });
      |                 ^
nvcc_internal_extended_lambda_implementation:696:13: note: candidate: ‘template<class Lambda> static decltype (typename __nv_hdl_helper_trait_outer<IsMutable, HasFuncPtrConv, CaptureArgs ...>::__nv_hdl_helper_trait<Tag, Lambda>::get(lam, __nv_hdl_create_wrapper_t::__nv_hdl_create_wrapper::args ...)) __nv_hdl_create_wrapper_t<IsMutable, HasFuncPtrConv, Tag, CaptureArgs>::__nv_hdl_create_wrapper(Lambda&&, CaptureArgs ...) [with Lambda = Lambda; bool IsMutable = false; bool HasFuncPtrConv = false; Tag = __nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, const amrex::MFIter&, const amrex::ParticleTile<0, 0, 4, 0, amrex::ArenaAllocator>&), ParticleUtils::findParticlesInEachCell, 1>; CaptureArgs = {const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3}]’
nvcc_internal_extended_lambda_implementation:696:13: note:   substitution of deduced template arguments resulted in errors seen above
```

Since this lambda is only needed on device, we can relax the qualifier.