### PR TITLE
[WIP] Performance: CPU ApplyStencil w/o Temporaries

### DIFF
--- a/Source/Filter/Filter.H
+++ b/Source/Filter/Filter.H
@@ -1,4 +1,4 @@
-/* Copyright 2019 Maxence Thevenet, Weiqun Zhang
+/* Copyright 2019-2021 Maxence Thevenet, Weiqun Zhang, Axel Huebl
  *
  * This file is part of WarpX.
  *
@@ -28,9 +28,9 @@ public:
      * \param dcomp first component of dstmf on which the filter is applied
      * \param ncomp Number of components on which the filter is applied.
      */
-    void ApplyStencil(amrex::MultiFab& dstmf,
-                              const amrex::MultiFab& srcmf, const int lev, int scomp=0,
-                              int dcomp=0, int ncomp=10000);
+    void ApplyStencil (amrex::MultiFab& dstmf,
+                       const amrex::MultiFab& srcmf, const int lev, int scomp=0,
+                       int dcomp=0, int ncomp=10000);
 
     /** Apply stencil on a FArrayBox.
      *
@@ -45,21 +45,32 @@ public:
                        const amrex::FArrayBox& srcfab, const amrex::Box& tbx,
                        int scomp=0, int dcomp=0, int ncomp=10000);
 
-    // public for cuda
-    void DoFilter(const amrex::Box& tbx,
-                          amrex::Array4<amrex::Real const> const& src,
-                          amrex::Array4<amrex::Real      > const& dst,
-                          int scomp, int dcomp, int ncomp);
+    /** Apply Filter
+     *
+     * This also handles guard cells (padded to zero).
+     *
+     * @param tbx Grown box on which srcfab is defined
+     * @param src Source
+     * @param dst Destination
+     * @param scomp first component of srcfab on which the filter is applied
+     * @param dcomp first component of dstfab on which the filter is applied
+     * @param ncomp Number of components on which the filter is applied
+     */
+    void DoFilter (const amrex::Box& tbx,
+                   amrex::Array4<amrex::Real const> const& src,
+                   amrex::Array4<amrex::Real      > const& dst,
+                   int scomp, int dcomp, int ncomp);
 
-    // In 2D, stencil_length_each_dir = {length(stencil_x), length(stencil_z)}
+    //! In 2D, stencil_length_each_dir = {length(stencil_x), length(stencil_z)}
     amrex::IntVect stencil_length_each_dir;
 
 protected:
-    // Stencil along each direction.
-    // in 2D, stencil_y is not initialized.
+    /** Stencil along each direction.
+     *  in 2D, stencil_y is not initialized. */
     amrex::Gpu::DeviceVector<amrex::Real> stencil_x, stencil_y, stencil_z;
-    // Length of each stencil.
-    // In 2D, slen = {length(stencil_x), length(stencil_z), 1}
+
+    /** Length of each stencil.
+     *  In 2D, slen = {length(stencil_x), length(stencil_z), 1} */
     amrex::Dim3 slen;
 
 private:

--- a/Source/Filter/Filter.H
+++ b/Source/Filter/Filter.H
@@ -19,20 +19,35 @@ class Filter
 public:
     Filter () = default;
 
-    // Apply stencil on MultiFab.
-    // Guard cells are handled inside this function
+    /* Apply stencil on MultiFab (2D/3D).
+     *
+     * \param dstmf Destination MultiFab
+     * \param srcmf source MultiFab
+     * \param[in] lev mesh refinement level
+     * \param scomp first component of srcmf on which the filter is applied
+     * \param dcomp first component of dstmf on which the filter is applied
+     * \param ncomp Number of components on which the filter is applied.
+     */
     void ApplyStencil(amrex::MultiFab& dstmf,
                               const amrex::MultiFab& srcmf, const int lev, int scomp=0,
                               int dcomp=0, int ncomp=10000);
 
-    // Apply stencil on a FabArray.
+    /** Apply stencil on a FArrayBox.
+     *
+     * \param dstfab Destination FArrayBox
+     * \param srcfab source FArrayBox
+     * \param tbx Grown box on which srcfab is defined.
+     * \param scomp first component of srcfab on which the filter is applied
+     * \param dcomp first component of dstfab on which the filter is applied
+     * \param ncomp Number of components on which the filter is applied.
+     */
     void ApplyStencil (amrex::FArrayBox& dstfab,
                        const amrex::FArrayBox& srcfab, const amrex::Box& tbx,
                        int scomp=0, int dcomp=0, int ncomp=10000);
 
     // public for cuda
     void DoFilter(const amrex::Box& tbx,
-                          amrex::Array4<amrex::Real const> const& tmp,
+                          amrex::Array4<amrex::Real const> const& src,
                           amrex::Array4<amrex::Real      > const& dst,
                           int scomp, int dcomp, int ncomp);
 


### PR DESCRIPTION
Same as #2314 but for CPU: Avoid unnecessary temporary field for stencil/filter routines.

To be evaluated:
- keep tiled MFIter loop (first commit) or
- use unified parallel 4D routine (2nd commit) ?