### PR TITLE
Revert latest amrex updates in order to fix CI

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 652af10ae992e2cf5c1812e0908d9b88ac22126c
+branch = 614b9ebbbf04eb5b4532029ff4a7ae40e6663042
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 614b9ebbbf04eb5b4532029ff4a7ae40e6663042
+branch = 09a0ec56378f9f6a5f68f3ac025318af746432d5
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 614b9ebbbf04eb5b4532029ff4a7ae40e6663042
+branch = 09a0ec56378f9f6a5f68f3ac025318af746432d5
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -48,7 +48,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 652af10ae992e2cf5c1812e0908d9b88ac22126c
+branch = 614b9ebbbf04eb5b4532029ff4a7ae40e6663042
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -239,7 +239,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "614b9ebbbf04eb5b4532029ff4a7ae40e6663042"
+set(WarpX_amrex_branch "09a0ec56378f9f6a5f68f3ac025318af746432d5"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -239,7 +239,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "652af10ae992e2cf5c1812e0908d9b88ac22126c"
+set(WarpX_amrex_branch "614b9ebbbf04eb5b4532029ff4a7ae40e6663042"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 614b9ebbbf04eb5b4532029ff4a7ae40e6663042 && cd -
+cd amrex && git checkout --detach 09a0ec56378f9f6a5f68f3ac025318af746432d5 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout --detach a78be127f66adc1558f527edc8964e37e3a055ff && cd -

--- a/run_test.sh
+++ b/run_test.sh
@@ -51,7 +51,7 @@ echo "cd $PWD"
 
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 652af10ae992e2cf5c1812e0908d9b88ac22126c && cd -
+cd amrex && git checkout --detach 614b9ebbbf04eb5b4532029ff4a7ae40e6663042 && cd -
 # Use QED brach for QED tests
 git clone https://github.com/ECP-WarpX/picsar.git
 cd picsar && git checkout --detach a78be127f66adc1558f527edc8964e37e3a055ff && cd -


### PR DESCRIPTION
It seems that the latest amrex updates broke our CI, but this unfortunately wasn't detected because of a CI bug.

This PR therefore reverts the latest `amrex` update ; it will be reintroduced in a second PR.