### PR TITLE
setup.py: beta -> stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -293,7 +293,7 @@ setup(
     # cmdclass={'test': PyTest},
     # platforms='any',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Natural Language :: English',
         'Environment :: Console',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Mark the Python meta-data as production/stable.

Follow-up to #2520