### PR TITLE
Bug fixes and cleanup in load balancing

### DIFF
--- a/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
@@ -54,7 +54,7 @@ grid = picmi.Cartesian3DGrid(
     upper_boundary_conditions=['none', 'none', 'none'],
     lower_boundary_conditions_particles=['open', 'open', 'open'],
     upper_boundary_conditions_particles=['open', 'open', 'open'],
-    warpx_max_grid_size = 128
+    warpx_max_grid_size = 32
 )
 
 solver = picmi.ElectromagneticSolver(
@@ -86,7 +86,9 @@ sim = picmi.Simulation(
     solver = solver,
     max_steps = max_steps,
     warpx_embedded_boundary=embedded_boundary,
-    verbose=True
+    verbose=True,
+    warpx_load_balance_intervals=40,
+    warpx_load_balance_efficiency_ratio_threshold=0.9
 )
 
 sim.add_species(
@@ -112,8 +114,10 @@ sim.step(max_steps)
 
 from pywarpx import _libwarpx
 
+my_id = _libwarpx.libwarpx.warpx_getMyProc()
+
 n = _libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
-print("Number of electrons in buffer:", n)
+print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 612
 
 scraped_steps = _libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
@@ -121,11 +125,13 @@ for arr in scraped_steps:
     assert all(arr > 40)
 
 weights = _libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
-assert sum(len(arr) for arr in weights) == 612
+n = sum(len(arr) for arr in weights)
+print(f"Number of electrons in this proc's buffer (proc #{my_id}): {n}")
+assert n == 306
 
 # clear the particle buffer
 _libwarpx.libwarpx.warpx_clearParticleBoundaryBuffer()
 # confirm that the buffer was cleared
 n = _libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
-print("Number of electrons in buffer:", n)
+print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 0

--- a/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
@@ -113,6 +113,7 @@ sim.step(max_steps)
 ################################################
 
 from pywarpx import _libwarpx
+from mpi4py import MPI as mpi
 
 my_id = _libwarpx.libwarpx.warpx_getMyProc()
 
@@ -127,7 +128,8 @@ for arr in scraped_steps:
 weights = _libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
 n = sum(len(arr) for arr in weights)
 print(f"Number of electrons in this proc's buffer (proc #{my_id}): {n}")
-assert n == 306
+n_sum =  mpi.COMM_WORLD.allreduce(n, op=mpi.SUM)
+assert n_sum == 612
 
 # clear the particle buffer
 _libwarpx.libwarpx.warpx_clearParticleBoundaryBuffer()

--- a/Examples/Tests/embedded_circle/inputs_2d
+++ b/Examples/Tests/embedded_circle/inputs_2d
@@ -1,0 +1,92 @@
+# This is a 2D electrostatic simulation containing a circle embedded boundary at
+# the center of the grid domain, pre -seeded with equal density of argon ions
+# and electrons.
+
+max_step = 11
+warpx.const_dt = 3.99e-13
+warpx.do_electrostatic = labframe
+warpx.self_fields_required_precision = 1e-06
+warpx.eb_implicit_function = -((x-0.00005)**2+(z-0.00005)**2-1e-05**2)
+warpx.eb_potential(x,y,z,t) = -10
+warpx.self_fields_absolute_tolerance = 0.02
+
+# algo.load_balance_intervals = 5
+# algo.load_balance_efficiency_ratio_threshold = 1.001
+# algo.load_balance_with_sfc = 0
+# algo.load_balance_knapsack_factor = 2
+
+amr.n_cell = 128 128
+amr.max_grid_size = 16
+amr.max_level = 0
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0
+geometry.prob_hi = 0.0001 0.0001
+boundary.field_lo = pec periodic
+boundary.field_hi = pec periodic
+boundary.particle_lo = absorbing periodic
+boundary.particle_hi = absorbing periodic
+algo.particle_shape = 1
+
+particles.species_names = electrons ar_ions
+electrons.mass = m_e
+electrons.charge = -q_e
+electrons.injection_style = nuniformpercell
+electrons.initialize_self_fields = 1
+electrons.num_particles_per_cell_each_dim = 2 2
+electrons.density = 10.2e16
+electrons.momentum_distribution_type = gaussian
+electrons.profile = constant
+electrons.ux_m = 0.0
+electrons.uy_m = 0.0
+electrons.uz_m = 0.0
+electrons.ux_th = 0.0022492462021094224
+electrons.uy_th = 0.0022492462021094224
+electrons.uz_th = 0.0022492462021094224
+electrons.save_particles_at_zlo = 1
+electrons.save_particles_at_zhi = 1
+electrons.save_particles_at_eb = 1
+ar_ions.mass = 6.633520326333601e-26
+ar_ions.charge = q_e
+ar_ions.injection_style = nuniformpercell
+ar_ions.initialize_self_fields = 1
+ar_ions.num_particles_per_cell_each_dim = 2 2
+ar_ions.profile = constant
+ar_ions.density = 10.2e16
+ar_ions.momentum_distribution_type = gaussian
+ar_ions.ux_m = 0.0
+ar_ions.uy_m = 0.0
+ar_ions.uz_m = 0.0
+ar_ions.ux_th = 2.6285641070031447e-06
+ar_ions.uy_th = 2.6285641070031447e-06
+ar_ions.uz_th = 2.6285641070031447e-06
+ar_ions.save_particles_at_zlo = 1
+ar_ions.save_particles_at_zhi = 1
+ar_ions.save_particles_at_eb = 1
+
+collisions.collision_names = coll_electrons coll_ar_ions
+coll_electrons.type = background_mcc
+coll_electrons.species = electrons
+coll_electrons.background_density = 2.1458888524486985e+23
+coll_electrons.background_temperature = 450.00000000000006
+coll_electrons.background_mass = 6.633520326333601e-26
+coll_electrons.scattering_processes = excitation1 elastic ionization
+coll_electrons.excitation1_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/excitation_1.dat
+coll_electrons.excitation1_energy = 11.5
+coll_electrons.elastic_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/electron_scattering.dat
+coll_electrons.ionization_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/ionization.dat
+coll_electrons.ionization_energy = 15.7596112
+coll_electrons.ionization_species = ar_ions
+coll_ar_ions.type = background_mcc
+coll_ar_ions.species = ar_ions
+coll_ar_ions.background_density = 2.1458888524486985e+23
+coll_ar_ions.background_temperature = 450.00000000000006
+coll_ar_ions.scattering_processes = back elastic charge_exchange
+coll_ar_ions.back_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/ion_back_scatter.dat
+coll_ar_ions.elastic_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/ion_scattering.dat
+coll_ar_ions.charge_exchange_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/charge_exchange.dat
+
+diagnostics.diags_names = diag1
+diag1.diag_type = Full
+diag1.format = plotfile
+diag1.intervals = 1
+diag1.fields_to_plot = phi rho_electrons rho_ar_ions

--- a/Regression/Checksum/benchmarks_json/embedded_circle.json
+++ b/Regression/Checksum/benchmarks_json/embedded_circle.json
@@ -1,0 +1,27 @@
+{
+  "ar_ions": {
+    "particle_cpu": 31740.0,
+    "particle_id": 3219770578.0,
+    "particle_momentum_x": 2.661332598290843e-18,
+    "particle_momentum_y": 2.6484537197836753e-18,
+    "particle_momentum_z": 2.6446763485694346e-18,
+    "particle_position_x": 3.174118714858889,
+    "particle_position_y": 3.174074331596828,
+    "particle_weight": 988031616.2109375
+  },
+  "electrons": {
+    "particle_cpu": 30737.0,
+    "particle_id": 1041042475.0,
+    "particle_momentum_x": 3.014851468379113e-20,
+    "particle_momentum_y": 3.016132024233842e-20,
+    "particle_momentum_z": 3.0169481587733156e-20,
+    "particle_position_x": 3.0760407489559514,
+    "particle_position_y": 3.072305059445631,
+    "particle_weight": 956794738.7695312
+  },
+  "lev=0": {
+    "phi": 56888.72655917703,
+    "rho_ar_ions": 257.78992245244984,
+    "rho_electrons": 250.2854445348176
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2558,7 +2558,7 @@ dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
 restartTest = 0
 useMPI = 1
-numprocs = 1
+numprocs = 2
 useOMP = 1
 numthreads = 1
 compileTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2245,6 +2245,24 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
 tolerance = 1.e-12
 
+[embedded_circle]
+buildDir = .
+inputFile = Examples/Tests/embedded_circle/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString = USE_EB=TRUE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ar_ions
+analysisRoutine = Examples/analysis_default_regression.py
+tolerance = 1.e-12
+
 [initial_distribution]
 buildDir = .
 inputFile = Examples/Tests/initial_distribution/inputs

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -103,8 +103,8 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     for (int lev = 0; lev <= max_level; lev++) {
         BoxArray nba = boxArray(lev);
         nba.surroundingNodes();
-        rho[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, ng);
-        phi[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, 1);
+        rho[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, ng);
+        phi[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, 1);
         phi[lev]->setVal(0.);
     }
 
@@ -269,7 +269,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
 
         amrex::BoxArray nba = boxArray(lev);
         nba.enclosedCells(); // Get cell centered array (correct?)
-        sigma[lev] = std::make_unique<MultiFab>(nba, dmap[lev], 1, 0);
+        sigma[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, 0);
         for ( MFIter mfi(*sigma[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
             const amrex::Box& tbx = mfi.tilebox();
@@ -318,7 +318,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
     setPhiBC(phi, phi_bc_values_lo, phi_bc_values_hi);
 
     // Define the linear operator (Poisson operator)
-    MLNodeLaplacian linop( geom_scaled, boxArray(), dmap );
+    MLNodeLaplacian linop( geom_scaled, boxArray(), DistributionMap() );
 
     for (int lev = 0; lev <= max_level; ++lev) {
         linop.setSigma( lev, *sigma[lev] );
@@ -413,7 +413,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     for (int lev = 0; lev <= max_level; ++lev) {
       eb_factory[lev] = &WarpX::fieldEBFactory(lev);
     }
-    MLEBNodeFDLaplacian linop( Geom(), boxArray(), dmap, info, eb_factory);
+    MLEBNodeFDLaplacian linop( Geom(), boxArray(), DistributionMap(), info, eb_factory);
 
     // Note: this assumes that the beam is propagating along
     // one of the axes of the grid, i.e. that only *one* of the Cartesian

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -485,42 +485,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     }
 
 #ifdef AMREX_USE_EB
-    if(lev==maxLevel()) {
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
-
-            ComputeEdgeLengths();
-            ComputeFaceAreas();
-            ScaleEdges();
-            ScaleAreas();
-
-            const auto &period = Geom(lev).periodicity();
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][0], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][1], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][2], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][0], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][1], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][2], guard_cells.ng_alloc_EB, period);
-
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][2], guard_cells.ng_alloc_EB, period);
-                MarkCells();
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][2], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][2], guard_cells.ng_alloc_EB, period);
-                ComputeFaceExtensions();
-            }
-        }
-
-        ComputeDistanceToEB();
-
-    }
+    InitializeEBGridData(lev);
 #endif
 
     // if the input string for the B-field is "parse_b_ext_grid_function",
