### PR TITLE
Fix: Installed Symlink LIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,9 +343,14 @@ if(WarpX_LIB)
     else()
         set(mod_ext "so")
     endif()
+    if(IS_ABSOLUTE CMAKE_INSTALL_LIBDIR)
+        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
+    else()
+        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+    endif()
     install(CODE "file(CREATE_LINK
         $<TARGET_FILE_NAME:shared>
-        ${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
+        ${ABS_INSTALL_LIB_DIR}/libwarpx.${lib_suffix}.${mod_ext}
         COPY_ON_ERROR SYMBOLIC)")
 endif()
 


### PR DESCRIPTION
The latest patch to these routines broke our library alias in installs.

By default, this variable is relative and needs the prefix appended. In some cases, e.g., if externally set, it can already be absolute. In that case, we skip adding the prefix.

Fixes a regression with most package managers introduced in #2583.

The solution herein should also work with `nix`, cc @s9105947

Patch needs to be backported to the 21.12 releases in:
- [x] conda-forge: https://github.com/conda-forge/warpx-feedstock/pull/34
- [x] spack: https://github.com/spack/spack/pull/27800

Also needs to be fixed in ImpactX:
- [x] https://github.com/ECP-WarpX/impactx/pull/22