### PR TITLE
Performance: ApplyStencil w/o Temporaries

### DIFF
--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -51,26 +51,9 @@ Filter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, const int lev, int
         const auto& src = srcmf.array(mfi);
         const auto& dst = dstmf.array(mfi);
         const Box& tbx = mfi.growntilebox();
-        const Box& gbx = amrex::grow(tbx,stencil_length_each_dir-1);
-
-        // tmpfab has enough ghost cells for the stencil
-        FArrayBox tmp_fab(gbx,ncomp);
-        Elixir tmp_eli = tmp_fab.elixir();  // Prevent the tmp data from being deleted too early
-        auto const& tmp = tmp_fab.array();
-
-        // Copy values in srcfab into tmpfab
-        const Box& ibx = gbx & srcmf[mfi].box();
-        AMREX_PARALLEL_FOR_4D ( gbx, ncomp, i, j, k, n,
-        {
-            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                tmp(i,j,k,n) = src(i,j,k,n+scomp);
-            } else {
-                tmp(i,j,k,n) = 0.0;
-            }
-        });
 
         // Apply filter
-        DoFilter(tbx, tmp, dst, 0, dcomp, ncomp);
+        DoFilter(tbx, src, dst, 0, dcomp, ncomp);
 
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
@@ -97,32 +80,15 @@ Filter::ApplyStencil (FArrayBox& dstfab, const FArrayBox& srcfab,
     ncomp = std::min(ncomp, srcfab.nComp());
     const auto& src = srcfab.array();
     const auto& dst = dstfab.array();
-    const Box& gbx = amrex::grow(tbx,stencil_length_each_dir-1);
-
-    // tmpfab has enough ghost cells for the stencil
-    FArrayBox tmp_fab(gbx,ncomp);
-    Elixir tmp_eli = tmp_fab.elixir();  // Prevent the tmp data from being deleted too early
-    auto const& tmp = tmp_fab.array();
-
-    // Copy values in srcfab into tmpfab
-    const Box& ibx = gbx & srcfab.box();
-    AMREX_PARALLEL_FOR_4D ( gbx, ncomp, i, j, k, n,
-        {
-            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                tmp(i,j,k,n) = src(i,j,k,n+scomp);
-            } else {
-                tmp(i,j,k,n) = 0.0;
-            }
-        });
 
     // Apply filter
