### PR TITLE
WarpX::Version: Not Empty

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2289,19 +2289,25 @@ WarpX::RestoreCurrent (int lev)
 std::string
 WarpX::Version ()
 {
+    std::string version;
 #ifdef WARPX_GIT_VERSION
-    return std::string(WARPX_GIT_VERSION);
-#else
-    return std::string("Unknown");
+    version = std::string(WARPX_GIT_VERSION);
 #endif
+    if( version.empty() )
+        return std::string("Unknown");
+    else
+        return version;
 }
 
 std::string
 WarpX::PicsarVersion ()
 {
+    std::string version;
 #ifdef PICSAR_GIT_VERSION
-    return std::string(PICSAR_GIT_VERSION);
-#else
-    return std::string("Unknown");
+    version = std::string(PICSAR_GIT_VERSION);
 #endif
+    if( version.empty() )
+        return std::string("Unknown");
+    else
+        return version;
 }


### PR DESCRIPTION
Make sure we do not return an empty string in `WarpX::Version()`. In some situations, e.g., in CI/run_test.sh, the macro for the `WARPX_GIT_VERSION` version in GNUmake is set but empty.

Since empty versions are problematic for HDF5 attributes and confusing anyway, we return a proper `"Unknown"` in such a situation now, too.

Detected as bug in #2150
X-ref:
- https://github.com/openPMD/openPMD-api/pull/1087
- https://github.com/openPMD/openPMD-api/pull/979