### PR TITLE
Implement Higginson's nuclear fusion algorithm

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -93,7 +93,7 @@ public:
         else
             m_isSameSpecies = false;
 
-        m_binary_collision_functor = CollisionFunctorType(collision_name, mypc);
+        m_binary_collision_functor = CollisionFunctorType(collision_name, mypc, m_isSameSpecies);
 
         amrex::ParmParse pp_collision_name(collision_name);
         pp_collision_name.queryarr("product_species", m_product_species);

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
@@ -9,6 +9,7 @@
 #define NUCLEAR_FUSION_FUNC_H_
 
 #include "BinaryCollisionUtils.H"
+#include "SingleNuclearFusionEvent.H"
 
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/MultiParticleContainer.H"
@@ -16,6 +17,7 @@
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Random.H>
@@ -48,8 +50,10 @@ public:
      *
      * @param[in] collision_name the name of the collision
      * @param[in] mypc pointer to the MultiParticleContainer
+     * @param[in] isSameSpecies whether the two colliding species are the same
      */
-    NuclearFusionFunc (const std::string collision_name, MultiParticleContainer const * const mypc)
+    NuclearFusionFunc (const std::string collision_name, MultiParticleContainer const * const mypc,
+                       const bool isSameSpecies) : m_isSameSpecies(isSameSpecies)
     {
         using namespace amrex::literals;
 
@@ -73,32 +77,128 @@ public:
         // default fusion multiplier
         m_fusion_multiplier = 1.0_rt;
         queryWithParser(pp_collision_name, "fusion_multiplier", m_fusion_multiplier);
+        // default fusion probability threshold
+        m_probability_threshold = 0.02_rt;
+        queryWithParser(pp_collision_name, "fusion_probability_threshold",
+                                            m_probability_threshold);
+        // default fusion probability target_value
+        m_probability_threshold = 0.002_rt;
+        queryWithParser(pp_collision_name, "fusion_probability_target_value",
+                                            m_probability_target_value);
     }
 
     /**
-     * \brief operator() of the NuclearFusionFunc class. Needs to be implemented.
+     * \brief operator() of the NuclearFusionFunc class. Performs nuclear fusions at the cell level
+     * using the algorithm described in Higginson et al., Journal of Computational Physics 388,
+     * 439-453 (2019).
+     *
+     * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
+     * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
+     * @param[in] I1 and I2 are the index arrays. They determine all elements that will be used.
+     * @param[in] soa_1 and soa_2 contain the struct of array data of the two species
+     * @param[in] m1 and m2 are masses.
+     * @param[in] dt is the time step length between two collision calls.
+     * @param[in] dV is the volume of the corresponding cell.
+     * @param[in] cell_start_pair is the start index of the pairs in that cell
+     * @param[out] p_mask is a mask that will be set to true if a fusion event occurs for a given
+     * pair
+     * @param[out] p_pair_indices_1 and p_pair_indices_2 are arrays that store the indices of the
+     * particles of a given pair
+     * @param[out] p_pair_reaction_weight stores the weight of the product particles
+     * @param[in] engine the random engine.
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void operator() (
-        index_type const /*I1s*/, index_type const /*I1e*/,
-        index_type const /*I2s*/, index_type const /*I2e*/,
-        index_type* /*I1*/,       index_type* /*I2*/,
-        SoaData_type /*soa_1*/, SoaData_type /*soa_2*/,
+        index_type const I1s, index_type const I1e,
+        index_type const I2s, index_type const I2e,
+        index_type* I1,       index_type* I2,
+        SoaData_type soa_1, SoaData_type soa_2,
         GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
