### PR TITLE
Move kinetic energy computation into Particles/Algorithms

### DIFF
--- a/Source/Particles/Algorithms/KineticEnergy.H
+++ b/Source/Particles/Algorithms/KineticEnergy.H
@@ -1,0 +1,81 @@
+/* Copyright 2021 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef PARTICLES_KINETIC_ENERGY_H_
+#define PARTICLES_KINETIC_ENERGY_H_
+
+#include "Utils/WarpXConst.H"
+
+#include "AMReX_Extension.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_REAL.H"
+
+#include <cmath>
+
+namespace Algorithms{
+
+    // This marks the gamma threshold to switch between the full relativistic expression
+    // for particle kinetic energy and a Taylor expansion.
+    static constexpr auto gamma_relativistic_threshold =
+        static_cast<amrex::Real>(1.005);
+
+    /**
+     * \brief Computes the kinetic energy of a particle. Below a threshold for the
+     * Lorentz factor (gamma_relativistic_threshold) it uses a Taylor expansion instead of
+     * the full relativistic expression. This method should not be used with photons.
+     *
+     * @param[in] ux x component of the particle momentum (code units)
+     * @param[in] uy y component of the particle momentum (code units)
+     * @param[in] uz z component of the particle momentum (code units)
+     * @param[in] mass mass of the particle (in S.I. units)
+     *
+     * @return the kinetic energy of the particle (in S.I. units)
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    amrex::Real KineticEnergy(
+        const amrex::Real ux, const amrex::Real uy, const amrex::Real uz,
+        const amrex::Real mass)
+    {
+        using namespace amrex;
+
+        constexpr auto c2 = PhysConst::c * PhysConst::c;
+        constexpr auto inv_c2 = 1.0_rt/c2;
+
+        const auto u2 = (ux*ux + uy*uy + uz*uz)*inv_c2;
+        const auto gamma = std::sqrt(1.0_rt + u2);
+
+        const auto kk = (gamma > gamma_relativistic_threshold)?
+            (gamma-1.0_rt):
+            (u2*0.5_rt - u2*u2*(1.0_rt/8.0_rt) + u2*u2*u2*(1.0_rt/16.0_rt)-
+            u2*u2*u2*u2*(5.0_rt/128.0_rt) + (7.0_rt/256_rt)*u2*u2*u2*u2*u2); //Taylor expansion
+
+        return kk*mass*c2;
+    }
+
+    /**
+     * \brief Computes the kinetic energy of a photon.
+     *
+     * @param[in] ux x component of the particle momentum (code units)
+     * @param[in] uy y component of the particle momentum (code units)
+     * @param[in] uz z component of the particle momentum (code units)
+     *
+     * @return the kinetic energy of the photon (in S.I. units)
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    amrex::Real KineticEnergyPhotons(
+        const amrex::Real ux, const amrex::Real uy, const amrex::Real uz)
+    {
+        // Photons have zero mass, but ux, uy and uz are calculated assuming a mass equal to the
+        // electron mass. Hence, photons need a special treatment to calculate the total energy.
+        constexpr auto me_c = PhysConst::m_e * PhysConst::c;
+
+        return me_c * std::sqrt(ux*ux + uy*uy + uz*uz);
+    }
+
+}
+
+#endif // PARTICLES_ALGORITHMS_H_

--- a/Source/Particles/Algorithms/Make.package
+++ b/Source/Particles/Algorithms/Make.package
@@ -1,0 +1,1 @@
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Particles/Algorithms

--- a/Source/Particles/CMakeLists.txt
+++ b/Source/Particles/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(WarpX
     ParticleBoundaryBuffer.cpp
 )
 
+#add_subdirectory(Algorithms)
 add_subdirectory(Collision)
 #add_subdirectory(Deposition)
 add_subdirectory(ElementaryProcess)

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -7,6 +7,7 @@ CEXE_sources += LaserParticleContainer.cpp
 CEXE_sources += ParticleBoundaryBuffer.cpp
 CEXE_sources += ParticleBoundaries.cpp
 
+include $(WARPX_HOME)/Source/Particles/Algorithms/Make.package
 include $(WARPX_HOME)/Source/Particles/Pusher/Make.package
 include $(WARPX_HOME)/Source/Particles/Deposition/Make.package
 include $(WARPX_HOME)/Source/Particles/Gather/Make.package

--- a/Source/Utils/WarpXConst.H
+++ b/Source/Utils/WarpXConst.H
@@ -44,11 +44,6 @@ namespace PhysConst
     static constexpr auto xi_c2 = static_cast<amrex::Real>( 1.1728865132395492e-35 ); // This should be usable for single precision, though
     // very close to smallest number possible (1.2e-38)
 
-    // This marks the gamma threshold to switch between the full relativistic expression
-    // for particle kinetic energy and a Taylor expansion. It is used in the reduced diagnostics.
-    static constexpr auto gamma_relativistic_threshold =
-        static_cast<amrex::Real>(1.005);
-
     static constexpr auto kb   = static_cast<amrex::Real>( 1.380649e-23 );  // Boltzmann's constant, J/K (exact)
 }
 


### PR DESCRIPTION
According to @ax3l's  suggestion, this PR extracts the computation of the kinetic energy of particles and photons (used in reduced diags) and places them into a dedicated folder (Particles/Algorithms).