### PR TITLE
Docs: Add GPU Memory Sizes

### DIFF
--- a/Docs/source/install/hpc/juwels.rst
+++ b/Docs/source/install/hpc/juwels.rst
@@ -94,6 +94,8 @@ Running
 Queue: gpus (4 x Nvidia V100 GPUs)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The `Juwels GPUs <https://apps.fz-juelich.de/jsc/hps/juwels/configuration.html>`__ are V100 (16GB) and A100 (40GB).
+
 An example submission script reads
 
 .. literalinclude:: ../../../../Tools/BatchScripts/batch_juwels.sh

--- a/Docs/source/install/hpc/lassen.rst
+++ b/Docs/source/install/hpc/lassen.rst
@@ -97,8 +97,8 @@ Running
 
 .. _running-cpp-lassen-V100-GPUs:
 
-V100 GPUs
-^^^^^^^^^
+V100 GPUs (16GB)
+^^^^^^^^^^^^^^^^
 
 The batch script below can be used to run a WarpX simulation on 2 nodes on the supercomputer Lassen at LLNL.
 Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<input file>`` could be ``plasma_mirror_inputs``.

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -36,7 +36,7 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
 .. code-block:: bash
 
    # please set your project account
-   export proj=<yourProject>
+   export proj=<yourProject>  # LBNL/AMP: m3906_g
 
    # required dependencies
    module load cmake/git-20210830  # 3.22-dev
@@ -48,19 +48,19 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
    # module load nano  # TODO: request from support
 
    # optional: for openPMD support
-   module load cray-hdf5-parallel/1.12.0.6
+   module load cray-hdf5-parallel/1.12.0.7
    export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/adios2-2.7.1:$CMAKE_PREFIX_PATH
 
    # optional: Python, ...
    # TODO
 
-   # GPU-aware MPI
-   export MPICH_GPU_SUPPORT_ENABLED=1
-
    # optional: an alias to request an interactive node for two hours
    function getNode() {
        salloc -N 1 --ntasks-per-node=4 -t 2:00:00 -C gpu -c 32 -G 4 -A $proj
    }
+
+   # GPU-aware MPI
+   export MPICH_GPU_SUPPORT_ENABLED=1
 
    # optimize CUDA compilation for A100
    export AMREX_CUDA_ARCH=8.0
@@ -107,8 +107,8 @@ Running
 
 .. _running-cpp-perlmutter-A100-GPUs:
 
-A100 GPUs
-^^^^^^^^^
+A100 GPUs (40 GB)
+^^^^^^^^^^^^^^^^^
 
 The batch script below can be used to run a WarpX simulation on multiple nodes (change ``-N`` accordingly) on the supercomputer Perlmutter at NERSC.
 Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<input file>`` could be ``plasma_mirror_inputs``.

--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -89,8 +89,8 @@ Running
 
 .. _running-cpp-spock-MI100-GPUs:
 
-MI100 GPUs
-^^^^^^^^^^
+MI100 GPUs (32 GB)
+^^^^^^^^^^^^^^^^^^
 
 After requesting an interactive node with the ``getNode`` alias above, run a simulation like this, here using 4 MPI ranks:
 

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -166,8 +166,8 @@ Running
 
 .. _running-cpp-summit-V100-GPUs:
 
-V100 GPUs
-^^^^^^^^^
+V100 GPUs (16GB)
+^^^^^^^^^^^^^^^^
 
 The batch script below can be used to run a WarpX simulation on 2 nodes on
 the supercomputer Summit at OLCF. Replace descriptions between chevrons ``<>``

--- a/Tools/BatchScripts/batch_perlmutter.sh
+++ b/Tools/BatchScripts/batch_perlmutter.sh
@@ -36,6 +36,9 @@
 #
 # ============
 
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
 EXE=./warpx
 #EXE=../WarpX/build/bin/warpx.3d.MPI.CUDA.DP.OPMD.QED
 #EXE=./main3d.gnu.TPROF.MPI.CUDA.ex


### PR DESCRIPTION
Add the size of GPU HBM on documented HPC machines.
This helps users to quickly transition node hours between them for memory-size-limited problems.