### PR TITLE
BinaryCollision: use more general particle data structure

### DIFF
--- a/Source/Particles/Collision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision.H
@@ -10,6 +10,7 @@
 #include "Particles/Collision/CollisionBase.H"
 #include "Particles/Collision/PairWiseCoulombCollisionFunc.H"
 #include "Particles/Collision/ShuffleFisherYates.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/ParticleUtils.H"
@@ -36,9 +37,9 @@
 #include <AMReX_PODVector.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Particles.H>
+#include <AMReX_ParticleTile.H>
 #include <AMReX_Random.H>
 #include <AMReX_REAL.H>
-#include <AMReX_StructOfArrays.H>
 #include <AMReX_Utility.H>
 #include <AMReX_Vector.H>
 
@@ -164,19 +165,13 @@ public:
             // Extract low-level data
             int const n_cells = bins_1.numBins();
             // - Species 1
-            auto& soa_1 = ptile_1.GetStructOfArrays();
-            amrex::ParticleReal * const AMREX_RESTRICT ux_1 =
-                soa_1.GetRealData(PIdx::ux).data();
-            amrex::ParticleReal * const AMREX_RESTRICT uy_1 =
-                soa_1.GetRealData(PIdx::uy).data();
-            amrex::ParticleReal * const AMREX_RESTRICT uz_1  =
-                soa_1.GetRealData(PIdx::uz).data();
-            amrex::ParticleReal const * const AMREX_RESTRICT w_1 =
-                soa_1.GetRealData(PIdx::w).data();
+            const auto soa_1 = ptile_1.getParticleTileData();
             index_type* indices_1 = bins_1.permutationPtr();
             index_type const* cell_offsets_1 = bins_1.offsetsPtr();
             amrex::Real q1 = species_1.getCharge();
             amrex::Real m1 = species_1.getMass();
+            constexpr int getpos_offset = 0;
+            auto get_position_1  = GetParticlePosition(ptile_1, getpos_offset);
 
             const amrex::Real dt = WarpX::GetInstance().getdt(lev);
             amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
@@ -218,7 +213,7 @@ public:
                         cell_start_1, cell_half_1,
                         cell_half_1, cell_stop_1,
                         indices_1, indices_1,
-                        ux_1, uy_1, uz_1, ux_1, uy_1, uz_1, w_1, w_1,
+                        soa_1, soa_1, get_position_1, get_position_1,
                         q1, q1, m1, m1, dt*ndt, dV, engine );
                 }
             );
@@ -238,29 +233,20 @@ public:
             // Extract low-level data
             int const n_cells = bins_1.numBins();
             // - Species 1
-            auto& soa_1 = ptile_1.GetStructOfArrays();
-            amrex::ParticleReal * const AMREX_RESTRICT ux_1 =
-                soa_1.GetRealData(PIdx::ux).data();
-            amrex::ParticleReal * const AMREX_RESTRICT uy_1 =
-                soa_1.GetRealData(PIdx::uy).data();
-            amrex::ParticleReal * const AMREX_RESTRICT uz_1 =
-                soa_1.GetRealData(PIdx::uz).data();
-            amrex::ParticleReal const * const AMREX_RESTRICT w_1 =
-                soa_1.GetRealData(PIdx::w).data();
+            const auto soa_1 = ptile_1.getParticleTileData();
             index_type* indices_1 = bins_1.permutationPtr();
             index_type const* cell_offsets_1 = bins_1.offsetsPtr();
             amrex::Real q1 = species_1.getCharge();
             amrex::Real m1 = species_1.getMass();
+            constexpr int getpos_offset = 0;
+            auto get_position_1  = GetParticlePosition(ptile_1, getpos_offset);
             // - Species 2
-            auto& soa_2 = ptile_2.GetStructOfArrays();
-            amrex::Real* ux_2  = soa_2.GetRealData(PIdx::ux).data();
-            amrex::Real* uy_2  = soa_2.GetRealData(PIdx::uy).data();
-            amrex::Real* uz_2  = soa_2.GetRealData(PIdx::uz).data();
-            amrex::Real* w_2   = soa_2.GetRealData(PIdx::w).data();
+            const auto soa_2 = ptile_2.getParticleTileData();
             index_type* indices_2 = bins_2.permutationPtr();
             index_type const* cell_offsets_2 = bins_2.offsetsPtr();
             amrex::Real q2 = species_2.getCharge();
             amrex::Real m2 = species_2.getMass();
+            auto get_position_2  = GetParticlePosition(ptile_2, getpos_offset);
 
             const amrex::Real dt = WarpX::GetInstance().getdt(lev);
             amrex::Geometry const& geom = WarpX::GetInstance().Geom(lev);
@@ -308,7 +294,7 @@ public:
                     binary_collision_functor(
                         cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,
                         indices_1, indices_2,
-                        ux_1, uy_1, uz_1, ux_2, uy_2, uz_2, w_1, w_2,
+                        soa_1, soa_2, get_position_1, get_position_2,
                         q1, q2, m1, m2, dt*ndt, dV, engine );
                 }
             );

