### PR TITLE
CI: EB on Intel DPC++/SYCL

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -123,7 +123,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
-          -DWarpX_EB=OFF               \
+          -DWarpX_EB=ON                \
           -DWarpX_LIB=ON               \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \


### PR DESCRIPTION
Compile with embedded boundaries with Intel's `dpcpp` compiler.

This is the beginning of a reproducer for an ICE in `dpcpp` for @rscohn2 et al.
First seen in https://github.com/ECP-WarpX/WarpX/pull/2170#issuecomment-909623632
```
[ 50%] Building CXX object _deps/fetchedamrex-build/Src/CMakeFiles/amrex.dir/EB/AMReX_EB2_MultiGFab.cpp.o
cd /home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-build/Src && /opt/intel/oneapi/compiler/2021.3.0/linux/bin/dpcpp -Damrex_EXPORTS -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/Base -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/Base/Parser -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/Boundary -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/AmrCore -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/EB -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/LinearSolvers/MLMG -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/LinearSolvers/Projections -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/Particle -I/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-build -Werror -O3 -DNDEBUG -fPIC -pthread -Wno-error=sycl-strict -Wno-pass-failed -fsycl -fsycl-device-code-split=per_kernel -mlong-double-64 -Xclang -mlong-double-64 -fno-sycl-early-optimizations -MD -MT _deps/fetchedamrex-build/Src/CMakeFiles/amrex.dir/EB/AMReX_EB2_MultiGFab.cpp.o -MF CMakeFiles/amrex.dir/EB/AMReX_EB2_MultiGFab.cpp.o.d -o CMakeFiles/amrex.dir/EB/AMReX_EB2_MultiGFab.cpp.o -c /home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedamrex-src/Src/EB/AMReX_EB2_MultiGFab.cpp
dpcpp: error: unable to execute command: Segmentation fault (core dumped)
dpcpp: error: clang frontend command failed due to signal (use -v to see invocation)
Intel(R) oneAPI DPC++/C++ Compiler 2021.3.0 (2021.3.0.20210619)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2021.3.0/linux/bin
```