### PR TITLE
Use correct positions for the moving window of the BTD, after restart

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -180,11 +180,12 @@ WarpX::InitDiagnostics () {
         const Real* current_lo = geom[0].ProbLo();
         const Real* current_hi = geom[0].ProbHi();
         Real dt_boost = dt[0];
+        Real boosted_moving_window_v = (moving_window_v - beta_boost*PhysConst::c)/(1 - beta_boost*moving_window_v/PhysConst::c);
         // Find the positions of the lab-frame box that corresponds to the boosted-frame box at t=0
         Real zmin_lab = static_cast<Real>(
-            current_lo[moving_window_dir]/( (1.+beta_boost)*gamma_boost ));
+            (current_lo[moving_window_dir] - boosted_moving_window_v*t_new[0])/( (1.+beta_boost)*gamma_boost ));
         Real zmax_lab = static_cast<Real>(
-            current_hi[moving_window_dir]/( (1.+beta_boost)*gamma_boost ));
+            (current_hi[moving_window_dir] - boosted_moving_window_v*t_new[0])/( (1.+beta_boost)*gamma_boost ));
         myBFD = std::make_unique<BackTransformedDiagnostic>(
                                                zmin_lab,
                                                zmax_lab,


### PR DESCRIPTION
When using checkpoint/restart, the old back-transformed diagnostics were not properly initialized. 

More specifically the position of the moving window in the lab-frame was not properly calculated, because it used the current positions of domain (in the boosted-frame), but assumed that it corresponded to `t = 0`.