### PR TITLE
openPMD-api: 0.14.2

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
       sudo chmod a+x /usr/local/bin/cmake-easyinstall
       if [ "${WARPX_CI_OPENPMD:-FALSE}" == "TRUE" ]; then
-        cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.13.2 \
+        cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.14.2 \
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
         python -m pip install --upgrade openpmd-api
       fi

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         .github/workflows/dependencies/nvcc11.sh
         export CEI_SUDO="sudo"
-        cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.13.2 -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
+        cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.14.2 -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
     - name: build WarpX
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -30,7 +30,7 @@ jobs:
         sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
         sudo chmod a+x /usr/local/bin/cmake-easyinstall
         export CEI_SUDO="sudo"
-        CXX=$(which icpc) CC=$(which icc) cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.13.2 -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
+        CXX=$(which icpc) CC=$(which icc) cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.14.2 -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
     - name: build WarpX
       run: |
         set +e

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Axel Huebl
+# Copyright 2019-2021 Axel Huebl
 #
 # This file is part of WarpX.
 #

--- a/Docs/source/dataanalysis/paraview.rst
+++ b/Docs/source/dataanalysis/paraview.rst
@@ -19,7 +19,7 @@ openPMD
 -------
 
 WarpX' openPMD files can be visualized with ParaView 5.9+.
-ParaView supports ADIOS1, ADIOS2 and HDF5 files, as it implements (liked WarpX) against `openPMD-api <https://github.com/openPMD/openPMD-api>`__.
+ParaView supports ADIOS1, ADIOS2 and HDF5 files, as it implements (like WarpX) against `openPMD-api <https://github.com/openPMD/openPMD-api>`__.
 
 For openPMD output, WarpX automatically creates an ``.pmd`` file per diagnostics, which can be opened with ParaView.
 

--- a/Docs/source/developers/gnumake/openpmd.rst
+++ b/Docs/source/developers/gnumake/openpmd.rst
@@ -9,7 +9,7 @@ therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library 0.13.0 or newer <https://openpmd-api.readthedocs.io/en/0.13.0/>`_
+`openPMD-api library 0.14.2 or newer <https://openpmd-api.readthedocs.io/en/0.14.2/>`_
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.
@@ -89,7 +89,7 @@ If optional dependencies are installed in non-system paths, one needs to `hint t
 
    # optional: only if you manually installed HDF5 and/or ADIOS2 in custom directories
    export HDF5_ROOT=$HOME/path_to_installed_software/hdf5-1.12.0/
-   export ADIOS2_ROOT=$HOME/path_to_installed_software/adios2-2.6.0/
+   export ADIOS2_ROOT=$HOME/path_to_installed_software/adios2-2.7.1/
 
 Then, in the ``$HOME/warpx_directory/``, download and build openPMD-api:
 

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -106,7 +106,7 @@ CMake Option                  Default & Values                               Des
 ``WarpX_amrex_internal``      **ON**/OFF                                     Needs a pre-installed AMReX library if set to ``OFF``
 ``WarpX_openpmd_src``         *None*                                         Path to openPMD-api source directory (preferred if set)
 ``WarpX_openpmd_repo``        ``https://github.com/openPMD/openPMD-api.git`` Repository URI to pull and build openPMD-api from
-``WarpX_openpmd_branch``      ``0.13.2``                                     Repository branch for ``WarpX_openpmd_repo``
+``WarpX_openpmd_branch``      ``0.14.2``                                     Repository branch for ``WarpX_openpmd_repo``
 ``WarpX_openpmd_internal``    **ON**/OFF                                     Needs a pre-installed openPMD-api library if set to ``OFF``
 ``WarpX_picsar_src``          *None*                                         Path to PICSAR source directory (preferred if set)
 ``WarpX_picsar_repo``         ``https://github.com/ECP-WarpX/picsar.git``    Repository URI to pull and build PICSAR from

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -20,7 +20,7 @@ Optional dependencies include:
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
 - `BLAS++ <https://bitbucket.org/icl/blaspp>`_ and `LAPACK++ <https://bitbucket.org/icl/lapackpp>`_: for spectral solver (PSATD) support in RZ geometry
 - `Boost 1.66.0+ <https://www.boost.org/>`__: for QED lookup tables generation support
-- `openPMD-api 0.13.0+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
+- `openPMD-api 0.14.2+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (needs 3.7.9+ for CUDA)

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -51,7 +51,7 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    # optional: for openPMD support
    module load ums
    module load ums-aph114
