### PR TITLE
Remove predefined constants from example input files

### DIFF
--- a/Examples/Modules/embedded_boundary_cube/inputs_3d
+++ b/Examples/Modules/embedded_boundary_cube/inputs_3d
@@ -24,16 +24,14 @@ warpx.B_ext_grid_init_style = parse_B_ext_grid_function
 my_constants.m = 0
 my_constants.n = 1
 my_constants.p = 1
-my_constants.pi = 3.141592653589793
 my_constants.Lx = 1
 my_constants.Ly = 1
 my_constants.Lz = 1
 my_constants.h_2 = (m * pi / Lx) ** 2 + (n * pi / Ly) ** 2 + (p * pi / Lz) ** 2
-my_constants.mu_0 = 1.25663706212e-06
 
-warpx.By_external_grid_function(x,y,z) = -2/h_2 * (n * pi / Ly) * (p * pi / Lz) * cos(m * pi / Lx * (x - Lx / 2)) * sin(n * pi / Ly * (y - Ly / 2)) * cos(p * pi / Lz * (z - Lz / 2))*mu_0*(x>-Lx/2)*(x<Lx/2)*(y>-Ly/2)*(y<Ly/2)*(z>-Lz/2)*(z<Lz/2)
-warpx.Bx_external_grid_function(x,y,z) = -2/h_2 * (m * pi / Lx) * (p * pi / Lz) * sin(m * pi / Lx * (x - Lx / 2)) * cos(n * pi / Ly * (y - Ly / 2)) * cos(p * pi / Lz * (z - Lz / 2))*mu_0*(x>-Lx/2)*(x<Lx/2)*(y>-Ly/2)*(y<Ly/2)*(z>-Lz/2)*(z<Lz/2)
-warpx.Bz_external_grid_function(x,y,z) = cos(m * pi / Lx * (x - Lx / 2)) * cos(n * pi / Ly * (y - Ly / 2)) * sin(p * pi / Lz * (z - Lz / 2))*mu_0*(x>-0.5)*(x<0.5)*(y>-0.5)*(y<0.5)*(z>-0.5)*(z<0.5)
+warpx.By_external_grid_function(x,y,z) = -2/h_2 * (n * pi / Ly) * (p * pi / Lz) * cos(m * pi / Lx * (x - Lx / 2)) * sin(n * pi / Ly * (y - Ly / 2)) * cos(p * pi / Lz * (z - Lz / 2))*mu0*(x>-Lx/2)*(x<Lx/2)*(y>-Ly/2)*(y<Ly/2)*(z>-Lz/2)*(z<Lz/2)
+warpx.Bx_external_grid_function(x,y,z) = -2/h_2 * (m * pi / Lx) * (p * pi / Lz) * sin(m * pi / Lx * (x - Lx / 2)) * cos(n * pi / Ly * (y - Ly / 2)) * cos(p * pi / Lz * (z - Lz / 2))*mu0*(x>-Lx/2)*(x<Lx/2)*(y>-Ly/2)*(y<Ly/2)*(z>-Lz/2)*(z<Lz/2)
+warpx.Bz_external_grid_function(x,y,z) = cos(m * pi / Lx * (x - Lx / 2)) * cos(n * pi / Ly * (y - Ly / 2)) * sin(p * pi / Lz * (z - Lz / 2))*mu0*(x>-0.5)*(x<0.5)*(y>-0.5)*(y<0.5)*(z>-0.5)*(z<0.5)
 
 diagnostics.diags_names = diag1
 diag1.intervals = 1000

--- a/Examples/Modules/resampling/inputs_leveling_thinning
+++ b/Examples/Modules/resampling/inputs_leveling_thinning
@@ -15,8 +15,6 @@ algo.particle_shape = 1
 
 particles.species_names = resampled_part1 resampled_part2
 
-my_constants.pi = 3.141592653589793
-
 # First particle species. The particles are distributed throughout the simulation box and all have
 # the same weight.
 resampled_part1.species_type = electron

