### PR TITLE
CI: Test Windows + openPMD

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,12 +17,13 @@ jobs:
       run: |
         cmake -S . -B build               `
               -DCMAKE_BUILD_TYPE=Debug    `
-              -DCMAKE_CXX_STANDARD=17     `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DWarpX_COMPUTE=NOACC       `
               -DWarpX_OPENPMD=ON          `
               -DWarpX_MPI=OFF             `
-              -DWarpX_LIB=ON
+              -DWarpX_LIB=ON              `
+              -DWarpX_openpmd_repo=https://github.com/ax3l/openPMD-api.git `
+              -DWarpX_openpmd_branch=fix-rememberCXXversion
         cmake --build build --config Debug --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel
@@ -48,14 +49,15 @@ jobs:
               -G "Ninja"      ^
               -DCMAKE_C_COMPILER=clang-cl   ^
               -DCMAKE_CXX_COMPILER=clang-cl ^
-              -DCMAKE_CXX_STANDARD=17       ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
               -DWarpX_EB=ON                 ^
               -DWarpX_LIB=ON                ^
               -DWarpX_MPI=OFF               ^
-              -DWarpX_OPENPMD=ON
+              -DWarpX_OPENPMD=ON            ^
+              -DWarpX_openpmd_repo=https://github.com/ax3l/openPMD-api.git ^
+              -DWarpX_openpmd_branch=fix-rememberCXXversion
         cmake --build build --config Release --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,13 +17,12 @@ jobs:
       run: |
         cmake -S . -B build               `
               -DCMAKE_BUILD_TYPE=Debug    `
+              -DCMAKE_CXX_STANDARD=17     `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DWarpX_COMPUTE=NOACC       `
               -DWarpX_OPENPMD=ON          `
               -DWarpX_MPI=OFF             `
-              -DWarpX_LIB=ON              `
-              -DWarpX_openpmd_repo=https://github.com/ax3l/openPMD-api.git `
-              -DWarpX_openpmd_branch=fix-rememberCXXversion
+              -DWarpX_LIB=ON
         cmake --build build --config Debug --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel
@@ -33,6 +32,7 @@ jobs:
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 
 # -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121
+# and can be removed with openPMD-api 0.14.3+
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -49,15 +49,14 @@ jobs:
               -G "Ninja"      ^
               -DCMAKE_C_COMPILER=clang-cl   ^
               -DCMAKE_CXX_COMPILER=clang-cl ^
+              -DCMAKE_CXX_STANDARD=17       ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
               -DWarpX_EB=ON                 ^
               -DWarpX_LIB=ON                ^
               -DWarpX_MPI=OFF               ^
-              -DWarpX_OPENPMD=ON            ^
-              -DWarpX_openpmd_repo=https://github.com/ax3l/openPMD-api.git ^
-              -DWarpX_openpmd_branch=fix-rememberCXXversion
+              -DWarpX_OPENPMD=ON
         cmake --build build --config Release --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel
@@ -67,3 +66,4 @@ jobs:
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 
 # -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121
+# and can be removed with openPMD-api 0.14.3+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         cmake -S . -B build               `
               -DCMAKE_BUILD_TYPE=Debug    `
+              -DCMAKE_CXX_STANDARD=17     `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DWarpX_COMPUTE=NOACC       `
               -DWarpX_OPENPMD=ON          `
@@ -29,6 +30,8 @@ jobs:
         python3 -m pip install . -vv --no-build-isolation
 
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+
+# -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -45,6 +48,7 @@ jobs:
               -G "Ninja"      ^
               -DCMAKE_C_COMPILER=clang-cl   ^
               -DCMAKE_CXX_COMPILER=clang-cl ^
+              -DCMAKE_CXX_STANDARD=17       ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
@@ -59,3 +63,5 @@ jobs:
         python3 -m pip install . -vv --no-build-isolation
 
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+
+# -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,10 +28,7 @@ jobs:
         $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
-
-# TODO (needs debugging)
-# --diagformat=openpmd
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -61,7 +58,4 @@ jobs:
         set "PYWARPX_LIB_DIR=%cd%\build\lib\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
-
-# TODO (needs debugging)
-# --diagformat=openpmd
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd


### PR DESCRIPTION
- [x] CI: openPMD + PICMI on Windows
- [x] rebase after #2438 was merged
- [x] test https://github.com/openPMD/openPMD-api/pull/1128
- [x] add `CMAKE_CXX_STANDARD=17` to work-around https://github.com/openPMD/openPMD-api/pull/1121 / https://github.com/ECP-WarpX/WarpX/issues/1776#issuecomment-942689086 ?


## Follow-up PRs

- wait for openPMD-api 0.14.3 release to remove `CMAKE_CXX_STANDARD=17` again
- Install HDF5 or ADIOS2? Otherwise just writes to serial `.json` files (ok for now, too)
