### PR TITLE
Add "-d" to the checkout to suppress the detached head notice

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -51,10 +51,10 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout -d 4914d5e42c2ee02c80645722b2d336e4dba6b4b3 && cd -
+cd amrex && git checkout --detach 4914d5e42c2ee02c80645722b2d336e4dba6b4b3 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
-cd picsar && git checkout -d a78be127f66adc1558f527edc8964e37e3a055ff && cd -
+cd picsar && git checkout --detach a78be127f66adc1558f527edc8964e37e3a055ff && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,10 +51,10 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout 4914d5e42c2ee02c80645722b2d336e4dba6b4b3 && cd -
+cd amrex && git checkout -d 4914d5e42c2ee02c80645722b2d336e4dba6b4b3 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
-cd picsar && git checkout a78be127f66adc1558f527edc8964e37e3a055ff && cd -
+cd picsar && git checkout -d a78be127f66adc1558f527edc8964e37e3a055ff && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 


### PR DESCRIPTION
The makes the output cleaner when running the run_test.sh script since it suppresses the long notice from git about checking out a detached head. This may also avoid confusion from testers who might misinterpret the notice as an error message.