### PR TITLE
Ascent: Fixing shadowing issue

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -76,11 +76,11 @@ FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_di
 
         // WarpXParticleContainer compile-time extra SoA attributes (Real): PIdx::nattribs
         // not an efficient search, but N is small...
-        for(int i = 0; i < PIdx::nattribs; ++i)
+        for(int j = 0; j < PIdx::nattribs; ++j)
         {
             auto rvn_it = real_comps_map.begin();
             for (; rvn_it != real_comps_map.end(); ++rvn_it)
-                if (rvn_it->second == i)
+                if (rvn_it->second == j)
                     break;
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 rvn_it != real_comps_map.end(),


### PR DESCRIPTION
This PR fixes the following issue:
```
./Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp: In member function ‘void FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>&, conduit::Node&) const’:
./Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp:79:17: warning: declaration of ‘i’ shadows a previous local [-Wshadow]
   79 |         for(int i = 0; i < PIdx::nattribs; ++i)
      |                 ^
./Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp:62:19: note: shadowed declaration is here
   62 |     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
      |                   ^

```