### PR TITLE
update use-sensei flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ option(WarpX_LIB           "Build WarpX as a shared library"            OFF)
 option(WarpX_MPI           "Multi-node support (message-passing)"       ON)
 option(WarpX_OPENPMD       "openPMD I/O (HDF5, ADIOS)"                  OFF)
 option(WarpX_PSATD         "spectral solver support"                    OFF)
+option(WarpX_SENSEI        "SENSEI in situ diagnostics"                 OFF)
 option(WarpX_QED           "QED support (requires PICSAR)"                    ON)
 option(WarpX_QED_TABLE_GEN "QED table generation (requires PICSAR and Boost)" OFF)
-# TODO: sensei, legacy hdf5?
 
 set(WarpX_DIMS_VALUES 2 3 RZ)
 set(WarpX_DIMS 3 CACHE STRING "Simulation dimensionality (2/3/RZ)")

--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -792,7 +792,7 @@ WARN_LOGFILE           =
 
 INPUT                  = ../Source/ ../Tools/ ../Regression/Checksum/
 RECURSIVE              = YES
-    
+
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv
@@ -2047,24 +2047,24 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = AMREX_Linux=1            \
-                         AMREX_PARTICLES=1        \
-                         AMREX_USE_MPI=1          \
-                         AMREX_USE_OMP=1          \
-                         AMREX_SPACEDIM=3         \
-                         AMREX_TINY_PROFILING=1   \
-                         BL_Linux=1               \
-                         BL_USE_MPI=1             \
-                         BL_USE_OMP=1             \
-                         BL_USE_SENSEI_INSITU=1   \
-                         WARPX=1                  \
-                         WARPX_DIM_RZ=1           \
-                         WARPX_DIM_XZ=1           \
-                         WARPX_USE_GPU=1          \
-                         WARPX_USE_OPENPMD=1      \
-                         WARPX_USE_PSATD=1        \
-                         WARPX_QED=1              \
-                         WARPX_QED_TABLE_GEN=1    \
+PREDEFINED             = AMREX_Linux=1             \
+                         AMREX_PARTICLES=1         \
+                         AMREX_USE_MPI=1           \
+                         AMREX_USE_OMP=1           \
+                         AMREX_SPACEDIM=3          \
+                         AMREX_TINY_PROFILING=1    \
+                         BL_Linux=1                \
+                         BL_USE_MPI=1              \
+                         BL_USE_OMP=1              \
+                         AMREX_USE_SENSEI_INSITU=1 \
+                         WARPX=1                   \
+                         WARPX_DIM_RZ=1            \
+                         WARPX_DIM_XZ=1            \
+                         WARPX_USE_GPU=1           \
+                         WARPX_USE_OPENPMD=1       \
+                         WARPX_USE_PSATD=1         \
+                         WARPX_QED=1               \
+                         WARPX_QED_TABLE_GEN=1     \
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -90,6 +90,7 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_PSATD``               ON/**OFF**                                   Spectral solver
 ``WarpX_QED``                 **ON**/OFF                                   QED support (requires PICSAR)
 ``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation support (requires PICSAR and Boost)
+``WarpX_SENSEI``              ON/**OFF**                                   SENSEI in situ visualization
 ============================= ============================================ =========================================================
 
 WarpX can be configured in further detail with options from AMReX, which are `documented in the AMReX manual <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options>`_.

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -12,7 +12,7 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX_PML_kernels.H"
 
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_Array4.H>

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -268,7 +268,7 @@ Diagnostics::InitBaseData ()
     } else if (m_format == "ascent"){
         m_flush_format = std::make_unique<FlushFormatAscent>();
     } else if (m_format == "sensei"){
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
         m_flush_format = std::make_unique<FlushFormatSensei>(
             dynamic_cast<amrex::AmrMesh*>(const_cast<WarpX*>(&warpx)),
             m_diag_name);

--- a/Source/Diagnostics/FlushFormats/CMakeLists.txt
+++ b/Source/Diagnostics/FlushFormats/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(WarpX
     FlushFormatAscent.cpp
     FlushFormatCheckpoint.cpp
     FlushFormatPlotfile.cpp
+    FlushFormatSensei.cpp
 )
 
 if(WarpX_HAVE_OPENPMD)

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -4,7 +4,7 @@
 #include "FlushFormat.H"
 
 #include <AMReX_AmrMesh.H>
-#if defined(BL_USE_SENSEI_INSITU)
+#if defined(AMREX_USE_SENSEI_INSITU)
 #  include <AMReX_AmrMeshInSituBridge.H>
 #else
 namespace amrex {

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -2,7 +2,7 @@
 
 #include "WarpX.H"
 
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 # include <AMReX_AmrMeshInSituBridge.H>
 #endif
 
@@ -16,7 +16,7 @@ FlushFormatSensei::FlushFormatSensei (amrex::AmrMesh *amr_mesh,
     m_insitu_config(), m_insitu_pin_mesh(0), m_insitu_bridge(nullptr),
     m_amr_mesh(amr_mesh)
 {
-#ifndef BL_USE_SENSEI_INSITU
+#ifndef AMREX_USE_SENSEI_INSITU
     amrex::ignore_unused(m_insitu_pin_mesh, m_insitu_bridge, m_amr_mesh, diag_name);
 #else
     amrex::ParmParse pp_diag_name(diag_name);
@@ -41,7 +41,7 @@ FlushFormatSensei::FlushFormatSensei (amrex::AmrMesh *amr_mesh,
 
 FlushFormatSensei::~FlushFormatSensei ()
 {
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
     delete m_insitu_bridge;
 #endif
 }
@@ -58,7 +58,7 @@ FlushFormatSensei::WriteToFile (
     bool /*isBTD*/, int /*snapshotID*/,
     const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
