### PR TITLE
Fix compile error in FlushFormatSensei with new include

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -1,3 +1,4 @@
+#include "Utils/WarpXProfilerWrapper.H"
 #include "FlushFormatSensei.H"
 
 #include "WarpX.H"


### PR DESCRIPTION
I got a compiler error trying to compile the current version of `FlushFormatSensei.cpp`

```
[build] /home/corey/Git/WarpX/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp:76:5: error: ‘WARPX_PROFILE’ was not declared in this scope; did you mean ‘BL_PROFILE’?
[build]    76 |     WARPX_PROFILE("FlushFormatSensei::WriteToFile()");
[build]       |     ^~~~~~~~~~~~~
[build]       |     BL_PROFILE
```

Adding the include fixes the error, but I am not sure if this is best practice. Is there a higher level include file that would be better here? Also, I am nervous that `FlushFormatAscent.cpp` is also affected by a missing include, but I am not setup at the moment to test against Ascent locally. 