### PR TITLE
Bug Fix: Averaged Galilean PSATD Implemented only with `update_with_rho=1`

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -112,6 +112,10 @@ PsatdAlgorithm::PsatdAlgorithm(
     {
         amrex::Abort("PSATD: warpx.do_divb_cleaning = 1 implemented only with psatd.J_linear_in_time = 1");
     }
+    if (time_averaging && !update_with_rho)
+    {
+        amrex::Abort("PSATD: warpx.time_averaging = 1 implemented only with psatd.update_with_rho = 1");
+    }
 }
 
 void


### PR DESCRIPTION
Added an abort error message to prevent using averaged Galilean PSATD with `psatd.update_with_rho = 0`. Otherwise averaged Galilean PSATD would run with wrong coefficients, e.g. X2, X3.