### PR TITLE
Added execution of beforeEsolve and afterEsolve callbacks when the electrostatic solver is used

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -296,6 +296,7 @@ WarpX::Evolve (int numsteps)
         }
 
         if( do_electrostatic != ElectrostaticSolverAlgo::None ) {
+            if (warpx_py_beforeEsolve) warpx_py_beforeEsolve();
             // Electrostatic solver:
             // For each species: deposit charge and add the associated space-charge
             // E and B field to the grid ; this is done at the end of the PIC
@@ -304,6 +305,7 @@ WarpX::Evolve (int numsteps)
             // and so that the fields are at the correct time in the output.
             bool const reset_fields = true;
             ComputeSpaceChargeField( reset_fields );
+            if (warpx_py_afterEsolve) warpx_py_afterEsolve();
         }
 
         // sync up time


### PR DESCRIPTION
Currently the callbacks `warpx_py_beforeEsolve` and `warpx_py_afterEsolve` is only called for electromagnetic simulations. This PR adds execution of those callbacks for electrostatic simulations.