### PR TITLE
Fix out-of-bound in Inverse FFT of F,G

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1688,12 +1688,12 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     if (do_dive_cleaning)
     {
-        F_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, F_nodal_flag), dm, ncomps, ngF.max(), tag("F_fp"));
+        F_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, F_nodal_flag), dm, ncomps, ngF, tag("F_fp"));
     }
 
     if (do_divb_cleaning)
     {
-        G_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, ncomps, ngG.max(), tag("G_fp"));
+        G_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, ncomps, ngG, tag("G_fp"));
     }
 
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)


### PR DESCRIPTION
This fixes an out-of-bound access in the inverse FFT of the F and G fields. The F and G MultiFabs were constructed using a number of guard cells (`ngF.max()` and `ngG.max()`, respectively) that was uniform in all directions and therefore incompatible with the box used to construct the spectral solver (grown by `ngE`, which equals `ngF` and `ngG` instead and is not necessarily uniform in all directions).

This input file can be used to reproduce the out-of-bound access and verify that this PR fixes it: [inputs_2d.txt](https://github.com/ECP-WarpX/WarpX/files/7644217/inputs_2d.txt).
