### PR TITLE
Rename `eb_potential` parameter

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -285,10 +285,10 @@ Embedded Boundary Conditions
     the physics simulation area is where the function value is negative ;
     the interior of the embeddded boundary is where the function value is positive.
 
-* ``warpx.eb_potential(t)`` (`string`)
+* ``warpx.eb_potential(x,y,z,t)`` (`string`)
     Only used when ``warpx.do_electrostatic=labframe``. Gives the value of
     the electric potential at the surface of the embedded boundary,
-    as a function of time.
+    as a function of  `x`, `y`, `z` and time.
 
 .. _running-cpp-parameters-parallelization:
 

--- a/Examples/Tests/ElectrostaticSphereEB/inputs_3d
+++ b/Examples/Tests/ElectrostaticSphereEB/inputs_3d
@@ -18,7 +18,7 @@ warpx.const_dt = 1e-6
 
 warpx.do_electrostatic = labframe
 warpx.eb_implicit_function = "-(x**2+y**2+z**2-0.3**2)"
-warpx.eb_potential(t) = "1."
+warpx.eb_potential(x,y,z,t) = "1."
 warpx.self_fields_required_precision = 1.e-7
 
 algo.field_gathering = momentum-conserving

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -804,7 +804,7 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         if self.potential is not None:
             assert isinstance(solver, ElectrostaticSolver), Exception('The potential is only supported with the ElectrostaticSolver')
             expression = pywarpx.my_constants.mangle_expression(self.potential, self.mangle_dict)
-            pywarpx.warpx.__setattr__('eb_potential(t)', expression)
+            pywarpx.warpx.__setattr__('eb_potential(x,y,z,t)', expression)
 
 
 class Simulation(picmistandard.PICMI_Simulation):

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -578,7 +578,7 @@ WarpX::ReadParameters ()
             pp_warpx.query("self_fields_verbosity", self_fields_verbosity);
 
             // Build the handler for the field boundary conditions
-            pp_warpx.query("eb_potential(t)", field_boundary_value_handler.potential_eb_str);
+            pp_warpx.query("eb_potential(x,y,z,t)", field_boundary_value_handler.potential_eb_str);
             field_boundary_value_handler.buildParsers();
             // TODO add the parsers for the domain boundary values as well
         }


### PR DESCRIPTION
This parameter is now a function of *space* and time. 

Therefore, I renamed this parameter `eb_potential(x,y,z,t)` (instead of `eb_potential(t)`)