### PR TITLE
openPMD: 1D3V Support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,7 +23,6 @@ jobs:
       cartesian1d:
         WARPX_CI_REGULAR_CARTESIAN_1D: 'TRUE'
         WARPX_CI_PSATD: 'FALSE'
-        WARPX_CI_OPENPMD: 'FALSE'
       cartesian2d:
         WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
       cartesian3d:

--- a/Examples/Modules/laser_injection/inputs_1d_rt
+++ b/Examples/Modules/laser_injection/inputs_1d_rt
@@ -50,9 +50,13 @@ laser1.profile_focal_distance = 13.109e-6  # Focal distance from the antenna (in
                                            #     at the end of the simulation.
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 openpmd
 diag1.intervals = 20
 diag1.diag_type = Full
+
+openpmd.intervals = 20
+openpmd.diag_type = Full
+openpmd.format = openpmd
 
 # Moving window
 warpx.do_moving_window = 1

--- a/Examples/Tests/Langmuir/inputs_1d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_1d_multi_rt
@@ -76,6 +76,10 @@ positrons.momentum_function_uy(x,y,z) = "-epsilon * k/kp * cos(k*x) * sin(k*y) *
 positrons.momentum_function_uz(x,y,z) = "-epsilon * k/kp * cos(k*x) * cos(k*y) * sin(k*z)"
 
 # Diagnostics
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 openpmd
 diag1.intervals = 40
 diag1.diag_type = Full
+
+openpmd.intervals = 40
+openpmd.diag_type = Full
+openpmd.format = openpmd

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -692,7 +692,7 @@ buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_1d_multi_rt
 runtime_params = algo.current_deposition=esirkepov diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
 dim = 1
-addToCompileString = QED=FALSE
+addToCompileString = QED=FALSE USE_OPENPMD=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -844,7 +844,7 @@ buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs_1d_rt
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 1
-addToCompileString = QED=FALSE
+addToCompileString = QED=FALSE USE_OPENPMD=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -604,7 +604,9 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
   // TODO allow this per direction in the openPMD standard, ED-PIC extension?
   currSpecies.setAttribute( "particleShapes", [](){
       return std::vector< double >{
+#if AMREX_SPACEDIM>=2
           double(WarpX::nox),
+#endif
 #if AMREX_SPACEDIM==3
           double(WarpX::noy),
 #endif
@@ -951,10 +953,8 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
       auto const period = full_geom.periodicity(); // TODO double-check: is this the proper global bound or of some level?
       std::vector<std::string> fieldBoundary(6, "reflecting");
       std::vector<std::string> particleBoundary(6, "absorbing");
-#if AMREX_SPACEDIM != 3
-      fieldBoundary.resize(4);
-      particleBoundary.resize(4);
-#endif
+      fieldBoundary.resize(AMREX_SPACEDIM * 2);
+      particleBoundary.resize(AMREX_SPACEDIM * 2);
 
       for (auto i = 0u; i < fieldBoundary.size() / 2u; ++i)
           if (m_fieldPMLdirections.at(i))
@@ -990,12 +990,16 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
           meshes.setAttribute("currentSmoothingParameters", []() {
               std::stringstream ss;
               ss << "period=1;compensator=false";
+#if (AMREX_SPACEDIM >= 2)
               ss << ";numPasses_x=" << WarpX::filter_npass_each_dir[0];
+#endif
 #if (AMREX_SPACEDIM == 3)
               ss << ";numPasses_y=" << WarpX::filter_npass_each_dir[1];
               ss << ";numPasses_z=" << WarpX::filter_npass_each_dir[2];
-#else
+#elif (AMREX_SPACEDIM == 2)
               ss << ";numPasses_z=" << WarpX::filter_npass_each_dir[1];
+#elif (AMREX_SPACEDIM == 1)
+              ss << ";numPasses_z=" << WarpX::filter_npass_each_dir[0];
 #endif
               std::string currentSmoothingParameters = ss.str();
               return currentSmoothingParameters;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -187,7 +187,9 @@ namespace detail
     getParticlePositionComponentLabels ()
     {
         using vs = std::vector< std::string >;
-#if defined(WARPX_DIM_XZ)
+#if defined(WARPX_DIM_1D_Z)
+        vs const positionComponents{"z"};
+#elif defined(WARPX_DIM_XZ)
         vs const positionComponents{"x", "z"};
 #elif defined(WARPX_DIM_RZ)
         // note: although we internally store particle positions
@@ -197,7 +199,7 @@ namespace detail
         //       Other attributes like momentum are consequently
         //       stored in x,y,z internally.
         vs const positionComponents{"x", "y", "z"};
-#elif (AMREX_SPACEDIM==3)
+#elif defined(WARPX_DIM_3D)
         vs const positionComponents{"x", "y", "z"};
 #else
 #   error Unknown WarpX dimensionality.
@@ -216,7 +218,9 @@ namespace detail
         using vs = std::vector< std::string >;
 
         // Fortran order of the index labels for the AMReX FArrayBox
-#if defined(WARPX_DIM_XZ)
+#if defined(WARPX_DIM_1D_Z)
+        vs const axisLabels{"z"};
+#elif defined(WARPX_DIM_XZ)
         vs const axisLabels{"x", "z"};
 #elif defined(WARPX_DIM_RZ)
         // if we are start to write individual modes


### PR DESCRIPTION
Add 1D output support with openPMD.

![Screenshot from 2021-11-19 16-32-03](https://user-images.githubusercontent.com/1353258/142707462-94d0329e-d221-4f43-afc4-49c8b240f4d4.png)
![Screenshot from 2021-11-19 16-27-23](https://user-images.githubusercontent.com/1353258/142707463-e392d9e2-4809-4e94-8389-74e2d0dd6c6d.png)
