### PR TITLE
Minor fix to the documentation of the plasma lens

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1161,7 +1161,7 @@ Laser initialization
     ``repeated_plasma_lens_strengths_B``, the focusing strength of each lens, an array of floats.
     The applied field is uniform longitudinally (along z) with a hard edge,
     where residence corrections are used for more accurate field calculation.
-    The field is of the form :math:`B_x = \mathrm{strength} \cdot y` and :math:`B_y = \mathrm{strength} \cdot x`, :math`:B_z = 0`.
+    The field is of the form :math:`B_x = \mathrm{strength} \cdot y` and :math:`B_y = -\mathrm{strength} \cdot x`, :math`:B_z = 0`.
 
 * ``particles.E_ext_particle_init_style`` (string) optional (default is "default")
     This parameter determines the type of initialization for the external


### PR DESCRIPTION
According [this line of code](https://github.com/ECP-WarpX/WarpX/pull/2163/files#diff-2d6fa0fc50ba38d4c5666cf025a979b4d773abc020a165c5a39eaaab78ae19fdR103), I think that there should be a minus sign in the formula.