### PR TITLE
Add Python Wrappers for F,G in PML

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -197,10 +197,18 @@ libwarpx.warpx_getFfieldCP.restype = _LP_LP_c_real
 libwarpx.warpx_getFfieldCPLoVects.restype = _LP_c_int
 libwarpx.warpx_getFfieldFP.restype = _LP_LP_c_real
 libwarpx.warpx_getFfieldFPLoVects.restype = _LP_c_int
+libwarpx.warpx_getFfieldCP_PML.restype = _LP_LP_c_real
+libwarpx.warpx_getFfieldCPLoVects_PML.restype = _LP_c_int
+libwarpx.warpx_getFfieldFP_PML.restype = _LP_LP_c_real
+libwarpx.warpx_getFfieldFPLoVects_PML.restype = _LP_c_int
 libwarpx.warpx_getGfieldCP.restype = _LP_LP_c_real
 libwarpx.warpx_getGfieldCPLoVects.restype = _LP_c_int
 libwarpx.warpx_getGfieldFP.restype = _LP_LP_c_real
 libwarpx.warpx_getGfieldFPLoVects.restype = _LP_c_int
+libwarpx.warpx_getGfieldCP_PML.restype = _LP_LP_c_real
+libwarpx.warpx_getGfieldCPLoVects_PML.restype = _LP_c_int
+libwarpx.warpx_getGfieldFP_PML.restype = _LP_LP_c_real
+libwarpx.warpx_getGfieldFPLoVects_PML.restype = _LP_c_int
 libwarpx.warpx_getParticleBoundaryBufferSize.restype = ctypes.c_int
 libwarpx.warpx_getParticleBoundaryBuffer.restype = _LP_LP_c_particlereal
 libwarpx.warpx_getParticleBoundaryBufferScrapedSteps.restype = _LP_LP_c_int
@@ -1502,6 +1510,62 @@ def get_mesh_F_fp(level, include_ghosts=True):
     return _get_mesh_field_list(libwarpx.warpx_getFfieldFP, level, None, include_ghosts)
 
 
+def get_mesh_F_fp_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh F field
+    data on each grid for this process. This version returns the F field on
+    the fine patch for the PML on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+    try:
+        return _get_mesh_field_list(libwarpx.warpx_getFfieldFP_PML, level, None, include_ghosts)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
+def get_mesh_F_cp_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh F field
+    data on each grid for this process. This version returns the F field on
+    the coarse patch for the PML on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+    try:
+        return _get_mesh_field_list(libwarpx.warpx_getFfieldCP_PML, level, None, include_ghosts)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
 def get_mesh_G_cp(level, include_ghosts=True):
     '''
 
@@ -1552,6 +1616,62 @@ def get_mesh_G_fp(level, include_ghosts=True):
     '''
 
     return _get_mesh_field_list(libwarpx.warpx_getGfieldFP, level, None, include_ghosts)
+
+
+def get_mesh_G_cp_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh G field
+    data on each grid for this process. This version returns the G field on
+    the coarse patch for the PML on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+    try:
+        return _get_mesh_field_list(libwarpx.warpx_getGfieldCP_PML, level, None, include_ghosts)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
+def get_mesh_G_fp_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of numpy arrays containing the mesh G field
+    data on each grid for this process. This version returns the G field on
+    the fine patch for the PML on the given level.
+
+    The data for the numpy arrays are not copied, but share the underlying
+    memory buffer with WarpX. The numpy arrays are fully writeable.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A List of numpy arrays.
+
+    '''
+    try:
+        return _get_mesh_field_list(libwarpx.warpx_getGfieldFP_PML, level, None, include_ghosts)
+    except ValueError:
+        raise Exception('PML not initialized')
 
 
 def _get_mesh_array_lovects(level, direction, include_ghosts=True, getlovectsfunc=None):
@@ -2042,6 +2162,54 @@ def get_mesh_F_fp_lovects(level, include_ghosts=True):
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldFPLoVects)
 
 
+def get_mesh_F_cp_lovects_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh F field
+    data on each PML grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    try:
+        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldCPLoVects_PML)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
+def get_mesh_F_fp_lovects_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh F field
+    data on each PML grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    try:
+        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getFfieldFPLoVects_PML)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
 def get_mesh_G_cp_lovects(level, include_ghosts=True):
     '''
 
