### PR TITLE
Initialize physical_species

### DIFF
--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -129,7 +129,7 @@ protected:
 
     amrex::Real mass, charge;
 
-    PhysicalSpecies physical_species;
+    PhysicalSpecies physical_species = PhysicalSpecies::unspecified;
 
     amrex::Real density;
 


### PR DESCRIPTION
While looking into something unrelated, valgrind complained about some uninitialized value, that ended up being the physical species.

Indeed, in the case where we don't specify a physical species in the input file but use mass+charge instead, the `physical_species` variable remains uninitialized. However, we use it in particleIO to determine if the species is a photon:

https://github.com/ECP-WarpX/WarpX/blob/134d2799218cc81bf6d4559b673b5aa278308f17/Source/Diagnostics/ParticleIO.cpp#L131-L135

Fortunately, I think this doesn't affect anything, unless the uninitialized value ends up being exactly `PhysicalSpecies::Photon`, which seems unlikely.