### PR TITLE
Docs: Update JSC Juwels-Booster

### DIFF
--- a/Docs/source/install/hpc/juwels.rst
+++ b/Docs/source/install/hpc/juwels.rst
@@ -40,7 +40,7 @@ We use the following modules and environments on the system.
    module load ccache
    module load CMake
    module load GCC
-   module load CUDA
+   module load CUDA/11.3
    module load OpenMPI
    module load FFTW
    module load HDF5

--- a/Tools/BatchScripts/batch_juwels.sh
+++ b/Tools/BatchScripts/batch_juwels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #SBATCH -A $proj
-#SBATCH --partition=gpus
+#SBATCH --partition=booster
 #SBATCH --nodes=2
 #SBATCH --ntasks=8
 #SBATCH --ntasks-per-node=4
@@ -14,9 +14,11 @@
 export OMP_NUM_THREADS=1
 export OMPI_MCA_io=romio321  # for HDF5 support in openPMD
 
+# you can comment this out if you sourced the warpx.profile
+# files before running sbatch:
 module load GCC
 module load OpenMPI
-module load CUDA
+module load CUDA/11.3
 module load HDF5
 module load Python
 


### PR DESCRIPTION
Update CUDA from 11.0 (default) to 11.3 .
(We already upgrade in our system documentation survey to anticipate switching to C++17 soonish.)