### PR TITLE
Close BTD Snapshot when last slice is filled in. 

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -185,7 +185,7 @@ private:
      *  If the snapshot is full, then the snapshot files are closed.
      */
     amrex::Vector<int> m_snapshot_full;
-    /** Vector of integeres to store if the last valid slice in the lab-frame
+    /** Vector of integers to store if the last valid slice in the lab-frame
      *  is being filled. When the value is 1, then the buffer is flushed, and
      *  m_snapshot_full is set to 1 for that snapshot index.
      */

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -289,7 +289,7 @@ private:
      *  for the ith snapshot index, given by, i_buffer, is filled.
      *
      *  \param[in] i_buffer snapshot index
-     *  \param[in] lev      mesh-refinement level of the output buffer 
+     *  \param[in] lev      mesh-refinement level of the output buffer
      */
     void SetSnapshotFullStatus (const int i_buffer, const int lev = 0);
     /** Vector of field-data stored in the cell-centered multifab, m_cell_centered_data.

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -180,9 +180,16 @@ private:
      *  generate each lab-frame snapshot. At the final flush, m_buffer_flush_counter
      *  will be equal to the predicted m_max_buffer_multifabs for each snapshot.
      */
-    amrex::Vector<int> m_snapshot_full;
-    amrex::Vector<int> m_lastValidZSlice;
     amrex::Vector<int> m_max_buffer_multifabs;
+    /** Vector of integers to indicate if the snapshot is full (0 not full, 1 for full).
+     *  If the snapshot is full, then the snapshot files are closed.
+     */
+    amrex::Vector<int> m_snapshot_full;
+    /** Vector of integeres to store if the last valid slice in the lab-frame
+     *  is being filled. When the value is 1, then the buffer is flushed, and
+     *  m_snapshot_full is set to 1 for that snapshot index.
+     */
+    amrex::Vector<int> m_lastValidZSlice;
     /** Vector of counters tracking number of times the buffer of multifab is
      *  flushed out and emptied before being refilled again for each snapshot */
     amrex::Vector<int> m_buffer_flush_counter;
@@ -278,6 +285,12 @@ private:
     void IncrementBufferFlushCounter(int i_buffer) {
         m_buffer_flush_counter[i_buffer]++;
     }
+    /** Set Snapshot full status to 1 if the last valid zslice, m_lastValidZSlice,
+     *  for the ith snapshot index, given by, i_buffer, is filled.
+     *
+     *  \param[in] i_buffer snapshot index
+     *  \param[in] lev      mesh-refinement level of the output buffer 
+     */
     void SetSnapshotFullStatus (const int i_buffer, const int lev = 0);
     /** Vector of field-data stored in the cell-centered multifab, m_cell_centered_data.
      *  All the fields are stored regardless of the specific fields to plot selected

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -289,9 +289,8 @@ private:
      *  for the ith snapshot index, given by, i_buffer, is filled.
      *
      *  \param[in] i_buffer snapshot index
-     *  \param[in] lev      mesh-refinement level of the output buffer
      */
-    void SetSnapshotFullStatus (const int i_buffer, const int lev = 0);
+    void SetSnapshotFullStatus (const int i_buffer);
     /** Vector of field-data stored in the cell-centered multifab, m_cell_centered_data.
      *  All the fields are stored regardless of the specific fields to plot selected
      *  by the user.

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -180,6 +180,7 @@ private:
      *  generate each lab-frame snapshot. At the final flush, m_buffer_flush_counter
      *  will be equal to the predicted m_max_buffer_multifabs for each snapshot.
      */
+    amrex::Vector<int> m_snapshot_full;
     amrex::Vector<int> m_max_buffer_multifabs;
     /** Vector of counters tracking number of times the buffer of multifab is
      *  flushed out and emptied before being refilled again for each snapshot */
@@ -276,6 +277,7 @@ private:
     void IncrementBufferFlushCounter(int i_buffer) {
         m_buffer_flush_counter[i_buffer]++;
     }
