### PR TITLE
Fix the scope of profiler for SYCL

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -55,11 +55,11 @@ int main(int argc, char* argv[])
     CheckGriddingForRZSpectral();
 #endif
 
-    WARPX_PROFILE_VAR("main()", pmain);
-
-    const auto strt_total = static_cast<Real>(amrex::second());
-
     {
+        WARPX_PROFILE_VAR("main()", pmain);
+
+        const auto strt_total = static_cast<Real>(amrex::second());
+
         WarpX warpx;
 
         warpx.InitData();
@@ -73,9 +73,9 @@ int main(int argc, char* argv[])
             ParallelDescriptor::ReduceRealMax(end_total, ParallelDescriptor::IOProcessorNumber());
             Print() << "Total Time                     : " << end_total << '\n';
         }
-    }
 
-    WARPX_PROFILE_VAR_STOP(pmain);
+        WARPX_PROFILE_VAR_STOP(pmain);
+    }
 
 #if defined(AMREX_USE_HIP) && defined(WARPX_USE_PSATD)
     rocfft_cleanup();


### PR DESCRIPTION
In main.cpp, the destructor of the profiler was called after
amrex::Finalize.  This caused an error in SYCL due to a device
synchronization call in the dtor, because the SYCL queues in amrex had been
deleted.  In this commit, we limit the scope of the profiler so that its
destructor is called before the queues are deleted.  Note that it was never
an issue for CUDA/HIP, because the device synchronization calls in those
backends do not need any amrex objects.