### PR TITLE
Explicitly load libwarpx DLL after import

### DIFF
--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -74,6 +74,8 @@ class WarpX(Bucket):
         return argv
 
     def init(self, mpi_comm=None):
+        from . import _libwarpx
+        _libwarpx.load_libwarpx()
         from . import wx
         argv = ['warpx'] + self.create_argv_list()
         wx.initialize(argv, mpi_comm=mpi_comm)


### PR DESCRIPTION
This is an alternative to #2637, addressing #2633, as a way to explicitly load the libwarpx C DLL into pywarpx, and print errors if it is accessed before it is explicitly loaded.

In the default case, when `WarpX.init()` is called the DLL is loaded at that time.

I didn't want to take the multitude of variables like `_LP_c_real` and make them part of the DLL object, and didn't want them all explicit globals to handle, so I introduced a separate `lwxinfo` object to hold all of them.