+    void SetSnapshotFullStatus (const int i_buffer, const int lev = 0);
     /** Vector of field-data stored in the cell-centered multifab, m_cell_centered_data.
      *  All the fields are stored regardless of the specific fields to plot selected
      *  by the user.

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -181,6 +181,7 @@ private:
      *  will be equal to the predicted m_max_buffer_multifabs for each snapshot.
      */
     amrex::Vector<int> m_snapshot_full;
+    amrex::Vector<int> m_lastValidZSlice;
     amrex::Vector<int> m_max_buffer_multifabs;
     /** Vector of counters tracking number of times the buffer of multifab is
      *  flushed out and emptied before being refilled again for each snapshot */

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -166,7 +166,7 @@ BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
         return false;
     // If buffer for this lab snapshot is full then dump it and continue to collect
     // slices afterwards; or
-    // If last z-slice in the lab-frame snapshot is filled, call dump to close
+    // If last z-slice in the lab-frame snapshot is filled, call dump to
     // write the buffer and close the file.
     else if (buffer_full(i_buffer) || m_lastValidZSlice[i_buffer] == 1)
         return true;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -487,7 +487,7 @@ BTDiagnostics::k_index_zlab (int i_buffer, int lev)
 }
 
 void
-BTDiagnostics::SetSnapshotFullStatus (const int i_buffer, const int lev)
+BTDiagnostics::SetSnapshotFullStatus (const int i_buffer)
 {
    if (m_snapshot_full[i_buffer] == 1) return;
    // if the last valid z-index of the snapshot, which is 0, is filled, then

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -165,7 +165,7 @@ BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
     else if (m_snapshot_full[i_buffer] == 1)
         return false;
     // If buffer for this lab snapshot is full then dump it and continue to collect
-    // slices afters; or
+    // slices afterwards; or
     // If last z-slice in the lab-frame snapshot is filled, call dump to close
     // write the buffer and close the file.
     else if (buffer_full(i_buffer) || m_lastValidZSlice[i_buffer] == 1)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -317,7 +317,6 @@ BTDiagnostics::InitializeFieldBufferData ( int i_buffer , int lev)
 #else
     m_snapshot_ncells_lab[i_buffer] = {Nx_lab, Nz_lab};
 #endif
-    amrex::Print() << "Nx lab nz lab " << Nx_lab << " " << Nz_lab << "\n";
 }
 
 void
@@ -438,7 +437,6 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                 // Initialize and define field buffer multifab if buffer is empty
                 if (ZSliceInDomain) {
                     if ( buffer_empty(i_buffer) ) {
-                        amrex::Print() << " ibuffer : " << i_buffer << " start filling buffer\n";
                         if ( m_buffer_flush_counter[i_buffer] == 0) {
                             // Compute the geometry, snapshot lab-domain extent
                             // and box-indices
@@ -446,9 +444,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                         }
                         DefineFieldBufferMultiFab(i_buffer, lev);
                     }
-                    amrex::Print() << i_buffer << " buffer counter : " << m_buffer_counter[i_buffer] << "\n";
                 }
-                amrex::Print() << " snapshot full " << m_snapshot_full[i_buffer] << " zslice in domain : " << ZSliceInDomain << "\n";
                 m_all_field_functors[lev][i]->PrepareFunctorData (
                                              i_buffer, ZSliceInDomain,
                                              m_current_z_boost[i_buffer],
@@ -478,22 +474,12 @@ BTDiagnostics::k_index_zlab (int i_buffer, int lev)
     amrex::Real prob_domain_zmin_lab = m_prob_domain_lab[i_buffer].lo( m_moving_window_dir );
     amrex::IntVect ref_ratio = amrex::IntVect(1);
     if (lev > 0 ) ref_ratio = WarpX::RefRatio(lev-1);
-    int k_lab = static_cast<unsigned>( (
+    int k_lab = static_cast<int>(floor (
                           ( m_current_z_lab[i_buffer]
                             - (prob_domain_zmin_lab + 0.5*dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]) ) )
                           / dz_lab( warpx.getdt(lev), ref_ratio[m_moving_window_dir] )
                       ) );
-    int k2_lab = static_cast<int>(floor (
-                          ( m_current_z_lab[i_buffer]
-                            - (prob_domain_zmin_lab + 0.5*dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]) ) )
-                          / dz_lab( warpx.getdt(lev), ref_ratio[m_moving_window_dir] )
-                      ) );
-    amrex::Print() << " ibuffer : " << i_buffer << " zlab : " << m_current_z_lab[i_buffer];
-    amrex::Print() << " max prob dom lab : " << m_prob_domain_lab[i_buffer].hi( m_moving_window_dir );
-    amrex::Print() << " min prob dom lab : " << prob_domain_zmin_lab ;
-    amrex::Print() << " half dz : " << (prob_domain_zmin_lab + 0.5*dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]) )  << "\n";
-    amrex::Print() << " ibuffer : " << i_buffer << " klab : " << k_lab << " " << k2_lab << "\n";
-    return k2_lab;
+    return k_lab;
 }
 
 void
