### PR TITLE
BTD: Don't Flush If Written

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -155,12 +155,19 @@ BTDiagnostics::ReadParameters ()
 bool
 BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
 {
-    // Return true if buffer is full or if force_flush == true
-    // Return false if timestep < 0, i.e., at initialization when step == -1.
-    if (step < 0 ) return false;
-    else if ( buffer_full(i_buffer) || force_flush) {
+    // timestep < 0, i.e., at initialization time when step == -1
+    if (step < 0 )
+        return false;
+    // buffer for this lab snapshot is full, time to dump it and continue
+    // to collect more slices afterwards
+    else if (buffer_full(i_buffer))
         return true;
-    }
+    // forced: at the end of the simulation
+    // empty: either lab snapshot was already fully written and buffer was reset
+    //        to zero size or that lab snapshot was not even started to be
+    //        backtransformed yet
+    else if (force_flush && !buffer_empty(i_buffer))
+        return true;
     return false;
 }
 


### PR DESCRIPTION
Written BTD buffers for lab snapshot data are reset to zero size (count). When we do the final write of all partly filled buffers in `FilterComputePackFlushLastTimestep`, we should not write such already completed backtransformed lab snapshots again.

This also solves the concrete error message & crash in #1915.

But there are more underlying issues that we spotted in the thread of this issue, e.g., that some buffers are only partly filled even when complete and thus are not finalized/closed until `FilterComputePackFlushLastTimestep` is called. This will require another PR.