### PR TITLE
CI: Remove (`particle_`)`tolerance`

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -19,6 +19,10 @@ purge_output = 1
 MAKE = make
 numMakeJobs = 8
 
+# Control the build of the particle_compare tool.
+# Needed for test particle_tolerance option.
+use_ctools = 0
+
 # MPIcommand should use the placeholders:
 #   @host@ to indicate where to put the hostname to run on
 #   @nprocs@ to indicate where to put the number of processors
@@ -74,7 +78,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_yee.py
-tolerance = 1e-9
 
 [pml_x_ckc]
 buildDir = .
@@ -90,7 +93,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
-tolerance = 1e-9
 
 #[pml_x_psatd]
 #buildDir = .
@@ -106,8 +108,7 @@ tolerance = 1e-9
 #compileTest = 0
 #doVis = 0
 #analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
-#tolerance = 1.e-14
-
+#
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
@@ -123,7 +124,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
-tolerance = 1e-12
 
 [RigidInjection_boost_backtransformed]
 buildDir = .
@@ -142,7 +142,6 @@ compareParticles = 0
 doComparison = 0
 aux1File = Tools/PostProcessing/read_raw_data.py
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
-tolerance = 1.e-14
 
 [nci_corrector]
 buildDir = .
@@ -159,7 +158,6 @@ compileTest = 0
 doVis = 0
 doComparison = 0
 analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
-tolerance = 1.e-14
 
 # [nci_correctorMR]
 # buildDir = .
@@ -176,8 +174,7 @@ tolerance = 1.e-14
 # doVis = 0
 # doComparison = 0
 # analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
-# tolerance = 1.e-14
-
+#
 # [ionization_lab]
 # buildDir = .
 # inputFile = Examples/Modules/ionization/inputs_2d_rt
@@ -192,8 +189,7 @@ tolerance = 1.e-14
 # compileTest = 0
 # doVis = 0
 # analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
-# tolerance = 1.e-14
-
+#
 # [ionization_boost]
 # buildDir = .
 # inputFile = Examples/Modules/ionization/inputs_2d_bf_rt
@@ -208,8 +204,7 @@ tolerance = 1.e-14
 # compileTest = 0
 # doVis = 0
 # analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
-# tolerance = 1.e-14
-
+#
 [bilinear_filter]
 buildDir = .
 inputFile = Examples/Tests/SingleParticle/inputs_2d
@@ -224,7 +219,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
-tolerance = 1e-15
 
 [Langmuir_2d]
 buildDir = .
@@ -243,7 +237,6 @@ particleTypes = electrons
 runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 diag1.fields_to_plot=Ex jx diag1.electrons.variables=w ux
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
 analysisOutputImage = langmuir2d_analysis.png
-tolerance = 1e-12
 
 [Langmuir_2d_single_precision]
 buildDir = .
@@ -262,7 +255,6 @@ compareParticles = 0
 particleTypes = electrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
 analysisOutputImage = langmuir2d_analysis.png
-tolerance = 1.0e-4
 
 [Langmuir_2d_nompi]
 buildDir = .
@@ -281,7 +273,6 @@ particleTypes = electrons
 runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 diag1.fields_to_plot=Ex jx diag1.electrons.variables=w ux
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir2d.py
 analysisOutputImage = langmuir2d_analysis.png
-tolerance = 1e-12
 
 [Langmuir_x]
 buildDir = .
@@ -300,7 +291,6 @@ particleTypes = electrons
 runtime_params = electrons.ux=0.01 electrons.xmax=0.e-6 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex jx diag1.electrons.variables=w ux
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
 analysisOutputImage = langmuir_x_analysis.png
-tolerance = 5e-11
 
 [Langmuir_y]
 buildDir = .
@@ -319,7 +309,6 @@ particleTypes = electrons
 runtime_params = electrons.uy=0.01 electrons.ymax=0.e-6 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ey jy diag1.electrons.variables=w uy
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
 analysisOutputImage = langmuir_y_analysis.png
-tolerance = 5e-11
 
 [Langmuir_z]
 buildDir = .
