### PR TITLE
Docs: ADIOS2 Fixed on Summit

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -49,7 +49,7 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    module load boost/1.76.0
 
    # optional: for openPMD support
-   #module load adios2/2.7.1 # currently broken: OLCFHELP-3319
+   module load adios2/2.7.1
    module load hdf5/1.10.7
 
    # optional: for PSATD in RZ geometry support

--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -18,8 +18,7 @@
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
-module load gcc
-module load cuda
+source $HOME/warpx.profile
 
 export OMP_NUM_THREADS=1
 jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
The adios2 system module is now fixed on Summit (OLCFHELP-3319 / https://github.com/ornladios/ADIOS2/issues/2836).

We don't need to load the openpmd-api module for CMake, as we build it on-the-fly at the moment against the ADIOS2 and HDF5 modules.

Will document to load `openpmd-api` for GNUmake users once OLCF deploys 0.14.2+ (latest on Summit: 0.13.4).