### PR TITLE
For plasma lens, mapped particle to lab frame

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1154,7 +1154,7 @@ Laser initialization
     Note that the current implementation of the parser for B-field on particles
     is applied in cartesian co-ordinates as a function of (x,y,z) even for RZ.
     To apply a series of plasma lenses, use the option ``repeated_plasma_lens``. This
-    option requires the following parameters,
+    option requires the following parameters, in the lab frame,
     ``repeated_plasma_lens_period``, the period length of the repeat, a single float number,
     ``repeated_plasma_lens_starts``, the start of each lens relative to the period, an array of floats,
     ``repeated_plasma_lens_lengths``, the length of each lens, an array of floats,
@@ -1184,7 +1184,7 @@ Laser initialization
     Note that the current implementation of the parser for E-field on particles
     is applied in cartesian co-ordinates as a function of (x,y,z) even for RZ.
     To apply a series of plasma lenses, use the option ``repeated_plasma_lens``. This
-    option requires the following parameters,
+    option requires the following parameters, in the lab frame,
     ``repeated_plasma_lens_period``, the period length of the repeat, a single float number,
     ``repeated_plasma_lens_starts``, the start of each lens relative to the period, an array of floats,
     ``repeated_plasma_lens_lengths``, the length of each lens, an array of floats,

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -30,6 +30,8 @@ struct GetExternalField
     amrex::Real m_time;
 
     amrex::Real m_repeated_plasma_lens_period;
+    amrex::Real m_gamma_boost;
+    amrex::Real m_uz_boost;
     const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_starts = nullptr;
     const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_lengths = nullptr;
     const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_strengths = nullptr;
@@ -66,16 +68,21 @@ struct GetExternalField
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);
 
-            amrex::ParticleReal const uxp = m_ux[i];
-            amrex::ParticleReal const uyp = m_uy[i];
-            amrex::ParticleReal const uzp = m_uz[i];
-            constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
-            const amrex::Real inv_gamma = 1._rt/std::sqrt(1._rt + (uxp*uxp + uyp*uyp + uzp*uzp)*inv_c2);
-            const amrex::ParticleReal vzp = uzp*inv_gamma;
+            const amrex::ParticleReal uxp = m_ux[i];
+            const amrex::ParticleReal uyp = m_uy[i];
+            const amrex::ParticleReal uzp = m_uz[i];
 
-            // This assumes that vzp > 0.
-            amrex::ParticleReal const zl = z;
-            amrex::ParticleReal const zr = z + vzp*m_dt;
+            constexpr amrex::Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
+            const amrex::ParticleReal gamma = std::sqrt(1._rt + (uxp*uxp + uyp*uyp + uzp*uzp)*inv_c2);
+            const amrex::ParticleReal vzp = uzp/gamma;
+
+            amrex::ParticleReal zl = z;
+            amrex::ParticleReal zr = z + vzp*m_dt;
+
+            if (m_gamma_boost > 1._rt) {
+                zl = m_gamma_boost*zl + m_uz_boost*m_time;
+                zr = m_gamma_boost*zr + m_uz_boost*m_time;
+            }
 
             // This assumes that zl > 0.
             int i_lens = static_cast<int>(std::floor(zl/m_repeated_plasma_lens_period));
@@ -86,14 +93,14 @@ struct GetExternalField
             // Calculate the residence correction
             // frac will be 1 if the step is completely inside the lens, between 0 and 1
             // when entering or leaving the lens, and otherwise 0.
+            // This assumes that vzp > 0.
             amrex::Real fl = 0.;
             if (zl >= lens_start && zl < lens_end) fl = 1.;
             amrex::Real fr = 0.;
             if (zr >= lens_start && zr < lens_end) fr = 1.;
             amrex::Real frac = fl;
-            amrex::Real dzi = 1./(vzp*m_dt);
-            if (fl > fr) frac = (lens_end - zl)*dzi;
-            if (fr > fl) frac = (zr - lens_start)*dzi;
+            if (fl > fr) frac = (lens_end - zl)/(zr - zl);
+            if (fr > fl) frac = (zr - lens_start)/(zr - zl);
 
             if (m_lens_is_electric) {
                 field_x += x*frac*m_repeated_plasma_lens_strengths[i_lens];

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -8,6 +8,7 @@
 
 #include <string>
 
+using namespace amrex::literals;
 
 GetExternalEField::GetExternalEField (const WarpXParIter& a_pti, int a_offset) noexcept
 {
@@ -32,6 +33,9 @@ GetExternalEField::GetExternalEField (const WarpXParIter& a_pti, int a_offset) n
     else if (mypc.m_E_ext_particle_s=="repeated_plasma_lens")
     {
         m_type = RepeatedPlasmaLens;
+        m_time = warpx.gett_new(a_pti.GetLevel());
+        m_gamma_boost = WarpX::gamma_boost;
+        m_uz_boost = std::sqrt(WarpX::gamma_boost*WarpX::gamma_boost - 1._rt)*PhysConst::c;
         m_lens_is_electric = 1;
         m_dt = warpx.getdt(a_pti.GetLevel());
         m_get_position = GetParticlePosition(a_pti, a_offset);
@@ -70,6 +74,9 @@ GetExternalBField::GetExternalBField (const WarpXParIter& a_pti, int a_offset) n
     else if (mypc.m_B_ext_particle_s=="repeated_plasma_lens")
     {
         m_type = RepeatedPlasmaLens;
+        m_time = warpx.gett_new(a_pti.GetLevel());
+        m_gamma_boost = WarpX::gamma_boost;
+        m_uz_boost = std::sqrt(WarpX::gamma_boost*WarpX::gamma_boost - 1._rt)*PhysConst::c;
         m_lens_is_electric = 0;
         m_dt = warpx.getdt(a_pti.GetLevel());
         m_get_position = GetParticlePosition(a_pti, a_offset);


### PR DESCRIPTION
This is one more fix for the plasma lens. This change maps the particle to the lab frame to calculate the field there.