### PR TITLE
Gaussian Laser : fix possible NaN in the calculation of theta_stc

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -71,8 +71,11 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     auto arg = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
         m_params.stc_direction[2]*m_common_params.p_X[2];
-    arg = std::max(-1.0_rt,std::min(1.0_rt, arg)); //limit arg between -1 and 1
-    m_params.theta_stc = std::acos(arg);
+
+    if (arg < -1.0_rt || arg > 1.0_rt)
+        m_params.theta_stc = 0._rt;
+    else
+        m_params.theta_stc = std::acos(arg);
 #else
     m_params.theta_stc = 0.;
 #endif

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -68,11 +68,11 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane
 #if AMREX_SPACEDIM == 3
-    const auto arg = m_params.stc_direction[0]*m_common_params.p_X[0] +
+    const auto tt = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
         m_params.stc_direction[2]*m_common_params.p_X[2];
-    arg = std::max(-1.0_rt,std::min(1.0_rt,arg));//limit arg between -1 and 1
-    m_params.theta_stc = std::acos(arg);
+    tt = std::max(-1.0_rt,std::min(1.0_rt, tt)); //limit arg between -1 and 1
+    m_params.theta_stc = std::acos(tt);
 #else
     m_params.theta_stc = 0.;
 #endif

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -71,7 +71,7 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     auto arg = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
         m_params.stc_direction[2]*m_common_params.p_X[2];
-    targmp = std::max(-1.0_rt,std::min(1.0_rt, arg)); //limit arg between -1 and 1
+    arg = std::max(-1.0_rt,std::min(1.0_rt, arg)); //limit arg between -1 and 1
     m_params.theta_stc = std::acos(arg);
 #else
     m_params.theta_stc = 0.;

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -68,11 +68,11 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane
 #if AMREX_SPACEDIM == 3
-    const auto tt = m_params.stc_direction[0]*m_common_params.p_X[0] +
+    const auto temp = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
         m_params.stc_direction[2]*m_common_params.p_X[2];
-    tt = std::max(-1.0_rt,std::min(1.0_rt, tt)); //limit arg between -1 and 1
-    m_params.theta_stc = std::acos(tt);
+    temp = std::max(-1.0_rt,std::min(1.0_rt, temp)); //limit arg between -1 and 1
+    m_params.theta_stc = std::acos(temp);
 #else
     m_params.theta_stc = 0.;
 #endif

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -68,10 +68,11 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane
 #if AMREX_SPACEDIM == 3
-    m_params.theta_stc = std::acos(
-        m_params.stc_direction[0]*m_common_params.p_X[0] +
+    const auto arg = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
-        m_params.stc_direction[2]*m_common_params.p_X[2]);
+        m_params.stc_direction[2]*m_common_params.p_X[2];
+    arg = std::max(-1.0_rt,std::min(1.0_rt,arg));//limit arg between -1 and 1
+    m_params.theta_stc = std::acos(arg);
 #else
     m_params.theta_stc = 0.;
 #endif

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -68,11 +68,11 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane
 #if AMREX_SPACEDIM == 3
-    const auto temp = m_params.stc_direction[0]*m_common_params.p_X[0] +
+    auto arg = m_params.stc_direction[0]*m_common_params.p_X[0] +
         m_params.stc_direction[1]*m_common_params.p_X[1] +
         m_params.stc_direction[2]*m_common_params.p_X[2];
-    temp = std::max(-1.0_rt,std::min(1.0_rt, temp)); //limit arg between -1 and 1
-    m_params.theta_stc = std::acos(temp);
+    targmp = std::max(-1.0_rt,std::min(1.0_rt, arg)); //limit arg between -1 and 1
+    m_params.theta_stc = std::acos(arg);
 #else
     m_params.theta_stc = 0.;
 #endif


### PR DESCRIPTION
Due to numerical errors, the parameter
```
        m_params.stc_direction[0]*m_common_params.p_X[0] +
        m_params.stc_direction[1]*m_common_params.p_X[1] +
        m_params.stc_direction[2]*m_common_params.p_X[2]
```
can slightly exceed 1, leading to a NaN when fed to `std::acos` . This PR limit its value in [-1,1] .