### PR TITLE
Work-Around: ROCm/rocFFT <=4.3.0

### DIFF
--- a/Source/FieldSolver/SpectralSolver/AnyFFT.H
+++ b/Source/FieldSolver/SpectralSolver/AnyFFT.H
@@ -14,6 +14,9 @@
 #if defined(AMREX_USE_CUDA)
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
+// cstddef: work-around for ROCm/rocFFT <=4.3.0
+// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
+#  include <cstddef>
 #  include <rocfft.h>
 #else
 #  include <fftw3.h>

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -22,11 +22,14 @@
 #include <AMReX_Utility.H>
 
 #if defined(AMREX_USE_MPI)
-    #include <mpi.h>
+#  include <mpi.h>
 #endif
 
 #if defined(AMREX_USE_HIP) && defined(WARPX_USE_PSATD)
-#include <rocfft.h>
+// cstddef: work-around for ROCm/rocFFT <=4.3.0
+// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
+#  include <cstddef>
+#  include <rocfft.h>
 #endif
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
C++ template typedefs do not work in `extern C` blocks.
This work-arounds this construct:
  https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42

This is fixed in the post 4.3.0 rocFFT `develop` branch already.

Fixes build errors of the kind:
```
AnyFFT.H:15:
In file included from /opt/rocm-4.1.0/hip/../include/rocfft.h:38:
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../include/c++/7/cstddef:69:21: error: explicit specialization of undeclared template struct '__byte_operand'
  template<> struct __byte_operand<bool> { using __type = byte; };
```