### PR TITLE
Interpolate mu to B-location when computing H

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -25,11 +25,10 @@ struct FieldAccessorMacroscopic
     FieldAccessorMacroscopic ( amrex::Array4<amrex::Real const> const a_field,
                                T_GetMacroparameter const& a_getParameter,
                                amrex::GpuArray<int,3> const& a_field_stag,
-                               amrex::GpuArray<int,3> const& a_parameter_stag,
                                amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const a_domain_lo,
                                amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const a_dx )
         : m_field(a_field), m_getParameter(a_getParameter), m_field_stag(a_field_stag),
-          m_parameter_stag(a_parameter_stag), m_domain_lo(a_domain_lo), m_dx(a_dx) {}
+          m_domain_lo(a_domain_lo), m_dx(a_dx) {}
 
     /**
      * \brief return field value at (i,j,k,ncomp) scaled by (1/m_parameters(i,j,k,ncomp))
@@ -58,8 +57,6 @@ private:
     T_GetMacroparameter const m_getParameter;
     /**  Staggering of the field multifab, m_field */
     amrex::GpuArray<int,3> const m_field_stag;
-    /**  Staggering of the macroparameter multifab, m_parameter_stag */
-    amrex::GpuArray<int,3> const m_parameter_stag;
     /**  Coarsening ratio when interpolated macroparameter to location of field */
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_domain_lo;
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_dx;

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -10,21 +10,26 @@
 
 #include "WarpX.H"
 #include "Utils/CoarsenIO.H"
+#include "Utils/WarpXUtil.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #include <AMReX_Array.H>
 
 /**
  * \brief Functor that returns the division of the source m_field Array4 value
           by macroparameter, m_parameter value at the respective (i,j,k,ncomp).
  */
+template< typename T_GetMacroparameter>
 struct FieldAccessorMacroscopic
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     FieldAccessorMacroscopic ( amrex::Array4<amrex::Real const> const a_field,
-                               amrex::Array4<amrex::Real const> const a_parameter,
+                               T_GetMacroparameter const& a_getParameter,
                                amrex::GpuArray<int,3> const& a_field_stag,
                                amrex::GpuArray<int,3> const& a_parameter_stag,
-                               amrex::GpuArray<int,3> const& a_cr_ratio )
-        : m_field(a_field), m_parameter(a_parameter), m_field_stag(a_field_stag), m_parameter_stag(a_parameter_stag), m_cr_ratio(a_cr_ratio) {}
+                               amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const a_domain_lo,
+                               amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const a_dx )
+        : m_field(a_field), m_getParameter(a_getParameter), m_field_stag(a_field_stag),
+          m_parameter_stag(a_parameter_stag), m_domain_lo(a_domain_lo), m_dx(a_dx) {}
 
     /**
      * \brief return field value at (i,j,k,ncomp) scaled by (1/m_parameters(i,j,k,ncomp))
@@ -43,23 +48,21 @@ struct FieldAccessorMacroscopic
     amrex::Real operator() (int const i, int const j,
                             int const k, int const ncomp) const noexcept
     {
-        // Interpolate the material properties from where it is described to
-        // the location of the field.
-        amrex::Real const parameter_interp = CoarsenIO::Interp( m_parameter, m_parameter_stag,
-                                             m_field_stag, m_cr_ratio, i, j, k, 0);
-        return ( m_field(i, j, k, ncomp)  /  parameter_interp ) ;
+        amrex::Real x, y, z;
+        WarpXUtilAlgo::getCellCoordinates(i, j, k, m_field_stag, m_domain_lo, m_dx, x, y, z);
+        return ( m_field(i, j, k, ncomp)  /  m_getParameter(x, y, z) ) ;
     }
 private:
     /** Array4 of the source field to be scaled and returned by the operator() */
     amrex::Array4<amrex::Real const> const m_field;
-    /** Array4 of the macroscopic parameter used to divide m_field in the operator() */
-    amrex::Array4<amrex::Real const> const m_parameter;
+    T_GetMacroparameter const m_getParameter;
     /**  Staggering of the field multifab, m_field */
     amrex::GpuArray<int,3> const m_field_stag;
     /**  Staggering of the macroparameter multifab, m_parameter_stag */
     amrex::GpuArray<int,3> const m_parameter_stag;
     /**  Coarsening ratio when interpolated macroparameter to location of field */
