### PR TITLE
openPMD: Style Cleaning (Dec/Def)

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl, Junmin Gu, Maxence Thevenet
+/* Copyright 2019-2021 Axel Huebl, Junmin Gu, Maxence Thevenet
  *
  *
  * This file is part of WarpX.
@@ -40,8 +40,8 @@
 class Timer
 {
 public:
-  Timer(const char* tag) {m_Tag = tag; m_Start = amrex::second();}
-  ~Timer() {
+  Timer (const char* tag) {m_Tag = tag; m_Start = amrex::second();}
+  ~Timer () {
       m_End = amrex::second();
       amrex::ParallelDescriptor::ReduceRealMax(m_End, amrex::ParallelDescriptor::IOProcessorNumber());
       amrex::Print()<<m_Tag<<" took:"<<m_End - m_Start<<" seconds\n";
@@ -61,8 +61,8 @@ public:
   using ParticleContainer = typename amrex::AmrParticleContainer<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
   using ParticleIter = typename amrex::ParIter<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
 
-  WarpXParticleCounter(ParticleContainer* pc);
-  unsigned long GetTotalNumParticles() {return m_Total;}
+  WarpXParticleCounter (ParticleContainer* pc);
+  unsigned long GetTotalNumParticles () {return m_Total;}
 
   std::vector<unsigned long long> m_ParticleOffsetAtRank;
   std::vector<unsigned long long> m_ParticleSizeAtRank;
@@ -73,7 +73,7 @@ private:
   * @param[out] offset particle offset over all, mpi-global amrex fabs
   * @param[out] sum number of all particles from all amrex fabs
   */
-  void GetParticleOffsetOfProcessor(const long& numParticles,
+  void GetParticleOffsetOfProcessor (const long& numParticles,
                     unsigned long long& offset,
                     unsigned long long& sum)  const ;
 
@@ -162,17 +162,23 @@ private:
    *  @param[in] meshes   The meshes in a series
    *  @param[in] full_geom The geometry
    */
-  void SetupFields(  openPMD::Container< openPMD::Mesh >& meshes, amrex::Geometry& full_geom  ) const;
+  void SetupFields (
+      openPMD::Container< openPMD::Mesh >& meshes,
+      amrex::Geometry& full_geom
+  ) const;
 
-  void SetupMeshComp( openPMD::Mesh& mesh,
-                      amrex::Geometry& full_geom,
-                      openPMD::MeshRecordComponent& mesh_comp
-                     ) const;
+  void SetupMeshComp (
+      openPMD::Mesh& mesh,
+      amrex::Geometry& full_geom,
+      openPMD::MeshRecordComponent& mesh_comp
+  ) const;
 
-  void GetMeshCompNames( int meshLevel,
-                         const std::string& varname,
-                         std::string& field_name,
-                         std::string& comp_name ) const;
+  void GetMeshCompNames (
+      int meshLevel,
+      const std::string& varname,
+      std::string& field_name,
+      std::string& comp_name
+  ) const;
 
   /** This function sets up the entries for storing the particle positions, global IDs, and constant records (charge, mass)
   *

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl, Junmin Gu
+/* Copyright 2019-2021 Axel Huebl, Junmin Gu
  *
  * This file is part of WarpX.
  *
@@ -317,7 +317,7 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot (
     m_OpenPMDoptions = detail::getSeriesOptions(operator_type, operator_parameters);
 }
 
-WarpXOpenPMDPlot::~WarpXOpenPMDPlot()
+WarpXOpenPMDPlot::~WarpXOpenPMDPlot ()
 {
   if( m_Series )
   {
@@ -850,7 +850,7 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
 
 
 void
-WarpXOpenPMDPlot::SetupPos(
+WarpXOpenPMDPlot::SetupPos (
     openPMD::ParticleSpecies& currSpecies,
     const unsigned long long& np,
     amrex::ParticleReal const charge,
@@ -894,15 +894,15 @@ WarpXOpenPMDPlot::SetupPos(
 
 
 /*
- * Set up paramter for mesh container using the geometry (from level 0)
+ * Set up parameter for mesh container using the geometry (from level 0)
  *
  * @param [IN] meshes: openPMD-api mesh container
  * @param [IN] full_geom: field geometry
  *
  */
 void
-WarpXOpenPMDPlot::SetupFields(  openPMD::Container< openPMD::Mesh >& meshes,
-                                amrex::Geometry& full_geom  ) const
+WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
+                                amrex::Geometry& full_geom ) const
 {
       // meta data for ED-PIC extension
       auto const period = full_geom.periodicity(); // TODO double-check: is this the proper global bound or of some level?
@@ -973,9 +973,9 @@ WarpXOpenPMDPlot::SetupFields(  openPMD::Container< openPMD::Mesh >& meshes,
  * @param [IN]: mesh_comp     a component for the mesh
  */
 void
-WarpXOpenPMDPlot::SetupMeshComp( openPMD::Mesh& mesh,
+WarpXOpenPMDPlot::SetupMeshComp (openPMD::Mesh& mesh,
                                  amrex::Geometry& full_geom,
-                                 openPMD::MeshRecordComponent& mesh_comp ) const
+                                 openPMD::MeshRecordComponent& mesh_comp) const
 {
        amrex::Box const & global_box = full_geom.Domain();
        auto const global_size = getReversedVec(global_box.size());
@@ -1009,10 +1009,10 @@ WarpXOpenPMDPlot::SetupMeshComp( openPMD::Mesh& mesh,
  * @param comp_name [OUT]:   comp name for openPMD-api output
  */
 void
-WarpXOpenPMDPlot::GetMeshCompNames( int meshLevel,
+WarpXOpenPMDPlot::GetMeshCompNames (int meshLevel,
                                     const std::string& varname,
                                     std::string& field_name,
-                                    std::string& comp_name ) const
+                                    std::string& comp_name) const
 {
     if (varname.size() >= 2u ) {
         std::string const varname_1st = varname.substr(0u, 1u); // 1st character
@@ -1131,7 +1131,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
 //
 //
 //
-WarpXParticleCounter::WarpXParticleCounter(ParticleContainer* pc)
+WarpXParticleCounter::WarpXParticleCounter (ParticleContainer* pc)
 {
   m_MPISize = amrex::ParallelDescriptor::NProcs();
   m_MPIRank = amrex::ParallelDescriptor::MyProc();
@@ -1178,11 +1178,11 @@ WarpXParticleCounter::WarpXParticleCounter(ParticleContainer* pc)
 //     sum of all particles in the comm
 //
 void
-WarpXParticleCounter::GetParticleOffsetOfProcessor(const long& numParticles,
-                           unsigned long long& offset,
-                           unsigned long long& sum)  const
-
-
+WarpXParticleCounter::GetParticleOffsetOfProcessor (
+    const long& numParticles,
+    unsigned long long& offset,
+    unsigned long long& sum
+) const
 {
     offset = 0;
 #if defined(AMREX_USE_MPI)


### PR DESCRIPTION
In our code base, definitions and declarations of functions need a space after their name. This makes them easy to search for.

Ref.:
  https://warpx.readthedocs.io/en/21.08/developers/contributing.html#style-and-conventions