### PR TITLE
C++17, CMake 3.17+

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,9 +100,11 @@ jobs:
       if [[ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" || "${WARPX_CI_PYTHON_MAIN:-FALSE}" == "TRUE" ]]; then
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
+          -DCMAKE_CXX_STANDARD=17                       \
           -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
+          -DCMAKE_CXX_STANDARD=17                       \
           -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
       fi
       rm -rf ${CEI_TMP}

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -24,7 +24,13 @@ jobs:
       run: |
         .github/workflows/dependencies/nvcc11.sh
         export CEI_SUDO="sudo"
-        cmake-easyinstall --prefix=/usr/local git+https://github.com/openPMD/openPMD-api.git@0.14.3 -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
+        cmake-easyinstall --prefix=/usr/local \
+          git+https://github.com/openPMD/openPMD-api.git@0.14.3 \
+          -DopenPMD_USE_PYTHON=OFF    \
+          -DBUILD_TESTING=OFF         \
+          -DBUILD_EXAMPLES=OFF        \
+          -DBUILD_CLI_TOOLS=OFF       \
+          -DCMAKE_VERBOSE_MAKEFILE=ON
     - name: build WarpX
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.17.0)
 project(WarpX VERSION 21.12)
 
 include(${WarpX_SOURCE_DIR}/cmake/WarpXFunctions.cmake)
@@ -19,11 +19,11 @@ endif()
 # AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
 # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if(CMAKE_VERSION VERSION_LESS 3.20)
+#if(CMAKE_VERSION VERSION_LESS 3.20)
     if(POLICY CMP0104)
         cmake_policy(SET CMP0104 OLD)
     endif()
-endif()
+#endif()
 
 
 # CCache Support ##############################################################
@@ -192,9 +192,9 @@ add_subdirectory(Source/Particles)
 add_subdirectory(Source/Python)
 add_subdirectory(Source/Utils)
 
-# C++ properties: at least a C++14 capable compiler is needed
+# C++ properties: at least a C++17 capable compiler is needed
 foreach(warpx_tgt IN LISTS _ALL_TARGETS)
-    target_compile_features(${warpx_tgt} PUBLIC cxx_std_14)
+    target_compile_features(${warpx_tgt} PUBLIC cxx_std_17)
 endforeach()
 set_target_properties(${_ALL_TARGETS} PROPERTIES
     CXX_EXTENSIONS OFF
@@ -236,15 +236,13 @@ if(WarpX_COMPUTE STREQUAL CUDA)
     foreach(warpx_tgt IN LISTS _ALL_TARGETS)
         setup_target_for_cuda_compilation(${warpx_tgt})
     endforeach()
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        foreach(warpx_tgt IN LISTS _ALL_TARGETS)
-            target_compile_features(${warpx_tgt} PUBLIC cuda_std_14)
-        endforeach()
-        set_target_properties(${_ALL_TARGETS} PROPERTIES
-            CUDA_EXTENSIONS OFF
-            CUDA_STANDARD_REQUIRED ON
-        )
-    endif()
+    foreach(warpx_tgt IN LISTS _ALL_TARGETS)
+        target_compile_features(${warpx_tgt} PUBLIC cuda_std_17)
+    endforeach()
+    set_target_properties(${_ALL_TARGETS} PROPERTIES
+        CUDA_EXTENSIONS OFF
+        CUDA_STANDARD_REQUIRED ON
+    )
 endif()
 
 # fancy binary name for build variants

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,13 @@ endif()
 #endif()
 
 
+# C++ Standard in Superbuilds #################################################
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+set_cxx17_superbuild()
+
+
 # CCache Support ##############################################################
 #
 # this is an optional tool that stores compiled object files; allows fast

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -6,8 +6,8 @@ Dependencies
 WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
-- a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 5, Clang 3.6 or newer
-- `CMake 3.15.0+ <https://cmake.org>`__
+- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 7, Clang 6, NVCC 11.0, MSVC 19.15 or newer
+- `CMake 3.17.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `PICSAR <https://github.com/ECP-WarpX/picsar>`__: we automatically download and compile a copy of PICSAR
@@ -15,7 +15,7 @@ Please see installation instructions below.
 Optional dependencies include:
 
 - `MPI 3.0+ <https://www.mpi-forum.org/docs/>`__: for multi-node and/or multi-GPU execution
-- `CUDA Toolkit 9.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
+- `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
 - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution (currently not fully accelerated)
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
 - `BLAS++ <https://bitbucket.org/icl/blaspp>`_ and `LAPACK++ <https://bitbucket.org/icl/lapackpp>`_: for spectral solver (PSATD) support in RZ geometry

--- a/Docs/source/install/hpc/cori.rst
+++ b/Docs/source/install/hpc/cori.rst
@@ -70,13 +70,13 @@ And install ADIOS2, BLAS++ and LAPACK++:
    # BLAS++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/blaspp.git src/blaspp
    rm -rf src/blaspp-knl-build
-   cmake -S src/blaspp -B src/blaspp-knl-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_INSTALL_PREFIX=$HOME/sw/blaspp-master-knl-install
+   cmake -S src/blaspp -B src/blaspp-knl-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/blaspp-master-knl-install
    cmake --build src/blaspp-knl-build --target install --parallel 16
 
    # LAPACK++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/lapackpp.git src/lapackpp
    rm -rf src/lapackpp-knl-build
-   CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-knl-build -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DLAPACK_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_INSTALL_PREFIX=$HOME/sw/lapackpp-master-knl-install
+   CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-knl-build -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DLAPACK_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/lapackpp-master-knl-install
    cmake --build src/lapackpp-knl-build --target install --parallel 16
 
 For PICMI and Python workflows, also install a virtual environment:
@@ -132,13 +132,13 @@ And install ADIOS2, BLAS++ and LAPACK++:
    # BLAS++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/blaspp.git src/blaspp
    rm -rf src/blaspp-haswell-build
-   cmake -S src/blaspp -B src/blaspp-haswell-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_INSTALL_PREFIX=$HOME/sw/blaspp-master-haswell-install
+   cmake -S src/blaspp -B src/blaspp-haswell-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/blaspp-master-haswell-install
    cmake --build src/blaspp-haswell-build --target install --parallel 16
 
    # LAPACK++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/lapackpp.git src/lapackpp
    rm -rf src/lapackpp-haswell-build
-   CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-haswell-build -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DLAPACK_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_INSTALL_PREFIX=$HOME/sw/lapackpp-master-haswell-install
+   CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-haswell-build -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DLAPACK_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/lapackpp-master-haswell-install
    cmake --build src/lapackpp-haswell-build --target install --parallel 16
 
 For PICMI and Python workflows, also install a virtual environment:

--- a/Docs/source/install/hpc/quartz.rst
+++ b/Docs/source/install/hpc/quartz.rst
@@ -34,7 +34,7 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
 
    # required dependencies
    module load cmake/3.20.2
-   module load intel/19.1.2
+   module load intel/2021.4
    module load mvapich2/2.3
 
    # optional: for PSATD support

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -41,7 +41,7 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    # required dependencies
    module load cmake/3.20.2
    module load gcc/9.3.0
-   module load cuda/11.0.3
+   module load cuda/11.3.1
 
    # optional: faster re-builds
    module load ccache

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Supported Platforms](https://img.shields.io/badge/platforms-linux%20|%20osx%20|%20win-blue)](https://warpx.readthedocs.io/en/latest/install/users.html)
 [![GitHub commits since last release](https://img.shields.io/github/commits-since/ECP-WarpX/WarpX/latest/development.svg)](https://github.com/ECP-WarpX/WarpX/compare/development)
 [![Exascale Computing Project](https://img.shields.io/badge/supported%20by-ECP-orange)](https://www.exascaleproject.org/research/)
-[![Language: C++14](https://img.shields.io/badge/language-C%2B%2B14-orange.svg)](https://isocpp.org/)
+[![Language: C++17](https://img.shields.io/badge/language-C%2B%2B17-orange.svg)](https://isocpp.org/)
 [![Language: Python](https://img.shields.io/badge/language-Python-orange.svg)](https://python.org/)  
 [![License WarpX](https://img.shields.io/badge/license-BSD--3--Clause--LBNL-blue.svg)](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)
 [![DOI (source)](https://img.shields.io/badge/DOI%20(source)-10.5281/zenodo.4571577-blue.svg)](https://doi.org/10.5281/zenodo.4571577)

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -7,11 +7,7 @@ USE_PARTICLES = TRUE
 USE_RPATH     = TRUE
 USE_GPU_RDC   = FALSE
 BL_NO_FORT    = TRUE
-ifeq ($(USE_DPCPP),TRUE)
-  CXXSTD        = c++17
-else
-  CXXSTD        = c++14
-endif
+CXXSTD        = c++17
 
 # required for AMReX async I/O
 MPI_THREAD_MULTIPLE = TRUE

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -1,3 +1,31 @@
+# Set C++17 for the whole build if not otherwise requested
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+#
+macro(set_cxx17_superbuild)
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    endif()
+
+    if(NOT DEFINED CMAKE_CUDA_STANDARD)
+        set(CMAKE_CUDA_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_EXTENSIONS)
+        set(CMAKE_CUDA_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_STANDARD_REQUIRED)
+        set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    endif()
+endmacro()
+
+
 # find the CCache tool and use it if found
 #
 macro(set_ccache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.15.0,<4.0.0"
+    "cmake>=3.17.0,<4.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
-                "CMake 3.15.0+ must be installed to build the following " +
+                "CMake 3.17.0+ must be installed to build the following " +
                 "extensions: " +
                 ", ".join(e.name for e in self.extensions))
 
@@ -60,8 +60,8 @@ class CMakeBuild(build_ext):
             r'version\s*([\d.]+)',
             out.decode()
         ).group(1))
-        if cmake_version < '3.15.0':
-            raise RuntimeError("CMake >= 3.15.0 is required")
+        if cmake_version < '3.17.0':
+            raise RuntimeError("CMake >= 3.17.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
Update C++ requirements to compile with C++17 or newer.

Proper C++17 compilers:
- [x] Clang 6+
- [x] GCC 7+
- [x] NVCC 11.0+
- [x] NVC++ 19.1+ 
- [x] ROCm `hipcc`/`clang++ -x hip` (already used as C++17)
- [x] oneAPI `dpcpp`/`icpx` (already used as C++17)
- [x] Intel `icpc` 19.0.1+ (version 2021+ recommended)
- [x] MSVC 19.15+ (already used as C++17)
- [x] etc. https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B17_features

Checklist:
- [x] depends on #2551
- [x] depends on #2596
- [x] depends on #2595
- [x] test and update documented HPC machines
  - [x] Cori (NERSC)
  - [ ] Perlmutter (NERSC): major update downtime and will need a general module update afterwards anyway (separate PR)
  - [x] Summit (OLCF): note - slight `cuda/` module update needed (see below)
  - [x] Juwels (JSC)
  - [x] Lassen (LLNL)
  - [x] Quartz (LLNL): will need openPMD-api 0.14.4: https://github.com/openPMD/openPMD-api/pull/1157 or a bump `intel/19.1.2` to `intel/2021.4`
  - [x] Ookami (Stony Brook)
    - [x] GCC (recommended)
    - [ ] FujitsuClang (wrote to support for newer CMake, not tested yet)

Potentially force to build AMReX, PICSAR and openPMD-api in super-builds to C++17, too:
  - [x] ensured to be fine if build in C++14 and used in C++17 with openPMD-api [0.14.3+](https://github.com/openPMD/openPMD-api/releases/tag/0.14.3) #2551 
  - [x] AMReX and PICSAR: seem to cause no problems yet
  - [x] BLAS++/LAPACK++: seem to cause no problems yet