-    amrex::GpuArray<int,3> const m_cr_ratio;
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_domain_lo;
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_dx;
 };
 
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -28,13 +28,15 @@ struct FieldAccessorMacroscopic
 
     /**
      * \brief return field value at (i,j,k,ncomp) scaled by (1/m_parameters(i,j,k,ncomp))
+     *        Note that if the m_parameter has a different staggering than the field, then the
+     *        value is first interpolated to the location of the field and then scaled.
      * \param[in] i      index along x of the Array4, m_field and m_parameter.
      * \param[in] j      index along y of the Array4, m_field and m_parameter.
      * \param[in] k      index along z of the Array4, m_field and m_parameter.
      * \param[in] ncomp  index along fourth component of the Array4, containing field-data
                          to be returned after diving with zero-th component
                          of m_paramter.
-     *
+     * 
      * \return           m_field/m_paramter at (i,j,k,ncomp)
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -1,7 +1,16 @@
+/* Copyright 2020 Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
 #ifndef WARPX_FIELD_ACCESSOR_FUNCTORS_H
 #define WARPX_FIELD_ACCESSOR_FUNCTORS_H
 
 #include "WarpX.H"
+#include "Utils/CoarsenIO.H"
+#include <AMReX_Array.H>
 
 /**
  * \brief Functor that returns the division of the source m_field Array4 value
@@ -11,8 +20,11 @@ struct FieldAccessorMacroscopic
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     FieldAccessorMacroscopic ( amrex::Array4<amrex::Real const> const a_field,
-                               amrex::Array4<amrex::Real const> const a_parameter )
-        : m_field(a_field), m_parameter(a_parameter) {}
+                               amrex::Array4<amrex::Real const> const a_parameter,
+                               amrex::GpuArray<int,3> const& a_field_stag,
+                               amrex::GpuArray<int,3> const& a_parameter_stag,
+                               amrex::GpuArray<int,3> const& a_cr_ratio )
+        : m_field(a_field), m_parameter(a_parameter), m_field_stag(a_field_stag), m_parameter_stag(a_parameter_stag), m_cr_ratio(a_cr_ratio) {}
 
     /**
      * \brief return field value at (i,j,k,ncomp) scaled by (1/m_parameters(i,j,k,ncomp))
@@ -29,13 +41,20 @@ struct FieldAccessorMacroscopic
     amrex::Real operator() (int const i, int const j,
                             int const k, int const ncomp) const noexcept
     {
-        return ( m_field(i, j, k, ncomp)  /  m_parameter(i, j, k, 0) ) ;
+        // Interpolate the material properties from where it is described to
+        // the location of the field.
+        amrex::Real const parameter_interp = CoarsenIO::Interp( m_parameter, m_parameter_stag,
+                                             m_field_stag, m_cr_ratio, i, j, k, 0);
+        return ( m_field(i, j, k, ncomp)  /  parameter_interp ) ;
     }
 private:
     /** Array4 of the source field to be scaled and returned by the operator() */
     amrex::Array4<amrex::Real const> const m_field;
     /** Array4 of the macroscopic parameter used to divide m_field in the operator() */
     amrex::Array4<amrex::Real const> const m_parameter;
+    amrex::GpuArray<int,3> const m_field_stag;
+    amrex::GpuArray<int,3> const m_parameter_stag;
+    amrex::GpuArray<int,3> const m_cr_ratio;
 };
 
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -36,7 +36,7 @@ struct FieldAccessorMacroscopic
      * \param[in] ncomp  index along fourth component of the Array4, containing field-data
                          to be returned after diving with zero-th component
                          of m_paramter.
-     * 
+     *
      * \return           m_field/m_paramter at (i,j,k,ncomp)
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -16,7 +16,8 @@
 
 /**
  * \brief Functor that returns the division of the source m_field Array4 value
-          by macroparameter, m_parameter value at the respective (i,j,k,ncomp).
+          by macroparameter obtained using functor, m_getParameter,
+          at the respective (i,j,k,ncomp).
  */
 template< typename T_GetMacroparameter>
 struct FieldAccessorMacroscopic
@@ -31,17 +32,15 @@ struct FieldAccessorMacroscopic
           m_domain_lo(a_domain_lo), m_dx(a_dx) {}
 
     /**
-     * \brief return field value at (i,j,k,ncomp) scaled by (1/m_parameters(i,j,k,ncomp))
-     *        Note that if the m_parameter has a different staggering than the field, then the
-     *        value is first interpolated to the location of the field and then scaled.
+     * \brief return field value at (i,j,k,ncomp) scaled by (1/m_getParameter(x,y,z))
+     *
      * \param[in] i      index along x of the Array4, m_field and m_parameter.
      * \param[in] j      index along y of the Array4, m_field and m_parameter.
      * \param[in] k      index along z of the Array4, m_field and m_parameter.
      * \param[in] ncomp  index along fourth component of the Array4, containing field-data
-                         to be returned after diving with zero-th component
-                         of m_paramter.
+                         to be returned after dividing by the macroparameter.
      *
-     * \return           m_field/m_paramter at (i,j,k,ncomp)
+     * \return           m_field/m_getParameter(x,y,z) at (i,j,k,ncomp)
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (int const i, int const j,
@@ -54,11 +53,13 @@ struct FieldAccessorMacroscopic
 private:
     /** Array4 of the source field to be scaled and returned by the operator() */
     amrex::Array4<amrex::Real const> const m_field;
+    /** Functor object to return the macroparameter at a given position on the grid.*/
     T_GetMacroparameter const m_getParameter;
-    /**  Staggering of the field multifab, m_field */
+    /** Staggering of the field multifab, m_field */
     amrex::GpuArray<int,3> const m_field_stag;
-    /**  Coarsening ratio when interpolated macroparameter to location of field */
+    /** Lower physical coordinates of the simulation domain. */
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_domain_lo;
+    /** Cell-size array */
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const m_dx;
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -52,8 +52,11 @@ private:
     amrex::Array4<amrex::Real const> const m_field;
     /** Array4 of the macroscopic parameter used to divide m_field in the operator() */
     amrex::Array4<amrex::Real const> const m_parameter;
