### PR TITLE
Capitalize python environment variables in CI workflows

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -84,7 +84,9 @@ jobs:
           -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
         cmake --build build -j 2
 
-        python3 -m pip install --upgrade pip setuptools wheel
-        export WARPX_MPI=ON
-        PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
-        python3 -m pip install *.whl
+        # mpi4py compile issue:
+        #   https://github.com/mpi4py/mpi4py/issues/114
+        #python3 -m pip install --upgrade pip setuptools wheel
+        #export WARPX_MPI=ON
+        #PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
+        #python3 -m pip install *.whl

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -44,7 +44,7 @@ jobs:
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel
-        export WarpX_MPI=ON
+        export WARPX_MPI=ON
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl
 
@@ -85,6 +85,6 @@ jobs:
         cmake --build build -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel
-        export WarpX_MPI=ON
+        export WARPX_MPI=ON
         PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
         python3 -m pip install *.whl

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -44,7 +44,7 @@ jobs:
           -DWarpX_PSATD=ON
         cmake --build build_sp -j 2
 
-        export WarpX_MPI=OFF
+        export WARPX_MPI=OFF
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl
 
@@ -86,6 +86,6 @@ jobs:
           -DWarpX_PSATD=ON
         cmake --build build_2d -j 2
 
-        export WarpX_MPI=OFF
+        export WARPX_MPI=OFF
         PYWARPX_LIB_DIR=$PWD/build_2d/lib python3 -m pip wheel .
         python3 -m pip install *.whl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
         cmake --build build_sp -j 2
 
         python3 -m pip install --upgrade pip setuptools wheel
-        export WarpX_MPI=ON
+        export WARPX_MPI=ON
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -45,10 +45,10 @@ jobs:
     - name: build WarpX
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
-        export WarpX_MPI=ON
-        export WarpX_OPENPMD=ON
-        export WarpX_PSATD=ON
-        export WarpX_QED_TABLE_GEN=ON
+        export WARPX_MPI=ON
+        export WARPX_OPENPMD=ON
+        export WARPX_PSATD=ON
+        export WARPX_QED_TABLE_GEN=ON
         export CC=$(which clang)
         export CXX=$(which clang++)
         export CXXFLAGS="-Werror -Wno-error=pass-failed"

--- a/Docs/source/install/hpc/cori.rst
+++ b/Docs/source/install/hpc/cori.rst
@@ -230,7 +230,7 @@ The general :ref:`cmake compile-time options and instructions for Python (PICMI)
    cd $HOME/src/warpx
 
    # compile parallel PICMI interfaces with openPMD support and 3D, 2D and RZ
-   WarpX_MPI=ON WarpX_OPENPMD=ON BUILD_PARALLEL=16 python3 -m pip install --force-reinstall -v .
+   WARPX_MPI=ON WARPX_OPENPMD=ON BUILD_PARALLEL=16 python3 -m pip install --force-reinstall -v .
 
 .. _running-cpp-cori:
 

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -156,7 +156,7 @@ We only prefix it to request a node for the compilation (``runNode``), so we can
    cd $HOME/src/warpx
 
    # compile parallel PICMI interfaces with openPMD support and 3D, 2D and RZ
-   runNode WarpX_MPI=ON WarpX_COMPUTE=CUDA WarpX_PSATD=ON WarpX_OPENPMD=ON BUILD_PARALLEL=32 python3 -m pip install --force-reinstall -v .
+   runNode WARPX_MPI=ON WARPX_COMPUTE=CUDA WARPX_PSATD=ON WARPX_OPENPMD=ON BUILD_PARALLEL=32 python3 -m pip install --force-reinstall -v .
 
 
 .. _running-cpp-summit:


### PR DESCRIPTION
Since #2317, python installation environment variables are capitalized. However, it looks like some variables have not been updated in a few CI workflows. Maybe this could explain why the CI failed in #2375? 