@@ -867,5 +832,45 @@ void WarpX::CheckGuardCells(amrex::MultiFab const& mf)
                << " or increase the grid size by changing domain decomposition";
             amrex::Abort(ss.str());
         }
+    }
+}
+
+void WarpX::InitializeEBGridData(int lev)
+{
+    if(lev==maxLevel()) {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+
+            ComputeEdgeLengths();
+            ComputeFaceAreas();
+            ScaleEdges();
+            ScaleAreas();
+
+            const auto &period = Geom(lev).periodicity();
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][0], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][1], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][2], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][0], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][1], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][2], guard_cells.ng_alloc_EB, period);
+
+            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][2], guard_cells.ng_alloc_EB, period);
+                MarkCells();
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][2], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][2], guard_cells.ng_alloc_EB, period);
+                ComputeFaceExtensions();
+            }
+        }
+
+        ComputeDistanceToEB();
+
     }
 }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -171,12 +171,19 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            RemakeMultiFab(Venl[lev][idim], dm, false);
-            RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
-            RemakeMultiFab(m_face_areas[lev][idim], dm, false);
-            RemakeMultiFab(m_flag_info_face[lev][idim], dm, false);
-            RemakeMultiFab(m_flag_ext_face[lev][idim], dm, false);
-            RemakeMultiFab(m_area_mod[lev][idim], dm, false);
+            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee || 
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT || 
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){ 
+                RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
+                RemakeMultiFab(m_face_areas[lev][idim], dm, false);
+                if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+                    RemakeMultiFab(Venl[lev][idim], dm, false);
+                    RemakeMultiFab(m_flag_info_face[lev][idim], dm, false);
+                    RemakeMultiFab(m_flag_ext_face[lev][idim], dm, false);
+                    RemakeMultiFab(m_area_mod[lev][idim], dm, false);
+                    RemakeMultiFab(ECTRhofield[lev][idim], dm, false);
+                }
+            }
 #endif
         }
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -144,6 +144,17 @@ WarpX::LoadBalance ()
 }
 
 
