### PR TITLE
PML: Fix Index Type of G in Nodal Case

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -564,14 +564,17 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
 
     if (m_dive_cleaning)
     {
-        pml_F_fp = std::make_unique<MultiFab>(amrex::convert(ba,IntVect::TheUnitVector()), dm, 3, ngf);
+        const amrex::IntVect& F_nodal_flag = amrex::IntVect::TheNodeVector();
+        pml_F_fp = std::make_unique<MultiFab>(amrex::convert(ba, F_nodal_flag), dm, 3, ngf);
         pml_F_fp->setVal(0.0);
     }
 
     if (m_divb_cleaning)
     {
         // TODO Shall we define a separate guard cells parameter ngG?
-        pml_G_fp = std::make_unique<MultiFab>(amrex::convert(ba, IntVect::TheZeroVector()), dm, 3, ngf);
+        const amrex::IntVect& G_nodal_flag = (do_nodal) ? amrex::IntVect::TheNodeVector()
+                                                        : amrex::IntVect::TheCellVector();
+        pml_G_fp = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, 3, ngf);
         pml_G_fp->setVal(0.0);
     }
 
@@ -664,14 +667,17 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
 
         if (m_dive_cleaning)
         {
-            pml_F_cp = std::make_unique<MultiFab>(amrex::convert(cba,IntVect::TheUnitVector()), cdm, 3, ngf);
+            const amrex::IntVect& F_nodal_flag = amrex::IntVect::TheNodeVector();
+            pml_F_cp = std::make_unique<MultiFab>(amrex::convert(cba, F_nodal_flag), cdm, 3, ngf);
             pml_F_cp->setVal(0.0);
         }
 
         if (m_divb_cleaning)
         {
             // TODO Shall we define a separate guard cells parameter ngG?
-            pml_G_cp = std::make_unique<MultiFab>(amrex::convert(cba, IntVect::TheZeroVector()), cdm, 3, ngf);
+            const amrex::IntVect& G_nodal_flag = (do_nodal) ? amrex::IntVect::TheNodeVector()
+                                                            : amrex::IntVect::TheCellVector();
+            pml_G_cp = std::make_unique<MultiFab>(amrex::convert(cba, G_nodal_flag), cdm, 3, ngf);
             pml_G_cp->setVal(0.0);
         }
 


### PR DESCRIPTION
In the valid domain G is fully cell-centered if `do_nodal = 0` and fully nodal if `do_nodal = 1` (see lines 1443-1444 and 1458):
https://github.com/ECP-WarpX/WarpX/blob/3fa7d28987e8f641a24f658dc06d4a75eeba3597/Source/WarpX.cpp#L1443-L1459
In the PML G was always fully cell-centered, regardless of the value of `do_nodal`. Instead, I think we should do the same as in the valid domain.

Here's a summary of the proposed behavior, for both valid domain and PML, please let me know if you think that we should not do the same things in the valid domain and in the PML:
- F: always fully nodal, regardless of the value of `do_nodal`;
- G: fully nodal if `do_nodal = 1`, fully cell-centered if `do_nodal = 0`.