### PR TITLE
Added --detach to the updating scripts

### DIFF
--- a/Tools/Release/updateAMReX.py
+++ b/Tools/Release/updateAMReX.py
@@ -109,7 +109,7 @@ with open(run_test_path, encoding='utf-8') as f:
     #   branch/commit/tag (git fetcher) version
     #     cd amrex && git checkout COMMIT_TAG_OR_BRANCH && cd -
     run_test_content = re.sub(
-        r'(.*cd\s+amrex.+git checkout\s+)(.+)(\s+&&\s.*)',
+        r'(.*cd\s+amrex.+git checkout\s+--detach\s+)(.+)(\s+&&\s.*)',
         r'\g<1>{}\g<3>'.format(amrex_new_branch),
         run_test_content, flags = re.MULTILINE)
 

--- a/Tools/Release/updatePICSAR.py
+++ b/Tools/Release/updatePICSAR.py
@@ -109,7 +109,7 @@ with open(run_test_path, encoding='utf-8') as f:
     #   branch/commit/tag (git fetcher) version
     #     cd picsar && git checkout COMMIT_TAG_OR_BRANCH && cd -
     run_test_content = re.sub(
-        r'(.*cd\s+picsar.+git checkout\s+)(.+)(\s+&&\s.*)',
+        r'(.*cd\s+picsar.+git checkout\s+--detach\s+)(.+)(\s+&&\s.*)',
         r'\g<1>{}\g<3>'.format(PICSAR_new_branch),
         run_test_content, flags = re.MULTILINE)
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout 09a0ec56378f9f6a5f68f3ac025318af746432d5 && cd -
+cd amrex && git checkout --detach 09a0ec56378f9f6a5f68f3ac025318af746432d5 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout --detach a78be127f66adc1558f527edc8964e37e3a055ff && cd -


### PR DESCRIPTION
This is a follow on to PR #2418, which added the `--detach` option to the `git checkout` commands in `run_tests.sh`. This PR adds the option to the scripts that update the versions of AMReX and PICSAR in `run_tests.sh` so that the option is preserved.