### PR TITLE
Reduced diagnostics: fix calculation of particle energy in single precision 

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -164,7 +164,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     const auto kk = (gamma > PhysConst::gamma_relativistic_threshold)?
                         (gamma-1.0_rt):
                         (u2*0.5_rt - u2*u2*(1.0_rt/8.0_rt) + u2*u2*u2*(1.0_rt/16.0_rt)-
-                            u2*u2*u2*u2*(5.0_rt/128.0_rt)); //Taylor expansion
+                            u2*u2*u2*u2*(5.0_rt/128.0_rt) + (7.0_rt/256_rt)*u2*u2*u2*u2*u2); //Taylor expansion
 
                     return {w*m*c2*kk, w};
                 },

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -163,7 +163,8 @@ void ParticleEnergy::ComputeDiags (int step)
 
                     const auto kk = (gamma > PhysConst::gamma_relativistic_threshold)?
                         (gamma-1.0_rt):
-                        (u2*0.5_rt - u2*u2/8.0_rt + u2*u2*u2/16.0_rt); //third order Taylor expansion
+                        (u2*0.5_rt - u2*u2*(1.0_rt/8.0_rt) + u2*u2*u2*(1.0_rt/16.0_rt)-
+                            u2*u2*u2*u2*(5.0_rt/128.0_rt)); //Taylor expansion
 
                     return {w*m*c2*kk, w};
                 },

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -159,8 +159,14 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real ux = p.rdata(PIdx::ux);
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
-                    const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    return {w*(std::sqrt(us*m2*c2 + m2*c4) - m*c2), w};
+
+                    //the kinetic energy must be always computed in
+                    //double precision to avoid numerical errors
+                    const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
+                    const auto ee = static_cast<amrex::Real>(
+                        std::sqrt(us*m2*c2 + m2*c4) - m*c2);
+
+                    return {w*ee, w};
                 },
                 reduce_ops);
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -117,7 +117,6 @@ void ParticleEnergy::ComputeDiags (int step)
 
         // Get mass (used only for particles other than photons, see below)
         amrex::Real m = myspc.getMass();
-        amrex::Real m2 = m * m;
 
         using PType = typename WarpXParticleContainer::SuperParticleType;
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -159,14 +159,8 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real ux = p.rdata(PIdx::ux);
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
-
-                    //the kinetic energy must be always computed in
-                    //double precision to avoid numerical errors
-                    const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
-                    const auto ee = static_cast<amrex::Real>(
-                        std::sqrt(us*m2*c2 + m2*c4) - m*c2);
-
-                    return {w*ee, w};
+                    const amrex::Real us = ux*ux + uy*uy + uz*uz;
+                    return {w*m*c2*(std::sqrt(us/c2 + 1.0) - 1.0), w};
                 },
                 reduce_ops);
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -140,7 +140,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
                     const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    return {me_c*std::sqrt(us)*w, w};
+                    return {w*me_c*std::sqrt(us), w};
                 },
                 reduce_ops);
 
@@ -165,7 +165,7 @@ void ParticleEnergy::ComputeDiags (int step)
                         (std::sqrt(us/c2 + 1.0) - 1.0)
                     );
 
-                    return {m*c2*kk*w, w};
+                    return {w*m*c2*kk, w};
                 },
                 reduce_ops);
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -140,7 +140,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
                     const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    return {w*me_c*std::sqrt(us), w};
+                    return {me_c*std::sqrt(us)*w, w};
                 },
                 reduce_ops);
 
@@ -157,8 +157,15 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real ux = p.rdata(PIdx::ux);
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
-                    const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    return {w*m*c2*(std::sqrt(us/c2 + 1.0_rt) - 1.0_rt), w};
+
+                    //The following calculation must be in double precision to avoid
+                    //numerical issues in single precision
+                    const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
+                    const auto kk = std:::static_cast<amrex::Real>(
+                        (std::sqrt(us/c2 + 1.0) - 1.0)
+                    );
+
+                    return {m*c2*kk*w, w};
                 },
                 reduce_ops);
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -101,7 +101,8 @@ void ParticleEnergy::ComputeDiags (int step)
     const int nSpecies = mypc.nSpecies();
 
     // Some useful constants
-    amrex::Real c2 = PhysConst::c * PhysConst::c;
+    constexpr amrex::Real c2 = PhysConst::c * PhysConst::c;
+    constexpr amrex::Real inv_c2 = 1.0_rt/c2;
 
     // Some useful offsets to fill m_data below
     int offset_total_species, offset_mean_species, offset_mean_all;
@@ -157,13 +158,12 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real ux = p.rdata(PIdx::ux);
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
+                    const amrex::Real us = ux*ux + uy*uy + uz*uz;
+                    const auto gamma = std::sqrt(1.0_rt + us*inv_c2);
 
