### PR TITLE
WarpX.cpp: Use Explicit Types, not `auto`

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -449,7 +449,7 @@ void
 WarpX::PrintLocalWarnings(const std::string& when)
 {
     WARPX_PROFILE("WarpX::PrintLocalWarnings");
-    const auto warn_string = m_p_warn_manager->print_local_warnings(when);
+    const std::string warn_string = m_p_warn_manager->print_local_warnings(when);
     amrex::AllPrint() << warn_string;
 }
 
@@ -457,7 +457,7 @@ void
 WarpX::PrintGlobalWarnings(const std::string& when)
 {
     WARPX_PROFILE("WarpX::PrintGlobalWarnings");
-    const auto warn_string = m_p_warn_manager->print_global_warnings(when);
+    const std::string warn_string = m_p_warn_manager->print_global_warnings(when);
     amrex::Print() << warn_string;
 }
 
@@ -2049,7 +2049,7 @@ void WarpX::AllocLevelSpectralSolver (amrex::Vector<std::unique_ptr<SpectralSolv
 std::array<Real,3>
 WarpX::CellSize (int lev)
 {
-    const auto& gm = GetInstance().Geom(lev);
+    const amrex::Geometry& gm = GetInstance().Geom(lev);
     const Real* dx = gm.CellSize();
 #if (AMREX_SPACEDIM == 3)
     return { dx[0], dx[1], dx[2] };
@@ -2063,7 +2063,7 @@ WarpX::CellSize (int lev)
 amrex::RealBox
 WarpX::getRealBox(const Box& bx, int lev)
 {
-    const auto& gm = GetInstance().Geom(lev);
+    const amrex::Geometry& gm = GetInstance().Geom(lev);
     const RealBox grid_box{bx, gm.CellSize(), gm.ProbLo()};
     return( grid_box );
 }
@@ -2136,10 +2136,10 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
     for (MFIter mfi(divB, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         const Box& bx = mfi.tilebox();
-        auto const& Bxfab = B[0]->array(mfi);
-        auto const& Byfab = B[1]->array(mfi);
-        auto const& Bzfab = B[2]->array(mfi);
-        auto const& divBfab = divB.array(mfi);
+        amrex::Array4<const amrex::Real> const& Bxfab = B[0]->array(mfi);
+        amrex::Array4<const amrex::Real> const& Byfab = B[1]->array(mfi);
+        amrex::Array4<const amrex::Real> const& Bzfab = B[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& divBfab = divB.array(mfi);
 
         ParallelFor(bx,
         [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -2174,10 +2174,10 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
     for (MFIter mfi(divB, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         Box bx = mfi.growntilebox(ngrow);
-        auto const& Bxfab = B[0]->array(mfi);
-        auto const& Byfab = B[1]->array(mfi);
-        auto const& Bzfab = B[2]->array(mfi);
-        auto const& divBfab = divB.array(mfi);
+        amrex::Array4<const amrex::Real> const& Bxfab = B[0]->array(mfi);
+        amrex::Array4<const amrex::Real> const& Byfab = B[1]->array(mfi);
+        amrex::Array4<const amrex::Real> const& Bzfab = B[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& divBfab = divB.array(mfi);
 
         ParallelFor(bx,
         [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -2225,7 +2225,7 @@ WarpX::getPMLdirections() const
 #endif
     if( do_pml )
     {
-        for( auto i = 0u; i < dirsWithPML.size() / 2u; ++i )
+        for( unsigned int i = 0u; i < dirsWithPML.size() / 2u; ++i )
         {
             dirsWithPML.at( 2u*i      ) = bool(do_pml_Lo[i]);
             dirsWithPML.at( 2u*i + 1u ) = bool(do_pml_Hi[i]);
@@ -2264,7 +2264,7 @@ WarpX::BuildBufferMasks ()
                 const int physbnd = 1;
                 const int interior = 1;
                 const Box& dom = Geom(lev).Domain();
-                const auto& period = Geom(lev).periodicity();
+                const amrex::Periodicity& period = Geom(lev).periodicity();
                 tmp.BuildMask(dom, period, covered, notcovered, physbnd, interior);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -2292,8 +2292,8 @@ WarpX::BuildBufferMasksInBox ( const amrex::Box tbx, amrex::IArrayBox &buffer_ma
                                const amrex::IArrayBox &guard_mask, const int ng )
 {
     bool setnull;
-    const auto lo = amrex::lbound( tbx );
-    const auto hi = amrex::ubound( tbx );
+    const amrex::Dim3 lo = amrex::lbound( tbx );
+    const amrex::Dim3 hi = amrex::ubound( tbx );
     Array4<int> msk = buffer_mask.array();
     Array4<int const> gmsk = guard_mask.array();
 #if (AMREX_SPACEDIM == 1)


### PR DESCRIPTION
Use explicit types instead of `auto` as much as possible, it makes the code easier to understand and (re)use for developers. This targets the file WarpX.cpp.