### PR TITLE
Add anisotropic mesh refinement example

### DIFF
--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_anisotropic.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_anisotropic.json
@@ -1,0 +1,44 @@
+{
+  "electrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 1123057664.0,
+    "particle_momentum_x": 4.2409233886523047e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.239636641708783e-20,
+    "particle_position_x": 0.6553604498033957,
+    "particle_position_y": 0.6553602617123965,
+    "particle_weight": 3200000000000000.5
+  },
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 29.033843714475076,
+    "Bz": 0.0,
+    "Ex": 7575734617759.523,
+    "Ey": 0.0,
+    "Ez": 7575399948801.469,
+    "jx": 7296519320465208.0,
+    "jy": 0.0,
+    "jz": 7297090426947096.0
+  },
+  "lev=1": {
+    "Bx": 0.0,
+    "By": 71.46369739075365,
+    "Bz": 0.0,
+    "Ex": 4602033610493.496,
+    "Ey": 0.0,
+    "Ez": 7017735833493.598,
+    "jx": 4492590664379721.0,
+    "jy": 0.0,
+    "jz": 6825856952745953.0
+  },
+  "positrons": {
+    "particle_cpu": 32768.0,
+    "particle_id": 3371204608.0,
+    "particle_momentum_x": 4.240515207391037e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 4.2396984750798293e-20,
+    "particle_position_x": 0.6553601899702647,
+    "particle_position_y": 0.6553597467035968,
+    "particle_weight": 3200000000000000.5
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -577,6 +577,25 @@ analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
 tolerance = 1.e-14
 
+[Langmuir_multi_2d_MR_anisotropic]
+buildDir = .
+inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
+runtime_params = algo.maxwell_solver = ckc  warpx.use_filter = 1  amr.max_level = 1 amr.ref_ratio_vect = 4 2 warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
+dim = 2
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+analysisOutputImage = Langmuir_multi_2d_MR.png
+tolerance = 1.e-14
+
 [Langmuir_multi_2d_MR_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt


### PR DESCRIPTION
This adds a 2D Langmuir test where the mesh refinement ratio is different in x and z (4 and 2 respectively).