### PR TITLE
CI: Trap NaNs, Divisions by Zero, Overflows

### DIFF
--- a/Regression/prepare_file_travis.py
+++ b/Regression/prepare_file_travis.py
@@ -67,9 +67,10 @@ if ci_ccache:
     text = re.sub('addToCompileString =',
                   'addToCompileString = USE_CCACHE=TRUE ', text)
 
-# Add runtime option: crash for unused variables
+# Add runtime options: crash for unused variables; trap NaNs, divisions by zero, and overflows
 text = re.sub('runtime_params =',
-              'runtime_params = amrex.abort_on_unused_inputs=1 ',
+              'runtime_params = amrex.abort_on_unused_inputs=1 amrex.fpe_trap_invalid=1 ' +
+              'amrex.fpe_trap_zero=1 amrex.fpe_trap_overflow=1',
               text)
 
 # Use less/more cores for compiling, e.g. public CI only provides 2 cores


### PR DESCRIPTION
Trap NaNs, divisions by zero, and overflows when running our CI tests.