-                    //The following calculation must be in double precision to avoid
-                    //numerical issues in single precision
-                    const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
-                    const auto kk = static_cast<amrex::Real>(
-                        (std::sqrt(us/c2 + 1.0) - 1.0)
-                    );
+                    const auto kk = (gamma > PhysConst::gamma_relativistic_threshold)?
+                        (gamma-1.0_rt):
+                        (us*0.5_rt - us*us/8.0_rt + us*us*us/16.0_rt); //third order Taylor expansion
 
                     return {w*m*c2*kk, w};
                 },

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -102,7 +102,6 @@ void ParticleEnergy::ComputeDiags (int step)
 
     // Some useful constants
     amrex::Real c2 = PhysConst::c * PhysConst::c;
-    amrex::Real c4 = c2 * c2;
 
     // Some useful offsets to fill m_data below
     int offset_total_species, offset_mean_species, offset_mean_all;

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -158,12 +158,12 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real ux = p.rdata(PIdx::ux);
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
-                    const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    const auto gamma = std::sqrt(1.0_rt + us*inv_c2);
+                    const amrex::Real u2 = (ux*ux + uy*uy + uz*uz)*inv_c2;
+                    const auto gamma = std::sqrt(1.0_rt + u2);
 
                     const auto kk = (gamma > PhysConst::gamma_relativistic_threshold)?
                         (gamma-1.0_rt):
-                        (us*0.5_rt - us*us/8.0_rt + us*us*us/16.0_rt); //third order Taylor expansion
+                        (u2*0.5_rt - u2*u2/8.0_rt + u2*u2*u2/16.0_rt); //third order Taylor expansion
 
                     return {w*m*c2*kk, w};
                 },

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -161,7 +161,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     //The following calculation must be in double precision to avoid
                     //numerical issues in single precision
                     const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
-                    const auto kk = std:::static_cast<amrex::Real>(
+                    const auto kk = std::static_cast<amrex::Real>(
                         (std::sqrt(us/c2 + 1.0) - 1.0)
                     );
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -160,7 +160,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     const amrex::Real uy = p.rdata(PIdx::uy);
                     const amrex::Real uz = p.rdata(PIdx::uz);
                     const amrex::Real us = ux*ux + uy*uy + uz*uz;
-                    return {w*m*c2*(std::sqrt(us/c2 + 1.0) - 1.0), w};
+                    return {w*m*c2*(std::sqrt(us/c2 + 1.0_rt) - 1.0_rt), w};
                 },
                 reduce_ops);
 

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -161,7 +161,7 @@ void ParticleEnergy::ComputeDiags (int step)
                     //The following calculation must be in double precision to avoid
                     //numerical issues in single precision
                     const auto us = static_cast<double>(ux*ux + uy*uy + uz*uz);
-                    const auto kk = std::static_cast<amrex::Real>(
+                    const auto kk = static_cast<amrex::Real>(
                         (std::sqrt(us/c2 + 1.0) - 1.0)
                     );
 

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -44,6 +44,11 @@ namespace PhysConst
     static constexpr auto xi_c2 = static_cast<amrex::Real>( 1.1728865132395492e-35 ); // This should be usable for single precision, though
     // very close to smallest number possible (1.2e-38)
 
+    // This marks the gamma threshold to switch between the full relativistic expression
+    // for particle kinetic energy and a Taylor expansion. It is used in the reduced diagnostics.
+    static constexpr auto gamma_relativistic_threshold =
+        static_cast<amrex::Real>(1.005);
+
     static constexpr auto kb   = static_cast<amrex::Real>( 1.380649e-23 );  // Boltzmann's constant, J/K (exact)
 }
 

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -47,7 +47,7 @@ namespace PhysConst
     // This marks the gamma threshold to switch between the full relativistic expression
     // for particle kinetic energy and a Taylor expansion. It is used in the reduced diagnostics.
     static constexpr auto gamma_relativistic_threshold =
-        static_cast<amrex::Real>(1.001);
+        static_cast<amrex::Real>(1.005);
 
     static constexpr auto kb   = static_cast<amrex::Real>( 1.380649e-23 );  // Boltzmann's constant, J/K (exact)
 }

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -47,7 +47,7 @@ namespace PhysConst
     // This marks the gamma threshold to switch between the full relativistic expression
     // for particle kinetic energy and a Taylor expansion. It is used in the reduced diagnostics.
     static constexpr auto gamma_relativistic_threshold =
-        static_cast<amrex::Real>(1.005);
+        static_cast<amrex::Real>(1.001);
 
     static constexpr auto kb   = static_cast<amrex::Real>( 1.380649e-23 );  // Boltzmann's constant, J/K (exact)
 }


### PR DESCRIPTION
This PR rearranges the calculation of particle energy in reduced diags to avoid numerical errors when single precision is used. 
There were two issues:
- m^2 is too small to be represented with a `float`
- performing `sqrt(p^2c^2  + m^2c^4)-mc^2` in single precision gives 0 if momenta are small (as often happens for ions)  

Following @ax3l 's suggestion, I have introduced a gamma threshold (1.005) to switch between the full relativistic expression of the kinetic energy and its Taylor expansion (up to 10th order in |momentum| ) . I've also updated the reduced diag test accordingly, so that it performs the same calculation of the code.

❓ **Question:** should we still calculate gamma in double precision?