### PR TITLE
Make tests `pml_x_psatd` and `pml_x_yee` also restart tests.

### DIFF
--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -63,5 +63,37 @@ print("reflectivity_max = " + str(reflectivity_max))
 
 assert(reflectivity < reflectivity_max)
 
+##########################
+###### RESTART CHECK #####
+##########################
+
+# Load output data generated after restart
+ds_restart = yt.load(filename)
+ad_restart = ds_restart.covering_grid(level = 0,
+    left_edge = ds_restart.domain_left_edge,
+    dims = ds_restart.domain_dimensions)
+
+# Load output data generated from initial run
+benchmark = 'orig_' + filename
+ds_benchmark = yt.load(benchmark)
+ad_benchmark = ds_benchmark.covering_grid(level = 0,
+    left_edge = ds_benchmark.domain_left_edge,
+    dims = ds_benchmark.domain_dimensions)
+
+# Loop over all fields (all particle species, all particle attributes, all grid fields)
+# and compare output data generated from initial run with output data generated after restart
+tolerance = 1e-12
+print('\ntolerance = {:g}'.format(tolerance))
+print()
+for field in ds_benchmark.field_list:
+    dr = ad_restart[field].squeeze().v
+    db = ad_benchmark[field].squeeze().v
+    error = np.amax(np.abs(dr - db))
+    if (np.amax(np.abs(db)) != 0.):
+        error /= np.amax(np.abs(db))
+    print('field: {}; error = {:g}'.format(field, error))
+    assert(error < tolerance)
+print()
+
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -61,7 +61,7 @@ reflectivity_max = 1e-06
 print("reflectivity     = " + str(reflectivity))
 print("reflectivity_max = " + str(reflectivity_max))
 
-#assert(reflectivity < reflectivity_max)
+assert(reflectivity < reflectivity_max)
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #
@@ -61,7 +61,7 @@ reflectivity_max = 1e-06
 print("reflectivity     = " + str(reflectivity))
 print("reflectivity_max = " + str(reflectivity_max))
 
-assert(reflectivity < reflectivity_max)
+#assert(reflectivity < reflectivity_max)
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -51,5 +51,37 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
+##########################
+###### RESTART CHECK #####
+##########################
+
+# Load output data generated after restart
+ds_restart = yt.load(filename)
+ad_restart = ds_restart.covering_grid(level = 0,
+    left_edge = ds_restart.domain_left_edge,
+    dims = ds_restart.domain_dimensions)
+
+# Load output data generated from initial run
+benchmark = 'orig_' + filename
+ds_benchmark = yt.load(benchmark)
+ad_benchmark = ds_benchmark.covering_grid(level = 0,
+    left_edge = ds_benchmark.domain_left_edge,
+    dims = ds_benchmark.domain_dimensions)
+
+# Loop over all fields (all particle species, all particle attributes, all grid fields)
+# and compare output data generated from initial run with output data generated after restart
+tolerance = 1e-12
+print('\ntolerance = {:g}'.format(tolerance))
+print()
+for field in ds_benchmark.field_list:
+    dr = ad_restart[field].squeeze().v
+    db = ad_benchmark[field].squeeze().v
+    error = np.amax(np.abs(dr - db))
+    if (np.amax(np.abs(db)) != 0.):
+        error /= np.amax(np.abs(db))
+    print('field: {}; error = {:g}'.format(field, error))
+    assert(error < tolerance)
+print()
+
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe
@@ -49,7 +49,7 @@ tolerance_rel = 5./100
 print("error_rel    : " + str(error_rel))
 print("tolerance_rel: " + str(tolerance_rel))
 
-assert( error_rel < tolerance_rel )
+#assert( error_rel < tolerance_rel )
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -49,7 +49,7 @@ tolerance_rel = 5./100
 print("error_rel    : " + str(error_rel))
 print("tolerance_rel: " + str(tolerance_rel))
 
-#assert( error_rel < tolerance_rel )
+assert( error_rel < tolerance_rel )
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/inputs_2d
+++ b/Examples/Tests/PML/inputs_2d
@@ -48,6 +48,9 @@ laser1.profile_focal_distance = 1.e-6  # Focal distance from the antenna (in met
 laser1.wavelength = 2.e-6         # The wavelength of the laser (in meters)
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 chk
 diag1.intervals = 50
 diag1.diag_type = Full
+chk.intervals = 150
+chk.diag_type = Full
+chk.format = checkpoint

--- a/Examples/Tests/PML/inputs_2d
+++ b/Examples/Tests/PML/inputs_2d
@@ -49,7 +49,7 @@ laser1.wavelength = 2.e-6         # The wavelength of the laser (in meters)
 
 # Diagnostics
 diagnostics.diags_names = diag1 chk
-diag1.intervals = 1
+diag1.intervals = 50
 diag1.diag_type = Full
 chk.intervals = 150
 chk.diag_type = Full

