### PR TITLE
Summit: Work-Around IBM MPI Collectives

### DIFF
--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -21,5 +21,9 @@
 # make output group-readable by default
 umask 0027
 
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 export OMP_NUM_THREADS=1
 jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/batch_summit_power9.sh
+++ b/Tools/BatchScripts/batch_summit_power9.sh
@@ -20,5 +20,9 @@
 # make output group-readable by default
 umask 0027
 
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 export OMP_NUM_THREADS=21
 jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/script_profiling_summit.sh
+++ b/Tools/BatchScripts/script_profiling_summit.sh
@@ -16,6 +16,10 @@
 # make output group-readable by default
 umask 0027
 
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 #module load pgi
 #module load cuda/9.1.85
 #module list


### PR DESCRIPTION
Fix crashes on Summit at scale (>~224 nodes) due to failing Barriers in IBM's MPI stack.

Seen mostly with I/O routines and only since the RHEL8 upgrade. We see no significant performance impact from this work-around until OLCF & IBM fix the problem (OLCFHELP-3545).

An alternative work-around via
```
export OMPI_MCA_coll_ibm_collselect_mode_barrier=failsafe
```
was tested and is a tiny bit slower than just falling back to HCOLL
or OMPI's barrier implementations via
```
export OMPI_MCA_coll_ibm_skip_barrier=true
```

Thanks to @lucafedeli88 for triaging this with me!
Thanks to Brian Smith at OLCF for the support!

X-ref https://github.com/ornladios/ADIOS2/issues/2846

Typical failures were of the form:
```
 0: ./warpx_sp() [0x104cd82c]
    amrex::BLBackTrace::print_backtrace_info(_IO_FILE*) at ??:?

 1: ./warpx_sp() [0x104d0070]
    amrex::BLBackTrace::handler(int) at ??:?

 2: linux-vdso64.so.1(__kernel_sigtramp_rt64+0) [0x2000000504d8]
    ?? ??:0

 3: /lib64/power9/libc.so.6(gsignal+0xd8) [0x20000a733618]

 4: /lib64/power9/libc.so.6(abort+0x164) [0x20000a713a2c]

 5: /lib64/power9/libc.so.6(+0x36f70) [0x20000a726f70]

 6: /lib64/power9/libc.so.6(__assert_fail+0x64) [0x20000a727014]

 7: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libcollectives.so.3(_ZN4CCMI9Protocols7Barrier26MultiLeaderBarrierFactoryTINS1_19MultiLeaderBarrierTIN7LibColl10Interfaces15NativeInterfaceELNS4_15topologyIndex_tE0EEENS_17ConnectionManager13SimpleConnMgrEE8cb_asyncEPvSC_PKvjjmPPNS4_13PipeWorkQueueEPPFvSC_SC_16libcoll_result_tEPSC_+0x39c) [0x20000f350c7c]
    ?? ??:0

 8: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libcollectives.so.3(_ZN7LibColl18NativeInterfaceP2PILb1ELb0EE20dispatch_mcast_shortEPvS2_PKvmS4_mjP11pami_recv_t+0x80) [0x20000f3bd3d0]
    ?? ??:0

 9: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libpami.so.3(_ZN4PAMI8Protocol4Send11EagerSimpleINS_6Device5Shmem11PacketModelINS3_11ShmemDeviceINS_4Fifo8WrapFifoINS7_10FifoPacketILj64ELj4096EEENS_7Counter15IndirectBoundedINS_6Atomic12NativeAtomicEEELj256EEENSB_8IndirectINSB_6NativeEEENS4_9CMAShaddrELj256ELj512EEEEELNS1_15configuration_tE1EE15dispatch_packedEPvSP_mSP_SP_+0x4c) [0x20000ed0255c]
    ?? ??:0

10: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libpami.so.3(PAMI_Context_advancev+0x6a0) [0x20000ecf9ec0]
    ?? ??:0

11: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libcollectives.so.3(LIBCOLL_Advance_pami+0x34) [0x20000f2efb14]
    ?? ??:0

12: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/pami_port/libcollectives.so.3(LIBCOLL_Advance+0x18) [0x20000f2da128]
    ?? ??:0

13: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/spectrum_mpi/mca_coll_ibm.so(start_libcoll_blocking_collective+0x120) [0x20000f1efe50]
    ?? ??:0

14: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/spectrum_mpi/mca_coll_ibm.so(mca_coll_ibm_barrier+0x70) [0x20000f1f51d0]
    ?? ??:0

15: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw/container/../lib/libmpi_ibm.so.3(MPI_Barrier+0x104) [0x20000a100b34]
    ?? ??:0

16: /sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/adios2-2.7.1-yivst3ulepk672qvfiduywxkg4rk2qwn/lib64/../lib64/libadios2_core_mpi.so.2(_ZNK6adios26helper11CommImplMPI7BarrierERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x24) [0x20000a947e34]
    ?? ??:0
```