@@ -502,7 +488,6 @@ BTDiagnostics::SetSnapshotFullStatus (const int i_buffer, const int lev)
    if (m_snapshot_full[i_buffer] == 1) return;
 
    const int k_lab = k_index_zlab(i_buffer, lev);
-   amrex::Print() << " at set snapshot status for buffer : " <<i_buffer << " k_lab : " << k_lab << "\n";
    if (k_lab <= 0) m_snapshot_full[i_buffer] = 1;
 
 }
@@ -568,11 +553,9 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
 void
 BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
 {
-    amrex::Print() << " Defining snapshot : " << i_buffer << "\n";
     if ( m_do_back_transformed_fields ) {
         auto & warpx = WarpX::GetInstance();
         const int k_lab = k_index_zlab (i_buffer, lev);
-        amrex::Print() << " klab : " << k_lab << "\n";
         // Box covering the extent of the user-defined diag in the back-transformed frame
         // for the ith snapshot
         // estimating the maximum number of buffer multifabs needed to obtain the
@@ -595,8 +578,6 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
                              num_z_cells_in_snapshot *
                              dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]);
         m_snapshot_domain_lab[i_buffer].setLo(m_moving_window_dir, new_lo);
-        amrex::Print() << " numzcells : " << num_z_cells_in_snapshot << " max_buffer_mfs : " << m_max_buffer_multifabs[i_buffer] << " " << m_buffer_size << "\n";
-        amrex::Print() << " snapshot box : " << m_snapshot_box[i_buffer] << "\n";
         if (lev == 0) {
             // The extent of the physical domain covered by the ith snapshot
             // Default non-periodic geometry for diags
@@ -640,7 +621,6 @@ BTDiagnostics::GetZSliceInDomainFlag (const int i_buffer, const int lev)
 void
 BTDiagnostics::Flush (int i_buffer)
 {
-    amrex::Print() << " in flush for i buffer : " << i_buffer << "\n";
     auto & warpx = WarpX::GetInstance();
     std::string file_name = m_file_prefix;
     if (m_format=="plotfile") {
@@ -651,7 +631,6 @@ BTDiagnostics::Flush (int i_buffer)
     //bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
     //                           - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
     bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 ) ? true : false;
-    if (isLastBTDFlush) amrex::Print() << " *** ClosingSnapshot This timestep : " << i_buffer <<"\n";
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];
     m_flush_format->WriteToFile(

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -489,7 +489,7 @@ BTDiagnostics::k_index_zlab (int i_buffer, int lev)
     amrex::Print() << " max prob dom lab : " << m_prob_domain_lab[i_buffer].hi( m_moving_window_dir );
     amrex::Print() << " min prob dom lab : " << prob_domain_zmin_lab ;
     amrex::Print() << " half dz : " << (prob_domain_zmin_lab + 0.5*dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir]) )  << "\n";
-    amrex::Print() << " ibuffer : " << i_buffer << " klab : " << k_lab << " " << k2_lab << "\n"; 
+    amrex::Print() << " ibuffer : " << i_buffer << " klab : " << k_lab << " " << k2_lab << "\n";
     return k2_lab;
 }
 
@@ -500,7 +500,7 @@ BTDiagnostics::SetSnapshotFullStatus (const int i_buffer, const int lev)
 
    const int k_lab = k_index_zlab(i_buffer, lev);
    if (k_lab <= 0) m_snapshot_full[i_buffer] = 1;
