### PR TITLE
PEC Analysis: Remove Unused Imports

### DIFF
--- a/Examples/Tests/PEC/analysis_pec.py
+++ b/Examples/Tests/PEC/analysis_pec.py
@@ -20,7 +20,6 @@ import matplotlib.pyplot as plt
 import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
-from scipy.constants import e, m_e, epsilon_0, c
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 

--- a/Examples/Tests/PEC/analysis_pec_mr.py
+++ b/Examples/Tests/PEC/analysis_pec_mr.py
@@ -20,7 +20,6 @@ import matplotlib.pyplot as plt
 import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
-from scipy.constants import e, m_e, epsilon_0, c
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 


### PR DESCRIPTION
Fix a LGTM warning on unused imports in our PEC analysis scripts.

Seen in https://github.com/ECP-WarpX/WarpX/pull/2150#issuecomment-893104436