### PR TITLE
FillBoundaryG: Add PML Exchange

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -165,6 +165,9 @@ public:
     void ExchangeF (amrex::MultiFab* F_fp, amrex::MultiFab* F_cp, int do_pml_in_domain);
     void ExchangeF (PatchType patch_type, amrex::MultiFab* Fp, int do_pml_in_domain);
 
+    void ExchangeG (amrex::MultiFab* G_fp, amrex::MultiFab* G_cp, int do_pml_in_domain);
+    void ExchangeG (PatchType patch_type, amrex::MultiFab* Gp, int do_pml_in_domain);
+
     void FillBoundary ();
     void FillBoundaryE ();
     void FillBoundaryB ();

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -966,6 +966,24 @@ PML::ExchangeF (PatchType patch_type, amrex::MultiFab* Fp, int do_pml_in_domain)
     }
 }
 
+void PML::ExchangeG (amrex::MultiFab* G_fp, amrex::MultiFab* G_cp, int do_pml_in_domain)
+{
+    ExchangeG(PatchType::fine, G_fp, do_pml_in_domain);
+    ExchangeG(PatchType::coarse, G_cp, do_pml_in_domain);
+}
+
+void PML::ExchangeG (PatchType patch_type, amrex::MultiFab* Gp, int do_pml_in_domain)
+{
+    if (patch_type == PatchType::fine && pml_G_fp && Gp)
+    {
+        Exchange(*pml_G_fp, *Gp, *m_geom, do_pml_in_domain);
+    }
+    else if (patch_type == PatchType::coarse && pml_G_cp && Gp)
+    {
+        Exchange(*pml_G_cp, *Gp, *m_cgeom, do_pml_in_domain);
+    }
+}
+
 void
 PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
                 int do_pml_in_domain)

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -821,7 +821,11 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng)
 {
     if (patch_type == PatchType::fine && G_fp[lev])
     {
-        // TODO Exchange in PML cells will go here
+        if (do_pml && pml[lev]->ok())
+        {
+            pml[lev]->ExchangeG(patch_type, G_fp[lev].get(), do_pml_in_domain);
+            pml[lev]->FillBoundaryG(patch_type);
+        }
 
         const auto& period = Geom(lev).periodicity();
 
@@ -839,7 +843,11 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng)
     }
     else if (patch_type == PatchType::coarse && G_cp[lev])
     {
-        // TODO Exchange in PML cells will go here
+        if (do_pml && pml[lev]->ok())
+        {
+            pml[lev]->ExchangeG(patch_type, G_cp[lev].get(), do_pml_in_domain);
+            pml[lev]->FillBoundaryG(patch_type);
+        }
 
         const auto& cperiod = Geom(lev-1).periodicity();
 


### PR DESCRIPTION
Calls to exchange/fill the guard cells of the G MultiFab (used with div(B) cleaning) in the PMLs were missing from the function `WarpX::FillBoundaryG`. We will try to reduce duplicate code later on.