### PR TITLE
[mini-PR] Improved doc on fwd headers

### DIFF
--- a/Docs/source/developers/repo_organization.rst
+++ b/Docs/source/developers/repo_organization.rst
@@ -80,6 +80,7 @@ include guards. Below we provide a simple example:
 ``MyClass_fwd.H``:
 
 .. code-block:: cpp
+
    #ifndef MY_CLASS_FWD_H
    #define MY_CLASS_FWD_H
 
@@ -90,6 +91,7 @@ include guards. Below we provide a simple example:
 ``MyClass.H``:
 
 .. code-block:: cpp
+
    #ifndef MY_CLASS_H
    #define MY_CLASS_H
 
@@ -102,12 +104,14 @@ include guards. Below we provide a simple example:
 ``MyClass.cpp``:
 
 .. code-block:: cpp
+
    #include "MyClass.H"
    class MyClass{/* stuff */};
 
 Usage: in ``SimpleUsage.H``
 
 .. code-block:: cpp
+
    #include "MyClass_fwd.H"
    #include <memory>
 

--- a/Docs/source/developers/repo_organization.rst
+++ b/Docs/source/developers/repo_organization.rst
@@ -90,7 +90,6 @@ include guards. Below we provide a simple example:
 ``MyClass.H``:
 
 .. code-block:: cpp
-
    #ifndef MY_CLASS_H
    #define MY_CLASS_H
 
@@ -103,14 +102,12 @@ include guards. Below we provide a simple example:
 ``MyClass.cpp``:
 
 .. code-block:: cpp
-
    #include "MyClass.H"
    class MyClass{/* stuff */};
 
 Usage: in ``SimpleUsage.H``
 
 .. code-block:: cpp
-
    #include "MyClass_fwd.H"
    #include <memory>
 

--- a/Docs/source/developers/repo_organization.rst
+++ b/Docs/source/developers/repo_organization.rst
@@ -74,22 +74,31 @@ Forward Declaration Headers
 ---------------------------
 Forward declarations can be used when a header file needs only to know that a given class exists, without any further detail (e.g., when only a pointer to an instance of
 that class is used). Forward declaration headers are a convenient way to organize forward declarations. If a forward declaration is needed for a given class ``MyClass``, declared in ``MyClass.H``,
-the forward declaration should appear in a header file named ``MyClass_fwd.H``, placed in the same folder containing ``MyClass.H``.
-Below we provide a simple example:
+the forward declaration should appear in a header file named ``MyClass_fwd.H``, placed in the same folder containing ``MyClass.H``. As for regular header files, forward declaration headers must have
+include guards. Below we provide a simple example:
 
 ``MyClass_fwd.H``:
 
 .. code-block:: cpp
+   #ifndef MY_CLASS_FWD_H
+   #define MY_CLASS_FWD_H
 
-  class MyClass;
+   class MyClass;
+
+   #endif //MY_CLASS_FWD_H
 
 ``MyClass.H``:
 
 .. code-block:: cpp
 
+   #ifndef MY_CLASS_H
+   #define MY_CLASS_H
+
    #include "MyClass_fwd.H"
    #include "someHeader.H"
    class MyClass{/* stuff */};
+
+   #endif //MY_CLASS_H
 
 ``MyClass.cpp``:
 
@@ -104,4 +113,8 @@ Usage: in ``SimpleUsage.H``
 
    #include "MyClass_fwd.H"
    #include <memory>
+
+   /* stuff */
+   std::unique_ptr<MyClass> p_my_class;
+   /* stuff */
 


### PR DESCRIPTION
This PR improves the documentation on forward declaration headers. In particular:

1. It specifies that forward declaration headers must have include guards (code examples are updated accordingly)
2. It provides a use case (`unique_ptr<MyClass>`) which requires to know only the existence of a class named `MyClass` (i.e., what is inside a fwd header)