### PR TITLE
Print "re-sorting particles" only in verbose

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -285,7 +285,9 @@ WarpX::Evolve (int numsteps)
         mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
 #endif
         if (sort_intervals.contains(step+1)) {
-            amrex::Print() << "re-sorting particles \n";
+            if (verbose) {
+                amrex::Print() << "re-sorting particles \n";
+            }
             mypc->SortParticlesByBin(sort_bin_size);
         }
 


### PR DESCRIPTION
The GPU run would continually print 're-sorting particles' to stdout even with verbose turned off.