### PR TITLE
pre-commit: check json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     - id: end-of-file-fixer
       exclude: '.json$'
     - id: mixed-line-ending
+    - id: check-json
     - id: check-toml
     - id: check-yaml
     - id: check-added-large-files


### PR DESCRIPTION
This helps checking that we don't make Syntax errors in `.zenodo.json`.