### PR TITLE
Raw Diagnostics: Plot rho,F Automatically

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1798,11 +1798,6 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Whether to include the guard cells in the output of the raw fields.
     Only works with ``<diag_name>.format = plotfile``.
 
-    * ``<diag_name>.plot_raw_rho`` (`0` or `1`) optional (default `0`)
-    By default, the charge density written in the plot files is averaged on the cell centers.
-    When ``<diag_name>.plot_raw_rho = 1``, then the raw (i.e. non-averaged) charge density is also saved in the output files.
-    Only works with ``<diag_name>.format = plotfile``.
-
 * ``<diag_name>.coarsening_ratio`` (list of `int`) optional (default `1 1 1`)
     Reduce size of the field output by this ratio in each dimension.
     (This is done by averaging the field over 1 or 2 points along each direction, depending on the staggering).

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -29,10 +29,6 @@ private:
     bool m_plot_raw_fields = false;
     /** Whether to plot guard cells of raw fields */
     bool m_plot_raw_fields_guards = false;
-    /** Whether to plot charge density rho in raw fields */
-    bool m_plot_raw_rho = false;
-    /** Whether to plot F (charge conservation error) in raw fields */
-    bool m_plot_raw_F = false;
     /** Read relevant parameters for BTD */
     void ReadParameters ();
     /** \brief Flush m_mf_output and particles to file.

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -617,7 +617,7 @@ BTDiagnostics::Flush (int i_buffer)
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         labtime, m_output_species, nlev_output, file_name, m_file_min_digits,
-        m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F,
+        m_plot_raw_fields, m_plot_raw_fields_guards,
         isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush);
 
     if (m_format == "plotfile") {

--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -20,7 +20,6 @@ public:
         const std::string prefix, const int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const = 0;

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -37,7 +37,6 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override;

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -16,7 +16,7 @@ FlushFormatAscent::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int /*file_min_digits*/, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool /*plot_raw_rho*/, bool plot_raw_F,
+    bool plot_raw_fields_guards,
     bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
 #ifdef AMREX_USE_ASCENT
@@ -59,8 +59,7 @@ FlushFormatAscent::WriteToFile (
     amrex::ignore_unused(varnames, mf, geom, iteration, time,
         particle_diags, nlev);
 #endif // AMREX_USE_ASCENT
-    amrex::ignore_unused(prefix, plot_raw_fields, plot_raw_fields_guards,
-        plot_raw_F);
+    amrex::ignore_unused(prefix, plot_raw_fields, plot_raw_fields_guards);
 }
 
 #ifdef AMREX_USE_ASCENT

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -24,7 +24,6 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override final;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -31,7 +31,6 @@ FlushFormatCheckpoint::WriteToFile (
         const std::string prefix, int file_min_digits,
         bool /*plot_raw_fields*/,
         bool /*plot_raw_fields_guards*/,
-        bool /*plot_raw_rho*/, bool /*plot_raw_F*/,
         bool /*isBTD*/, int /*snapshotID*/,
         const amrex::Geometry& /*full_BTD_snapshot*/,
         bool /*isLastBTDFlush*/) const

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -36,7 +36,6 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override;

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -92,14 +92,14 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F,
+    bool plot_raw_fields_guards,
     bool isBTD, int snapshotID, const amrex::Geometry& full_BTD_snapshot,
     bool isLastBTDFlush) const
 {
     WARPX_PROFILE("FlushFormatOpenPMD::WriteToFile()");
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        !plot_raw_fields && !plot_raw_fields_guards && !plot_raw_rho && !plot_raw_F,
+        !plot_raw_fields && !plot_raw_fields_guards,
         "Cannot plot raw data with OpenPMD output format. Use plotfile instead.");
 
     // we output at full steps of the coarsest level

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -31,7 +31,6 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override;
@@ -42,8 +41,7 @@ public:
     void WriteWarpXHeader(const std::string& name, amrex::Vector<amrex::Geometry>& geom) const;
     void WriteAllRawFields (const bool plot_raw_fields, const int nlevels,
                             const std::string& plotfilename,
-                            const bool plot_raw_fields_guards,
-                            const bool plot_raw_rho, bool plot_raw_F) const;
+                            const bool plot_raw_fields_guards) const;
     /** \brief Write particles data to file.
      * \param[in] filename name of output directory
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -57,7 +57,7 @@ FlushFormatPlotfile::WriteToFile (
     const amrex::Vector<int> iteration, const double time,
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
-    bool plot_raw_fields_guards, bool plot_raw_rho, bool plot_raw_F,
+    bool plot_raw_fields_guards,
     bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/,
     bool /*isLastBTDFlush*/) const
 {
@@ -80,8 +80,7 @@ FlushFormatPlotfile::WriteToFile (
                                    rfs
                                    );
 
-    WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards,
-                      plot_raw_rho, plot_raw_F);
+    WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards);
 
     WriteParticles(filename, particle_diags);
 
