### PR TITLE
Update amrex commit, so as to fix CI bug

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 93788e33e689b77a14290580eca0cf9f25be6523
+branch = 4914d5e42c2ee02c80645722b2d336e4dba6b4b3
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 93788e33e689b77a14290580eca0cf9f25be6523
+branch = 4914d5e42c2ee02c80645722b2d336e4dba6b4b3
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -178,7 +178,7 @@ void FieldProbe::ComputeDiags (int step)
                     amrex::Real Ex_interp = 0._rt, Ey_interp = 0._rt, Ez_interp = 0._rt;
                     amrex::Real Bx_interp = 0._rt, By_interp = 0._rt, Bz_interp = 0._rt;
 
-                    const amrex::Array<amrex::Real, 3> v_galilean = {{0}};
+                    amrex::Vector<amrex::Real> v_galilean{amrex::Vector<amrex::Real>(3, amrex::Real(0.))};
                     const auto
                         &xyzmin = WarpX::GetInstance().LowerCornerWithGalilean(box, v_galilean,
                                                                                lev);

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -239,7 +239,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "93788e33e689b77a14290580eca0cf9f25be6523"
+set(WarpX_amrex_branch "4914d5e42c2ee02c80645722b2d336e4dba6b4b3"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout 93788e33e689b77a14290580eca0cf9f25be6523 && cd -
+cd amrex && git checkout 4914d5e42c2ee02c80645722b2d336e4dba6b4b3 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout a78be127f66adc1558f527edc8964e37e3a055ff && cd -


### PR DESCRIPTION
This changes the CI so that it uses the latest version of `amrex`, which incorporates this commit:
https://github.com/AMReX-Codes/amrex/pull/2396

It fixes a bug whereby the CI ends early and erroneously reports green status.

In addition, this also fixes a small compilation bug that was not caught by CI previously.