### PR TITLE
Clean-up: Remove array of ints `done_injecting`

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -49,21 +49,12 @@ RigidInjectedParticleContainer::ReadHeader (std::istream& is)
     WarpX::GotoNextLine(is);
 
     AMREX_ASSERT(zinject_plane_levels.size() == 0);
-    AMREX_ASSERT(done_injecting.size() == 0);
 
     for (int i = 0; i < nlevs; ++i)
     {
         int zinject_plane_tmp;
         is >> zinject_plane_tmp;
         zinject_plane_levels.push_back(zinject_plane_tmp);
-        WarpX::GotoNextLine(is);
-    }
-
-    for (int i = 0; i < nlevs; ++i)
-    {
-        int done_injecting_tmp;
-        is >> done_injecting_tmp;
-        done_injecting.push_back(done_injecting_tmp);
         WarpX::GotoNextLine(is);
     }
 }
@@ -78,10 +69,6 @@ RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
     for (int i = 0; i < nlevs; ++i)
     {
         os << zinject_plane_levels[i] << "\n";
-    }
-    for (int i = 0; i < nlevs; ++i)
-    {
-        os << done_injecting[i] << "\n";
     }
 }
 

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -117,7 +117,6 @@ private:
 
     amrex::Real vzbeam_ave_boosted;
 
-    amrex::Vector<int> done_injecting;
     amrex::Vector<amrex::Real> zinject_plane_levels;
 
     // Temporary quantites

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -72,7 +72,6 @@ RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_cor
 
 void RigidInjectedParticleContainer::InitData()
 {
-    done_injecting.resize(finestLevel()+1, 0);
     zinject_plane_levels.resize(finestLevel()+1, zinject_plane/WarpX::gamma_boost);
 
     AddParticles(0); // Note - add on level 0
@@ -386,9 +385,8 @@ RigidInjectedParticleContainer::Evolve (int lev,
     const Real* plo = Geom(lev).ProbLo();
     const Real* phi = Geom(lev).ProbHi();
     const int zdir = AMREX_SPACEDIM-1;
-    done_injecting[lev] = ((zinject_plane_levels[lev] < plo[zdir] && WarpX::moving_window_v + WarpX::beta_boost*PhysConst::c >= 0.) ||
+    done_injecting_lev = ((zinject_plane_levels[lev] < plo[zdir] && WarpX::moving_window_v + WarpX::beta_boost*PhysConst::c >= 0.) ||
                            (zinject_plane_levels[lev] > phi[zdir] && WarpX::moving_window_v + WarpX::beta_boost*PhysConst::c <= 0.));
-    done_injecting_lev = done_injecting[lev];
 
     PhysicalParticleContainer::Evolve (lev,
                                        Ex, Ey, Ez,


### PR DESCRIPTION
The `done_injecting` array was saved as a *state* in the rigid particles (and the corresponding checkpoints), but is not really used as such in the code: instead `done_injecting` is recomputed at each iteration (from other variables).

Thus, this PR removes the `done_injecting` array altogether.