-        amrex::Real const  /*q1*/, amrex::Real const  /*q2*/,
-        amrex::Real const  /*m1*/, amrex::Real const  /*m2*/,
-        amrex::Real const  /*dt*/, amrex::Real const /*dV*/,
-        index_type const /*cell_start_pair*/, index_type* /*p_mask*/,
-        index_type* /*p_pair_indices_1*/, index_type* /*p_pair_indices_2*/,
-        amrex::ParticleReal* /*p_pair_reaction_weight*/,
-        amrex::RandomEngine const& /*engine*/) const
+        amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
+        amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
+        amrex::Real const  dt, amrex::Real const dV,
+        index_type const cell_start_pair, index_type* p_mask,
+        index_type* p_pair_indices_1, index_type* p_pair_indices_2,
+        amrex::ParticleReal* p_pair_reaction_weight,
+        amrex::RandomEngine const& engine) const
         {
-            amrex::Abort("Nuclear fusion module not yet implemented");
+
+            amrex::ParticleReal * const AMREX_RESTRICT w1 = soa_1.m_rdata[PIdx::w];
+            amrex::ParticleReal * const AMREX_RESTRICT u1x = soa_1.m_rdata[PIdx::ux];
+            amrex::ParticleReal * const AMREX_RESTRICT u1y = soa_1.m_rdata[PIdx::uy];
+            amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
+
+            amrex::ParticleReal * const AMREX_RESTRICT w2 = soa_2.m_rdata[PIdx::w];
+            amrex::ParticleReal * const AMREX_RESTRICT u2x = soa_2.m_rdata[PIdx::ux];
+            amrex::ParticleReal * const AMREX_RESTRICT u2y = soa_2.m_rdata[PIdx::uy];
+            amrex::ParticleReal * const AMREX_RESTRICT u2z = soa_2.m_rdata[PIdx::uz];
+
+            // Number of macroparticles of each species
+            const int NI1 = I1e - I1s;
+            const int NI2 = I2e - I2s;
+            const int max_N = amrex::max(NI1,NI2);
+
+            int i1 = I1s;
+            int i2 = I2s;
+            int pair_index = cell_start_pair;
+
+            // Because the number of particles of each species is not always equal (NI1 != NI2
+            // in general), some macroparticles will be paired with multiple macroparticles of the
+            // other species and we need to decrease their weight accordingly.
+            // c1 corresponds to the minimum number of times a particle of species 1 will be paired
+            // with a particle of species 2. Same for c2.
+            const int c1 = amrex::max(NI2/NI1,1);
+            const int c2 = amrex::max(NI1/NI2,1);
+
+            // multiplier ratio to take into account unsampled pairs
+            int multiplier_ratio;
+            if (m_isSameSpecies)
+            {
+                multiplier_ratio = 2*max_N - 1;
+            }
+            else
+            {
+                multiplier_ratio = max_N;
+            }
+
+            for (int k = 0; k < max_N; ++k)
+            {
+                // c1k : how many times the current particle of species 1 is paired with a particle
+                // of species 2. Same for c2k.
+                const int c1k = (k%NI1 < max_N%NI1) ? c1 + 1: c1;
+                const int c2k = (k%NI2 < max_N%NI2) ? c2 + 1: c2;
+                SingleNuclearFusionEvent(
+                    u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
+                    u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
+                    m1, m2, w1[ I1[i1] ]/c1k, w2[ I2[i2] ]/c2k,
+                    dt, dV, pair_index, p_mask, p_pair_reaction_weight,
+                    m_fusion_multiplier, multiplier_ratio,
+                    m_probability_threshold,
+                    m_probability_target_value,
+                    m_fusion_type, engine);
+                p_pair_indices_1[pair_index] = I1[i1];
+                p_pair_indices_2[pair_index] = I2[i2];
+                ++i1; if ( i1 == static_cast<int>(I1e) ) { i1 = I1s; }
+                ++i2; if ( i2 == static_cast<int>(I2e) ) { i2 = I2s; }
+                ++pair_index;
+            }
+
         }
 
 private:
+    // Factor used to increase the number of fusion reaction by decreasing the weight of the
+    // produced particles
     amrex::Real m_fusion_multiplier;
+    // If the fusion multiplier is too high and results in a fusion probability that approaches
+    // 1, there is a risk of underestimating the total fusion yield. In these cases, we reduce
+    // the fusion multiplier used in a given collision. m_probability_threshold is the fusion
+    // probability threshold above which we reduce the fusion multiplier.
+    // m_probability_target_value is the target probability used to determine by how much
+    // the fusion multiplier should be reduced.
+    amrex::Real m_probability_threshold;
+    amrex::Real m_probability_target_value;
     NuclearFusionType m_fusion_type;
