### PR TITLE
Do not call BTD at initialization.

### DIFF
--- a/Source/Diagnostics/MultiDiagnostics.H
+++ b/Source/Diagnostics/MultiDiagnostics.H
@@ -25,14 +25,24 @@ public:
     void ReadParameters ();
     /** \brief Loop over diags in alldiags and call their InitDiags */
     void InitData ();
-    /** \brief Called at each iteration. Compute diags and flush. */
-    void FilterComputePackFlush (int step, bool force_flush=false);
+    /** \brief Called at each iteration. Compute diags and flush.
+     *
+     * \param[in] step simulation timestep when diagnostics is invoked
+     * \param[in] force_flush     whether to enforce flushing data even if plot interval
+     *                            criterion is not satisfied
+     * \param[in] BackTranform    whether the diagnostics call is for regular or back transformed diagnostics
+     */
+    void FilterComputePackFlush (int step, bool force_flush=false, bool BackTransform=false);
     /** \brief Called only at the last iteration. Loop over each diag and if m_dump_last_timestep
-     *         is true, compute diags and flush with force_flush=true. */
+     *         is true, compute diags and flush with force_flush=true.
+     *
+     * \param[in] step last timestep when diagnostics is invoked
+     */
     void FilterComputePackFlushLastTimestep (int step);
     /** \brief Loop over diags in all diags and call their InitializeFieldFunctors.
-               Called when a new partitioning is generated at level, lev.
-      * \param[in] lev level at this the field functors are initialized.
+               Called when a new partitioning is generated at level, lev
+      *
+      * \param[in] lev mesh-refinement level at this the field functors are initialized
       */
     void InitializeFieldFunctors (int lev);
     /** Start a new iteration, i.e., dump has not been done yet. */

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -69,10 +69,18 @@ MultiDiagnostics::ReadParameters ()
 }
 
 void
-MultiDiagnostics::FilterComputePackFlush (int step, bool force_flush)
+MultiDiagnostics::FilterComputePackFlush (int step, bool force_flush, bool BackTransform)
 {
+    int i = 0;
     for (auto& diag : alldiags){
-        diag->FilterComputePackFlush (step, force_flush);
+        if (BackTransform == true) {
+            if (diags_types[i] == DiagTypes::BackTransformed)
+                diag->FilterComputePackFlush (step, force_flush);
+        } else {
+            if (diags_types[i] != DiagTypes::BackTransformed)
+                diags->FilterComputePackFlush (step, force_flush);
+        }
+        ++i;
     }
 }
 

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -78,7 +78,7 @@ MultiDiagnostics::FilterComputePackFlush (int step, bool force_flush, bool BackT
                 diag->FilterComputePackFlush (step, force_flush);
         } else {
             if (diags_types[i] != DiagTypes::BackTransformed)
-                diags->FilterComputePackFlush (step, force_flush);
+                diag->FilterComputePackFlush (step, force_flush);
         }
         ++i;
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -321,6 +321,10 @@ WarpX::Evolve (int numsteps)
             reduced_diags->ComputeDiags(step);
             reduced_diags->WriteToFile(step);
         }
+ 
+        // Calling backtransform diagnstics, passing step, force-flush=false, back-transform = true
+        multi_diags->FilterComputePackFlush( step, false, true );
+        // Calling regular diagnostics
         multi_diags->FilterComputePackFlush( step );
 
         // inputs: unused parameters (e.g. typos) check after step 1 has finished

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -321,7 +321,7 @@ WarpX::Evolve (int numsteps)
             reduced_diags->ComputeDiags(step);
             reduced_diags->WriteToFile(step);
         }
- 
+
         // Calling backtransform diagnstics, passing step, force-flush=false, back-transform = true
         multi_diags->FilterComputePackFlush( step, false, true );
         // Calling regular diagnostics


### PR DESCRIPTION
Issue #2382 showed that CI test was crashing for BTD. 
The Backtrace shows that BTD was crashing at the first initialization timestep, because the analysis was calling the full diagnostic at 0th timestep.

No buffer is filled at initialization, causing this crash.
This PR is an attempt to fix this, by adding a boolean for backtransform diagnostics. 
By default, a call to diagnostics using `FilterComputePackAndFlush` is for full diagnostics, unless we turn the boolean for back-transform to true.
A similar fix is already implemented in #1898 , with some differences since we call BTD before redistribute when collecting particle buffer in #1898.



