### PR TITLE
Fix restart for rigid-injected particles

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -163,7 +163,7 @@ public:
                         RealVector& uzp,
                         RealVector& wp );
 
-    virtual void PostRestart () final {}
+    virtual void PostRestart () override {}
 
     void SplitParticles (int lev);
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -52,6 +52,8 @@ public:
 
     virtual void InitData() override;
 
+  virtual void PostRestart() override final;
+
     virtual void RemapParticles();
     virtual void BoostandRemapParticles();
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -52,7 +52,7 @@ public:
 
     virtual void InitData() override;
 
-  virtual void PostRestart() override final;
+    virtual void PostRestart() override final;
 
     virtual void RemapParticles();
     virtual void BoostandRemapParticles();

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -79,7 +79,7 @@ void RigidInjectedParticleContainer::InitData()
 
     // Store velocity with which rigid particles move
     vzbeam_ave_boosted = meanParticleVelocity(false)[2];
-    
+
     // Particles added by AddParticles should already be in the boosted frame
     RemapParticles();
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -77,10 +77,35 @@ void RigidInjectedParticleContainer::InitData()
 
     AddParticles(0); // Note - add on level 0
 
+    // Store velocity with which rigid particles move
+    vzbeam_ave_boosted = meanParticleVelocity(false)[2];
+    
     // Particles added by AddParticles should already be in the boosted frame
     RemapParticles();
 
     Redistribute();  // We then redistribute
+}
+
+void
+RigidInjectedParticleContainer::PostRestart()
+{
+    // Call parent class
+    PhysicalParticleContainer::PostRestart();
+
+    // Store velocity with which rigid particles move
+    vzbeam_ave_boosted = meanParticleVelocity(false)[2];
+
+    // Compute the position of the injection plane in the
+    // boosted frame at restart time
+    zinject_plane_levels.resize(finestLevel()+1,0);
+    for (int lev=0; lev<=finestLevel(); lev++){
+        Real t = WarpX::GetInstance().gett_new(0);
+        zinject_plane_levels[lev] = zinject_plane/WarpX::gamma_boost - WarpX::beta_boost*PhysConst::c*t;
+    }
+
+    // The `done_injecting` flag is only here for computational efficiency
+    // We set it to false at restart (`0`), but it will be reset in `Evolve`
+    done_injecting.resize(finestLevel()+1, 0);
 }
 
 void
@@ -103,8 +128,6 @@ RigidInjectedParticleContainer::RemapParticles()
 
         const Real uz_boost = WarpX::gamma_boost*WarpX::beta_boost*PhysConst::c;
         const Real csqi = 1./(PhysConst::c*PhysConst::c);
-
-        vzbeam_ave_boosted = meanParticleVelocity(false)[2];
 
         for (int lev = 0; lev <= finestLevel(); lev++) {
 


### PR DESCRIPTION
Some of the rigid-injected particles's properties were not properly initialized during restart.
In particular, the mean velocity with which the rigid particles move before the injection plane, as well as the position of the injection planes were not correct.

In this PR, these quantities are initialized in the (virtual) function `PostRestart`, which is called at restart time.

Many thanks to @ax3l for answering my basic C++ questions on class inheritance, as part of this PR!