### PR TITLE
Remove unused variable from backtransformed diagnostics

### DIFF
--- a/Source/Diagnostics/BackTransformedDiagnostic.H
+++ b/Source/Diagnostics/BackTransformedDiagnostic.H
@@ -67,7 +67,6 @@ class LabFrameDiag {
     std::vector<std::string> m_mesh_field_names_;
 
     int m_file_num;
-    int m_initial_i;
 
     // For back-transformed diagnostics of grid fields, data_buffer_
     // stores a buffer of the fields in the lab frame (in a MultiFab, i.e.

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -1173,7 +1173,6 @@ LabFrameSnapShot(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
    m_current_z_boost = 0.0;
    updateCurrentZPositions(t_boost, m_inv_gamma_boost_, m_inv_beta_boost_);
    Real zmin_lab = m_prob_domain_lab_.lo(AMREX_SPACEDIM-1);
-   m_initial_i = static_cast<int>((m_current_z_lab - zmin_lab) / m_dz_lab_) ;
    m_file_name = Concatenate(WarpX::lab_data_directory + "/snapshots/snapshot",
                            m_file_num, 5);
    createLabFrameDirectories();
@@ -1345,7 +1344,6 @@ LabFrameSlice(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
     m_current_z_boost = 0.0;
     updateCurrentZPositions(t_boost, m_inv_gamma_boost_, m_inv_beta_boost_);
     Real zmin_lab = m_prob_domain_lab_.lo(AMREX_SPACEDIM-1);
-    m_initial_i = static_cast<int>((m_current_z_lab - zmin_lab)/m_dz_lab_);
     m_file_name = Concatenate(WarpX::lab_data_directory+"/slices/slice",m_file_num,5);
     createLabFrameDirectories();
     m_buff_counter_ = 0;

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -1172,7 +1172,6 @@ LabFrameSnapShot(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
    m_current_z_lab = 0.0;
    m_current_z_boost = 0.0;
    updateCurrentZPositions(t_boost, m_inv_gamma_boost_, m_inv_beta_boost_);
-   Real zmin_lab = m_prob_domain_lab_.lo(AMREX_SPACEDIM-1);
    m_file_name = Concatenate(WarpX::lab_data_directory + "/snapshots/snapshot",
                            m_file_num, 5);
    createLabFrameDirectories();
@@ -1343,7 +1342,6 @@ LabFrameSlice(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
     m_current_z_lab = 0.0;
     m_current_z_boost = 0.0;
     updateCurrentZPositions(t_boost, m_inv_gamma_boost_, m_inv_beta_boost_);
-    Real zmin_lab = m_prob_domain_lab_.lo(AMREX_SPACEDIM-1);
     m_file_name = Concatenate(WarpX::lab_data_directory+"/slices/slice",m_file_num,5);
     createLabFrameDirectories();
     m_buff_counter_ = 0;


### PR DESCRIPTION
I found that the `static_cast` here could overflow in some cases. At first I thought I'd use something like the function `safeCastToInt` in `WarpXUtils`. However, it looks like the variable that we cast to is not used anywhere, so I figured that we may as well directly remove that variable. Unless maybe we want to keep it (e.g. if we plan on using it in the future)?