### PR TITLE
Multi-J & Galilean RZ PSATD: Serialize RNG

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1853,7 +1853,7 @@ tolerance = 1.e-14
 [galilean_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_rz
-runtime_params = electrons.random_theta=0 ions.random_theta=0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 restartTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2015,7 +2015,7 @@ tolerance = 1e-14
 [multi_J_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/multi_J/inputs_rz
-runtime_params =
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 restartTest = 0


### PR DESCRIPTION
The `multi_J_rz_psatd` test uses:
- RZ particles (default: random theta angle)
- a temperature for the driver

which are all RNG dependent. Serialize the RNG to avoid discrepancies with varying compile/runtime environments.

Update: The test `galilean_rz_psatd` does not use random theta positions for the particles, but has a temperature on the particles. Should thus also serialize the RNG.

Related to #2132 & #2302