+template <typename MultiFabType> void
+RemakeMultiFab (std::unique_ptr<MultiFabType>& mf, const DistributionMapping& dm,
+                const bool redistribute)
+{
+    if (mf == nullptr) return;
+    const IntVect& ng = mf->nGrowVect();
+    auto pmf = std::make_unique<MultiFabType>(mf->boxArray(), dm, mf->nComp(), ng);
+    if (redistribute) pmf->Redistribute(*mf, 0, 0, mf->nComp(), ng);
+    mf = std::move(pmf);
+}
+
 void
 WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const DistributionMapping& dm)
 {
@@ -324,17 +335,6 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 
     // Reduced diagnostics
     // not needed yet
-}
-
-template <typename MultiFabType> void
-WarpX::RemakeMultiFab (std::unique_ptr<MultiFabType>& mf, const DistributionMapping& dm,
-                       const bool redistribute)
-{
-    if (mf == nullptr) return;
-    const IntVect& ng = mf->nGrowVect();
-    auto pmf = std::make_unique<MultiFabType>(mf->boxArray(), dm, mf->nComp(), ng);
-    if (redistribute) pmf->Redistribute(*mf, 0, 0, mf->nComp(), ng);
-    mf = std::move(pmf);
 }
 
 void

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -184,7 +184,6 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                     RemakeMultiFab(ECTRhofield[lev][idim], dm, false);
                     m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, Bfield_fp[lev][idim]->ixType().toIntVect()), dm);
                 }
-
             }
 #endif
         }
@@ -201,20 +200,26 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         m_field_factory[lev] = amrex::makeEBFabFactory(Geom(lev), ba, dm,
                                                        {1,1,1}, // Not clear how many ghost cells we need yet
                                                        amrex::EBSupport::full);