--- a/Source/Particles/Collision/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/ElasticCollisionPerez.H
@@ -9,6 +9,7 @@
 
 #include "ComputeTemperature.H"
 #include "UpdateMomentumPerezElastic.H"
+#include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_Random.H>
@@ -33,24 +34,32 @@
  * @param[in] dV is the volume of the corresponding cell.
 */
 
-template <typename T_index, typename T_R>
+template <typename T_index, typename T_R, typename SoaData_type, typename GetParticlePosition>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ElasticCollisionPerez (
     T_index const I1s, T_index const I1e,
     T_index const I2s, T_index const I2e,
     T_index *I1,       T_index *I2,
-    T_R *u1x, T_R *u1y, T_R *u1z,
-    T_R *u2x, T_R *u2y, T_R *u2z,
-    T_R const *w1, T_R const *w2,
+    SoaData_type soa_1, SoaData_type soa_2,
+    GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
     T_R const  q1, T_R const  q2,
     T_R const  m1, T_R const  m2,
     T_R const  T1, T_R const  T2,
     T_R const  dt, T_R const   L, T_R const dV,
     amrex::RandomEngine const& engine)
 {
-
     int NI1 = I1e - I1s;
     int NI2 = I2e - I2s;
+
+    T_R * const AMREX_RESTRICT w1 = soa_1.m_rdata[PIdx::w];
+    T_R * const AMREX_RESTRICT u1x = soa_1.m_rdata[PIdx::ux];
+    T_R * const AMREX_RESTRICT u1y = soa_1.m_rdata[PIdx::uy];
+    T_R * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
+
+    T_R * const AMREX_RESTRICT w2 = soa_2.m_rdata[PIdx::w];
+    T_R * const AMREX_RESTRICT u2x = soa_2.m_rdata[PIdx::ux];
+    T_R * const AMREX_RESTRICT u2y = soa_2.m_rdata[PIdx::uy];
+    T_R * const AMREX_RESTRICT u2z = soa_2.m_rdata[PIdx::uz];
 
     // get local T1t and T2t
     T_R T1t; T_R T2t;

--- a/Source/Particles/Collision/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/PairWiseCoulombCollisionFunc.H
@@ -9,6 +9,7 @@
 #define PAIRWISE_COULOMB_COLLISION_FUNC_H_
 
 #include "ElasticCollisionPerez.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXUtil.H"
 
@@ -27,6 +28,7 @@ class PairWiseCoulombCollisionFunc{
     using ParticleType = WarpXParticleContainer::ParticleType;
     using ParticleBins = amrex::DenseBins<ParticleType>;
     using index_type = ParticleBins::index_type;
+    using SoaData_type = WarpXParticleContainer::ParticleTileType::ParticleTileDataType;
 
 public:
     /**
@@ -69,9 +71,8 @@ public:
         index_type const I1s, index_type const I1e,
         index_type const I2s, index_type const I2e,
         index_type* I1,       index_type* I2,
-        amrex::Real* u1x, amrex::Real* u1y, amrex::Real* u1z,
-        amrex::Real* u2x, amrex::Real* u2y, amrex::Real* u2z,
-        amrex::Real const * w1, amrex::Real const * w2,
+        SoaData_type soa_1, SoaData_type soa_2,
+        GetParticlePosition get_position_1, GetParticlePosition get_position_2,
         amrex::Real const  q1, amrex::Real const  q2,
         amrex::Real const  m1, amrex::Real const  m2,
         amrex::Real const  dt, amrex::Real const dV,
@@ -79,7 +80,7 @@ public:
         {
             ElasticCollisionPerez(
                     I1s, I1e, I2s, I2e, I1, I2,
-                    u1x, u1y, u1z, u2x, u2y, u2z, w1, w2,
+                    soa_1, soa_2, get_position_1, get_position_2,
                     q1, q2, m1, m2, amrex::Real(-1.0), amrex::Real(-1.0),
                     dt, m_CoulombLog, dV, engine );
         }

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -45,6 +45,8 @@ void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel
  *
+ * \tparam ptiType the type of the particle iterator used in the constructor
+ *
  * \param a_pti iterator to the tile containing the macroparticles
  * \param a_offset offset to apply to the particle indices
 */
@@ -62,7 +64,8 @@ struct GetParticlePosition
 
     GetParticlePosition () = default;
 
-    GetParticlePosition (const WarpXParIter& a_pti, int a_offset = 0) noexcept
+    template <typename ptiType>
+    GetParticlePosition (const ptiType& a_pti, int a_offset = 0) noexcept
     {
         const auto& aos = a_pti.GetArrayOfStructs();
         m_structs = aos().dataPtr() + a_offset;


### PR DESCRIPTION
This is a follow-up to #2057 . As suggested in [this comment](https://github.com/ECP-WarpX/WarpX/pull/2057#discussion_r665438698), this uses a more general particle data structure to pass the soa quantities to the binary collision functors (the same data structure as in the ionization module is used).

This also adds the possibility to use the particle positions in the binary collision modules, by passing `GetParticlePosition` functors.

Does that sound like a good way to do this? We could also consider adding a new struct that contains the soa struct, the `GetParticlePosition` functor and the charge and mass of the particles, and then only pass this struct to the binary collision functor. I'm not sure which solution is better though.