### PR TITLE
Synchronize GPU before stopping profile timer

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1639,7 +1639,7 @@ Numerics and algorithms
      value here will make the simulation unphysical, but will allow QED effects to become more apparent.
      Note that this option will only have an effect if the ``warpx.use_Hybrid_QED`` flag is also triggered.
 
-* ``warpx.do_device_synchronize_before_profile`` (`bool`) optional (default `1`)
+* ``warpx.do_device_synchronize`` (`int`) optional (default `1`)
     When running in an accelerated platform, whether to call a deviceSynchronize around profiling regions.
     This allows the profiler to give meaningful timers, but (hardly) slows down the simulation.
 

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -29,6 +29,8 @@ struct synchronizeOnDestruct {
     }
 };
 
+// `BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__)` and `SYNC_V_##vname` used to make unique names for
+// synchronizeOnDestruct objects, like `SYNC_SCOPE_0` and `SYNC_V_pmain`
 #define WARPX_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
 #define WARPX_PROFILE_VAR(fname, vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
 #define WARPX_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -29,18 +29,18 @@ struct synchronizeOnDestruct {
     }
 };
 
-#define WARPX_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> SYNC_SCOPE{}
+#define WARPX_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
 #define WARPX_PROFILE_VAR(fname, vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
 #define WARPX_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
 #define WARPX_PROFILE_VAR_START(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_START(vname)
 #define WARPX_PROFILE_VAR_STOP(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_STOP(vname)
-#define WARPX_PROFILE_REGION(rname) doDeviceSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> SYNC_R{}
+#define WARPX_PROFILE_REGION(rname) doDeviceSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
 
-#define WARPX_DETAIL_PROFILE(fname) doDeviceSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> SYNC_SCOPE{}
+#define WARPX_DETAIL_PROFILE(fname) doDeviceSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
 #define WARPX_DETAIL_PROFILE_VAR(fname, vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
 #define WARPX_DETAIL_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
 #define WARPX_DETAIL_PROFILE_VAR_START(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_START(vname)
 #define WARPX_DETAIL_PROFILE_VAR_STOP(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_STOP(vname)
-#define WARPX_DETAIL_PROFILE_REGION(rname) doDeviceSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> SYNC_R{}
+#define WARPX_DETAIL_PROFILE_REGION(rname) doDeviceSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
 
 #endif // WARPX_PROFILERWRAPPER_H_

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -12,18 +12,35 @@
 #include <AMReX_GpuDevice.H>
 #include <WarpX.H>
 
+template<int detail_level>
 AMREX_FORCE_INLINE
-void doDeviceSynchronize(int do_device_synchronize)
+void doDeviceSynchronize ()
 {
-    if ( do_device_synchronize )
+    if ( WarpX::do_device_synchronize >= detail_level )
         amrex::Gpu::synchronize();
 }
 
-#define WARPX_PROFILE(fname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE(fname)
-#define WARPX_PROFILE_VAR(fname, vname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE_VAR(fname, vname)
-#define WARPX_PROFILE_VAR_NS(fname, vname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE_VAR_NS(fname, vname)
-#define WARPX_PROFILE_VAR_START(vname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE_VAR_START(vname)
-#define WARPX_PROFILE_VAR_STOP(vname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE_VAR_STOP(vname)
-#define WARPX_PROFILE_REGION(rname) doDeviceSynchronize(WarpX::do_device_synchronize_before_profile); BL_PROFILE_REGION(rname)
+// Note that objects are destructed in the reverse order of declaration
+template<int detail_level>
+struct synchronizeOnDestruct {
+    AMREX_FORCE_INLINE
+    ~synchronizeOnDestruct () {
+        doDeviceSynchronize<detail_level>();
+    }
+};
+
+#define WARPX_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> SYNC_SCOPE{}
+#define WARPX_PROFILE_VAR(fname, vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
+#define WARPX_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
+#define WARPX_PROFILE_VAR_START(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_START(vname)
+#define WARPX_PROFILE_VAR_STOP(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_STOP(vname)
+#define WARPX_PROFILE_REGION(rname) doDeviceSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> SYNC_R{}
+
+#define WARPX_DETAIL_PROFILE(fname) doDeviceSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> SYNC_SCOPE{}
+#define WARPX_DETAIL_PROFILE_VAR(fname, vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
+#define WARPX_DETAIL_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
+#define WARPX_DETAIL_PROFILE_VAR_START(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_START(vname)
+#define WARPX_DETAIL_PROFILE_VAR_STOP(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_STOP(vname)
+#define WARPX_DETAIL_PROFILE_REGION(rname) doDeviceSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> SYNC_R{}
 
 #endif // WARPX_PROFILERWRAPPER_H_

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -223,7 +223,7 @@ public:
     static int do_multi_J_n_depositions;
     static int J_linear_in_time;
 
-    static bool do_device_synchronize_before_profile;
+    static int do_device_synchronize;
     static bool safe_guard_cells;
 
     // buffers

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -189,9 +189,9 @@ int WarpX::n_current_deposition_buffer = -1;
 int WarpX::do_nodal = false;
 
 #ifdef AMREX_USE_GPU
-bool WarpX::do_device_synchronize_before_profile = true;
+int WarpX::do_device_synchronize = 1;
 #else
-bool WarpX::do_device_synchronize_before_profile = false;
+int WarpX::do_device_synchronize = 0;
 #endif
 
 WarpX* WarpX::m_instance = nullptr;
@@ -486,7 +486,7 @@ WarpX::ReadParameters ()
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
 
-        pp_warpx.query("do_device_synchronize_before_profile", do_device_synchronize_before_profile);
+        pp_warpx.query("do_device_synchronize", do_device_synchronize);
 
         // queryWithParser returns 1 if argument zmax_plasma_to_compute_max_step is
         // specified by the user, 0 otherwise.


### PR DESCRIPTION
This PR fixes the `WARPX_PROFILE()` macros to also call `amrex::Gpu::synchronize()` before exiting a profiled section of code. 

Previously it was only called before entering, leading to inaccurate measurements for functions launching GPU kernels without synchronizing.

The name of the option was updated accordingly from `warpx.do_device_synchronize_before_profile` to:
```
warpx.do_device_synchronize = 1
```
Test:
` ~/WarpX/build/bin/warpx.3d.MPI.CUDA.SP.QED ~/WarpX/Examples/Physics_applications/plasma_acceleration/inputs_3d_boost warpx.do_device_synchronize = 1`

[old_synchronize_0.txt](https://github.com/ECP-WarpX/WarpX/files/7339106/old_synchronize_0.txt)
[old_synchronize_1.txt](https://github.com/ECP-WarpX/WarpX/files/7339107/old_synchronize_1.txt)
[new_synchronize_0.txt](https://github.com/ECP-WarpX/WarpX/files/7339104/new_synchronize_0.txt)
[new_synchronize_1.txt](https://github.com/ECP-WarpX/WarpX/files/7339105/new_synchronize_1.txt)

1. The behavior between the old `warpx.do_device_synchronize_before_profile = 0` and new `warpx.do_device_synchronize = 0` is unchanged (no calls of `amrex::Gpu::synchronize()`).
2. The old `warpx.do_device_synchronize_before_profile = 1` underreports the time for e.g. `Filter::ApplyStencil(FArrayBox)`. With the new `warpx.do_device_synchronize = 1` it is profiled as 1.467s instead of 0.2812s.

If synchronizing is known to take a significant amount of time for a particular function, the `WARPX_DETAIL_PROFILE()` macros can be used. These only synchronize if  `warpx.do_device_synchronize = 2` or greater. This is currently not used as I didn't know where this would be applicable.