### PR TITLE
Fix out-of-bound in the initialization of EB

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -220,7 +220,7 @@ WarpX::ComputeFaceAreas () {
 #endif
             amrex::Box box = mfi.tilebox(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
             amrex::FabType fab_type = flags[mfi].getType(box);
-            box.grow(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
+            box.grow(m_face_areas[maxLevel()][idim]->nGrowVect());
             auto const &face_areas_dim = m_face_areas[maxLevel()][idim]->array(mfi);
             if (fab_type == amrex::FabType::regular) {
                 // every cell in box is all regular

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -135,8 +135,7 @@ WarpX::ComputeEdgeLengths () {
 #else
         amrex::Abort("ComputeEdgeLengths: Only implemented in 2D3V and 3D3V");
 #endif
-            const amrex::Box& box = mfi.tilebox(m_edge_lengths[maxLevel()][idim]->ixType().toIntVect(),
-                                                m_edge_lengths[maxLevel()][idim]->nGrowVect() );
+            const amrex::Box& box = mfi.tilebox(m_edge_lengths[maxLevel()][idim]->ixType().toIntVect() );
             amrex::FabType fab_type = flags[mfi].getType(box);
             auto const &edge_lengths_dim = m_edge_lengths[maxLevel()][idim]->array(mfi);
 
@@ -177,6 +176,14 @@ WarpX::ComputeEdgeLengths () {
             }
         }
     }
+    // Echange guard cells
+    for (int idim = 0; idim < 3; ++idim){
+#ifdef WARPX_DIM_XZ
+        if(idim == 1) continue;
+#endif
+        m_edge_lengths[maxLevel()][idim]->FillBoundary();
+    }
+
 #endif
 }
 
@@ -210,8 +217,7 @@ WarpX::ComputeFaceAreas () {
 #else
         amrex::Abort("ComputeFaceAreas: Only implemented in 2D3V and 3D3V");
 #endif
-            const amrex::Box& box = mfi.tilebox(m_face_areas[maxLevel()][idim]->ixType().toIntVect(),
-                                                m_face_areas[maxLevel()][idim]->nGrowVect() );
+            const amrex::Box& box = mfi.tilebox(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
             amrex::FabType fab_type = flags[mfi].getType(box);
             auto const &face_areas_dim = m_face_areas[maxLevel()][idim]->array(mfi);
             if (fab_type == amrex::FabType::regular) {
@@ -238,6 +244,14 @@ WarpX::ComputeFaceAreas () {
             }
         }
     }
+    // Echange guard cells
+    for (int idim = 0; idim < 3; ++idim){
+#ifdef WARPX_DIM_XZ
+        if(idim == 1) continue;
+#endif
+        m_face_areas[maxLevel()][idim]->FillBoundary();
+    }
+
 #endif
 }
 

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -135,8 +135,9 @@ WarpX::ComputeEdgeLengths () {
 #else
         amrex::Abort("ComputeEdgeLengths: Only implemented in 2D3V and 3D3V");
 #endif
-            const amrex::Box& box = mfi.tilebox(m_edge_lengths[maxLevel()][idim]->ixType().toIntVect() );
+            amrex::Box box = mfi.tilebox(m_edge_lengths[maxLevel()][idim]->ixType().toIntVect() );
             amrex::FabType fab_type = flags[mfi].getType(box);
+            box.grow(m_edge_lengths[maxLevel()][idim]->nGrowVect());
             auto const &edge_lengths_dim = m_edge_lengths[maxLevel()][idim]->array(mfi);
 
             if (fab_type == amrex::FabType::regular) {
@@ -217,8 +218,9 @@ WarpX::ComputeFaceAreas () {
 #else
         amrex::Abort("ComputeFaceAreas: Only implemented in 2D3V and 3D3V");
 #endif
-            const amrex::Box& box = mfi.tilebox(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
+            amrex::Box box = mfi.tilebox(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
             amrex::FabType fab_type = flags[mfi].getType(box);
+            box.grow(m_face_areas[maxLevel()][idim]->ixType().toIntVect());
             auto const &face_areas_dim = m_face_areas[maxLevel()][idim]->array(mfi);
             if (fab_type == amrex::FabType::regular) {
                 // every cell in box is all regular

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -177,14 +177,6 @@ WarpX::ComputeEdgeLengths () {
             }
         }
     }
-    // Echange guard cells
-    for (int idim = 0; idim < 3; ++idim){
-#ifdef WARPX_DIM_XZ
-        if(idim == 1) continue;
-#endif
-        m_edge_lengths[maxLevel()][idim]->FillBoundary();
-    }
-
 #endif
 }
 
@@ -246,14 +238,6 @@ WarpX::ComputeFaceAreas () {
             }
         }
     }
-    // Echange guard cells
-    for (int idim = 0; idim < 3; ++idim){
-#ifdef WARPX_DIM_XZ
-        if(idim == 1) continue;
-#endif
-        m_face_areas[maxLevel()][idim]->FillBoundary();
-    }
-
 #endif
 }
 


### PR DESCRIPTION
When compiling with EB in debug mode, I got an out-of-bound message at this line:
https://github.com/ECP-WarpX/WarpX/blob/development/Source/EmbeddedBoundary/WarpXInitEB.cpp#L140
It seems that some of the internal structures for EB in `amrex` (used e.g. in `getType`) have only 1 guard cells, whereas we pass a box that has more guard cells.

~~Instead, this PR does not add the guard cells in the box passed in `getType`, and instead the guard cells are filled by an additional `FillBoundary`.~~
Instead, this PR calls `getType` by passing a box that does not have guard cells (but adds the guard cells when actually touching the `edge_length` and `face_area` arrays.