### PR TITLE
openPMD: Use Steps if != BTD

### DIFF
--- a/Docs/source/developers/gnumake/openpmd.rst
+++ b/Docs/source/developers/gnumake/openpmd.rst
@@ -9,7 +9,7 @@ therefore we recommend to use `spack <https://
 spack.io>`__ in order to facilitate the installation.
 
 More specifically, we recommend that you try installing the
-`openPMD-api library 0.12.0a or newer <https://openpmd-api.readthedocs.io/en/0.12.0-alpha/>`_
+`openPMD-api library 0.13.0 or newer <https://openpmd-api.readthedocs.io/en/0.13.0/>`_
 using spack (first section below). If this fails, a back-up solution
 is to install parallel HDF5 with spack, and then install the openPMD-api
 library from source.

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -20,7 +20,7 @@ Optional dependencies include:
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
 - `BLAS++ <https://bitbucket.org/icl/blaspp>`_ and `LAPACK++ <https://bitbucket.org/icl/lapackpp>`_: for spectral solver (PSATD) support in RZ geometry
 - `Boost 1.66.0+ <https://www.boost.org/>`__: for QED lookup tables generation support
-- `openPMD-api 0.12.0+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
+- `openPMD-api 0.13.0+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (needs 3.7.9+ for CUDA)

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -121,7 +121,7 @@ FlushFormatOpenPMD::WriteToFile (
         varnames, mf, geom, output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
-    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags);
+    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, isBTD);
 
     // signal that no further updates will be written to this iteration
     m_OpenPMDPlotWriter->CloseStep(isBTD, isLastBTDFlush);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -127,7 +127,8 @@ public:
    */
   void CloseStep (bool isBTD = false, bool isLastBTDFlush = false);
 
