### PR TITLE
Quick bug fix: Make regex string into r-string

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -61,7 +61,7 @@ class Species(picmistandard.PICMI_Species):
                 else:
                     self.charge = self.charge_state*constants.q_e
             # Match a string of the format '#nXx', with the '#n' optional isotope number.
-            m = re.match('(?P<iso>#[\d+])*(?P<sym>[A-Za-z]+)', self.particle_type)
+            m = re.match(r'(?P<iso>#[\d+])*(?P<sym>[A-Za-z]+)', self.particle_type)
             if m is not None:
                 element = periodictable.elements.symbol(m['sym'])
                 if m['iso'] is not None:


### PR DESCRIPTION
Newer versions of Python changed the `DeprecationWarning` for invalid escape sequences to `SyntaxError`. Most of the other regex patterns are already raw strings, which bypasses this error. This PR is just making the last one that I could find into a raw string as well.