@@ -338,7 +327,6 @@ particleTypes = electrons
 runtime_params = electrons.uz=0.01 electrons.zmax=0.e-6 warpx.do_dynamic_scheduling=0  diag1.fields_to_plot = Ez jz diag1.electrons.variables=w uz
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir.py
 analysisOutputImage = langmuir_z_analysis.png
-tolerance = 5e-11
 
 [Langmuir_multi]
 buildDir = .
@@ -357,7 +345,6 @@ runtime_params = warpx.do_dynamic_scheduling=0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 2e-9
 
 [Langmuir_multi_nodal]
 buildDir = .
@@ -376,7 +363,6 @@ runtime_params = warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_dep
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5e-11
 
 [Langmuir_multi_psatd]
 buildDir = .
@@ -395,7 +381,6 @@ compareParticles = 0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 2.e-9
 
 [Langmuir_multi_psatd_nodal]
 buildDir = .
@@ -414,7 +399,6 @@ compareParticles = 0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
 
 [Langmuir_multi_2d_nodal]
 buildDir = .
@@ -433,7 +417,6 @@ runtime_params = warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 5e-11
 
 [Langmuir_multi_2d_psatd]
 buildDir = .
@@ -452,7 +435,6 @@ compareParticles = 0
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 5e-11
 
 # [Langmuir_multi_2d_psatd_nodal]
 # buildDir = .
@@ -471,8 +453,7 @@ tolerance = 5e-11
 # particleTypes = electrons positrons
 # analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 # analysisOutputImage = langmuir_multi_2d_analysis.png
-# tolerance = 5e-11
-
+#
 # [Langmuir_multi_rz]
 # buildDir = .
 # inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -490,8 +471,7 @@ tolerance = 5e-11
 # particleTypes = electrons ions
 # analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 # analysisOutputImage = langmuir_multi_rz_analysis.png
-# tolerance = 5e-11
-
+#
 # [Langmuir_rz_multimode]
 # buildDir = .
 # inputFile = Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -509,8 +489,7 @@ tolerance = 5e-11
 # compareParticles = 0
 # particleTypes = electrons protons
 # outputFile = diags/plotfiles/plt00040
-# tolerance = 5e-11
-
+#
 [LaserInjection]
 buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs_3d_rt
@@ -527,7 +506,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/laser_injection/analysis_laser.py
 analysisOutputImage = laser_analysis.png
-tolerance = 1.e-14
 
 [LaserInjection_2d]
 buildDir = .
@@ -543,7 +521,6 @@ compileTest = 0
 doVis = 0
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 compareParticles = 0
-tolerance = 1.e-14
 
 #xxxxx
 #[LaserAcceleration]
@@ -561,8 +538,7 @@ tolerance = 1.e-14
 #doVis = 0
 #compareParticles = 0
 #particleTypes = electrons
-#tolerance = 5e-11
-
+#
 [subcyclingMR]
 buildDir = .
 inputFile = Examples/Tests/subcycling/inputs_2d
@@ -577,7 +553,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-tolerance = 1.e-10
 
 [LaserAccelerationMR]
 buildDir = .
@@ -594,7 +569,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 particleTypes = electrons beam
-tolerance = 5e-11
 
 [PlasmaAccelerationMR]
 buildDir = .
@@ -611,7 +585,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 particleTypes = beam driver plasma_e
-tolerance = 5e-11
 
 [Python_Langmuir]
 buildDir = .
@@ -630,7 +603,6 @@ doVis = 0
 compareParticles = 0
 particleTypes = electrons
 outputFile = diags/diag200040
-tolerance = 5e-11
 
 [uniform_plasma_restart]
 buildDir = .
@@ -648,7 +620,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 particleTypes = electrons
-tolerance = 1.e-12
 
 [particles_in_pml_2d]
 buildDir = .
@@ -665,7 +636,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1e-12
 
 [particles_in_pml]
 buildDir = .
@@ -682,7 +652,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1e-10
 
 [photon_pusher]
 buildDir = .
