### PR TITLE
run_test.sh: Own virtual env

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -74,19 +74,16 @@ jobs:
   - bash: |
       cat /proc/cpuinfo | grep "model name" | sort -u
       df -h
-      sudo apt install -y ccache gcc gfortran g++ openmpi-bin libopenmpi-dev \
+      sudo apt install -y ccache curl gcc gfortran git g++ openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
       ccache --set-config=max_size=10.0G
-      sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
-      sudo update-alternatives --set python /usr/bin/python3
-      python -m pip install --upgrade pip
-      python -m pip install --upgrade wheel
-      python -m pip install --upgrade pipx
-      python -m pipx install cmake
-      python -m pipx ensurepath
+      python3 -m pip install --upgrade pip
+      python3 -m pip install --upgrade wheel
+      python3 -m pip install --upgrade pipx
+      python3 -m pipx install cmake
+      python3 -m pipx ensurepath
       export PATH="$HOME/.local/bin:$PATH"
-      python -m pip install --upgrade matplotlib mpi4py numpy scipy yt
       sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
       sudo chmod a+x /usr/local/bin/cmake-easyinstall
       if [ "${WARPX_CI_OPENPMD:-FALSE}" == "TRUE" ]; then
@@ -95,7 +92,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)         \
           -DCMAKE_VERBOSE_MAKEFILE=ON                           \
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
-        python -m pip install --upgrade openpmd-api
+        python3 -m pip install --upgrade openpmd-api
       fi
       if [[ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" || "${WARPX_CI_PYTHON_MAIN:-FALSE}" == "TRUE" ]]; then
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \

--- a/run_test.sh
+++ b/run_test.sh
@@ -57,6 +57,12 @@ ln -s ${tmp_dir} test_dir
 cd test_dir
 echo "cd $PWD"
 
+# Prepare a virtual environment
+rm -rf py-venv
+python3 -m venv py-venv
+source py-venv/bin/activate
+python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
+
 # Clone PICSAR, AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
 cd amrex && git checkout --detach 60fe729fe2ba65ebffc88c0af18743c254d3992c && cd -
@@ -73,7 +79,7 @@ git clone https://github.com/ECP-WarpX/regression_testing.git
 mkdir -p rt-WarpX/WarpX-benchmarks
 cd warpx/Regression
 echo "cd $PWD"
-python prepare_file_ci.py
+python3 prepare_file_ci.py
 cp ci-tests.ini ../../rt-WarpX
 cp -r Checksum ../../regression_testing/
 
@@ -82,8 +88,13 @@ cd ../../regression_testing/
 echo "cd $PWD"
 # run only tests specified in variable tests_arg (single test or multiple tests)
 if [[ ! -z "${tests_arg}" ]]; then
-  python regtest.py ../rt-WarpX/ci-tests.ini --no_update all "${tests_run}"
+  python3 regtest.py ../rt-WarpX/ci-tests.ini --no_update all "${tests_run}"
 # run all tests (variables tests_arg and tests_run are empty)
 else
-  python regtest.py ../rt-WarpX/ci-tests.ini --no_update all
+  python3 regtest.py ../rt-WarpX/ci-tests.ini --no_update all
 fi
+
+# clean up python virtual environment
+cd ../
+echo "cd $PWD"
+deactivate


### PR DESCRIPTION
Isolate builds locally, so we don't overwrite a developer's setup anymore. This also avoids a couple of nifty problems that can occur by mixing those envs.

Originally part of #2556

Missing file added in 8f93e010ccf2bb2c5b1236330ebd27d104732890 & aa8e0b552054c683c68798834d3f70236e96ac30, docs added in #2656
Python prefix hacks removed in 70e19bd38dc5b0eb93da851f2adc09f050a3ba62