### PR TITLE
Restart: Handle Header File Read Errors

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -40,6 +40,7 @@ BTDPlotfileHeaderImpl::ReadHeaderData ()
     HeaderCharPtr[fileLength] = '\0';
 
     std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
+    is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
     is >> m_file_version;
 
@@ -190,6 +191,7 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
     HeaderCharPtr[fileLength] = '\0';
 
     std::istringstream is(HeaderCharPtr.dataPtr(), std::istringstream::in);
+    is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
     is >> m_vers;
     is >> m_how;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -50,7 +50,7 @@ FlushFormatCheckpoint::WriteToFile (
     // const int nlevels = finestLevel()+1;
     amrex::PreBuildDirectorHierarchy(checkpointname, default_level_prefix, nlev, true);
 
-    WriteWarpXHeader(checkpointname, particle_diags, geom);
+    WriteWarpXHeader(checkpointname, geom);
 
     WriteJobInfo(checkpointname);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -39,13 +39,11 @@ public:
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;
     /** Write WarpX-specific plotfile header */
-    void WriteWarpXHeader(const std::string& name, const amrex::Vector<ParticleDiag>& particle_diags, amrex::Vector<amrex::Geometry>& geom) const;
+    void WriteWarpXHeader(const std::string& name, amrex::Vector<amrex::Geometry>& geom) const;
     void WriteAllRawFields (const bool plot_raw_fields, const int nlevels,
                             const std::string& plotfilename,
                             const bool plot_raw_fields_guards,
                             const bool plot_raw_rho, bool plot_raw_F) const;
-    void WriteHeaderParticle(std::ostream& os,
-                             const amrex::Vector<ParticleDiag>& particle_diags) const;
     /** \brief Write particles data to file.
      * \param[in] filename name of output directory
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -87,7 +87,7 @@ FlushFormatPlotfile::WriteToFile (
 
     WriteJobInfo(filename);
 
-    WriteWarpXHeader(filename, particle_diags, geom);
+    WriteWarpXHeader(filename, geom);
 
     VisMF::SetHeaderVersion(current_version);
 }
@@ -217,7 +217,6 @@ FlushFormatPlotfile::WriteJobInfo(const std::string& dir) const
 void
 FlushFormatPlotfile::WriteWarpXHeader(
     const std::string& name,
-    const amrex::Vector<ParticleDiag>& particle_diags,
     amrex::Vector<amrex::Geometry>& geom) const
 {
     auto & warpx = WarpX::GetInstance();
@@ -285,23 +284,13 @@ FlushFormatPlotfile::WriteWarpXHeader(
             HeaderFile << '\n';
         }
 
-        WriteHeaderParticle(HeaderFile, particle_diags);
+        warpx.GetPartContainer().WriteHeader(HeaderFile);
 
         HeaderFile << warpx.getcurrent_injection_position() << "\n";
 
         HeaderFile << warpx.getdo_moving_window() << "\n";
 
         HeaderFile << warpx.time_of_last_gal_shift << "\n";
-    }
-}
-
-void
-FlushFormatPlotfile::WriteHeaderParticle(
-    std::ostream& os, const amrex::Vector<ParticleDiag>& particle_diags) const
-{
-    for (const auto& particle_diag : particle_diags)
-    {
-        particle_diag.getParticleContainer()->WriteHeader(os);
     }
 }
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -102,8 +102,8 @@ WarpXParticleContainer::WriteHeader (std::ostream& os) const
 void
 MultiParticleContainer::Restart (const std::string& dir)
 {
-    for (unsigned i = 0, n = species_names.size(); i < n; ++i) {
-        allcontainers[i]->Restart(dir, species_names[i]);
+    for (unsigned i = 0, n = species_names.size() + lasers_names.size(); i < n; ++i) {
+        allcontainers.at(i)->Restart(dir, species_names.at(i));
     }
 }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -67,6 +67,7 @@ WarpX::GetRestartDMap (const std::string& chkfile, const amrex::BoxArray& ba, in
     std::string fileCharPtrString(fileCharPtr.dataPtr());
     std::istringstream DMFile(fileCharPtrString, std::istringstream::in);
     if ( ! DMFile.good()) amrex::FileOpenFailed(DMFileName);
+    DMFile.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
     int nprocs_in_checkpoint;
     DMFile >> nprocs_in_checkpoint;
@@ -100,6 +101,7 @@ WarpX::InitFromCheckpoint ()
         ParallelDescriptor::ReadAndBcastFile(File, fileCharPtr);
         std::string fileCharPtrString(fileCharPtr.dataPtr());
         std::istringstream is(fileCharPtrString, std::istringstream::in);
+        is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
         std::string line, word;
 
@@ -113,6 +115,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 istep[i++] = std::stoi(word);
@@ -122,6 +125,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 nsubsteps[i++] = std::stoi(word);
@@ -131,6 +135,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 t_new[i++] = static_cast<Real>(std::stod(word));
@@ -140,6 +145,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 t_old[i++] = static_cast<Real>(std::stod(word));
@@ -149,6 +155,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 dt[i++] = static_cast<Real>(std::stod(word));
@@ -166,6 +173,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 prob_lo[i++] = static_cast<Real>(std::stod(word));
@@ -176,6 +184,7 @@ WarpX::InitFromCheckpoint ()
         std::getline(is, line);
         {
             std::istringstream lis(line);
+            is.exceptions(std::ios_base::failbit | std::ios_base::badbit);
             int i = 0;
             while (lis >> word) {
                 prob_hi[i++] = static_cast<Real>(std::stod(word));


### PR DESCRIPTION
`std::istringstream` does not throw automatically if errors occur.
This leads to silently skipped reads.

- [x] Enable throwing on all errors to avoid hard to debug follow-up errors.
- [x] fix read bugs (tested on DGX with a failing MS run for Summit)

Before this fix, every simulation that had a laser & moving window was potentially corrupted after restart - everything that we read after the particles was essentially not initialized. (All things we read after that section are moving window related: `current_injection_position`, `do_moving_window_before_restart` and `time_of_last_gal_shift`.)

Forgot to write laser particle containers but then tried to read them in. This invalidated the rest of the read string.
    
Note on fix: The mass & charge of laser particles are not essential for us to restore, but it avoids confusion and extra logic if we just write them properly at the general location.