### PR TITLE
ES Solver: Fix HIP SP Build

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -227,7 +227,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
                    int const verbosity) const
 {
     // Create a new geometry with the z coordinate scaled by gamma
-    amrex::Real const gamma = std::sqrt(1._rt/(1. - beta[2]*beta[2]));
+    amrex::Real const gamma = std::sqrt(1._rt/(1._rt - beta[2]*beta[2]));
 
     amrex::Vector<amrex::Geometry> geom_scaled(max_level + 1);
     for (int lev = 0; lev <= max_level; ++lev) {
@@ -431,7 +431,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     // one of the axes of the grid, i.e. that only *one* of the Cartesian
     // components of `beta` is non-negligible.
     linop.setSigma({AMREX_D_DECL(
-        1.-beta[0]*beta[0], 1.-beta[1]*beta[1], 1.-beta[2]*beta[2])});
+        1._rt-beta[0]*beta[0], 1._rt-beta[1]*beta[1], 1._rt-beta[2]*beta[2])});
 
     // get the EB potential at the current time
     std::string potential_eb_str = "0";


### PR DESCRIPTION
Fix HIP build in the electrostatic solver with embedded boundaries on:
```
/home/runner/work/WarpX/WarpX/Source/FieldSolver/ElectrostaticSolver.cpp:434:9: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
        1.-beta[0]*beta[0], 1.-beta[1]*beta[1], 1.-beta[2]*beta[2])});
        ^~~~~~~~~~~~~~~~~~
/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/Base/AMReX_SPACE.H:151:31: note: expanded from macro 'AMREX_D_DECL'
                              ^
/home/runner/work/WarpX/WarpX/Source/FieldSolver/ElectrostaticSolver.cpp:434:9: note: insert an explicit cast to silence this issue
        1.-beta[0]*beta[0], 1.-beta[1]*beta[1], 1.-beta[2]*beta[2])});
        ^~~~~~~~~~~~~~~~~~
```

Seen with #2170