### PR TITLE
Made explicit several casts

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -131,13 +131,13 @@ void FieldProbe::ComputeDiags (int step)
 
         const auto cell_size = gm.CellSizeArray();
 
-        const int i_probe = amrex::Math::floor((x_probe - prob_lo[0]) / cell_size[0]);
+        const int i_probe = static_cast<int>(amrex::Math::floor((x_probe - prob_lo[0]) / cell_size[0]));
 #if (AMREX_SPACEDIM == 2)
-        const int j_probe = amrex::Math::floor((z_probe - prob_lo[1]) / cell_size[1]);
+        const int j_probe = static_cast<int>(amrex::Math::floor((z_probe - prob_lo[1]) / cell_size[1]));
         const int k_probe = 0;
 #elif(AMREX_SPACEDIM == 3)
-        const int j_probe = amrex::Math::floor((y_probe - prob_lo[1]) / cell_size[1]);
-        const int k_probe = amrex::Math::floor((z_probe - prob_lo[2]) / cell_size[2]);
+        const int j_probe = static_cast<int>(amrex::Math::floor((y_probe - prob_lo[1]) / cell_size[1]));
+        const int k_probe = static_cast<int>(amrex::Math::floor((z_probe - prob_lo[2]) / cell_size[2]));
 #endif
         // get MultiFab data at lev
         const amrex::MultiFab &Ex = warpx.getEfield(lev, 0);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -393,7 +393,7 @@ queryWithParser (const amrex::ParmParse& a_pp, char const * const str, float& va
         // If so, create a parser object and apply it to the value provided by the user.
         std::string str_val;
         Store_parserString(a_pp, str, str_val);
-        val = parseStringtoReal(str_val);
+        val = static_cast<float>(parseStringtoReal(str_val));
     }
     // return the same output as amrex::ParmParse::query
     return is_specified;
@@ -405,7 +405,7 @@ getWithParser (const amrex::ParmParse& a_pp, char const * const str, float& val)
     // If so, create a parser object and apply it to the value provided by the user.
     std::string str_val;
     Store_parserString(a_pp, str, str_val);
-    val = parseStringtoReal(str_val);
+    val = static_cast<float>(parseStringtoReal(str_val));
 }
 
 int


### PR DESCRIPTION
Several static down casts were being done without `static_cast`, causing warnings to pop up. This PR adds `static_cast` to make the casts explicit.

Note - this PR will have conflicts with PR #2430.