+    /**  Staggering of the field multifab, m_field */
     amrex::GpuArray<int,3> const m_field_stag;
+    /**  Staggering of the macroparameter multifab, m_parameter_stag */
     amrex::GpuArray<int,3> const m_parameter_stag;
+    /**  Coarsening ratio when interpolated macroparameter to location of field */
     amrex::GpuArray<int,3> const m_cr_ratio;
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -92,10 +92,11 @@ class FiniteDifferenceSolver
           */
 
         void MacroscopicEvolveE ( std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
-                            std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
-                            std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Jfield,
-                            amrex::Real const dt,
-                            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties);
+                      std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
+                      std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Jfield,
+                      amrex::Real const dt,
+                      std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+                      int const lev);
 
         void EvolveBPML ( std::array< amrex::MultiFab*, 3 > Bfield,
                       std::array< amrex::MultiFab*, 3 > const Efield,
@@ -211,7 +212,8 @@ class FiniteDifferenceSolver
             std::array< std::unique_ptr< amrex::MultiFab>, 3> const &Bfield,
             std::array< std::unique_ptr< amrex::MultiFab>, 3> const& Jfield,
             amrex::Real const dt,
-            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties);
+            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+            int const lev);
 
         template< typename T_Algo >
         void EvolveBPMLCartesian (

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -10,6 +10,7 @@
 #include "MacroscopicProperties/MacroscopicProperties.H"
 #include "Utils/CoarsenIO.H"
 #include "Utils/WarpXAlgorithmSelection.H"
+#include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
 #include <AMReX.H>
@@ -112,6 +113,14 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
     amrex::GpuArray<int, 3> const& Bz_stag = macroscopic_properties->Bz_IndexType;
     amrex::GpuArray<int, 3> const& macro_cr     = macroscopic_properties->macro_cr_ratio;
 
+    // temporarily declare and define lev
+    const int lev = 0;
+    const auto getSigma = GetSigmaMacroparameter();
+    const auto getEpsilon = GetEpsilonMacroparameter();
+    const auto getMu = GetMuMacroparameter();
+    auto &warpx = WarpX::GetInstance();
+    const auto problo = warpx.Geom(lev).ProbLoArray();
+    const auto dx = warpx.Geom(lev).CellSizeArray();
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
@@ -143,9 +152,9 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         int const n_coefs_z = m_stencil_coefs_z.size();
 
-        FieldAccessorMacroscopic const Hx(Bx, mu_arr, Bx_stag, mu_stag, macro_cr);
-        FieldAccessorMacroscopic const Hy(By, mu_arr, By_stag, mu_stag, macro_cr);
-        FieldAccessorMacroscopic const Hz(Bz, mu_arr, Bz_stag, mu_stag, macro_cr);
+        FieldAccessorMacroscopic<GetMuMacroparameter> const Hx(Bx, getMu, Bx_stag, mu_stag, problo, dx);
+        FieldAccessorMacroscopic<GetMuMacroparameter> const Hy(By, getMu, By_stag, mu_stag, problo, dx);
+        FieldAccessorMacroscopic<GetMuMacroparameter> const Hz(Bz, getMu, Bz_stag, mu_stag, problo, dx);
 
         // Extract tileboxes for which to loop
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
@@ -156,14 +165,13 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
         // Loop over the cells and update the fields
         amrex::ParallelFor(tex, tey, tez,
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                //// Interpolate conductivity, sigma, to Ex position on the grid
-                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
-                                           Ex_stag, macro_cr, i, j, k, scomp);
-                // Interpolated permittivity, epsilon, to Ex position on the grid
-                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
-                                           Ex_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+                amrex::Real x, y, z;
+                WarpXUtilAlgo::getCellCoordinates (i, j, k, Ex_stag, problo, dx,
+                                                   x, y, z );
+                amrex::Real const sigma = getSigma(x, y, z);
+                amrex::Real const epsilon = getEpsilon(x, y, z);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma, epsilon, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma, epsilon, dt);
                 Ex(i, j, k) = alpha * Ex(i, j, k)
                             + beta * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
                                        + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)
@@ -171,12 +179,13 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
             },
 
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
-                                           Ey_stag, macro_cr, i, j, k, scomp);
-                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
-                                           Ey_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+                amrex::Real x, y, z;
+                WarpXUtilAlgo::getCellCoordinates (i, j, k, Ey_stag, problo, dx,
+                                                   x, y, z );
+                amrex::Real const sigma = getSigma(x, y, z); 
+                amrex::Real const epsilon = getEpsilon(x, y, z);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma, epsilon, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma, epsilon, dt);
 
                 Ey(i, j, k) = alpha * Ey(i, j, k)
                             + beta * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
