### PR TITLE
Fix floating point exception issue in single precision

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -619,9 +619,9 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
 
 #if !(defined WARPX_DIM_RZ)
-    const float small_float_coeff = 1.e-25f;
-    const double small_double_coeff = 1.e-50;
-    const Real small_coeff = std::is_same<Real,float>::value ?
+    constexpr float small_float_coeff = 1.e-25f;
+    constexpr double small_double_coeff = 1.e-50;
+    constexpr Real small_coeff = std::is_same<Real,float>::value ?
         static_cast<Real>(small_float_coeff) :
         static_cast<Real>(small_double_coeff);
     const auto eps = static_cast<Real>(dx[0]*small_coeff);

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -621,10 +621,10 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 #if !(defined WARPX_DIM_RZ)
     const float small_float_coeff = 1.e-25f;
     const double small_double_coeff = 1.e-50;
-    constexpr Real small_coeff = std::is_same<Real,float>::value()?
+    constexpr Real small_coeff = std::is_same<Real,float>::value ?
         static_cast<Real>(small_float_coeff) :
         static_cast<Real>(small_double_coeff);
-    const eps = static_cast<Real>(dx[0]*small_coeff);
+    const auto eps = static_cast<Real>(dx[0]*small_coeff);
 #endif
 #if (AMREX_SPACEDIM == 3)
     Sx = std::min(std::min(dx[0]/(std::abs(m_u_X[0])+eps),

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -64,6 +64,7 @@
 #include <numeric>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 using namespace amrex;
 using namespace WarpXLaserProfiles;
@@ -619,11 +620,11 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 
 #if !(defined WARPX_DIM_RZ)
     const float small_float_coeff = 1.e-25f;
-    const float small_double_coeff = 1.e-50;
-    const Real eps = std::is_same<Real,float>()?
-        static_cast<Real>(dx[0]*small_float_coeff) :
-        static_cast<Real>(dx[0]*small_double_coeff);
-     ;
+    const double small_double_coeff = 1.e-50;
+    constexpr Real small_coeff = std::is_same<Real,float>()?
+        static_cast<Real>(small_float_coeff) :
+        static_cast<Real>(small_double_coeff);
+    const eps = static_cast<Real>(dx[0]*small_coeff);
 #endif
 #if (AMREX_SPACEDIM == 3)
     Sx = std::min(std::min(dx[0]/(std::abs(m_u_X[0])+eps),

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -618,7 +618,12 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
 
 #if !(defined WARPX_DIM_RZ)
-    const Real eps = static_cast<Real>(dx[0]*1.e-50);
+    const float small_float_coeff = 1.e-25f;
+    const float small_double_coeff = 1.e-50;
+    constexpr const Real eps = std::is_same<Real,float>()?
+        static_cast<Real>(dx[0]*small_float_coeff) ?
+        static_cast<Real>(dx[0]*small_double_coeff);
+     ;
 #endif
 #if (AMREX_SPACEDIM == 3)
     Sx = std::min(std::min(dx[0]/(std::abs(m_u_X[0])+eps),

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -620,7 +620,7 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 #if !(defined WARPX_DIM_RZ)
     const float small_float_coeff = 1.e-25f;
     const float small_double_coeff = 1.e-50;
-    constexpr const Real eps = std::is_same<Real,float>()?
+    const Real eps = std::is_same<Real,float>()?
         static_cast<Real>(dx[0]*small_float_coeff) :
         static_cast<Real>(dx[0]*small_double_coeff);
      ;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -621,7 +621,7 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 #if !(defined WARPX_DIM_RZ)
     const float small_float_coeff = 1.e-25f;
     const double small_double_coeff = 1.e-50;
-    constexpr Real small_coeff = std::is_same<Real,float>::value ?
+    const Real small_coeff = std::is_same<Real,float>::value ?
         static_cast<Real>(small_float_coeff) :
         static_cast<Real>(small_double_coeff);
     const auto eps = static_cast<Real>(dx[0]*small_coeff);

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -621,7 +621,7 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
     const float small_float_coeff = 1.e-25f;
     const float small_double_coeff = 1.e-50;
     constexpr const Real eps = std::is_same<Real,float>()?
-        static_cast<Real>(dx[0]*small_float_coeff) ?
+        static_cast<Real>(dx[0]*small_float_coeff) :
         static_cast<Real>(dx[0]*small_double_coeff);
      ;
 #endif

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -621,7 +621,7 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 #if !(defined WARPX_DIM_RZ)
     const float small_float_coeff = 1.e-25f;
     const double small_double_coeff = 1.e-50;
-    constexpr Real small_coeff = std::is_same<Real,float>()?
+    constexpr Real small_coeff = std::is_same<Real,float>::value()?
         static_cast<Real>(small_float_coeff) :
         static_cast<Real>(small_double_coeff);
     const eps = static_cast<Real>(dx[0]*small_coeff);


### PR DESCRIPTION
This PR fixes a floating point exception due to the fact that `1e-50` becomes zero when casted to `float` 