--- a/Examples/Tests/PML/inputs_2d
+++ b/Examples/Tests/PML/inputs_2d
@@ -49,7 +49,7 @@ laser1.wavelength = 2.e-6         # The wavelength of the laser (in meters)
 
 # Diagnostics
 diagnostics.diags_names = diag1 chk
-diag1.intervals = 50
+diag1.intervals = 1
 diag1.diag_type = Full
 chk.intervals = 150
 chk.diag_type = Full

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -95,7 +95,7 @@ tolerance = 1.e-14
 [pml_x_psatd]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 restartTest = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -98,7 +98,8 @@ inputFile = Examples/Tests/PML/inputs_2d
 runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
-restartTest = 0
+restartTest = 1
+restartFileNum = 150
 useMPI = 1
 numprocs = 2
 useOMP = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -63,10 +63,11 @@ branch = a78be127f66adc1558f527edc8964e37e3a055ff
 [pml_x_yee]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee diag1.file_prefix=pml_x_yee_plt
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee diag1.file_prefix=pml_x_yee_plt chk.file_prefix=pml_x_yee_chk
 dim = 2
 addToCompileString =
-restartTest = 0
+restartTest = 1
+restartFileNum = 150
 useMPI = 1
 numprocs = 2
 useOMP = 1

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1179,7 +1179,6 @@ PML::CheckPoint (const std::string& dir) const
 {
     if (pml_E_fp[0])
     {
-        std::cout << "Inside if (pml_E_fp[0]) at line 1180." << std::endl;
         VisMF::AsyncWrite(*pml_E_fp[0], dir+"_Ex_fp");
         VisMF::AsyncWrite(*pml_E_fp[1], dir+"_Ey_fp");
         VisMF::AsyncWrite(*pml_E_fp[2], dir+"_Ez_fp");
@@ -1202,10 +1201,8 @@ PML::CheckPoint (const std::string& dir) const
 void
 PML::Restart (const std::string& dir)
 {
-    std::cout << "Outside if (pml_E_fp[0]) at line 1203." << std::endl;
     if (pml_E_fp[0])
     {
-        std::cout << "Inside if (pml_E_fp[0]) at line 1205." << std::endl;
         VisMF::Read(*pml_E_fp[0], dir+"_Ex_fp");
         VisMF::Read(*pml_E_fp[1], dir+"_Ey_fp");
         VisMF::Read(*pml_E_fp[2], dir+"_Ez_fp");

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1179,6 +1179,7 @@ PML::CheckPoint (const std::string& dir) const
 {
     if (pml_E_fp[0])
     {
+        std::cout << "Inside if (pml_E_fp[0]) at line 1180." << std::endl;
         VisMF::AsyncWrite(*pml_E_fp[0], dir+"_Ex_fp");
         VisMF::AsyncWrite(*pml_E_fp[1], dir+"_Ey_fp");
         VisMF::AsyncWrite(*pml_E_fp[2], dir+"_Ez_fp");
@@ -1201,8 +1202,10 @@ PML::CheckPoint (const std::string& dir) const
 void
 PML::Restart (const std::string& dir)
 {
+    std::cout << "Outside if (pml_E_fp[0]) at line 1203." << std::endl;
     if (pml_E_fp[0])
     {
+        std::cout << "Inside if (pml_E_fp[0]) at line 1205." << std::endl;
         VisMF::Read(*pml_E_fp[0], dir+"_Ex_fp");
         VisMF::Read(*pml_E_fp[1], dir+"_Ey_fp");
         VisMF::Read(*pml_E_fp[2], dir+"_Ez_fp");

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -325,9 +325,10 @@ WarpX::InitFromCheckpoint ()
             }
         }
     }
-
+std::cout << "In WarpXIO.cpp outside if (do_pml)." << std::endl;
     if (do_pml)
     {
+std::cout << "In WarpXIO.cpp inside if (do_pml)." << std::endl;
         InitPML();
         for (int lev = 0; lev < nlevs; ++lev) {
             pml[lev]->Restart(amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml"));

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -325,11 +325,10 @@ WarpX::InitFromCheckpoint ()
             }
         }
     }
-std::cout << "In WarpXIO.cpp outside if (do_pml)." << std::endl;
+
+    InitPML();
     if (do_pml)
     {
-std::cout << "In WarpXIO.cpp inside if (do_pml)." << std::endl;
-        InitPML();
         for (int lev = 0; lev < nlevs; ++lev) {
             pml[lev]->Restart(amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml"));
         }


### PR DESCRIPTION
Description edited by @RemiLehe :

This PR makes the `pml_x_psatd` and `pml_x_yee` restart tests. We chose a restart iteration that corresponds to a timestep at which the pulses reached the PML. 

An important bug in PML is also fixed as part of this PR: The variable `do_pml` was not properly initialized when doing a restart.