### PR TITLE
Add plot_raw_rho in parameters doc

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1766,7 +1766,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
     * ``<diag_name>.plot_raw_rho`` (`0` or `1`) optional (default `0`)
     By default, the charge density written in the plot files is averaged on the cell centers.
-    When ``<diag_name>.plot_raw_rho = 1``, then the raw (i.e. non-averaged) charge density also saved in the output files.
+    When ``<diag_name>.plot_raw_rho = 1``, then the raw (i.e. non-averaged) charge density is also saved in the output files.
     Only works with ``<diag_name>.format = plotfile``.
 
 * ``<diag_name>.coarsening_ratio`` (list of `int`) optional (default `1 1 1`)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1764,6 +1764,11 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Whether to include the guard cells in the output of the raw fields.
     Only works with ``<diag_name>.format = plotfile``.
 
+    * ``<diag_name>.plot_raw_rho`` (`0` or `1`) optional (default `0`)
+    By default, the charge density written in the plot files is averaged on the cell centers.
+    When ``<diag_name>.plot_raw_rho = 1``, then the raw (i.e. non-averaged) charge density also saved in the output files.
+    Only works with ``<diag_name>.format = plotfile``.
+
 * ``<diag_name>.coarsening_ratio`` (list of `int`) optional (default `1 1 1`)
     Reduce size of the field output by this ratio in each dimension.
     (This is done by averaging the field over 1 or 2 points along each direction, depending on the staggering).


### PR DESCRIPTION
Noticed that we had this option to plot the raw charge density but it's not included in the parameters documentation, so I've added it.