### PR TITLE
Bug fixed: looping over all species now within `OneStep_multiJ`

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -511,14 +511,13 @@ MultiParticleContainer::DepositCharge (
     if (relative_t != 0.) PushX(relative_t);
 
     // Call the deposition kernel for each species
-    for (int ispecies = 0; ispecies < nSpecies(); ispecies++)
+    for (auto& pc : allcontainers)
     {
-        WarpXParticleContainer& species = GetParticleContainer(ispecies);
         bool const local = true;
         bool const reset = false;
         bool const do_rz_volume_scaling = false;
         bool const interpolate_across_levels = false;
-        species.DepositCharge(rho, local, reset, do_rz_volume_scaling,
+        pc->DepositCharge(rho, local, reset, do_rz_volume_scaling,
                               interpolate_across_levels, icomp);
     }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -482,10 +482,9 @@ MultiParticleContainer::DepositCurrent (
     }
 
     // Call the deposition kernel for each species
-    for (int ispecies = 0; ispecies < nSpecies(); ispecies++)
+    for (auto& pc : allcontainers)
     {
-        WarpXParticleContainer& species = GetParticleContainer(ispecies);
-        species.DepositCurrent(J, dt, relative_t);
+        pc->DepositCurrent(J, dt, relative_t);
     }
 
 #ifdef WARPX_DIM_RZ


### PR DESCRIPTION
Bug fix: now we loop over all species within `OneStep_multiJ` with multi-J algorithm.

Thanks @RemiLehe and @EZoni for localizing the problem.

<img width="1921" alt="Screen Shot 2021-08-17 at 3 36 23 PM" src="https://user-images.githubusercontent.com/30510597/129948459-dad881c8-8555-4ccc-ae71-86cb92de9365.png">
