### PR TITLE
Increase number of guard cells allocated with multi-J algorithm

### DIFF
--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -53,7 +53,9 @@ public:
         const amrex::Array<amrex::Real,3> v_galilean,
         const amrex::Array<amrex::Real,3> v_comoving,
         const bool safe_guard_cells,
-        const int do_electrostatic);
+        const int do_electrostatic,
+        const int do_multi_J,
+        const bool fft_do_time_averaging);
 
     // Guard cells allocated for MultiFabs E and B
     amrex::IntVect ng_alloc_EB = amrex::IntVect::TheZeroVector();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1380,7 +1380,9 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         WarpX::m_v_galilean,
         WarpX::m_v_comoving,
         safe_guard_cells,
-        WarpX::do_electrostatic);
+        WarpX::do_electrostatic,
+        WarpX::do_multi_J,
+        WarpX::fft_do_time_averaging);
 
     if (mypc->nSpeciesDepositOnMainGrid() && n_current_deposition_buffer == 0) {
         n_current_deposition_buffer = 1;


### PR DESCRIPTION
With the multi-J algorithm, the particles can move for 1 dt (without time averaging) or 2 dt (with time averaging) per PIC cycle while they deposit their charge or current, but this was not taken into account in the calculation of the number of guard cells allocated for J and Rho.

This is very likely the source of the CI crash in #2336 (in this PR the failing test has multi-J + time averaging) and could potentially have created segfaults during current deposition on CPU in some cases.