-        ComputeEdgeLengths();
-        ComputeFaceAreas();
-        ScaleEdges();
-        ScaleAreas();
-        ComputeDistanceToEB();
 
-        // Since we have reset m_borrowing we need to recompute the extensions.
-        // To do so we need to recompute m_flag_ext_face since it has been changed
-        // since the last time ComputeFaceExtensions has been called. For this reason
-        // we call MarkCells before ComputeFaceExtensions
-        if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
-            MarkCells();
-            ComputeFaceExtensions();
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
+
+            ComputeEdgeLengths();
+            ComputeFaceAreas();
+            ScaleEdges();
+            ScaleAreas();
+
+            // Since we have reset m_borrowing we need to recompute the extensions.
+            // To do so we need to recompute m_flag_ext_face since it has been changed
+            // since the last time ComputeFaceExtensions was called. For this reason
+            // we call MarkCells before ComputeFaceExtensions
+            if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+                MarkCells();
+                ComputeFaceExtensions();
+            }
         }
+        ComputeDistanceToEB();
 #else
         m_field_factory[lev] = std::make_unique<FArrayBoxFactory>();
 #endif

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -169,7 +169,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 #endif
         }
 
-        RemakeMultiFab(F_fp[lev], dm);
+        RemakeMultiFab(F_fp[lev], dm, true);
         RemakeMultiFab(rho_fp[lev], dm, false);
         // phi_fp should be redistributed since we use the solution from
         // the last step as the initial guess for the next solve

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -183,6 +183,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                     RemakeMultiFab(m_area_mod[lev][idim], dm, false);
                     RemakeMultiFab(ECTRhofield[lev][idim], dm, false);
                 }
+
+                m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, Bfield_fp[lev][idim]->ixType().toIntVect()), dm);
+
             }
 #endif
         }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -10,6 +10,7 @@
 
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
+#include "Parallelization/WarpXCommUtil.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -210,12 +211,29 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             ScaleEdges();
             ScaleAreas();
 