-    DoFilter(tbx, tmp, dst, 0, dcomp, ncomp);
+    DoFilter(tbx, src, dst, 0, dcomp, ncomp);
 }
 
 /* \brief Apply stencil (2D/3D, CPU/GPU)
  */
 void Filter::DoFilter (const Box& tbx,
-                       Array4<Real const> const& tmp,
+                       Array4<Real const> const& src,
                        Array4<Real      > const& dst,
                        int scomp, int dcomp, int ncomp)
 {
@@ -132,23 +98,31 @@ void Filter::DoFilter (const Box& tbx,
 #endif
     amrex::Real const* AMREX_RESTRICT sz = stencil_z.data();
     Dim3 slen_local = slen;
+
 #if (AMREX_SPACEDIM == 3)
     AMREX_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
     {
         Real d = 0.0;
 
+        // Pad source array with zeros beyond ghost cells
+        // for out-of-bound accesses due to large-stencil operations
+        const auto src_zeropad = [src] (const int jj, const int kk, const int ll, const int nn) noexcept
+        {
+            return src.contains(jj,kk,ll) ? src(jj,kk,ll,nn) : 0.0_rt;
+        };
+
         for         (int iz=0; iz < slen_local.z; ++iz){
             for     (int iy=0; iy < slen_local.y; ++iy){
                 for (int ix=0; ix < slen_local.x; ++ix){
                     Real sss = sx[ix]*sy[iy]*sz[iz];
-                    d += sss*( tmp(i-ix,j-iy,k-iz,scomp+n)
-                              +tmp(i+ix,j-iy,k-iz,scomp+n)
-                              +tmp(i-ix,j+iy,k-iz,scomp+n)
-                              +tmp(i+ix,j+iy,k-iz,scomp+n)
-                              +tmp(i-ix,j-iy,k+iz,scomp+n)
-                              +tmp(i+ix,j-iy,k+iz,scomp+n)
-                              +tmp(i-ix,j+iy,k+iz,scomp+n)
-                              +tmp(i+ix,j+iy,k+iz,scomp+n));
+                    d += sss*( src_zeropad(i-ix,j-iy,k-iz,scomp+n)
+                              +src_zeropad(i+ix,j-iy,k-iz,scomp+n)
+                              +src_zeropad(i-ix,j+iy,k-iz,scomp+n)
+                              +src_zeropad(i+ix,j+iy,k-iz,scomp+n)
+                              +src_zeropad(i-ix,j-iy,k+iz,scomp+n)
+                              +src_zeropad(i+ix,j-iy,k+iz,scomp+n)
+                              +src_zeropad(i-ix,j+iy,k+iz,scomp+n)
+                              +src_zeropad(i+ix,j+iy,k+iz,scomp+n));
                 }
             }
         }
@@ -164,10 +138,10 @@ void Filter::DoFilter (const Box& tbx,
             for     (int iy=0; iy < slen_local.y; ++iy){
                 for (int ix=0; ix < slen_local.x; ++ix){
                     Real sss = sx[ix]*sz[iy];
-                    d += sss*( tmp(i-ix,j-iy,k,scomp+n)
-                              +tmp(i+ix,j-iy,k,scomp+n)
-                              +tmp(i-ix,j+iy,k,scomp+n)
-                              +tmp(i+ix,j+iy,k,scomp+n));
+                    d += sss*( src_zeropad(i-ix,j-iy,k,scomp+n)
+                              +src_zeropad(i+ix,j-iy,k,scomp+n)
+                              +src_zeropad(i-ix,j+iy,k,scomp+n)
+                              +src_zeropad(i+ix,j+iy,k,scomp+n));
                 }
             }
         }

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -53,7 +53,7 @@ Filter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, const int lev, int
         const Box& tbx = mfi.growntilebox();
 
         // Apply filter
-        DoFilter(tbx, src, dst, 0, dcomp, ncomp);
+        DoFilter(tbx, src, dst, scomp, dcomp, ncomp);
 
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
@@ -82,7 +82,7 @@ Filter::ApplyStencil (FArrayBox& dstfab, const FArrayBox& srcfab,
     const auto& dst = dstfab.array();
 
     // Apply filter
-    DoFilter(tbx, src, dst, 0, dcomp, ncomp);
+    DoFilter(tbx, src, dst, scomp, dcomp, ncomp);
 }
 
 /* \brief Apply stencil (2D/3D, CPU/GPU)


### PR DESCRIPTION
Most of the time in this code is spend in allocating/freeing the temporary. Wrap invalid values to zero on the fly instead.

This reduces kernel execution time by 1.73x.


# DGX A100 Tests

## Before

### Tiny Profiler
```
TinyProfiler total time across processes [min...avg...max]: 3.827 ... 3.839 ... 3.846

----------------------------------------------------------------------------------------------------------
Name                                                       NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
----------------------------------------------------------------------------------------------------------
...
Filter::ApplyStencil(MultiFab)                                 16     0.2196     0.2359     0.2574   6.69%
...

Total GPU global memory (MB) spread across MPI: [40537 ... 40537]
Free  GPU global memory (MB) spread across MPI: [17153 ... 17153]
[The         Arena] space (MB) allocated spread across MPI: [30402 ... 30402]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [235 ... 446]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
AMReX (21.09-28-g69b69c2b281c) finalized
```

## After

### Tiny Profiler
```
TinyProfiler total time across processes [min...avg...max]: 3.766 ... 3.773 ... 3.778

----------------------------------------------------------------------------------------------------------
Name                                                       NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
----------------------------------------------------------------------------------------------------------
...
Filter::ApplyStencil(MultiFab)                                 16     0.1339     0.1367     0.1396   3.69%
...

Total GPU global memory (MB) spread across MPI: [40537 ... 40537]
Free  GPU global memory (MB) spread across MPI: [17153 ... 17153]
[The         Arena] space (MB) allocated spread across MPI: [30402 ... 30402]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [235 ... 446]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
AMReX (21.09-28-g69b69c2b281c) finalized
```