@@ -699,4 +668,3 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine =  Examples/Tests/photon_pusher/analysis_photon_pusher.py
-tolerance = 1.e-14

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -19,6 +19,10 @@ purge_output = 1
 MAKE = make
 numMakeJobs = 8
 
+# Control the build of the particle_compare tool.
+# Needed for test particle_tolerance option.
+use_ctools = 0
+
 # MPIcommand should use the placeholders:
 #   @host@ to indicate where to put the hostname to run on
 #   @nprocs@ to indicate where to put the number of processors
@@ -75,7 +79,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_yee.py
-tolerance = 1.e-14
 
 [pml_x_ckc]
 buildDir = .
@@ -91,7 +94,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
-tolerance = 1.e-14
 
 [pml_x_psatd]
 buildDir = .
@@ -108,7 +110,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
-tolerance = 1.e-14
 
 [pml_psatd_dive_divb_cleaning]
 buildDir = .
@@ -124,7 +125,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [silver_mueller_2d_x]
 buildDir = .
@@ -140,7 +140,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/SilverMueller/analysis_silver_mueller.py
-tolerance = 1.e-14
 
 [silver_mueller_2d_z]
 buildDir = .
@@ -156,7 +155,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/SilverMueller/analysis_silver_mueller.py
-tolerance = 1.e-14
 
 [silver_mueller_rz_z]
 buildDir = .
@@ -172,7 +170,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/SilverMueller/analysis_silver_mueller.py
-tolerance = 1.e-14
 
 [RigidInjection_lab]
 buildDir = .
@@ -189,7 +186,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
-tolerance = 1.e-14
 
 [RigidInjection_BTD]
 buildDir = .
@@ -208,7 +204,6 @@ compareParticles = 0
 doComparison = 0
 aux1File = Tools/PostProcessing/read_raw_data.py
 analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
-tolerance = 1.e-14
 
 [BTD_ReducedSliceDiag]
 buildDir = .
@@ -227,7 +222,6 @@ compareParticles = 0
 doComparison = 0
 aux1File = Tools/PostProcessing/read_raw_data.py
 analysisRoutine = Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
-tolerance = 1.e-14
 
 [nci_corrector]
 buildDir = .
@@ -244,7 +238,6 @@ compileTest = 0
 doVis = 0
 doComparison = 0
 analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
-tolerance = 1.e-14
 
 [nci_correctorMR]
 buildDir = .
@@ -261,7 +254,6 @@ compileTest = 0
 doVis = 0
 doComparison = 0
 analysisRoutine = Examples/Modules/nci_corrector/analysis_ncicorr.py
-tolerance = 1.e-14
 
 [ionization_lab]
 buildDir = .
@@ -277,7 +269,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
-tolerance = 1.e-14
 
 [ionization_boost]
 buildDir = .
@@ -293,7 +284,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/ionization/analysis_ionization.py
-tolerance = 1.e-14
 
 [bilinear_filter]
 buildDir = .
@@ -309,7 +299,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/SingleParticle/analysis_bilinear_filter.py
-tolerance = 1.e-14
 
 [Langmuir_multi]
 buildDir = .
@@ -328,7 +317,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_single_precision]
 buildDir = .
@@ -347,7 +335,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 1.0e-4
 
 [Langmuir_multi_nodal]
 buildDir = .
@@ -366,7 +353,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_psatd]
 buildDir = .
@@ -385,7 +371,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
 
 [Langmuir_multi_psatd_div_cleaning]
 buildDir = .
@@ -404,7 +389,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
 
 [Langmuir_multi_psatd_current_correction]
 buildDir = .
@@ -420,7 +404,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-tolerance = 5.e-11
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -439,7 +422,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-tolerance = 5.e-11
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -458,7 +440,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-tolerance = 5.e-11
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -477,7 +458,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-tolerance = 5.e-11
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
@@ -499,7 +479,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
 
 [Langmuir_multi_psatd_nodal]
 buildDir = .
@@ -518,7 +497,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-11
 
 [Langmuir_multi_psatd_single_precision]
 buildDir = .
