### PR TITLE
requirements.txt - PICMI development version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
+# basic dependencies
 numpy~=1.15
 periodictable~=1.5
+
+# PICMI
 picmistandard==0.0.16
+#   for development against an unreleased PICMI version, use:
+#picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
+
 # optional, some used for testing:
 # yt
 # openpmd-api


### PR DESCRIPTION
Document in `requirements.txt` on how to install a pre-release version of PICMI.