-  void WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags);
+  void WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags,
+                              const bool isBTD = false);
 
   void WriteOpenPMDFieldsAll (
               const std::vector<std::string>& varnames,
@@ -142,11 +143,19 @@ private:
   void Init (openPMD::Access access, bool isBTD);
 
 
-  inline openPMD::Iteration& GetIteration(int iteration) const
+  /** Get the openPMD::Iteration object of the current Series
+   *
+   * We use this helper function to differentiate between efficient, temporally
+   * sequentially increasing writes to iteration numbers and random-access
+   * writes to iterations, e.g., as needed for back-transformed diagnostics.
+   *
+   * @param[in] iteration iteration number (lab-frame for BTD)
+   * @param[in] isBTD is this a backtransformed diagnostics write?
+   * @return the iteration object
+   */
+  inline openPMD::Iteration& GetIteration (int const iteration, bool const isBTD) const
   {
-    // so BTD will be able to revisit previous steps, so we do not use steps with these two encodings,
-    if (  (openPMD::IterationEncoding::fileBased == m_Encoding ) ||
-          (openPMD::IterationEncoding::groupBased == m_Encoding )  )
+    if (isBTD)
     {
         openPMD::Iteration& it = m_Series->iterations[iteration];
         return it;
@@ -238,6 +247,7 @@ private:
    * @param[in] int_comp_names The int attribute names, from WarpX
    * @param[in] charge         Charge of the particles (note: fix for ions)
    * @param[in] mass           Mass of the particles
+   * @param[in] isBTD is this a backtransformed diagnostics write?
    */
   void DumpToFile (ParticleContainer* pc,
             const std::string& name,
@@ -247,7 +257,8 @@ private:
             const amrex::Vector<std::string>& real_comp_names,
             const amrex::Vector<std::string>&  int_comp_names,
             amrex::ParticleReal const charge,
-            amrex::ParticleReal const mass) const;
+            amrex::ParticleReal const mass,
+            const bool isBTD) const;
 
   /** Get the openPMD-api filename for openPMD::Series
    *

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -374,7 +374,7 @@ void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
     if (isBTD and !isLastBTDFlush) callClose = false;
     if (callClose) {
         if (m_Series) {
-            GetIteration(m_CurrentStep).close();
+            GetIteration(m_CurrentStep, isBTD).close();
         }
 
         // create a little helper file for ParaView 5.9+
@@ -442,7 +442,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
 }
 
 void
-WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags)
+WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags,
+                                         const bool isBTD)
 {
   WARPX_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDParticles()");
 
@@ -530,7 +531,8 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
          real_flags,
          int_flags,
          real_names, int_names,
-         pc->getCharge(), pc->getMass()
+         pc->getCharge(), pc->getMass(),
+         isBTD
       );
     }
 
@@ -548,12 +550,13 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
                     const amrex::Vector<std::string>& real_comp_names,
                     const amrex::Vector<std::string>&  int_comp_names,
                     amrex::ParticleReal const charge,
-                    amrex::ParticleReal const mass) const
+                    amrex::ParticleReal const mass,
+                    const bool isBTD) const
 {
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD: series must be initialized");
 
   WarpXParticleCounter counter(pc);
-  openPMD::Iteration& currIteration = GetIteration(iteration);
+  openPMD::Iteration& currIteration = GetIteration(iteration, isBTD);
 
   openPMD::ParticleSpecies currSpecies = currIteration.particles[name];
   // meta data for ED-PIC extension
@@ -1061,7 +1064,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
   bool const first_write_to_iteration = ! m_Series->iterations.contains( iteration );
 
   // meta data
-  openPMD::Iteration& series_iteration = GetIteration(m_CurrentStep);
+  openPMD::Iteration& series_iteration = GetIteration(m_CurrentStep, isBTD);
 
   auto meshes = series_iteration.meshes;
   if (first_write_to_iteration) {

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1066,6 +1066,9 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
   // meta data
   openPMD::Iteration& series_iteration = GetIteration(m_CurrentStep, isBTD);
 
+  // collective open
+  series_iteration.open();
+
   auto meshes = series_iteration.meshes;
   if (first_write_to_iteration) {
     // lets see whether full_geom varies from geom[0]   xgeom[1]

--- a/Source/Diagnostics/requirements.txt
+++ b/Source/Diagnostics/requirements.txt
@@ -5,4 +5,4 @@
 # License: BSD-3-Clause-LBNL
 
 # keep this entry for GitHub's dependency graph
-openPMD-api>=0.12.0
+openPMD-api>=0.13.0

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -144,7 +144,7 @@ endif
 
 ifeq ($(USE_OPENPMD), TRUE)
    # try pkg-config query
-   ifeq (0, $(shell pkg-config "openPMD >= 0.12.0"; echo $$?))
+   ifeq (0, $(shell pkg-config "openPMD >= 0.13.0"; echo $$?))
        CXXFLAGS += $(shell pkg-config --cflags openPMD)
        LIBRARY_LOCATIONS += $(shell pkg-config --variable=libdir openPMD)
        libraries += $(shell pkg-config --libs-only-l openPMD)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -10,7 +10,7 @@ function(find_openpmd)
     if(WarpX_openpmd_internal OR WarpX_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.12.0-alpha/dev/buildoptions.html
+        # see https://openpmd-api.readthedocs.io/en/0.13.0/dev/buildoptions.html
         set(openPMD_USE_MPI    ${WarpX_MPI}  CACHE INTERNAL "")
         set(openPMD_USE_PYTHON OFF           CACHE INTERNAL "")
         set(BUILD_CLI_TOOLS    OFF           CACHE INTERNAL "")  # FIXME
@@ -65,7 +65,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.12.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.13.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()


### PR DESCRIPTION
For all but back-transformed diagnostics, we can use efficient, temporally sequentially increasing writes to iteration numbers for iterations.

This allows us to give a guarantee to HPC I/O libraries on how to arrange data, e.g., we can use ADIOS2 BeginStep() and EndStep().

This enables paths to:
- streaming workflows, such as ADIOS2 SST or SSC, where we stage data over the network instead of using files
  https://openpmd-api.readthedocs.io/en/0.14.0/usage/streaming.html

This mitigates:
- host-side memory aggregation for ADIOS2 with openPMD `groupBased` iteration encoding
  https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#memory-usage

# To Do

- [x] this is a 0.13.0+ feature, so we need to increase the API requirements slightly
- [x] check if this already works well with openPMD-viewer to read back data