### PR TITLE
ICC CI: Unbound Vars (`setvars.sh`)

### DIFF
--- a/.github/workflows/dependencies/icc.sh
+++ b/.github/workflows/dependencies/icc.sh
@@ -26,9 +26,9 @@ sudo apt-get update
 sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
 # activate now via
-set +e
+set +eu
 source /opt/intel/oneapi/setvars.sh
-set -e
+set -eu
 
 # cmake-easyinstall
 sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -23,9 +23,9 @@ jobs:
         .github/workflows/dependencies/icc.sh
     - name: build WarpX
       run: |
-        set +e
+        set +eu
         source /opt/intel/oneapi/setvars.sh
-        set -e
+        set -eu
         export CXX=$(which icpc)
         export CC=$(which icc)
 


### PR DESCRIPTION
Ignore:
```
/opt/intel/oneapi/compiler/latest/env/vars.sh: line 236: OCL_ICD_FILENAMES: unbound variable
```

CC @rscohn2:
It looks like `source /opt/intel/oneapi/setvars.sh` got a bit worse in the last release of oneAPI.
Currently only seen when installing `intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic`.