### PR TITLE
Throwing a warning if particle_shape>1 with EB

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -912,7 +912,7 @@ void WarpX::InitializeEBGridData(int lev)
         ComputeDistanceToEB();
 
     }
-#elif
+#else
     amrex::ignore_unused(lev);
 #endif
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -865,6 +865,17 @@ void WarpX::CheckGuardCells(amrex::MultiFab const& mf)
 void WarpX::InitializeEBGridData(int lev)
 {
     if(lev==maxLevel()) {
+
+        //Throw a warning if EB is on and particle_shape > 1
+        bool flag_eb_on = not fieldEBFactory(lev).isAllRegular();
+
+        if ((nox > 1 or noy > 1 or noz > 1) and flag_eb_on)
+        {
+            this->RecordWarning("Particles",
+                                "when algo.particle_shape > 1, numerical artifacts will be present when\n"
+                                "particles are close to embedded boundaries");
+        }
+
         if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
             WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
             WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -864,6 +864,7 @@ void WarpX::CheckGuardCells(amrex::MultiFab const& mf)
 
 void WarpX::InitializeEBGridData(int lev)
 {
+#ifdef AMREX_USE_EB
     if(lev==maxLevel()) {
 
         //Throw a warning if EB is on and particle_shape > 1
@@ -911,4 +912,5 @@ void WarpX::InitializeEBGridData(int lev)
         ComputeDistanceToEB();
 
     }
+#endif
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -912,5 +912,7 @@ void WarpX::InitializeEBGridData(int lev)
         ComputeDistanceToEB();
 
     }
+#elif
+    amrex::ignore_unused(lev);
 #endif
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -862,12 +862,12 @@ void WarpX::CheckGuardCells(amrex::MultiFab const& mf)
     }
 }
 
-void WarpX::InitializeEBGridData(int lev)
+void WarpX::InitializeEBGridData (int lev)
 {
 #ifdef AMREX_USE_EB
-    if(lev==maxLevel()) {
+    if (lev == maxLevel()) {
 
-        //Throw a warning if EB is on and particle_shape > 1
+        // Throw a warning if EB is on and particle_shape > 1
         bool flag_eb_on = not fieldEBFactory(lev).isAllRegular();
 
         if ((nox > 1 or noy > 1 or noz > 1) and flag_eb_on)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -960,9 +960,11 @@ WarpX::ReadParameters ()
                     noz = particle_shape;
                 }
 #ifdef AMREX_USE_EB
-                if (particle_shape != 1)
+                if (particle_shape > 1)
                 {
-                    amrex::Abort("\nalgo.particle_shape can only be 1 with embedded boundaries");
+                    this->RecordWarning("Particles",
+                        "when algo.particle_shape > 1, numerical artifacts will be present when\n"
+                        "particles are close to embedded boundaries");
                 }
 #endif
             }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -959,6 +959,12 @@ WarpX::ReadParameters ()
                     noy = particle_shape;
                     noz = particle_shape;
                 }
+#ifdef AMREX_USE_EB
+                if (particle_shape != 1)
+                {
+                    amrex::Abort("\nalgo.particle_shape can only be 1 with embedded boundaries");
+                }
+#endif
             }
 
             if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -959,14 +959,6 @@ WarpX::ReadParameters ()
                     noy = particle_shape;
                     noz = particle_shape;
                 }
-#ifdef AMREX_USE_EB
-                if (particle_shape > 1)
-                {
-                    this->RecordWarning("Particles",
-                        "when algo.particle_shape > 1, numerical artifacts will be present when\n"
-                        "particles are close to embedded boundaries");
-                }
-#endif
             }
 
             if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))


### PR DESCRIPTION
Following the discussion on slack, we disable the possibility to use EB with `particle_shape != 1 ` because it would require special care for the field gather.