@@ -185,12 +194,13 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
             },
 
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
-                                           Ez_stag, macro_cr, i, j, k, scomp);
-                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
-                                           Ez_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+                amrex::Real x, y, z;
+                WarpXUtilAlgo::getCellCoordinates (i, j, k, Ez_stag, problo, dx,
+                                                   x, y, z );
+                amrex::Real const sigma = getSigma(x, y, z); 
+                amrex::Real const epsilon = getEpsilon(x, y, z);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma, epsilon, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma, epsilon, dt);
 
                 Ez(i, j, k) = alpha * Ez(i, j, k)
                             + beta * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -103,9 +103,13 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
     // properties from their respective staggering to the Ex, Ey, Ez locations
     amrex::GpuArray<int, 3> const& sigma_stag = macroscopic_properties->sigma_IndexType;
     amrex::GpuArray<int, 3> const& epsilon_stag = macroscopic_properties->epsilon_IndexType;
+    amrex::GpuArray<int, 3> const& mu_stag = macroscopic_properties->mu_IndexType;
     amrex::GpuArray<int, 3> const& Ex_stag = macroscopic_properties->Ex_IndexType;
     amrex::GpuArray<int, 3> const& Ey_stag = macroscopic_properties->Ey_IndexType;
     amrex::GpuArray<int, 3> const& Ez_stag = macroscopic_properties->Ez_IndexType;
+    amrex::GpuArray<int, 3> const& Bx_stag = macroscopic_properties->Bx_IndexType;
+    amrex::GpuArray<int, 3> const& By_stag = macroscopic_properties->By_IndexType;
+    amrex::GpuArray<int, 3> const& Bz_stag = macroscopic_properties->Bz_IndexType;
     amrex::GpuArray<int, 3> const& macro_cr     = macroscopic_properties->macro_cr_ratio;
 
 
@@ -139,9 +143,9 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         int const n_coefs_z = m_stencil_coefs_z.size();
 
-        FieldAccessorMacroscopic const Hx(Bx, mu_arr);
-        FieldAccessorMacroscopic const Hy(By, mu_arr);
-        FieldAccessorMacroscopic const Hz(Bz, mu_arr);
+        FieldAccessorMacroscopic const Hx(Bx, mu_arr, Bx_stag, mu_stag, macro_cr);
+        FieldAccessorMacroscopic const Hy(By, mu_arr, By_stag, mu_stag, macro_cr);
+        FieldAccessorMacroscopic const Hz(Bz, mu_arr, Bz_stag, mu_stag, macro_cr);
 
         // Extract tileboxes for which to loop
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -15,6 +15,49 @@
 #include <memory>
 #include <string>
 
+
+enum MacroparameterInitType { ConstantValue, ParserFunction};
+
+struct GetMacroparameter
+{
+    MacroparameterInitType m_type;
+    amrex::Real m_value;
+    amrex::ParserExecutor<3> m_parser;
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::Real operator () (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
+    {
+        using namespace amrex::literals;
+        if (m_type == ConstantValue)
+        {
+            return m_value;        
+        }
+        else if (m_type == ParserFunction)
+        {
+            return m_parser(x,y,z);
+        }
+        else
+        {
+            amrex::Abort("macroparameter init type not valid.");
+            return 0.;
+        }
+        return 0.;
+    }        
+};
+
+struct GetSigmaMacroparameter : GetMacroparameter
+{
+    GetSigmaMacroparameter () noexcept;
+};
+
+struct GetMuMacroparameter : GetMacroparameter
+{
+    GetMuMacroparameter () noexcept;
+};
+
+struct GetEpsilonMacroparameter : GetMacroparameter
+{
+    GetEpsilonMacroparameter () noexcept;
+};
 /**
  * \brief This class contains the macroscopic properties of the medium needed to
  * evaluate macroscopic Maxwell equation.
@@ -63,7 +106,10 @@ public:
      /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
      amrex::GpuArray<int, 3> macro_cr_ratio;
 
-private:
+     MacroparameterInitType m_sigma_type;
+     MacroparameterInitType m_mu_type;
+     MacroparameterInitType m_epsilon_type;
+
      /** Conductivity, sigma, of the medium */
      amrex::Real m_sigma = 0.0;
      /** Permittivity, epsilon, of the medium */
@@ -91,6 +137,7 @@ private:
      std::unique_ptr<amrex::Parser> m_sigma_parser;
      std::unique_ptr<amrex::Parser> m_epsilon_parser;
      std::unique_ptr<amrex::Parser> m_mu_parser;
+
 };
 
 /**

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -72,25 +72,6 @@ public:
      /** Initialize multifabs storing macroscopic multifabs */
      void InitData ();
 
-     /** return MultiFab, sigma (conductivity) of the medium. */
-     amrex::MultiFab& getsigma_mf  () {return (*m_sigma_mf);}
-     /** return MultiFab, epsilon (permittivity) of the medium. */
-     amrex::MultiFab& getepsilon_mf  () {return (*m_eps_mf);}
-     /** return MultiFab, mu (permeability) of the medium. */
-     amrex::MultiFab& getmu_mf  () {return (*m_mu_mf);}
-
-     /** Initializes the Multifabs storing macroscopic properties
-      *  with user-defined functions(x,y,z).
-      */
-     void InitializeMacroMultiFabUsingParser (amrex::MultiFab *macro_mf,
-                                              amrex::ParserExecutor<3> const& macro_parser,
-                                              int lev);
-     /** Gpu Vector with index type of the conductivity multifab */
-     amrex::GpuArray<int, 3> sigma_IndexType;
-     /** Gpu Vector with index type of the permittivity multifab */
-     amrex::GpuArray<int, 3> epsilon_IndexType;
-     /** Gpu Vector with index type of the permeability multifab */
-     amrex::GpuArray<int, 3> mu_IndexType;
      /** Gpu Vector with index type of the Ex multifab */
      amrex::GpuArray<int, 3> Ex_IndexType;
      /** Gpu Vector with index type of the Ey multifab */
