### PR TITLE
Multi-J: Optimize Allocations of rho MultiFabs

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -489,13 +489,13 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         // 3) Deposit rho (in rho_new, since it will be moved during the loop)
         if (WarpX::update_with_rho)
         {
-            // Deposit rho at relative time -dt in component 1 (rho_new)
+            // Deposit rho at relative time -dt
             // (dt[0] denotes the time step on mesh refinement level 0)
-            mypc->DepositCharge(rho_fp, -dt[0], 1);
+            mypc->DepositCharge(rho_fp, -dt[0]);
             // Filter, exchange boundary, and interpolate across levels
             SyncRho();
             // Forward FFT of rho_new
-            PSATDForwardTransformRho(1);
+            PSATDForwardTransformRho(0, 1);
         }
 
         // 4) Deposit J if needed
@@ -544,12 +544,12 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
             // Deposit new rho
             if (WarpX::update_with_rho)
             {
-                // Deposit rho at relative time (i_depose-n_depose+1)*sub_dt in component 1 (rho_new)
-                mypc->DepositCharge(rho_fp, (i_depose-n_depose+1)*sub_dt, 1);
+                // Deposit rho at relative time (i_depose-n_depose+1)*sub_dt
+                mypc->DepositCharge(rho_fp, (i_depose-n_depose+1)*sub_dt);
                 // Filter, exchange boundary, and interpolate across levels
                 SyncRho();
                 // Forward FFT of rho_new
-                PSATDForwardTransformRho(1);
+                PSATDForwardTransformRho(0, 1);
             }
 
             // Advance E,B,F,G fields in time and update the average fields

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -264,12 +264,12 @@ WarpX::PSATDForwardTransformJ ()
 }
 
 void
-WarpX::PSATDForwardTransformRho (const int icomp)
+WarpX::PSATDForwardTransformRho (const int icomp, const int dcomp)
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
     // Select index in k space
-    const int dst_comp = (icomp == 0) ? Idx.rho_old : Idx.rho_new;
+    const int dst_comp = (dcomp == 0) ? Idx.rho_old : Idx.rho_new;
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
@@ -410,8 +410,8 @@ WarpX::PushPSATD ()
 
     PSATDForwardTransformEB();
     PSATDForwardTransformJ();
-    PSATDForwardTransformRho(0); // rho old
-    PSATDForwardTransformRho(1); // rho new
+    PSATDForwardTransformRho(0, 0); // rho old
+    PSATDForwardTransformRho(1, 1); // rho new
     PSATDPushSpectralFields();
     PSATDBackwardTransformEB();
     if (WarpX::fft_do_time_averaging) PSATDBackwardTransformEBavg();

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -146,11 +146,10 @@ public:
      *             a fraction of dt). When different than 0, the particle
      *             position will be temporarily modified to match the time
      *             of the deposition.
-     * \param[in] icomp component of the MultiFab where rho is deposited (old, new)
      */
     void
     DepositCharge (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-                   const amrex::Real relative_t, const int icomp = 0);
+                   const amrex::Real relative_t);
 
     /**
      * \brief Deposit current density.

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -521,13 +521,12 @@ MultiParticleContainer::DepositCurrent (
 void
 MultiParticleContainer::DepositCharge (
     amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-    const amrex::Real relative_t, const int icomp)
+    const amrex::Real relative_t)
 {
     // Reset the rho array
     for (int lev = 0; lev < rho.size(); ++lev)
     {
-        int const nc = WarpX::ncomps;
-        rho[lev]->setVal(0.0, icomp*nc, nc, rho[lev]->nGrowVect());
+        rho[lev]->setVal(0.0, 0, WarpX::ncomps, rho[lev]->nGrowVect());
     }
 
     // Push the particles in time, if needed
@@ -541,7 +540,7 @@ MultiParticleContainer::DepositCharge (
         bool const do_rz_volume_scaling = false;
         bool const interpolate_across_levels = false;
         pc->DepositCharge(rho, local, reset, do_rz_volume_scaling,
-                              interpolate_across_levels, icomp);
+                              interpolate_across_levels);
     }
 
     // Push the particles back in time

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1184,8 +1184,9 @@ private:
      *        with k-space filtering (if needed)
      *
      * \param[in] icomp index of fourth component (0 for rho_old, 1 for rho_new)
+     * \param[in] dcomp index of spectral component (0 for rho_old, 1 for rho_new)
      */
-    void PSATDForwardTransformRho (const int icomp);
+    void PSATDForwardTransformRho (const int icomp, const int dcomp);
 
     /**
      * \brief Copy rho_new to rho_old in spectral space

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1506,7 +1506,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     }
     if (deposit_charge)
     {
-        rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,2*ncomps,ngRho,tag("rho_fp"));
+        // For the multi-J algorithm we can allocate only one rho component (no distinction between old and new)
+        const int rho_ncomps = (WarpX::do_multi_J) ? ncomps : 2*ncomps;
+        rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_fp"));
     }
 
     if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
@@ -1665,7 +1667,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         current_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_cp[z]"));
 
         if (deposit_charge) {
-            rho_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,rho_nodal_flag),dm,2*ncomps,ngRho,tag("rho_cp"));
+            // For the multi-J algorithm we can allocate only one rho component (no distinction between old and new)
+            const int rho_ncomps = (WarpX::do_multi_J) ? ncomps : 2*ncomps;
+            rho_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_cp"));
         }
 
         if (do_dive_cleaning)


### PR DESCRIPTION
In the case of the multi-J algorithm, we can allocate only one component for the rho MultiFab (thus remove the distinction between old and new rho, in real space).