@@ -537,7 +515,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi.py
 analysisOutputImage = langmuir_multi_analysis.png
-tolerance = 5.e-7
 
 [Langmuir_multi_2d_nodal]
 buildDir = .
@@ -556,7 +533,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_MR]
 buildDir = .
@@ -575,7 +551,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_MR_anisotropic]
 buildDir = .
@@ -594,7 +569,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_MR_psatd]
 buildDir = .
@@ -613,7 +587,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_psatd]
 buildDir = .
@@ -632,7 +605,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_psatd_momentum_conserving]
 buildDir = .
@@ -651,7 +623,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_2d_psatd_current_correction]
 buildDir = .
@@ -742,7 +713,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_1d]
 buildDir = .
@@ -761,7 +731,6 @@ compareParticles = 1
 particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_1d.py
 analysisOutputImage = langmuir_multi_1d_analysis.png
-tolerance = 1.e-14
 
 [Langmuir_multi_rz]
 buildDir = .
@@ -781,7 +750,6 @@ particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-14
 
 [Langmuir_multi_rz_psatd]
 buildDir = .
@@ -801,7 +769,6 @@ particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-14
 
 [Langmuir_multi_rz_psatd_current_correction]
 buildDir = .
@@ -821,7 +788,6 @@ particleTypes = electrons ions
 analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-14
 
 [Python_Langmuir_rz_multimode]
 buildDir = .
@@ -840,7 +806,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons protons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_restart_runtime_components]
 buildDir = .
@@ -859,7 +824,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 particleTypes = electrons
-tolerance = 1.e-14
 
 [LaserInjection]
 buildDir = .
@@ -877,7 +841,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/laser_injection/analysis_laser.py
 analysisOutputImage = laser_analysis.png
-tolerance = 1.e-14
 
 [LaserInjection_2d]
 buildDir = .
@@ -894,7 +857,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/laser_injection/analysis_2d.py
-tolerance = 1.e-14
 
 [LaserInjection_1d]
 buildDir = .
@@ -911,7 +873,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/laser_injection/analysis_1d.py
-tolerance = 1.e-14
 
 [LaserAcceleration]
 buildDir = .
@@ -929,7 +890,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserAcceleration_1d]
 buildDir = .
@@ -947,7 +907,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserAcceleration_single_precision_comms]
 buildDir = .
@@ -965,7 +924,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 2.e-7
 
 [subcyclingMR]
 buildDir = .
@@ -982,7 +940,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-10
 
 [LaserAccelerationMR]
 buildDir = .
@@ -1000,8 +957,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
-particle_tolerance = 1e-14
 
 [RefinedInjection]
 buildDir = .
@@ -1019,8 +974,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons beam
 analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
-tolerance = 1.e-14
-particle_tolerance = 1e-14
 
 [PlasmaAccelerationMR]
 buildDir = .
@@ -1038,8 +991,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = beam driver plasma_e
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-12
-particle_tolerance = 1.e-12
 
 [Python_Langmuir]
 buildDir = .
@@ -1058,7 +1009,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [uniform_plasma_restart]
 buildDir = .
@@ -1077,7 +1027,6 @@ doVis = 0
 compareParticles = 0
 particleTypes = electrons
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
-tolerance = 1.e-14
 
 [restart]
 buildDir = .
@@ -1096,7 +1045,6 @@ doVis = 0
 compareParticles = 0
 particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
-tolerance = 1.e-14
 
 [restart_psatd]
 buildDir = .
@@ -1115,7 +1063,6 @@ doVis = 0
 compareParticles = 0
 particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
-tolerance = 1.e-14
 
 [restart_psatd_time_avg]
 buildDir = .
@@ -1134,7 +1081,6 @@ doVis = 0
 compareParticles = 0
 particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
-tolerance = 1.e-14
 
 [space_charge_initialization_2d]
 buildDir = .
@@ -1152,7 +1098,6 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
-tolerance = 1.e-14
 
 [space_charge_initialization]
 buildDir = .