@@ -103,8 +84,6 @@ public:
      amrex::GpuArray<int, 3> By_IndexType;
      /** Gpu Vector with index type of the Bz multifab */
      amrex::GpuArray<int, 3> Bz_IndexType;
-     /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
-     amrex::GpuArray<int, 3> macro_cr_ratio;
 
      MacroparameterInitType m_sigma_type;
      MacroparameterInitType m_mu_type;
@@ -116,12 +95,6 @@ public:
      amrex::Real m_epsilon = PhysConst::ep0;
      /** Permeability, mu, of the medium */
      amrex::Real m_mu = PhysConst::mu0;
-     /** Multifab for m_sigma */
-     std::unique_ptr<amrex::MultiFab> m_sigma_mf;
-     /** Multifab for m_epsilon */
-     std::unique_ptr<amrex::MultiFab> m_eps_mf;
-     /** Multifab for m_mu */
-     std::unique_ptr<amrex::MultiFab> m_mu_mf;
      /** Stores initialization type for conductivity : constant or parser */
      std::string m_sigma_s = "constant";
      /** Stores initialization type for permittivity : constant or parser */

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -1,3 +1,10 @@
+/* Copyright 2020 Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
 #ifndef WARPX_MACROSCOPICPROPERTIES_H_
 #define WARPX_MACROSCOPICPROPERTIES_H_
 
@@ -18,11 +25,31 @@
 
 enum MacroparameterInitType { ConstantValue, ParserFunction};
 
+/**
+ * \brief Functor to return macropameter, either constant value, m_value, or
+ *        spatially varying scalar value computed using the parser function, m_parser.
+ */
+
 struct GetMacroparameter
 {
+    /* Type of initialization for macroparameter, constant or parser function */
     MacroparameterInitType m_type;
+    /* Constant value of the macroparameter. */
     amrex::Real m_value;
+    /* Parser funtion of the spatially varying macroparameter*/
     amrex::ParserExecutor<3> m_parser;
+    /**
+     * \brief Functor call. This method returns the value of the macroparameter,
+     *        or property of the medium needed for the macroscopic Maxwell solver,
+     *        at a given location (x,y,z) in the domain.
+     *
+     * @param[in] x x-coordinate of a given location
+     * @param[in] y y-coordinate of a given location
+     * @param[in] z z-coordinate of a given location
+     * @return value of the macroparameter at (x,y,z).
+     *         m_value if init-type is constant
+     *         m_parser(x,y,z) if init-type is parser function
+     */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator () (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
     {
@@ -44,18 +71,30 @@ struct GetMacroparameter
     }
 };
 
+/**
+ * \brief Functor for conductivity, sigma, of the medium.
+ */
 struct GetSigmaMacroparameter : GetMacroparameter
 {
+    /** Constructor to store the type of intialization, m_type, and the value or parser function. */
     GetSigmaMacroparameter () noexcept;
 };
 
+/**
+ * \brief Functor for permeability, mu, of the medium.
+ */
 struct GetMuMacroparameter : GetMacroparameter
 {
+    /** Constructor to store the type of intialization, m_type, and the value or parser function. */
     GetMuMacroparameter () noexcept;
 };
 
+/**
+ * \brief Functor for permittivity, epsilon, of the medium.
+ */
 struct GetEpsilonMacroparameter : GetMacroparameter
 {
+    /** Constructor to store the type of intialization, m_type, and the value or parser function. */
     GetEpsilonMacroparameter () noexcept;
 };
 /**
@@ -84,10 +123,6 @@ public:
      amrex::GpuArray<int, 3> By_IndexType;
      /** Gpu Vector with index type of the Bz multifab */
      amrex::GpuArray<int, 3> Bz_IndexType;
-
-     MacroparameterInitType m_sigma_type;
-     MacroparameterInitType m_mu_type;
-     MacroparameterInitType m_epsilon_type;
 
      /** Conductivity, sigma, of the medium */
      amrex::Real m_sigma = 0.0;

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -54,6 +54,12 @@ public:
      amrex::GpuArray<int, 3> Ey_IndexType;
      /** Gpu Vector with index type of the Ez multifab */
      amrex::GpuArray<int, 3> Ez_IndexType;
+     /** Gpu Vector with index type of the Bx multifab */
+     amrex::GpuArray<int, 3> Bx_IndexType;
+     /** Gpu Vector with index type of the By multifab */
+     amrex::GpuArray<int, 3> By_IndexType;
+     /** Gpu Vector with index type of the Bz multifab */
+     amrex::GpuArray<int, 3> Bz_IndexType;
      /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
      amrex::GpuArray<int, 3> macro_cr_ratio;
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -29,7 +29,7 @@ struct GetMacroparameter
         using namespace amrex::literals;
         if (m_type == ConstantValue)
         {
-            return m_value;        
+            return m_value;
         }
         else if (m_type == ParserFunction)
         {
@@ -41,7 +41,7 @@ struct GetMacroparameter
             return 0.;
         }
         return 0.;
-    }        
+    }
 };
 
 struct GetSigmaMacroparameter : GetMacroparameter

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -148,52 +148,6 @@ MacroscopicProperties::InitData ()
     amrex::Print() << "we are in init data of macro \n";
     auto & warpx = WarpX::GetInstance();
 
