### PR TITLE
WarpXComm.cpp: Use Explicit Types, not `auto`

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1288,8 +1288,8 @@ void WarpX::NodalSyncPML (int lev, PatchType patch_type)
                                                       pml[lev]->GetE_fp() : pml[lev]->GetE_cp();
         const std::array<amrex::MultiFab*,3>& pml_B = (patch_type == PatchType::fine) ?
                                                       pml[lev]->GetB_fp() : pml[lev]->GetB_cp();
-        amrex::MultiFab* const& pml_F = (patch_type == PatchType::fine) ? pml[lev]->GetF_fp() : pml[lev]->GetF_cp();
-        amrex::MultiFab* const& pml_G = (patch_type == PatchType::fine) ? pml[lev]->GetG_fp() : pml[lev]->GetG_cp();
+        amrex::MultiFab* const pml_F = (patch_type == PatchType::fine) ? pml[lev]->GetF_fp() : pml[lev]->GetF_cp();
+        amrex::MultiFab* const pml_G = (patch_type == PatchType::fine) ? pml[lev]->GetG_fp() : pml[lev]->GetG_cp();
 
         // Always synchronize nodal points
         const amrex::Periodicity& period = Geom(lev).periodicity();

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -163,7 +163,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         BoxArray const& nba = Bfield_aux[lev][0]->boxArray();
         BoxArray const& cnba = amrex::coarsen(nba,2);
         DistributionMapping const& dm = Bfield_aux[lev][0]->DistributionMap();