@@ -1170,7 +1115,6 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
-tolerance = 1.e-14
 
 [relativistic_space_charge_initialization]
 buildDir = .
@@ -1188,7 +1132,6 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/relativistic_space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
-tolerance = 1.e-14
 
 [parabolic_channel_initialization_2d_single_precision]
 buildDir = .
@@ -1205,7 +1148,6 @@ doVis = 0
 compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Tests/initial_plasma_profile/analysis.py
-tolerance = 1.e-14
 
 [divb_cleaning_3d]
 buildDir = .
@@ -1222,7 +1164,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/divb_cleaning/analysis.py
-tolerance = 1.e-14
 
 [dive_cleaning_2d]
 buildDir = .
@@ -1240,7 +1181,6 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0 diag1.file_prefix=dive_cleaning_2d_plt
 analysisRoutine = Examples/Modules/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
-tolerance = 1.e-14
 
 [dive_cleaning_3d]
 buildDir = .
@@ -1258,7 +1198,6 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0 diag1.file_prefix=dive_cleaning_3d_plt
 analysisRoutine = Examples/Modules/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
-tolerance = 1.e-14
 
 [particles_in_pml_2d]
 buildDir = .
@@ -1275,7 +1214,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1.e-14
 
 
 [particles_in_pml_2d_MR]
@@ -1293,7 +1231,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1.e-14
 
 [particles_in_pml]
 buildDir = .
@@ -1310,7 +1247,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1.e-14
 
 
 [particles_in_pml_3d_MR]
@@ -1328,7 +1264,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
-tolerance = 1.e-14
 
 [photon_pusher]
 buildDir = .
@@ -1345,7 +1280,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/photon_pusher/analysis_photon_pusher.py
-tolerance = 1.e-14
 
 [radiation_reaction]
 buildDir = .
@@ -1362,7 +1296,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
-tolerance = 1.e-14
 
 [qed_breit_wheeler_2d]
 buildDir = .
@@ -1380,7 +1313,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_yt.py
-tolerance = 1.e-14
 
 [qed_breit_wheeler_3d]
 buildDir = .
@@ -1398,7 +1330,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_yt.py
-tolerance = 1.e-14
 
 [qed_breit_wheeler_2d_opmd]
 buildDir = .
@@ -1416,7 +1347,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_opmd.py
-tolerance = 1.e-14
 
 [qed_breit_wheeler_3d_opmd]
 buildDir = .
@@ -1434,7 +1364,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/breit_wheeler/analysis_opmd.py
-tolerance = 1.e-14
 
 [qed_quantum_sync_2d]
 buildDir = .
@@ -1451,7 +1380,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/quantum_synchrotron/analysis.py
-tolerance = 1.e-14
 
 [qed_quantum_sync_3d]
 buildDir = .
@@ -1468,7 +1396,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Modules/qed/quantum_synchrotron/analysis.py
-tolerance = 1.e-14
 
 [qed_schwinger1]
 buildDir = .
@@ -1484,7 +1411,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/qed/schwinger/analysis_schwinger.py
-tolerance = 1.e-14
 
 [qed_schwinger2]
 buildDir = .
@@ -1500,7 +1426,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/qed/schwinger/analysis_schwinger.py
-tolerance = 1.e-14
 
 [qed_schwinger3]
 buildDir = .
@@ -1516,7 +1441,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/qed/schwinger/analysis_schwinger.py
-tolerance = 1.e-14
 
 [qed_schwinger4]
 buildDir = .
@@ -1532,7 +1456,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Modules/qed/schwinger/analysis_schwinger.py
-tolerance = 1.e-14
 
 [particle_pusher]
 buildDir = .
@@ -1549,7 +1472,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine =  Examples/Tests/particle_pusher/analysis_pusher.py
-tolerance = 1.e-14
 
 [Python_gaussian_beam]
 buildDir = .
@@ -1568,7 +1490,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_gaussian_beam_opmd]
 buildDir = .
@@ -1587,7 +1508,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine =
-tolerance = 1.e-14
 
 [PlasmaAccelerationBoost2d]
 buildDir = .
