### PR TITLE
CI: Groups Include Branch

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: 🐧 CUDA
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-cuda
+  group: ${{ github.ref }}-${{ github.head_ref }}-cuda
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -3,7 +3,7 @@ name: 🐧 HIP
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-hip
+  group: ${{ github.ref }}-${{ github.head_ref }}-hip
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -3,7 +3,7 @@ name: 🐧 Intel
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-intel
+  group: ${{ github.ref }}-${{ github.head_ref }}-intel
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: 🍏 macOS
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-macos
+  group: ${{ github.ref }}-${{ github.head_ref }}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -9,7 +9,7 @@ name: 📜 Source
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-source
+  group: ${{ github.ref }}-${{ github.head_ref }}-source
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: 🐧 OpenMP
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-ubuntu
+  group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: 🪟 Windows
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-windows
+  group: ${{ github.ref }}-${{ github.head_ref }}-windows
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
On pushes to mainline, if mainline contains multiple branches, these branches cancelled each other. This should fix this.

First seen by @PhilMiller in their fork.