-    // Get BoxArray and DistributionMap of warpx instant.
-    int lev = 0;
-    BoxArray ba = warpx.boxArray(lev);
-    DistributionMapping dmap = warpx.DistributionMap(lev);
-    const amrex::IntVect ng = warpx.getngE();
-    // Define material property multifabs using ba and dmap from WarpX instance
-    // sigma is cell-centered MultiFab
-    m_sigma_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
-    // epsilon is cell-centered MultiFab
-    m_eps_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
-    // mu is cell-centered MultiFab
-    m_mu_mf = std::make_unique<MultiFab>(ba, dmap, 1, ng);
-    // Initialize sigma
-    if (m_sigma_s == "constant") {
-
-        m_sigma_mf->setVal(m_sigma);
-
-    } else if (m_sigma_s == "parse_sigma_function") {
-
-        InitializeMacroMultiFabUsingParser(m_sigma_mf.get(), m_sigma_parser->compile<3>(), lev);
-    }
-    // Initialize epsilon
-    if (m_epsilon_s == "constant") {
-
-        m_eps_mf->setVal(m_epsilon);
-
-    } else if (m_epsilon_s == "parse_epsilon_function") {
-
-        InitializeMacroMultiFabUsingParser(m_eps_mf.get(), m_epsilon_parser->compile<3>(), lev);
-
-    }
-    // Initialize mu
-    if (m_mu_s == "constant") {
-
-        m_mu_mf->setVal(m_mu);
-
-    } else if (m_mu_s == "parse_mu_function") {
-
-        InitializeMacroMultiFabUsingParser(m_mu_mf.get(), m_mu_parser->compile<3>(), lev);
-
-    }
-
-
-    IntVect sigma_stag = m_sigma_mf->ixType().toIntVect();
-    IntVect epsilon_stag = m_eps_mf->ixType().toIntVect();
-    IntVect mu_stag = m_mu_mf->ixType().toIntVect();
     IntVect Ex_stag = warpx.getEfield_fp(0,0).ixType().toIntVect();
     IntVect Ey_stag = warpx.getEfield_fp(0,1).ixType().toIntVect();
     IntVect Ez_stag = warpx.getEfield_fp(0,2).ixType().toIntVect();
@@ -203,67 +157,22 @@ MacroscopicProperties::InitData ()
 
 
     for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        sigma_IndexType[idim]   = sigma_stag[idim];
-        epsilon_IndexType[idim] = epsilon_stag[idim];
-        mu_IndexType[idim]      = mu_stag[idim];
         Ex_IndexType[idim]      = Ex_stag[idim];
         Ey_IndexType[idim]      = Ey_stag[idim];
         Ez_IndexType[idim]      = Ez_stag[idim];
         Bx_IndexType[idim]      = Bx_stag[idim];
         By_IndexType[idim]      = By_stag[idim];
         Bz_IndexType[idim]      = Bz_stag[idim];
-        macro_cr_ratio[idim]    = 1;
     }
 #if (AMREX_SPACEDIM==2)
-        sigma_IndexType[2]   = 0;
-        epsilon_IndexType[2] = 0;
-        mu_IndexType[2]      = 0;
         Ex_IndexType[2]      = 0;
         Ey_IndexType[2]      = 0;
         Ez_IndexType[2]      = 0;
         Bx_IndexType[2]      = 0;
         By_IndexType[2]      = 0;
         Bz_IndexType[2]      = 0;
-        macro_cr_ratio[2]    = 1;
 #endif
 
 
 }
 