@@ -1603,7 +1523,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_PlasmaAcceleration]
 buildDir = .
@@ -1622,7 +1541,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_PlasmaAccelerationMR]
 buildDir = .
@@ -1641,7 +1559,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_PlasmaAcceleration1d]
 buildDir = .
@@ -1660,7 +1577,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [PlasmaAccelerationBoost3d]
 buildDir = .
@@ -1676,7 +1592,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 2.e-14
 
 [PlasmaMirror]
 buildDir = .
@@ -1692,7 +1607,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserIonAcc2d]
 buildDir = .
@@ -1708,7 +1622,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [momentum-conserving-gather]
 buildDir = .
@@ -1726,7 +1639,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = beam driver plasma_e
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserAccelerationRZ]
 buildDir = .
@@ -1744,7 +1656,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_LaserAccelerationMR]
 buildDir = .
@@ -1763,7 +1674,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_Langmuir_2d]
 buildDir = .
@@ -1782,7 +1692,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserOnFine]
 buildDir = .
@@ -1798,7 +1707,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [RepellingParticles]
 buildDir = .
@@ -1814,7 +1722,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/RepellingParticles/analysis_repelling.py
-tolerance = 1.e-14
 
 [Larmor]
 buildDir = .
@@ -1830,7 +1737,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-12
 
 [Uniform_2d]
 buildDir = .
@@ -1846,7 +1752,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserAccelerationBoost]
 buildDir = .
@@ -1862,7 +1767,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [LaserInjectionFromTXYEFile]
 buildDir = .
@@ -1881,7 +1785,6 @@ compileTest = 0
 selfTest = 1
 stSuccessString = Passed
 doVis = 0
-tolerance = 1.e-14
 
 [collisionXYZ]
 buildDir = .
@@ -1899,7 +1802,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_3d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-14
 
 [collisionXZ]
 buildDir = .
@@ -1917,7 +1819,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-14
 
 [collisionRZ]
 buildDir = .
@@ -1935,7 +1836,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_rz.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-tolerance = 1.e-15
 
 [Maxwell_Hybrid_QED_solver]
 buildDir = .
@@ -1951,7 +1851,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/Maxwell_Hybrid_QED/analysis_Maxwell_QED_Hybrid.py
-tolerance = 1.e-14
 
 [reduced_diags]
 buildDir = .
@@ -1969,7 +1868,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
-tolerance = 1e-12
 
 [reduced_diags_single_precision]
 buildDir = .
@@ -1987,13 +1885,11 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
-tolerance = 5e-6
 
 [reduced_diags_loadbalancecosts_timers]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
-tolerance = 1e-12
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -2010,7 +1906,6 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
-tolerance = 1e-12
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 restartTest = 0
@@ -2038,7 +1933,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
-tolerance = 1e-12
 
 [galilean_2d_psatd]
 buildDir = .
@@ -2056,7 +1950,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1.e-14
 
 [galilean_2d_psatd_current_correction]
 buildDir = .
@@ -2074,7 +1967,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1.e-14
 
 [galilean_2d_psatd_hybrid]
 buildDir = .
@@ -2092,7 +1984,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [comoving_2d_psatd_hybrid]
 buildDir = .
@@ -2110,7 +2001,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions beam
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [galilean_rz_psatd]
 buildDir = .
@@ -2128,7 +2018,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1.e-14
 
 [galilean_rz_psatd_current_correction]
 buildDir = .
@@ -2146,7 +2035,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1.e-14
 
 [galilean_3d_psatd]
 buildDir = .
@@ -2164,7 +2052,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_3d.py
-tolerance = 1.e-14
 
 [galilean_3d_psatd_current_correction]
 buildDir = .
@@ -2182,7 +2069,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_3d.py
-tolerance = 1.e-14
 
 [averaged_galilean_2d_psatd]
 buildDir = .
@@ -2200,7 +2086,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1e-6
 
 [averaged_galilean_2d_psatd_hybrid]
 buildDir = .
