### PR TITLE
[mini-PR] Avoid a "naked new" in WarpX class

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -336,7 +336,7 @@ public:
     amrex::Vector<int> mirror_z_npoints;
 
     /// object with all reduced diagnotics, similar to MultiParticleContainer for species.
-    MultiReducedDiags* reduced_diags;
+    std::unique_ptr<MultiReducedDiags> reduced_diags;
 
     void applyMirrors(amrex::Real time);
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -261,7 +261,7 @@ WarpX::WarpX ()
     multi_diags = std::make_unique<MultiDiagnostics>();
 
     /** create object for reduced diagnostics */
-    reduced_diags = new MultiReducedDiags();
+    reduced_diags = std::make_unique<MultiReducedDiags>();
 
     Efield_aux.resize(nlevs_max);
     Bfield_aux.resize(nlevs_max);
@@ -406,8 +406,6 @@ WarpX::~WarpX ()
     for (int lev = 0; lev < nlevs_max; ++lev) {
         ClearLevel(lev);
     }
-
-    delete reduced_diags;
 }
 
 void


### PR DESCRIPTION
This PR replaces a naked new in WarpX class with a unique pointer.