### PR TITLE
PSATD: Abort when `do_div<eb>_cleaning=1` but `J_linear_in_time=0`

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -102,6 +102,16 @@ PsatdAlgorithm::PsatdAlgorithm(
         X6_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
         InitializeSpectralCoefficientsAvgLin(spectral_kspace, dm, dt);
     }
+
+    if (dive_cleaning && !J_linear_in_time)
+    {
+        amrex::Abort("PSATD: warpx.do_dive_cleaning = 1 implemented only with psatd.J_linear_in_time = 1");
+    }
+
+    if (divb_cleaning && !J_linear_in_time)
+    {
+        amrex::Abort("PSATD: warpx.do_divb_cleaning = 1 implemented only with psatd.J_linear_in_time = 1");
+    }
 }
 
 void


### PR DESCRIPTION
div(E) and div(B) cleaning are currently implemented for the spectral solver in Cartesian geometry only when `psatd.J_linear_in_time=1` (the corresponding spectral field data for F and G are not allocated otherwise). This PR adds an `amrex::Abort` in the constructor of the class `PsatdAlgorithm`, in order to make sure that the user does not set `warpx.do_dive_cleaning=1` or `warpx.do_divb_cleaning=1` without also setting `psatd.J_linear_in_time=1` (which would otherwise lead to a segmentation fault due to out-of-bound access of the spectral field data with index -1 -- the ones that are not allocated).