### PR TITLE
LaserInjectionFromTXYEFile Test: Use MPI

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1743,7 +1743,7 @@ runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_OPENPMD=FALSE
 restartTest = 0
-useMPI = 0
+useMPI = 1
 useOMP = 1
 numthreads = 1
 compileTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1744,6 +1744,7 @@ dim = 2
 addToCompileString = USE_OPENPMD=FALSE
 restartTest = 0
 useMPI = 1
+numprocs = 1
 useOMP = 1
 numthreads = 1
 compileTest = 0


### PR DESCRIPTION
Enable MPI for the one regression test (`LaserInjectionFromTXYEFile`) that does not use it. Still uses one rank there.

This saves a compile per CI run.