### PR TITLE
Fix: GNUmake Python Link -g

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -246,7 +246,7 @@ libwarpx.$(PYDIM).so: $(objForExecs)
 ifeq ($(USE_CUDA),TRUE)
 	$(SILENT) $(CXX) $(LINKFLAGS) $(SHARED_OPTION) -Xlinker=$(SHARED_OPTION) -Xlinker=-fPIC -o $@ $^ $(LDFLAGS) $(libraries)
 else
-	$(SILENT) $(CXX) $(SHARED_OPTION) -fPIC -o $@ $^ $(LDFLAGS) $(libraries)
+	$(SILENT) $(CXX) $(LINKFLAGS) $(SHARED_OPTION) -fPIC -o $@ $^ $(LDFLAGS) $(libraries)
 endif
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 	@echo SUCCESS


### PR DESCRIPTION
On CPU links of the GNUmake Python lib, we forgot our `-g`, which we add to all build and optimization types. This is part of the `LINKFLAGS` variable.

Before:
```
mpicxx -shared -fPIC -o libwarpx.3d.so [...]
```

After:
```
mpicxx  -Werror=return-type -g -O3 -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -std=c++14  -fopenmp -pthread -fPIC -DWARPX_QED -shared -fPIC -o libwarpx.3d.so [...]
```