### PR TITLE
Initialize guard cells for spatially varying macroproperties

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -109,7 +109,7 @@ MacroscopicProperties::InitData ()
     int lev = 0;
     BoxArray ba = warpx.boxArray(lev);
     DistributionMapping dmap = warpx.DistributionMap(lev);
-    int ng = 3;
+    const amrex::IntVect ng = warpx.getngE();
     // Define material property multifabs using ba and dmap from WarpX instance
     // sigma is cell-centered MultiFab
     m_sigma_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
@@ -190,7 +190,7 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         // Initialize ghost cells in addition to valid cells
 
-        const Box& tb = mfi.growntilebox(grown_iv);
+        const Box& tb = mfi.tilebox(grown_iv, macro_mf->nGrowVect());
         auto const& macro_fab =  macro_mf->array(mfi);
         amrex::ParallelFor (tb,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {


### PR DESCRIPTION
For an electrom beam simulation with spatially varying material properties, the code was failing with very high field-values as shown in the figure below
![image(2)](https://user-images.githubusercontent.com/41089244/128075024-ef14be38-6001-4bba-a127-a6fccd4d84aa.png)

After turning on the DEBUG=TRUE flag, the code crashed in the 2nd timestep with the following assertion
`
0::Assertion `amrex::numParticlesOutOfRange(pti, range) == 0' failed, file "./Source/Particles/WarpXParticleContainer.cpp", line 326, Msg: "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for current deposition" !!!`

The error was found to originate in the initialization of macroscopic parameters. We were filling in only the valid cells.
In this PR, we now initialize the guard cells and valid cells for the multifabs that store these material properties.

After the fix, we now get the following result and the field-values do not blow up

![Screenshot from 2021-08-03 12-34-55](https://user-images.githubusercontent.com/41089244/128075468-a5641cce-027d-4ea4-becc-fbdd91d256f7.png)

Here is the input file used for these tests which was shared by Wei-Hou.
[inputs.txt](https://github.com/ECP-WarpX/WarpX/files/6926655/inputs.txt)

Thanks Wei-Hou for testing this and letting us know about the error!

