### PR TITLE
[Mini-PR] Initialising the size BaseFab on Device

### DIFF
--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -94,7 +94,7 @@ WarpX::InitBorrowing() {
         auto &borrowing_x = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_x.inds_pointer.resize(box);
         borrowing_x.size.resize(box);
-        borrowing_x.size.setVal<amrex::RunOn::Host>(0);
+        borrowing_x.size.setVal<amrex::RunOn::Device>(0);
         amrex::Long ncells = box.numPts();
         // inds, neigh_faces and area are extended to their largest possible size here, but they are
         // resized to a much smaller size later on, based on the actual number of neighboring
@@ -110,7 +110,7 @@ WarpX::InitBorrowing() {
         auto &borrowing_y = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_y.inds_pointer.resize(box);
         borrowing_y.size.resize(box);
-        borrowing_y.size.setVal<amrex::RunOn::Host>(0);
+        borrowing_y.size.setVal<amrex::RunOn::Device>(0);
         amrex::Long ncells = box.numPts();
         borrowing_y.inds.resize(8*ncells);
         borrowing_y.neigh_faces.resize(8*ncells);
@@ -123,7 +123,7 @@ WarpX::InitBorrowing() {
         auto &borrowing_z = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_z.inds_pointer.resize(box);
         borrowing_z.size.resize(box);
-        borrowing_z.size.setVal<amrex::RunOn::Host>(0);
+        borrowing_z.size.setVal<amrex::RunOn::Device>(0);
         amrex::Long ncells = box.numPts();
         borrowing_z.inds.resize(8*ncells);
         borrowing_z.neigh_faces.resize(8*ncells);


### PR DESCRIPTION
As discussed offline we try to switch from `borrowing_z.size.setVal<amrex::RunOn::Host>(0)` to `borrowing_z.size.setVal<amrex::RunOn::Device>(0)`