### PR TITLE
Updated the installation instructions

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -77,7 +77,7 @@ try:
 except OSError as e:
     value = e.args[0]
     if f'{libname}: cannot open shared object file: No such file or directory' in value:
-        raise Exception('"%s" was not installed. It can be installed by running "make" in the Python directory of WarpX' % libname) from e
+        raise Exception(f'"{libname}" was not installed. Installation instructions can be found here https://warpx.readthedocs.io/en/latest/install/users.html') from e
     else:
         print("Failed to load the libwarpx shared object library")
         raise


### PR DESCRIPTION
From this comment https://github.com/ECP-WarpX/WarpX/pull/2215#issuecomment-902867996, simply link to the installation instructions for pywarpx if the shared object library does not exist.