### PR TITLE
Fix nvcc compilation bug

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -44,7 +44,7 @@ public:
 
     ParticleBuffer::BufferType<amrex::PinnedArenaAllocator>& getParticleBuffer(const std::string species_name, int boundary);
 
-    constexpr int numBoundaries () const {
+    static constexpr int numBoundaries () {
         return AMREX_SPACEDIM*2
 #ifdef AMREX_USE_EB
             + 1


### PR DESCRIPTION
This small seems to fix a compilation bug with certain versions of the nvcc compiler:
```
/home/rlehe/Documents/codes/warpx_directory/WarpX/Source/Particles/ParticleBoundaryBuffer.H:47:15: error: enclosing class of constexpr non-static member function 'int ParticleBoundaryBuffer::numBoundaries() const' is not a literal type
     constexpr int numBoundaries () const {
               ^
/home/rlehe/Documents/codes/warpx_directory/WarpX/Source/Particles/ParticleBoundaryBuffer.H:18:7: note: 'ParticleBoundaryBuffer' is not literal because:
 class ParticleBoundaryBuffer
       ^
/home/rlehe/Documents/codes/warpx_directory/WarpX/Source/Particles/ParticleBoundaryBuffer.H:18:7: note:   'ParticleBoundaryBuffer' has a non-trivial destructor
```
Observed with:
```
nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2020 NVIDIA Corporation
Built on Thu_Jun_11_22:26:38_PDT_2020
Cuda compilation tools, release 11.0, V11.0.194
Build cuda_11.0_bu.TC445_37.28540450_0
```

Many thanks to @ax3l for suggesting this bug fix!!