-    
+
 }
 
 void

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -161,10 +161,13 @@ BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
     // timestep < 0, i.e., at initialization time when step == -1
     if (step < 0 )
         return false;
+    // Do not call dump if the snapshot is already full and the files are closed.
     else if (m_snapshot_full[i_buffer] == 1)
         return false;
-    // buffer for this lab snapshot is full, time to dump it and continue
-    // to collect more slices afterwards
+    // If buffer for this lab snapshot is full then dump it and continue to collect
+    // slices afters; or
+    // If last z-slice in the lab-frame snapshot is filled, call dump to close
+    // write the buffer and close the file.
     else if (buffer_full(i_buffer) || m_lastValidZSlice[i_buffer] == 1)
         return true;
     // forced: at the end of the simulation
@@ -453,6 +456,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                                              m_snapshot_full[i_buffer] );
 
                 if (ZSliceInDomain) ++m_buffer_counter[i_buffer];
+                // when the 0th z-index is filled, then set lastValidZSlice to 1
                 if (k_index_zlab(i_buffer, lev) == 0) m_lastValidZSlice[i_buffer] = 1;
             }
         }
@@ -486,9 +490,9 @@ void
 BTDiagnostics::SetSnapshotFullStatus (const int i_buffer, const int lev)
 {
    if (m_snapshot_full[i_buffer] == 1) return;
-
-   const int k_lab = k_index_zlab(i_buffer, lev);
-   if (k_lab <= 0) m_snapshot_full[i_buffer] = 1;
+   // if the last valid z-index of the snapshot, which is 0, is filled, then
+   // set the snapshot full integer to 1
+   if (m_lastValidZSlice[i_buffer] == 1) m_snapshot_full[i_buffer] = 1;
 
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -632,8 +632,6 @@ BTDiagnostics::Flush (int i_buffer)
         file_name = file_name+"/buffer";
     }
     SetSnapshotFullStatus(i_buffer);
-    //bool isLastBTDFlush = ( ( m_max_buffer_multifabs[i_buffer]
-    //                           - m_buffer_flush_counter[i_buffer]) == 1) ? true : false;
     bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 ) ? true : false;
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -60,22 +60,22 @@ public:
 
     /** \brief Prepare data required to back-transform fields for lab-frame snapshot, i_buffer
      *
-     * \param[in] i_buffer       index of the snapshot
-     * \param[in] ZSliceInDomain if the z-slice at current_z_boost is within
+     * \param[in] i_buffer          index of the snapshot
+     * \param[in] z_slice_in_domain if the z-slice at current_z_boost is within
      *            the boosted-frame and lab-frame domain.
      *            The fields are sliced and back-transformed only if this value is true.
-     * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
-     * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
-     *                           current z co-ordinate in the lab-frame for the ith buffer.
-     * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
-     * \param[in] SnapshotFull   if the current snapshot, with index, i_buffer, is full (1)
-                                 or not (0). If it is full, then Lorentz-transform
-                                 is not performed by setting m_perform_backtransform to 0; 
+     * \param[in] buffer_box        Box with index-space in lab-frame for the ith buffer
+     * \param[in] k_index_zlab      k-index in the lab-frame corresponding to the
+     *            current z co-ordinate in the lab-frame for the ith buffer.
+     * \param[in] max_box_size      maximum box size for the multifab to generate box arrays
+     * \param[in] snapshot_full     if the current snapshot, with index, i_buffer, is full (1)
+                  or not (0). If it is full, then Lorentz-transform is not performed
+                  by setting m_perform_backtransform to 0.
      */
-    void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
+    void PrepareFunctorData ( int i_buffer, bool z_slice_in_domain,
                               amrex::Real current_z_boost,
                               amrex::Box buffer_box, const int k_index_zlab,
-                              const int max_box_size, const int SnapshotFull ) override;
+                              const int max_box_size, const int snapshot_full ) override;
     /** Allocate and initialize member variables and arrays required to back-transform
      *  field-data from boosted-frame to lab-frame.
      */
