### PR TITLE
Ascent/SENSEI: Add Profiler

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -19,29 +19,48 @@ FlushFormatAscent::WriteToFile (
     bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
 #ifdef AMREX_USE_ASCENT
+    WARPX_PROFILE("FlushFormatAscent::WriteToFile()");
+    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::MultiLevelToBlueprint",
+                         prof_ascent_mesh_blueprint);
+    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::WriteParticles",
+                         prof_ascent_particles);
+    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::publish",
+                         prof_ascent_publish);
+    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::execute",
+                         prof_ascent_execute);
+
     auto & warpx = WarpX::GetInstance();
 
     // wrap mesh data
+    WARPX_PROFILE_VAR_START(prof_ascent_mesh_blueprint);
     conduit::Node bp_mesh;
     amrex::MultiLevelToBlueprint(
         nlev, amrex::GetVecOfConstPtrs(mf), varnames, geom, time, iteration, warpx.refRatio(), bp_mesh);
+    WARPX_PROFILE_VAR_STOP(prof_ascent_mesh_blueprint);
 
+    WARPX_PROFILE_VAR_START(prof_ascent_particles);
     WriteParticles(particle_diags, bp_mesh);
+    WARPX_PROFILE_VAR_STOP(prof_ascent_particles);
 
     // If you want to save blueprint HDF5 files w/o using an Ascent
     // extract, you can call the following AMReX helper:
     // const auto step = istep[0];
     // WriteBlueprintFiles(bp_mesh,"bp_export",step,"hdf5");
 
+    WARPX_PROFILE_VAR_START(prof_ascent_publish);
     ascent::Ascent ascent;
     conduit::Node opts;
     opts["exceptions"] = "catch";
     opts["mpi_comm"] = MPI_Comm_c2f(ParallelDescriptor::Communicator());
     ascent.open(opts);
     ascent.publish(bp_mesh);
+    WARPX_PROFILE_VAR_STOP(prof_ascent_publish);
+
+    WARPX_PROFILE_VAR_START(prof_ascent_execute);
     conduit::Node actions;
     ascent.execute(actions);
     ascent.close();
+    WARPX_PROFILE_VAR_STOP(prof_ascent_execute);
 
 #else
     amrex::ignore_unused(varnames, mf, geom, iteration, time,
@@ -55,6 +74,8 @@ FlushFormatAscent::WriteToFile (
 void
 FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags, conduit::Node& a_bp_mesh) const
 {
+    WARPX_PROFILE("FlushFormatAscent::WriteParticles()");
+
     // wrap particle data for each species
     // we prefix the fields with "particle_{species_name}" b/c we
     // want to to uniquely name all the fields that can be plotted

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -20,25 +20,17 @@ FlushFormatAscent::WriteToFile (
 {
 #ifdef AMREX_USE_ASCENT
     WARPX_PROFILE("FlushFormatAscent::WriteToFile()");
-    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::MultiLevelToBlueprint",
-                         prof_ascent_mesh_blueprint);
-    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::WriteParticles",
-                         prof_ascent_particles);
-    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::publish",
-                         prof_ascent_publish);
-    WARPX_PROFILE_VAR_NS("FlushFormatAscent::WriteToFile::execute",
-                         prof_ascent_execute);
 
     auto & warpx = WarpX::GetInstance();
 
     // wrap mesh data
-    WARPX_PROFILE_VAR_START(prof_ascent_mesh_blueprint);
+    WARPX_PROFILE_VAR("FlushFormatAscent::WriteToFile::MultiLevelToBlueprint", prof_ascent_mesh_blueprint);
     conduit::Node bp_mesh;
     amrex::MultiLevelToBlueprint(
         nlev, amrex::GetVecOfConstPtrs(mf), varnames, geom, time, iteration, warpx.refRatio(), bp_mesh);
     WARPX_PROFILE_VAR_STOP(prof_ascent_mesh_blueprint);
 
-    WARPX_PROFILE_VAR_START(prof_ascent_particles);
+    WARPX_PROFILE_VAR("FlushFormatAscent::WriteToFile::WriteParticles", prof_ascent_particles);
     WriteParticles(particle_diags, bp_mesh);
     WARPX_PROFILE_VAR_STOP(prof_ascent_particles);
 
@@ -47,7 +39,7 @@ FlushFormatAscent::WriteToFile (
     // const auto step = istep[0];
     // WriteBlueprintFiles(bp_mesh,"bp_export",step,"hdf5");
 
-    WARPX_PROFILE_VAR_START(prof_ascent_publish);
+    WARPX_PROFILE_VAR("FlushFormatAscent::WriteToFile::publish", prof_ascent_publish);
     ascent::Ascent ascent;
     conduit::Node opts;
     opts["exceptions"] = "catch";
@@ -56,7 +48,7 @@ FlushFormatAscent::WriteToFile (
     ascent.publish(bp_mesh);
     WARPX_PROFILE_VAR_STOP(prof_ascent_publish);
 
-    WARPX_PROFILE_VAR_START(prof_ascent_execute);
+    WARPX_PROFILE_VAR("FlushFormatAscent::WriteToFile::execute", prof_ascent_execute);
     conduit::Node actions;
     ascent.execute(actions);
     ascent.close();

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -72,6 +72,8 @@ FlushFormatSensei::WriteToFile (
     (void)plot_raw_rho;
     (void)plot_raw_F;
 #else
+    WARPX_PROFILE("FlushFormatSensei::WriteToFile()");
+
     amrex::Vector<amrex::MultiFab> *mf_ptr =
         const_cast<amrex::Vector<amrex::MultiFab>*>(&mf);
 


### PR DESCRIPTION
Add overall write profilers to Ascent & SENSEI.
Add detailed profile for sub-operations (blueprint, publish, execute) to Ascent as well.