### PR TITLE
PICMI parameter for turning off charge and current deposition

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -84,6 +84,7 @@ class Species(picmistandard.PICMI_Species):
         self.self_fields_max_iters = kw.pop('warpx_self_fields_max_iters', None)
         self.self_fields_verbosity = kw.pop('warpx_self_fields_verbosity', None)
         self.save_previous_position = kw.pop('warpx_save_previous_position', None)
+        self.do_not_deposit = kw.pop('warpx_do_not_deposit', None)
 
         # For the scraper buffer
         self.save_particles_at_xlo = kw.pop('warpx_save_particles_at_xlo', None)
@@ -124,7 +125,8 @@ class Species(picmistandard.PICMI_Species):
                                              save_particles_at_zlo = self.save_particles_at_zlo,
                                              save_particles_at_zhi = self.save_particles_at_zhi,
                                              save_particles_at_eb = self.save_particles_at_eb,
-                                             save_previous_position = self.save_previous_position)
+                                             save_previous_position = self.save_previous_position,
+                                             do_not_deposit = self.do_not_deposit)
         pywarpx.Particles.particles_list.append(self.species)
 
         if self.initial_distribution is not None:


### PR DESCRIPTION
Currently the `do_not_deposit` flag for a species cannot be set from Python. This PR simply adds that option.