### PR TITLE
Regression Testing: Use Mainline & CMake

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
     BLASPP_HOME: '/usr/local'
     CEI_SUDO: 'sudo'
     CEI_TMP: '/tmp/cei'
+    CMAKE_GENERATOR: 'Ninja'
     FFTW_HOME: '/usr'
     LAPACKPP_HOME: '/usr/local'
     OMP_NUM_THREADS: 1
@@ -75,7 +76,8 @@ jobs:
       set -eu -o pipefail
       cat /proc/cpuinfo | grep "model name" | sort -u
       df -h
-      sudo apt install -y ccache curl gcc gfortran git g++ openmpi-bin libopenmpi-dev \
+      sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
+        openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
       ccache --set-config=max_size=10.0G

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,7 @@ endif()
 #
 
 # calling `python -m pip wheel .` and install re-using the build directory
-# note: this is mainly for our CI Python regression scrips, users and package
+# note: this is mainly for our CI Python regression scripts, users and package
 #       managers should just use `python -m pip wheel .` and `... install *whl`
 #       directly
 set(PYINSTALLOPTIONS "" CACHE STRING "Additional parameters to pass to `pip install`")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,25 @@ endif()
 #)
 
 
+# CI Helper ###################################################################
+#
+
+# calling `python -m pip wheel .` and install re-using the build directory
+# note: this is mainly for our CI Python regression scrips, users and package
+#       managers should just use `python -m pip wheel .` and `... install *whl`
+#       directly
+set(PYINSTALLOPTIONS "" CACHE STRING "Additional parameters to pass to `pip install`")
+add_custom_target(install_pip
+    ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY} python3 -m pip wheel -v --use-feature=in-tree-build ${WarpX_SOURCE_DIR}
+    COMMAND
+        python3 -m pip install --force-reinstall -v ${PYINSTALLOPTIONS} ${CMAKE_BINARY_DIR}/*whl
+    WORKING_DIRECTORY
+        ${CMAKE_BINARY_DIR}
+    DEPENDS
+        shared
+)
+
+
 # Tests #######################################################################
 #
 

--- a/Docs/source/developers/testing.rst
+++ b/Docs/source/developers/testing.rst
@@ -89,11 +89,12 @@ There are three steps to follow to add a new automated test (illustrated here fo
    runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee
    dim = 2
    addToCompileString =
+   cmakeSetupOpts = -DWarpX_DIMS=2
    restartTest = 0
    useMPI = 1
    numprocs = 2
    useOMP = 1
-   numthreads = 2
+   numthreads = 1
    compileTest = 0
    doVis = 0
    analysisRoutine = Examples/Tests/PML/analysis_pml_yee.py
@@ -104,8 +105,14 @@ If you re-use an existing input file, you can add arguments to ``runtime_params`
 
    If you added ``analysisRoutine = Examples/analysis_default_regression.py``, then run the new test case locally and add the :ref:`checksum <developers-checksum>` file for the expected output.
 
+.. note::
+
+   We run those tests on our continuous integration services, which at the moment only have 2 virtual CPU cores.
+   Thus, make sure that the product of ``numprocs`` and ``numthreads`` for a test is ``<=2``.
+
+
 Useful tool for plotfile comparison: ``fcompare``
---------------------------------------------------
+-------------------------------------------------
 
 AMReX provides ``fcompare``, an executable that takes two ``plotfiles`` as input and returns the absolute and relative difference for each field between these two plotfiles. For some changes in the code, it is very convenient to run the same input file with an old and your current version, and ``fcompare`` the plotfiles at the same iteration. To use it:
 

--- a/Examples/Modules/laser_injection_from_file/analysis.py
+++ b/Examples/Modules/laser_injection_from_file/analysis.py
@@ -218,7 +218,7 @@ def launch_analysis(executable):
 
 
 def main() :
-    executables = glob.glob("main2d*")
+    executables = glob.glob("*.ex")
     if len(executables) == 1 :
         launch_analysis(executables[0])
     else :

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -19,6 +19,10 @@ purge_output = 1
 MAKE = make
 numMakeJobs = 8
 
+# We build by default a few tools for output comparison.
+# The build time for those can be skipped if they are not needed.
+ftools =
+
 # Control the build of the particle_compare tool.
 # Needed for test particle_tolerance option.
 use_ctools = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -11,13 +11,16 @@ sourceTree = C_Src
 # suiteName is the name prepended to all output directories
 suiteName = WarpX
 
-COMP = g++
-add_to_c_make_command = TEST=TRUE USE_ASSERTION=TRUE WarpxBinDir=
-
 purge_output = 1
 
+useCmake = 1
+isSuperbuild = 1
 MAKE = make
 numMakeJobs = 8
+
+# We build by default a few tools for output comparison.
+# The build time for those can be skipped if they are not needed.
+ftools =
 
 # Control the build of the particle_compare tool.
 # Needed for test particle_tolerance option.
@@ -57,10 +60,7 @@ branch = 85284ea15a3c5ca7d6d8e3f1045ac1e5a48c6a19
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx
 branch = development
-
-[extra-PICSAR]
-dir = /home/regtester/AMReX_RegTesting/picsar/
-branch = 7b5449f92a4b30a095cc4a67f0a8b1fc69680e15
+cmakeSetupOpts = -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON
 
 # individual problems follow
 
@@ -70,6 +70,7 @@ inputFile = Examples/Tests/PML/inputs_2d
 runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee diag1.file_prefix=pml_x_yee_plt chk.file_prefix=pml_x_yee_chk
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 1
 restartFileNum = 150
 useMPI = 1
@@ -86,6 +87,7 @@ inputFile = Examples/Tests/PML/inputs_2d
 runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=ckc
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -101,6 +103,7 @@ inputFile = Examples/Tests/PML/inputs_2d
 runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 1
 restartFileNum = 150
 useMPI = 1
@@ -117,6 +120,7 @@ inputFile = Examples/Tests/PML/inputs_3d
 runtime_params = warpx.do_similar_dm_pml = 0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -132,6 +136,7 @@ inputFile = Examples/Tests/SilverMueller/inputs_2d_x
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -147,6 +152,7 @@ inputFile = Examples/Tests/SilverMueller/inputs_2d_z
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -162,6 +168,7 @@ inputFile = Examples/Tests/SilverMueller/inputs_rz_z
 runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -177,6 +184,7 @@ inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -193,6 +201,7 @@ inputFile = Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
 runtime_params =
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -211,6 +220,7 @@ inputFile = Examples/Modules/boosted_diags/inputs_3d_slice
 runtime_params =
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -229,6 +239,7 @@ inputFile = Examples/Modules/nci_corrector/inputs_2d
 runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -245,6 +256,7 @@ inputFile = Examples/Modules/nci_corrector/inputs_2d
 runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -261,6 +273,7 @@ inputFile = Examples/Modules/ionization/inputs_2d_rt
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -276,6 +289,7 @@ inputFile = Examples/Modules/ionization/inputs_2d_bf_rt
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -291,6 +305,7 @@ inputFile = Examples/Tests/SingleParticle/inputs_2d
 runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -306,6 +321,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = warpx.do_dynamic_scheduling=0
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -324,6 +340,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = warpx.do_dynamic_scheduling=0
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -342,6 +359,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -360,6 +378,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -378,6 +397,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F G
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -396,6 +416,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd algo.current_deposition=esirkepov psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -414,6 +435,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd algo.current_deposition=direct psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.do_nodal=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -432,6 +454,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd psatd.periodic_single_box_fft=1 algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -450,6 +473,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 psatd.periodic_single_box_fft=1 algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -468,6 +492,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -486,6 +511,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -504,6 +530,7 @@ inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
 dim = 3
 addToCompileString = USE_PSATD=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON -DWarpX_PRECISION=SINGLE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -522,6 +549,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -540,6 +568,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver = ckc  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -558,6 +587,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver = ckc  warpx.use_filter = 1  amr.max_level = 1 amr.ref_ratio_vect = 4 2 warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -576,6 +606,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -594,6 +625,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -612,6 +644,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -630,6 +663,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 algo.current_deposition=esirkepov psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot =Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -648,6 +682,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 algo.current_deposition=direct psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.do_nodal=1 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot =Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -666,6 +701,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 psatd.periodic_single_box_fft=1 algo.current_deposition=vay diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -684,6 +720,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 warpx.do_nodal=1 psatd.periodic_single_box_fft=1 algo.current_deposition=vay diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -702,6 +739,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -719,7 +757,8 @@ buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_1d_multi_rt
 runtime_params = algo.current_deposition=esirkepov diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
 dim = 1
-addToCompileString = USE_OPENPMD=TRUE
+addToCompileString = USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -738,6 +777,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
 runtime_params = diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0
 dim = 2
 addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -757,6 +797,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
 runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -776,6 +817,7 @@ inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
 runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 amr.max_grid_size=128 psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.fields_to_plot=jx jz Ex Ez By rho divE electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -796,6 +838,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -814,6 +858,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_runtime_component_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 1
 restartFileNum = 5
 useMPI = 1
@@ -831,6 +877,7 @@ inputFile = Examples/Modules/laser_injection/inputs_3d_rt
 runtime_params = max_step=20
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -848,6 +895,7 @@ inputFile = Examples/Modules/laser_injection/inputs_2d_rt
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -863,7 +911,8 @@ buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs_1d_rt
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 1
-addToCompileString = USE_OPENPMD=TRUE
+addToCompileString = USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -880,6 +929,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
 runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -897,6 +947,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_1d
 runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=256 max_step=100 electrons.zmin=10.e-6 warpx.serialize_ics=1
 dim = 1
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=1
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -914,6 +965,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
 runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1 warpx.do_single_precision_comms=1
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -931,6 +983,7 @@ inputFile = Examples/Tests/subcycling/inputs_2d
 runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -947,6 +1000,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
 runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -964,6 +1018,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
 runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6 warpx.refine_plasma=1
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -981,6 +1036,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
 runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -999,6 +1055,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir_rt.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1016,6 +1074,7 @@ inputFile = Examples/Physics_applications/uniform_plasma/inputs_3d
 runtime_params = chk.file_prefix=uniform_plasma_restart_chk
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 1
 restartFileNum = 6
 useMPI = 1
@@ -1034,6 +1093,7 @@ inputFile = Examples/Tests/restart/inputs
 runtime_params = chk.file_prefix=restart_chk
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 1
 restartFileNum = 5
 useMPI = 1
@@ -1052,6 +1112,7 @@ inputFile = Examples/Tests/restart/inputs
 runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 1
 restartFileNum = 5
 useMPI = 1
@@ -1070,6 +1131,7 @@ inputFile = Examples/Tests/restart/inputs
 runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 1
 restartFileNum = 5
 useMPI = 1
@@ -1087,6 +1149,7 @@ buildDir = .
 inputFile = Examples/Modules/space_charge_initialization/inputs_3d
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1104,6 +1167,7 @@ buildDir = .
 inputFile = Examples/Modules/space_charge_initialization/inputs_3d
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1121,6 +1185,7 @@ buildDir = .
 inputFile = Examples/Modules/relativistic_space_charge_initialization/inputs_3d
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1138,6 +1203,7 @@ buildDir = .
 inputFile = Examples/Tests/initial_plasma_profile/inputs
 dim = 2
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PRECISION=SINGLE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1155,6 +1221,7 @@ inputFile = Examples/Tests/divb_cleaning/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1170,6 +1237,7 @@ buildDir = .
 inputFile = Examples/Modules/dive_cleaning/inputs_3d
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1187,6 +1255,7 @@ buildDir = .
 inputFile = Examples/Modules/dive_cleaning/inputs_3d
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1205,6 +1274,7 @@ inputFile = Examples/Tests/particles_in_PML/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1222,6 +1292,7 @@ inputFile = Examples/Tests/particles_in_PML/inputs_mr_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1238,6 +1309,7 @@ inputFile = Examples/Tests/particles_in_PML/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1255,6 +1327,7 @@ inputFile = Examples/Tests/particles_in_PML/inputs_mr_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1271,6 +1344,7 @@ inputFile = Examples/Tests/photon_pusher/inputs_3d
 runtime_params = diag1.file_prefix=photon_pusher_plt
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1287,6 +1361,7 @@ inputFile = Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1304,6 +1379,7 @@ aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
 runtime_params =
 dim = 2
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1321,6 +1397,7 @@ aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
 runtime_params =
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1338,6 +1415,7 @@ aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
 runtime_params = diag1.format = openpmd diag1.openpmd_backend = h5
 dim = 2
 addToCompileString = QED=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_QED=ON -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1346,6 +1424,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
+outputFile = qed_breit_wheeler_2d_opmd_plt
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_opmd.py
 
 [qed_breit_wheeler_3d_opmd]
@@ -1355,6 +1434,7 @@ aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
 runtime_params = diag1.format = openpmd diag1.openpmd_backend = h5
 dim = 3
 addToCompileString = QED=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1363,6 +1443,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
+outputFile = qed_breit_wheeler_3d_opmd_plt
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_opmd.py
 
 [qed_quantum_sync_2d]
@@ -1371,6 +1452,7 @@ inputFile = Examples/Modules/qed/quantum_synchrotron/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1387,6 +1469,7 @@ inputFile = Examples/Modules/qed/quantum_synchrotron/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1403,6 +1486,7 @@ inputFile = Examples/Modules/qed/schwinger/inputs_3d_schwinger
 runtime_params = warpx.E_external_grid = 1.e16 0 0 warpx.B_external_grid = 16792888.570516706 5256650.141557486 18363530.799561853
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1418,6 +1502,7 @@ inputFile = Examples/Modules/qed/schwinger/inputs_3d_schwinger
 runtime_params = warpx.E_external_grid = 1.e18 0 0 warpx.B_external_grid = 1679288857.0516706 525665014.1557486 1836353079.9561853 qed_schwinger.xmin = -2.5e-7 qed_schwinger.xmax = 2.49e-7
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1433,6 +1518,7 @@ inputFile = Examples/Modules/qed/schwinger/inputs_3d_schwinger
 runtime_params = warpx.E_external_grid = 0 1.090934525450495e+17 0
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1448,6 +1534,7 @@ inputFile = Examples/Modules/qed/schwinger/inputs_3d_schwinger
 runtime_params = warpx.E_external_grid = 0 0 2.5e+20 warpx.B_external_grid = 0 833910140000. 0 qed_schwinger.ymin = -2.5e-7 qed_schwinger.zmax = 2.49e-7
 dim = 3
 addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1463,6 +1550,7 @@ inputFile = Examples/Tests/particle_pusher/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1480,6 +1568,8 @@ customRunCmd = python3 PICMI_inputs_gaussian_beam.py
 runtime_params =
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1498,6 +1588,8 @@ customRunCmd = python3 PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 runtime_params =
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1515,6 +1607,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 256 max_step=20
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1531,6 +1624,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1549,6 +1644,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration_mr.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1567,6 +1664,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1584,6 +1683,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 64 128 max_step=5
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1599,6 +1699,7 @@ inputFile = Examples/Physics_applications/plasma_mirror/inputs_2d
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=256 128 max_step=20
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1614,6 +1715,7 @@ inputFile = Examples/Physics_applications/laser_ion/inputs
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=384 512 max_step=100
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1629,6 +1731,7 @@ inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
 runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1646,6 +1749,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_rz
 runtime_params = diag1.electrons.variables=w ux uy uz diag1.beam.variables=w ux uy uz max_step=10
 dim = 2
 addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1664,6 +1768,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_laser_acceleration.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1682,6 +1788,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1699,6 +1807,7 @@ inputFile = Examples/Tests/laser_on_fine/inputs_2d
 runtime_params = max_step=50
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1714,6 +1823,7 @@ inputFile = Examples/Tests/RepellingParticles/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1729,6 +1839,7 @@ inputFile = Examples/Tests/Larmor/inputs_2d_mr
 runtime_params = max_step=10
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1744,6 +1855,7 @@ inputFile = Examples/Physics_applications/uniform_plasma/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1759,6 +1871,7 @@ inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_boost
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 512 max_step=20
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1776,6 +1889,7 @@ customRunCmd = ./analysis.py
 runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_OPENPMD=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1792,6 +1906,7 @@ inputFile = Examples/Tests/collision/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1809,6 +1924,7 @@ inputFile = Examples/Tests/collision/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1826,6 +1942,7 @@ inputFile = Examples/Tests/collision/inputs_rz
 runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1843,6 +1960,7 @@ inputFile = Examples/Tests/Maxwell_Hybrid_QED/inputs_2d
 runtime_params = warpx.cfl=0.7071067811865475
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1859,6 +1977,7 @@ aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1876,6 +1995,7 @@ aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1892,6 +2012,7 @@ inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1908,6 +2029,7 @@ inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1924,6 +2046,7 @@ inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Heuristic
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1940,6 +2063,7 @@ inputFile = Examples/Tests/galilean/inputs_2d
 runtime_params = warpx.do_nodal=1 algo.current_deposition=direct
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1957,6 +2081,7 @@ inputFile = Examples/Tests/galilean/inputs_2d
 runtime_params = psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1974,6 +2099,7 @@ inputFile = Examples/Tests/galilean/inputs_2d_hybrid
 runtime_params =
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1991,6 +2117,7 @@ inputFile = Examples/Tests/comoving/inputs_2d_hybrid
 runtime_params =
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2008,6 +2135,7 @@ inputFile = Examples/Tests/galilean/inputs_rz
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2025,6 +2153,7 @@ inputFile = Examples/Tests/galilean/inputs_rz
 runtime_params = psatd.periodic_single_box_fft=1 psatd.current_correction=1 electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2042,6 +2171,7 @@ inputFile = Examples/Tests/galilean/inputs_3d
 runtime_params = warpx.do_nodal=1 algo.current_deposition=direct
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2059,6 +2189,7 @@ inputFile = Examples/Tests/galilean/inputs_3d
 runtime_params = psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2076,6 +2207,7 @@ inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2093,6 +2225,7 @@ inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
 runtime_params = amr.max_grid_size_x = 128  amr.max_grid_size_y = 64  warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noz = 8
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2110,6 +2243,7 @@ inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
 runtime_params =
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2127,6 +2261,7 @@ inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
 runtime_params = warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noy = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noy = 8  interpolation.current_centering_noz = 8
 dim = 3
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2144,6 +2279,7 @@ inputFile = Examples/Tests/multi_J/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2161,6 +2297,7 @@ inputFile = Examples/Tests/multi_J/inputs_2d_pml
 runtime_params =
 dim = 2
 addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2178,6 +2315,7 @@ inputFile = Examples/Tests/multi_J/inputs_rz
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2196,6 +2334,7 @@ inputFile = Examples/Tests/ElectrostaticSphereEB/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2212,6 +2351,7 @@ inputFile = Examples/Tests/ElectrostaticSphereEB/inputs_rz
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2229,6 +2369,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2245,6 +2387,7 @@ inputFile = Examples/Tests/ElectrostaticSphereEB/inputs_3d_mixed_BCs
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2261,6 +2404,7 @@ inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2276,6 +2420,7 @@ buildDir = .
 inputFile = Examples/Tests/ElectrostaticSphere/inputs_rz
 dim = 2
 addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2292,6 +2437,7 @@ inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d
 runtime_params = warpx.do_electrostatic=labframe
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2308,6 +2454,7 @@ inputFile = Examples/Tests/embedded_circle/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2325,6 +2472,7 @@ inputFile = Examples/Tests/initial_distribution/inputs
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2342,6 +2490,7 @@ inputFile = Examples/Modules/resampling/inputs_leveling_thinning
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2358,6 +2507,7 @@ inputFile = Examples/Tests/boundaries/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2374,6 +2524,7 @@ inputFile = Examples/Modules/embedded_boundary_cube/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2390,6 +2541,7 @@ inputFile = Examples/Modules/embedded_boundary_cube/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2406,6 +2558,7 @@ inputFile = Examples/Modules/embedded_boundary_rotated_cube/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2422,6 +2575,7 @@ inputFile = Examples/Modules/embedded_boundary_rotated_cube/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2438,6 +2592,7 @@ inputFile = Examples/Tests/ElectrostaticDirichletBC/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2455,6 +2610,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2471,6 +2628,7 @@ inputFile = Examples/Tests/PEC/inputs_field_PEC_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2487,6 +2645,7 @@ inputFile = Examples/Tests/PEC/inputs_field_PEC_mr_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2503,6 +2662,7 @@ inputFile = Examples/Tests/PEC/inputs_particle_PEC_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2521,6 +2681,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2538,6 +2700,7 @@ inputFile = Examples/Tests/plasma_lens/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2555,6 +2718,7 @@ inputFile = Examples/Tests/plasma_lens/inputs_boosted_3d
 runtime_params =
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2572,6 +2736,7 @@ inputFile = Examples/Physics_applications/capacitive_discharge/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2590,6 +2755,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=ON
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2606,6 +2773,7 @@ inputFile = Examples/Modules/ParticleBoundaryProcess/inputs_absorption
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2623,6 +2791,7 @@ inputFile = Examples/Modules/ParticleBoundaryScrape/inputs_scrape
 runtime_params =
 dim = 3
 addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2641,6 +2810,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_scrape.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2659,6 +2830,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_reflection.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2675,6 +2848,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2691,6 +2866,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py --unique
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2707,6 +2884,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_prev_pos_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2723,6 +2902,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_1_uniform_rest_32ppc
 runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2740,6 +2920,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_2_uniform_rest_1ppc
 runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2757,6 +2938,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_3_uniform_drift_4ppc
 runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2774,6 +2956,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_4_labdiags_2ppc
 runtime_params = amr.n_cell=64 64 64 max_step=10 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2791,6 +2974,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_5_loadimbalance
 runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2808,6 +2992,7 @@ inputFile = Examples/Tests/PerformanceTests/automated_test_6_output_2ppc
 runtime_params = amr.n_cell=64 64 64 max_step=10
 dim = 3
 addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2826,6 +3011,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PSATD=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2843,6 +3030,8 @@ runtime_params =
 customRunCmd = python PICMI_inputs_EB_API.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = install_pip
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2859,6 +3048,7 @@ inputFile = Examples/Tests/scraping/inputs_rz
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Tools/Release/updatePICSAR.py
+++ b/Tools/Release/updatePICSAR.py
@@ -15,15 +15,6 @@ import sys
 
 import requests
 
-try:
-    from configupdater import ConfigUpdater
-except ImportError:
-    print("Warning: Cannot update .ini files without 'configupdater'")
-    print("Consider running 'python -m pip install configupdater'")
-    ConfigUpdater = None
-    sys.exit(1)
-
-
 # Maintainer Inputs ###########################################################
 
 print("""Hi there, this is a WarpX maintainer tool to update the source
@@ -103,37 +94,6 @@ if not REPLY in ["Y", "y"]:
 
 
 # Updates #####################################################################
-
-# run_test.sh (used also for Azure Pipelines)
-run_test_path = str(REPO_DIR.joinpath("run_test.sh"))
-with open(run_test_path, encoding='utf-8') as f:
-    run_test_content = f.read()
-    #   branch/commit/tag (git fetcher) version
-    #     cd picsar && git checkout COMMIT_TAG_OR_BRANCH && cd -
-    run_test_content = re.sub(
-        r'(.*cd\s+picsar.+git checkout\s+--detach\s+)(.+)(\s+&&\s.*)',
-        r'\g<1>{}\g<3>'.format(PICSAR_new_branch),
-        run_test_content, flags = re.MULTILINE)
-
-with open(run_test_path, "w", encoding='utf-8') as f:
-    f.write(run_test_content)
-
-if ConfigUpdater is not None:
-    # WarpX-tests.ini
-    tests_ini_path = str(REPO_DIR.joinpath("Regression/WarpX-tests.ini"))
-    cp = ConfigUpdater()
-    cp.optionxform = str
-    cp.read(tests_ini_path)
-    cp['extra-PICSAR']['branch'].value = PICSAR_new_branch
-    cp.update_file()
-
-    # WarpX-GPU-tests.ini
-    tests_gpu_ini_path = str(REPO_DIR.joinpath("Regression/WarpX-GPU-tests.ini"))
-    cp = ConfigUpdater()
-    cp.optionxform = str
-    cp.read(tests_gpu_ini_path)
-    cp['extra-PICSAR']['branch'].value = PICSAR_new_branch
-    cp.update_file()
 
 # WarpX references to PICSAR: cmake/dependencies/PICSAR.cmake
 with open(PICSAR_cmake_path, encoding='utf-8') as f:

--- a/run_test.sh
+++ b/run_test.sh
@@ -68,12 +68,9 @@ python3 -m pip install --upgrade pip setuptools wheel
 export SETUPTOOLS_USE_DISTUTILS="stdlib"
 python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
-# Clone PICSAR, AMReX and warpx-data
+# Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
 cd amrex && git checkout --detach 85284ea15a3c5ca7d6d8e3f1045ac1e5a48c6a19 && cd -
-# Use QED brach for QED tests
-git clone https://github.com/ECP-WarpX/picsar.git
-cd picsar && git checkout --detach 7b5449f92a4b30a095cc4a67f0a8b1fc69680e15 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -78,7 +78,7 @@ cd picsar && git checkout --detach 7b5449f92a4b30a095cc4a67f0a8b1fc69680e15 && c
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 
 # Clone the AMReX regression test utility
-git clone https://github.com/ECP-WarpX/regression_testing.git
+git clone https://github.com/AMReX-Codes/regression_testing.git
 
 # Prepare regression tests
 mkdir -p rt-WarpX/WarpX-benchmarks


### PR DESCRIPTION
## Mainline

- [x] use mainline repo
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/92
- [x] remove unused tools
  - [x] unused entries `tolerance = 1.e-14` and `particle_tolerance` -> our own checksums now (`rtol` in `checksum.evaluate`)
  - [x] set `self.use_ctools = 0` (default: `1`)
  - [x] expose and set `self.ftools = `
- [x] rebase after all fixes from https://github.com/ECP-WarpX/WarpX/pull/2653#issuecomment-990519921 are in
- [ ] modernize (can be a follow-up):
  - `Regression/prepare_file_ci.py`
  - `.github/workflows/source/test_ci_matrix.sh`
  - this will allow to remove old GNUmake-only keys like `dim =...` and `addToCompileString =` from `WarpX-tests.ini`

## CMake

- [x] transition to CMake
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/90
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/91
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/99
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/101
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/103
  - requires: post-install step for Python bindings
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/104
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/107
  - requires: https://github.com/AMReX-Codes/regression_testing/pull/110 / https://github.com/AMReX-Codes/regression_testing/pull/112
  - nice-to-have: https://github.com/AMReX-Codes/regression_testing/pull/102
  - nice-to-have: https://github.com/AMReX-Codes/regression_testing/pull/105
- [x] make sure this compiles the current checked out source and not `development`
- [ ] make sure compile time stays about the same -> to reasonable extent, extra `cmake` re-configure step needed atm until we re-group runs/cache executables as in https://github.com/AMReX-Codes/regression_testing/pull/69