### PR TITLE
Avoid Unnecessary FFTs of rho

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -410,8 +410,12 @@ WarpX::PushPSATD ()
 
     PSATDForwardTransformEB();
     PSATDForwardTransformJ();
-    PSATDForwardTransformRho(0); // rho old
-    PSATDForwardTransformRho(1); // rho new
+    // Do rho FFTs only if needed
+    if (WarpX::update_with_rho || WarpX::current_correction || WarpX::do_dive_cleaning)
+    {
+        PSATDForwardTransformRho(0); // rho old
+        PSATDForwardTransformRho(1); // rho new
+    }
     PSATDPushSpectralFields();
     PSATDBackwardTransformEB();
     if (WarpX::fft_do_time_averaging) PSATDBackwardTransformEBavg();


### PR DESCRIPTION
Small performance optimization: I think we can avoid computing forward FFTs of rho (old and new), unless needed when we set `psatd.update_with_rho=1` or `psatd.current_correction=1` or `warpx.do_dive_cleaning=1` (e.g. F terms with multi-J algorithm) in the input file.