### PR TITLE
CI: Cancel Prev. GH Action on Push

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -2,6 +2,10 @@ name: 🐧 CUDA
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-cuda
+  cancel-in-progress: true
+
 jobs:
 # Ref.:
 #   https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/ubuntu18.04/10.1/base/Dockerfile

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -2,6 +2,10 @@ name: 🐧 HIP
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-hip
+  cancel-in-progress: true
+
 jobs:
   build_hip:
     name: HIP SP

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -2,6 +2,10 @@ name: 🐧 Intel
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-intel
+  cancel-in-progress: true
+
 jobs:
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,10 @@ name: 🍏 macOS
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-macos
+  cancel-in-progress: true
+
 jobs:
   build_gcc9:
     name: AppleClang

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -8,6 +8,10 @@ name: 📜 Source
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-source
+  cancel-in-progress: true
+
 jobs:
   style:
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,10 @@ name: 🐧 OpenMP
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-ubuntu
+  cancel-in-progress: true
+
 jobs:
   build_cxxminimal:
     name: GCC Minimal w/o MPI

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,10 @@ name: 🪟 Windows
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-windows
+  cancel-in-progress: true
+
 jobs:
   build_win_msvc:
     name: MSVC C++17 w/o MPI


### PR DESCRIPTION
Save CI resources by canceling already running or waiting builds
if a PR is updated.

This was previously only done for Azure and now also for GH actions.

X-ref:
- #1974
- https://github.com/AMReX-Codes/amrex/pull/2254
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run