-void
-MacroscopicProperties::InitializeMacroMultiFabUsingParser (
-                       MultiFab *macro_mf, ParserExecutor<3> const& macro_parser,
-                       int lev)
-{
-    auto& warpx = WarpX::GetInstance();
-    const auto dx_lev = warpx.Geom(lev).CellSizeArray();
-    const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-    IntVect iv = macro_mf->ixType().toIntVect();
-    for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
-        // Initialize ghost cells in addition to valid cells
-
-        const Box& tb = mfi.tilebox(iv, macro_mf->nGrowVect());
-        auto const& macro_fab =  macro_mf->array(mfi);
-        amrex::ParallelFor (tb,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                // Shift x, y, z position based on index type
-                Real fac_x = (1._rt - iv[0]) * dx_lev[0] * 0.5_rt;
-                Real x = i * dx_lev[0] + real_box.lo(0) + fac_x;
-#if (AMREX_SPACEDIM==2)
-                amrex::Real y = 0._rt;
-                Real fac_z = (1._rt - iv[1]) * dx_lev[1] * 0.5_rt;
-                Real z = j * dx_lev[1] + real_box.lo(1) + fac_z;
-#else
-                Real fac_y = (1._rt - iv[1]) * dx_lev[1] * 0.5_rt;
-                Real y = j * dx_lev[1] + real_box.lo(1) + fac_y;
-                Real fac_z = (1._rt - iv[2]) * dx_lev[2] * 0.5_rt;
-                Real z = k * dx_lev[2] + real_box.lo(2) + fac_z;
-#endif
-                // initialize the macroparameter
-                macro_fab(i,j,k) = macro_parser(x,y,z);
-        });
-
-    }
-
-
-}

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -154,6 +154,10 @@ MacroscopicProperties::InitData ()
     IntVect Ex_stag = warpx.getEfield_fp(0,0).ixType().toIntVect();
     IntVect Ey_stag = warpx.getEfield_fp(0,1).ixType().toIntVect();
     IntVect Ez_stag = warpx.getEfield_fp(0,2).ixType().toIntVect();
+    IntVect Bx_stag = warpx.getBfield_fp(0,0).ixType().toIntVect();
+    IntVect By_stag = warpx.getBfield_fp(0,1).ixType().toIntVect();
+    IntVect Bz_stag = warpx.getBfield_fp(0,2).ixType().toIntVect();
+
 
     for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         sigma_IndexType[idim]   = sigma_stag[idim];
@@ -162,6 +166,9 @@ MacroscopicProperties::InitData ()
         Ex_IndexType[idim]      = Ex_stag[idim];
         Ey_IndexType[idim]      = Ey_stag[idim];
         Ez_IndexType[idim]      = Ez_stag[idim];
+        Bx_IndexType[idim]      = Bx_stag[idim];
+        By_IndexType[idim]      = By_stag[idim];
+        Bz_IndexType[idim]      = Bz_stag[idim];
         macro_cr_ratio[idim]    = 1;
     }
 #if (AMREX_SPACEDIM==2)
@@ -171,6 +178,9 @@ MacroscopicProperties::InitData ()
         Ex_IndexType[2]      = 0;
         Ey_IndexType[2]      = 0;
         Ez_IndexType[2]      = 0;
+        Bx_IndexType[2]      = 0;
+        By_IndexType[2]      = 0;
+        Bz_IndexType[2]      = 0;
         macro_cr_ratio[2]    = 1;
 #endif
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -22,6 +22,49 @@
 
 using namespace amrex;
 
