### PR TITLE
Docs: Spock CMake 3.20.2, ROCm 4.3.0

### DIFF
--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -35,7 +35,7 @@ We use the following modules and environments on the system (``$HOME/warpx_spock
    export proj=<yourProject>
 
    # required dependencies
-   module load cmake/3.20.0
+   module load cmake/3.20.2
    module load craype-accel-amd-gfx908
    module load rocm/4.1.0
 

--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -37,7 +37,7 @@ We use the following modules and environments on the system (``$HOME/warpx_spock
    # required dependencies
    module load cmake/3.20.2
    module load craype-accel-amd-gfx908
-   module load rocm/4.1.0
+   module load rocm/4.3.0
 
    # optional: faster builds
    module load ccache
@@ -56,7 +56,7 @@ We use the following modules and environments on the system (``$HOME/warpx_spock
    export AMREX_AMD_ARCH=gfx908
 
    # compiler environment hints
-   export CC=$(which clang)
+   export CC=$ROCM_PATH/llvm/bin/clang
    export CXX=$(which hipcc)
    export LDFLAGS="-L${CRAYLIBS_X86_64} $(CC --cray-print-opts=libs) -lmpi"
    # GPU aware MPI: ${PE_MPICH_GTL_DIR_gfx908} -lmpi_gtl_hsa


### PR DESCRIPTION
### ROCm

Update to 4.3.0 (tested: compiled & ran).

### CMake

Slightly update CMake to avoid that we run into
  https://gitlab.kitware.com/cmake/cmake/-/issues/21887

at some point. (Proactively guarding this, might be CUDA-only.)

Thx to @balos1 for raising this in AMReX.