### PR TITLE
RZ PSATD, make blocking_factor a power of 2

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -547,9 +547,15 @@ void CheckGriddingForRZSpectral ()
     Vector<int> blocking_factor_x(max_level+1);
     Vector<int> max_grid_size_x(max_level+1);
 
-    // Set the radial block size to be equal to the radial grid size.
-    blocking_factor_x[0] = n_cell[0];
-    max_grid_size_x[0] = n_cell[0];
+    // Set the radial block size to be the power of 2 greater than or equal to
+    // the number of grid cells. The blocking_factor must be a poower of 2
+    // and the max_grid_size should be a multiple of the blocking_factor.
+    int k = 1;
+    while (k < n_cell[0]) {
+        k *= 2;
+    }
+    blocking_factor_x[0] = k;
+    max_grid_size_x[0] = k;
 
     for (int lev=1 ; lev <= max_level ; lev++) {
         // For this to be correct, this needs to read in any user specified refinement ratios.

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -548,7 +548,7 @@ void CheckGriddingForRZSpectral ()
     Vector<int> max_grid_size_x(max_level+1);
 
     // Set the radial block size to be the power of 2 greater than or equal to
-    // the number of grid cells. The blocking_factor must be a poower of 2
+    // the number of grid cells. The blocking_factor must be a power of 2
     // and the max_grid_size should be a multiple of the blocking_factor.
     int k = 1;
     while (k < n_cell[0]) {


### PR DESCRIPTION
With RZ PSATD, the blocking factor and max grid size are set so that each box contains the entire radial extent. The code was setting the two parameters equal to the number of radial grid cells. However, the blocking factor must be a power of 2. This PR ensures this by setting the blocking factor to the next power of 2 greater than the number of grid cells.