+            const auto &period = Geom(lev).periodicity();
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][0], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][1], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][2], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][0], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][1], guard_cells.ng_alloc_EB, period);
+            WarpXCommUtil::FillBoundary(*m_face_areas[lev][2], guard_cells.ng_alloc_EB, period);
+
             // Since we have reset m_borrowing we need to recompute the extensions.
             // To do so we need to recompute m_flag_ext_face since it has been changed
             // since the last time ComputeFaceExtensions was called. For this reason
             // we call MarkCells before ComputeFaceExtensions
             if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_area_mod[lev][2], guard_cells.ng_alloc_EB, period);
                 MarkCells();
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][2], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][0], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][1], guard_cells.ng_alloc_EB, period);
+                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][2], guard_cells.ng_alloc_EB, period);
                 ComputeFaceExtensions();
             }
         }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -11,6 +11,7 @@
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 #include "Particles/MultiParticleContainer.H"
+#include "Particles/ParticleBoundaryBuffer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -130,6 +131,9 @@ WarpX::LoadBalance ()
     {
         mypc->Redistribute();
         mypc->defineAllParticleTiles();
+
+        // redistribute particle boundary buffer
+        m_particle_boundary_buffer->redistribute();
 
         // diagnostics & reduced diagnostics
         // not yet needed:

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -147,7 +147,31 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
     {
         if (ParallelDescriptor::NProcs() == 1) return;
 
+        // Fine patch
+        for (int idim=0; idim < 3; ++idim)
+        {
+            RemakeMultiFab(Bfield_fp[lev][idim], dm, true);
+            RemakeMultiFab(Efield_fp[lev][idim], dm, true);
+            RemakeMultiFab(current_fp[lev][idim], dm, false);
+            RemakeMultiFab(current_store[lev][idim], dm, false);
+
 #ifdef AMREX_USE_EB
+            RemakeMultiFab(Venl[lev][idim], dm, false);
+            RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
+            RemakeMultiFab(m_face_areas[lev][idim], dm, false);
+            RemakeiMultiFab(m_flag_info_face[lev][idim], dm, false);
+            RemakeiMultiFab(m_flag_ext_face[lev][idim], dm, false);
+            RemakeMultiFab(m_area_mod[lev][idim], dm, false);
+#endif
+        }
+
+        RemakeMultiFab(F_fp[lev], dm);
+        RemakeMultiFab(rho_fp[lev], dm, false);
+        RemakeMultiFab(phi_fp[lev], dm, false);
+
+#ifdef AMREX_USE_EB
+        RemakeMultiFab(m_distance_to_eb[lev], dm, false);
+
         m_field_factory[lev] = amrex::makeEBFabFactory(Geom(lev), ba, dm,
                                                        {1,1,1}, // Not clear how many ghost cells we need yet
                                                        amrex::EBSupport::full);
@@ -159,63 +183,6 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 #else
         m_field_factory[lev] = std::make_unique<FArrayBoxFactory>();
 #endif
-
-        // Fine patch
-        for (int idim=0; idim < 3; ++idim)
-        {
-            {
-                const IntVect& ng = Bfield_fp[lev][idim]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(Bfield_fp[lev][idim]->boxArray(),
-                                                                  dm, Bfield_fp[lev][idim]->nComp(), ng);
-                pmf->Redistribute(*Bfield_fp[lev][idim], 0, 0, Bfield_fp[lev][idim]->nComp(), ng);
-                Bfield_fp[lev][idim] = std::move(pmf);
-            }
-            {
-                const IntVect& ng = Efield_fp[lev][idim]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(Efield_fp[lev][idim]->boxArray(),
-                                                      dm, Efield_fp[lev][idim]->nComp(), ng);
-                pmf->Redistribute(*Efield_fp[lev][idim], 0, 0, Efield_fp[lev][idim]->nComp(), ng);
-                Efield_fp[lev][idim] = std::move(pmf);
-            }
-            {
-                const IntVect& ng = current_fp[lev][idim]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(current_fp[lev][idim]->boxArray(),
-                                                      dm, current_fp[lev][idim]->nComp(), ng);
-                current_fp[lev][idim] = std::move(pmf);
-            }
-            if (current_store[lev][idim])
-            {
-                const IntVect& ng = current_store[lev][idim]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(current_store[lev][idim]->boxArray(),
-                                                      dm, current_store[lev][idim]->nComp(), ng);
-                // no need to redistribute
-                current_store[lev][idim] = std::move(pmf);
-            }
-        }
-
-        if (F_fp[lev] != nullptr) {
-            const IntVect& ng = F_fp[lev]->nGrowVect();
-            auto pmf = std::make_unique<MultiFab>(F_fp[lev]->boxArray(),
-                                                              dm, F_fp[lev]->nComp(), ng);
-            pmf->Redistribute(*F_fp[lev], 0, 0, F_fp[lev]->nComp(), ng);
-            F_fp[lev] = std::move(pmf);
-        }
-
-        if (rho_fp[lev] != nullptr) {
-            const int nc = rho_fp[lev]->nComp();
-            const IntVect& ng = rho_fp[lev]->nGrowVect();
-            auto pmf = std::make_unique<MultiFab>(rho_fp[lev]->boxArray(),
-                                                              dm, nc, ng);
-            rho_fp[lev] = std::move(pmf);
-        }
-
-        if (phi_fp[lev] != nullptr) {
-            const int nc = phi_fp[lev]->nComp();
-            const IntVect& ng = phi_fp[lev]->nGrowVect();
-            auto pmf = std::make_unique<MultiFab>(phi_fp[lev]->boxArray(),
-                                                              dm, nc, ng);
-            phi_fp[lev] = std::move(pmf);
-        }
 
 #ifdef WARPX_USE_PSATD
         if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
@@ -261,20 +228,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         } else {
             for (int idim=0; idim < 3; ++idim)
             {
-                {
-                    const IntVect& ng = Bfield_aux[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Bfield_aux[lev][idim]->boxArray(),
-                                                                      dm, Bfield_aux[lev][idim]->nComp(), ng);
-                    // pmf->Redistribute(*Bfield_aux[lev][idim], 0, 0, Bfield_aux[lev][idim]->nComp(), ng);
-                    Bfield_aux[lev][idim] = std::move(pmf);
-                }
-                {
-                    const IntVect& ng = Efield_aux[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Efield_aux[lev][idim]->boxArray(),
-                                                                      dm, Efield_aux[lev][idim]->nComp(), ng);
-                    // pmf->Redistribute(*Efield_aux[lev][idim], 0, 0, Efield_aux[lev][idim]->nComp(), ng);
-                    Efield_aux[lev][idim] = std::move(pmf);
-                }
+                RemakeMultiFab(Bfield_aux[lev][idim], dm, false);
+                RemakeMultiFab(Efield_aux[lev][idim], dm, false);
             }
         }
 
@@ -282,43 +237,12 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         if (lev > 0) {
             for (int idim=0; idim < 3; ++idim)
             {
-                {
-                    const IntVect& ng = Bfield_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Bfield_cp[lev][idim]->boxArray(),
-                                                                      dm, Bfield_cp[lev][idim]->nComp(), ng);
-                    pmf->Redistribute(*Bfield_cp[lev][idim], 0, 0, Bfield_cp[lev][idim]->nComp(), ng);
-                    Bfield_cp[lev][idim] = std::move(pmf);
-                }
-                {
-                    const IntVect& ng = Efield_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Efield_cp[lev][idim]->boxArray(),
-                                                                      dm, Efield_cp[lev][idim]->nComp(), ng);
-                    pmf->Redistribute(*Efield_cp[lev][idim], 0, 0, Efield_cp[lev][idim]->nComp(), ng);
-                    Efield_cp[lev][idim] = std::move(pmf);
-                }
-                {
-                    const IntVect& ng = current_cp[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(current_cp[lev][idim]->boxArray(),
-                                                                       dm, current_cp[lev][idim]->nComp(), ng);
-                    current_cp[lev][idim] = std::move(pmf);
-                }
+                RemakeMultiFab(Bfield_cp[lev][idim], dm, true);
+                RemakeMultiFab(Efield_cp[lev][idim], dm, true);
+                RemakeMultiFab(current_cp[lev][idim], dm, false);
             }
-
-            if (F_cp[lev] != nullptr) {
-                const IntVect& ng = F_cp[lev]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(F_cp[lev]->boxArray(),
-                                                                  dm, F_cp[lev]->nComp(), ng);
-                pmf->Redistribute(*F_cp[lev], 0, 0, F_cp[lev]->nComp(), ng);
-                F_cp[lev] = std::move(pmf);
-            }
-
-            if (rho_cp[lev] != nullptr) {
-                const int nc = rho_cp[lev]->nComp();
-                const IntVect& ng = rho_cp[lev]->nGrowVect();
-                auto pmf  = std::make_unique<MultiFab>(rho_cp[lev]->boxArray(),
-                                                                  dm, nc, ng);
-                rho_cp[lev] = std::move(pmf);
-            }
+            RemakeMultiFab(F_cp[lev], dm, true);
+            RemakeMultiFab(rho_cp[lev], dm, false);
 
 #ifdef WARPX_USE_PSATD
             if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
@@ -358,57 +282,14 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         if (lev > 0 && (n_field_gather_buffer > 0 || n_current_deposition_buffer > 0)) {
             for (int idim=0; idim < 3; ++idim)
             {
-                if (Bfield_cax[lev][idim])
-                {
-                    const IntVect& ng = Bfield_cax[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Bfield_cax[lev][idim]->boxArray(),
-                                                                      dm, Bfield_cax[lev][idim]->nComp(), ng);
-                    // pmf->ParallelCopy(*Bfield_cax[lev][idim], 0, 0, Bfield_cax[lev][idim]->nComp(), ng, ng);
-                    Bfield_cax[lev][idim] = std::move(pmf);
-                }
-                if (Efield_cax[lev][idim])
-                {
-                    const IntVect& ng = Efield_cax[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(Efield_cax[lev][idim]->boxArray(),
-                                                                      dm, Efield_cax[lev][idim]->nComp(), ng);
-                    // pmf->ParallelCopy(*Efield_cax[lev][idim], 0, 0, Efield_cax[lev][idim]->nComp(), ng, ng);
-                    Efield_cax[lev][idim] = std::move(pmf);
-                }
-                if (current_buf[lev][idim])
-                {
-                    const IntVect& ng = current_buf[lev][idim]->nGrowVect();
-                    auto pmf = std::make_unique<MultiFab>(current_buf[lev][idim]->boxArray(),
-                                                                      dm, current_buf[lev][idim]->nComp(), ng);
-                    // pmf->ParallelCopy(*current_buf[lev][idim], 0, 0, current_buf[lev][idim]->nComp(), ng, ng);
-                    current_buf[lev][idim] = std::move(pmf);
-                }
+                RemakeMultiFab(Bfield_cax[lev][idim], dm, false);
+                RemakeMultiFab(Efield_cax[lev][idim], dm, false);
+                RemakeMultiFab(current_buf[lev][idim], dm, false);
             }
-            if (charge_buf[lev])
-            {
-                const IntVect& ng = charge_buf[lev]->nGrowVect();
-                auto pmf = std::make_unique<MultiFab>(charge_buf[lev]->boxArray(),
-                                                                  dm, charge_buf[lev]->nComp(), ng);
-                // pmf->ParallelCopy(*charge_buf[lev][idim], 0, 0, charge_buf[lev]->nComp(), ng, ng);
-                charge_buf[lev] = std::move(pmf);
-            }
-            if (current_buffer_masks[lev])
-            {
-                const IntVect& ng = current_buffer_masks[lev]->nGrowVect();
-                auto pmf = std::make_unique<iMultiFab>(current_buffer_masks[lev]->boxArray(),
-                                                                    dm, current_buffer_masks[lev]->nComp(), ng);
-                // we can avoid this since we immediately re-build the values via BuildBufferMasks()
-                // pmf->Redistribute(*current_buffer_masks[lev], 0, 0, current_buffer_masks[lev]->nComp(), ng);
-                current_buffer_masks[lev] = std::move(pmf);
-            }
-            if (gather_buffer_masks[lev])
-            {
-                const IntVect& ng = gather_buffer_masks[lev]->nGrowVect();
-                auto pmf = std::make_unique<iMultiFab>(gather_buffer_masks[lev]->boxArray(),
-                                                                    dm, gather_buffer_masks[lev]->nComp(), ng);
-                // we can avoid this since we immediately re-build the values via BuildBufferMasks()
-                // pmf->Redistribute(*gather_buffer_masks[lev], 0, 0, gather_buffer_masks[lev]->nComp(), ng);
-                gather_buffer_masks[lev] = std::move(pmf);
-            }
+            RemakeMultiFab(charge_buf[lev], dm, false);
+            RemakeiMultiFab(current_buffer_masks[lev], dm, false);
+            RemakeiMultiFab(gather_buffer_masks[lev], dm, false);
+
             if (current_buffer_masks[lev] || gather_buffer_masks[lev])
                 BuildBufferMasks();
         }
@@ -439,6 +320,28 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 }
 
 void
+WarpX::RemakeMultiFab (std::unique_ptr<amrex::MultiFab>& mf, const DistributionMapping& dm,
+                       const bool redistribute)
+{
+    if (mf == nullptr) return;
+    const IntVect& ng = mf->nGrowVect();
+    auto pmf = std::make_unique<MultiFab>(mf->boxArray(), dm, mf->nComp(), ng);
+    if (redistribute) pmf->Redistribute(*mf, 0, 0, mf->nComp(), ng);
+    mf = std::move(pmf);
+}
+
+void
+WarpX::RemakeiMultiFab (std::unique_ptr<amrex::iMultiFab>& mf, const DistributionMapping& dm,
+                        const bool redistribute)
+{
+    if (mf == nullptr) return;
+    const IntVect& ng = mf->nGrowVect();
+    auto pmf = std::make_unique<iMultiFab>(mf->boxArray(), dm, mf->nComp(), ng);
+    if (redistribute) pmf->Redistribute(*mf, 0, 0, mf->nComp(), ng);
+    mf = std::move(pmf);
+}
+
+void
 WarpX::ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<amrex::Real> > >& a_costs)
 {
     for (int lev = 0; lev <= finest_level; ++lev)
@@ -458,7 +361,7 @@ WarpX::ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<am
             }
         }
 
