### PR TITLE
Redistribute particles in ContinuousFluxInjection

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -199,10 +199,9 @@ public:
     /**
      * Create new macroparticles for this species, with a fixed
      * number of particles per cell in a plane.
-     * @param[in] lev the index of the refinement level
      * @param[in] dt time step size, used to partially advance the particles
     */
-    void AddPlasmaFlux (int lev, amrex::Real dt);
+    void AddPlasmaFlux (amrex::Real dt);
 
     void MapParticletoBoostedFrame (amrex::Real& x, amrex::Real& y, amrex::Real& z,
                                     amrex::Real& ux, amrex::Real& uy, amrex::Real& uz);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1566,8 +1566,8 @@ PhysicalParticleContainer::AddPlasmaFlux (int lev, amrex::Real dt)
         // Extract tiles
         const int grid_id = mfi.index();
         const int tile_id = mfi.LocalTileIndex();
-        auto src_tile = tmp_pc.DefineAndReturnParticleTile(lev, grid_id, tile_id);
-        auto dst_tile = this->DefineAndReturnParticleTile(lev, grid_id, tile_id);
+        auto& src_tile = tmp_pc.DefineAndReturnParticleTile(lev, grid_id, tile_id);
+        auto& dst_tile = this->DefineAndReturnParticleTile(lev, grid_id, tile_id);
 
         // Resize container and copy particles
         auto old_size = dst_tile.numParticles();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1190,9 +1190,10 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     // Create temporary particle container to which particles will be added;
     // we will then call Redistribute on this new container and finally
     // add the new particles to the original container.
-    amrex::AmrParticleContainer<0,0,PIdx::nattribs> tmp_pc(&WarpX::GetInstance());
+    PhysicalParticleContainer tmp_pc(&WarpX::GetInstance());
     for (int ic = 0; ic < NumRuntimeRealComps(); ++ic) { tmp_pc.AddRealComp(false); }
     for (int ic = 0; ic < NumRuntimeIntComps(); ++ic) { tmp_pc.AddIntComp(false); }
+    tmp_pc.defineAllParticleTiles();
 
     const int nlevs = numLevels();
     static bool refine_injection = false;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1223,7 +1223,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     }
 #ifdef AMREX_USE_OMP
     info.SetDynamic(true);
-#pragma omp parallel if (not WarpX::serialize_ics)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi = MakeMFIter(0, info); mfi.isValid(); ++mfi)
     {
@@ -1559,7 +1559,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     // Add the particles to the current container, tile by tile
     for (int lev=0; lev<numLevels(); lev++) {
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (not WarpX::serialize_ics)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi = MakeMFIter(lev, info); mfi.isValid(); ++mfi)
         {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -31,7 +31,6 @@
 #include "Particles/Pusher/UpdatePosition.H"
 #include "Particles/SpeciesPhysicalProperties.H"
 #include "Particles/WarpXParticleContainer.H"
-#include "Particles/ParticleBuffer.H"
 #include "Utils/IonizationEnergiesTable.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
@@ -73,6 +72,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Particle.H>
 #include <AMReX_ParticleContainerBase.H>
+#include <AMReX_AmrParticles.H>
 #include <AMReX_ParticleTile.H>
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
@@ -1190,7 +1190,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     // Create temporary particle container to which particles will be added;
     // we will then call Redistribute on this new container and finally
     // add the new particles to the original container.
-    auto tmp_pc = ParticleBuffer::getTmpPC<amrex::ArenaAllocator>(this);
+    amrex::AmrParticleContainer<0,0,PIdx::nattribs> tmp_pc(&WarpX::GetInstance());
+    for (int ic = 0; ic < NumRuntimeRealComps(); ++ic) { tmp_pc.AddRealComp(false); }
+    for (int ic = 0; ic < NumRuntimeIntComps(); ++ic) { tmp_pc.AddIntComp(false); }
 
     const int nlevs = numLevels();
     static bool refine_injection = false;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1557,7 +1557,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     tmp_pc.Redistribute();
 
     // Add the particles to the current container, tile by tile
-    for (int lev=0; lev<=max_level; lev++) {
+    for (int lev=0; lev<numLevels(); lev++) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (not WarpX::serialize_ics)
 #endif


### PR DESCRIPTION
The particles that are added in `ContinuousFluxInjection` are not immediately redistributed (instead, the function relies on the fact that we call `Redistribute` at the end of the PIC loop).
However, when using embedded boundaries, particle scraping gets called before the `Redistribute` and this can lead to an out-of-bound when looking up the EB data for each particle.

In order to fix the issue, this PR adds the new particles to a separate particle buffer, which is redistributed separately and then added to the original particle buffer.