### PR TITLE
Fix Bug in PSATD Restart with Time Averaging

### DIFF
--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -12,6 +12,7 @@ print('tolerance = ', tolerance)
 
 filename = sys.argv[1]
 psatd = True if re.search('psatd', filename) else False
+averaged = True if re.search('avg', filename) else False
 
 ds  = yt.load( filename )
 ad  = ds.all_data()
@@ -20,7 +21,11 @@ xe  = ad['plasma_e', 'particle_position_x'].to_ndarray()
 zb  = ad['beam',     'particle_position_z'].to_ndarray()
 ze  = ad['plasma_e', 'particle_position_z'].to_ndarray()
 
-filename = 'orig_restart_psatd_plt00010' if (psatd) else 'orig_restart_plt00010'
+filename = 'orig_restart_plt00010'
+if psatd:
+    filename = 'orig_restart_psatd_plt00010'
+if averaged:
+    filename = 'orig_restart_psatd_time_avg_plt00010'
 ds  = yt.load( filename )
 ad  = ds.all_data()
 xb0 = ad['beam',     'particle_position_x'].to_ndarray()

--- a/Regression/Checksum/benchmarks_json/restart_psatd_time_avg.json
+++ b/Regression/Checksum/benchmarks_json/restart_psatd_time_avg.json
@@ -1,0 +1,68 @@
+{
+  "beam": {
+    "particle_cpu": 0.0,
+    "particle_id": 1500500.0,
+    "particle_momentum_x": 4.254691979750989e-19,
+    "particle_momentum_y": 4.1535435963437147e-19,
+    "particle_momentum_z": 2.728767021901075e-17,
+    "particle_position_x": 0.001517680460798969,
+    "particle_position_y": 0.001493038909816312,
+    "particle_position_z": 1.9017771013093303,
+    "particle_weight": 3120754537.230381
+  },
+  "driver": {
+    "particle_cpu": 0.0,
+    "particle_id": 500500.0,
+    "particle_momentum_x": 4.747251762692475e+21,
+    "particle_momentum_y": 4.957368621566193e+21,
+    "particle_momentum_z": 2.9967719884827463e+25,
+    "particle_position_x": 0.0015297460887947526,
+    "particle_position_y": 0.0016025569807081841,
+    "particle_position_z": 0.30618320806025484,
+    "particle_weight": 6241509074.460762
+  },
+  "driverback": {
+    "particle_cpu": 0.0,
+    "particle_id": 2500500.0,
+    "particle_momentum_x": 4.683153456335865e+21,
+    "particle_momentum_y": 5.084648482174756e+21,
+    "particle_momentum_z": 2.999729460061163e+25,
+    "particle_position_x": 0.0015293780426403722,
+    "particle_position_y": 0.0016041310861395035,
+    "particle_position_z": 0.4918072823278685,
+    "particle_weight": 6241509074.460762
+  },
+  "lev=0": {
+    "Bx": 97770.61191599404,
+    "By": 97780.70810712027,
+    "Bz": 31.008136828149073,
+    "Ex": 12838801235406.88,
+    "Ey": 12837507519031.262,
+    "Ez": 32438660943782.914,
+    "jx": 635272636369.7802,
+    "jy": 612269127739.1005,
+    "jz": 904274462562314.8
+  },
+  "plasma_e": {
+    "particle_cpu": 4116.0,
+    "particle_id": 22919946.0,
+    "particle_momentum_x": 5.744114065909579e-22,
+    "particle_momentum_y": 5.721131408219794e-22,
+    "particle_momentum_z": 1.1184397774427398e-17,
+    "particle_position_x": 0.1350592713852672,
+    "particle_position_y": 0.13505925001090735,
+    "particle_position_z": 0.20362720922167768,
+    "particle_weight": 126912632943.36244
+  },
+  "plasma_p": {
+    "particle_cpu": 4116.0,
+    "particle_id": 25328394.0,
+    "particle_momentum_x": 5.7443089782205155e-22,
+    "particle_momentum_y": 5.721334024352466e-22,
+    "particle_momentum_z": 2.0535791479091608e-14,
+    "particle_position_x": 0.1350562483544117,
+    "particle_position_y": 0.13505624836605168,
+    "particle_position_z": 0.20362719494726217,
+    "particle_weight": 126912632943.36244
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -931,7 +931,7 @@ tolerance = 1.e-14
 [restart_psatd_time_avg]
 buildDir = .
 inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -928,6 +928,25 @@ particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 tolerance = 1.e-14
 
+[restart_psatd_time_avg]
+buildDir = .
+inputFile = Examples/Tests/restart/inputs
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+restartTest = 1
+restartFileNum = 5
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = beam
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+tolerance = 1.e-14
+
 [space_charge_initialization_2d]
 buildDir = .
 inputFile = Examples/Modules/space_charge_initialization/inputs_3d

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -68,6 +68,24 @@ FlushFormatCheckpoint::WriteToFile (
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_fp"));
         VisMF::Write(warpx.getBfield_fp(lev, 2),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_fp"));
+
+        if (WarpX::fft_do_time_averaging)
+        {
+            VisMF::Write(warpx.getEfield_avg_fp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_fp"));
+            VisMF::Write(warpx.getEfield_avg_fp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_fp"));
+            VisMF::Write(warpx.getEfield_avg_fp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_fp"));
+
+            VisMF::Write(warpx.getBfield_avg_fp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_fp"));
+            VisMF::Write(warpx.getBfield_avg_fp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_fp"));
+            VisMF::Write(warpx.getBfield_avg_fp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_fp"));
+        }
+
         if (warpx.getis_synchronized()) {
             // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
             VisMF::Write(warpx.getcurrent_fp(lev, 0),
@@ -92,6 +110,24 @@ FlushFormatCheckpoint::WriteToFile (
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_cp"));
             VisMF::Write(warpx.getBfield_cp(lev, 2),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_cp"));
+
+            if (WarpX::fft_do_time_averaging)
+            {
+                VisMF::Write(warpx.getEfield_avg_cp(lev, 0),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_cp"));
+                VisMF::Write(warpx.getEfield_avg_cp(lev, 1),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_cp"));
+                VisMF::Write(warpx.getEfield_avg_cp(lev, 2),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_cp"));
+
+                VisMF::Write(warpx.getBfield_avg_cp(lev, 0),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_cp"));
+                VisMF::Write(warpx.getBfield_avg_cp(lev, 1),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_cp"));
+                VisMF::Write(warpx.getBfield_avg_cp(lev, 2),
+                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_cp"));
+            }
+
             if (warpx.getis_synchronized()) {
                 // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
                 VisMF::Write(warpx.getcurrent_cp(lev, 0),

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -246,6 +246,23 @@ WarpX::InitFromCheckpoint ()
         VisMF::Read(*Bfield_fp[lev][2],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_fp"));
 
+        if (WarpX::fft_do_time_averaging)
+        {
+            VisMF::Read(*Efield_avg_fp[lev][0],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_fp"));
+            VisMF::Read(*Efield_avg_fp[lev][1],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_fp"));
+            VisMF::Read(*Efield_avg_fp[lev][2],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_fp"));
+
+            VisMF::Read(*Bfield_avg_fp[lev][0],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_fp"));
+            VisMF::Read(*Bfield_avg_fp[lev][1],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_fp"));
+            VisMF::Read(*Bfield_avg_fp[lev][2],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_fp"));
+        }
+
         if (is_synchronized) {
             VisMF::Read(*current_fp[lev][0],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jx_fp"));
@@ -270,6 +287,23 @@ WarpX::InitFromCheckpoint ()
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_cp"));
             VisMF::Read(*Bfield_cp[lev][2],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_cp"));
+
+            if (WarpX::fft_do_time_averaging)
+            {
+                VisMF::Read(*Efield_avg_cp[lev][0],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_cp"));
+                VisMF::Read(*Efield_avg_cp[lev][1],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_cp"));
+                VisMF::Read(*Efield_avg_cp[lev][2],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_cp"));
+
+                VisMF::Read(*Bfield_avg_cp[lev][0],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_cp"));
+                VisMF::Read(*Bfield_avg_cp[lev][1],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_cp"));
+                VisMF::Read(*Bfield_avg_cp[lev][2],
+                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_cp"));
+            }
 
             if (is_synchronized) {
                 VisMF::Read(*current_cp[lev][0],

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -286,6 +286,8 @@ public:
 
     const amrex::MultiFab& getEfield_avg_fp (int lev, int direction) {return *Efield_avg_fp[lev][direction];}
     const amrex::MultiFab& getBfield_avg_fp (int lev, int direction) {return *Bfield_avg_fp[lev][direction];}
+    const amrex::MultiFab& getEfield_avg_cp (int lev, int direction) {return *Efield_avg_cp[lev][direction];}
+    const amrex::MultiFab& getBfield_avg_cp (int lev, int direction) {return *Bfield_avg_cp[lev][direction];}
 
     bool DoPML () const {return do_pml;}
 


### PR DESCRIPTION
Fix bug in restart functionality for PSATD runs when time averaging is activated (`psatd.do_time_averaging = 1`). The `avg_fp` and `avg_cp` MultiFab need to be written to and read from checkpoint files. Thanks @RemiLehe, @atmyers, @WeiqunZhang, and @ax3l for finding and debugging this.