### PR TITLE
gitignore: add WarpX tagfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Python/pywarpx.egg-info/
 # Sphinx #
 ##########
 Docs/amrex-doxygen-web.tag.xml
+Docs/warpx-doxygen-web.tag.xml
 Docs/doxyhtml/
 Docs/doxyxml/
 Docs/source/_static/


### PR DESCRIPTION
Temporarily created during documentation build.

Follow-up to #2463