+GetSigmaMacroparameter::GetSigmaMacroparameter () noexcept
+{
+    auto& warpx = WarpX::GetInstance();
+    auto& macroscopic_properties = warpx.GetMacroscopicProperties();
+    if (macroscopic_properties.m_sigma_s == "constant") {
+        m_type = ConstantValue;
+        m_value = macroscopic_properties.m_sigma;
+    }
+    else if (macroscopic_properties.m_sigma_s == "parse_sigma_function") {
+        m_type = ParserFunction;
+        m_parser = macroscopic_properties.m_sigma_parser->compile<3>();
+    }
+}
+
+GetMuMacroparameter::GetMuMacroparameter () noexcept
+{
+    auto& warpx = WarpX::GetInstance();
+    auto& macroscopic_properties = warpx.GetMacroscopicProperties();
+    if (macroscopic_properties.m_mu_s == "constant") {
+        m_type = ConstantValue;
+        m_value = macroscopic_properties.m_mu;
+    }
+    else if (macroscopic_properties.m_mu_s == "parse_mu_function") {
+        m_type = ParserFunction;
+        m_parser = macroscopic_properties.m_mu_parser->compile<3>();
+    }
+}
+
+GetEpsilonMacroparameter::GetEpsilonMacroparameter () noexcept
+{
+    auto& warpx = WarpX::GetInstance();
+    auto& macroscopic_properties = warpx.GetMacroscopicProperties();
+    if (macroscopic_properties.m_epsilon_s == "constant") {
+        m_type = ConstantValue;
+        m_value = macroscopic_properties.m_epsilon;
+    }
+    else if (macroscopic_properties.m_epsilon_s == "parse_epsilon_function") {
+        m_type = ParserFunction;
+        m_parser = macroscopic_properties.m_epsilon_parser->compile<3>();
+    }
+}
+
+
 MacroscopicProperties::MacroscopicProperties ()
 {
     ReadParameters();

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -651,7 +651,7 @@ WarpX::MacroscopicEvolveE (int lev, PatchType patch_type, amrex::Real a_dt) {
     if (patch_type == PatchType::fine) {
         m_fdtd_solver_fp[lev]->MacroscopicEvolveE( Efield_fp[lev], Bfield_fp[lev],
                                              current_fp[lev], a_dt,
-                                             m_macroscopic_properties);
+                                             m_macroscopic_properties, lev);
     }
     else {
         amrex::Abort("Macroscopic EvolveE is not implemented for lev > 0, yet.");

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -175,7 +175,7 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
  * \param[out] y   physical coordinate along y
  * \param[out] z   physical coordinate along z
  */
-AMREX_GPU_HOSE_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void getCellCoordinates (int i, int j, int k,
                          amrex::GpuArray<int, 3> const mf_type,
                          amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const domain_lo,

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -161,6 +161,39 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
     return linear_interp(z0, z1, fxy0, fxy1, z);
 }
 
+/** \brief Compute physical coordinates (x,y,z) that correspond to a given (i,j,k) and
+ *  the corresponding staggering, mf_type.
+ *
+ * \param[in] i    index along x
+ * \param[in] j    index along y
+ * \param[in] k    index along z
+ * \param[in] mf_type GpuArray containing the staggering type to convert (i,j,k) to (x,y,z)
+ * \param[in] domain_lo Physical coordinates of the lowest corner of the simulation domain
+ * \param[in] dx   Cell size of the simulation domain
+ *
+ * \param[out] x   physical coordinate along x
+ * \param[out] y   physical coordinate along y
+ * \param[out] z   physical coordinate along z
+ */
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void getCellCoordinates (int i, int j, int k,
+                         amrex::GpuArray<int, 3> const mf_type,
+                         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const domain_lo,
+                         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+                         amrex::Real &x, amrex::Real &y, amrex::Real &z)
+{
+    using namespace amrex::literals;
+    x = domain_lo[0] + i*dx[0] + (1._rt - mf_type[0]) * dx[0]*0.5;
+#if (AMREX_SPACEDIM==2)
+    amrex::ignore_unused(j);
+    y = 0._rt;
+    z = domain_lo[1] + k*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5;
+#else
+    y = domain_lo[1] + j*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5;
+    z = domain_lo[2] + k*dx[2] + (1._rt - mf_type[2]) * dx[2]*0.5;
+#endif
+}
+
 }
 
 /**

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -175,7 +175,7 @@ T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
  * \param[out] y   physical coordinate along y
  * \param[out] z   physical coordinate along z
  */
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOSE_DEVICE AMREX_FORCE_INLINE
 void getCellCoordinates (int i, int j, int k,
                          amrex::GpuArray<int, 3> const mf_type,
                          amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const domain_lo,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -95,6 +95,7 @@ public:
     void Evolve (int numsteps = -1);
 
     MultiParticleContainer& GetPartContainer () { return *mypc; }
+    MacroscopicProperties& GetMacroscopicProperties () { return *m_macroscopic_properties; }
 
     static void shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
                          int num_shift, int dir, amrex::Real external_field=0.0,
@@ -1032,7 +1033,6 @@ private:
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;
-
 
     // Load balancing
     /** Load balancing intervals that reads the "load_balance_intervals" string int the input file


### PR DESCRIPTION
H = B/mu is computed when taking curl of H to update E in the macroscopic solver.
However, B and mu are not defined at the same location in the grid - for yee , B is on the face-center and mu is at the cell-center.
This PR computes macroparameters at a given location (x,y,z) instead of storing in a multifab with some predefined staggering.

Many thanks to Wei Hou Tan for bringing this to my attention in an offline conversation.

As tested in a previous PR #1016 
5 tests were performed to verify the implementation with on-the-fly computation of the macroparameters.

**Case 1 : Skin depth poor conductor**
input file :
[inputs_sigma1000.txt](https://github.com/ECP-WarpX/WarpX/files/7188883/inputs_sigma1000.txt)
 Variation of skin-depth is as expected.
![skindepth_sigma1000](https://user-images.githubusercontent.com/41089244/133865398-a1aedeaa-a439-415f-81a0-72347716d890.png)

**Case 2  : Perfect conductor**
Input file : 
[inputs_perfectconductor.txt](https://github.com/ECP-WarpX/WarpX/files/7188886/inputs_perfectconductor.txt)
standing wave generated : 
![good_conductor](https://user-images.githubusercontent.com/41089244/133865448-98f68fb5-0613-4b85-b7b7-0afd8b85e263.gif)

**Case 3 : Varying epsilon** 
epsilon_r = 9 : reflection coefficient = 0.5, transmission coefficient = 0.5
Input file :
[inputs_epsilon9.txt](https://github.com/ECP-WarpX/WarpX/files/7188889/inputs_epsilon9.txt)
![epsilon9](https://user-images.githubusercontent.com/41089244/133865522-9549831a-0bed-4a41-9ccb-24b09960d389.gif)
 
Case 4 : Varying mu and epsilon:
epsilon_r = 9, mu_r = 9 : transmission coefficient = 1
[inputs_eps9_mu9.txt](https://github.com/ECP-WarpX/WarpX/files/7188893/inputs_eps9_mu9.txt)
![eps9_mu9](https://user-images.githubusercontent.com/41089244/133865564-d0274d13-6b9b-4f39-9501-f8ae5a22850f.gif)

Case 5 : Varying only mu
mu_r = 40000: reflection coefficient = 1
input file : 
[inputs_mu40000.txt](https://github.com/ECP-WarpX/WarpX/files/7188897/inputs_mu40000.txt)
![only_mu](https://user-images.githubusercontent.com/41089244/133865595-0ac46c2f-c8ca-445b-8f14-50f38fc36975.gif)

