### PR TITLE
Doxygen: Tagfile on RTD

### DIFF
--- a/Docs/Makefile
+++ b/Docs/Makefile
@@ -14,7 +14,7 @@ help:
 
 clean:
 	rm -rf
-	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)"
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" amrex-doxygen-web.tag.xml warpx-doxygen-web.tag.xml
 
 .PHONY: help Makefile
 

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -189,4 +189,8 @@ urllib.request.urlretrieve(url, '../amrex-doxygen-web.tag.xml')
 
 
 # Build Doxygen
-subprocess.call('cd ../; doxygen; mkdir -p source/_static; cp -r doxyhtml source/_static/', shell=True)
+subprocess.call('cd ../; doxygen;'
+                'mkdir -p source/_static;'
+                'cp -r doxyhtml source/_static/;'
+                'cp warpx-doxygen-web.tag.xml source/_static/doxyhtml/',
+                shell=True)


### PR DESCRIPTION
Publish the doxygen tagfile on readthedocs.
Clean temporary tagfiles in `make clean`.