### PR TITLE
Python Analysis of Restart Tests: Small Cleanup

### DIFF
--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -11,9 +11,6 @@ tolerance = sys.float_info.epsilon
 print('tolerance = ', tolerance)
 
 filename = sys.argv[1]
-psatd = True if re.search('psatd', filename) else False
-averaged = True if re.search('avg', filename) else False
-
 ds  = yt.load( filename )
 ad  = ds.all_data()
 xb  = ad['beam',     'particle_position_x'].to_ndarray()
@@ -21,11 +18,7 @@ xe  = ad['plasma_e', 'particle_position_x'].to_ndarray()
 zb  = ad['beam',     'particle_position_z'].to_ndarray()
 ze  = ad['plasma_e', 'particle_position_z'].to_ndarray()
 
-filename = 'orig_restart_plt00010'
-if psatd:
-    filename = 'orig_restart_psatd_plt00010'
-if averaged:
-    filename = 'orig_restart_psatd_time_avg_plt00010'
+filename = 'orig_' + filename
 ds  = yt.load( filename )
 ad  = ds.all_data()
 xb0 = ad['beam',     'particle_position_x'].to_ndarray()

--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import sys
-import re
 import yt
 import numpy as np
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')


### PR DESCRIPTION
I plan to try to improve the Python analysis script that we use for our restart tests and make it a bit more robust and thorough, if possible. This PR is just a small preliminary cleanup that simplifies the logic of the file names used for benchmarking the restarted data with the original output while running the analysis (the old naming logic had created some hiccup while adding new restart tests using the same analysis script in the past).