### PR TITLE
Docs: Tagfile (Doxygen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Python/pywarpx.egg-info/
 ##########
 # Sphinx #
 ##########
+Docs/amrex-doxygen-web.tag.xml
 Docs/doxyhtml/
 Docs/doxyxml/
 Docs/source/_static/

--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -328,7 +328,8 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+# TAGFILES += "cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -2109,7 +2110,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = warpx-doxygen-web.tag.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -2104,7 +2104,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = amrex-doxygen-web.tag.xml=https://amrex-codes.github.io/amrex/doxygen/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -25,7 +25,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os, sys, subprocess
+import os, sys, urllib.request, subprocess
 import sphinx_rtd_theme
 sys.path.insert(0, os.path.join( os.path.abspath(__file__), '../Python') )
 
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'WarpX'
-copyright = '2017, WarpX collaboration'
+copyright = '2017-2021, WarpX collaboration'
 author = 'WarpX collaboration'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -183,4 +183,10 @@ primary_domain = 'cpp'
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = 'cpp'
 
+# Download AMReX Doxygen Tagfile to interlink Doxygen docs
+url = 'https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml'
+urllib.request.urlretrieve(url, '../amrex-doxygen-web.tag.xml')
+
+
+# Build Doxygen
 subprocess.call('cd ../; doxygen; mkdir -p source/_static; cp -r doxyhtml source/_static/', shell=True)


### PR DESCRIPTION
Interlink the WarpX Doxygen with the AMReX Doxygen pages.

Also generate a WarpX/ABLASTR tagfile. Used as an anchor in external projects.

## Before
![Screenshot from 2021-10-21 15-44-58](https://user-images.githubusercontent.com/1353258/138371995-3fd03bdb-4969-42cd-b96d-419ef00f3291.png)

## After
![Screenshot from 2021-10-21 15-44-48](https://user-images.githubusercontent.com/1353258/138371999-ae74f686-c317-45a0-b2b0-0b27d8b99100.png)
