### PR TITLE
[WIP] Implement do_backward_propagation for more injection_styles

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1135,6 +1135,10 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 pa[PIdx::uy][ip] = u.y;
                 pa[PIdx::uz][ip] = u.z;
 
+                if (do_backward_propagation) {
+                  pa[PIdx::uz][ip] = -u.z;
+                }
+
 #if (AMREX_SPACEDIM == 3)
                 p.pos(0) = pos.x;
                 p.pos(1) = pos.y;


### PR DESCRIPTION
The option `do_backward_propagation` is currently only working for certain injection_styles, where we inject particle individually with `AddParticles` (e.g. `SingleParticle`, `MultipleParticle`, `gaussian_beam`.

However, it was not implemented for the injection_styles in which we loop through cells and fill cells with a given number of particles, using a prescribed density in that cell. (e.g. `NUniformPerCell`, `NRandomPerCell`). This PR fixes the issue.