### PR TITLE
[Mini-PR] Fixes to the EB init

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -486,13 +486,14 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
 #ifdef AMREX_USE_EB
     if(lev==maxLevel()) {
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee
-            || WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+
             ComputeEdgeLengths();
             ComputeFaceAreas();
             ScaleEdges();
             ScaleAreas();
-            ComputeDistanceToEB();
 
             const auto &period = Geom(lev).periodicity();
             WarpXCommUtil::FillBoundary(*m_edge_lengths[lev][0], guard_cells.ng_alloc_EB, period);
@@ -516,6 +517,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                 ComputeFaceExtensions();
             }
         }
+
+        ComputeDistanceToEB();
+
     }
 #endif
 


### PR DESCRIPTION
2 fixes:

- Do the initialization of `edge_lengths` and `face_areas` also for CKC solver + EB

This makes it possible to have a CKC solver with staircased boundaries

- Move the call to `ComputeDistanceToEB` 

For the second point: ComputeDistanceToEB is called in the wrong place and when the ES solver is used it is called just because `WarpX::maxwell_solver_id` is set to `MaxwellSolverAlgo::Yee` by default.
To make the code more clear we move it just outside of the if statement.