### PR TITLE
Include Diagnostics in Evolve Timer

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -325,7 +325,7 @@ WarpX::Evolve (int numsteps)
             amrex::ParmParse().QueryUnusedInputs();
             early_params_checked = true;
         }
- 
+
         // warpx_py_afterstep runs with the updated global time. It is included
         // in the evolve timing.
         if (warpx_py_afterstep) warpx_py_afterstep();

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -305,6 +305,11 @@ WarpX::Evolve (int numsteps)
             bool const reset_fields = true;
             ComputeSpaceChargeField( reset_fields );
         }
+        
+        // sync up time
+        for (int i = 0; i <= max_level; ++i) {
+            t_new[i] = cur_time;
+        }
 
         /// reduced diags
         if (reduced_diags->m_plot_rd != 0)
@@ -320,12 +325,7 @@ WarpX::Evolve (int numsteps)
             amrex::ParmParse().QueryUnusedInputs();
             early_params_checked = true;
         }
-
-        // sync up time
-        for (int i = 0; i <= max_level; ++i) {
-            t_new[i] = cur_time;
-        }
-
+ 
         // warpx_py_afterstep runs with the updated global time. It is included
         // in the evolve timing.
         if (warpx_py_afterstep) warpx_py_afterstep();

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -305,7 +305,7 @@ WarpX::Evolve (int numsteps)
             bool const reset_fields = true;
             ComputeSpaceChargeField( reset_fields );
         }
-        
+
         // sync up time
         for (int i = 0; i <= max_level; ++i) {
             t_new[i] = cur_time;

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -306,6 +306,21 @@ WarpX::Evolve (int numsteps)
             ComputeSpaceChargeField( reset_fields );
         }
 
+        /// reduced diags
+        if (reduced_diags->m_plot_rd != 0)
+        {
+            reduced_diags->ComputeDiags(step);
+            reduced_diags->WriteToFile(step);
+        }
+        multi_diags->FilterComputePackFlush( step );
+
+        // inputs: unused parameters (e.g. typos) check after step 1 has finished
+        if (!early_params_checked) {
+            amrex::Print() << "\n"; // better: conditional \n based on return value
+            amrex::ParmParse().QueryUnusedInputs();
+            early_params_checked = true;
+        }
+
         // sync up time
         for (int i = 0; i <= max_level; ++i) {
             t_new[i] = cur_time;
@@ -324,21 +339,6 @@ WarpX::Evolve (int numsteps)
             amrex::Print()<< "Evolve time = " << evolve_time
                       << " s; This step = " << evolve_time_end_step-evolve_time_beg_step
                       << " s; Avg. per step = " << evolve_time/(step+1) << " s\n";
-        }
-
-        /// reduced diags
-        if (reduced_diags->m_plot_rd != 0)
-        {
-            reduced_diags->ComputeDiags(step);
-            reduced_diags->WriteToFile(step);
-        }
-        multi_diags->FilterComputePackFlush( step );
-
-        // inputs: unused parameters (e.g. typos) check after step 1 has finished
-        if (!early_params_checked) {
-            amrex::Print() << "\n"; // better: conditional \n based on return value
-            amrex::ParmParse().QueryUnusedInputs();
-            early_params_checked = true;
         }
 
         if (cur_time >= stop_time - 1.e-3*dt[0]) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -311,6 +311,10 @@ WarpX::Evolve (int numsteps)
             t_new[i] = cur_time;
         }
 
+        // warpx_py_afterstep runs with the updated global time. It is included
+        // in the evolve timing.
+        if (warpx_py_afterstep) warpx_py_afterstep();
+
         /// reduced diags
         if (reduced_diags->m_plot_rd != 0)
         {
@@ -326,10 +330,7 @@ WarpX::Evolve (int numsteps)
             early_params_checked = true;
         }
 
-        // warpx_py_afterstep runs with the updated global time. It is included
-        // in the evolve timing.
-        if (warpx_py_afterstep) warpx_py_afterstep();
-
+        // create ending time stamp for calculating ellapsed time each iteration
         Real evolve_time_end_step = amrex::second();
         evolve_time += evolve_time_end_step - evolve_time_beg_step;
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -330,7 +330,7 @@ WarpX::Evolve (int numsteps)
             early_params_checked = true;
         }
 
-        // create ending time stamp for calculating ellapsed time each iteration
+        // create ending time stamp for calculating elapsed time each iteration
         Real evolve_time_end_step = amrex::second();
         evolve_time += evolve_time_end_step - evolve_time_beg_step;
 


### PR DESCRIPTION
Move reduced diags before evolve timing for more accurate elapsed time per loop iteration