+    bool m_isSameSpecies;
 };
 
 #endif // NUCLEAR_FUSION_FUNC_H_

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
@@ -90,7 +90,19 @@ public:
     /**
      * \brief operator() of the NuclearFusionFunc class. Performs nuclear fusions at the cell level
      * using the algorithm described in Higginson et al., Journal of Computational Physics 388,
-     * 439-453 (2019).
+     * 439-453 (2019). Note that this function does not yet create the product particles, but
+     * instead fills an array p_mask that stores which collisions result in a fusion event.
+     *
+     * Also note that there are three main differences between this implementation and the
+     * algorithm described in Higginson's paper:
+     * - 1) The transformation from the lab frame to the center of mass frame is nonrelativistic
+     * in Higginson's paper. Here, we implement a relativistic generalization.
+     * - 2) The behaviour when the estimated fusion probability is greater than one is not
+     * specified in Higginson's paper. Here, we provide an implementation using two runtime
+     * dependent parameters (fusion probability threshold and fusion probability target value). See
+     * documentation for more details.
+     * - 3) Here, we divide the weight of a particle by the number of times it is paired with other
+     * particles. This was not explicitly specified in Higginson's paper.
      *
      * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
      * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
@@ -99,12 +111,16 @@ public:
      * @param[in] m1 and m2 are masses.
      * @param[in] dt is the time step length between two collision calls.
      * @param[in] dV is the volume of the corresponding cell.
-     * @param[in] cell_start_pair is the start index of the pairs in that cell
+     * @param[in] cell_start_pair is the start index of the pairs in that cell.
      * @param[out] p_mask is a mask that will be set to true if a fusion event occurs for a given
-     * pair
+     * pair. It is only needed here to store information that will be used later on when actually
+     * creating the product particles.
      * @param[out] p_pair_indices_1 and p_pair_indices_2 are arrays that store the indices of the
-     * particles of a given pair
-     * @param[out] p_pair_reaction_weight stores the weight of the product particles
+     * particles of a given pair. They are only needed here to store information that will be used
+     * later on when actually creating the product particles.
+     * @param[out] p_pair_reaction_weight stores the weight of the product particles. It is only
+     * needed here to store information that will be used later on when actually creating the
+     * product particles.
      * @param[in] engine the random engine.
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
@@ -82,7 +82,7 @@ public:
         queryWithParser(pp_collision_name, "fusion_probability_threshold",
                                             m_probability_threshold);
         // default fusion probability target_value
-        m_probability_threshold = 0.002_rt;
+        m_probability_target_value = 0.002_rt;
         queryWithParser(pp_collision_name, "fusion_probability_target_value",
                                             m_probability_target_value);
     }

--- a/Source/Particles/Collision/BinaryCollision/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/PairWiseCoulombCollisionFunc.H
@@ -42,7 +42,8 @@ public:
      * @param[in] collision_name the name of the collision
      */
     PairWiseCoulombCollisionFunc (const std::string collision_name,
-                                  MultiParticleContainer const * const /*mypc*/)
+                                  MultiParticleContainer const * const /*mypc*/,
+                                  const bool /*isSameSpecies*/)
     {
         using namespace amrex::literals;
         amrex::ParmParse pp_collision_name(collision_name);
@@ -58,10 +59,7 @@ public:
      * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
      * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
      * @param[in] I1 and I2 are the index arrays. They determine all elements that will be used.
-     * @param[in,out] u1 and u2 are the velocity arrays (u=v*gamma),
-     *                they could be either different or the same,
-     *                their lengths are not needed,
-     * @param[in] w1 and w2 are arrays of weights.
+     * @param[in, out] soa_1 and soa_2 contain the struct of array data of the two species.
      * @param[in] q1 and q2 are charges. m1 and m2 are masses.
      * @param[in] dt is the time step length between two collision calls.
      * @param[in] dV is the volume of the corresponding cell.

--- a/Source/Particles/Collision/BinaryCollision/ProtonBoronFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/ProtonBoronFusionCrossSection.H
@@ -1,0 +1,24 @@
+/* Copyright 2021 Neil Zaim
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef PROTON_BORON_FUSION_CROSS_SECTION_H
+#define PROTON_BORON_FUSION_CROSS_SECTION_H
+
+#include <AMReX_REAL.H>
+
+
+/**
+ * \brief Computes the total proton-boron fusion cross section. Needs to be implemented.
+ */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+amrex::ParticleReal ProtonBoronFusionCrossSection (const amrex::ParticleReal& /*E_star*/)
+{
+    return amrex::ParticleReal(0.);
+}
+
+
+#endif // PROTON_BORON_FUSION_CROSS_SECTION_H

--- a/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
@@ -174,6 +174,10 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
         p_mask[pair_index] = true;
         p_pair_reaction_weight[pair_index] = w_min/fusion_multiplier_eff;
     }
