### PR TITLE
[WIP] Use the function SyncRho and the array rho_fp in the relativistic Electrostatic solver

### DIFF
--- a/Examples/Modules/space_charge_initialization/inputs_3d
+++ b/Examples/Modules/space_charge_initialization/inputs_3d
@@ -2,6 +2,7 @@ max_step = 1
 amr.n_cell =  64 64 64
 amr.max_grid_size = 32
 amr.max_level = 0
+warpx.use_filter = 0
 
 geometry.coord_sys   = 0                  # 0: Cartesian
 boundary.field_lo = pec pec pec

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -94,14 +94,10 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
                                      "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
-    // Allocate fields for potential
+    // Reset potential to 0 before the field solve
     const int num_levels = max_level + 1;
-    Vector<std::unique_ptr<MultiFab> > phi(num_levels);
     for (int lev = 0; lev <= max_level; lev++) {
-        BoxArray nba = boxArray(lev);
-        nba.surroundingNodes();
-        phi[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, 1);
-        phi[lev]->setVal(0.);
+        phi_fp[lev]->setVal(0.);
     }
 
     // Deposit particle charge density (source of Poisson solver)
@@ -124,11 +120,11 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     for (Real& beta_comp : beta) beta_comp /= PhysConst::c; // Normalize
 
     // Compute the potential phi, by solving the Poisson equation
-    computePhi( rho_fp, phi, beta, pc.self_fields_required_precision, pc.self_fields_max_iters, pc.self_fields_verbosity );
+    computePhi( rho_fp, phi_fp, beta, pc.self_fields_required_precision, pc.self_fields_max_iters, pc.self_fields_verbosity );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
-    computeE( Efield_fp, phi, beta );
-    computeB( Bfield_fp, phi, beta );
+    computeE( Efield_fp, phi_fp, beta );
+    computeB( Bfield_fp, phi_fp, beta );
 
 }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1585,7 +1585,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     }
 #endif
 
-    bool deposit_charge = do_dive_cleaning || (do_electrostatic == ElectrostaticSolverAlgo::LabFrame);
+    bool deposit_charge = true; //do_dive_cleaning || (do_electrostatic == ElectrostaticSolverAlgo::LabFrame);
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         deposit_charge = do_dive_cleaning || update_with_rho || current_correction;
     }


### PR DESCRIPTION
This is a follow-up on #1811.
It uses the array `rho_fp` and the function `SyncRho` in the relativistic Electrostatic solver.
As a consequence, filtering is automatically taken into account.