### PR TITLE
PICMI: Add max_grid_size, blocking_factor in (x,y,z)

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -406,6 +406,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         self.max_grid_size_x = kw.pop('warpx_max_grid_size_x', None)
         self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
+        self.blocking_factor_x = kw.pop('warpx_blocking_factor_x', None)
+        self.blocking_factor_y = kw.pop('warpx_blocking_factor_y', None)
 
         self.potential_xmin = None
         self.potential_xmax = None
@@ -423,6 +425,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         pywarpx.amr.max_grid_size_x = self.max_grid_size_x
         pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
+        pywarpx.amr.blocking_factor_x = self.blocking_factor_x
+        pywarpx.amr.blocking_factor_y = self.blocking_factor_y
 
         assert self.lower_bound[0] >= 0., Exception('Lower radial boundary must be >= 0.')
         assert self.bc_rmin != 'periodic' and self.bc_rmax != 'periodic', Exception('Radial boundaries can not be periodic')
@@ -465,6 +469,8 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.max_grid_size_x = kw.pop('warpx_max_grid_size_x', None)
         self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
+        self.blocking_factor_x = kw.pop('warpx_blocking_factor_x', None)
+        self.blocking_factor_y = kw.pop('warpx_blocking_factor_y', None)
 
         self.potential_xmin = kw.pop('warpx_potential_lo_x', None)
         self.potential_xmax = kw.pop('warpx_potential_hi_x', None)
@@ -482,6 +488,8 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         pywarpx.amr.max_grid_size_x = self.max_grid_size_x
         pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
+        pywarpx.amr.blocking_factor_x = self.blocking_factor_x
+        pywarpx.amr.blocking_factor_y = self.blocking_factor_y
 
         # Geometry
         pywarpx.geometry.coord_sys = 0  # Cartesian
@@ -521,6 +529,9 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
         self.max_grid_size_z = kw.pop('warpx_max_grid_size_z', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
+        self.blocking_factor_x = kw.pop('warpx_blocking_factor_x', None)
+        self.blocking_factor_y = kw.pop('warpx_blocking_factor_y', None)
+        self.blocking_factor_z = kw.pop('warpx_blocking_factor_z', None)
 
         self.potential_xmin = kw.pop('warpx_potential_lo_x', None)
         self.potential_xmax = kw.pop('warpx_potential_hi_x', None)
@@ -539,6 +550,9 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.max_grid_size_z = self.max_grid_size_z
         pywarpx.amr.blocking_factor = self.blocking_factor
+        pywarpx.amr.blocking_factor_x = self.blocking_factor_x
+        pywarpx.amr.blocking_factor_y = self.blocking_factor_y
+        pywarpx.amr.blocking_factor_z = self.blocking_factor_z
 
         # Geometry
         pywarpx.geometry.coord_sys = 0  # Cartesian

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -403,6 +403,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
+        self.max_grid_size_x = kw.pop('warpx_max_grid_size_x', None)
+        self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
 
         self.potential_xmin = None
@@ -417,7 +419,11 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        pywarpx.amr.max_grid_size = self.max_grid_size
+        if self.max_grid_size_x is None or self.max_grid_size_y is None:
+            pywarpx.amr.max_grid_size = self.max_grid_size
+        else:
+            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         assert self.lower_bound[0] >= 0., Exception('Lower radial boundary must be >= 0.')
@@ -458,6 +464,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
 class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
+        self.max_grid_size_x = kw.pop('warpx_max_grid_size_x', None)
+        self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
 
         self.potential_xmin = kw.pop('warpx_potential_lo_x', None)
@@ -472,7 +480,11 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        pywarpx.amr.max_grid_size = self.max_grid_size
+        if self.max_grid_size_x is None or self.max_grid_size_y is None:
+            pywarpx.amr.max_grid_size = self.max_grid_size
+        else:
+            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry
@@ -509,6 +521,9 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
+        self.max_grid_size_x = kw.pop('warpx_max_grid_size_x', None)
+        self.max_grid_size_y = kw.pop('warpx_max_grid_size_y', None)
+        self.max_grid_size_z = kw.pop('warpx_max_grid_size_z', None)
         self.blocking_factor = kw.pop('warpx_blocking_factor', None)
 
         self.potential_xmin = kw.pop('warpx_potential_lo_x', None)
@@ -523,7 +538,12 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        pywarpx.amr.max_grid_size = self.max_grid_size
+        if self.max_grid_size_x is None or self.max_grid_size_y is None or self.max_grid_size_z is None:
+            pywarpx.amr.max_grid_size = self.max_grid_size
+        else:
+            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
+            pywarpx.amr.max_grid_size_z = self.max_grid_size_z
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -419,11 +419,9 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        if self.max_grid_size_x is None or self.max_grid_size_y is None:
-            pywarpx.amr.max_grid_size = self.max_grid_size
-        else:
-            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
-            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
+        pywarpx.amr.max_grid_size = self.max_grid_size
+        pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+        pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         assert self.lower_bound[0] >= 0., Exception('Lower radial boundary must be >= 0.')
@@ -480,11 +478,9 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        if self.max_grid_size_x is None or self.max_grid_size_y is None:
-            pywarpx.amr.max_grid_size = self.max_grid_size
-        else:
-            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
-            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
+        pywarpx.amr.max_grid_size = self.max_grid_size
+        pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+        pywarpx.amr.max_grid_size_y = self.max_grid_size_y
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry
@@ -538,12 +534,10 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
         # Maximum allowable size of each subdomain in the problem domain;
         #    this is used to decompose the domain for parallel calculations.
-        if self.max_grid_size_x is None or self.max_grid_size_y is None or self.max_grid_size_z is None:
-            pywarpx.amr.max_grid_size = self.max_grid_size
-        else:
-            pywarpx.amr.max_grid_size_x = self.max_grid_size_x
-            pywarpx.amr.max_grid_size_y = self.max_grid_size_y
-            pywarpx.amr.max_grid_size_z = self.max_grid_size_z
+        pywarpx.amr.max_grid_size = self.max_grid_size
+        pywarpx.amr.max_grid_size_x = self.max_grid_size_x
+        pywarpx.amr.max_grid_size_y = self.max_grid_size_y
+        pywarpx.amr.max_grid_size_z = self.max_grid_size_z
         pywarpx.amr.blocking_factor = self.blocking_factor
 
         # Geometry


### PR DESCRIPTION
Add the possibility to set `amr.max_grid_size_x`, `amr.max_grid_size_y` and `amr.max_grid_size_z` through the Python interface, to customize the domain decomposition separately in each direction.

The relevant flags for 2D and RZ are `amr.max_grid_size_x` and `amr.max_grid_size_y`, while `amr.max_grid_size_z` is read only in 3D.

Added the same capability for `amr.blocking_factor`.