### PR TITLE
Python Install Env Vars: All CAPS

### DIFF
--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -176,25 +176,25 @@ Environment variables can be used to control the build step:
 ============================= ============================================ ================================================================
 Environment Variable          Default & Values                             Description
 ============================= ============================================ ================================================================
-``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
-``WarpX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
-``WarpX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
-``WarpX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
-``WarpX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
-``WarpX_PRECISION``           SINGLE/**DOUBLE**                            Floating point precision (single/double)
-``WarpX_PSATD``               ON/**OFF**                                   Spectral solver
-``WarpX_QED``                 **ON**/OFF                                   PICSAR QED (requires PICSAR)
-``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation (requires PICSAR and Boost)
+``WARPX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
+``WARPX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
+``WARPX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
+``WARPX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
+``WARPX_OPENPMD``             ON/**OFF**                                   openPMD I/O (HDF5, ADIOS)
+``WARPX_PRECISION``           SINGLE/**DOUBLE**                            Floating point precision (single/double)
+``WARPX_PSATD``               ON/**OFF**                                   Spectral solver
+``WARPX_QED``                 **ON**/OFF                                   PICSAR QED (requires PICSAR)
+``WARPX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation (requires PICSAR and Boost)
 ``BUILD_PARALLEL``            ``2``                                        Number of threads to use for parallel builds
 ``BUILD_SHARED_LIBS``         ON/**OFF**                                   Build shared libraries for dependencies
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)
 ``ADIOS_USE_STATIC_LIBS``     ON/**OFF**                                   Prefer static libraries for ADIOS1 dependency (openPMD)
-``WarpX_amrex_src``           *None*                                       Absolute path to AMReX source directory (preferred if set)
-``WarpX_amrex_internal``      **ON**/OFF                                   Needs a pre-installed AMReX library if set to ``OFF``
-``WarpX_openpmd_src``         *None*                                       Absolute path to openPMD-api source directory (preferred if set)
-``WarpX_openpmd_internal``    **ON**/OFF                                   Needs a pre-installed openPMD-api library if set to ``OFF``
-``WarpX_picsar_src``          *None*                                       Absolute path to PICSAR source directory (preferred if set)
-``WarpX_picsar_internal``     **ON**/OFF                                   Needs a pre-installed PICSAR library if set to ``OFF``
+``WARPX_AMREX_SRC``           *None*                                       Absolute path to AMReX source directory (preferred if set)
+``WARPX_AMREX_INTERNAL``      **ON**/OFF                                   Needs a pre-installed AMReX library if set to ``OFF``
+``WARPX_OPENPMD_SRC``         *None*                                       Absolute path to openPMD-api source directory (preferred if set)
+``WARPX_OPENPMD_INTERNAL``    **ON**/OFF                                   Needs a pre-installed openPMD-api library if set to ``OFF``
+``WARPX_PICSAR_SRC``          *None*                                       Absolute path to PICSAR source directory (preferred if set)
+``WARPX_PICSAR_INTERNAL``     **ON**/OFF                                   Needs a pre-installed PICSAR library if set to ``OFF``
 ``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built WarpX C++ libraries (see below)
 ============================= ============================================ ================================================================
 
@@ -212,17 +212,17 @@ Some Developers like to code directly against a local copy of AMReX, changing bo
 
 .. code-block:: bash
 