-        //Cell loop
+        // Cell loop
         MultiFab* Ex = Efield_fp[lev][0].get();
         for (MFIter mfi(*Ex, false); mfi.isValid(); ++mfi)
         {

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -171,9 +171,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee || 
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT || 
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){ 
+            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
                 RemakeMultiFab(m_face_areas[lev][idim], dm, false);
                 if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -206,6 +206,15 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         ScaleEdges();
         ScaleAreas();
         ComputeDistanceToEB();
+
+        // Since we have reset m_borrowing we need to recompute the extensions.
+        // To do so we need to recompute m_flag_ext_face since it has been changed
+        // since the last time ComputeFaceExtensions has been called. For this reason
+        // we call MarkCells before ComputeFaceExtensions
+        if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+            MarkCells();
+            ComputeFaceExtensions();
+        }
 #else
         m_field_factory[lev] = std::make_unique<FArrayBoxFactory>();
 #endif

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -171,7 +171,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 
         RemakeMultiFab(F_fp[lev], dm);
         RemakeMultiFab(rho_fp[lev], dm, false);
-        RemakeMultiFab(phi_fp[lev], dm, false);
+        // phi_fp should be redistributed since we use the solution from
+        // the last step as the initial guess for the next solve
+        RemakeMultiFab(phi_fp[lev], dm, true);
 
 #ifdef AMREX_USE_EB
         RemakeMultiFab(m_distance_to_eb[lev], dm, false);

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -182,9 +182,8 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                     RemakeMultiFab(m_flag_ext_face[lev][idim], dm, false);
                     RemakeMultiFab(m_area_mod[lev][idim], dm, false);
                     RemakeMultiFab(ECTRhofield[lev][idim], dm, false);
