### PR TITLE
CI: mpi4py NVHPC work-around

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -84,9 +84,12 @@ jobs:
           -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
         cmake --build build -j 2
 
-        # mpi4py compile issue:
+        # work-around for mpi4py 3.1.1 build system issue with using
+        # a GNU-built Python executable with non-GNU Python modules
         #   https://github.com/mpi4py/mpi4py/issues/114
-        #python3 -m pip install --upgrade pip setuptools wheel
-        #export WARPX_MPI=ON
-        #PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
-        #python3 -m pip install *.whl
+        export CFLAGS="-noswitcherror"
+
+        python3 -m pip install --upgrade pip setuptools wheel
+        export WARPX_MPI=ON
+        PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
+        python3 -m pip install *.whl


### PR DESCRIPTION
Compiling Python modules with NVHPC again after work-arounding the mpi4py build issue.

Follow-up to #2376 #2317