### PR TITLE
Improved error handling when the libwarpx shared object library can't be loaded

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -82,7 +82,6 @@ except OSError as e:
         print("Failed to load the libwarpx shared object library")
         print(e)
 
-
 # WarpX can be compiled using either double or float
 libwarpx.warpx_Real_size.restype = ctypes.c_int
 libwarpx.warpx_ParticleReal_size.restype = ctypes.c_int

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -74,8 +74,14 @@ libname = "libwarpx.{0}.{1}".format(geometry_dim, mod_ext)
 
 try:
     libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), libname))
-except OSError:
-    raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname)
+except OSError as e:
+    value = e.args[0]
+    if any(so in value for so in ["libwarpx.2d.so", "libwarpx.3d.so"]):
+        raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname)
+    else:
+        print("Failed to load the libwarpx shared object library")
+        print(e)
+
 
 # WarpX can be compiled using either double or float
 libwarpx.warpx_Real_size.restype = ctypes.c_int

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -76,11 +76,11 @@ try:
     libwarpx = ctypes.CDLL(os.path.join(_get_package_root(), libname))
 except OSError as e:
     value = e.args[0]
-    if any(so in value for so in ["libwarpx.2d.so", "libwarpx.3d.so"]):
-        raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname)
+    if f'{libname}: cannot open shared object file: No such file or directory' in value:
+        raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname) from e
     else:
         print("Failed to load the libwarpx shared object library")
-        print(e)
+        raise
 
 # WarpX can be compiled using either double or float
 libwarpx.warpx_Real_size.restype = ctypes.c_int


### PR DESCRIPTION
If the libwarpx shared object library (for 2d `libwarpx.2d.so`) can't be located by `_libwarpx.py` the user is told that they need to run `make` in the Python directory of WarpX. However this is not the only reason that an `OSError` may be raised when trying to load the shared object library. 

During development it's possible to make a mistake in either `_libwarpx.py` or in the C++ code that interacts with the shared object library, and in this case the current error is inaccurate.

Now when an `OSError` is raised, it will check to see if the problem is a _missing_ shared library file, and if it's not, simply says that it could not be loaded.