@@ -2083,6 +2251,53 @@ def get_mesh_G_fp_lovects(level, include_ghosts=True):
     '''
     return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldFPLoVects)
 
+
+def get_mesh_G_cp_lovects_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh G field
+    data on each PML grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    try:
+        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldCPLoVects_PML)
+    except ValueError:
+        raise Exception('PML not initialized')
+
+
+def get_mesh_G_fp_lovects_pml(level, include_ghosts=True):
+    '''
+
+    This returns a list of the lo vectors of the arrays containing the mesh G field
+    data on each PML grid for this process.
+
+    Parameters
+    ----------
+
+        level          : the AMR level to get the data for
+        include_ghosts : whether to include ghost zones or not
+
+    Returns
+    -------
+
+        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+    '''
+    try:
+        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.warpx_getGfieldFPLoVects_PML)
+    except ValueError:
+        raise Exception('PML not initialized')
 
 def _get_nodal_flag(getdatafunc):
     data = getdatafunc()

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -2400,3 +2400,15 @@ def get_G_nodal_flag():
     This returns a 1d array of the nodal flags for G along each direction. A 1 means node centered, and 0 cell centered.
     '''
     return _get_nodal_flag(libwarpx.warpx_getG_nodal_flag)
+
+def get_F_pml_nodal_flag():
+    '''
+    This returns a 1d array of the nodal flags for F in the PML along each direction. A 1 means node centered, and 0 cell centered.
+    '''
+    return _get_nodal_flag(libwarpx.warpx_getF_pml_nodal_flag)
+
+def get_G_pml_nodal_flag():
+    '''
+    This returns a 1d array of the nodal flags for G in the PML along each direction. A 1 means node centered, and 0 cell centered.
+    '''
+    return _get_nodal_flag(libwarpx.warpx_getG_pml_nodal_flag)

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -226,6 +226,8 @@ libwarpx.warpx_getRho_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getPhi_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getF_nodal_flag.restype = _LP_c_int
 libwarpx.warpx_getG_nodal_flag.restype = _LP_c_int
+libwarpx.warpx_getF_pml_nodal_flag.restype = _LP_c_int
+libwarpx.warpx_getG_pml_nodal_flag.restype = _LP_c_int
 
 #libwarpx.warpx_getPMLSigma.restype = _LP_c_real
 #libwarpx.warpx_getPMLSigmaStar.restype = _LP_c_real

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -835,6 +835,22 @@ def JzCPPMLWrapper(level=1, include_ghosts=False):
                             get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
+def FCPPMLWrapper(level=1, include_ghosts=False):
+    assert level>0, Exception('Coarse patch only available on levels > 0')
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_F_cp_lovects_pml,
+                            get_fabs=_libwarpx.get_mesh_F_cp_pml,
+                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def GCPPMLWrapper(level=1, include_ghosts=False):
+    assert level>0, Exception('Coarse patch only available on levels > 0')
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_G_cp_lovects_pml,
+                            get_fabs=_libwarpx.get_mesh_G_cp_pml,
+                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
 def ExFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
                             get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects_pml,