-#ifndef BL_USE_SENSEI_INSITU
+#ifndef AMREX_USE_SENSEI_INSITU
     (void)varnames;
     (void)mf;
     (void)geom;
@@ -90,7 +90,7 @@ void
 FlushFormatSensei::WriteParticles (
     const amrex::Vector<ParticleDiag>& particle_diags) const
 {
-#ifndef BL_USE_SENSEI_INSITU
+#ifndef AMREX_USE_SENSEI_INSITU
     (void)particle_diags;
 #else
     amrex::ErrorStream() << "FlushFormatSensei::WriteParticles : "

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -14,7 +14,7 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_BoxArray.H>

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -26,7 +26,7 @@
 #include "WarpX_FDTD.H"
 
 #include <AMReX.H>
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_Array4.H>

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -11,7 +11,7 @@
 #include "WarpX_QED_K.H"
 
 #include <AMReX.H>
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_Array4.H>

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -25,7 +25,7 @@
 
 #include <AMReX.H>
 #include <AMReX_AmrCore.H>
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_Array.H>

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -33,7 +33,7 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 
-#ifdef BL_USE_SENSEI_INSITU
+#ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
 #endif
 #include <AMReX_Array4.H>

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -206,6 +206,10 @@ function(set_warpx_binary_name)
             set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".GENQEDTABLES")
         endif()
 
+        if(WarpX_SENSEI)
+            set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".SENSEI")
+        endif()
+
 
         if(CMAKE_BUILD_TYPE MATCHES "Debug")
             set_property(TARGET ${tgt} APPEND_STRING PROPERTY OUTPUT_NAME ".DEBUG")
@@ -349,5 +353,6 @@ function(warpx_print_summary)
     message("    OPENPMD: ${WarpX_OPENPMD}")
     message("    QED: ${WarpX_QED}")
     message("    QED table generation: ${WarpX_QED_TABLE_GEN}")
+    message("    SENSEI: ${WarpX_SENSEI}")
     message("")
 endfunction()

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -61,6 +61,10 @@ macro(find_amrex)
             set(AMReX_PARTICLES_PRECISION "SINGLE" CACHE INTERNAL "")
         endif()
 
+        if(WarpX_SENSEI)
+            set(AMReX_SENSEI ON CACHE INTERNAL "")
+        endif()
+
         set(AMReX_INSTALL ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
         set(AMReX_AMRLEVEL OFF CACHE INTERNAL "")
         set(AMReX_ENABLE_TESTS OFF CACHE INTERNAL "")
@@ -72,7 +76,7 @@ macro(find_amrex)
         set(AMReX_TINY_PROFILE ON CACHE BOOL "")
 
         if(WarpX_COMPUTE STREQUAL CUDA)
-            if(WarpX_ASCENT)
+            if(WarpX_ASCENT OR WarpX_SENSEI)
                 set(AMReX_GPU_RDC ON CACHE BOOL "")
             else()
                 # we don't need RDC and disabling it simplifies the build
@@ -81,7 +85,6 @@ macro(find_amrex)
             endif()
         endif()
 
-        # AMReX_SENSEI
         # shared libs, i.e. for Python bindings, need relocatable code
         if(WarpX_LIB)
             set(AMReX_PIC ON CACHE INTERNAL "")
@@ -215,9 +218,14 @@ macro(find_amrex)
         else()
             set(COMPONENT_PIC)
         endif()
+        if(WarpX_SENSEI)
+            set(COMPONENT_SENSEI AMReX_SENSEI)
+        else()
+            set(COMPONENT_SENSEI)
+        endif()
         set(COMPONENT_PRECISION ${WarpX_PRECISION} P${WarpX_PRECISION})
 
-        find_package(AMReX 21.08 CONFIG REQUIRED COMPONENTS ${COMPONENT_ASCENT} ${COMPONENT_DIM} ${COMPONENT_EB} PARTICLES ${COMPONENT_PIC} ${COMPONENT_PRECISION} TINYP LSOLVERS)
+        find_package(AMReX 21.08 CONFIG REQUIRED COMPONENTS ${COMPONENT_ASCENT} ${COMPONENT_DIM} ${COMPONENT_EB} PARTICLES ${COMPONENT_PIC} ${COMPONENT_PRECISION} ${COMPONENT_SENSEI} TINYP LSOLVERS)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
     endif()
 endmacro()


### PR DESCRIPTION
This PR updates the SENSEI compiler flag to match the updated flag in the AMReX library. 

The old flag: BL_USE_SENSEI_INSITU
The new flag: AMREX_USE_SENSEI_INSITU

This new flag was introduced in https://github.com/AMReX-Codes/amrex/pull/2016 

This PR also add FlushFormatSensei.cpp to CMakeLists.txt file where it was missing. 

Tested with the [3D beam-driven election acceleration](https://warpx.readthedocs.io/en/latest/usage/examples.html#beam-driven-electron-acceleration) example and the sensei script from AMReX-Codes/amrex-tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/write_pvd_m.xml in mpi on 8 processes in Ubuntu 18.04.