### PR TITLE
Spack: No More `load -r`

### DIFF
--- a/Docs/source/developers/gnumake/spack.rst
+++ b/Docs/source/developers/gnumake/spack.rst
@@ -29,7 +29,7 @@ WarpX is built with the single command
 
 This will build the 3-D version of WarpX using the ``development`` branch.
 At the very end of the output from build sequence, Spack tells you where the WarpX executable has been placed.
-Alternatively, ``spack load -r warpx`` can be called, which will put the executable in your ``PATH`` environment variable.
+Alternatively, ``spack load warpx`` can be called, which will put the executable in your ``PATH`` environment variable.
 
 WarpX can be built in several variants, see
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -64,7 +64,7 @@ The package ``warpx`` installs executables and the package ``py-warpx`` includes
 
    # optional:            -mpi ^warpx dims=2 compute=cuda
    spack install py-warpx
-   spack load -r py-warpx
+   spack load py-warpx
 
 See ``spack info warpx`` or ``spack info py-warpx`` and `the official Spack tutorial <https://spack-tutorial.readthedocs.io>`__ for more information.
 


### PR DESCRIPTION
The `-r` argument was removed from `spack load` and is now implied.