+    else
+    {
+        p_mask[pair_index] = false;
+    }
 
 }
 

--- a/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
@@ -102,7 +102,7 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
     const amrex::ParticleReal E_kin_star = std::sqrt(E_star_sq) - (m1 + m2)*c_sq;
 
     // Compute fusion cross section as a function of kinetic energy in the center of mass frame
-    amrex::ParticleReal fusion_cross_section;
+    auto fusion_cross_section = amrex::ParticleReal(0.);
     if (fusion_type == NuclearFusionType::ProtonBoron)
     {
         fusion_cross_section = ProtonBoronFusionCrossSection(E_kin_star);

--- a/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
@@ -1,0 +1,167 @@
+/* Copyright 2021 Neil Zaim
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef SINGLE_NUCLEAR_FUSION_EVENT_H_
+#define SINGLE_NUCLEAR_FUSION_EVENT_H_
+
+#include "BinaryCollisionUtils.H"
+#include "ProtonBoronFusionCrossSection.H"
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_Algorithm.H>
+#include <AMReX_Random.H>
+#include <AMReX_REAL.H>
+
+#include <cmath>
+
+
+/**
+ * \brief This function computes whether the collision between two particles result in a
+ * nuclear fusion event, using the algorithm described in Higginson et al., Journal of
+ * Computational Physics 388, 439-453 (2019). If nuclear fusion occurs, the mask is set to true
+ * for that given pair of particles and the weight of the produced particles is stored in
+ * p_pair_reaction_weight.
+ *
+ * @param[in] u1x, u1y, u1z, u2x, u2y and u2z are the momenta of the colliding particles
+ * @param[in] m1 and m2 are masses.
+ * @param[in] w1 and w2 are the effective weight of the colliding particles
+ * @param[in] dt is the time step length between two collision calls.
+ * @param[in] dV is the volume of the corresponding cell.
+ * @param[in] pair_index is the index of the colliding pair
+ * @param[out] p_mask is a mask that will be set to true if fusion occurs for that pair
+ * @param[out] p_pair_reaction_weight stores the weight of the product particles
+ * @param[in] fusion_multiplier factor used to increase the number of fusion events by
+ * decreasing the weight of the produced particles
+ * @param[in] multiplier_ratio factor used to take into account unsampled pairs (i.e. the fact
+ * that a particle only collides with one or few particles of the other species)
+ * @param[in] probability_threshold probability threshold above which we decrease the fusion
+ * multiplier
+ * @param[in] probability_target_value if the probability threshold is exceeded, this is used
+ * to determine by how much the fusion multiplier is reduced
+ * @param[in] engine the random engine.
+ */
+template <typename index_type>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::ParticleReal& u1y,
+                               const amrex::ParticleReal& u1z, const amrex::ParticleReal& u2x,
+                               const amrex::ParticleReal& u2y, const amrex::ParticleReal& u2z,
+                               const amrex::ParticleReal& m1, const amrex::ParticleReal& m2,
+                               amrex::ParticleReal w1, amrex::ParticleReal w2,
+                               const amrex::Real& dt, const amrex::Real& dV, const int& pair_index,
+                               index_type* p_mask, amrex::ParticleReal* p_pair_reaction_weight,
+                               const amrex::Real& fusion_multiplier,
+                               const int& multiplier_ratio,
+                               const amrex::Real& probability_threshold,
+                               const amrex::Real& probability_target_value,
+                               const NuclearFusionType& fusion_type,
+                               const amrex::RandomEngine& engine)
+{
+    // General notations in this function:
+    //     x_sq denotes the square of x
+    //     x_star denotes the value of x in the center of mass frame
+
+    const amrex::ParticleReal w_min = amrex::min(w1, w2);
+    const amrex::ParticleReal w_max = amrex::max(w1, w2);
+
+    constexpr auto one_pr = amrex::ParticleReal(1.);
+    constexpr auto inv_two_pr = amrex::ParticleReal(1./2.);
+    constexpr auto inv_four_pr = amrex::ParticleReal(1./4.);
+    constexpr amrex::ParticleReal c_sq = PhysConst::c * PhysConst::c;
+    constexpr amrex::ParticleReal inv_csq = one_pr / ( c_sq );
+
+    const amrex::ParticleReal m1_sq = m1*m1;
+    const amrex::ParticleReal m2_sq = m2*m2;
+
+    // Compute Lorentz factor gamma in the lab frame
+    const amrex::ParticleReal g1 = std::sqrt( one_pr + (u1x*u1x+u1y*u1y+u1z*u1z)*inv_csq );
+    const amrex::ParticleReal g2 = std::sqrt( one_pr + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_csq );
+
+    // Compute momenta
+    const amrex::ParticleReal p1x = u1x * m1;
+    const amrex::ParticleReal p1y = u1y * m1;
+    const amrex::ParticleReal p1z = u1z * m1;
+    const amrex::ParticleReal p2x = u2x * m2;
+    const amrex::ParticleReal p2y = u2y * m2;
+    const amrex::ParticleReal p2z = u2z * m2;
+    // Square norm of the total (sum between the two particles) momenta in the lab frame
+    const amrex::ParticleReal p_total_sq = std::pow(p1x+p2x, 2) +
+                                     std::pow(p1y+p2y, 2) +
+                                     std::pow(p1z+p2z, 2);
+
+    // Total energy in the lab frame
+    const amrex::ParticleReal E_lab = (m1 * g1 + m2 * g2) * c_sq;
+    // Total energy squared in the center of mass frame, calculated using the Lorentz invariance
+    // of the four-momentum norm
+    const amrex::ParticleReal E_star_sq = E_lab*E_lab - c_sq*p_total_sq;
+
+    // Kinetic energy in the center of mass frame
+    const amrex::ParticleReal E_kin_star = std::sqrt(E_star_sq) - (m1 + m2)*c_sq;
+
+    // Compute fusion cross section as a function of kinetic energy in the center of mass frame
+    amrex::ParticleReal fusion_cross_section;
+    if (fusion_type == NuclearFusionType::ProtonBoron)
+    {
+        fusion_cross_section = ProtonBoronFusionCrossSection(E_kin_star);
+    }
+
+    // Square of the norm of the momentum of one of the particles in the center of mass frame
+    // Formula obtained by inverting E^2 = p^2*c^2 + m^2*c^4 in the COM frame for each particle
+    const amrex::ParticleReal p_star_sq =
+            E_star_sq*inv_four_pr*inv_csq - (m1_sq + m2_sq)*c_sq*inv_two_pr +
+            std::pow(c_sq, 3)*inv_four_pr*std::pow(m1_sq - m2_sq, 2)/E_star_sq;
+
+    // Lorentz factors in the center of mass frame
+    const amrex::ParticleReal g1_star = std::sqrt(1 + p_star_sq / (m1_sq*c_sq));
+    const amrex::ParticleReal g2_star = std::sqrt(1 + p_star_sq / (m2_sq*c_sq));
+
+    // relative velocity in the center of mass frame
+    const amrex::ParticleReal v_rel = std::sqrt(p_star_sq) * (one_pr/(m1*g1_star) +
+                                                              one_pr/(m2*g2_star));
+
+    // Fusion cross section and relative velocity are computed in the center of mass frame.
+    // On the other hand, the particle densities (weight over volume) in the lab frame are used. To
+    // take into account this discrepancy, we need to multiply the fusion probability by the ratio
+    // between the Lorentz factors in the COM frame and the Lorentz factors in the lab frame
+    // (see Perez et al., Phys.Plasmas.19.083104 (2012))
+    const amrex::ParticleReal lab_to_COM_factor = g1_star*g2_star/(g1*g2);
+
+    // First estimate of probability to have fusion reaction
+    amrex::ParticleReal probability_estimate = multiplier_ratio * fusion_multiplier *
+                                lab_to_COM_factor * w_max * fusion_cross_section * v_rel * dt / dV;
+
+    // Effective fusion multiplier
+    amrex::ParticleReal fusion_multiplier_eff = fusion_multiplier;
+
+    // If the fusion probability is too high and the fusion multiplier greater than one, we risk to
+    // systematically underestimate the fusion yield. In this case, we reduce the fusion multiplier
+    // to reduce the fusion probability
+    if (probability_estimate > probability_threshold)
+    {
+        // We aim for a fusion probability of probability_target_value but take into account
+        // the constraint that the fusion_multiplier cannot be smaller than one
+        fusion_multiplier_eff  = amrex::max(fusion_multiplier *
+                                         probability_target_value / probability_estimate , one_pr);
+        probability_estimate *= fusion_multiplier_eff/fusion_multiplier;
+    }
+
+    // Actual fusion probability that is always between zero and one
+    const amrex::ParticleReal probability = one_pr - std::exp(-probability_estimate);
+
+    // Get a random number
+    amrex::ParticleReal random_number = amrex::Random(engine);
+
+    // If we have a fusion event, set the mask the true and fill the product weight array
+    if (random_number < probability)
+    {
+        p_mask[pair_index] = true;
+        p_pair_reaction_weight[pair_index] = w_min/fusion_multiplier_eff;
+    }
+
+}
+
+
+#endif // SINGLE_NUCLEAR_FUSION_EVENT_H_

