### PR TITLE
Fix: Missing Include Guards (FWD)

### DIFF
--- a/Source/BoundaryConditions/PML_fwd.H
+++ b/Source/BoundaryConditions/PML_fwd.H
@@ -5,8 +5,8 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#ifndef WARPX_INJECTOR_POSITION_FWD_H
-#define WARPX_INJECTOR_POSITION_FWD_H
+#ifndef WARPX_PML_FWD_H
+#define WARPX_PML_FWD_H
 
 struct Sigma;
 struct SigmaBox;
@@ -18,4 +18,4 @@ enum struct PatchType;
 
 class PML;
 
-#endif /* WARPX_INJECTOR_POSITION_FWD_H */
+#endif /* WARPX_PML_FWD_H */

--- a/Source/BoundaryConditions/PML_fwd.H
+++ b/Source/BoundaryConditions/PML_fwd.H
@@ -1,9 +1,12 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
+
+#ifndef WARPX_INJECTOR_POSITION_FWD_H
+#define WARPX_INJECTOR_POSITION_FWD_H
 
 struct Sigma;
 struct SigmaBox;
@@ -14,3 +17,5 @@ class MultiSigmaBox;
 enum struct PatchType;
 
 class PML;
+
+#endif /* WARPX_INJECTOR_POSITION_FWD_H */

--- a/Source/Diagnostics/BackTransformedDiagnostic_fwd.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic_fwd.H
@@ -1,11 +1,15 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_BACK_TRANSFORMED_DIAGNOSTICS_FWD_H
+#define WARPX_BACK_TRANSFORMED_DIAGNOSTICS_FWD_H
 
 class LabFrameDiag;
 class LabFrameSnapShot;
 class BackTransformedDiagnostic;
+
+#endif /* WARPX_BACK_TRANSFORMED_DIAGNOSTICS_FWD_H */

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor_fwd.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_COMPUTEDIAGFUNCTOR_FWD_H
+#define WARPX_COMPUTEDIAGFUNCTOR_FWD_H
+
 class ComputeDiagFunctor;
+
+#endif /* WARPX_COMPUTEDIAGFUNCTOR_FWD_H */

--- a/Source/Diagnostics/FlushFormats/FlushFormat_fwd.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_FLUSH_FORMAT_FWD_H
+#define WARPX_FLUSH_FORMAT_FWD_H
+
 class FlushFormat;
+
+#endif /* WARPX_FLUSH_FORMAT_FWD_H */

--- a/Source/Diagnostics/MultiDiagnostics_fwd.H
+++ b/Source/Diagnostics/MultiDiagnostics_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_MULTI_DIAGNOSTICS_FWD_H
+#define WARPX_MULTI_DIAGNOSTICS_FWD_H
+
 class MultiDiagnostics;
+
+#endif /* WARPX_MULTI_DIAGNOSTICS_FWD_H */

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag_fwd.H
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag_fwd.H
@@ -1,10 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_PARTICLE_DIAG_FWD_H
+#define WARPX_PARTICLE_DIAG_FWD_H
+
 class ParticleDiag;
 
-
+#endif /* WARPX_PARTICLE_DIAG_FWD_H */

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags_fwd.H
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_MULTIREDUCEDDIAGS_FWD_H
+#define WARPX_MULTIREDUCEDDIAGS_FWD_H
+
 class MultiReducedDiags;
+
+#endif /* WARPX_MULTIREDUCEDDIAGS_FWD_H */

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
+ 
+ #ifndef WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
+ #define WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
 
 class FiniteDifferenceSolver;
+
+#endif /* WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H */

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H
@@ -4,9 +4,9 @@
  *
  * License: BSD-3-Clause-LBNL
  */
- 
- #ifndef WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
- #define WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
+
+#ifndef WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
+#define WARPX_FINITE_DIFFERENCE_SOLVER_FWD_H
 
 class FiniteDifferenceSolver;
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_MACROSCOPICPROPERIES_FWD_H
+#define WARPX_MACROSCOPICPROPERIES_FWD_H
+
 class MacroscopicProperties;
+
+#endif /* WARPX_MACROSCOPICPROPERIES_FWD_H */

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData_fwd.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData_fwd.H
@@ -1,9 +1,14 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_SPECTRALFIELDDATA_FWD_H
+#define WARPX_SPECTRALFIELDDATA_FWD_H
+
 class SpectralFieldIndex;
 class SpectralFieldData;