-   WarpX_amrex_src=$PWD/../amrex python3 -m pip install --force-reinstall -v .
+   WARPX_AMREX_SRC=$PWD/../amrex python3 -m pip install --force-reinstall -v .
 
 Additional environment control as common for CMake (:ref:`see above <building-cmake-intro>`) can be set as well, e.g. ``CC``, `CXX``, and ``CMAKE_PREFIX_PATH`` hints.
 So another sophisticated example might be: use Clang as the compiler, build with local source copies of PICSAR and AMReX, support the PSATD solver, MPI and openPMD, hint a parallel HDF5 installation in ``$HOME/sw/hdf5-parallel-1.10.4``, and only build 3D geometry:
 
 .. code-block:: bash
 
-   CC=$(which clang) CXX=$(which clang++) WarpX_amrex_src=$PWD/../amrex WarpX_picsar_src=$PWD/../picsar WarpX_PSATD=ON WarpX_MPI=ON WarpX_OPENPMD=ON WarpX_DIMS=3 CMAKE_PREFIX_PATH=$HOME/sw/hdf5-parallel-1.10.4:$CMAKE_PREFIX_PATH python3 -m pip install --force-reinstall -v .
+   CC=$(which clang) CXX=$(which clang++) WARPX_AMREX_SRC=$PWD/../amrex WARPX_PICSAR_SRC=$PWD/../picsar WARPX_PSATD=ON WARPX_MPI=ON WARPX_OPENPMD=ON WARPX_DIMS=3 CMAKE_PREFIX_PATH=$HOME/sw/hdf5-parallel-1.10.4:$CMAKE_PREFIX_PATH python3 -m pip install --force-reinstall -v .
 
 Here we wrote this all in one line, but one can also set all environment variables in a development environment and keep the pip call nice and short as in the beginning.
-Note that you need to use absolute paths for external source trees, because pip builds in a temporary directory, e.g. ``export WarpX_amrex_src=$HOME/src/amrex``.
+Note that you need to use absolute paths for external source trees, because pip builds in a temporary directory, e.g. ``export WARPX_AMREX_SRC=$HOME/src/amrex``.
 
 The Python library ``pywarpx`` can also be created by pre-building WarpX into one or more shared libraries externally.
 For example, a package manager might split WarpX into a C++ package and a Python package.

--- a/setup.py
+++ b/setup.py
@@ -177,32 +177,34 @@ PYWARPX_LIB_DIR = os.environ.get('PYWARPX_LIB_DIR')
 env = os.environ.copy()
 # ... build WarpX libraries with CMake
 #   note: changed default for SHARED, MPI, TESTING and EXAMPLES
-WarpX_COMPUTE = env.pop('WarpX_COMPUTE', 'OMP')
-WarpX_MPI = env.pop('WarpX_MPI', 'OFF')
-WarpX_EB = env.pop('WarpX_EB', 'OFF')
-WarpX_OPENPMD = env.pop('WarpX_OPENPMD', 'OFF')
-WarpX_PRECISION = env.pop('WarpX_PRECISION', 'DOUBLE')
-WarpX_PSATD = env.pop('WarpX_PSATD', 'OFF')
-WarpX_QED = env.pop('WarpX_QED', 'ON')
-WarpX_QED_TABLE_GEN = env.pop('WarpX_QED_TABLE_GEN', 'OFF')
-WarpX_DIMS = env.pop('WarpX_DIMS', '2;3;RZ')
+#   note: we use all-uppercase variable names for environment control to be
+#         consistent across platforms (especially Windows)
+WarpX_COMPUTE = env.pop('WARPX_COMPUTE', 'OMP')
+WarpX_MPI = env.pop('WARPX_MPI', 'OFF')
+WarpX_EB = env.pop('WARPX_EB', 'OFF')
+WarpX_OPENPMD = env.pop('WARPX_OPENPMD', 'OFF')
+WarpX_PRECISION = env.pop('WARPX_PRECISION', 'DOUBLE')
+WarpX_PSATD = env.pop('WARPX_PSATD', 'OFF')
+WarpX_QED = env.pop('WARPX_QED', 'ON')
+WarpX_QED_TABLE_GEN = env.pop('WARPX_QED_TABLE_GEN', 'OFF')
+WarpX_DIMS = env.pop('WARPX_DIMS', '2;3;RZ')
 BUILD_PARALLEL = env.pop('BUILD_PARALLEL', '2')
-BUILD_SHARED_LIBS = env.pop('WarpX_BUILD_SHARED_LIBS',
+BUILD_SHARED_LIBS = env.pop('WARPX_BUILD_SHARED_LIBS',
                                    'OFF')
-#BUILD_TESTING = env.pop('WarpX_BUILD_TESTING',
+#BUILD_TESTING = env.pop('WARPX_BUILD_TESTING',
 #                               'OFF')
-#BUILD_EXAMPLES = env.pop('WarpX_BUILD_EXAMPLES',
+#BUILD_EXAMPLES = env.pop('WARPX_BUILD_EXAMPLES',
 #                                'OFF')
 # openPMD-api sub-control
 HDF5_USE_STATIC_LIBRARIES = env.pop('HDF5_USE_STATIC_LIBRARIES', 'OFF')
 ADIOS_USE_STATIC_LIBS = env.pop('ADIOS_USE_STATIC_LIBS', 'OFF')
 # CMake dependency control (developers & package managers)
-WarpX_amrex_src = env.pop('WarpX_amrex_src', '')
-WarpX_amrex_internal = env.pop('WarpX_amrex_internal', 'ON')
-WarpX_openpmd_src = env.pop('WarpX_openpmd_src', '')
-WarpX_openpmd_internal = env.pop('WarpX_openpmd_internal', 'ON')
-WarpX_picsar_src = env.pop('WarpX_picsar_src', '')
-WarpX_picsar_internal = env.pop('WarpX_picsar_internal', 'ON')
+WarpX_amrex_src = env.pop('WARPX_AMREX_SRC', '')
+WarpX_amrex_internal = env.pop('WARPX_AMREX_INTERNAL', 'ON')
+WarpX_openpmd_src = env.pop('WARPX_OPENPMD_SRC', '')
+WarpX_openpmd_internal = env.pop('WARPX_OPENPMD_INTERNAL', 'ON')
+WarpX_picsar_src = env.pop('WARPX_PICSAR_SRC', '')
+WarpX_picsar_internal = env.pop('WARPX_PICSAR_INTERNAL', 'ON')
 
 for key in env.keys():
     if key.lower().startswith('warpx'):

--- a/setup.py
+++ b/setup.py
@@ -85,16 +85,16 @@ class CMakeBuild(build_ext):
             '-DWarpX_APP:BOOL=OFF',
             '-DWarpX_LIB:BOOL=ON',
             ## variants
-            '-DWarpX_COMPUTE=' + WarpX_COMPUTE,
-            '-DWarpX_MPI:BOOL=' + WarpX_MPI,
-            '-DWarpX_EB:BOOL=' + WarpX_EB,
-            '-DWarpX_OPENPMD:BOOL=' + WarpX_OPENPMD,
-            '-DWarpX_PRECISION=' + WarpX_PRECISION,
-            '-DWarpX_PSATD:BOOL=' + WarpX_PSATD,
-            '-DWarpX_QED:BOOL=' + WarpX_QED,
-            '-DWarpX_QED_TABLE_GEN:BOOL=' + WarpX_QED_TABLE_GEN,
+            '-DWarpX_COMPUTE=' + WARPX_COMPUTE,
+            '-DWarpX_MPI:BOOL=' + WARPX_MPI,
+            '-DWarpX_EB:BOOL=' + WARPX_EB,
+            '-DWarpX_OPENPMD:BOOL=' + WARPX_OPENPMD,
+            '-DWarpX_PRECISION=' + WARPX_PRECISION,
+            '-DWarpX_PSATD:BOOL=' + WARPX_PSATD,
+            '-DWarpX_QED:BOOL=' + WARPX_QED,
+            '-DWarpX_QED_TABLE_GEN:BOOL=' + WARPX_QED_TABLE_GEN,
             ## dependency control (developers & package managers)
-            '-DWarpX_amrex_internal=' + WarpX_amrex_internal,
+            '-DWarpX_amrex_internal=' + WARPX_AMREX_INTERNAL,
             #        see PICSAR and openPMD below
             ## static/shared libs
             '-DBUILD_SHARED_LIBS:BOOL=' + BUILD_SHARED_LIBS,
@@ -106,21 +106,21 @@ class CMakeBuild(build_ext):
             # Windows: has no RPath concept, all `.dll`s must be in %PATH%
             #          or same dir as calling executable
         ]
-        if WarpX_QED.upper() in ['1', 'ON', 'TRUE', 'YES']:
-            cmake_args.append('-DWarpX_picsar_internal=' + WarpX_picsar_internal)
-        if WarpX_OPENPMD.upper() in ['1', 'ON', 'TRUE', 'YES']:
+        if WARPX_QED.upper() in ['1', 'ON', 'TRUE', 'YES']:
+            cmake_args.append('-DWarpX_picsar_internal=' + WARPX_PICSAR_INTERNAL)
+        if WARPX_OPENPMD.upper() in ['1', 'ON', 'TRUE', 'YES']:
             cmake_args += [
                 '-DHDF5_USE_STATIC_LIBRARIES:BOOL=' + HDF5_USE_STATIC_LIBRARIES,
                 '-DADIOS_USE_STATIC_LIBS:BOOL=' + ADIOS_USE_STATIC_LIBS,
-                '-DWarpX_openpmd_internal=' + WarpX_openpmd_internal,
+                '-DWarpX_openpmd_internal=' + WARPX_OPENPMD_INTERNAL,
             ]
         # further dependency control (developers & package managers)
-        if WarpX_amrex_src:
-            cmake_args.append('-DWarpX_amrex_src=' + WarpX_amrex_src)
-        if WarpX_openpmd_src:
-            cmake_args.append('-DWarpX_openpmd_src=' + WarpX_openpmd_src)
-        if WarpX_picsar_src:
-            cmake_args.append('-DWarpX_picsar_src=' + WarpX_picsar_src)
+        if WARPX_AMREX_SRC:
+            cmake_args.append('-DWarpX_amrex_src=' + WARPX_AMREX_SRC)
+        if WARPX_OPENPMD_SRC:
+            cmake_args.append('-DWarpX_openpmd_src=' + WARPX_OPENPMD_SRC)
+        if WARPX_PICSAR_SRC:
+            cmake_args.append('-DWarpX_picsar_src=' + WARPX_PICSAR_SRC)
 
         if sys.platform == "darwin":
             cmake_args.append('-DCMAKE_INSTALL_RPATH=@loader_path')
@@ -179,15 +179,15 @@ env = os.environ.copy()
 #   note: changed default for SHARED, MPI, TESTING and EXAMPLES
 #   note: we use all-uppercase variable names for environment control to be
 #         consistent across platforms (especially Windows)
-WarpX_COMPUTE = env.pop('WARPX_COMPUTE', 'OMP')
-WarpX_MPI = env.pop('WARPX_MPI', 'OFF')
-WarpX_EB = env.pop('WARPX_EB', 'OFF')
-WarpX_OPENPMD = env.pop('WARPX_OPENPMD', 'OFF')
-WarpX_PRECISION = env.pop('WARPX_PRECISION', 'DOUBLE')
-WarpX_PSATD = env.pop('WARPX_PSATD', 'OFF')
-WarpX_QED = env.pop('WARPX_QED', 'ON')
-WarpX_QED_TABLE_GEN = env.pop('WARPX_QED_TABLE_GEN', 'OFF')
-WarpX_DIMS = env.pop('WARPX_DIMS', '2;3;RZ')
+WARPX_COMPUTE = env.pop('WARPX_COMPUTE', 'OMP')
+WARPX_MPI = env.pop('WARPX_MPI', 'OFF')
+WARPX_EB = env.pop('WARPX_EB', 'OFF')
+WARPX_OPENPMD = env.pop('WARPX_OPENPMD', 'OFF')
+WARPX_PRECISION = env.pop('WARPX_PRECISION', 'DOUBLE')
+WARPX_PSATD = env.pop('WARPX_PSATD', 'OFF')
+WARPX_QED = env.pop('WARPX_QED', 'ON')
+WARPX_QED_TABLE_GEN = env.pop('WARPX_QED_TABLE_GEN', 'OFF')
+WARPX_DIMS = env.pop('WARPX_DIMS', '2;3;RZ')
 BUILD_PARALLEL = env.pop('BUILD_PARALLEL', '2')
 BUILD_SHARED_LIBS = env.pop('WARPX_BUILD_SHARED_LIBS',
                                    'OFF')
@@ -199,12 +199,12 @@ BUILD_SHARED_LIBS = env.pop('WARPX_BUILD_SHARED_LIBS',
 HDF5_USE_STATIC_LIBRARIES = env.pop('HDF5_USE_STATIC_LIBRARIES', 'OFF')
 ADIOS_USE_STATIC_LIBS = env.pop('ADIOS_USE_STATIC_LIBS', 'OFF')
 # CMake dependency control (developers & package managers)
-WarpX_amrex_src = env.pop('WARPX_AMREX_SRC', '')
-WarpX_amrex_internal = env.pop('WARPX_AMREX_INTERNAL', 'ON')
-WarpX_openpmd_src = env.pop('WARPX_OPENPMD_SRC', '')
-WarpX_openpmd_internal = env.pop('WARPX_OPENPMD_INTERNAL', 'ON')
-WarpX_picsar_src = env.pop('WARPX_PICSAR_SRC', '')
-WarpX_picsar_internal = env.pop('WARPX_PICSAR_INTERNAL', 'ON')
+WARPX_AMREX_SRC = env.pop('WARPX_AMREX_SRC', '')
+WARPX_AMREX_INTERNAL = env.pop('WARPX_AMREX_INTERNAL', 'ON')
+WARPX_OPENPMD_SRC = env.pop('WARPX_OPENPMD_SRC', '')
+WARPX_OPENPMD_INTERNAL = env.pop('WARPX_OPENPMD_INTERNAL', 'ON')
+WARPX_PICSAR_SRC = env.pop('WARPX_PICSAR_SRC', '')
+WARPX_PICSAR_INTERNAL = env.pop('WARPX_PICSAR_INTERNAL', 'ON')
 
 for key in env.keys():
     if key.lower().startswith('warpx'):
@@ -212,16 +212,16 @@ for key in env.keys():
 
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
-if WarpX_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:
-    WarpX_MPI = "ON"
+if WARPX_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:
+    WARPX_MPI = "ON"
 else:
-    WarpX_MPI = "OFF"
+    WARPX_MPI = "OFF"
 
 # Include embedded boundary functionality
-if WarpX_EB.upper() in ['1', 'ON', 'TRUE', 'YES']:
-    WarpX_EB = "ON"
+if WARPX_EB.upper() in ['1', 'ON', 'TRUE', 'YES']:
+    WARPX_EB = "ON"
 else:
-    WarpX_EB = "OFF"
+    WARPX_EB = "OFF"
 
 
 # for CMake
@@ -234,7 +234,7 @@ if PYWARPX_LIB_DIR:
 # CMake: build WarpX libraries ourselves
 else:
     cmdclass = dict(build_ext=CMakeBuild)
-    for dim in [x.lower() for x in WarpX_DIMS.split(';')]:
+    for dim in [x.lower() for x in WARPX_DIMS.split(';')]:
         name = dim if dim == "rz" else dim + "d"
         cxx_modules.append(CMakeExtension("warpx_" + name))
 
@@ -242,7 +242,7 @@ else:
 install_requires = []
 with open('./requirements.txt') as f:
     install_requires = [line.strip('\n') for line in f.readlines()]
-    if WarpX_MPI == "ON":
+    if WARPX_MPI == "ON":
         install_requires.append('mpi4py>=2.1.0')
 
 # keyword reference:


### PR DESCRIPTION
On Windows, environment variable names are case insensitive and often mapped to all CAPS spelling.

- https://stackoverflow.com/questions/7797269/python-environment-case-senstivity-os-environ
- https://en.wikipedia.org/wiki/Environment_variable#Syntax

This leads to an inconsistency between Unix and Windows like systems if we use case sensitive environment variable names for install control in Python.

Luckily, it is quite common to use all-CAPS variables in UNIX for environment controls as well, so we will make a breaking change to unify on that. Existing usage will see a warning of an unused variable with `python3 -m pip install -v .` (thanks to #2208)