### PR TITLE
Added parallel pragma to ApplyBoundaryConditions

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1128,6 +1128,9 @@ WarpXParticleContainer::ApplyBoundaryConditions (){
 
     for (int lev = 0; lev <= finestLevel(); ++lev)
     {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             auto GetPosition = GetParticlePosition(pti);


### PR DESCRIPTION
The openMP parallelization was missing from this routine.