### PR TITLE
CMake 3.22+: Policy CMP0127

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,16 @@ endif()
 # AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
 # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-#if(CMAKE_VERSION VERSION_LESS 3.20)
-    if(POLICY CMP0104)
-        cmake_policy(SET CMP0104 OLD)
-    endif()
-#endif()
+if(POLICY CMP0104)
+    cmake_policy(SET CMP0104 OLD)
+endif()
+
+# We use simple syntax in cmake_dependent_option, so we are compatible with the
+# extended syntax in CMake 3.22+
+# https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
+if(POLICY CMP0127)
+    cmake_policy(SET CMP0127 NEW)
+endif()
 
 
 # C++ Standard in Superbuilds #################################################


### PR DESCRIPTION
Fix a warning with CMake 3.22+.

We use simple syntax in `cmake_dependent_option`, so we are compatible with the extended syntax in CMake 3.22+:
  https://cmake.org/cmake/help/v3.22/policy/CMP0127.html

We also need https://github.com/AMReX-Codes/amrex/pull/2525 with the next weekly update.