@@ -104,7 +104,7 @@ private:
     amrex::Vector<amrex::Real> m_current_z_boost;
     /** Vector of 0s and 1s stored to check if back-transformation is to be performed
      *  for the ith buffer. The value is set 0 (false) or 1 (true) using the boolean
-     *  ZSliceInDomain in PrepareFunctorData().
+     *  z_slice_in_domain in PrepareFunctorData().
      */
     amrex::Vector<int> m_perform_backtransform;
     /** Vector of k-index correspoding to the current lab-frame z co-ordinate for each buffer */

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -74,7 +74,7 @@ public:
     void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                               amrex::Real current_z_boost,
                               amrex::Box buffer_box, const int k_index_zlab,
-                              const int max_box_size ) override;
+                              const int max_box_size, const int SnapshotFull ) override;
     /** Allocate and initialize member variables and arrays required to back-transform
      *  field-data from boosted-frame to lab-frame.
      */

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -60,16 +60,17 @@ public:
 
     /** \brief Prepare data required to back-transform fields for lab-frame snapshot, i_buffer
      *
-     * \param[in] i_buffer        index of the snapshot
-     * \param[in] ZSliceInDomain  if the z-slice at current_z_boost is within
-     *                            the boosted-frame and lab-frame domain.
-     *                            The fields are sliced and back-transformed only
-     *                            if this value is true.
-     * \param[in] current_z_boost current z-coordinate of the slice in boosted-frame
-     * \param[in] buffer_box      Box with index-space in lab-frame for the ith buffer
-     * \param[in] k_index_zlab    k-index in the lab-frame corresponding to the
-     *                            current z co-ordinate in the lab-frame for the ith buffer.
-     * \param[in] max_box_size    maximum box size for the multifab to generate box arrays
+     * \param[in] i_buffer       index of the snapshot
+     * \param[in] ZSliceInDomain if the z-slice at current_z_boost is within
+     *            the boosted-frame and lab-frame domain.
+     *            The fields are sliced and back-transformed only if this value is true.
+     * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
+     * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
+     *                           current z co-ordinate in the lab-frame for the ith buffer.
+     * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
+     * \param[in] SnapshotFull   if the current snapshot, with index, i_buffer, is full (1)
+                                 or not (0). If it is full, then Lorentz-transform
+                                 is not performed by setting m_perform_backtransform to 0; 
      */
     void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                               amrex::Real current_z_boost,

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -121,13 +121,13 @@ void
 BackTransformFunctor::PrepareFunctorData (int i_buffer,
                           bool ZSliceInDomain, amrex::Real current_z_boost,
                           amrex::Box buffer_box, const int k_index_zlab,
-                          const int max_box_size )
+                          const int max_box_size, const int SnapshotFull)
 {
     m_buffer_box[i_buffer] = buffer_box;
     m_current_z_boost[i_buffer] = current_z_boost;
     m_k_index_zlab[i_buffer] = k_index_zlab;
     m_perform_backtransform[i_buffer] = 0;
-    if (ZSliceInDomain) m_perform_backtransform[i_buffer] = 1;
+    if (ZSliceInDomain == true and SnapshotFull == 0) m_perform_backtransform[i_buffer] = 1;
     m_max_box_size = max_box_size;
 }
 

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -119,15 +119,15 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
 
 void
 BackTransformFunctor::PrepareFunctorData (int i_buffer,
-                          bool ZSliceInDomain, amrex::Real current_z_boost,
+                          bool z_slice_in_domain, amrex::Real current_z_boost,
                           amrex::Box buffer_box, const int k_index_zlab,
-                          const int max_box_size, const int SnapshotFull)
+                          const int max_box_size, const int snapshot_full)
 {
     m_buffer_box[i_buffer] = buffer_box;
     m_current_z_boost[i_buffer] = current_z_boost;
     m_k_index_zlab[i_buffer] = k_index_zlab;
     m_perform_backtransform[i_buffer] = 0;
-    if (ZSliceInDomain == true and SnapshotFull == 0) m_perform_backtransform[i_buffer] = 1;
+    if (z_slice_in_domain == true and snapshot_full == 0) m_perform_backtransform[i_buffer] = 1;
     m_max_box_size = max_box_size;
 }
 

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -35,25 +35,25 @@ public:
      *         back-transformed diagnostics, that are unused for regular diagnostics.
      *
      * \param[in] i_buffer       index of the back-transform snapshot
