### PR TITLE
Add automated test for repelling particles

### DIFF
--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -58,7 +58,7 @@ beta2 = np.array(beta2)
 # Plot velocities, compare with theory
 w = 5.e12
 re = physical_constants['classical electron radius'][0]
-beta_th = np.sqrt( beta1[1]**2 - 2*w*re*np.log( (x2[1]-x1[1])/(x2-x1) ) )
+beta_th = np.sqrt( beta1[0]**2 - 2*w*re*np.log( (x2[0]-x1[0])/(x2-x1) ) )
 plt.plot( beta1, '+', label='Particle 1' )
 plt.plot( -beta2, 'x', label='Particle 2' )
 plt.plot( beta_th, '*', label='Theory' )

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -72,6 +72,7 @@ assert np.allclose( beta1, beta_th, atol=0.05 )
 assert np.allclose( beta1, beta_th, atol=0.05  )
 
 # Run checksum regression test
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 test_name = last_filename[:-9]
 checksumAPI.evaluate_checksum(test_name, last_filename)

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -69,7 +69,7 @@ plt.savefig('Comparison.png')
 
 # Check that the results are close to the theory
 assert np.allclose( beta1, beta_th, atol=0.05 )
-assert np.allclose( beta1, beta_th, atol=0.05  )
+assert np.allclose( beta2, beta_th, atol=0.05  )
 
 # Run checksum regression test
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python
+#
+# Copyright 2021 Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+"""
+This script tests the interaction between 2 electron macroparticles.
+
+The macroparticles are moving towards each other and slow down due to the
+repelling force between charges of the same sign. The particles should
+be moving slow enough for relativistic effects to be negligible. In
+this case the conservation of energy gives:
+
+beta(t)^2 = beta(0)^2 + 2 * w * re * log(d(0)/d(t))
+
+where:
+re is the classical electron radius
+w is the weight of the individual macroparticles
+d is the distance between them
+beta is the velocity normalized by the speed of light
+"""
+import numpy as np
+from scipy.constants import m_e, c, physical_constants
+import sys, re
+import yt
+import glob
+import matplotlib.pyplot as plt
+yt.funcs.mylog.setLevel(0)
+
+# Check plotfile name specified in command line
+last_filename = sys.argv[1]
+filename_radical = re.findall('(.*?)\d+/*$', last_filename)[0]
+
+# Loop through files, and extract the position and velocity of both particles
+x1 = []
+x2 = []
+beta1 = []
+beta2 = []
+for filename in sorted(glob.glob(filename_radical + '*')):
+    print(filename)
+    ds = yt.load(filename)
+    ad = ds.all_data()
+
+    x1.append( float(ad[('electron1','particle_position_x')]) )
+    x2.append( float(ad[('electron2','particle_position_x')]) )
+    beta1.append( float(ad[('electron1','particle_momentum_x')])/(m_e*c) )
+    beta2.append( float(ad[('electron2','particle_momentum_x')])/(m_e*c) )
+
+# Convert to numpy array
+x1 = np.array(x1)
+x2 = np.array(x2)
+beta1 = np.array(beta1)
+beta2 = np.array(beta2)
+
+# Plot velocities, compare with theory
+w = 5.e12
+re = physical_constants['classical electron radius'][0]
+beta_th = np.sqrt( beta1[0]**2 - 2*w*re*np.log( (x2[0]-x1[0])/(x2-x1) ) )
+plt.plot( beta1, '+', label='Particle 1' )
+plt.plot( -beta2, 'x', label='Particle 2' )
+plt.plot( beta_th, '*', label='Theory' )
+plt.legend(loc=0)
+plt.xlabel('Time (a.u.)')
+plt.ylabel('Normalized velocity')
+plt.savefig('Comparison.png')
+
+# Check that the results are close
+assert np.allclose( beta1, beta_th, atol=0.05 )
+assert np.allclose( beta1, beta_th, atol=0.05  )

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -58,7 +58,7 @@ beta2 = np.array(beta2)
 # Plot velocities, compare with theory
 w = 5.e12
 re = physical_constants['classical electron radius'][0]
-beta_th = np.sqrt( beta1[0]**2 - 2*w*re*np.log( (x2[0]-x1[0])/(x2-x1) ) )
+beta_th = np.sqrt( beta1[1]**2 - 2*w*re*np.log( (x2[1]-x1[1])/(x2-x1) ) )
 plt.plot( beta1, '+', label='Particle 1' )
 plt.plot( -beta2, 'x', label='Particle 2' )
 plt.plot( beta_th, '*', label='Theory' )
@@ -68,8 +68,8 @@ plt.ylabel('Normalized velocity')
 plt.savefig('Comparison.png')
 
 # Check that the results are close to the theory
-assert np.allclose( beta1, beta_th, atol=0.05 )
-assert np.allclose( beta2, beta_th, atol=0.05  )
+assert np.allclose( beta1[1:], beta_th[1:], atol=0.01 )
+assert np.allclose( -beta2[1:], beta_th[1:], atol=0.01  )
 
 # Run checksum regression test
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -67,6 +67,11 @@ plt.xlabel('Time (a.u.)')
 plt.ylabel('Normalized velocity')
 plt.savefig('Comparison.png')
 
-# Check that the results are close
+# Check that the results are close to the theory
 assert np.allclose( beta1, beta_th, atol=0.05 )
 assert np.allclose( beta1, beta_th, atol=0.05  )
+
+# Run checksum regression test
+import checksumAPI
+test_name = last_filename[:-9]
+checksumAPI.evaluate_checksum(test_name, last_filename)

--- a/Examples/Tests/RepellingParticles/inputs_2d
+++ b/Examples/Tests/RepellingParticles/inputs_2d
@@ -36,7 +36,7 @@ electron1.single_particle_weight = 5.e12
 electron1.initialize_self_fields = 1
 
 electron2.charge = q_e
-electron2.mass = m_e    # Very heavy ; should not move
+electron2.mass = m_e
 electron2.injection_style = "singleparticle"
 electron2.single_particle_pos = 16e-6 0. 0.
 electron2.single_particle_vel = -0.2 0. 0.

--- a/Examples/Tests/RepellingParticles/inputs_2d
+++ b/Examples/Tests/RepellingParticles/inputs_2d
@@ -50,4 +50,4 @@ algo.particle_shape = 3
 diagnostics.diags_names = diag1
 diag1.intervals = 20
 diag1.diag_type = Full
-diag1.fields_to_plot = Ex Ey Ez divE rho
+diag1.fields_to_plot = Bx By Bz Ex Ey Ez jx jy jz divE rho F

--- a/Examples/Tests/RepellingParticles/inputs_2d
+++ b/Examples/Tests/RepellingParticles/inputs_2d
@@ -11,8 +11,8 @@ geometry.prob_lo     = -32.e-6    -32.e-6      # physical domain
 geometry.prob_hi     =  32.e-6     32.e-6
 
 # Boundary condition
-boundary.field_lo = pec pec pec
-boundary.field_hi = pec pec pec
+boundary.field_lo = pec pec
+boundary.field_hi = pec pec
 
 # Algorithms
 algo.current_deposition = esirkepov
@@ -30,16 +30,16 @@ particles.species_names = electron1 electron2
 electron1.charge = q_e
 electron1.mass = m_e
 electron1.injection_style = "singleparticle"
-electron1.single_particle_pos = -16e-6 0. 0.
-electron1.single_particle_vel = 0.2 0. 0.
+electron1.single_particle_pos = 1.e-6 0. 0.
+electron1.single_particle_vel = 0. 0. 0.
 electron1.single_particle_weight = 5.e12
 electron1.initialize_self_fields = 1
 
 electron2.charge = q_e
 electron2.mass = m_e
 electron2.injection_style = "singleparticle"
-electron2.single_particle_pos = 16e-6 0. 0.
-electron2.single_particle_vel = -0.2 0. 0.
+electron2.single_particle_pos = -1.e-6 0. 0.
+electron2.single_particle_vel = 0. 0. 0.
 electron2.single_particle_weight = 5.e12
 electron2.initialize_self_fields = 1
 

--- a/Examples/Tests/RepellingParticles/inputs_2d
+++ b/Examples/Tests/RepellingParticles/inputs_2d
@@ -48,6 +48,6 @@ algo.particle_shape = 3
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 1
+diag1.intervals = 20
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez divE rho

--- a/Examples/Tests/RepellingParticles/inputs_2d
+++ b/Examples/Tests/RepellingParticles/inputs_2d
@@ -1,0 +1,53 @@
+max_step = 200
+amr.n_cell = 128 128
+
+amr.blocking_factor = 16
+amr.max_grid_size = 1024
+amr.max_level = 0
+
+# Geometry
+geometry.coord_sys   = 0                  # 0: Cartesian
+geometry.prob_lo     = -32.e-6    -32.e-6      # physical domain
+geometry.prob_hi     =  32.e-6     32.e-6
+
+# Boundary condition
+boundary.field_lo = pec pec pec
+boundary.field_hi = pec pec pec
+
+# Algorithms
+algo.current_deposition = esirkepov
+algo.field_gathering = momentum-conserving
+algo.charge_deposition = standard
+algo.particle_pusher = vay
+algo.maxwell_solver = yee
+warpx.cfl = 0.9
+warpx.use_filter = 0
+warpx.do_dive_cleaning = 1
+
+# Particle species
+particles.species_names = electron1 electron2
+
+electron1.charge = q_e
+electron1.mass = m_e
+electron1.injection_style = "singleparticle"
+electron1.single_particle_pos = -16e-6 0. 0.
+electron1.single_particle_vel = 0.2 0. 0.
+electron1.single_particle_weight = 5.e12
+electron1.initialize_self_fields = 1
+
+electron2.charge = q_e
+electron2.mass = m_e    # Very heavy ; should not move
+electron2.injection_style = "singleparticle"
+electron2.single_particle_pos = 16e-6 0. 0.
+electron2.single_particle_vel = -0.2 0. 0.
+electron2.single_particle_weight = 5.e12
+electron2.initialize_self_fields = 1
+
+# Order of particle shape factors
+algo.particle_shape = 3
+
+# Diagnostics
+diagnostics.diags_names = diag1
+diag1.intervals = 1
+diag1.diag_type = Full
+diag1.fields_to_plot = Ex Ey Ez divE rho

--- a/Regression/Checksum/benchmarks_json/RepellingParticles.json
+++ b/Regression/Checksum/benchmarks_json/RepellingParticles.json
@@ -1,0 +1,29 @@
+{
+  "electron1": {
+    "particle_cpu": 0.0,
+    "particle_id": 1.0,
+    "particle_momentum_x": 2.960773412224425e-23,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.509968918046099e-35,
+    "particle_position_x": 5.888278028103897e-06,
+    "particle_position_y": 1.1838659096600272e-17,
+    "particle_weight": 5000000000000.0
+  },
+  "electron2": {
+    "particle_cpu": 0.0,
+    "particle_id": 2.0,
+    "particle_momentum_x": 2.9607734122203367e-23,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 1.057250890885279e-34,
+    "particle_position_x": 5.888278028074152e-06,
+    "particle_position_y": 2.4190108833071488e-17,
+    "particle_weight": 5000000000000.0
+  },
+  "lev=0": {
+    "Ex": 13618955610250.484,
+    "Ey": 0.0,
+    "Ez": 16624111598186.973,
+    "divE": 1.8774751422864922e+18,
+    "rho": 6408706.535999998
+  }
+}

--- a/Regression/Checksum/benchmarks_json/RepellingParticles.json
+++ b/Regression/Checksum/benchmarks_json/RepellingParticles.json
@@ -2,28 +2,35 @@
   "electron1": {
     "particle_cpu": 0.0,
     "particle_id": 1.0,
-    "particle_momentum_x": 2.960773412224425e-23,
+    "particle_momentum_x": 7.290949775645051e-23,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 4.509968918046099e-35,
-    "particle_position_x": 5.888278028103897e-06,
-    "particle_position_y": 1.1838659096600272e-17,
+    "particle_momentum_z": 1.513278897057852e-34,
+    "particle_position_x": 1.2979353623843636e-05,
+    "particle_position_y": 2.5918801452693848e-17,
     "particle_weight": 5000000000000.0
   },
   "electron2": {
     "particle_cpu": 0.0,
     "particle_id": 2.0,
-    "particle_momentum_x": 2.9607734122203367e-23,
+    "particle_momentum_x": 7.290949775607332e-23,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.057250890885279e-34,
-    "particle_position_x": 5.888278028074152e-06,
-    "particle_position_y": 2.4190108833071488e-17,
+    "particle_momentum_z": 5.946822451302689e-36,
+    "particle_position_x": 1.2979353623849498e-05,
+    "particle_position_y": 1.965966968442628e-17,
     "particle_weight": 5000000000000.0
   },
   "lev=0": {
-    "Ex": 13618955610250.484,
+    "Bx": 0.0,
+    "By": 10242.068161511446,
+    "Bz": 0.0,
+    "Ex": 11293464466157.39,
     "Ey": 0.0,
-    "Ez": 16624111598186.973,
-    "divE": 1.8774751422864922e+18,
+    "Ez": 15385290305753.018,
+    "F": 8593.555096981512,
+    "divE": 1.709174685907196e+18,
+    "jx": 495250727461219.1,
+    "jy": 0.0,
+    "jz": 564.3956467573765,
     "rho": 6408706.535999998
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1593,6 +1593,22 @@ doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 tolerance = 1.e-14
 
+[RepellingParticles]
+buildDir = .
+inputFile = Examples/Tests/RepellingParticles/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/RepellingParticles/analysis_repelling.py
+tolerance = 1.e-14
+
 [Larmor]
 buildDir = .
 inputFile = Examples/Tests/Larmor/inputs_2d_mr


### PR DESCRIPTION
**Note: I modified this test so that the particles start close to each other, and at rest. This mitigates some of the effects that occur at the boundaries.**

This PR adds a simple test with 2 particles of the same charge ~~moving towards each other and slowing down~~ starting at rest and moving away from each other due to their repulsive force.

The long-term objective is to use this test with various advanced MR features in the future, e.g. with one macroparticle depositing in the fine patch and the other one in the coarse patch. (This test can be useful in this sense, because it involves both deposition and gather, but at the same time remains simple and has an analytical solution.)

Here is a movie of the test:
![plot](https://user-images.githubusercontent.com/6685781/137417535-c8ed9183-75fe-4135-98f8-5fbc010a8f7e.gif)
The automated test checks the evolution of the velocity of the particles and compares it with the theory:

![Comparison](https://user-images.githubusercontent.com/6685781/137417380-c116af54-7c98-4950-b0e5-f71441f501e1.png)

The fact that the theory and simulation do not agree exactly seems to be due to ~~small errors in the initial space charge calculation ; this will be fixed in the future~~ to divE-cleaning effects propagating from the boundaries towards the particles.