### PR TITLE
GNUmake: Fix Python Install (force)

### DIFF
--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -235,7 +235,7 @@ endif
 
 installwarpx: libwarpx.$(PYDIM).so
 	mv libwarpx.$(PYDIM).so Python/pywarpx
-	cd Python; python setup.py install --with-libwarpx $(PYDIM) $(PYINSTALLOPTIONS)
+	cd Python; python setup.py install --force --with-libwarpx $(PYDIM) $(PYINSTALLOPTIONS)
 
 libwarpx.$(PYDIM).a: $(objForExecs)
 	@echo Making static library $@ ...


### PR DESCRIPTION
Local developers and cached CI installs did never install `pywarpx` if and old version existed. The `--force` must be with us.