-   module load openpmd-api/0.13.2
+   module load openpmd-api/0.14.2
 
    # optional: for PSATD in RZ geometry support
    #   note: needs the ums modules above

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -29,11 +29,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
 
     openPMD::IterationEncoding encoding = openPMD::IterationEncoding::groupBased;
     if ( 0 == openpmd_encoding.compare("v") )
-#if OPENPMDAPI_VERSION_GE(0, 14, 0)
       encoding = openPMD::IterationEncoding::variableBased;
-#else
-      encoding = openPMD::IterationEncoding::groupBased;
-#endif
     else if ( 0 == openpmd_encoding.compare("g") )
       encoding = openPMD::IterationEncoding::groupBased;
     else if ( 0 == openpmd_encoding.compare("f") )

--- a/Source/Diagnostics/requirements.txt
+++ b/Source/Diagnostics/requirements.txt
@@ -1,8 +1,8 @@
-# Copyright 2020 Axel Huebl
+# Copyright 2020-2021 Axel Huebl
 #
 # This file is part of WarpX.
 #
 # License: BSD-3-Clause-LBNL
 
 # keep this entry for GitHub's dependency graph
-openPMD-api>=0.13.0
+openPMD-api>=0.14.2

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -144,7 +144,7 @@ endif
 
 ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
-   ifeq (0, $(shell pkg-config "openPMD >= 0.13.0"; echo $$?))
+   ifeq (0, $(shell pkg-config "openPMD >= 0.14.2"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
        libraries += $(shell pkg-config --libs-only-l openPMD)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -10,13 +10,13 @@ function(find_openpmd)
     if(WarpX_openpmd_internal OR WarpX_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.13.0/dev/buildoptions.html
-        set(openPMD_USE_MPI    ${WarpX_MPI}  CACHE INTERNAL "")
-        set(openPMD_USE_PYTHON OFF           CACHE INTERNAL "")
-        set(BUILD_CLI_TOOLS    OFF           CACHE INTERNAL "")  # FIXME
-        set(BUILD_EXAMPLES     OFF           CACHE INTERNAL "")  # FIXME
-        set(BUILD_TESTING      OFF           CACHE INTERNAL "")  # FIXME
-        set(openPMD_INSTALL    ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
+        # see https://openpmd-api.readthedocs.io/en/0.14.1/dev/buildoptions.html
+        set(openPMD_USE_MPI         ${WarpX_MPI}  CACHE INTERNAL "")
+        set(openPMD_USE_PYTHON      OFF           CACHE INTERNAL "")
+        set(openPMD_BUILD_CLI_TOOLS OFF           CACHE INTERNAL "")
+        set(openPMD_BUILD_EXAMPLES  OFF           CACHE INTERNAL "")
+        set(openPMD_BUILD_TESTING   OFF           CACHE INTERNAL "")
+        set(openPMD_INSTALL  ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
 
         if(WarpX_openpmd_src)
             add_subdirectory(${WarpX_openpmd_src} _deps/localopenpmd-build/)
@@ -65,7 +65,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.13.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.14.2 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()
@@ -81,7 +81,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "0.13.4"
+    set(WarpX_openpmd_branch "0.14.2"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 

--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,7 @@ setup(
     #    ]
     #},
     extras_require={
-        'all': ['openPMD-api~=0.13.0', 'openPMD-viewer~=1.1', 'yt~=3.6', 'matplotlib'],
+        'all': ['openPMD-api~=0.14.2', 'openPMD-viewer~=1.1', 'yt~=3.6,>=4.0.1', 'matplotlib'],
     },
     # cmdclass={'test': PyTest},
     # platforms='any',


### PR DESCRIPTION
This updates our requirements to openPMD-api 0.14.2+

Among others, this release introduced resizable data sets, which we will soon use for particle backtransformed diagnostics.

- [x] rebase after #2149 was merged
- [x] rebase after #2152 was merged
- [x] rebase after #2157 was merged
- [x] potentially needs fixes in a 0.14.1 release: https://github.com/openPMD/openPMD-api/pull/1073
- [x] let's also add the 0.14.2 fixes, even if they mainly concern read: https://github.com/openPMD/openPMD-api/pulls?q=is%3Apr+milestone%3A0.14.2
- [x] rebase after #2189 was merged
- [x] rebase after #2193 was merged
- [x] update Summit module