@@ -896,4 +912,18 @@ def JzFPPMLWrapper(level=0, include_ghosts=False):
                             get_lovects=_libwarpx.get_mesh_current_density_fp_lovects_pml,
                             get_fabs=_libwarpx.get_mesh_current_density_fp_pml,
                             get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def FFPPMLWrapper(level=1, include_ghosts=False):
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_F_fp_lovects_pml,
+                            get_fabs=_libwarpx.get_mesh_F_fp_pml,
+                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            level=level, include_ghosts=include_ghosts)
+
+def GFPPMLWrapper(level=1, include_ghosts=False):
+    return _MultiFABWrapper(direction=None,
+                            get_lovects=_libwarpx.get_mesh_G_fp_lovects_pml,
+                            get_fabs=_libwarpx.get_mesh_G_fp_pml,
+                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -918,12 +918,12 @@ def FFPPMLWrapper(level=1, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
                             get_lovects=_libwarpx.get_mesh_F_fp_lovects_pml,
                             get_fabs=_libwarpx.get_mesh_F_fp_pml,
-                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            get_nodal_flag=_libwarpx.get_F_pml_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GFPPMLWrapper(level=1, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
                             get_lovects=_libwarpx.get_mesh_G_fp_lovects_pml,
                             get_fabs=_libwarpx.get_mesh_G_fp_pml,
-                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            get_nodal_flag=_libwarpx.get_G_pml_nodal_flag,
                             level=level, include_ghosts=include_ghosts)

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -914,14 +914,14 @@ def JzFPPMLWrapper(level=0, include_ghosts=False):
                             get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
-def FFPPMLWrapper(level=1, include_ghosts=False):
+def FFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
                             get_lovects=_libwarpx.get_mesh_F_fp_lovects_pml,
                             get_fabs=_libwarpx.get_mesh_F_fp_pml,
                             get_nodal_flag=_libwarpx.get_F_pml_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
-def GFPPMLWrapper(level=1, include_ghosts=False):
+def GFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
                             get_lovects=_libwarpx.get_mesh_G_fp_lovects_pml,
                             get_fabs=_libwarpx.get_mesh_G_fp_pml,

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -424,6 +424,36 @@ extern "C"
     WARPX_GET_LOVECTS_PML(warpx_getCurrentDensityCPLoVects_PML, Getj_cp)
     WARPX_GET_LOVECTS_PML(warpx_getCurrentDensityFPLoVects_PML, Getj_fp)
 
+#define WARPX_GET_SCALAR_PML(SCALAR, GETTER) \
+    amrex::Real** SCALAR(int lev, \
+                        int *return_size, int *ncomps, int **ngrowvect, int **shapes) { \
+        auto * pml = WarpX::GetInstance().GetPML(lev); \
+        if (!pml) return nullptr; \
+        auto * mf = pml->GETTER(); \
+        if (!mf) return nullptr; \
+        return getMultiFabPointers(*mf, return_size, ncomps, ngrowvect, shapes); \
+    }
+
+#define WARPX_GET_LOVECTS_PML_SCALAR(SCALAR, GETTER) \
+    int* SCALAR(int lev, \
+               int *return_size, int **ngrowvect) { \
+        auto * pml = WarpX::GetInstance().GetPML(lev); \
+        if (!pml) return nullptr; \
+        auto * mf = pml->GETTER(); \
+        if (!mf) return nullptr; \
+        return getMultiFabLoVects(*mf, return_size, ngrowvect); \
+    }
+
+    // F and G
+    WARPX_GET_SCALAR_PML(warpx_getFfieldCP_PML, GetF_cp)
+    WARPX_GET_SCALAR_PML(warpx_getFfieldFP_PML, GetF_fp)
+    WARPX_GET_LOVECTS_PML_SCALAR(warpx_getFfieldCPLoVects_PML, GetF_cp)
+    WARPX_GET_LOVECTS_PML_SCALAR(warpx_getFfieldFPLoVects_PML, GetF_fp)
+    WARPX_GET_SCALAR_PML(warpx_getGfieldCP_PML, GetG_cp)
+    WARPX_GET_SCALAR_PML(warpx_getGfieldFP_PML, GetG_fp)
+    WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldCPLoVects_PML, GetG_cp)
+    WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldFPLoVects_PML, GetG_fp)
+
     amrex::ParticleReal** warpx_getParticleStructs(
             const char* char_species_name, int lev,
             int* num_tiles, int** particles_per_tile) {

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -454,6 +454,9 @@ extern "C"
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldCPLoVects_PML, GetG_cp)
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldFPLoVects_PML, GetG_fp)
 
+    int* warpx_getF_pml_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getPML(0).GetF_fp() );}
+    int* warpx_getG_pml_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getPML(0).GetG_fp() );}
+
     amrex::ParticleReal** warpx_getParticleStructs(
             const char* char_species_name, int lev,
             int* num_tiles, int** particles_per_tile) {

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -454,8 +454,19 @@ extern "C"
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldCPLoVects_PML, GetG_cp)
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldFPLoVects_PML, GetG_fp)
 
-    int* warpx_getF_pml_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getPML(0).GetF_fp() );}
-    int* warpx_getG_pml_nodal_flag() {return getFieldNodalFlagData( WarpX::GetInstance().getPML(0).GetG_fp() );}
+    int* warpx_getF_pml_nodal_flag()
+    {
+        auto * pml = WarpX::GetInstance().GetPML(0);
+        if (!pml) return nullptr;
+        return getFieldNodalFlagData(pml->GetF_fp());
+    }
+
+    int* warpx_getG_pml_nodal_flag()
+    {
+        auto * pml = WarpX::GetInstance().GetPML(0);
+        if (!pml) return nullptr;
+        return getFieldNodalFlagData(pml->GetG_fp());
+    }
 
     amrex::ParticleReal** warpx_getParticleStructs(
             const char* char_species_name, int lev,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -345,6 +345,8 @@ public:
     const amrex::MultiFab& getEfield_avg_cp (int lev, int direction) {return *Efield_avg_cp[lev][direction];}
     const amrex::MultiFab& getBfield_avg_cp (int lev, int direction) {return *Bfield_avg_cp[lev][direction];}
 
+    PML& getPML(int lev) {return *pml[lev];}
+
     bool DoPML () const {return do_pml;}
 
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -345,8 +345,6 @@ public:
     const amrex::MultiFab& getEfield_avg_cp (int lev, int direction) {return *Efield_avg_cp[lev][direction];}
     const amrex::MultiFab& getBfield_avg_cp (int lev, int direction) {return *Bfield_avg_cp[lev][direction];}
 
-    PML& getPML(int lev) {return *pml[lev];}
-
     bool DoPML () const {return do_pml;}
 
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */


### PR DESCRIPTION
Add Python wrappers for the F and G scalar fields (used with div(E) and div(B) cleaning, respectively). This adds the wrappers for the mesh data in the PML, following up on #2460.

Tested locally using the PICMI script attached in https://github.com/ECP-WarpX/WarpX/pull/2481#issuecomment-961379129.