@@ -2218,7 +2103,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_2d.py
-tolerance = 1e-6
 
 [averaged_galilean_3d_psatd]
 buildDir = .
@@ -2236,7 +2120,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_3d.py
-tolerance = 1e-4
 
 [averaged_galilean_3d_psatd_hybrid]
 buildDir = .
@@ -2254,7 +2137,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine = Examples/Tests/galilean/analysis_3d.py
-tolerance = 1e-4
 
 [multi_J_2d_psatd]
 buildDir = .
@@ -2272,7 +2154,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = driver driver_back plasma_e plasma_p
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1e-14
 
 [multi_J_2d_psatd_pml]
 buildDir = .
@@ -2290,7 +2171,6 @@ doVis = 0
 compareParticles = 1
 particleTypes =
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1e-14
 
 [multi_J_rz_psatd]
 buildDir = .
@@ -2309,7 +2189,6 @@ compareParticles = 1
 particleTypes = driver plasma_e plasma_p
 # TODO: intentionally empty because still unstable
 analysisRoutine =
-tolerance = 1e-14
 
 [ElectrostaticSphereEB]
 buildDir = .
@@ -2326,7 +2205,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-12
 
 [Python_ElectrostaticSphereEB]
 buildDir = .
@@ -2360,7 +2238,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-12
 
 [ElectrostaticSphere]
 buildDir = .
@@ -2377,7 +2254,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
-tolerance = 1.e-12
 
 [ElectrostaticSphereRZ]
 buildDir = .
@@ -2393,7 +2269,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
-tolerance = 1.e-12
 
 [ElectrostaticSphereLabFrame]
 buildDir = .
@@ -2410,7 +2285,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
-tolerance = 1.e-12
 
 [embedded_circle]
 buildDir = .
@@ -2623,7 +2497,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electron proton
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.e-14
 
 [Python_pass_mpi_comm]
 buildDir = .
@@ -2642,7 +2515,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
-tolerance = 1.e-14
 
 [Plasma_lens]
 buildDir = .
@@ -2660,7 +2532,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-tolerance = 1.e-14
 
 [Plasma_lens_boosted]
 buildDir = .
@@ -2678,7 +2549,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-tolerance = 1.e-14
 
 [background_mcc]
 buildDir = .
@@ -2696,7 +2566,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons he_ions
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.0e-4
 
 [Python_background_mcc]
 buildDir = .
@@ -2731,7 +2600,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Modules/ParticleBoundaryProcess/analysis_absorption.py
-tolerance = 1.0e-4
 
 [particle_scrape]
 buildDir = .
@@ -2749,7 +2617,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Modules/ParticleBoundaryScrape/analysis_scrape.py
-tolerance = 1.0e-4
 
 [Python_particle_scrape]
 buildDir = .
@@ -2768,7 +2635,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Modules/ParticleBoundaryScrape/analysis_scrape.py
-tolerance = 1.0e-4
 
 [Python_particle_reflection]
 buildDir = .
@@ -2834,7 +2700,6 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 1.0e-4
 
 [Performance_works_1_uniform_rest_32ppc]
 buildDir = .
@@ -2852,7 +2717,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Performance_works_2_uniform_rest_1ppc]
 buildDir = .
@@ -2870,7 +2734,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Performance_works_3_uniform_drift_4ppc]
 buildDir = .
@@ -2888,7 +2751,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Performance_works_4_labdiags_2ppc]
 buildDir = .
@@ -2906,7 +2768,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Performance_works_5_loadimbalance]
 buildDir = .
@@ -2924,7 +2785,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Performance_works_6_output_2ppc]
 buildDir = .
@@ -2942,7 +2802,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
 analysisRoutine =
-tolerance = 1.0e-4
 
 [Python_wrappers]
 buildDir = .


### PR DESCRIPTION
We compare field and particle tolerances now without silver files, using our checksum API.

This allows us to reduce CI time a bit by skipping the build of plotfile tools.

X-ref:
- https://github.com/AMReX-Codes/regression_testing/pull/110
- https://github.com/AMReX-Codes/regression_testing/pull/112