### PR TITLE
Python CI: Only 2 Ranks

### DIFF
--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -126,7 +126,7 @@ from pywarpx import wx
 
 if color == 0:
     # verify that communicator contains correct number of procs (1)
-    assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 2
+    assert wx.libwarpx.warpx_getNProcs() == comm_world_size - 1
     assert wx.libwarpx.warpx_getNProcs() == new_comm_size
 
 else:

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2268,7 +2268,7 @@ dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
-numprocs = 3
+numprocs = 2
 useOMP = 1
 numthreads = 1
 compileTest = 0
@@ -2395,7 +2395,7 @@ dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
-numprocs = 3
+numprocs = 2
 useOMP = 0
 numthreads = 0
 compileTest = 0


### PR DESCRIPTION
Public CI only offers two virtual cores and thus only 2 MPI ranks.

CI oversubscription generally leads to unstable builds (sporadic suspension of processes by the host system) and newer MPI versions won't start at all without requesting oversubscription (https://github.com/ECP-WarpX/WarpX/pull/2302#issuecomment-923707914).