### PR TITLE
Add function for computing a DistributionMapping that is similar to a given MultiFab.

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -227,6 +227,23 @@ private:
                                          const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
 
     static void CopyToPML (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom);
+
+    /**
+     *  \brief Function that creates a DistributionMapping "similar" to that of a MultiFab.
+     *
+     *  "Similar" means that, if a box in "ba" intersects with any of the
+     *  boxes in the BoxArray associated with "mf", taking "ngrow" ghost cells into account,
+     *  then that box will be assigned to the proc owning the one it has the maximum amount
+     *  of overlap with.
+     *
+     *  @param[in] ba The BoxArray we want to generate a DistributionMapping for.
+     *  @param[in] mf The MultiFab we want said DistributionMapping to be similar to.
+     *  @param[in] ng The number of grow cells to use when computing intersection / overlap
+     *  @return The computed DistributionMapping.
+     */
+    static amrex::DistributionMapping MakeSimilarDM (const amrex::BoxArray& ba,
+                                                     const amrex::MultiFab& mf,
+                                                     const amrex::IntVect& ng);
 };
 
 #ifdef WARPX_USE_PSATD

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1111,7 +1111,7 @@ amrex::DistributionMapping PML::MakeSimilarDM (const amrex::BoxArray& ba,
 {
     amrex::Vector<int> pmap(ba.size());
     const amrex::DistributionMapping& mf_dm = mf.DistributionMap();
-    const amrex::BoxArray& mf_ba = mf.boxArray();
+    const amrex::BoxArray& mf_ba = amrex::convert(mf.boxArray(),ba.ixType());
 
     for (amrex::Long i = 0; i < ba.size(); ++i) {
         amrex::Box box = ba[i];
@@ -1137,7 +1137,7 @@ amrex::DistributionMapping PML::MakeSimilarDM (const amrex::BoxArray& ba,
             pmap[i] = mf_dm[max_overlap_index];
         }
     }
-    return amrex::DistributionMapping(pmap);
+    return amrex::DistributionMapping(std::move(pmap));
 }
 
 void

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -88,7 +88,7 @@ amrex::DistributionMapping makeSimilarDM (const amrex::BoxArray& ba,
                 }
             }
             AMREX_ASSERT(max_overlap > 0);
-            pmap[i] = mf_dm[i];
+            pmap[i] = mf_dm[max_overlap_index];
         }
     }
     return amrex::DistributionMapping(pmap);

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -46,6 +46,54 @@
 
 using namespace amrex;
 
+/**
+ *  \brief Function that creates a DistributionMapping "similar" to that of a MultiFab.
+ *
+ *  "Similar" means that, if a box in "ba" intersects with any of the
+ *  boxes in the BoxArray associated with "mf", taking "ngrow" ghost cells into account,
+ *  then that box will be assigned to the proc owning the one it has the maximum amount
+ *  of overlap with.
+ *
+ *  @param[in] ba The BoxArray we want to generate a DistributionMapping for.
+ *  @param[in] mf The MultiFab we want said DistributionMapping to be similar to.
+ *  @param[in] ng The number of grow cells to use when computing intersection / overlap
+ *  @return The computed DistributionMapping.
+ */
+amrex::DistributionMapping makeSimilarDM (const amrex::BoxArray& ba,
+                                          const amrex::MultiFab& mf,
+                                          const amrex::IntVect& ng)
+{
+    amrex::Vector<int> pmap(ba.size());
+    const amrex::DistributionMapping& mf_dm = mf.DistributionMap();
+    const amrex::BoxArray& mf_ba = mf.boxArray();
+
+    for (amrex::Long i = 0; i < ba.size(); ++i) {
+        amrex::Box box = ba[i];
+        box.grow(ng);
+        bool first_only = false;
+        auto isects = mf_ba.intersections(box, first_only, ng);
+        if (isects.empty()) {
+            // no intersection found, revert to round-robin
+            int nprocs = amrex::ParallelContext::NProcsSub();
+            pmap[i] = i % nprocs;
+        } else {
+            amrex::Long max_overlap = 0;
+            int max_overlap_index = -1;
+            for (const auto& isect : isects) {
+                int gid = isect.first;
+                amrex::Box isect_box = isect.second;
+                if (isect_box.numPts() > max_overlap) {
+                    max_overlap = isect_box.numPts();
+                    max_overlap_index = gid;
+                }
+            }
+            AMREX_ASSERT(max_overlap > 0);
+            pmap[i] = mf_dm[i];
+        }
+    }
+    return amrex::DistributionMapping(pmap);
+}
+
 void
 WarpX::LoadBalance ()
 {


### PR DESCRIPTION
Example, PML dmap with the old strategy:

![original](https://user-images.githubusercontent.com/4329158/145269550-22a80de8-15bb-40c8-bd6b-4c1f55dde881.png)

with this function:

![similarity](https://user-images.githubusercontent.com/4329158/145269614-fe0522d5-cf71-4717-9e44-fd135302713e.png)

The initial use for this is in the PML, but it could potentially be used for coarse / fine levels as well. 
