### PR TITLE
extern 'C': Only in Headers

### DIFF
--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -86,6 +86,8 @@ extern "C" {
 
     amrex::Real warpx_getProbHi(int dir);
 
+    amrex::Real warpx_getCellSize(int dir, int lev);
+
     long warpx_getNumParticles(const char* char_species_name);
 
     amrex::ParticleReal** warpx_getParticleStructs(

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -146,6 +146,88 @@ extern "C" {
 
   void mypc_Redistribute ();
 
+  amrex::Real** warpx_getEfield (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getEfieldCP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getEfieldFP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+
+  amrex::Real** warpx_getBfield (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getBfieldCP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getBfieldFP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+
+  amrex::Real** warpx_getCurrentDensity (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getCurrentDensityCP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getCurrentDensityFP (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+
+  int* warpx_getEfieldLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getEfieldCPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getEfieldFPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+
+  int* warpx_getBfieldLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getBfieldCPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getBfieldFPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+
+  int* warpx_getCurrentDensityLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getCurrentDensityCPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getCurrentDensityFPLoVects (int lev, int direction, int *return_size, int **ngrowvect);
+
+  int* warpx_getEx_nodal_flag ();
+  int* warpx_getEy_nodal_flag ();
+  int* warpx_getEz_nodal_flag ();
+  int* warpx_getBx_nodal_flag ();
+  int* warpx_getBy_nodal_flag ();
+  int* warpx_getBz_nodal_flag ();
+  int* warpx_getJx_nodal_flag ();
+  int* warpx_getJy_nodal_flag ();
+  int* warpx_getJz_nodal_flag ();
+  int* warpx_getRho_nodal_flag ();
+  int* warpx_getPhi_nodal_flag ();
+  int* warpx_getF_nodal_flag ();
+  int* warpx_getG_nodal_flag ();
+
+  amrex::Real** warpx_getChargeDensityCP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getChargeDensityFP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  int* warpx_getChargeDensityCPLoVects (int lev, int *return_size, int **ngrowvect);
+  int* warpx_getChargeDensityFPLoVects (int lev, int *return_size, int **ngrowvect);
+
+  amrex::Real** warpx_getPhiFP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+
+  int* warpx_getPhiFPLoVects (int lev, int *return_size, int **ngrowvect);
+
+  amrex::Real** warpx_getFfieldCP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getFfieldFP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  int* warpx_getFfieldCPLoVects (int lev, int *return_size, int **ngrowvect);
+  int* warpx_getFfieldFPLoVects (int lev, int *return_size, int **ngrowvect);
+  amrex::Real** warpx_getGfieldCP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getGfieldFP (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  int* warpx_getGfieldCPLoVects (int lev, int *return_size, int **ngrowvect);
+  int* warpx_getGfieldFPLoVects (int lev, int *return_size, int **ngrowvect);
+
+  amrex::Real** warpx_getEfieldCP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getEfieldFP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getBfieldCP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getBfieldFP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getCurrentDensityCP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getCurrentDensityFP_PML (int lev, int direction, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+
+  int* warpx_getEfieldCPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getEfieldFPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getBfieldCPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getBfieldFPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getCurrentDensityCPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+  int* warpx_getCurrentDensityFPLoVects_PML (int lev, int direction, int *return_size, int **ngrowvect);
+
+  amrex::Real** warpx_getFfieldCP_PML (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getFfieldFP_PML (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  int* warpx_getFfieldCPLoVects_PML (int lev, int *return_size, int **ngrowvect);
+  int* warpx_getFfieldFPLoVects_PML (int lev, int *return_size, int **ngrowvect);
+  amrex::Real** warpx_getGfieldCP_PML (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  amrex::Real** warpx_getGfieldFP_PML (int lev, int *return_size, int *ncomps, int **ngrowvect, int **shapes);
+  int* warpx_getGfieldCPLoVects_PML (int lev, int *return_size, int **ngrowvect);
+  int* warpx_getGfieldFPLoVects_PML (int lev, int *return_size, int **ngrowvect);
+
+  int* warpx_getF_pml_nodal_flag ();
+  int* warpx_getG_pml_nodal_flag ();
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -38,9 +38,7 @@ extern "C" {
 
     void amrex_init (int argc, char* argv[]);
 
-#ifdef AMREX_USE_MPI
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm);
-#endif
 
     void amrex_finalize (int finalize_mpi);
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -101,9 +101,6 @@ namespace
     }
 }
 
-extern "C"
-{
-
     int warpx_Real_size()
     {
         return (int)sizeof(amrex::Real);
@@ -728,5 +725,3 @@ extern "C"
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         mypc.Redistribute();
     }
-
-}

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -458,14 +458,14 @@ namespace
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldCPLoVects_PML, GetG_cp)
     WARPX_GET_LOVECTS_PML_SCALAR(warpx_getGfieldFPLoVects_PML, GetG_fp)
 
-    int* warpx_getF_pml_nodal_flag()
+    int* warpx_getF_pml_nodal_flag ()
     {
         auto * pml = WarpX::GetInstance().GetPML(0);
         if (!pml) return nullptr;
         return getFieldNodalFlagData(pml->GetF_fp());
     }
 
-    int* warpx_getG_pml_nodal_flag()
+    int* warpx_getG_pml_nodal_flag ()
     {
         auto * pml = WarpX::GetInstance().GetPML(0);
         if (!pml) return nullptr;

--- a/Source/Python/WarpX_py.cpp
+++ b/Source/Python/WarpX_py.cpp
@@ -7,21 +7,16 @@
  */
 #include "WarpX_py.H"
 
-
-extern "C" {
-
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterinit = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforeEsolve = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_poissonsolver = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterEsolve = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforedeposition = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterdeposition = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_particlescraper = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_particleloader = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforestep = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterstep = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterrestart = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_particleinjection = nullptr;
-    WARPX_CALLBACK_PY_FUNC_0 warpx_py_appliedfields = nullptr;
-
-}
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterinit = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforeEsolve = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_poissonsolver = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterEsolve = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforedeposition = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterdeposition = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_particlescraper = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_particleloader = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_beforestep = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterstep = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_afterrestart = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_particleinjection = nullptr;
+WARPX_CALLBACK_PY_FUNC_0 warpx_py_appliedfields = nullptr;


### PR DESCRIPTION
This does not belong in source files.

Seen as missing symbols on CI for macOS and Intel, both clang compiles.

```
  File "/usr/local/lib/python3.9/site-packages/pywarpx/_libwarpx.py", line 94, in <module>
    from ._libwarpx import *
  File "/usr/local/lib/python3.9/site-packages/pywarpx/_libwarpx.py", line 94, in <module>
    libwarpx.warpx_Real_size.restype = ctypes.c_int
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ctypes/__init__.py", line 387, in __getattr__
    libwarpx.warpx_Real_size.restype = ctypes.c_int
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ctypes/__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: dlsym(0x7f89a3edb820, warpx_Real_size): symbol not found
    func = self.__getitem__(name)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: dlsym(0x7fe5d36c5190, warpx_Real_size): symbol not found

AttributeError: /home/runner/.local/lib/python3.8/site-packages/pywarpx/libwarpx.3d.so: undefined symbol: warpx_Real_size
```

Refs.:
- https://stackoverflow.com/questions/2168241/is-it-required-to-add-extern-c-in-source-file-also
- https://isocpp.org/wiki/faq/mixing-c-and-cpp#call-cpp