### PR TITLE
Removed n_buffer

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1023,7 +1023,6 @@ private:
     int num_injected_species = -1;
     amrex::Vector<int> injected_plasma_species;
 
-    int n_buffer = 4;
     amrex::Real const_dt = amrex::Real(0.5e-11);
 
     // Macroscopic properties

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -567,7 +567,6 @@ WarpX::ReadParameters ()
             // input for each species.
         }
 
-        pp_warpx.query("n_buffer", n_buffer);
         queryWithParser(pp_warpx, "const_dt", const_dt);
 
         // Filter currently not working with FDTD solver in RZ geometry: turn OFF by default


### PR DESCRIPTION
This is a small fix, removing an unused input parameter. I grepped both WarpX and AMReX, and n_buffer only appears in this line reading it in, so I'm assuming that it is no longer needed.