### PR TITLE
Apply PEC to split pml fields

### DIFF
--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -1,4 +1,5 @@
 #include "WarpX.H"
+#include "BoundaryConditions/PML.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "Evolve/WarpXDtType.H"
 #include "WarpX_PEC.H"
@@ -25,9 +26,23 @@ void WarpX::ApplyEfieldBoundary(const int lev, PatchType patch_type)
 {
     if (PEC::isAnyBoundaryPEC()) {
         if (patch_type == PatchType::fine) {
-            PEC::ApplyPECtoEfield( Efield_fp[lev], lev, patch_type);
+            PEC::ApplyPECtoEfield( { get_pointer_Efield_fp(lev, 0),
+                                     get_pointer_Efield_fp(lev, 1),
+                                     get_pointer_Efield_fp(lev, 2) }, lev, patch_type);
+            if (WarpX::isAnyBoundaryPML()) {
+                // apply pec on split E-fields in PML region
+                const bool split_pml_field = true;
+                PEC::ApplyPECtoEfield( pml[lev]->GetE_fp(), lev, patch_type, split_pml_field);
+            }
         } else {
-            PEC::ApplyPECtoEfield( Efield_cp[lev], lev, patch_type);
+            PEC::ApplyPECtoEfield( { get_pointer_Efield_cp(lev, 0),
+                                     get_pointer_Efield_cp(lev, 1),
+                                     get_pointer_Efield_cp(lev, 2) }, lev, patch_type);
+            if (WarpX::isAnyBoundaryPML()) {
+                // apply pec on split E-fields in PML region
+                const bool split_pml_field = true;
+                PEC::ApplyPECtoEfield( pml[lev]->GetE_cp(), lev, patch_type, split_pml_field);
+            }
         }
     }
 }