-     * \param[in] ZSliceInDomain if the z-slice at current_z_boost is within
+     * \param[in] z_slice_in_domain if the z-slice at current_z_boost is within
      *            the boosted-frame and lab-frame domain.
      *            The fields are sliced and back-transformed only if this value is true.
      * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
      *                           current z co-ordinate in the lab-frame for the ith buffer.
      * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
-     * \param[in] SnapshotFull   if the current snapshot, with index, i_buffer, is full (1)
+     * \param[in] snapshot_full   if the current snapshot, with index, i_buffer, is full (1)
                                  or not (0). If it is full, then Lorentz-transform
                                  is not performed by setting m_perform_backtransform to 0; 
      */     
-    virtual void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
+    virtual void PrepareFunctorData ( int i_buffer, bool z_slice_in_domain,
                                       amrex::Real current_z_boost,
                                       amrex::Box buffer_box, const int k_index_zlab,
-                                      const int max_box_size, const int SnapshotFull) {
+                                      const int max_box_size, const int snapshot_full) {
                                           amrex::ignore_unused(i_buffer,
-                                          ZSliceInDomain,
+                                          z_slice_in_domain,
                                           current_z_boost, buffer_box,
-                                          k_index_zlab, max_box_size, SnapshotFull);
+                                          k_index_zlab, max_box_size, snapshot_full);
                                       }
     virtual void InitData() {}
 private:

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -33,11 +33,11 @@ public:
     virtual void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                                       amrex::Real current_z_boost,
                                       amrex::Box buffer_box, const int k_index_zlab,
-                                      const int max_box_size) {
+                                      const int max_box_size, const int SnapshotFull) {
                                           amrex::ignore_unused(i_buffer,
                                           ZSliceInDomain,
                                           current_z_boost, buffer_box,
-                                          k_index_zlab, max_box_size);
+                                          k_index_zlab, max_box_size, SnapshotFull);
                                       }
     virtual void InitData() {}
 private:

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -30,6 +30,22 @@ public:
      * multifab */
     int nComp () const { return m_ncomp; }
 
+    /** \brief Prepare data required to process fields in the operator()
+     *         Note that this function has parameters that are specific to
+     *         back-transformed diagnostics, that are unused for regular diagnostics.
+     *
+     * \param[in] i_buffer       index of the back-transform snapshot
+     * \param[in] ZSliceInDomain if the z-slice at current_z_boost is within
+     *            the boosted-frame and lab-frame domain.
+     *            The fields are sliced and back-transformed only if this value is true.
+     * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
+     * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
+     *                           current z co-ordinate in the lab-frame for the ith buffer.
+     * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
+     * \param[in] SnapshotFull   if the current snapshot, with index, i_buffer, is full (1)
+                                 or not (0). If it is full, then Lorentz-transform
+                                 is not performed by setting m_perform_backtransform to 0; 
+     */     
     virtual void PrepareFunctorData ( int i_buffer, bool ZSliceInDomain,
                                       amrex::Real current_z_boost,
                                       amrex::Box buffer_box, const int k_index_zlab,

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -44,8 +44,8 @@ public:
      * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
      * \param[in] snapshot_full   if the current snapshot, with index, i_buffer, is full (1)
                                  or not (0). If it is full, then Lorentz-transform
-                                 is not performed by setting m_perform_backtransform to 0; 
-     */     
+                                 is not performed by setting m_perform_backtransform to 0;
+     */
     virtual void PrepareFunctorData ( int i_buffer, bool z_slice_in_domain,
                                       amrex::Real current_z_boost,
                                       amrex::Box buffer_box, const int k_index_zlab,


### PR DESCRIPTION
This PR ensures that the BTD snapshots are closed properly. The snapshots are filled from the last index to 0 in the z-direction. when the 0th slice is filled, the snapshot full parameter is flipped from 0 to 1.
And in the following timesteps, the operators for Backtransform and flush are not called if the snapshot is full.

Fix #2466