### PR TITLE
C++17: Work-Around NVCC gatherParticles

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -232,7 +232,8 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                 int timestep = warpx_instance.getistep(0);
                 using SrcData = WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType;
                 auto count = amrex::filterAndTransformParticles(ptile_buffer, ptile,
-                    [=] AMREX_GPU_HOST_DEVICE (const SrcData& /*src*/, const int ip) noexcept
+                    [=] AMREX_GPU_HOST_DEVICE (const SrcData& /*src*/, const int ip)
+                    /* NVCC 11.3.109 chokes in C++17 on this: noexcept */
                     {
                         amrex::ParticleReal xp, yp, zp;
                         getPosition(ip, xp, yp, zp);


### PR DESCRIPTION
The `noexcept` lambda does not compile in C++17 mode (#2300) due to an NVCC compiler bug, at least in NVCC 11.3.109.

Compiles in C++14 mode with the same compiler.

Error:
```
nvcc_internal_extended_lambda_implementation:732:77: error: ‘operator()’ is not a member of ‘int (ParticleBoundaryBuffer::gatherParticles(MultiParticleContainer&, const amrex::Vector<const amrex::MultiFab*>&)::<lambda(const SrcData&, int)>::*)(const amrex::ConstParticleTileData<0, 0, 4, 0>&, int) const noexcept’
Source/Particles/ParticleBoundaryBuffer.cpp: In member function ‘void ParticleBoundaryBuffer::gatherParticles(MultiParticleContainer&, const amrex::Vector<const amrex::MultiFab*>&)’:
Source/Particles/ParticleBoundaryBuffer.cpp:245:34: error: no matching function for call to ‘__nv_hdl_create_wrapper_t<false, false, __nv_dl_tag<void (ParticleBoundaryBuffer::*)(MultiParticleContainer&, const amrex::Vector<const amrex::MultiFab*>&), &ParticleBoundaryBuffer::gatherParticles, 1>, const GetParticlePosition, amrex::Array4<const float>, amrex::GpuArray<float, 3>, amrex::GpuArray<float, 3> >::__nv_hdl_create_wrapper(ParticleBoundaryBuffer::gatherParticles(MultiParticleContainer&, const amrex::Vector<const amrex::MultiFab*>&)::<lambda(const SrcData&, int)>, const GetParticlePosition&, amrex::Array4<const float>&, amrex::GpuArray<float, 3>&, amrex::GpuArray<float, 3>&)’
  245 |                     },
      |                                  ^
```

Thx to @atmyers for the hint :)

## To Do

- [x] file an Nvidia bug report (no.: 3447924) and ping @maxpkatz on it :)

```C++
cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_OPENPMD=ON -DAMReX_CUDA_ARCH=6.0 -DWarpX_EB=ON -DWarpX_PRECISION=SINGLE -DWarpX_PSATD=ON -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON -DCMAKE_VERBOSE_MAKEFILE=ON
cmake --build build
```