### PR TITLE
Plasma lens - transform fields from lab to boosted frame

### DIFF
--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -34,7 +34,8 @@ struct GetExternalField
     amrex::Real m_uz_boost;
     const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_starts = nullptr;
     const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_lengths = nullptr;
-    const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_strengths = nullptr;
+    const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_strengths_E = nullptr;
+    const amrex::Real* AMREX_RESTRICT m_repeated_plasma_lens_strengths_B = nullptr;
     int m_n_lenses;
     int m_lens_is_electric;
     amrex::Real m_dt;
@@ -103,11 +104,35 @@ struct GetExternalField
             if (fr > fl) frac = (zr - lens_start)/(zr - zl);
 
             if (m_lens_is_electric) {
-                field_x += x*frac*m_repeated_plasma_lens_strengths[i_lens];
-                field_y += y*frac*m_repeated_plasma_lens_strengths[i_lens];
+                amrex::Real Ex = x*frac*m_repeated_plasma_lens_strengths_E[i_lens];
+                amrex::Real Ey = y*frac*m_repeated_plasma_lens_strengths_E[i_lens];
+                if (m_gamma_boost > 1._rt) {
+                    // Transform the fields to the boosted frame
+                    const amrex::Real Bx = +y*frac*m_repeated_plasma_lens_strengths_B[i_lens];
+                    const amrex::Real By = -x*frac*m_repeated_plasma_lens_strengths_B[i_lens];
+                    const amrex::Real vz_boost = m_uz_boost/m_gamma_boost;
+                    const amrex::Real Ex_boost = m_gamma_boost*(Ex - vz_boost*By);
+                    const amrex::Real Ey_boost = m_gamma_boost*(Ey + vz_boost*Bx);
+                    Ex = Ex_boost;
+                    Ey = Ey_boost;
+                }
+                field_x += Ex;
+                field_y += Ey;
             } else {
-                field_x += y*frac*m_repeated_plasma_lens_strengths[i_lens];
-                field_y -= x*frac*m_repeated_plasma_lens_strengths[i_lens];
+                amrex::Real Bx = +y*frac*m_repeated_plasma_lens_strengths_B[i_lens];
+                amrex::Real By = -x*frac*m_repeated_plasma_lens_strengths_B[i_lens];
+                if (m_gamma_boost > 1._rt) {
+                    // Transform the fields to the boosted frame
+                    const amrex::Real Ex = x*frac*m_repeated_plasma_lens_strengths_E[i_lens];
+                    const amrex::Real Ey = y*frac*m_repeated_plasma_lens_strengths_E[i_lens];
+                    const amrex::Real vz_boost = m_uz_boost/m_gamma_boost;
+                    const amrex::Real Bx_boost = m_gamma_boost*(Bx + vz_boost*Ey*inv_c2);
+                    const amrex::Real By_boost = m_gamma_boost*(By - vz_boost*Ex*inv_c2);
+                    Bx = Bx_boost;
+                    By = By_boost;
+                }
+                field_x += Bx;
+                field_y += By;
             }
 
         }

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -47,7 +47,8 @@ GetExternalEField::GetExternalEField (const WarpXParIter& a_pti, int a_offset) n
         m_n_lenses = static_cast<int>(mypc.h_repeated_plasma_lens_starts.size());
         m_repeated_plasma_lens_starts = mypc.d_repeated_plasma_lens_starts.data();
         m_repeated_plasma_lens_lengths = mypc.d_repeated_plasma_lens_lengths.data();
-        m_repeated_plasma_lens_strengths = mypc.d_repeated_plasma_lens_strengths_E.data();
+        m_repeated_plasma_lens_strengths_E = mypc.d_repeated_plasma_lens_strengths_E.data();
+        m_repeated_plasma_lens_strengths_B = mypc.d_repeated_plasma_lens_strengths_B.data();
     }
 }
 
@@ -88,6 +89,7 @@ GetExternalBField::GetExternalBField (const WarpXParIter& a_pti, int a_offset) n
         m_n_lenses = static_cast<int>(mypc.h_repeated_plasma_lens_starts.size());
         m_repeated_plasma_lens_starts = mypc.d_repeated_plasma_lens_starts.data();
         m_repeated_plasma_lens_lengths = mypc.d_repeated_plasma_lens_lengths.data();
-        m_repeated_plasma_lens_strengths = mypc.d_repeated_plasma_lens_strengths_B.data();
+        m_repeated_plasma_lens_strengths_E = mypc.d_repeated_plasma_lens_strengths_E.data();
+        m_repeated_plasma_lens_strengths_B = mypc.d_repeated_plasma_lens_strengths_B.data();
     }
 }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -244,13 +244,36 @@ MultiParticleContainer::ReadParameters ()
 
             if (m_E_ext_particle_s == "repeated_plasma_lens") {
                 getArrWithParser(pp_particles, "repeated_plasma_lens_strengths_E", h_repeated_plasma_lens_strengths_E);
+            }
+            if (m_B_ext_particle_s == "repeated_plasma_lens") {
+                getArrWithParser(pp_particles, "repeated_plasma_lens_strengths_B", h_repeated_plasma_lens_strengths_B);
+            }
+            if (WarpX::gamma_boost > 1._rt) {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                     m_E_ext_particle_s == "repeated_plasma_lens" || m_E_ext_particle_s == "default",
+                     "With gamma_boost > 1, E_ext_particle_init_style and B_ext_particle_init_style"
+                     "must be either repeated_plasma_lens or unspecified");
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                     m_B_ext_particle_s == "repeated_plasma_lens" || m_B_ext_particle_s == "default",
+                     "With gamma_boost > 1, E_ext_particle_init_style and B_ext_particle_init_style"
+                     "must be either repeated_plasma_lens or unspecified");
+                if (m_E_ext_particle_s == "default") {
+                    m_E_ext_particle_s = "repeated_plasma_lens";
+                    h_repeated_plasma_lens_strengths_E.resize(n_lenses);
+                }
+                if (m_B_ext_particle_s == "default") {
+                    m_B_ext_particle_s = "repeated_plasma_lens";
+                    h_repeated_plasma_lens_strengths_B.resize(n_lenses);
+                }
+            }
+
+            if (m_E_ext_particle_s == "repeated_plasma_lens") {
                 d_repeated_plasma_lens_strengths_E.resize(n_lenses);
                 amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                            h_repeated_plasma_lens_strengths_E.begin(), h_repeated_plasma_lens_strengths_E.end(),
                            d_repeated_plasma_lens_strengths_E.begin());
             }
             if (m_B_ext_particle_s == "repeated_plasma_lens") {
-                getArrWithParser(pp_particles, "repeated_plasma_lens_strengths_B", h_repeated_plasma_lens_strengths_B);
                 d_repeated_plasma_lens_strengths_B.resize(n_lenses);
                 amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                            h_repeated_plasma_lens_strengths_B.begin(), h_repeated_plasma_lens_strengths_B.end(),


### PR DESCRIPTION
With this change, the focusing strengths should be specified in the lab frame. The new code transforms the calculated fields to the boosted frame.