### PR TITLE
Add Python Wrappers for F,G

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -193,6 +193,14 @@ libwarpx.warpx_getChargeDensityFP.restype = _LP_LP_c_real
 libwarpx.warpx_getChargeDensityFPLoVects.restype = _LP_c_int
 libwarpx.warpx_getPhiFP.restype = _LP_LP_c_real
 libwarpx.warpx_getPhiFPLoVects.restype = _LP_c_int
+libwarpx.warpx_getFfieldCP.restype = _LP_LP_c_real
+libwarpx.warpx_getFfieldCPLoVects.restype = _LP_c_int
+libwarpx.warpx_getFfieldFP.restype = _LP_LP_c_real
+libwarpx.warpx_getFfieldFPLoVects.restype = _LP_c_int
+libwarpx.warpx_getGfieldCP.restype = _LP_LP_c_real
+libwarpx.warpx_getGfieldCPLoVects.restype = _LP_c_int
+libwarpx.warpx_getGfieldFP.restype = _LP_LP_c_real
+libwarpx.warpx_getGfieldFPLoVects.restype = _LP_c_int
 libwarpx.warpx_getParticleBoundaryBufferSize.restype = ctypes.c_int
 libwarpx.warpx_getParticleBoundaryBuffer.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getParticleBoundaryBufferScrapedSteps.restype = _LP_LP_c_int
@@ -208,6 +216,8 @@ libwarpx.warpx_getJy_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getJz_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getRho_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getPhi_nodal_flag.restype = _LP_c_int
+libwarpx.warpx_getF_nodal_flag.restype = _LP_c_int
+libwarpx.warpx_getG_nodal_flag.restype = _LP_c_int
 
 #libwarpx.warpx_getPMLSigma.restype = _LP_c_real
 #libwarpx.warpx_getPMLSigmaStar.restype = _LP_c_real
@@ -1437,6 +1447,110 @@ def get_mesh_phi_fp(level, include_ghosts=True):
     return _get_mesh_field_list(libwarpx.warpx_getPhiFP, level, None, include_ghosts)
 
 
