### PR TITLE
Allow Restarts and Checkpoints in python picmi

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -8,6 +8,7 @@
 
 """Classes following the PICMI standard
 """
+import os
 import re
 import picmistandard
 import numpy as np
@@ -807,7 +808,11 @@ class Simulation(picmistandard.PICMI_Simulation):
             diagnostic.initialize_inputs()
 
         if self.amr_checkpoint:
-            pywarpx.amr.restart = self.amr_checkpoint
+            if os.path.exists(self.amr_checkpoint):
+                pywarpx.amr.restart = self.amr_checkpoint
+            else:
+                print(f'Could not find checkpoint {self.amr_checkpoint} !')
+                pywarpx.amr.restart = None
 
     def initialize_warpx(self, mpi_comm=None):
         if self.warpx_initialized:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -8,7 +8,6 @@
 
 """Classes following the PICMI standard
 """
-import os
 import re
 import picmistandard
 import numpy as np
@@ -807,12 +806,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         for diagnostic in self.diagnostics:
             diagnostic.initialize_inputs()
 
-        if self.amr_checkpoint:
-            if os.path.exists(self.amr_checkpoint):
-                pywarpx.amr.restart = self.amr_checkpoint
-            else:
-                print(f'Could not find checkpoint {self.amr_checkpoint} !')
-                pywarpx.amr.restart = None
+        if self.amr_restart:
+            pywarpx.amr.restart = self.amr_restart
 
     def initialize_warpx(self, mpi_comm=None):
         if self.warpx_initialized:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -735,7 +735,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.costs_heuristic_cells_wt = kw.pop('warpx_costs_heuristic_cells_wt', None)
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
         self.amr_check_input = kw.pop('warpx_amr_check_input', None)
-        self.amr_checkpoint = kw.pop('warpx_amr_checkpoint', None)
+        self.amr_restart = kw.pop('warpx_amr_restart', None)
 
         self.inputs_initialized = False
         self.warpx_initialized = False
@@ -942,16 +942,20 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic):
 ElectrostaticFieldDiagnostic = FieldDiagnostic
 
 
-class CheckpointDiagnostic(picmistandard.PICMI_FieldDiagnostic):
-    def init(self, kw):
+class Checkpoint(picmistandard.base._ClassWithInit):
 
-        self.format = kw.pop('warpx_format', 'plotfile')
-        self.openpmd_backend = kw.pop('warpx_openpmd_backend', None)
-        self.file_prefix = kw.pop('warpx_file_prefix', None)
+    def __init__(self, period = 1, write_dir = None, name = None, **kw):
+
+        self.period = period
+        self.write_dir = write_dir
+        self.name = name
+
+        if self.name is None:
+            self.name = 'chkpoint'
+
+        self.handle_init(kw)
 
     def initialize_inputs(self):
-
-        self.name = 'chkpoint'
 
         try:
             self.diagnostic = pywarpx.diagnostics._diagnostics_dict[self.name]

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -933,6 +933,29 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic):
 ElectrostaticFieldDiagnostic = FieldDiagnostic
 
 
+class CheckpointDiagnostic(picmistandard.PICMI_FieldDiagnostic):
+    def init(self, kw):
+
+        self.format = kw.pop('warpx_format', 'plotfile')
+        self.openpmd_backend = kw.pop('warpx_openpmd_backend', None)
+        self.file_prefix = kw.pop('warpx_file_prefix', None)
+
+    def initialize_inputs(self):
+
+        diagnostics_number = len(pywarpx.diagnostics._diagnostics_dict) + 1
+        self.name = 'chkpoint{}'.format(diagnostics_number)
+
+        try:
+            self.diagnostic = pywarpx.diagnostics._diagnostics_dict[self.name]
+        except KeyError:
+            self.diagnostic = pywarpx.Diagnostics.Diagnostic(self.name, _species_dict={})
+            pywarpx.diagnostics._diagnostics_dict[self.name] = self.diagnostic
+
+        self.diagnostic.intervals = self.period
+        self.diagnostic.diag_type = 'Full'
+        self.diagnostic.format = 'checkpoint'
+
+
 class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic):
     def init(self, kw):
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -734,6 +734,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.costs_heuristic_cells_wt = kw.pop('warpx_costs_heuristic_cells_wt', None)
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
         self.amr_check_input = kw.pop('warpx_amr_check_input', None)
+        self.amr_checkpoint = kw.pop('warpx_amr_checkpoint', None)
 
         self.inputs_initialized = False
         self.warpx_initialized = False
@@ -804,6 +805,9 @@ class Simulation(picmistandard.PICMI_Simulation):
 
         for diagnostic in self.diagnostics:
             diagnostic.initialize_inputs()
+
+        if self.amr_checkpoint:
+            pywarpx.amr.restart = self.amr_checkpoint
 
     def initialize_warpx(self, mpi_comm=None):
         if self.warpx_initialized:
@@ -942,8 +946,7 @@ class CheckpointDiagnostic(picmistandard.PICMI_FieldDiagnostic):
 
     def initialize_inputs(self):
 
-        diagnostics_number = len(pywarpx.diagnostics._diagnostics_dict) + 1
-        self.name = 'chkpoint{}'.format(diagnostics_number)
+        self.name = 'chkpoint'
 
         try:
             self.diagnostic = pywarpx.diagnostics._diagnostics_dict[self.name]


### PR DESCRIPTION
Currently restarts and checkpoints are not available through the python picmi interface.  

Contains a CheckpointDiagnostic inherited from FieldDiagnostic, which makes the checkpoint directories and an argument added to Simulation class to specify what checkpoint to start from.