### PR TITLE
NodalSync: Less Duplicate Code

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -418,8 +418,8 @@ WarpX::OneStep_nosub (Real cur_time)
         }
 
         // Synchronize E and B fields on nodal points
-        NodalSyncE();
-        NodalSyncB();
+        NodalSync(Efield_fp, Efield_cp);
+        NodalSync(Bfield_fp, Bfield_cp);
 
         if (do_pml) {
             DampPML();
@@ -450,8 +450,8 @@ WarpX::OneStep_nosub (Real cur_time)
         EvolveB(0.5_rt * dt[0], DtType::SecondHalf); // We now have B^{n+1}
 
         // Synchronize E and B fields on nodal points
-        NodalSyncE();
-        NodalSyncB();
+        NodalSync(Efield_fp, Efield_cp);
+        NodalSync(Bfield_fp, Bfield_cp);
 
         if (do_pml) {
             FillBoundaryF(guard_cells.ng_alloc_F);

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1307,68 +1307,24 @@ void WarpX::NodalSyncPML (int lev, PatchType patch_type)
     }
 }
 
-void WarpX::NodalSyncE ()
+void WarpX::NodalSync (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& mf_fp,
+                       amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& mf_cp)
 {
     if (!override_sync_intervals.contains(istep[0]) && !do_pml) return;
 
-    for (int lev = 0; lev <= finest_level; lev++) {
-        NodalSyncE(lev);
-    }
-}
-
-void WarpX::NodalSyncE (int lev)
-{
-    NodalSyncE(lev, PatchType::fine);
-    if (lev > 0) NodalSyncE(lev, PatchType::coarse);
-}
-
-void WarpX::NodalSyncE (int lev, PatchType patch_type)
-{
-    if (patch_type == PatchType::fine)
+    for (int lev = 0; lev <= WarpX::finest_level; lev++)
     {
-        const auto& period = Geom(lev).periodicity();
-        Efield_fp[lev][0]->OverrideSync(period);
-        Efield_fp[lev][1]->OverrideSync(period);
-        Efield_fp[lev][2]->OverrideSync(period);
-    }
-    else if (patch_type == PatchType::coarse)
-    {
-        const auto& cperiod = Geom(lev-1).periodicity();
-        Efield_cp[lev][0]->OverrideSync(cperiod);
-        Efield_cp[lev][1]->OverrideSync(cperiod);
-        Efield_cp[lev][2]->OverrideSync(cperiod);
-    }
-}
+        const amrex::Periodicity& period = Geom(lev).periodicity();
+        mf_fp[lev][0]->OverrideSync(period);
+        mf_fp[lev][1]->OverrideSync(period);
+        mf_fp[lev][2]->OverrideSync(period);
 
-void WarpX::NodalSyncB ()
-{
-    if (!override_sync_intervals.contains(istep[0]) && !do_pml) return;
-
-    for (int lev = 0; lev <= finest_level; lev++) {
-        NodalSyncB(lev);
-    }
-}
-
-void WarpX::NodalSyncB (int lev)
-{
-    NodalSyncB(lev, PatchType::fine);
-    if (lev > 0) NodalSyncB(lev, PatchType::coarse);
-}
-
-void WarpX::NodalSyncB (int lev, PatchType patch_type)
-{
-    if (patch_type == PatchType::fine)
-    {
-        const auto& period = Geom(lev).periodicity();
-        Bfield_fp[lev][0]->OverrideSync(period);
-        Bfield_fp[lev][1]->OverrideSync(period);
-        Bfield_fp[lev][2]->OverrideSync(period);
-    }
-    else if (patch_type == PatchType::coarse)
-    {
-        const auto& cperiod = Geom(lev-1).periodicity();
-        Bfield_cp[lev][0]->OverrideSync(cperiod);
-        Bfield_cp[lev][1]->OverrideSync(cperiod);
-        Bfield_cp[lev][2]->OverrideSync(cperiod);
+        if (lev > 0)
+        {
+            const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
+            mf_cp[lev][0]->OverrideSync(cperiod);
+            mf_cp[lev][1]->OverrideSync(cperiod);
+            mf_cp[lev][2]->OverrideSync(cperiod);
+        }
     }
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -779,34 +779,10 @@ private:
     void FillBoundaryE_avg (int lev, PatchType patch_type, amrex::IntVect ng);
 
     /**
-     * \brief Synchronize the nodal points of the electric field MultiFabs
+     * \brief Synchronize the nodal points of a given field MultiFab (all mesh refinement levels)
      */
-    void NodalSyncE ();
-
-    /**
-     * \brief Synchronize the nodal points of the electric field MultiFabs for given MR level
-     */
-    void NodalSyncE (int lev);
-
-    /**
-     * \brief Synchronize the nodal points of the electric field MultiFabs for given MR level and patch
-     */
-    void NodalSyncE (int lev, PatchType patch_type);
-
-    /**
-     * \brief Synchronize the nodal points of the magnetic field MultiFabs
-     */
-    void NodalSyncB ();
-
-    /**
-     * \brief Synchronize the nodal points of the magnetic field MultiFabs for given MR level
-     */
-    void NodalSyncB (int lev);
-
-    /**
-     * \brief Synchronize the nodal points of the magnetic field MultiFabs for given MR level and patch
-     */
-    void NodalSyncB (int lev, PatchType patch_type);
+    void NodalSync (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& mf_fp,
+                    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& mf_cp);
 
     void OneStep_nosub (amrex::Real t);
     void OneStep_sub1 (amrex::Real t);


### PR DESCRIPTION
Just trying to see if we can reduce duplicate code in some of our modules, starting from the NodalSync functions for E and B.