### PR TITLE
Fix Init of Vector Members

### DIFF
--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -11,6 +11,7 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
+#include <AMReX_Vector.H>
 
 /**
  * \brief This class computes and stores the number of guard cells needed for

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -372,7 +372,7 @@ public:
      void defineAllParticleTiles () noexcept;
 
 protected:
-    amrex::Vector<amrex::Real> m_v_galilean{amrex::Vector<amrex::Real>(3, amrex::Real(0.))};
+    amrex::Vector<amrex::Real> m_v_galilean = amrex::Vector<amrex::Real>(3, amrex::Real(0.));
     std::map<std::string, int> particle_comps;
     std::map<std::string, int> particle_icomps;
     std::map<std::string, int> particle_runtime_comps;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -379,11 +379,11 @@ public:
     amrex::Vector< std::unique_ptr<NCIGodfreyFilter> > nci_godfrey_filter_exeybz;
     amrex::Vector< std::unique_ptr<NCIGodfreyFilter> > nci_godfrey_filter_bxbyez;
 
-    amrex::Real time_of_last_gal_shift  = 0;
-    amrex::Vector<amrex::Real> m_v_galilean{amrex::Vector<amrex::Real>(3, amrex::Real(0.))};
+    amrex::Real time_of_last_gal_shift = 0;
+    amrex::Vector<amrex::Real> m_v_galilean = amrex::Vector<amrex::Real>(3, amrex::Real(0.));
     amrex::Array<amrex::Real,3> m_galilean_shift = {{0}};
 
-    amrex::Vector<amrex::Real> m_v_comoving{amrex::Vector<amrex::Real>(3, amrex::Real(0.))};
+    amrex::Vector<amrex::Real> m_v_comoving = amrex::Vector<amrex::Real>(3, amrex::Real(0.));
 
     static int num_mirrors;
     amrex::Vector<amrex::Real> mirror_z;


### PR DESCRIPTION
Fix default init of `Vector` member variables. The old construct is not valid C++.

https://stackoverflow.com/a/11491003/2719194

First seen, but not related to C++17, in #2300.