### PR TITLE
Docs: Summit umask (Permissions)

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -79,6 +79,9 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    # fix system defaults: do not escape $ with a \ on tab completion
    shopt -s direxpand
 
+   # make output group-readable by default
+   umask 0027
+
    # optimize CUDA compilation for V100
    export AMREX_CUDA_ARCH=7.0
 

--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -18,6 +18,9 @@
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
+# make output group-readable by default
+umask 0027
+
 source $HOME/warpx.profile
 
 export OMP_NUM_THREADS=1

--- a/Tools/BatchScripts/batch_summit_power9.sh
+++ b/Tools/BatchScripts/batch_summit_power9.sh
@@ -17,6 +17,8 @@
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
+# make output group-readable by default
+umask 0027
 
 export OMP_NUM_THREADS=21
 jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/script_profiling_summit.sh
+++ b/Tools/BatchScripts/script_profiling_summit.sh
@@ -13,6 +13,9 @@
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
+# make output group-readable by default
+umask 0027
+
 module load pgi
 module load cuda/9.1.85
 module list


### PR DESCRIPTION
After the update to RHEL8, Summit changed the default permissions of newly created files and directories (to be more restrictive and user-only).

This has been reported as OLCFHELP-3442, but we face some resistance from support to triage this properly at the moment.

Since we need to continue to keep working, we change the `umask` (aka defaults for new files & dirs) manually so that group members of the same project can read files and access dirs.

For files and dirs created since this update and not yet using this `umask`, please use the following fix.
```
find . -type -d -exec chmod a+rx {} \;
find . -type -f -exec chmod a+r {} \;
```

Replace `.` (current directory) with another path if needed.