### PR TITLE
CI: Add Missing Python Analysis for EB Test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2120,6 +2120,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
+analysisRoutine = Examples/Modules/embedded_boundary_cube/analysis_fields.py
 
 [dirichletbc]
 buildDir = .

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2114,7 +2114,7 @@ dim = 3
 addToCompileString = USE_EB=TRUE
 restartTest = 0
 useMPI = 1
-numprocs = 4
+numprocs = 1
 useOMP = 1
 numthreads = 1
 compileTest = 0


### PR DESCRIPTION
The Python analysis for the CI test `embedded_boundary_cube` was missing.

Also, I had to use 1 MPI process for the test to pass successfully. The maximum would be 2 on Azure (while it was set to 4 before), but changing it to 2 seems to require a slightly larger tolerance (@lgiacome this might need to be investigated further).