-        auto const& cperiod = Geom(lev-1).periodicity();
+        amrex::Periodicity const& cperiod = Geom(lev-1).periodicity();
 
         // Bfield
         {
@@ -285,7 +285,7 @@ WarpX::UpdateAuxilaryDataSameType ()
 {
     for (int lev = 1; lev <= finest_level; ++lev)
     {
-        const auto& crse_period = Geom(lev-1).periodicity();
+        const amrex::Periodicity& crse_period = Geom(lev-1).periodicity();
         const IntVect& ng = Bfield_cp[lev][0]->nGrowVect();
         const DistributionMapping& dm = Bfield_cp[lev][0]->DistributionMap();
 
@@ -558,7 +558,7 @@ WarpX::FillBoundaryE (int lev, PatchType patch_type, IntVect ng)
             pml[lev]->FillBoundaryE(patch_type);
         }
 
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Efield_fp[lev][0].get(),Efield_fp[lev][1].get(),Efield_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
@@ -582,7 +582,7 @@ WarpX::FillBoundaryE (int lev, PatchType patch_type, IntVect ng)
                                 do_pml_in_domain);
             pml[lev]->FillBoundaryE(patch_type);
         }
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Efield_cp[lev][0].get(),Efield_cp[lev][1].get(),Efield_cp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, cperiod);
@@ -619,7 +619,7 @@ WarpX::FillBoundaryB (int lev, PatchType patch_type, IntVect ng)
                               do_pml_in_domain);
         pml[lev]->FillBoundaryB(patch_type);
         }
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Bfield_fp[lev][0].get(),Bfield_fp[lev][1].get(),Bfield_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
@@ -644,7 +644,7 @@ WarpX::FillBoundaryB (int lev, PatchType patch_type, IntVect ng)
                         do_pml_in_domain);
         pml[lev]->FillBoundaryB(patch_type);
         }
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Bfield_cp[lev][0].get(),Bfield_cp[lev][1].get(),Bfield_cp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, cperiod);
@@ -677,7 +677,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             amrex::Abort("Averaged Galilean PSATD with PML is not yet implemented");
          }
 
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Efield_avg_fp[lev][0].get(),Efield_avg_fp[lev][1].get(),Efield_avg_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
@@ -697,7 +697,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             amrex::Abort("Averaged Galilean PSATD with PML is not yet implemented");
          }
 
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Efield_avg_cp[lev][0].get(),Efield_avg_cp[lev][1].get(),Efield_avg_cp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, cperiod);
@@ -730,7 +730,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
           {
             amrex::Abort("Averaged Galilean PSATD with PML is not yet implemented");
           }
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Bfield_avg_fp[lev][0].get(),Bfield_avg_fp[lev][1].get(),Bfield_avg_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
@@ -750,7 +750,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             amrex::Abort("Averaged Galilean PSATD with PML is not yet implemented");
           }
 
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Bfield_avg_cp[lev][0].get(),Bfield_avg_cp[lev][1].get(),Bfield_avg_cp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, cperiod);
@@ -863,7 +863,7 @@ WarpX::FillBoundaryAux (IntVect ng)
 void
 WarpX::FillBoundaryAux (int lev, IntVect ng)
 {
-    const auto& period = Geom(lev).periodicity();
+    const amrex::Periodicity& period = Geom(lev).periodicity();
     WarpXCommUtil::FillBoundary(*Efield_aux[lev][0], ng, period);
     WarpXCommUtil::FillBoundary(*Efield_aux[lev][1], ng, period);
     WarpXCommUtil::FillBoundary(*Efield_aux[lev][2], ng, period);
@@ -971,8 +971,9 @@ void
 WarpX::ApplyFilterandSumBoundaryJ (int lev, PatchType patch_type)
 {
     const int glev = (patch_type == PatchType::fine) ? lev : lev-1;
-    const auto& period = Geom(glev).periodicity();
-    auto& j = (patch_type == PatchType::fine) ? current_fp[lev] : current_cp[lev];
+    const amrex::Periodicity& period = Geom(glev).periodicity();
+    std::array<std::unique_ptr<amrex::MultiFab>,3>& j = (patch_type == PatchType::fine) ?
+                                                        current_fp[lev] : current_cp[lev];
     for (int idim = 0; idim < 3; ++idim) {
         IntVect ng = j[idim]->nGrowVect();
         IntVect ng_depos_J = get_ng_depos_J();
@@ -1023,7 +1024,7 @@ WarpX::AddCurrentFromFineLevelandSumBoundary (int lev)
         // When there are current buffers, unlike coarse patch,
         // we don't care about the final state of them.
 
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         for (int idim = 0; idim < 3; ++idim) {
             MultiFab mf(current_fp[lev][idim]->boxArray(),
                         current_fp[lev][idim]->DistributionMap(), current_fp[lev][idim]->nComp(), 0);
@@ -1114,7 +1115,7 @@ void
 WarpX::ApplyFilterandSumBoundaryRho (int lev, PatchType patch_type, int icomp, int ncomp)
 {
     const int glev = (patch_type == PatchType::fine) ? lev : lev-1;
-    auto& r = (patch_type == PatchType::fine) ? rho_fp[lev] : rho_cp[lev];
+    std::unique_ptr<amrex::MultiFab>& r = (patch_type == PatchType::fine) ? rho_fp[lev] : rho_cp[lev];
     if (r == nullptr) return;
     ApplyFilterandSumBoundaryRho(lev, glev, *r, icomp, ncomp);
 }
@@ -1122,7 +1123,7 @@ WarpX::ApplyFilterandSumBoundaryRho (int lev, PatchType patch_type, int icomp, i
 void
 WarpX::ApplyFilterandSumBoundaryRho (int /*lev*/, int glev, amrex::MultiFab& rho, int icomp, int ncomp)
 {
-    const auto& period = Geom(glev).periodicity();
+    const amrex::Periodicity& period = Geom(glev).periodicity();
     IntVect ng = rho.nGrowVect();
     IntVect ng_depos_rho = get_ng_depos_rho();
     if (use_filter) {
@@ -1160,7 +1161,7 @@ WarpX::AddRhoFromFineLevelandSumBoundary(int lev, int icomp, int ncomp)
 
     if (lev < finest_level){
 
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         MultiFab mf(rho_fp[lev]->boxArray(),
                     rho_fp[lev]->DistributionMap(),
                     ncomp, 0);
@@ -1233,14 +1234,14 @@ WarpX::NodalSyncJ (int lev, PatchType patch_type)
 
     if (patch_type == PatchType::fine)
     {
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         WarpXCommUtil::OverrideSync(*current_fp[lev][0], period);
         WarpXCommUtil::OverrideSync(*current_fp[lev][1], period);
         WarpXCommUtil::OverrideSync(*current_fp[lev][2], period);
     }
     else if (patch_type == PatchType::coarse)
     {
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         WarpXCommUtil::OverrideSync(*current_cp[lev][0], cperiod);
         WarpXCommUtil::OverrideSync(*current_cp[lev][1], cperiod);
         WarpXCommUtil::OverrideSync(*current_cp[lev][2], cperiod);
@@ -1254,13 +1255,13 @@ WarpX::NodalSyncRho (int lev, PatchType patch_type, int icomp, int ncomp)
 
     if (patch_type == PatchType::fine && rho_fp[lev])
     {
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         MultiFab rhof(*rho_fp[lev], amrex::make_alias, icomp, ncomp);
         WarpXCommUtil::OverrideSync(rhof, period);
     }
     else if (patch_type == PatchType::coarse && rho_cp[lev])
     {
-        const auto& cperiod = Geom(lev-1).periodicity();
+        const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         MultiFab rhoc(*rho_cp[lev], amrex::make_alias, icomp, ncomp);
         WarpXCommUtil::OverrideSync(rhoc, cperiod);
     }
@@ -1283,13 +1284,15 @@ void WarpX::NodalSyncPML (int lev, PatchType patch_type)
 {
     if (pml[lev]->ok())
     {
-        const auto& pml_E = (patch_type == PatchType::fine) ? pml[lev]->GetE_fp() : pml[lev]->GetE_cp();
-        const auto& pml_B = (patch_type == PatchType::fine) ? pml[lev]->GetB_fp() : pml[lev]->GetB_cp();
-        const auto& pml_F = (patch_type == PatchType::fine) ? pml[lev]->GetF_fp() : pml[lev]->GetF_cp();
-        const auto& pml_G = (patch_type == PatchType::fine) ? pml[lev]->GetG_fp() : pml[lev]->GetG_cp();
+        const std::array<amrex::MultiFab*,3>& pml_E = (patch_type == PatchType::fine) ?
+                                                      pml[lev]->GetE_fp() : pml[lev]->GetE_cp();
+        const std::array<amrex::MultiFab*,3>& pml_B = (patch_type == PatchType::fine) ?
+                                                      pml[lev]->GetB_fp() : pml[lev]->GetB_cp();
+        amrex::MultiFab* const& pml_F = (patch_type == PatchType::fine) ? pml[lev]->GetF_fp() : pml[lev]->GetF_cp();
+        amrex::MultiFab* const& pml_G = (patch_type == PatchType::fine) ? pml[lev]->GetG_fp() : pml[lev]->GetG_cp();
 
         // Always synchronize nodal points
-        const auto& period = Geom(lev).periodicity();
+        const amrex::Periodicity& period = Geom(lev).periodicity();
         WarpXCommUtil::OverrideSync(*pml_E[0], period);
         WarpXCommUtil::OverrideSync(*pml_E[1], period);
         WarpXCommUtil::OverrideSync(*pml_E[2], period);


### PR DESCRIPTION
Use explicit types instead of `auto` as much as possible. In my opinion, this makes the code easier to understand and (re)use for developers. This targets only the file WarpXComm.cpp. Will probably follow up with more PRs to target the rest of the repository.