+                    m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, Bfield_fp[lev][idim]->ixType().toIntVect()), dm);
                 }
-
-                m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, Bfield_fp[lev][idim]->ixType().toIntVect()), dm);
 
             }
 #endif

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -10,7 +10,6 @@
 
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -202,42 +201,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                                                        {1,1,1}, // Not clear how many ghost cells we need yet
                                                        amrex::EBSupport::full);
 
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
-
-            ComputeEdgeLengths();
-            ComputeFaceAreas();
-            ScaleEdges();
-            ScaleAreas();
-
-            const auto &period = Geom(lev).periodicity();
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][0], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][1], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][2], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][0], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][1], guard_cells.ng_alloc_EB, period);
-            WarpXCommUtil::FillBoundary(*m_face_areas[lev][2], guard_cells.ng_alloc_EB, period);
-
-            // Since we have reset m_borrowing we need to recompute the extensions.
-            // To do so we need to recompute m_flag_ext_face since it has been changed
-            // since the last time ComputeFaceExtensions was called. For this reason
-            // we call MarkCells before ComputeFaceExtensions
-            if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_area_mod[lev][2], guard_cells.ng_alloc_EB, period);
-                MarkCells();
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_info_face[lev][2], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][0], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][1], guard_cells.ng_alloc_EB, period);
-                WarpXCommUtil::FillBoundary(*m_flag_ext_face[lev][2], guard_cells.ng_alloc_EB, period);
-                ComputeFaceExtensions();
-            }
-        }
-        ComputeDistanceToEB();
+        InitializeEBGridData(lev);
 #else
         m_field_factory[lev] = std::make_unique<FArrayBoxFactory>();
 #endif

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -36,6 +36,7 @@ public:
     void gatherParticles (MultiParticleContainer& mypc,
                           const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
 
+    void redistribute ();
     void clearParticles ();
 
     void printNumParticles () const;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -112,6 +112,20 @@ void ParticleBoundaryBuffer::printNumParticles () const {
 #endif
 }
 
+void ParticleBoundaryBuffer::redistribute () {
+    for (int i = 0; i < numBoundaries(); ++i)
+    {
+        auto& buffer = m_particle_containers[i];
+        for (int ispecies = 0; ispecies < numSpecies(); ++ispecies)
+        {
+            auto& species_buffer = buffer[ispecies];
+            if (species_buffer.isDefined()) {
+                species_buffer.Redistribute();
+            }
+        }
+    }
+}
+
 void ParticleBoundaryBuffer::clearParticles () {
     for (int i = 0; i < numBoundaries(); ++i)
     {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -822,7 +822,7 @@ protected:
     template <typename MultiFabType>
     void RemakeMultiFab (std::unique_ptr<MultiFabType>& mf,
                          const amrex::DistributionMapping& dm,
-                         const bool redistribute = true);
+                         const bool redistribute);
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -819,10 +819,6 @@ protected:
     //! data.  Called by AmrCore::regrid.
     virtual void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
                               const amrex::DistributionMapping& dm) final;
-    template <typename MultiFabType>
-    void RemakeMultiFab (std::unique_ptr<MultiFabType>& mf,
-                         const amrex::DistributionMapping& dm,
-                         const bool redistribute);
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -748,7 +748,7 @@ public:
     /**
      * \brief
      * This function initializes and calculates grid quantities used along with
-     * EBs such as edge lengths, facec areas, distance to EB, etc. It also
+     * EBs such as edge lengths, face areas, distance to EB, etc. It also
      * appropriately communicates EB data to guard cells.
      *
      * \param[in] lev, level of the Multifabs that is initialized

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -819,12 +819,10 @@ protected:
     //! data.  Called by AmrCore::regrid.
     virtual void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
                               const amrex::DistributionMapping& dm) final;
-    virtual void RemakeMultiFab (std::unique_ptr<amrex::MultiFab>& mf,
-                                 const amrex::DistributionMapping& dm,
-                                 const bool redistribute = true) final;
-    virtual void RemakeiMultiFab (std::unique_ptr<amrex::iMultiFab>& mf,
-                                 const amrex::DistributionMapping& dm,
-                                 const bool redistribute = true) final;
+    template <typename MultiFabType>
+    void RemakeMultiFab (std::unique_ptr<MultiFabType>& mf,
+                         const amrex::DistributionMapping& dm,
+                         const bool redistribute = true);
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -819,6 +819,12 @@ protected:
     //! data.  Called by AmrCore::regrid.
     virtual void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
                               const amrex::DistributionMapping& dm) final;
+    virtual void RemakeMultiFab (std::unique_ptr<amrex::MultiFab>& mf,
+                                 const amrex::DistributionMapping& dm,
+                                 const bool redistribute = true) final;
+    virtual void RemakeiMultiFab (std::unique_ptr<amrex::iMultiFab>& mf,
+                                 const amrex::DistributionMapping& dm,
+                                 const bool redistribute = true) final;
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -745,6 +745,16 @@ public:
          amrex::ParserExecutor<3> const& zfield_parser,
          std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& geom_data, const int lev);
 
+    /**
+     * \brief
+     * This function initializes and calculates grid quantities used along with
+     * EBs such as edge lengths, facec areas, distance to EB, etc. It also
+     * appropriately communicates EB data to guard cells.
+     *
+     * \param[in] lev, level of the Multifabs that is initialized
+     */
+    void InitializeEBGridData(int lev);
+
     /** \brief adds particle and cell contributions in cells to compute heuristic
      * cost in each box on each level, and records in `costs`
      * @param[in] costs vector of (`unique_ptr` to) vectors; expected to be initialized


### PR DESCRIPTION
There are 5 changes made in this PR:
1. added rebuilding of EB multifabs to `WarpX::RemakeLevel()` - bug fix
2. added a helper function to remake `MultiFab`s and `iMultiFab`s to reduce duplicate code - clean-up
3. added a `redistribute` function to `ParticleBoundaryBuffer` that is called from `WarpX::LoadBalance` to enable current tracking while using load balancing - bug fix
4. consistently use `DistributionMap` rather than `dmap` in ElectrostaticSolver.cpp - I don't think this actually makes a difference but is probably worth it for the sake of consistency.
5. added a helper function `InitializeEBGridData()` to set up all the grid data quantities used with EBs that is called from both `WarpX::InitLevelData` and `WarpX::RemakeLevel` - clean-up

As far as I can tell these changes fixes all the issues discussed in #2554 (therefore fixes #2554).

Note that there are still a number of `MultiFab`s declared in `WarpX.H` that is not rebuilt during load balancing. These include `ECTRhofield`, `F_slice`, `G_slice`, `rho_slice`, `current_slice`, `Efield_slice` and `Bfield_slice`. I don't see those used anywhere in the code though.