### PR TITLE
Docs: Perlmutter sbatch

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -122,6 +122,6 @@ To run a simulation, copy the lines above to a file ``batch_perlmutter.sh`` and 
 
 .. code-block:: bash
 
-   bsub batch_perlmutter.sh
+   sbatch batch_perlmutter.sh
 
 to submit the job.


### PR DESCRIPTION
Typo: `bsub` is LSF, `sbatch` is SLURM.

Thanks for noticing @oshapoval 