### PR TITLE
No particle resorting when no species

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -856,6 +856,7 @@ WarpX::ReadParameters ()
         std::vector<std::string> lasers_names;
         pp_lasers.queryarr("names", lasers_names);
 
+        std::vector<std::string> sort_intervals_string_vec = {"-1"};
         if (!species_names.empty() || !lasers_names.empty()) {
             int particle_shape;
             if (queryWithParser(pp_algo, "particle_shape", particle_shape) == false)
@@ -886,14 +887,12 @@ WarpX::ReadParameters ()
 
             // default sort interval for particles if species or lasers vector is not empty
 #ifdef AMREX_USE_GPU
-            std::vector<std::string>sort_intervals_string_vec = {"4"};
+            sort_intervals_string_vec = {"4"};
 #else
-            std::vector<std::string> sort_intervals_string_vec = {"-1"};
+            sort_intervals_string_vec = {"-1"};
 #endif
-        } else {
-            // default sort interval for particles is -1 if species/laser vector is empty
-            std::vector<std::string>sort_intervals_string_vec = {"-1"};
         }
+
         amrex::ParmParse pp_warpx("warpx");
         pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
         sort_intervals = IntervalsParser(sort_intervals_string_vec);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -894,6 +894,7 @@ WarpX::ReadParameters ()
             // default sort interval for particles is -1 if species/laser vector is empty
             std::vector<std::string>sort_intervals_string_vec = {"-1"};
         }
+        amrex::ParmParse pp_warpx("warpx");
         pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
         sort_intervals = IntervalsParser(sort_intervals_string_vec);
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -883,8 +883,8 @@ WarpX::ReadParameters ()
                                " some numerical artifact will be present at the interface between coarse and fine patch."
                                "\nWe recommend setting algo.particle_shape = 1 in order to avoid this issue");
             }
-            
-            // default sort interval for particles if species or lasers vector is not empty 
+
+            // default sort interval for particles if species or lasers vector is not empty
 #ifdef AMREX_USE_GPU
             std::vector<std::string>sort_intervals_string_vec = {"4"};
 #else

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -627,22 +627,8 @@ WarpX::ReadParameters ()
         pp_warpx.query("refine_plasma", refine_plasma);
         pp_warpx.query("do_dive_cleaning", do_dive_cleaning);
         pp_warpx.query("do_divb_cleaning", do_divb_cleaning);
-        queryWithParser(pp_warpx, "n_field_gather_buffer", n_field_gather_buffer);
-        queryWithParser(pp_warpx, "n_current_deposition_buffer", n_current_deposition_buffer);
-#ifdef AMREX_USE_GPU
-        std::vector<std::string>sort_intervals_string_vec = {"4"};
-#else
-        std::vector<std::string> sort_intervals_string_vec = {"-1"};
-#endif
-        pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
-        sort_intervals = IntervalsParser(sort_intervals_string_vec);
-
-        Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
-        bool sort_bin_size_is_specified = queryArrWithParser(pp_warpx, "sort_bin_size", vect_sort_bin_size, 0, AMREX_SPACEDIM);
-        if (sort_bin_size_is_specified){
-            for (int i=0; i<AMREX_SPACEDIM; i++)
-                sort_bin_size[i] = vect_sort_bin_size[i];
-        }
+        pp_warpx.query("n_field_gather_buffer", n_field_gather_buffer);
+        pp_warpx.query("n_current_deposition_buffer", n_current_deposition_buffer);
 
         amrex::Real quantum_xi_tmp;
         int quantum_xi_is_specified = queryWithParser(pp_warpx, "quantum_xi", quantum_xi_tmp);
@@ -897,6 +883,25 @@ WarpX::ReadParameters ()
                                " some numerical artifact will be present at the interface between coarse and fine patch."
                                "\nWe recommend setting algo.particle_shape = 1 in order to avoid this issue");
             }
+            
+            // default sort interval for particles if species or lasers vector is not empty 
+#ifdef AMREX_USE_GPU
+            std::vector<std::string>sort_intervals_string_vec = {"4"};
+#else
+            std::vector<std::string> sort_intervals_string_vec = {"-1"};
+#endif
+        } else {
+            // default sort interval for particles is -1 if species/laser vector is empty
+            std::vector<std::string>sort_intervals_string_vec = {"-1"};
+        }
+        pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
+        sort_intervals = IntervalsParser(sort_intervals_string_vec);
+
+        Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
+        bool sort_bin_size_is_specified = pp_warpx.queryarr("sort_bin_size", vect_sort_bin_size);
+        if (sort_bin_size_is_specified){
+            for (int i=0; i<AMREX_SPACEDIM; i++)
+                sort_bin_size[i] = vect_sort_bin_size[i];
         }
     }
 


### PR DESCRIPTION
This PR sets the default particle sort interval to -1 for simulations that dont involve particles.
