### PR TITLE
Ascent: Include for Profiler

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -1,6 +1,7 @@
 #include "FlushFormatAscent.H"
 
 #include "WarpX.H"
+#include "Utils/WarpXProfilerWrapper.H"
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>


### PR DESCRIPTION
Forgot an include.

Follow-up to #2204.
Same as #2237 