### PR TITLE
Fix Bug with Python Wrappers for F,G

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -1994,7 +1994,7 @@ def get_mesh_phi_fp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getPhiFPLoVects)
 
 
-def get_mesh_F_field_cp_lovects(level, include_ghosts=True):
+def get_mesh_F_cp_lovects(level, include_ghosts=True):
     '''
 
     This returns a list of the lo vectors of the arrays containing the mesh F field
@@ -2015,7 +2015,7 @@ def get_mesh_F_field_cp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldCPLoVects)
 
 
-def get_mesh_F_field_fp_lovects(level, include_ghosts=True):
+def get_mesh_F_fp_lovects(level, include_ghosts=True):
     '''
 
     This returns a list of the lo vectors of the arrays containing the mesh F field
@@ -2036,7 +2036,7 @@ def get_mesh_F_field_fp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldFPLoVects)
 
 
-def get_mesh_G_field_cp_lovects(level, include_ghosts=True):
+def get_mesh_G_cp_lovects(level, include_ghosts=True):
     '''
 
     This returns a list of the lo vectors of the arrays containing the mesh G field
@@ -2057,7 +2057,7 @@ def get_mesh_G_field_cp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldCPLoVects)
 
 
-def get_mesh_G_field_fp_lovects(level, include_ghosts=True):
+def get_mesh_G_fp_lovects(level, include_ghosts=True):
     '''
 
     This returns a list of the lo vectors of the arrays containing the mesh G field

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -746,15 +746,15 @@ def PhiFPWrapper(level=0, include_ghosts=False):
 
 def FFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_F_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_F_field_fp,
+                            get_lovects=_libwarpx.get_mesh_F_fp_lovects,
+                            get_fabs=_libwarpx.get_mesh_F_fp,
                             get_nodal_flag=_libwarpx.get_F_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_G_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_G_field_fp,
+                            get_lovects=_libwarpx.get_mesh_G_fp_lovects,
+                            get_fabs=_libwarpx.get_mesh_G_fp,
                             get_nodal_flag=_libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 


### PR DESCRIPTION
The names of some of these `get_mesh` functions for F and G were not matching: this bug was introduced accidentally in #2460.