### PR TITLE
openPMD: Missing Include

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -35,6 +35,7 @@
 #include <AMReX_StructOfArrays.H>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Fix compile issue on Conda-Forge (Windows with Clang).
```
%SRC_DIR%\Source\Diagnostics\WarpXOpenPMD.cpp(67,60): error: no member named 'tolower' in namespace 'std'; did you mean simply 'tolower'?
```

Follow-up to #2126

X-ref: https://github.com/conda-forge/warpx-feedstock/pull/23