### PR TITLE
C++17: structured bindings to replace "std::tie(x,y,z) = f()"

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -776,7 +776,7 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
             auto currRecord = currSpecies[record_name];
 
             // meta data for ED-PIC extension
-            const auto [std::ignore, newRecord] = addedRecords.insert(record_name);
+            [[maybe_unused]] const auto [_, newRecord] = addedRecords.insert(record_name);
             if( newRecord ) {
                 currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
                 if( record_name == "weighting" )
@@ -798,7 +798,7 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
             auto currRecord = currSpecies[record_name];
 
             // meta data for ED-PIC extension
-            const auto [std::ignore, newRecord] = addedRecords.insert(record_name);
+            [[maybe_unused]] const auto [_, newRecord] = addedRecords.insert(record_name);
             if( newRecord ) {
                 currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
                 currRecord.setAttribute( "macroWeighted", 0u );

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -751,8 +751,7 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
     //
     auto const getComponentRecord = [&currSpecies](std::string const comp_name) {
         // handle scalar and non-scalar records by name
-        std::string record_name, component_name;
-        std::tie(record_name, component_name) = detail::name2openPMD(comp_name);
+        const auto [record_name, component_name] = detail::name2openPMD(comp_name);
         return currSpecies[record_name][component_name];
     };
     auto const real_counter = std::min(write_real_comp.size(), real_comp_names.size());
@@ -773,13 +772,11 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
         auto ii = m_NumAoSRealAttributes + idx; // jump over AoS names
         if (write_real_comp[ii]) {
             // handle scalar and non-scalar records by name
-            std::string record_name, component_name;
-            std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[ii]);
+            const auto [record_name, component_name] = detail::name2openPMD(real_comp_names[ii]);
             auto currRecord = currSpecies[record_name];
 
             // meta data for ED-PIC extension
-            bool newRecord = false;
-            std::tie(std::ignore, newRecord) = addedRecords.insert(record_name);
+            const auto [std::ignore, newRecord] = addedRecords.insert(record_name);
             if( newRecord ) {
                 currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
                 if( record_name == "weighting" )
@@ -797,13 +794,11 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
         auto ii = m_NumAoSIntAttributes + idx; // jump over AoS names
         if (write_int_comp[ii]) {
             // handle scalar and non-scalar records by name
-            std::string record_name, component_name;
-            std::tie(record_name, component_name) = detail::name2openPMD(int_comp_names[ii]);
+            const auto [record_name, component_name] = detail::name2openPMD(int_comp_names[ii]);
             auto currRecord = currSpecies[record_name];
 
             // meta data for ED-PIC extension
-            bool newRecord = false;
-            std::tie(std::ignore, newRecord) = addedRecords.insert(record_name);
+            const auto [std::ignore, newRecord] = addedRecords.insert(record_name);
             if( newRecord ) {
                 currRecord.setUnitDimension( detail::getUnitDimension(record_name) );
                 currRecord.setAttribute( "macroWeighted", 0u );
@@ -843,8 +838,7 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
     for( auto idx=0; idx<m_NumAoSRealAttributes; idx++ ) {
       if( write_real_comp[idx] ) {
           // handle scalar and non-scalar records by name
-          std::string record_name, component_name;
-          std::tie(record_name, component_name) = detail::name2openPMD(real_comp_names[idx]);
+          const auto [record_name, component_name] = detail::name2openPMD(real_comp_names[idx]);
           auto currRecord = currSpecies[record_name];
           auto currRecordComp = currRecord[component_name];
 
@@ -864,8 +858,7 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
 
   auto const getComponentRecord = [&currSpecies](std::string const comp_name) {
     // handle scalar and non-scalar records by name
-    std::string record_name, component_name;
-    std::tie(record_name, component_name) = detail::name2openPMD(comp_name);
+    const auto [record_name, component_name] = detail::name2openPMD(comp_name);
     return currSpecies[record_name][component_name];
   };
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -121,8 +121,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::fill_amplitude (
     }
 
     //Find left and right time indices
-    int idx_t_left, idx_t_right;
-    std::tie(idx_t_left, idx_t_right) = find_left_right_time_indices(t);
+    const auto [idx_t_left, idx_t_right] = find_left_right_time_indices(t);
 
     if(idx_t_left <  m_params.first_time_index){
         Abort("Something bad has happened with the simulation time");

--- a/Source/Utils/MsgLogger/MsgLogger.cpp
+++ b/Source/Utils/MsgLogger/MsgLogger.cpp
@@ -251,9 +251,7 @@ Logger::collective_gather_msgs_with_counter_and_ranks() const
     // Find out who is the "gather rank" and how many messages it has
     const auto my_msgs = get_msgs();
     const auto how_many_msgs = my_msgs.size();
-    int gather_rank = 0;
-    std::int64_t gather_rank_how_many_msgs = 0;
-    std::tie(gather_rank, gather_rank_how_many_msgs) =
+    const auto [gather_rank, gather_rank_how_many_msgs] =
         find_gather_rank_and_its_msgs(how_many_msgs);
 
     // If the "gather rank" has zero messages there are no messages at all
@@ -273,9 +271,7 @@ Logger::collective_gather_msgs_with_counter_and_ranks() const
             m_messages, is_gather_rank);
 
     // Send back all the data to the "gather rank"
-    auto all_data = std::vector<char>{};
-    auto displacements = std::vector<int>{};
-    std::tie(all_data, displacements) =
+    const auto [all_data, displacements] =
         ::gather_all_data(
             package_for_gather_rank,
             gather_rank, m_rank);


### PR DESCRIPTION
This PR takes advantage of the structured bindings feature available in C++17 to replace code like:
```
T1 x; T2 y; T3 z;
std::tie(x,y,z) = f(); 
```
with the more compact:
```
auto [x,y,z] = f();
```
or (if possible) with:
```
const auto [x,y,z] = f();
```