--- a/Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
+++ b/Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
@@ -28,7 +28,6 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1. # in units of the speed of light
 my_constants.lramp = 8.e-3
-my_constants.pi    = 3.141592653589793
 my_constants.dens  = 1e+23
 
 # Order of particle shape factors

--- a/Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
+++ b/Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
@@ -28,7 +28,6 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1. # in units of the speed of light
 my_constants.lramp = 8.e-3
-my_constants.pi    = 3.141592653589793
 my_constants.dens  = 1e+23
 
 # Order of particle shape factors

--- a/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
+++ b/Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
@@ -31,10 +31,7 @@ warpx.use_hybrid_QED = 1
 ############ FIELDS #############
 #################################
 
-my_constants.pi = 3.14159265359
 my_constants.L = 141.4213562373095e-6
-my_constants.eps0 = 8.8541878128e-12
-my_constants.c = 299792458.
 my_constants.wavelength = 64.e-6
 my_constants.Es = 1.e5
 my_constants.xi = 1.e-23
@@ -46,7 +43,7 @@ warpx.Ex_external_grid_function(x,y,z) = 0.
 warpx.Ey_external_grid_function(x,y,z) = "exp(-z**2/L**2)*cos(2*pi*z/wavelength) + Es"
 
 warpx.B_ext_grid_init_style = parse_B_ext_grid_function
-warpx.Bx_external_grid_function(x,y,z)= "-sqrt((1+(12*xi*Es**2)/eps0)/(1+(4*xi*Es**2)/eps0))*exp(-z**2/L**2)*cos(2*pi*z/wavelength)/c"
+warpx.Bx_external_grid_function(x,y,z)= "-sqrt((1+(12*xi*Es**2)/epsilon0)/(1+(4*xi*Es**2)/epsilon0))*exp(-z**2/L**2)*cos(2*pi*z/wavelength)/clight"
 warpx.By_external_grid_function(x,y,z)= 0.
 warpx.Bz_external_grid_function(x,y,z) = 0.
 

--- a/Examples/Tests/restart/inputs
+++ b/Examples/Tests/restart/inputs
@@ -29,7 +29,6 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1. # in units of the speed of light
 my_constants.lramp = 8.e-3
-my_constants.pi    = 3.141592653589793
 my_constants.dens  = 1e+23
 
 # Order of particle shape factors

--- a/Tools/LibEnsemble/sim/inputs
+++ b/Tools/LibEnsemble/sim/inputs
@@ -171,7 +171,6 @@ my_constants.wlen = 0.002
 my_constants.mcce = 510999.
 my_constants.gab = 30.0
 my_constants.vb = 299625860.344456
-my_constants.c = 299792458.
 my_constants.adjust_factor = 1.
 
 particles.E_ext_particle_init_style = parse_E_ext_particle_function
@@ -181,7 +180,7 @@ particles.Ez_external_particle_function(x,y,z,t) = "0."
 
 particles.B_ext_particle_init_style = parse_B_ext_particle_function
 particles.Bx_external_particle_function(x,y,z,t) = "0."
-particles.By_external_particle_function(x,y,z,t) = "( - adjust_factor * vb * gab * 2 * mcce * ga * x / (wlen * dlen * c * c) ) * ((gab*(z+vb*t))>=zlen) * ((gab*(z+vb*t))<=(zlen+wlen))"
+particles.By_external_particle_function(x,y,z,t) = "( - adjust_factor * vb * gab * 2 * mcce * ga * x / (wlen * dlen * clight * clight) ) * ((gab*(z+vb*t))>=zlen) * ((gab*(z+vb*t))<=(zlen+wlen))"
 particles.Bz_external_particle_function(x,y,z,t) = "0."
 
 warpx.num_mirrors=2


### PR DESCRIPTION
These constants are now predefined so I think they can be safely removed from the example input files.