--- a/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/SingleNuclearFusionEvent.H
@@ -148,8 +148,22 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
         probability_estimate *= fusion_multiplier_eff/fusion_multiplier;
     }
 
-    // Actual fusion probability that is always between zero and one
-    const amrex::ParticleReal probability = one_pr - std::exp(-probability_estimate);
+    // Compute actual fusion probability that is always between zero and one
+    // In principle this is obtained by computing 1 - exp(-probability_estimate)
+    // However, the computation of this quantity can fail numerically when probability_estimate is
+    // too small (e.g. exp(-probability_estimate) returns 1 and the computation returns 0).
+    // In this case, we simply use "probability_estimate" instead of 1 - exp(-probability_estimate)
+    // The threshold exp_threshold at which we switch between the two formulas is determined by the
+    // fact that computing the exponential is only useful if it can resolve the x^2/2 term of its
+    // Taylor expansion, i.e. the square of probability_estimate should be greater than the
+    // machine epsilon.
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+    constexpr auto exp_threshold = amrex::ParticleReal(1.e-3);
+#else
+    constexpr auto exp_threshold = amrex::ParticleReal(5.e-8);
+#endif
+    const amrex::ParticleReal probability = (probability_estimate < exp_threshold) ?
+                                    probability_estimate: one_pr - std::exp(-probability_estimate);
 
     // Get a random number
     amrex::ParticleReal random_number = amrex::Random(engine);


