### PR TITLE
Gaussian Laser: fix issue related to single precision

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -111,10 +111,9 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
     // Time stretching due to STCs and phi2 complex envelope
     // (1 if zeta=0, beta=0, phi2=0)
     const Complex stretch_factor = 1._rt + 4._rt *
-        (m_params.zeta+m_params.beta*m_params.focal_distance)
-        * (m_params.zeta+m_params.beta*m_params.focal_distance)
-        * (inv_tau2*inv_complex_waist_2) + 2._rt *I * (m_params.phi2
-        - m_params.beta*m_params.beta*k0*m_params.focal_distance) * inv_tau2;
+        (m_params.zeta+m_params.beta*m_params.focal_distance*inv_tau2)
+        * (m_params.zeta+m_params.beta*m_params.focal_distance*inv_complex_waist_2)
+        + 2._rt*I*(m_params.phi2-m_params.beta*m_params.beta*k0*m_params.focal_distance)*inv_tau2;
 
     // Amplitude and monochromatic oscillations
     Complex prefactor =


### PR DESCRIPTION
`inv_tau2` and `inv_complex_waist_2` can be very large for realistic laser parameters. Indeed, in a recent simulation I had `inv_tau2 = 1.000000062e+28` and  `inv_complex_waist_2 = 4.707382067e+10 + -1.367689789e+11i`. When these parameters were multiplied together to calculate the `stretch_factor`, in single precision the product was `inf - infi`, which finally lead to a crash of WarpX. I've rearranged the calculation so that this issue is much less likely. 

To fix all the issues related to single precision, I think that at some point we should consider performing all the internal calculations using a normalized unit system (while keeping the inputfile and the output in SI units), although I acknowledge that this would require a huge amount of work.