### PR TITLE
CI: Build EB

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -31,6 +31,7 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=CUDA         \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DAMReX_CUDA_ARCH=6.0        \
           -DWarpX_OPENPMD=ON           \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -35,6 +35,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DAMReX_AMD_ARCH=gfx900     \
           -DWarpX_COMPUTE=HIP         \
+          -DWarpX_EB=ON               \
           -DWarpX_LIB=ON              \
           -DWarpX_MPI=ON              \
           -DWarpX_OPENPMD=ON          \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -123,7 +123,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -80,6 +80,7 @@ jobs:
 
         cmake -S . -B build_sp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
@@ -122,6 +123,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,12 +29,14 @@ jobs:
       run: |
         cmake -S . -B build_dp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_EB=ON                \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF
         cmake --build build_dp -j 2
 
         cmake -S . -B build_sp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -43,7 +43,6 @@ jobs:
     - name: build WarpX
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
-        export WarpX_EB=ON
         export WarpX_MPI=ON
         export WarpX_OPENPMD=ON
         export WarpX_PSATD=ON

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,12 +20,14 @@ jobs:
       run: |
         cmake -S . -B build_3D         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_EB=OFF               \
           -DWarpX_MPI=OFF              \
           -DWarpX_QED=OFF
         cmake --build build_3D -j 2
         cmake -S . -B build_RZ         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_DIMS=RZ              \
+          -DWarpX_EB=OFF               \
           -DWarpX_MPI=OFF              \
           -DWarpX_QED=OFF
         cmake --build build_RZ -j 2
@@ -41,6 +43,7 @@ jobs:
     - name: build WarpX
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
+        export WarpX_EB=ON
         export WarpX_MPI=ON
         export WarpX_OPENPMD=ON
         export WarpX_PSATD=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
+              -DWarpX_EB=ON                 ^
               -DWarpX_OPENPMD=ON            ^
               -DWarpX_MPI=OFF
         cmake --build build --config Release --parallel 2

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -79,7 +79,7 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_ASCENT``              ON/**OFF**                                   Ascent in situ visualization
 ``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
 ``WarpX_DIMS``                **3**/2/RZ                                   Simulation dimensionality
-``WarpX_EB``                  ON/**OFF**                                   Embedded boundary support
+``WarpX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
 ``WarpX_GPUCLOCK``            **ON**/OFF                                   Add GPU kernel timers (cost function, +4 registers/kernel)
 ``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO)
 ``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a shared library
@@ -177,6 +177,7 @@ Environment Variable          Default & Values                             Descr
 ============================= ============================================ ================================================================
 ``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
 ``WarpX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
+``WarpX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
 ``WarpX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
 ``WarpX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
 ``WarpX_PRECISION``           SINGLE/**DOUBLE**                            Floating point precision (single/double)


### PR DESCRIPTION
Perform compile tests with EB on.
This should help to ensure single-precision, CUDA, DPC++, HIP and Windows builds work with EB on the long-term.

### To Do

- [x] requires AMReX fix: https://github.com/AMReX-Codes/amrex/pull/2232
- [x] fix gamma implicit casts (HIP build) #2174
- [x] fix warnings in RZ build #2176
- [x] fix CUDA compile #2247