### PR TITLE
Documentation: write default laser CEP

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1120,7 +1120,7 @@ Laser initialization
     ``<laser_name>.profile_focal_distance`` in the laboratory frame, and use ``warpx.gamma_boost``
     to automatically perform the conversion to the boosted frame.
 
-* ``<laser_name>.phi0`` (`float`; in radians)
+* ``<laser_name>.phi0`` (`float`; in radians) optional (default `0.`)
     The Carrier Envelope Phase, i.e. the phase of the laser oscillation, at the
     position where the laser envelope is maximum (only used for the ``"gaussian"`` profile)
 


### PR DESCRIPTION
Just so that we know what was used in a simulation that was run with no specified CEP, without having to look into the code.

We could also write that `phi0 = 0` corresponds to a maximum positive electric field in the polarization direction at the peak of the envelope, but I'm not sure if this is always true (especially if the laser is injected several Rayleigh lengths away from focus because of possible Gouy phase effects). I can run some tests on that if needed.