### PR TITLE
Replace AmrMesh bridge for AmrMeshParticle bridge

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -5,7 +5,7 @@
 
 #include <AMReX_AmrMesh.H>
 #if defined(AMREX_USE_SENSEI_INSITU)
-#  include <AMReX_AmrMeshInSituBridge.H>
+#  include <AMReX_AmrMeshParticleInSituBridge.H>
 #else
 namespace amrex {
 using AmrMeshInSituBridge = void;
@@ -66,7 +66,7 @@ public:
 private:
     std::string m_insitu_config;
     int m_insitu_pin_mesh = 0;
-    amrex::AmrMeshInSituBridge * m_insitu_bridge = nullptr;
+    amrex::AmrMeshParticleInSituBridge * m_insitu_bridge = nullptr;
     amrex::AmrMesh * m_amr_mesh = nullptr;
 };
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -8,7 +8,7 @@
 #  include <AMReX_AmrMeshParticleInSituBridge.H>
 #else
 namespace amrex {
-using AmrMeshInSituBridge = void;
+using AmrMeshParticleInSituBridge = void;
 }
 #endif
 


### PR DESCRIPTION
This PR replaces the SENSEI AmrMeshInSituBridge with the new AmrMeshParticleInSituBridge which allows for processing data streams derived from Particle Containers alongside AmrMesh data. Provided an existing SENSEI script which only looks for an AmrMesh, the adaptor will only process the mesh as expected. 

**This PR requires https://github.com/AMReX-Codes/amrex/pull/2285**

Limitations:
This current form only allows for 1 species of particle to be processed. 
The name of the particle species is not configurable. 