### PR TITLE
Bugfixes for ref_ratio = 4 in the moving window direction.

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -501,7 +501,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
 
     if (do_moving_window) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lev <= 1,
-            "The number of grow cells for the moving window currently assumes only 2 levels.");
+            "The number of grow cells for the moving window currently assumes 2 levels max.");
         int rr = ref_ratio[WarpX::moving_window_dir];
         nge[WarpX::moving_window_dir] = std::max(nge[WarpX::moving_window_dir], rr);
         ngb[WarpX::moving_window_dir] = std::max(ngb[WarpX::moving_window_dir], rr);

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -495,9 +495,18 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& /*g
     // Define the number of guard cells in each direction, for E, B, and F
     IntVect nge = IntVect(AMREX_D_DECL(2, 2, 2));
     IntVect ngb = IntVect(AMREX_D_DECL(2, 2, 2));
-    int ngf_int = (do_moving_window) ? 2 : 0;
+    int ngf_int = 0;
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
     IntVect ngf = IntVect(AMREX_D_DECL(ngf_int, ngf_int, ngf_int));
+
+    if (do_moving_window) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lev <= 1,
+            "The number of grow cells for the moving window currently assumes only 2 levels.");
+        int rr = ref_ratio[WarpX::moving_window_dir];
+        nge[WarpX::moving_window_dir] = std::max(nge[WarpX::moving_window_dir], rr);
+        ngb[WarpX::moving_window_dir] = std::max(ngb[WarpX::moving_window_dir], rr);
+        ngf[WarpX::moving_window_dir] = std::max(ngf[WarpX::moving_window_dir], rr);
+    }
 
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         // Increase the number of guard cells, in order to fit the extent

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -55,7 +55,8 @@ public:
         const bool safe_guard_cells,
         const int do_electrostatic,
         const int do_multi_J,
-        const bool fft_do_time_averaging);
+        const bool fft_do_time_averaging,
+        const amrex::Vector<amrex::IntVect>& ref_ratios);
 
     // Guard cells allocated for MultiFabs E and B
     amrex::IntVect ng_alloc_EB = amrex::IntVect::TheZeroVector();

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -95,7 +95,8 @@ guardCellManager::Init (
     // When calling the moving window (with one level of refinement), we shift
     // the fine grid by a number of cells equal to the ref_ratio in the moving
     // window direction. This may not be necessary for level 0.
-    if (do_moving_window) {
+    const int nlevs = ref_ratios.size()+1;
+    if (do_moving_window && (nlevs > 1)) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
             "The number of grow cells for the moving window currently assumes 2 levels max.");
         int max_r = ref_ratios[0][moving_window_dir];

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -48,7 +48,8 @@ guardCellManager::Init (
     const bool safe_guard_cells,
     const int do_electrostatic,
     const int do_multi_J,
-    const bool fft_do_time_averaging)
+    const bool fft_do_time_averaging,
+    const amrex::Vector<amrex::IntVect>& ref_ratios)
 {
     // When using subcycling, the particles on the fine level perform two pushes
     // before being redistributed ; therefore, we need one extra guard cell
@@ -91,16 +92,20 @@ guardCellManager::Init (
     int ngJy = ngy_tmp;
     int ngJz = ngz_tmp;
 
-    // When calling the moving window (with one level of refinement),  we shift
-    // the fine grid by 2 cells ; therefore, we need at least 2 guard cells
-    // on level 1. This may not be necessary for level 0.
+    // When calling the moving window (with one level of refinement), we shift
+    // the fine grid by a number of cells equal to the ref_ratio in the moving
+    // window direction. This may not be necessary for level 0.
     if (do_moving_window) {
-        ngx = std::max(ngx,2);
-        ngy = std::max(ngy,2);
-        ngz = std::max(ngz,2);
-        ngJx = std::max(ngJx,2);
-        ngJy = std::max(ngJy,2);
-        ngJz = std::max(ngJz,2);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() == 1,
+            "The number of grow cells for the moving window currently assumes only 2 levels.");
+        int max_r = ref_ratios[0][moving_window_dir];
+
+        ngx = std::max(ngx,max_r);
+        ngy = std::max(ngy,max_r);
+        ngz = std::max(ngz,max_r);
+        ngJx = std::max(ngJx,max_r);
+        ngJy = std::max(ngJy,max_r);
+        ngJz = std::max(ngJz,max_r);
     }
 
 #if (AMREX_SPACEDIM == 3)

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -96,8 +96,8 @@ guardCellManager::Init (
     // the fine grid by a number of cells equal to the ref_ratio in the moving
     // window direction. This may not be necessary for level 0.
     if (do_moving_window) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() == 1,
-            "The number of grow cells for the moving window currently assumes only 2 levels.");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
+            "The number of grow cells for the moving window currently assumes 2 levels max.");
         int max_r = ref_ratios[0][moving_window_dir];
 
         ngx = std::max(ngx,max_r);

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -94,7 +94,7 @@ guardCellManager::Init (
 
     // When calling the moving window (with one level of refinement), we shift
     // the fine grid by a number of cells equal to the ref_ratio in the moving
-    // window direction. This may not be necessary for level 0.
+    // window direction.
     if (do_moving_window) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
             "The number of grow cells for the moving window currently assumes 2 levels max.");

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -95,11 +95,11 @@ guardCellManager::Init (
     // When calling the moving window (with one level of refinement), we shift
     // the fine grid by a number of cells equal to the ref_ratio in the moving
     // window direction. This may not be necessary for level 0.
-    const int nlevs = ref_ratios.size()+1;
-    if (do_moving_window && (nlevs > 1)) {
+    if (do_moving_window) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
             "The number of grow cells for the moving window currently assumes 2 levels max.");
-        int max_r = ref_ratios[0][moving_window_dir];
+        const int nlevs = ref_ratios.size()+1;
+        int max_r = (nlevs > 1) ? ref_ratios[0][moving_window_dir] : 2;
 
         ngx = std::max(ngx,max_r);
         ngy = std::max(ngy,max_r);

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -286,7 +286,7 @@ WarpX::shiftMF (MultiFab& mf, const Geometry& geom, int num_shift, int dir,
     const int nc = mf.nComp();
     const IntVect& ng = mf.nGrowVect();
 
-    AMREX_ALWAYS_ASSERT(ng.min() >= num_shift);
+    AMREX_ALWAYS_ASSERT(ng[dir] >= num_shift);
 
     MultiFab tmpmf(ba, dm, nc, ng);
     MultiFab::Copy(tmpmf, mf, 0, 0, nc, ng);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1390,7 +1390,8 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         safe_guard_cells,
         WarpX::do_electrostatic,
         WarpX::do_multi_J,
-        WarpX::fft_do_time_averaging);
+        WarpX::fft_do_time_averaging,
+        this->refRatio());
 
     if (mypc->nSpeciesDepositOnMainGrid() && n_current_deposition_buffer == 0) {
         n_current_deposition_buffer = 1;


### PR DESCRIPTION
Addresses Issue #2451.

Our implementation of the moving window assumes that the incoming Multifabs have a least as many guard cells as the number of cells to be shifted. With mesh refinement, the number of cells shifted goes up by a factor of the refinement ratio. However, this was hard-coded to 2 in several places. This PR generalizes this so that you can use ref_ratios of greater than 2 in the moving window direction. 

I've also relaxed the assumption that ng must be >= the num_shift_cells is ALL directions - I believe it only needs to be >= in the shift direction. Could someone please verify that they agree with this change? 

Also, our approach here currently assumes only one level of refinement, and in general doesn't generalize well to multiple levels, because the number of guard cells needed will be really large with many levels of refinement. We may need to reimplement the moving window in the event that we want to do deep MR hierarchies, or least relax the assumption that multifabs have the same number of guard cells for all levels.