### PR TITLE
CMake: 3.18+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.18.0)
 project(WarpX VERSION 21.12)
 
 include(${WarpX_SOURCE_DIR}/cmake/WarpXFunctions.cmake)

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 7, Clang 6, NVCC 11.0, MSVC 19.15 or newer
-- `CMake 3.17.0+ <https://cmake.org>`__
+- `CMake 3.18.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `PICSAR <https://github.com/ECP-WarpX/picsar>`__: we automatically download and compile a copy of PICSAR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.17.0,<4.0.0"
+    "cmake>=3.18.0,<4.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
-                "CMake 3.17.0+ must be installed to build the following " +
+                "CMake 3.18.0+ must be installed to build the following " +
                 "extensions: " +
                 ", ".join(e.name for e in self.extensions))
 
@@ -60,8 +60,8 @@ class CMakeBuild(build_ext):
             r'version\s*([\d.]+)',
             out.decode()
         ).group(1))
-        if cmake_version < '3.17.0':
-            raise RuntimeError("CMake >= 3.17.0 is required")
+        if cmake_version < '3.18.0':
+            raise RuntimeError("CMake >= 3.18.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
With the C++17 switch, we required CMake 3.17+ since that one introduced the `cuda_std_17` target compile feature.

It turns out that one of the many CUDA improvements in CMake 3.18+ is also to fix that feature for good, so we bump our requirement in CMake. Since CMake is easy to install, it's easier to require a clean newer version than working around a broken old one.

Spotted first by Phil on AWS instances, thx!

```console
$ cmake ~/repos/WarpX/  -DWarpX_DIMS=2 -DWarpX_EB=OFF -DWarpX_LIB=OFF -DWarpX_COMPUTE=CUDA -DWarpX_OPENPMD=ON -G Ninja
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found CCache: /usr/local/bin/ccache
-- Downloading AMReX ...
-- AMReX repository: https://github.com/AMReX-Codes/amrex.git (60fe729fe2ba65ebffc88c0af18743c254d3992c)
-- Check for working CUDA compiler: /usr/local/cuda-11.3/bin/nvcc
CMake Error in CMakeFiles/CMakeTmp/CMakeLists.txt:
  Target "cmTC_342f9" requires the language dialect "CUDA17" , but CMake does
  not know the compile flags to use to enable it.


CMake Error at /home/ubuntu/cmake/share/cmake-3.17/Modules/CMakeTestCUDACompiler.cmake:30 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  cmake/dependencies/AMReX.cmake:129 (enable_language)
  cmake/dependencies/AMReX.cmake:246 (find_amrex)
  CMakeLists.txt:112 (include)


-- Configuring incomplete, errors occurred!
See also "CMakeFiles/CMakeOutput.log".
```
and
```console
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2021 NVIDIA Corporation
Built on Mon_May__3_19:15:13_PDT_2021
Cuda compilation tools, release 11.3, V11.3.109
Build cuda_11.3.r11.3/compiler.29920130_0


$ apt policy cuda
cuda:
  Installed: 11.3.1-1
  Candidate: 11.3.1-1
  Version table:
 *** 11.3.1-1 600
        600 file:/var/cuda-repo-ubuntu2004-11-3-local  Packages
        100 /var/lib/dpkg/status


$ ~/cmake/bin/cmake --version
cmake version 3.17.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```