+
+#endif /* WARPX_SPECTRALFIELDDATA_FWD_H */

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace_fwd.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace_fwd.H
@@ -1,10 +1,15 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_SPECTRALKSPACE_FWD_H
+#define WARPX_SPECTRALKSPACE_FWD_H
+
 struct ShiftType;
 
 class SpectralKSpace;
+
+#endif /* WARPX_SPECTRALKSPACE_FWD_H /*

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace_fwd.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace_fwd.H
@@ -12,4 +12,4 @@ struct ShiftType;
 
 class SpectralKSpace;
 
-#endif /* WARPX_SPECTRALKSPACE_FWD_H /*
+#endif /* WARPX_SPECTRALKSPACE_FWD_H */

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_SPECTRALSOLVERRZ_FWD_H
+#define WARPX_SPECTRALSOLVERRZ_FWD_H
+
 class SpectralSolverRZ;
+
+#endif /* WARPX_SPECTRALSOLVERRZ_FWD_H */

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver_fwd.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_SPECTRALSOLVER_FWD_H
+#define WARPX_SPECTRALSOLVER_FWD_H
+
 class SpectralSolver;
+
+#endif /* WARPX_SPECTRALSOLVER_FWD_H */

--- a/Source/Filter/NCIGodfreyFilter_fwd.H
+++ b/Source/Filter/NCIGodfreyFilter_fwd.H
@@ -1,10 +1,15 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_NCI_GODFREY_FILTER_FWD_H
+#define WARPX_NCI_GODFREY_FILTER_FWD_H
+
 enum class godfrey_coeff_set;
 
 class NCIGodfreyFilter;
+
+#endif /* WARPX_NCI_GODFREY_FILTER_FWD_H */

--- a/Source/Initialization/InjectorPosition_fwd.H
+++ b/Source/Initialization/InjectorPosition_fwd.H
@@ -1,10 +1,15 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_INJECTOR_POSITION_FWD_H
+#define WARPX_INJECTOR_POSITION_FWD_H
+
 struct InjectorPositionRandom;
 struct InjectorPositionRegular;
 struct InjectorPosition;
+
+#endif /* WARPX_INJECTOR_POSITION_FWD_H */

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
@@ -1,12 +1,17 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
+#define WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
+
 class BreitWheelerGetOpticalDepth;
 class BreitWheelerEvolveOpticalDepth;
 class BreitWheelerGeneratePairs;
 
 class BreitWheelerEngine;
+
+#endif /* WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H */

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper_fwd.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper_fwd.H
@@ -1,12 +1,17 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_QUANTUM_SYNC_ENGINE_WRAPPER_FWD_H
+#define WARPX_QUANTUM_SYNC_ENGINE_WRAPPER_FWD_H
+
 class QuantumSynchrotronGetOpticalDepth;
 class QuantumSynchrotronEvolveOpticalDepth;
 class QuantumSynchrotronPhotonEmission;
 
 class QuantumSynchrotronEngine;
+
+#endif /* WARPX_QUANTUM_SYNC_ENGINE_WRAPPER_FWD_H */

--- a/Source/Particles/MultiParticleContainer_fwd.H
+++ b/Source/Particles/MultiParticleContainer_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Luca Fedeli
+/* Copyright 2021 Luca Fedeli, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_MULTI_PARTICLE_CONTAINER_FWD_H
+#define WARPX_MULTI_PARTICLE_CONTAINER_FWD_H
+
 class MultiParticleContainer;
+
+#endif /* WARPX_MULTI_PARTICLE_CONTAINER_FWD_H */

--- a/Source/Particles/ParticleBoundaryBuffer_fwd.H
+++ b/Source/Particles/ParticleBoundaryBuffer_fwd.H
@@ -1,8 +1,13 @@
-/* Copyright 2021 Andrew Myers
+/* Copyright 2021 Andrew Myers, Axel Huebl
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
 
+#ifndef WARPX_PARTICLE_BOUNDARY_BUFFER_FWD_H
+#define WARPX_PARTICLE_BOUNDARY_BUFFER_FWD_H
+
 class ParticleBoundaryBuffer;
+
+#endif /* WARPX_PARTICLE_BOUNDARY_BUFFER_FWD_H */


### PR DESCRIPTION
All header files need include guards to avoid double definitions.

Follow-up to #2124 & #1947 
(First seen as an issue in #2223)