### PR TITLE
ROCm 4.5: Dev Packages

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -31,9 +31,18 @@ sudo apt-get install -y --no-install-recommends \
     ninja-build     \
     openmpi-bin     \
     rocm-dev        \
+    rocfft          \
+    rocprim         \
+    rocrand
+
+# add this to the above command once ROCm 4.5 is properly rolled out
+set +e
+sudo apt-get install -y --no-install-recommends \
     rocfft-devel    \
     rocprim-devel   \
     rocrand-devel
+
+set -e
 
 # activate
 #

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -31,18 +31,9 @@ sudo apt-get install -y --no-install-recommends \
     ninja-build     \
     openmpi-bin     \
     rocm-dev        \
-    rocfft          \
-    rocprim         \
-    rocrand
-
-# add this to the above command once ROCm 4.5 is properly rolled out
-set +e
-sudo apt-get install -y --no-install-recommends \
-    rocfft-devel    \
-    rocprim-devel   \
-    rocrand-devel
-
-set -e
+    rocfft-dev      \
+    rocprim-dev     \
+    rocrand-dev
 
 # activate
 #

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -31,9 +31,9 @@ sudo apt-get install -y --no-install-recommends \
     ninja-build     \
     openmpi-bin     \
     rocm-dev        \
-    rocfft          \
-    rocprim         \
-    rocrand
+    rocfft-devel    \
+    rocprim-devel   \
+    rocrand-devel
 
 # activate
 #


### PR DESCRIPTION
In ROCm 4.5, libraries were split into binary and `-dev` packages,
as often done in Debian/Ubuntu packaging.

We need the `-dev` packages for headers.

Release notes:
https://rocmdocs.amd.com/en/latest/Current_Release_Notes/Current-Release-Notes.html