### PR TITLE
DPC++: Disable -fPIC

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -127,11 +127,14 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
           -DWarpX_EB=ON                \
-          -DWarpX_LIB=ON               \
+          -DWarpX_LIB=OFF              \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
+     # TODO: re-enable -DWarpX_LIB=ON as soon as "dpcpp -fPIC" segfaults are
+     #       fixed
+
 
      # Skip this as it will copy the binary artifacts and we are tight on disk space
      #   python3 -m pip install --upgrade pip


### PR DESCRIPTION
Sporadic segfaults in `dpcpp` with shared objects since last release.
Needs to be triaged. Disabled to unblock community devs.

Refs.: #2279 #2303 