### PR TITLE
Python Module for Analysis of Restart Tests

### DIFF
--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -63,37 +63,10 @@ print("reflectivity_max = " + str(reflectivity_max))
 
 assert(reflectivity < reflectivity_max)
 
-##########################
-###### RESTART CHECK #####
-##########################
-
-# Load output data generated after restart
-ds_restart = yt.load(filename)
-ad_restart = ds_restart.covering_grid(level = 0,
-    left_edge = ds_restart.domain_left_edge,
-    dims = ds_restart.domain_dimensions)
-
-# Load output data generated from initial run
-benchmark = 'orig_' + filename
-ds_benchmark = yt.load(benchmark)
-ad_benchmark = ds_benchmark.covering_grid(level = 0,
-    left_edge = ds_benchmark.domain_left_edge,
-    dims = ds_benchmark.domain_dimensions)
-
-# Loop over all fields (all particle species, all particle attributes, all grid fields)
-# and compare output data generated from initial run with output data generated after restart
-tolerance = 1e-12
-print('\ntolerance = {:g}'.format(tolerance))
-print()
-for field in ds_benchmark.field_list:
-    dr = ad_restart[field].squeeze().v
-    db = ad_benchmark[field].squeeze().v
-    error = np.amax(np.abs(dr - db))
-    if (np.amax(np.abs(db)) != 0.):
-        error /= np.amax(np.abs(db))
-    print('field: {}; error = {:g}'.format(field, error))
-    assert(error < tolerance)
-print()
+# Check restart data v. original data
+sys.path.insert(0, '../../../../warpx/Examples/')
+from analysis_default_restart import check_restart
+check_restart(filename)
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -51,37 +51,10 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
-##########################
-###### RESTART CHECK #####
-##########################
-
-# Load output data generated after restart
-ds_restart = yt.load(filename)
-ad_restart = ds_restart.covering_grid(level = 0,
-    left_edge = ds_restart.domain_left_edge,
-    dims = ds_restart.domain_dimensions)
-
-# Load output data generated from initial run
-benchmark = 'orig_' + filename
-ds_benchmark = yt.load(benchmark)
-ad_benchmark = ds_benchmark.covering_grid(level = 0,
-    left_edge = ds_benchmark.domain_left_edge,
-    dims = ds_benchmark.domain_dimensions)
-
-# Loop over all fields (all particle species, all particle attributes, all grid fields)
-# and compare output data generated from initial run with output data generated after restart
-tolerance = 1e-12
-print('\ntolerance = {:g}'.format(tolerance))
-print()
-for field in ds_benchmark.field_list:
-    dr = ad_restart[field].squeeze().v
-    db = ad_benchmark[field].squeeze().v
-    error = np.amax(np.abs(dr - db))
-    if (np.amax(np.abs(db)) != 0.):
-        error /= np.amax(np.abs(db))
-    print('field: {}; error = {:g}'.format(field, error))
-    assert(error < tolerance)
-print()
+# Check restart data v. original data
+sys.path.insert(0, '../../../../warpx/Examples/')
+from analysis_default_restart import check_restart
+check_restart(filename)
 
 test_name = filename[:-9] # Could also be os.path.split(os.getcwd())[1]
 checksumAPI.evaluate_checksum(test_name, filename)

--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 
 import sys
-import yt
-import numpy as np
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 

--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -6,36 +6,12 @@ import numpy as np
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
-# Load output data generated after restart
 filename = sys.argv[1]
-ds_restart = yt.load(filename)
-ds_restart.force_periodicity()
-ad_restart = ds_restart.covering_grid(level = 0,
-                                      left_edge = ds_restart.domain_left_edge,
-                                      dims = ds_restart.domain_dimensions)
 
-# Load output data generated from initial run
-benchmark = 'orig_' + filename
-ds_benchmark = yt.load(benchmark)
-ds_benchmark.force_periodicity()
-ad_benchmark = ds_benchmark.covering_grid(level = 0,
-                                          left_edge = ds_benchmark.domain_left_edge,
-                                          dims = ds_benchmark.domain_dimensions)
-
-# Loop over all fields (all particle species, all particle attributes, all grid fields)
-# and compare output data generated from initial run with output data generated after restart
-tolerance = 1e-12
-print('\ntolerance = {:g}'.format(tolerance))
-print()
-for field in ds_benchmark.field_list:
-    dr = ad_restart[field].squeeze().v
-    db = ad_benchmark[field].squeeze().v
-    error = np.amax(np.abs(dr - db))
-    if (np.amax(np.abs(db)) != 0.):
-        error /= np.amax(np.abs(db))
-    print('field: {}; error = {:g}'.format(field, error))
-    assert(error < tolerance)
-print()
+# Check restart data v. original data
+sys.path.insert(0, '../../../../warpx/Examples/')
+from analysis_default_restart import check_restart
+check_restart(filename)
 
 # Check-sum analysis
 filename = sys.argv[1]

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+
+import numpy as np
+import yt
+
+def check_restart(filename, tolerance = 1e-12):
+    """
+    Compare output data generated from initial run with output data generated after restart.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the plotfile containing the output data generated after restart.
+    tolerance : float, optional (default = 1e-12)
+        Relative error between restart and original data must be smaller than tolerance.
+    """
+    # Load output data generated after restart
+    ds_restart = yt.load(filename)
+
+    # yt 4.0+ has rounding issues with our domain data:
+    # RuntimeError: yt attempted to read outside the boundaries
+    # of a non-periodic domain along dimension 0.
+    if 'force_periodicity' in dir(ds_restart): ds_restart.force_periodicity()
+
+    ad_restart = ds_restart.covering_grid(level = 0,
+            left_edge = ds_restart.domain_left_edge, dims = ds_restart.domain_dimensions)
+
+    # Load output data generated from initial run
+    benchmark = 'orig_' + filename
+    ds_benchmark = yt.load(benchmark)
+
+    # yt 4.0+ has rounding issues with our domain data:
+    # RuntimeError: yt attempted to read outside the boundaries
+    # of a non-periodic domain along dimension 0.
+    if 'force_periodicity' in dir(ds_benchmark): ds_benchmark.force_periodicity()
+
+    ad_benchmark = ds_benchmark.covering_grid(level = 0,
+            left_edge = ds_benchmark.domain_left_edge, dims = ds_benchmark.domain_dimensions)
+
+    # Loop over all fields (all particle species, all particle attributes, all grid fields)
+    # and compare output data generated from initial run with output data generated after restart
+    print('\ntolerance = {:g}'.format(tolerance))
+    print()
+    for field in ds_benchmark.field_list:
+        dr = ad_restart[field].squeeze().v
+        db = ad_benchmark[field].squeeze().v
+        error = np.amax(np.abs(dr - db))
+        if (np.amax(np.abs(db)) != 0.):
+            error /= np.amax(np.abs(db))
+        print('field: {}; error = {:g}'.format(field, error))
+        assert(error < tolerance)
+    print()


### PR DESCRIPTION
Add separate Python module containing the function `check_restart` to be used for comparison of restart v. original data in restart tests, to avoid code duplication.

Usage (within an existing analysis script):
```py
# Check restart data v. original data
sys.path.insert(0, '../../../../warpx/Examples/')
from analysis_default_restart import check_restart
check_restart(filename)
```