### PR TITLE
Use less guard cells in ParallelCopy of refined level's UpdateAuxilaryData

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -182,7 +182,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             for (int i = 0; i < 3; ++i) {
                 IntVect ng = Btmp[i]->nGrowVect();
                 // Guard cells may not be up to date beyond ng_FieldGather
-                const auto ng_src = guard_cells.ng_FieldGather;
+                const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
                 Btmp[i]->ParallelCopy(*Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -181,7 +181,9 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             // ParallelCopy from coarse level
             for (int i = 0; i < 3; ++i) {
                 IntVect ng = Btmp[i]->nGrowVect();
-                Btmp[i]->ParallelCopy(*Bfield_aux[lev-1][i], 0, 0, 1, ng, ng, cperiod);
+                // Guard cells may not be up to date beyond ng_FieldGather
+                const auto ng_src = guard_cells.ng_FieldGather;
+                Btmp[i]->ParallelCopy(*Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -231,7 +233,9 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             // ParallelCopy from coarse level
             for (int i = 0; i < 3; ++i) {
                 IntVect ng = Etmp[i]->nGrowVect();
-                Etmp[i]->ParallelCopy(*Efield_aux[lev-1][i], 0, 0, 1, ng, ng, cperiod);
+                // Guard cells may not be up to date beyond ng_FieldGather
+                const auto ng_src = guard_cells.ng_FieldGather;
+                Etmp[i]->ParallelCopy(*Efield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -282,9 +286,11 @@ WarpX::UpdateAuxilaryDataSameType ()
             dBx.setVal(0.0);
             dBy.setVal(0.0);
             dBz.setVal(0.0);
-            dBx.ParallelCopy(*Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng, ng, crse_period);
-            dBy.ParallelCopy(*Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng, ng, crse_period);
-            dBz.ParallelCopy(*Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng, ng, crse_period);
+            // Guard cells may not be up to date beyond ng_FieldGather
+            const auto ng_src = guard_cells.ng_FieldGather;
+            dBx.ParallelCopy(*Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
+            dBy.ParallelCopy(*Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
+            dBz.ParallelCopy(*Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
             if (Bfield_cax[lev][0])
             {
                 MultiFab::Copy(*Bfield_cax[lev][0], dBx, 0, 0, Bfield_cax[lev][0]->nComp(), ng);
@@ -340,9 +346,11 @@ WarpX::UpdateAuxilaryDataSameType ()
             dEx.setVal(0.0);
             dEy.setVal(0.0);
             dEz.setVal(0.0);
-            dEx.ParallelCopy(*Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng, ng, crse_period);
-            dEy.ParallelCopy(*Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng, ng, crse_period);
-            dEz.ParallelCopy(*Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng, ng, crse_period);
+            // Guard cells may not be up to date beyond ng_FieldGather
+            const auto ng_src = guard_cells.ng_FieldGather;
+            dEx.ParallelCopy(*Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
+            dEy.ParallelCopy(*Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
+            dEz.ParallelCopy(*Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
             if (Efield_cax[lev][0])
             {
                 MultiFab::Copy(*Efield_cax[lev][0], dEx, 0, 0, Efield_cax[lev][0]->nComp(), ng);

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -183,6 +183,8 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 IntVect ng = Btmp[i]->nGrowVect();
                 // Guard cells may not be up to date beyond ng_FieldGather
                 const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
+                // Copy Bfield_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
+                // Bfield_aux and filling up to ng (=nGrow) guard cells in Btmp
                 Btmp[i]->ParallelCopy(*Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
@@ -234,7 +236,9 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
             for (int i = 0; i < 3; ++i) {
                 IntVect ng = Etmp[i]->nGrowVect();
                 // Guard cells may not be up to date beyond ng_FieldGather
-                const auto ng_src = guard_cells.ng_FieldGather;
+                const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
+                // Copy Efield_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
+                // Efield_aux and filling up to ng (=nGrow) guard cells in Etmp
                 Etmp[i]->ParallelCopy(*Efield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
@@ -287,7 +291,9 @@ WarpX::UpdateAuxilaryDataSameType ()
             dBy.setVal(0.0);
             dBz.setVal(0.0);
             // Guard cells may not be up to date beyond ng_FieldGather
-            const auto ng_src = guard_cells.ng_FieldGather;
+            const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
+            // Copy Bfield_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
+            // cells from Bfield_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
             dBx.ParallelCopy(*Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
             dBy.ParallelCopy(*Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
             dBz.ParallelCopy(*Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
@@ -347,7 +353,9 @@ WarpX::UpdateAuxilaryDataSameType ()
             dEy.setVal(0.0);
             dEz.setVal(0.0);
             // Guard cells may not be up to date beyond ng_FieldGather
-            const auto ng_src = guard_cells.ng_FieldGather;
+            const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
+            // Copy Efield_aux to the dE MultiFabs, using up to ng_src (=ng_FieldGather) guard
+            // cells from Efield_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
             dEx.ParallelCopy(*Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
             dEy.ParallelCopy(*Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
             dEz.ParallelCopy(*Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);


### PR DESCRIPTION
Sometimes we call `UpdateAuxilaryData` but with only part of the guard cells (`ng_FieldGather`) up to date, e.g.: https://github.com/ECP-WarpX/WarpX/blob/bf7150fa83df0cb8e3b2156525099e0f63ada0c3/Source/Evolve/WarpXEvolve.cpp#L213-L220

Therefore, we shouldn't use the total number of guard cells in the `ParallelCopy` used for the refined level, otherwise the nonupdated guard cells at level 0 can end up affecting regular cells at level 1. In this PR, we use only `ng_FieldGather` guard cells for the source MultiFAB of the `ParallelCopy`, which should solve the issue.

I've verified that this modification removes some of the benchmark changes observed in #1952, but I prefer to do this modification in a separate PR to make sure that it does not affect anything else in the code.