### PR TITLE
Fix average wall time per step

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -70,6 +70,7 @@ WarpX::Evolve (int numsteps)
 
     static Real evolve_time = 0;
 
+    const int step_begin = istep[0];
     for (int step = istep[0]; step < numsteps_max && cur_time < stop_time; ++step)
     {
         WARPX_PROFILE("WarpX::Evolve::step");
@@ -339,7 +340,7 @@ WarpX::Evolve (int numsteps)
                         << " DT = " << dt[0] << "\n";
             amrex::Print()<< "Evolve time = " << evolve_time
                       << " s; This step = " << evolve_time_end_step-evolve_time_beg_step
-                      << " s; Avg. per step = " << evolve_time/(step+1) << " s\n";
+                      << " s; Avg. per step = " << evolve_time/(step-step_begin+1) << " s\n";
         }
 
         if (cur_time >= stop_time - 1.e-3*dt[0]) {


### PR DESCRIPTION
It should be computed using the number of steps in this run, otherwise the
number is incorrect for restart runs.