+def get_mesh_F_cp(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh F field
+    data on each grid for this process. This version returns the F field for
+    the coarse patch on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+
+    return _get_mesh_field_list(libwarpx.warpx_getFfieldCP, level, None, include_ghosts)
+
+
+def get_mesh_F_fp(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh F field
+    data on each grid for this process. This version returns the F field on
+    the fine patch for the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+
+    return _get_mesh_field_list(libwarpx.warpx_getFfieldFP, level, None, include_ghosts)
+
+
+def get_mesh_G_cp(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh G field
+    data on each grid for this process. This version returns the G field for
+    the coarse patch on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+
+    return _get_mesh_field_list(libwarpx.warpx_getGfieldCP, level, None, include_ghosts)
+
+
+def get_mesh_G_fp(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh G field
+    data on each grid for this process. This version returns the G field on
+    the fine patch for the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+
+    return _get_mesh_field_list(libwarpx.warpx_getGfieldFP, level, None, include_ghosts)
+
+
 def _get_mesh_array_lovects(level, direction, include_ghosts=True, getlovectsfunc=None):
     assert(0 <= level and level <= libwarpx.warpx_finestLevel())
 
@@ -1880,6 +1994,90 @@ def get_mesh_phi_fp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getPhiFPLoVects)
 
 
+def get_mesh_F_field_cp_lovects(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh F field
+    data on each grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldCPLoVects)
+
+
+def get_mesh_F_field_fp_lovects(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh F field
+    data on each grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldFPLoVects)
+
+
+def get_mesh_G_field_cp_lovects(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh G field
+    data on each grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldCPLoVects)
+
+
+def get_mesh_G_field_fp_lovects(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh G field
+    data on each grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldFPLoVects)
+
+
 def _get_nodal_flag(getdatafunc):
     data = getdatafunc()
     nodal_flag_ref = np.ctypeslib.as_array(data, (dim,))
@@ -1966,3 +2164,15 @@ def get_Phi_nodal_flag():
     This returns a 1d array of the nodal flags for Phi along each direction. A 1 means node centered, and 0 cell centered.
     '''
     return _get_nodal_flag(libwarpx.warpx_getPhi_nodal_flag)
+
+def get_F_nodal_flag():
+    '''
+    This returns a 1d array of the nodal flags for F along each direction. A 1 means node centered, and 0 cell centered.
+    '''
+    return _get_nodal_flag(libwarpx.warpx_getF_nodal_flag)
+
+def get_G_nodal_flag():
+    '''
+    This returns a 1d array of the nodal flags for G along each direction. A 1 means node centered, and 0 cell centered.
+    '''
+    return _get_nodal_flag(libwarpx.warpx_getG_nodal_flag)

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -651,6 +651,22 @@ def RhoCPWrapper(level=1, include_ghosts=False):
                             get_nodal_flag=_libwarpx.get_Rho_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
+def FCPWrapper(level=1, include_ghosts=False):
+    assert level>0, Exception('Coarse patch only available on levels > 0')
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_F_cp_lovects,
+                            get_fabs=_libwarpx.get_mesh_F_cp,
+                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def GCPWrapper(level=1, include_ghosts=False):
+    assert level>0, Exception('Coarse patch only available on levels > 0')
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_G_cp_lovects,
+                            get_fabs=_libwarpx.get_mesh_G_cp,
+                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
 def ExFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
                             get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects,
@@ -726,6 +742,20 @@ def PhiFPWrapper(level=0, include_ghosts=False):
                             get_lovects=_libwarpx.get_mesh_phi_fp_lovects,
                             get_fabs=_libwarpx.get_mesh_phi_fp,
                             get_nodal_flag=_libwarpx.get_Phi_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def FFPWrapper(level=0, include_ghosts=False):
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_F_field_fp_lovects,
+                            get_fabs=_libwarpx.get_mesh_F_field_fp,
+                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def GFPWrapper(level=0, include_ghosts=False):
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_G_field_fp_lovects,
+                            get_fabs=_libwarpx.get_mesh_G_field_fp,
+                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ExCPPMLWrapper(level=1, include_ghosts=False):

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -337,6 +337,8 @@ extern "C"
     int* warpx_getJz_nodal_flag()  {return getFieldNodalFlagData( WarpX::GetInstance().getcurrent(0,2) );}
     int* warpx_getRho_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getrho_fp(0) );}
     int* warpx_getPhi_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getphi_fp(0) );}
+    int* warpx_getF_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getF_fp(0) );}
+    int* warpx_getG_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getG_fp(0) );}
 
 #define WARPX_GET_SCALAR(SCALAR, GETTER) \
     amrex::Real** SCALAR(int lev, \
@@ -361,6 +363,16 @@ extern "C"
     WARPX_GET_SCALAR(warpx_getPhiFP, WarpX::GetInstance().getphi_fp)
 
     WARPX_GET_LOVECTS_SCALAR(warpx_getPhiFPLoVects, WarpX::GetInstance().getphi_fp)
+
+    // F and G
+    WARPX_GET_SCALAR(warpx_getFfieldCP, WarpX::GetInstance().getF_cp)
+    WARPX_GET_SCALAR(warpx_getFfieldFP, WarpX::GetInstance().getF_fp)
+    WARPX_GET_LOVECTS_SCALAR(warpx_getFfieldCPLoVects, WarpX::GetInstance().getF_cp)
+    WARPX_GET_LOVECTS_SCALAR(warpx_getFfieldFPLoVects, WarpX::GetInstance().getF_fp)
+    WARPX_GET_SCALAR(warpx_getGfieldCP, WarpX::GetInstance().getG_cp)
+    WARPX_GET_SCALAR(warpx_getGfieldFP, WarpX::GetInstance().getG_fp)
+    WARPX_GET_LOVECTS_SCALAR(warpx_getGfieldCPLoVects, WarpX::GetInstance().getG_cp)
+    WARPX_GET_LOVECTS_SCALAR(warpx_getGfieldFPLoVects, WarpX::GetInstance().getG_fp)
 
 #define WARPX_GET_FIELD_PML(FIELD, GETTER) \
     amrex::Real** FIELD(int lev, int direction, \

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -329,6 +329,8 @@ public:
     const amrex::MultiFab& getEfield_cp  (int lev, int direction) {return  *Efield_cp[lev][direction];}
     const amrex::MultiFab& getBfield_cp  (int lev, int direction) {return  *Bfield_cp[lev][direction];}
     const amrex::MultiFab& getrho_cp (int lev) {return  *rho_cp[lev];}
+    const amrex::MultiFab& getF_cp (int lev) {return *F_cp[lev];}
+    const amrex::MultiFab& getG_cp (int lev) {return *G_cp[lev];}
 
     const amrex::MultiFab& getcurrent_fp (int lev, int direction) {return *current_fp[lev][direction];}
     const amrex::MultiFab& getEfield_fp  (int lev, int direction) {return *Efield_fp[lev][direction];}


### PR DESCRIPTION
Add Python wrappers for the F and G scalar fields (used with div(E) and div(B) cleaning, respectively). This adds the wrappers for the mesh data in the valid domain, not yet in the PML.