@@ -491,7 +490,7 @@ WriteCoarseScalar( const std::string field_name,
 void
 FlushFormatPlotfile::WriteAllRawFields(
     const bool plot_raw_fields, const int nlevels, const std::string& plotfilename,
-    const bool plot_raw_fields_guards, const bool plot_raw_rho, bool plot_raw_F) const
+    const bool plot_raw_fields_guards) const
 {
     if (!plot_raw_fields) return;
     auto & warpx = WarpX::GetInstance();
@@ -520,24 +519,16 @@ FlushFormatPlotfile::WriteAllRawFields(
         WriteRawMF( warpx.getBfield_fp(lev, 0), dm, raw_pltname, default_level_prefix, "Bx_fp", lev, plot_raw_fields_guards);
         WriteRawMF( warpx.getBfield_fp(lev, 1), dm, raw_pltname, default_level_prefix, "By_fp", lev, plot_raw_fields_guards);
         WriteRawMF( warpx.getBfield_fp(lev, 2), dm, raw_pltname, default_level_prefix, "Bz_fp", lev, plot_raw_fields_guards);
-        if (plot_raw_F) {
-            if (warpx.get_pointer_F_fp(lev) == nullptr) {
-                WarpX::GetInstance().RecordWarning("Diagnostics",
-                    "The user requested to write raw F data, but F_fp was not allocated");
-            } else {
-                WriteRawMF(warpx.getF_fp(lev), dm, raw_pltname, default_level_prefix, "F_fp", lev, plot_raw_fields_guards);
-            }
+        if (warpx.get_pointer_F_fp(lev))
+        {
+            WriteRawMF(warpx.getF_fp(lev), dm, raw_pltname, default_level_prefix, "F_fp", lev, plot_raw_fields_guards);
         }
-        if (plot_raw_rho) {
-            if (warpx.get_pointer_rho_fp(lev) == nullptr) {
-                WarpX::GetInstance().RecordWarning("Diagnostics",
-                    "The user requested to write raw rho data, but rho_fp was not allocated");
-            } else {
-                // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
-                // If nComp > 1, this is the upper half of the list of components.
-                MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
-                WriteRawMF(rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
-            }
+        if (warpx.get_pointer_rho_fp(lev))
+        {
+            // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
+            // If nComp > 1, this is the upper half of the list of components.
+            MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
+            WriteRawMF(rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
         }
         if (warpx.get_pointer_phi_fp(lev) != nullptr) {
             WriteRawMF(warpx.getphi_fp(lev), dm, raw_pltname, default_level_prefix, "phi_fp", lev, plot_raw_fields_guards);
@@ -579,30 +570,16 @@ FlushFormatPlotfile::WriteAllRawFields(
                                warpx.get_pointer_current_cp(lev, 0), warpx.get_pointer_current_cp(lev, 1), warpx.get_pointer_current_cp(lev, 2),
                                warpx.get_pointer_current_fp(lev, 0), warpx.get_pointer_current_fp(lev, 1), warpx.get_pointer_current_fp(lev, 2),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
-            if (plot_raw_F) {
-                if (warpx.get_pointer_F_fp(lev) == nullptr) {
-                    WarpX::GetInstance().RecordWarning("Diagnostics",
-                        "The user requested to write raw F data, but F_fp was not allocated");
-                } else if (warpx.get_pointer_F_cp(lev) == nullptr) {
-                    WarpX::GetInstance().RecordWarning("Diagnostics",
-                        "The user requested to write raw F data, but F_cp was not allocated");
-                } else {
-                    WriteCoarseScalar("F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
-                        dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 0);
-                }
+            if (warpx.get_pointer_F_fp(lev) && warpx.get_pointer_F_cp(lev))
+            {
+                WriteCoarseScalar("F", warpx.get_pointer_F_cp(lev), warpx.get_pointer_F_fp(lev),
+                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 0);
             }
-            if (plot_raw_rho) {
-                if (warpx.get_pointer_rho_fp(lev) == nullptr) {
-                    WarpX::GetInstance().RecordWarning("Diagnostics",
-                        "The user requested to write raw rho data, but rho_fp was not allocated");
-                } else if (warpx.get_pointer_rho_cp(lev) == nullptr) {
-                    WarpX::GetInstance().RecordWarning("Diagnostics",
-                        "The user requested to write raw rho data, but rho_cp was not allocated");
-                } else {
-                    // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
-                    WriteCoarseScalar("rho", warpx.get_pointer_rho_cp(lev), warpx.get_pointer_rho_fp(lev),
-                        dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
-                }
+            if (warpx.get_pointer_rho_fp(lev) && warpx.get_pointer_rho_cp(lev))
+            {
+                // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
+                WriteCoarseScalar("rho", warpx.get_pointer_rho_cp(lev), warpx.get_pointer_rho_fp(lev),
+                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
             }
         }
     }

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -54,7 +54,6 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
-        bool plot_raw_rho, bool plot_raw_F,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false) const override;

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -56,13 +56,13 @@ FlushFormatSensei::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags,
     int nlev, const std::string prefix, int file_min_digits,
     bool plot_raw_fields, bool plot_raw_fields_guards,
-    bool plot_raw_rho, bool plot_raw_F, bool isBTD, int snapshotID,
+    bool isBTD, int snapshotID,
     const amrex::Geometry& full_BTD_snapshot, bool isLastBTDFlush) const
 {
     amrex::ignore_unused(
         geom, particle_diags, nlev, prefix, file_min_digits,
-        plot_raw_fields, plot_raw_fields_guards, plot_raw_rho,
-        plot_raw_F, isBTD, snapshotID, full_BTD_snapshot,
+        plot_raw_fields, plot_raw_fields_guards,
+        isBTD, snapshotID, full_BTD_snapshot,
         isLastBTDFlush);
 
 #ifndef AMREX_USE_SENSEI_INSITU

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -20,10 +20,6 @@ private:
     bool m_plot_raw_fields = false;
     /** Whether to plot guard cells of raw fields */
     bool m_plot_raw_fields_guards = false;
-    /** Whether to plot charge density rho in raw fields */
-    bool m_plot_raw_rho = false;
-    /** Whether to plot F (charge conservation error) in raw fields */
-    bool m_plot_raw_F = false;
     /** Flush m_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer) override;
     /** Flush raw data */

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -84,7 +84,6 @@ FullDiagnostics::ReadParameters ()
     m_intervals = IntervalsParser(intervals_string_vec);
     bool raw_specified = pp_diag_name.query("plot_raw_fields", m_plot_raw_fields);
     raw_specified += pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
-    raw_specified += pp_diag_name.query("plot_raw_rho", m_plot_raw_rho);
 
 #ifdef WARPX_DIM_RZ
     pp_diag_name.query("dump_rz_modes", m_dump_rz_modes);
@@ -125,7 +124,7 @@ FullDiagnostics::Flush ( int i_buffer )
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         warpx.gett_new(0), m_output_species, nlev_output, m_file_prefix, m_file_min_digits,
-        m_plot_raw_fields, m_plot_raw_fields_guards, m_plot_raw_rho, m_plot_raw_F);
+        m_plot_raw_fields, m_plot_raw_fields_guards);
 
     FlushRaw();
 }


### PR DESCRIPTION
We had two parameters, `plot_raw_rho` and `plot_raw_F`, to control whether to plot the raw rho and F fields. The output of the other raw fields is instead controlled by `plot_raw_fields` (and `plot_raw_fields_guards` to include the guard cells). Note that the parameter `plot_raw_F` was set to `false` by default and actually never parsed from the input.

Since we usually plot the raw fields anyways for debugging purposes, I think it's safe to include the raw rho and F fields automatically depending on whether the respective pointers are allocated (and exclude them if they're not).

What do you think?