@@ -36,9 +51,13 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 {
     if (PEC::isAnyBoundaryPEC()) {
         if (patch_type == PatchType::fine) {
-            PEC::ApplyPECtoBfield( Bfield_fp[lev], lev, patch_type);
+            PEC::ApplyPECtoBfield( { get_pointer_Bfield_fp(lev, 0),
+                                     get_pointer_Bfield_fp(lev, 1),
+                                     get_pointer_Bfield_fp(lev, 2) }, lev, patch_type);
         } else {
-            PEC::ApplyPECtoBfield( Bfield_cp[lev], lev, patch_type);
+            PEC::ApplyPECtoBfield( { get_pointer_Bfield_cp(lev, 0),
+                                     get_pointer_Bfield_cp(lev, 1),
+                                     get_pointer_Bfield_cp(lev, 2) }, lev, patch_type);
         }
     }
 

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -276,12 +276,15 @@ using namespace amrex;
      *        The guard cell values are set equal and opposite to the valid cell
      *        field value at the respective mirror locations.
      *
-     * \param[in,out] Efield     Boundary values of tangential Efield are set to zero.
-     * \param[in]     lev        level of the Multifab
-     * \param[in]     patch_type coarse or fine
+     * \param[in,out] Efield          Boundary values of tangential Efield are set to zero
+     * \param[in]     lev             level of the Multifab
+     * \param[in]     patch_type      coarse or fine
+     * \param[in]     split_pml_field whether pml the multifab is the regular Efield or
+     *                                split pml field
      */
-    void ApplyPECtoEfield ( std::array<std::unique_ptr<amrex::MultiFab>, 3>& Efield,
-                            const int lev, PatchType patch_type);
+    void ApplyPECtoEfield ( std::array<amrex::MultiFab*, 3> Efield,
+                            const int lev, PatchType patch_type,
+                            bool split_pml_field = false);
     /**
      * \brief Sets the normal component of the magnetic field at the PEC boundary to zero.
      *        The guard cell values are set equal and opposite to the valid cell
@@ -291,7 +294,7 @@ using namespace amrex;
      * \param[in]     lev        level of the Multifab
      * \param[in]     patch_type coarse or fine
      */
-    void ApplyPECtoBfield ( std::array<std::unique_ptr<amrex::MultiFab>, 3>& Bfield,
+    void ApplyPECtoBfield ( std::array<amrex::MultiFab*, 3> Bfield,
                             const int lev, PatchType patch_type);
 }
 

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -284,7 +284,7 @@ using namespace amrex;
      */
     void ApplyPECtoEfield ( std::array<amrex::MultiFab*, 3> Efield,
                             const int lev, PatchType patch_type,
-                            bool split_pml_field = false);
+                            const bool split_pml_field = false);
     /**
      * \brief Sets the normal component of the magnetic field at the PEC boundary to zero.
      *        The guard cell values are set equal and opposite to the valid cell

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -25,7 +25,7 @@ PEC::isAnyBoundaryPEC() {
 
 void
 PEC::ApplyPECtoEfield (std::array<amrex::MultiFab*, 3> Efield, const int lev,
-                       PatchType patch_type, bool split_pml_field)
+                       PatchType patch_type, const bool split_pml_field)
 {
     auto& warpx = WarpX::GetInstance();
     amrex::Box domain_box = warpx.Geom(lev).Domain();
@@ -148,6 +148,10 @@ PEC::ApplyPECtoBfield (std::array<amrex::MultiFab*, 3> Bfield, const int lev,
         amrex::Array4<amrex::Real> const& Bz = Bfield[2]->array(mfi);
 
         // Extract tileboxes for which to loop
+        // For B-field used in Maxwell's update, nodal flag plus cells that particles
+        // gather fields from in the guard-cell region are included.
+        // Note that for simulations without particles or laser, ng_field_gather is 0
+        // and the guard-cell values of the B-field multifab will not be modified.
         amrex::Box const& tbx = mfi.tilebox(Bfield[0]->ixType().toIntVect(), ng_fieldgather);
         amrex::Box const& tby = mfi.tilebox(Bfield[1]->ixType().toIntVect(), ng_fieldgather);
         amrex::Box const& tbz = mfi.tilebox(Bfield[2]->ixType().toIntVect(), ng_fieldgather);

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -61,7 +61,7 @@ PEC::ApplyPECtoEfield (std::array<amrex::MultiFab*, 3> Efield, const int lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(*Efield[0], false); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*Efield[0], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         // Extract field data
         amrex::Array4<amrex::Real> const& Ex = Efield[0]->array(mfi);
         amrex::Array4<amrex::Real> const& Ey = Efield[1]->array(mfi);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -673,6 +673,7 @@ public:
     const amrex::IntVect getngUpdateAux() const { return guard_cells.ng_UpdateAux; }
     const amrex::IntVect get_ng_depos_J() const {return guard_cells.ng_depos_J;}
     const amrex::IntVect get_ng_depos_rho() const {return guard_cells.ng_depos_rho;}
+    const amrex::IntVect get_ng_fieldgather () const {return guard_cells.ng_FieldGather;}
 
     /** Coarsest-level Domain Decomposition
      *


### PR DESCRIPTION
This PR fixes a bug that is observed when pml boundary is adjacent to the pec boundary.

The input to reproduce this error : 
[inputs_pec_pml.txt](https://github.com/ECP-WarpX/WarpX/files/7514589/inputs_pec_pml.txt)

The absorption is not clean at the pml boundary (at zmax boundary in this case) when the adjacent boundaries are pec (ymin, and ymax boundary in this case)
![dev](https://user-images.githubusercontent.com/41089244/141159216-6667d5ae-4139-4695-a513-3f89f9ecf287.gif)

Extending the pec boundary into the pml region by applying pec to the splits fields fixes this issue
![fix](https://user-images.githubusercontent.com/41089244/141159313-47ea1371-9387-49c1-9659-70249170c8dd.gif)


