### PR TITLE
Ionization.H: Fix Bug (Division by Zero)

### DIFF
--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -124,7 +124,7 @@ struct IonizationFilterFunc
                                );
 
             // Compute probability of ionization p
-            amrex::Real w_dtau = 1._rt/ ga * m_adk_prefactor[ion_lev] *
+            amrex::Real w_dtau = (E == 0._rt) ? 0._rt : 1._rt/ ga * m_adk_prefactor[ion_lev] *
                 std::pow(E, m_adk_power[ion_lev]) *
                 std::exp( m_adk_exp_prefactor[ion_lev]/E );
             amrex::Real p = 1._rt - std::exp( - w_dtau );


### PR DESCRIPTION
This fixes a bug in the computation of the ionization probability: when `E = 0` we now set `w_dtau = 0`. See https://github.com/ECP-WarpX/WarpX/pull/2205#issuecomment-902144277.