### PR TITLE
Various updates related to defining embedded boundaries in Python

### DIFF
--- a/Examples/Tests/ElectrostaticSphereEB/PICMI_inputs_3d.py
+++ b/Examples/Tests/ElectrostaticSphereEB/PICMI_inputs_3d.py
@@ -58,8 +58,9 @@ solver = picmi.ElectrostaticSolver(
 )
 
 embedded_boundary = picmi.EmbeddedBoundary(
-    implicit_function="-(x**2+y**2+z**2-0.3**2)",
-    potential=V_embedded_boundary
+    implicit_function="-(x**2+y**2+z**2-radius**2)",
+    potential=V_embedded_boundary,
+    radius = 0.3
 )
 
 ##########################

--- a/Python/pywarpx/Constants.py
+++ b/Python/pywarpx/Constants.py
@@ -27,7 +27,7 @@ class Constants(Bucket):
             # WarpX has a single global dictionary of expression variables, my_constants,
             # so each variable must be unique.
             # Check if keyword has already been defined. If so and it has a different
-            # value that the already defined value, then mangle the name.
+            # value than the already defined value, then mangle the name.
             mangle_number = 0
             k_mangled = k
             while k_mangled in self.argvattrs and self.argvattrs[k_mangled] != v:

--- a/Python/pywarpx/Constants.py
+++ b/Python/pywarpx/Constants.py
@@ -24,20 +24,19 @@ class Constants(Bucket):
     def add_keywords(self, kwdict):
         mangle_dict = {}
         for k,v in kwdict.items():
-            # Check if keyword has already been defined
-            # WarpX has a single global dictionary of expression variables so each
-            # variable must be unique
-            if k in self.argvattrs:
-                # if so, mangle the name by appending a numerical suffix
-                mangle_number = 1
+            # WarpX has a single global dictionary of expression variables, my_constants,
+            # so each variable must be unique.
+            # Check if keyword has already been defined. If so and it has a different
+            # value that the already defined value, then mangle the name.
+            mangle_number = 0
+            k_mangled = k
+            while k_mangled in self.argvattrs and self.argvattrs[k_mangled] != v:
+                mangle_number += 1
                 k_mangled = f'{k}{mangle_number}'
-                while k_mangled in self.argvattrs:
-                    # make sure that the mangled name has also not already been defined
-                    mangle_number += 1
-                    k_mangled = f'{k}{mangle_number}'
+            if mangle_number > 0:
+                # The mangle_dict contains only mangled names
                 mangle_dict[k] = k_mangled
-                k = k_mangled
-            setattr(self, k, v)
+            setattr(self, k_mangled, v)
         return mangle_dict
 
     def mangle_expression(self, expression, mangle_dict):

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -541,7 +541,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
 class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
     def init(self, kw):
-        assert self.method is None or self.method in ['Yee', 'CKC', 'PSATD'], Exception("Only 'Yee', 'CKC', and 'PSATD' are supported")
+        assert self.method is None or self.method in ['Yee', 'CKC', 'PSATD', 'ECT'], Exception("Only 'Yee', 'CKC', 'PSATD', and 'ECT' are supported")
 
         self.pml_ncell = kw.pop('warpx_pml_ncell', None)
 
@@ -766,19 +766,43 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
 
 
 class EmbeddedBoundary(picmistandard.base._ClassWithInit):
-    """Custom class to handle set up of embedded boundaries in WarpX.  If
-    embedded boundary initialization is added to picmistandard this can be
-    changed to inherit that functionality."""
-
+    """
+    Custom class to handle set up of embedded boundaries specific to WarpX.
+    If embedded boundary initialization is added to picmistandard this can be
+    changed to inherit that functionality.
+    - implicit_function: Analytic expression describing the embedded boundary
+    - potential: Analytic expression defining the potential. Can only be specified
+                 when the solver is electrostatic. Optional, defaults to 0.
+     Parameters used in the expressions should be given as additional keyword arguments.
+    """
     def __init__(self, implicit_function, potential=None, **kw):
         self.implicit_function = implicit_function
         self.potential = potential
 
+        # Handle keyword arguments used in expressions
+        self.user_defined_kw = {}
+        for k in list(kw.keys()):
+            if (re.search(r'\b%s\b'%k, implicit_function) or
+                (potential is not None and re.search(r'\b%s\b'%k, potential))):
+                self.user_defined_kw[k] = kw[k]
+                del kw[k]
+
         self.handle_init(kw)
 
-    def initialize_inputs(self):
-        pywarpx.warpx.eb_implicit_function = self.implicit_function
-        pywarpx.warpx.__setattr__('eb_potential(t)', self.potential)
+    def initialize_inputs(self, solver):
+
+        # Add the user defined keywords to my_constants
+        # The keywords are mangled if there is a conflicting variable already
+        # defined in my_constants with the same name but different value.
+        self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
+
+        expression = pywarpx.my_constants.mangle_expression(self.implicit_function, self.mangle_dict)
+        pywarpx.warpx.eb_implicit_function = expression
+
+        if self.potential is not None:
+            assert isinstance(solver, ElectrostaticSolver), Exception('The potential is only supported with the ElectrostaticSolver')
+            expression = pywarpx.my_constants.mangle_expression(self.potential, self.mangle_dict)
+            pywarpx.warpx.__setattr__('eb_potential(t)', expression)
 
 
 class Simulation(picmistandard.PICMI_Simulation):
@@ -849,7 +873,7 @@ class Simulation(picmistandard.PICMI_Simulation):
                 # --- If this was set for any species, use that value.
                 particle_shape = s.particle_shape
 
-        if particle_shape is not None:
+        if particle_shape is not None and (len(self.species) > 0 or len(self.lasers) > 0):
             if isinstance(particle_shape, str):
                 interpolation_order = {'NGP':0, 'linear':1, 'quadratic':2, 'cubic':3}[particle_shape]
             else:
@@ -871,7 +895,7 @@ class Simulation(picmistandard.PICMI_Simulation):
                 collision.initialize_inputs()
 
         if self.embedded_boundary is not None:
-            self.embedded_boundary.initialize_inputs()
+            self.embedded_boundary.initialize_inputs(self.solver)
 
         for i in range(len(self.lasers)):
             self.lasers[i].initialize_inputs()


### PR DESCRIPTION
This makes several changes to the PICMI interface:
- Adds ECT as an electromagnetic field solver method.
- Allows variables in the expressions used in the embedded boundary descriptions.
- Updates the ElectrostaticSphereEB CI test to check variables.
- Added more documentation to the EmbeddedBoundary class.
- Ensures that the EmbeddedBoundary potential option is only specified when using electrostatic.
- Cleans up how variable name mangling is done, now not mangling variables that have the same value.
- Only sets algo.particle_shape if there are species or lasers (this removes an unused input parameter in some cases).

Some of these changes could probably have gone in separate PRs, but they are all small changes so it was easy do do this all together.