### PR TITLE
Added parsing in intervals

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2376,8 +2376,10 @@ A single slice can have 0, 1 or 2 colons ``:``, just as `numpy slices <https://n
 Any value that is not given is set to default.
 Default is ``0`` for the start, ``std::numeric_limits<int>::max()`` for the stop and ``1`` for the
 period.
-For the 1 and 2 colon syntax, actually having the integers in the string is optional
+For the 1 and 2 colon syntax, actually having values in the string is optional
 (this means that ``::5``, ``100 ::10`` and ``100 :`` are all valid syntaxes).
+
+All values can be expressions that will be parsed in the same way as other integer input parameters.
 
 **Examples**
 

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -1,5 +1,16 @@
+# Parameters for the plasma wave
+my_constants.max_step = 80
+my_constants.epsilon = 0.01
+my_constants.n0 = 2.e24  # electron density, #/m^3
+my_constants.wp = sqrt(n0*q_e**2/(epsilon0*m_e))  # plasma frequency
+my_constants.kp = wp/clight  # plasma wavenumber
+my_constants.k0 = 2.*pi/20.e-6  # longitudianl perturbation wavenumber
+my_constants.w0 = 5.e-6  # transverse perturbation length
+# Note: kp is calculated in SI for a density of 2e24
+# k0 is calculated so as to have 2 periods within the 40e-6 wide box.
+
 # Maximum number of time steps
-max_step = 80
+max_step = max_step
 
 # number of grid points
 amr.n_cell =   64  128
@@ -36,16 +47,6 @@ warpx.cfl = 1.0
 
 # Having this turned on makes for a more sensitive test
 warpx.do_dive_cleaning = 1
-
-# Parameters for the plasma wave
-my_constants.epsilon = 0.01
-my_constants.n0 = 2.e24  # electron density, #/m^3
-my_constants.wp = sqrt(n0*q_e**2/(epsilon0*m_e))  # plasma frequency
-my_constants.kp = wp/clight  # plasma wavenumber
-my_constants.k0 = 2.*pi/20.e-6  # longitudianl perturbation wavenumber
-my_constants.w0 = 5.e-6  # transverse perturbation length
-# Note: kp is calculated in SI for a density of 2e24
-# k0 is calculated so as to have 2 periods within the 40e-6 wide box.
 
 # Particles
 particles.species_names = electrons ions
@@ -85,25 +86,25 @@ ions.uz = 0.
 
 # Diagnostics
 diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter
-diag1.intervals = 40
+diag1.intervals = max_step/2
 diag1.diag_type = Full
 diag1.fields_to_plot = jx jz Ex Ez By
 
 ## diag_parser_filter is a diag used to test the particle filter function.
-diag_parser_filter.intervals = 80:80:
+diag_parser_filter.intervals = max_step:max_step:
 diag_parser_filter.diag_type = Full
 diag_parser_filter.species = electrons
 diag_parser_filter.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = "(uy-uz < 0) *
                                                                  (sqrt(x**2+y**2)<10e-6) * (z > 0)"
 
 ## diag_uniform_filter is a diag used to test the particle uniform filter.
-diag_uniform_filter.intervals = 80:80:
+diag_uniform_filter.intervals = max_step:max_step:
 diag_uniform_filter.diag_type = Full
 diag_uniform_filter.species = electrons
 diag_uniform_filter.electrons.uniform_stride = 3
 
 ## diag_random_filter is a diag used to test the particle random filter.
-diag_random_filter.intervals = 80:80:
+diag_random_filter.intervals = max_step:max_step:
 diag_random_filter.diag_type = Full
 diag_random_filter.species = electrons
 diag_random_filter.electrons.random_fraction = 0.66

--- a/Examples/Tests/Langmuir/inputs_3d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -1,5 +1,18 @@
+# Parameters for the plasma wave
+my_constants.max_step = 40
+my_constants.lx = 40.e-6 # length of sides
+my_constants.dx = 6.25e-07 # grid cell size
+my_constants.nx = lx/dx # number of cells in each dimension
+my_constants.epsilon = 0.01
+my_constants.n0 = 2.e24  # electron and positron densities, #/m^3
+my_constants.wp = sqrt(2.*n0*q_e**2/(epsilon0*m_e))  # plasma frequency
+my_constants.kp = wp/clight  # plasma wavenumber
+my_constants.k = 2.*2.*pi/lx  # perturbation wavenumber
+# Note: kp is calculated in SI for a density of 4e24 (i.e. 2e24 electrons + 2e24 positrons)
+# k is calculated so as to have 2 periods within the 40e-6 wide box.
+
 # Maximum number of time steps
-max_step = 40
+max_step = max_step
 
 # number of grid points
 amr.n_cell =  nx nx nx
@@ -35,18 +48,6 @@ algo.particle_shape = 1
 
 # CFL
 warpx.cfl = 1.0
-
-# Parameters for the plasma wave
-my_constants.lx = 40.e-6 # length of sides
-my_constants.dx = 6.25e-07 # grid cell size
-my_constants.nx = lx/dx # number of cells in each dimension
-my_constants.epsilon = 0.01
-my_constants.n0 = 2.e24  # electron and positron densities, #/m^3
-my_constants.wp = sqrt(2.*n0*q_e**2/(epsilon0*m_e))  # plasma frequency
-my_constants.kp = wp/clight  # plasma wavenumber
-my_constants.k = 2.*2.*pi/lx  # perturbation wavenumber
-# Note: kp is calculated in SI for a density of 4e24 (i.e. 2e24 electrons + 2e24 positrons)
-# k is calculated so as to have 2 periods within the 40e-6 wide box.
 
 # Particles
 particles.species_names = electrons positrons
@@ -89,7 +90,7 @@ positrons.momentum_function_uz(x,y,z) = "-epsilon * k/kp * cos(k*x) * cos(k*y) *
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 40
+diag1.intervals = max_step
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho
 diag1.electrons.variables = w ux

--- a/Source/Utils/IntervalsParser.cpp
+++ b/Source/Utils/IntervalsParser.cpp
@@ -14,23 +14,23 @@ SliceParser::SliceParser (const std::string& instr)
     auto insplit = WarpXUtilStr::split<std::vector<std::string>>(instr, m_separator, true);
 
     if(insplit.size() == 1){ // no colon in input string. The input is the period.
-        WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[0], m_period),assert_msg);}
+        m_period = parseStringtoInt(insplit[0], "interval period");}
     else if(insplit.size() == 2) // 1 colon in input string. The input is start:stop
     {
         if (!insplit[0].empty()){
-            WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[0], m_start),assert_msg);}
+            m_start = parseStringtoInt(insplit[0], "interval start");}
         if (!insplit[1].empty()){
-            WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[1], m_stop),assert_msg);}
+            m_stop = parseStringtoInt(insplit[1], "interval stop");}
     }
     else // 2 colons in input string. The input is start:stop:period
     {
         WarpXUtilMsg::AlwaysAssert(insplit.size() == 3,assert_msg);
         if (!insplit[0].empty()){
-            WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[0], m_start),assert_msg);}
+            m_start = parseStringtoInt(insplit[0], "interval start");}
         if (!insplit[1].empty()){
-            WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[1], m_stop),assert_msg);}
+            m_stop = parseStringtoInt(insplit[1], "interval stop");}
         if (!insplit[2].empty()){
-            WarpXUtilMsg::AlwaysAssert(amrex::is_it<int>(insplit[2], m_period),assert_msg);}
+            m_period = parseStringtoInt(insplit[2], "interval period");}
     }
 }
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -182,13 +182,25 @@ safeCastToInt(amrex::Real x, const std::string& real_name);
 */
 amrex::Parser makeParser (std::string const& parse_function, amrex::Vector<std::string> const& varnames);
 
-/**
- * \brief Parse a string and return either a real or an int
+/** Parse a string and return as a real
+ *
+ * In case the string cannot be interpreted as Real,
+ * this function ... <throws an exception? aborts with error message?>
  *
  * \param str The string to be parsed
- * \param name For integers, the name, to be used in error messages
+ * \return representation as real
  */
 amrex::Real parseStringtoReal(std::string str);
+
+/** Parse a string and return an int
+ *
+ * In case the string cannot be interpreted as Real,
+ * this function ... <throws an exception? aborts with error message?>
+  *
+ * \param str The string to be parsed
+ * \param name For integers, the name, to be used in error messages
+ * \return rounded closest integer
+ */
 int parseStringtoInt(std::string str, std::string name);
 
 template <int N>

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -182,6 +182,15 @@ safeCastToInt(amrex::Real x, const std::string& real_name);
 */
 amrex::Parser makeParser (std::string const& parse_function, amrex::Vector<std::string> const& varnames);
 
+/**
+ * \brief Parse a string and return either a real or an int
+ *
+ * \param str The string to be parsed
+ * \param name For integers, the name, to be used in error messages
+ */
+amrex::Real parseStringtoReal(std::string str);
+int parseStringtoInt(std::string str, std::string name);
+
 template <int N>
 amrex::ParserExecutor<N> compileParser (amrex::Parser const* parser)
 {

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -359,6 +359,23 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
     return parser;
 }
 
+amrex::Real
+parseStringtoReal(std::string str)
+{
+    auto parser = makeParser(str, {});
+    auto exe = parser.compileHost<0>();
+    amrex::Real result = exe();
+    return result;
+}
+
+int
+parseStringtoInt(std::string str, std::string name)
+{
+    amrex::Real rval = parseStringtoReal(str);
+    int ival = safeCastToInt(std::round(rval), name);
+    return ival;
+}
+
 int
 queryWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
 {
@@ -370,11 +387,7 @@ queryWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Re
         // If so, create a parser object and apply it to the value provided by the user.
         std::string str_val;
         Store_parserString(a_pp, str, str_val);
-
-        auto parser = makeParser(str_val, {});
-        auto exe = parser.compileHost<0>();
-
-        val = exe();
+        val = parseStringtoReal(str_val);
     }
     // return the same output as amrex::ParmParse::query
     return is_specified;
@@ -386,10 +399,7 @@ getWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real
     // If so, create a parser object and apply it to the value provided by the user.
     std::string str_val;
     Store_parserString(a_pp, str, str_val);
-
-    auto parser = makeParser(str_val, {});
-    auto exe = parser.compileHost<0>();
-    val = exe();
+    val = parseStringtoReal(str_val);
 }
 
 int
@@ -405,9 +415,7 @@ queryArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::v
         int const n = static_cast<int>(tmp_str_arr.size());
         val.resize(n);
         for (int i=0 ; i < n ; i++) {
-            auto parser = makeParser(tmp_str_arr[i], {});
-            auto exe = parser.compileHost<0>();
-            val[i] = exe();
+            val[i] = parseStringtoReal(tmp_str_arr[i]);
         }
     }
     // return the same output as amrex::ParmParse::query
@@ -424,9 +432,7 @@ getArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::vec
     int const n = static_cast<int>(tmp_str_arr.size());
     val.resize(n);
     for (int i=0 ; i < n ; i++) {
-        auto parser = makeParser(tmp_str_arr[i], {});
-        auto exe = parser.compileHost<0>();
-        val[i] = exe();
+        val[i] = parseStringtoReal(tmp_str_arr[i]);
     }
 }
 
@@ -441,9 +447,7 @@ getArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::vec
     int const n = static_cast<int>(tmp_str_arr.size());
     val.resize(n);
     for (int i=0 ; i < n ; i++) {
-        auto parser = makeParser(tmp_str_arr[i], {});
-        auto exe = parser.compileHost<0>();
-        val[i] = exe();
+        val[i] = parseStringtoReal(tmp_str_arr[i]);
     }
 }
 


### PR DESCRIPTION
This allows expressions to be used when specifying intervals in the input files.

Since I added `parseStringtoInt`, I also added `parseStringtoReal` and used it to replace duplicated code in the query and get with parser routines for a minor cleanup.