### PR TITLE
Evolve: Reorder py_afterstep and cur_time break

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -302,6 +302,15 @@ WarpX::Evolve (int numsteps)
             ComputeSpaceChargeField( reset_fields );
         }
 
+        // sync up time
+        for (int i = 0; i <= max_level; ++i) {
+            t_new[i] = cur_time;
+        }
+
+        // warpx_py_afterstep runs with the updated global time. It is included
+        // in the evolve timing.
+        if (warpx_py_afterstep) warpx_py_afterstep();
+
         Real evolve_time_end_step = amrex::second();
         evolve_time += evolve_time_end_step - evolve_time_beg_step;
 
@@ -312,10 +321,6 @@ WarpX::Evolve (int numsteps)
                       << " s; This step = " << evolve_time_end_step-evolve_time_beg_step
                       << " s; Avg. per step = " << evolve_time/(step+1) << " s\n";
         }
-        // sync up time
-        for (int i = 0; i <= max_level; ++i) {
-            t_new[i] = cur_time;
-        }
 
         /// reduced diags
         if (reduced_diags->m_plot_rd != 0)
@@ -325,17 +330,15 @@ WarpX::Evolve (int numsteps)
         }
         multi_diags->FilterComputePackFlush( step );
 
-        if (cur_time >= stop_time - 1.e-3*dt[0]) {
-            break;
-        }
-
-        if (warpx_py_afterstep) warpx_py_afterstep();
-
         // inputs: unused parameters (e.g. typos) check after step 1 has finished
         if (!early_params_checked) {
             amrex::Print() << "\n"; // better: conditional \n based on return value
             amrex::ParmParse().QueryUnusedInputs();
             early_params_checked = true;
+        }
+
+        if (cur_time >= stop_time - 1.e-3*dt[0]) {
+            break;
         }
 
         // End loop on time steps


### PR DESCRIPTION
This reordering is based on the following assumptions:

- `warpx_py_afterstep` should run with an updated time variable, and be included in evolve timing. It should run even on the last step triggered by `stop_time`.
- there's no reason for the `cur_time >= stop_time - 1.e-3*dt[0]` based break to happen before anything else in the loop.

(By the way, I assume the reason that break is there is so that if someone intends to run a single step with cur_time minutely smaller than stop_time it'll still run one step? Otherwise it seems like that final break should just be in the initial for loop statement.)

If I'm missing anything I'm happy to update this. Thanks!