### PR TITLE
Add 2D Langmuir Test w/ MR & PSATD

### DIFF
--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_psatd.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_psatd.json
@@ -1,0 +1,44 @@
+{
+  "electrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 1123057664.0,
+    "particle_momentum_x": 4.2362974799075715e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.2362974818601834e-20,
+    "particle_position_x": 0.6553603056279188,
+    "particle_position_y": 0.6553603056279399,
+    "particle_weight": 3200000000000000.5
+  },
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 49.400846503194956,
+    "Bz": 0.0,
+    "Ex": 7590421951518.164,
+    "Ey": 0.0,
+    "Ez": 7590421950277.463,
+    "jx": 7279591576517866.0,
+    "jy": 0.0,
+    "jz": 7279591579334755.0
+  },
+  "lev=1": {
+    "Bx": 0.0,
+    "By": 564.3980303336011,
+    "Bz": 0.0,
+    "Ex": 7563548313704.213,
+    "Ey": 0.0,
+    "Ez": 7563548287845.812,
+    "jx": 6584893500547710.0,
+    "jy": 0.0,
+    "jz": 6584893531174318.0
+  },
+  "positrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 3371204608.0,
+    "particle_momentum_x": 4.236433706251501e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.23643370757891e-20,
+    "particle_position_x": 0.6553599973488732,
+    "particle_position_y": 0.6553599973488947,
+    "particle_weight": 3200000000000000.5
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -563,7 +563,7 @@ buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
 runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
 dim = 2
-addToCompileString =
+addToCompileString = USE_PSATD=TRUE
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -558,6 +558,25 @@ analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
 tolerance = 1.e-14
 
+[Langmuir_multi_2d_MR_psatd]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
+dim = 2
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
+tolerance = 1.e-14
+
 [Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt


### PR DESCRIPTION
Add a CI test with mesh refinement (ratio 4) and PSATD. Same test as `Langmuir_multi_2d_MR`, but with PSATD Maxwell solver instead of FDTD. The Python analysis comparing the electric field with theoretical predicions passes. However, I will post plots of E and B in comments below, to make sure that everything looks good.