### PR TITLE
Evolve: Mark Step in Profile

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -72,6 +72,7 @@ WarpX::Evolve (int numsteps)
 
     for (int step = istep[0]; step < numsteps_max && cur_time < stop_time; ++step)
     {
+        WARPX_PROFILE("WarpX::Evolve::step");
         Real evolve_time_beg_step = amrex::second();
 
         multi_diags->NewIteration();
@@ -365,6 +366,7 @@ WarpX::Evolve (int numsteps)
 void
 WarpX::OneStep_nosub (Real cur_time)
 {
+    WARPX_PROFILE("WarpX::OneStep_nosub()");
 
     // Push particle from x^{n} to x^{n+1}
     //               from p^{n-1/2} to p^{n+1/2}


### PR DESCRIPTION
Mark individual steps in the profiler.

This makes it easier to see the individual step timing in our tiny profiler and it also helps to see with NVTX (and equivalent) annotations to find the exact start/end of a time step in traces.

![Screenshot from 2021-09-16 22-58-49](https://user-images.githubusercontent.com/1353258/133732104-17825b47-4dca-4e25-ad2a-553e14e57e43.png)
