### PR TITLE
Comoving PSATD: New Input psatd.use_default_v_comoving

### DIFF
--- a/Examples/Tests/comoving/inputs_2d_hybrid
+++ b/Examples/Tests/comoving/inputs_2d_hybrid
@@ -23,7 +23,7 @@ algo.particle_pusher = vay
 # Order of particle shape factors
 algo.particle_shape = 3
 
-psatd.v_comoving = 0. 0. -0.9970370305242862
+psatd.use_default_v_comoving = 1
 
 warpx.cfl = 1.
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1004,7 +1004,6 @@ WarpX::ReadParameters ()
         }
 
         pp_psatd.query("current_correction", current_correction);
-        pp_psatd.query("v_comoving", m_v_comoving);
         pp_psatd.query("do_time_averaging", fft_do_time_averaging);
         pp_psatd.query("J_linear_in_time", J_linear_in_time);
 
@@ -1025,6 +1024,28 @@ WarpX::ReadParameters ()
         } else {
             pp_psatd.query("v_galilean", m_v_galilean);
         }
+
+        // Check whether the default comoving velocity should be used
+        bool use_default_v_comoving = false;
+        pp_psatd.query("use_default_v_comoving", use_default_v_comoving);
+        if (use_default_v_comoving)
+        {
+            m_v_comoving[2] = -std::sqrt(1._rt - 1._rt / (gamma_boost * gamma_boost));
+        }
+        else
+        {
+            pp_psatd.query("v_comoving", m_v_comoving);
+        }
+
+        // Galilean and comoving algorithms should not be used together
+        if (m_v_galilean[0] != 0. || m_v_galilean[1] != 0. || m_v_galilean[2] != 0.)
+        {
+            if (m_v_comoving[0] != 0. || m_v_comoving[1] != 0. || m_v_comoving[2] != 0.)
+            {
+                amrex::Abort("Galilean and comoving algorithms should not be used together");
+            }
+        }
+
         // Scale the Galilean/comoving velocity by the speed of light
         for (int i=0; i<3; i++) m_v_galilean[i] *= PhysConst::c;
         for (int i=0; i<3; i++) m_v_comoving[i] *= PhysConst::c;


### PR DESCRIPTION
Add new input parameter `psatd.use_default_v_comoving` for the comoving PSATD algorithm, similar to the one already in use for the Galilean algorithm.