### PR TITLE
Use ROCm 4.3 in CI

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -10,12 +10,10 @@ set -eu -o pipefail
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
 wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key \
   | sudo apt-key add -
-#echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' \
-# Use 4.1.1 till the VOP bug in 4.2 is fixed
-echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.1.1/ xenial main' \
+echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 
-echo 'export PATH=/opt/rocm-4.1.1/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
+echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -26,6 +26,11 @@ jobs:
         export CXX=$(which clang++)
         export CC=$(which clang)
 
+        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
+        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
+        #   https://github.com/open-mpi/ompi/issues/9317
+        export LDFLAGS="-lopen-pal"
+
         cmake -S . -B build_sp \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DAMReX_AMD_ARCH=gfx900     \


### PR DESCRIPTION
From @WeiqunZhang: "Since the VOP bug has been fixed in the latest ROCm release v4.3, CI can use the latest ROCm release now instead of 4.1."

We also need to work around an Ubuntu 20.04 LTS / OpenMPI 4.0.3 bug with Clang compiles regarding the missing linker flag for libopen-pal:
- https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
- https://github.com/open-mpi/ompi/issues/9317

Same as https://github.com/AMReX-Codes/amrex/pull/2280
Replaces work-around applied in #1963