### PR TITLE
Docs: Fix Summit Python

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -62,7 +62,7 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    export Ascent_DIR=/gpfs/alpine/world-shared/csc340/software/ascent/current/summit/cuda/gnu/ascent-install
 
    # optional: for Python bindings or libEnsemble
-   module load python/3.8-anaconda3
+   module load python/3.8.10
    module load openblas/0.3.15-omp
    module load netlib-lapack/3.9.1
    if [ -d "$HOME/sw/venvs/warpx" ]


### PR DESCRIPTION
We cannot use an anaconda base package, since anaconda ships its own libstdc++ for its compiler stack, which is not compatible with our compiler choice.

Please update as follows:
- update the `warpx.profile`
- remove the virtual env via `rm -rf $HOME/sw/venvs/warpx`
- re-log in
- `source warpx.profile`
- re-create the virtual environment as instructed

Thanks to @nckwcq for noticing!