### PR TITLE
Fix my_constants being cast to float in single precision

### DIFF
--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -190,7 +190,7 @@ amrex::Parser makeParser (std::string const& parse_function, amrex::Vector<std::
  * \param str The string to be parsed
  * \return representation as real
  */
-amrex::Real parseStringtoReal(std::string str);
+double parseStringtoReal(std::string str);
 
 /** Parse a string and return an int
  *
@@ -227,7 +227,8 @@ amrex::ParserExecutor<N> compileParser (amrex::Parser const* parser)
  * \param[in] start_ix start index in the list of inputs values (optional with arrays)
  * \param[in] num_val number of input values to use (optional with arrays)
  */
-int queryWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real& val);
+int queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val);
+int queryWithParser (const amrex::ParmParse& a_pp, char const * const str, double& val);
 int queryArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::vector<amrex::Real>& val,
                         const int start_ix, const int num_val);
 int queryWithParser (const amrex::ParmParse& a_pp, char const * const str, int& val);
@@ -248,7 +249,8 @@ int queryArrWithParser (const amrex::ParmParse& a_pp, char const * const str, st
  * \param[in] start_ix start index in the list of inputs values (optional with arrays)
  * \param[in] num_val number of input values to use (optional with arrays)
  */
-void getWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real& val);
+void getWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val);
+void getWithParser (const amrex::ParmParse& a_pp, char const * const str, double& val);
 void getArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::vector<amrex::Real>& val);
 void getArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std::vector<amrex::Real>& val,
                        const int start_ix, const int num_val);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -376,6 +376,8 @@ parseStringtoInt(std::string str, std::string name)
     return ival;
 }
 
+// overloads for float/double instead if amrex::Real to allow makeParser()
+// to query for my_constants as double even in single precision mode
 int
 queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)
 {

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -331,7 +331,7 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
       };
 
     for (auto it = symbols.begin(); it != symbols.end(); ) {
-        Real v;
+        double v;
 
         WarpXUtilMsg::AlwaysAssert(recursive_symbols.count(*it)==0, "Expressions contains recursive symbol "+*it);
         recursive_symbols.insert(*it);
@@ -339,6 +339,7 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         recursive_symbols.erase(*it);
 
         if (is_input) {
+            amrex::Print() << "##### my_constants: " << *it << "  " << v << "\n";
             parser.setConstant(*it, v);
             it = symbols.erase(it);
             continue;
@@ -359,12 +360,12 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
     return parser;
 }
 
-amrex::Real
+double
 parseStringtoReal(std::string str)
 {
     auto parser = makeParser(str, {});
     auto exe = parser.compileHost<0>();
-    amrex::Real result = exe();
+    double result = exe();
     return result;
 }
 
@@ -377,7 +378,7 @@ parseStringtoInt(std::string str, std::string name)
 }
 
 int
-queryWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
+queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)
 {
     // call amrex::ParmParse::query, check if the user specified str.
     std::string tmp_str;
@@ -394,7 +395,33 @@ queryWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Re
 }
 
 void
-getWithParser (const amrex::ParmParse& a_pp, char const * const str, amrex::Real& val)
+getWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)
+{
+    // If so, create a parser object and apply it to the value provided by the user.
+    std::string str_val;
+    Store_parserString(a_pp, str, str_val);
+    val = parseStringtoReal(str_val);
+}
+
+int
+queryWithParser (const amrex::ParmParse& a_pp, char const * const str, double& val)
+{
+    // call amrex::ParmParse::query, check if the user specified str.
+    std::string tmp_str;
+    int is_specified = a_pp.query(str, tmp_str);
+    if (is_specified)
+    {
+        // If so, create a parser object and apply it to the value provided by the user.
+        std::string str_val;
+        Store_parserString(a_pp, str, str_val);
+        val = parseStringtoReal(str_val);
+    }
+    // return the same output as amrex::ParmParse::query
+    return is_specified;
+}
+
+void
+getWithParser (const amrex::ParmParse& a_pp, char const * const str, double& val)
 {
     // If so, create a parser object and apply it to the value provided by the user.
     std::string str_val;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -339,7 +339,6 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         recursive_symbols.erase(*it);
 
         if (is_input) {
-            amrex::Print() << "##### my_constants: " << *it << "  " << v << "\n";
             parser.setConstant(*it, v);
             it = symbols.erase(it);
             continue;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -376,7 +376,7 @@ parseStringtoInt(std::string str, std::string name)
     return ival;
 }
 
-// overloads for float/double instead if amrex::Real to allow makeParser()
+// overloads for float/double instead of amrex::Real to allow makeParser()
 // to query for my_constants as double even in single precision mode
 int
 queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -331,6 +331,8 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
       };
 
     for (auto it = symbols.begin(); it != symbols.end(); ) {
+        // Always parsing in double precision avoids potential overflows that may occur when parsing
+        // user's expressions because of the limited range of exponentials in single precision
         double v;
 
         WarpXUtilMsg::AlwaysAssert(recursive_symbols.count(*it)==0, "Expressions contains recursive symbol "+*it);
@@ -376,8 +378,10 @@ parseStringtoInt(std::string str, std::string name)
     return ival;
 }
 
-// overloads for float/double instead of amrex::Real to allow makeParser()
-// to query for my_constants as double even in single precision mode
+// Overloads for float/double instead of amrex::Real to allow makeParser() to query for
+// my_constants as double even in single precision mode
+// Always parsing in double precision avoids potential overflows that may occur when parsing user's
+// expressions because of the limited range of exponentials in single precision
 int
 queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)
 {


### PR DESCRIPTION
Previously, if in `Examples/Physics_applications/plasma_acceleration/inputs_3d_boost`
`my_constants.dens  = 1e+23` where to be replaced with
```
my_constants.kp_inv = 1.680463852e-5
my_constants.kp = 1. / kp_inv
my_constants.wp = clight * kp
my_constants.wp_div_qe_sq = wp^2 / q_e^2
my_constants.dens = wp_div_qe_sq * m_e * epsilon0
```
WarpX would Abort in single precision with
```
STEP 1 starts ...
STEP 1 ends. TIME = 3.095892209e-14 DT = 3.095892209e-14
Evolve time = 0.01738357544 s; This step = 0.01738357544 s; Avg. per step = 0.01738357544 s

STEP 2 starts ...
0::Assertion `amrex::numParticlesOutOfRange(pti, range) == 0' failed,
file "/home/asinn/WarpX/Source/Particles/WarpXParticleContainer.cpp", line 345,
Msg: "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for current deposition" !!!
SIGABRT
See Backtrace.0 file for details
```
The cause of this is `my_constants.wp_div_qe_sq (= 1.239830339e+64)`
being casted to float such that it becomes `inf` in the calculation for `my_constants.dens`, resulting in infinite plasma density.

This PR fixes this issue by splitting the `queryWithParser` function used for `my_constants` from `amrex::Real` into `float` and `double` overloads.
