### PR TITLE
Stencil: Fix non-3D Compiles on GPU

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -82,7 +82,7 @@ jobs:
           -DWarpX_LIB=ON              \
           -DWarpX_MPI=ON              \
           -DWarpX_OPENPMD=ON          \
-          -DWarpX_PRECISION=SINGLE    \
+          -DWarpX_PRECISION=DOUBLE    \
           -DWarpX_PSATD=ON
         cmake --build build_2d -j 2
 

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -7,8 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_hip:
-    name: HIP SP
+  build_hip_3d_sp:
+    name: HIP 3D SP
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"}
     if: github.event.pull_request.draft == false
@@ -46,4 +46,46 @@ jobs:
 
         export WarpX_MPI=OFF
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
+        python3 -m pip install *.whl
+
+  build_hip_2d_dp:
+    name: HIP 2D DP
+    runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"}
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      shell: bash
+      run: .github/workflows/dependencies/hip.sh
+    - name: build WarpX
+      shell: bash
+      run: |
+        source /etc/profile.d/rocm.sh
+        hipcc --version
+        which clang
+        which clang++
+        export CXX=$(which clang++)
+        export CC=$(which clang)
+
+        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
+        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
+        #   https://github.com/open-mpi/ompi/issues/9317
+        export LDFLAGS="-lopen-pal"
+
+        cmake -S . -B build_2d \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DAMReX_AMD_ARCH=gfx900     \
+          -DWarpX_DIMS=2              \
+          -DWarpX_COMPUTE=HIP         \
+          -DWarpX_EB=ON               \
+          -DWarpX_LIB=ON              \
+          -DWarpX_MPI=ON              \
+          -DWarpX_OPENPMD=ON          \
+          -DWarpX_PRECISION=SINGLE    \
+          -DWarpX_PSATD=ON
+        cmake --build build_2d -j 2
+
+        export WarpX_MPI=OFF
+        PYWARPX_LIB_DIR=$PWD/build_2d/lib python3 -m pip wheel .
         python3 -m pip install *.whl

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -134,6 +134,13 @@ void Filter::DoFilter (const Box& tbx,
     {
         Real d = 0.0;
 
+        // Pad source array with zeros beyond ghost cells
+        // for out-of-bound accesses due to large-stencil operations
+        const auto src_zeropad = [src] (const int jj, const int kk, const int ll, const int nn) noexcept
+        {
+            return src.contains(jj,kk,ll) ? src(jj,kk,ll,nn) : 0.0_rt;
+        };
+
         for         (int iz=0; iz < slen_local.z; ++iz){
             for     (int iy=0; iy < slen_local.y; ++iy){
                 for (int ix=0; ix < slen_local.x; ++ix){


### PR DESCRIPTION
Fix a regression to #2314: non-3D GPU compiles did not compile (#2347)

- [x] Add a HIP 2D Test to compilation.
- [x] Fix #2347