### PR DESCRIPTION
This PR is based on #2217 ~~which is in turned based on #2245~~ (edit: #2245 has been merged), so it should probably be reviewed once these PRs have been merged.

It implements Higginson's algorithm for nuclear fusion (https://doi.org/10.1016/j.jcp.2019.03.020). The general idea of the algorithm is the following:
- Particles are paired in the same way as in the usual Coulomb collision algorithm (however, if a particle is paired with multiple particles, its effective weight used in the calculation must be decreased accordingly). A multiplier ratio is used to take into account unsampled pairs (i.e. the fact that a particle does not collide with all the particles of the other species)
- For each pair of colliding particles, we use the particles' momenta and weight as well as the total cross section to determine a probability of fusion occuring.
- A fusion multiplier can be used to artificially increase the number of generated particles by decreasing their weight. (basically we multiply the fusion probability by the fusion multiplier and decrease the weight of the generated particles by the fusion multiplier)
- However, one risk of using a fusion multiplier is that if it too high and the probability of a fusion event approaches 1, we can then systematically underestimate the fusion yield. Higginson's paper does not describe how to deal with this so I have tried the following: if we detect that the fusion probability becomes too high for a given colliding pair, we then decrease the fusion multiplier. This decrease is controlled by the input parameters `fusion_probability_threshold` and `fusion_probability_target_value`, which are the fusion probability threshold above which we need to decrease the fusion multiplier and the fusion probability that we aim for used to determine by how much we decrease the fusion multiplier (keeping in mind that the fusion multiplier cannot be decreased below 1).

Regarding the implementation:
- The pairing between the particle is done in the nuclear fusion functor (`NuclearFusionFunc`). It is the same pairing as for Coulomb collision, with the addition that we have to keep track of how many times a given particle will be paired with a particle of the other species and we also have to fill a pair index array.
- Then we call a new function called `SingleNuclearFusionEvent` which does the computation on a single colliding pair (Lorentz transform to center of mass frame, computation of fusion cross section and all necessary quantities) and fills a mask if nuclear fusion actually occurs for that pair. This mask will then be used by the particle creation functor (which will be implemented in a follow-up PR) to actually create fusion products.

Note that functions that compute total fusion cross sections of specific nuclear fusion processes will need to be implemented in follow-up PRs (I will do that soon for proton-boron fusion).