### PR TITLE
Fix installation location for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,7 @@ if(WarpX_LIB)
     endif()
     install(CODE "file(CREATE_LINK
         $<TARGET_FILE_NAME:shared>
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
+        ${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
         COPY_ON_ERROR SYMBOLIC)")
 endif()
 


### PR DESCRIPTION
Dear Maintainer,
 
The install path for warpx libraries of the current development branch uses **both** `CMAKE_INSTALL_PREFIX` and `CMAKE_INSTALL_LIBDIR`. This causes the install step to fail if this directory can't be created.

However, as dumped by `./cmake/WarpXFunctions.cmake` the variable `CMAKE_INSTALL_LIBDIR` already contains a full path,
and no other installation in warpx uses **both** prefix and install dir variables. (e.g. [here](https://github.com/ECP-WarpX/WarpX/blob/development/CMakeLists.txt#L325))

During configuration the installation location for libraries is given by dumping the cmake variable `CMAKE_INSTALL_LIBDIR`.

This PR adjusts the installation of WarpX libraries (WarpX_LIB=ON) to respect this setting by removing the use of the `CMAKE_INSTALL_PREFIX`.

*Note: This emerged when hacking a dirty package for nix, I can provide a derivation expression for reproduction if you need that.*