### PR TITLE
Store and read in (if present) dmaps in checkpoint files

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -29,8 +29,10 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override final;
 
-    void CheckpointParticles(const std::string& dir,
-                             const amrex::Vector<ParticleDiag>& particle_diags) const;
+    void CheckpointParticles (const std::string& dir,
+                              const amrex::Vector<ParticleDiag>& particle_diags) const;
+
+    void WriteDMaps (const std::string& dir, int nlev) const;
 };
 
 #endif // WARPX_FLUSHFORMATCHECKPOINT_H_

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -144,6 +144,7 @@ FlushFormatCheckpoint::WriteDMaps (const std::string& dir, int nlev) const
 
             if (!DMFile.good()) { amrex::FileOpenFailed(DMFileName); }
 
+            DMFile << ParallelDescriptor::NProcs() << "\n";
             warpx.DistributionMap(lev).writeOn(DMFile);
 
             DMFile.flush();

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -111,17 +111,46 @@ FlushFormatCheckpoint::WriteToFile (
 
     CheckpointParticles(checkpointname, particle_diags);
 
+    WriteDMaps(checkpointname, nlev);
+
     VisMF::SetHeaderVersion(current_version);
 
 }
 
 void
-FlushFormatCheckpoint::CheckpointParticles(
+FlushFormatCheckpoint::CheckpointParticles (
     const std::string& dir,
     const amrex::Vector<ParticleDiag>& particle_diags) const
 {
     for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
         particle_diags[i].getParticleContainer()->Checkpoint(
             dir, particle_diags[i].getSpeciesName());
+    }
+}
+
+void
+FlushFormatCheckpoint::WriteDMaps (const std::string& dir, int nlev) const
+{
+    if (ParallelDescriptor::IOProcessor()) {
+        auto & warpx = WarpX::GetInstance();
+        for (int lev = 0; lev < nlev; ++lev) {
+            std::string DMFileName = dir;
+            if (!DMFileName.empty() && DMFileName[DMFileName.size()-1] != '/') {DMFileName += '/';}
+            DMFileName = amrex::Concatenate(DMFileName + "Level_", lev, 1);
+            DMFileName += "/DM";
+
+            std::ofstream DMFile;
+            DMFile.open(DMFileName.c_str(), std::ios::out|std::ios::trunc);
+
+            if (!DMFile.good()) { amrex::FileOpenFailed(DMFileName); }
+
+            warpx.DistributionMap(lev).writeOn(DMFile);
+
+            DMFile.flush();
+            DMFile.close();
+            if (!DMFile.good()) {
+                amrex::Abort("FlushFormatCheckpoint::WriteDMaps: problem writing DMFile");
+            }
+        }
     }
 }

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -51,6 +51,38 @@ WarpX::GotoNextLine (std::istream& is)
     is.ignore(bl_ignore_max, '\n');
 }
 
+amrex::DistributionMapping
+WarpX::GetRestartDMap (const std::string& chkfile, const amrex::BoxArray& ba, int lev) const {
+    std::string DMFileName = chkfile;
+    if (!DMFileName.empty() && DMFileName[DMFileName.size()-1] != '/') {DMFileName += '/';}
+    DMFileName = amrex::Concatenate(DMFileName + "Level_", lev, 1);
+    DMFileName += "/DM";
+
+    if (!amrex::FileExists(DMFileName)) {
+        return amrex::DistributionMapping{ba, ParallelDescriptor::NProcs()};
+    }
+
+    Vector<char> fileCharPtr;
+    ParallelDescriptor::ReadAndBcastFile(DMFileName, fileCharPtr);
+    std::string fileCharPtrString(fileCharPtr.dataPtr());
+    std::istringstream DMFile(fileCharPtrString, std::istringstream::in);
+    if ( ! DMFile.good()) amrex::FileOpenFailed(DMFileName);
+
+    int nprocs_in_checkpoint;
+    DMFile >> nprocs_in_checkpoint;
+    if (nprocs_in_checkpoint != ParallelDescriptor::NProcs()) {
+        return amrex::DistributionMapping{ba, ParallelDescriptor::NProcs()};
+    }
+
+    amrex::DistributionMapping dm;
+    dm.readFrom(DMFile);
+    if (dm.size() != ba.size()) {
+        return amrex::DistributionMapping{ba, ParallelDescriptor::NProcs()};
+    }
+
+    return dm;
+}
+
 void
 WarpX::InitFromCheckpoint ()
 {
@@ -156,7 +188,7 @@ WarpX::InitFromCheckpoint ()
             BoxArray ba;
             ba.readFrom(is);
             GotoNextLine(is);
-            DistributionMapping dm { ba, ParallelDescriptor::NProcs() };
+            DistributionMapping dm = GetRestartDMap(restart_chkfile, ba, lev);
             SetBoxArray(lev, ba);
             SetDistributionMap(lev, dm);
             AllocLevelData(lev, ba, dm);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -848,6 +848,9 @@ private:
     void AllocLevelData (int lev, const amrex::BoxArray& new_grids,
                          const amrex::DistributionMapping& new_dmap);
 
+    amrex::DistributionMapping
+    GetRestartDMap (const std::string& chkfile, const amrex::BoxArray& ba, int lev) const;
+
     void InitFromCheckpoint ();
     void PostRestart ();
 


### PR DESCRIPTION
This PR adds the ability to write distribution mappings to checkpoint files, and to read them in on restart. This is useful when running with load balancing on, because the default SFC distributions may lead to some ranks running out of memory. 

Address Issue #1784.

Currently this PR always writes the dmaps and always uses them if they are present and compatible, i.e. if the number of procs is same. An open question is whether we want to make writing and or use the checkpoint dmap and optional feature.