### PR TITLE
Set EB (electrostatic) potential with a function of space and time

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -17,8 +17,7 @@ namespace ElectrostaticSolver {
 struct PhiCalculatorEB {
 
     amrex::Real t;
-    amrex::Parser potential_eb_parser;
-    amrex::ParserExecutor<4> potential_eb = potential_eb_parser.compile<4>();
+    amrex::ParserExecutor<4> potential_eb;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (const amrex::Real x, const amrex::Real z) const noexcept
@@ -42,12 +41,16 @@ public:
     void buildParsers ()
     {
         potential_eb_parser = makeParser(potential_eb_str, {"x", "y", "z", "t"});
+
+        potential_eb = potential_eb_parser.compile<4>();
     }
 
     PhiCalculatorEB getPhiEB (amrex::Real t) const noexcept
     {
-        return PhiCalculatorEB{t, potential_eb_parser};
+        return PhiCalculatorEB{t, potential_eb};
     }
+
+    amrex::ParserExecutor<4> potential_eb;
 
 private:
 

--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -1,0 +1,59 @@
+/* Copyright 2021 Modern Electron
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef ELECTROSTATICSOLVER_H_
+#define ELECTROSTATICSOLVER_H_
+
+#include "Utils/WarpXUtil.H"
+
+#include <AMReX_Parser.H>
+#include <AMReX_REAL.H>
+
+namespace ElectrostaticSolver {
+
+struct PhiCalculatorEB {
+
+    amrex::Real t;
+    amrex::Parser potential_eb_parser;
+    amrex::ParserExecutor<4> potential_eb = potential_eb_parser.compile<4>();
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::Real operator() (const amrex::Real x, const amrex::Real z) const noexcept
+    {
+        return potential_eb(x, 0.0, z, t);
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::Real operator() (const amrex::Real x, const amrex::Real y, const amrex::Real z) const noexcept
+    {
+        return potential_eb(x, y, z, t);
+    }
+};
+
+class BoundaryValueHandler {
+
+public:
+    std::string potential_eb_str = "0";
+    // TODO add handling of domain boundaries as well
+
+    void buildParsers ()
+    {
+        potential_eb_parser = makeParser(potential_eb_str, {"x", "y", "z", "t"});
+    };
+
+    PhiCalculatorEB getPhiEB (amrex::Real t) const noexcept
+    {
+        return PhiCalculatorEB{t, potential_eb_parser};
+    }
+
+private:
+
+    amrex::Parser potential_eb_parser;
+
+};
+
+}
+#endif

--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -42,7 +42,7 @@ public:
     void buildParsers ()
     {
         potential_eb_parser = makeParser(potential_eb_str, {"x", "y", "z", "t"});
-    };
+    }
 
     PhiCalculatorEB getPhiEB (amrex::Real t) const noexcept
     {

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -6,6 +6,7 @@
  */
 #include "WarpX.H"
 
+#include "FieldSolver/ElectrostaticSolver.H"
 #include "Parallelization/GuardCellManager.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -441,12 +442,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     linop.setSigma({AMREX_D_DECL(
         1._rt-beta[0]*beta[0], 1._rt-beta[1]*beta[1], 1._rt-beta[2]*beta[2])});
 
-    // get the EB potential at the current time
-    std::string potential_eb_str = "0";
-    ParmParse pp_embedded_boundary("warpx");
-    pp_embedded_boundary.query("eb_potential(t)", potential_eb_str);
-    auto parser_eb = makeParser(potential_eb_str, {"t"});
-    linop.setEBDirichlet( parser_eb.compile<1>()(gett_new(0)) );
+    linop.setEBDirichlet( field_boundary_value_handler.getPhiEB(gett_new(0)) );
 #endif
 
     // Solve the Poisson equation

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -18,6 +18,7 @@
 #include "Diagnostics/ReducedDiags/MultiReducedDiags_fwd.H"
 #include "Evolve/WarpXDtType.H"
 #include "EmbeddedBoundary/WarpXFaceInfoBox.H"
+#include "FieldSolver/ElectrostaticSolver.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H"
 #include "Particles/ParticleBoundaryBuffer_fwd.H"
@@ -617,6 +618,7 @@ public:
      */
     const amrex::IntVect get_numprocs() const {return numprocs;}
 
+    ElectrostaticSolver::BoundaryValueHandler field_boundary_value_handler;
     void ComputeSpaceChargeField (bool const reset_fields);
     void AddSpaceChargeField (WarpXParticleContainer& pc);
     void AddSpaceChargeFieldLabFrame ();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -571,11 +571,16 @@ WarpX::ReadParameters ()
         do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
 
         if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+            // Note that with the relativistic version, these parameters would be
+            // input for each species.
             queryWithParser(pp_warpx, "self_fields_required_precision", self_fields_required_precision);
             queryWithParser(pp_warpx, "self_fields_max_iters", self_fields_max_iters);
             pp_warpx.query("self_fields_verbosity", self_fields_verbosity);
-            // Note that with the relativistic version, these parameters would be
-            // input for each species.
+
+            // Build the handler for the field boundary conditions
+            pp_warpx.query("eb_potential(t)", field_boundary_value_handler.potential_eb_str);
+            field_boundary_value_handler.buildParsers();
+            // TODO add the parsers for the domain boundary values as well
         }
 
         queryWithParser(pp_warpx, "const_dt", const_dt);


### PR DESCRIPTION
The embedded boundary functionality for the electrostatic solver has been extended to allow a function of space and time to be used to set the EB potential.
In the example below the embedded boundary was defined (through PICMI) with:
```
embedded_boundary = picmi.EmbeddedBoundary(
    implicit_function="-(x**2+z**2-radius**2)",
    potential="if(x>0,1.0,-2.0)",
    radius = 0.3
)
```
![potential](https://user-images.githubusercontent.com/40245517/133028141-764cd830-7ad9-40c7-8616-280a939ff2ee.png)