### PR TITLE
Examples: Python ShellBang & Executable

### DIFF
--- a/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
+++ b/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Input file to test particle reflection off an absorbing boundary
 
 from pywarpx import picmi

--- a/Examples/Modules/ParticleBoundaryProcess/analysis_absorption.py
+++ b/Examples/Modules/ParticleBoundaryProcess/analysis_absorption.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import yt
 

--- a/Examples/Modules/ParticleBoundaryProcess/analysis_reflection.py
+++ b/Examples/Modules/ParticleBoundaryProcess/analysis_reflection.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Modern Electron
 #

--- a/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Input file to test the particle scraper and the Python wrappers
 # --- to access the buffer of scraped particles.
 

--- a/Examples/Modules/ParticleBoundaryScrape/analysis_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/analysis_scrape.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import yt
 from pathlib import Path

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_BoostedFrame.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Luca Fedeli, Maxence Thevenet, Revathi Jambunathan
 #

--- a/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
+++ b/Examples/Modules/RigidInjection/analysis_rigid_injection_LabFrame.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
 #

--- a/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
+++ b/Examples/Modules/boosted_diags/analysis_3Dbacktransformed_diag.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Maxence Thevenet, Revathi Jambunathan
 #

--- a/Examples/Modules/dive_cleaning/analysis.py
+++ b/Examples/Modules/dive_cleaning/analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Axel Huebl, Remi Lehe
 #

--- a/Examples/Modules/embedded_boundary_cube/analysis_fields.py
+++ b/Examples/Modules/embedded_boundary_cube/analysis_fields.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import yt
 import os, sys

--- a/Examples/Modules/embedded_boundary_cube/analysis_fields_2d.py
+++ b/Examples/Modules/embedded_boundary_cube/analysis_fields_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import yt
 import os

--- a/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
+++ b/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi, _libwarpx, fields
 import numpy as np
 

--- a/Examples/Modules/embedded_boundary_python_API/analysis.py
+++ b/Examples/Modules/embedded_boundary_python_API/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # This script just checks that the PICMI file executed successfully.
 # If it did there will be a plotfile for the final step.

--- a/Examples/Modules/embedded_boundary_rotated_cube/analysis_fields.py
+++ b/Examples/Modules/embedded_boundary_rotated_cube/analysis_fields.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Lorenzo Giacomel
 #

--- a/Examples/Modules/embedded_boundary_rotated_cube/analysis_fields_2d.py
+++ b/Examples/Modules/embedded_boundary_rotated_cube/analysis_fields_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import yt
 import os

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
 #from warp import picmi
 import argparse

--- a/Examples/Modules/ionization/analysis_ionization.py
+++ b/Examples/Modules/ionization/analysis_ionization.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Luca Fedeli, Maxence Thevenet
 #

--- a/Examples/Modules/laser_injection/analysis_1d.py
+++ b/Examples/Modules/laser_injection/analysis_1d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Prabhat Kumar, Remi Lehe
 #

--- a/Examples/Modules/laser_injection/analysis_2d.py
+++ b/Examples/Modules/laser_injection/analysis_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe, Weiqun Zhang, Luca Fedeli

--- a/Examples/Modules/laser_injection/analysis_laser.py
+++ b/Examples/Modules/laser_injection/analysis_laser.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe, Weiqun Zhang

--- a/Examples/Modules/nci_corrector/analysis_ncicorr.py
+++ b/Examples/Modules/nci_corrector/analysis_ncicorr.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 # Weiqun Zhang

--- a/Examples/Modules/qed/breit_wheeler/analysis_core.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_core.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
 # Copyright 2019 Luca Fedeli, Maxence Thevenet
 #
 # This file is part of WarpX.
 #
 # License: BSD-3-Clause-LBNL
-# -*- coding: utf-8 -*-
 
 import numpy as np
 import scipy.special as spe

--- a/Examples/Modules/qed/breit_wheeler/analysis_opmd.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_opmd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 Luca Fedeli
 #
 # This file is part of WarpX.

--- a/Examples/Modules/qed/breit_wheeler/analysis_yt.py
+++ b/Examples/Modules/qed/breit_wheeler/analysis_yt.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 Luca Fedeli
 #
 # This file is part of WarpX.

--- a/Examples/Modules/qed/quantum_synchrotron/analysis.py
+++ b/Examples/Modules/qed/quantum_synchrotron/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Luca Fedeli, Maxence Thevenet
 #

--- a/Examples/Modules/qed/schwinger/analysis_schwinger.py
+++ b/Examples/Modules/qed/schwinger/analysis_schwinger.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 Luca Fedeli, Neil Zaim
 #

--- a/Examples/Modules/relativistic_space_charge_initialization/analysis.py
+++ b/Examples/Modules/relativistic_space_charge_initialization/analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Axel Huebl, Remi Lehe
 #

--- a/Examples/Modules/resampling/analysis_leveling_thinning.py
+++ b/Examples/Modules/resampling/analysis_leveling_thinning.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 Neil Zaim
 #

--- a/Examples/Modules/space_charge_initialization/analysis.py
+++ b/Examples/Modules/space_charge_initialization/analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Axel Huebl, Remi Lehe
 #

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Input file for MCC testing. There is already a test of the MCC
 # --- functionality. This tests the PICMI interface for the MCC and
 # --- provides an example of how an external Poisson solver can be

--- a/Examples/Physics_applications/capacitive_discharge/analysis.py
+++ b/Examples/Physics_applications/capacitive_discharge/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Modern Electron
 

--- a/Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
+++ b/Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Andrew Myers
 #

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
 #from warp import picmi
 

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
 #from warp import picmi
 

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
 #from warp import picmi
 

--- a/Examples/Tests/ElectrostaticDirichletBC/PICMI_inputs_2d.py
+++ b/Examples/Tests/ElectrostaticDirichletBC/PICMI_inputs_2d.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
+
 
 ##########################
 # physics parameters

--- a/Examples/Tests/ElectrostaticDirichletBC/analysis.py
+++ b/Examples/Tests/ElectrostaticDirichletBC/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Roelof Groenewald
 

--- a/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/ElectrostaticSphere/analysis_electrostatic_sphere.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2019-2021 David Bizzozero, David Grote
 #

--- a/Examples/Tests/ElectrostaticSphereEB/PICMI_inputs_3d.py
+++ b/Examples/Tests/ElectrostaticSphereEB/PICMI_inputs_3d.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python3
+
 from pywarpx import picmi
+
 
 ##########################
 # physics parameters
@@ -6,6 +9,7 @@ from pywarpx import picmi
 
 V_domain_boundary = 0.0
 V_embedded_boundary = 1.0
+
 
 ##########################
 # numerics parameters

--- a/Examples/Tests/ElectrostaticSphereEB/analysis.py
+++ b/Examples/Tests/ElectrostaticSphereEB/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Run the default regression test for the PICMI version of the EB test
 # using the same reference file as for the non-PICMI test since the two

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir2d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Simple example of Langmuir oscillations in a uniform plasma
 # --- in two dimensions
 

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rt.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Simple example of Langmuir oscillations in a uniform plasma
 
 from pywarpx import picmi

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This is a script that analyses the multimode simulation results.
 # This simulates a RZ multimode periodic plasma wave.
 # The electric field from the simulation is compared to the analytic value

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_1d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_1d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2021 Jean-Luc Vay, Maxence Thevenet, Remi Lehe, Prabhat Kumar
 #

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 David Grote, Maxence Thevenet
 #

--- a/Examples/Tests/PEC/analysis_pec.py
+++ b/Examples/Tests/PEC/analysis_pec.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 #
 #

--- a/Examples/Tests/PEC/analysis_pec_mr.py
+++ b/Examples/Tests/PEC/analysis_pec_mr.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 #
 #

--- a/Examples/Tests/PML/analysis_pml_ckc.py
+++ b/Examples/Tests/PML/analysis_pml_ckc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe

--- a/Examples/Tests/PML/analysis_pml_psatd.py
+++ b/Examples/Tests/PML/analysis_pml_psatd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Jean-Luc Vay, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/PML/analysis_pml_yee.py
+++ b/Examples/Tests/PML/analysis_pml_yee.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018-2019 Andrew Myers, Jean-Luc Vay, Maxence Thevenet
 # Remi Lehe

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 from pywarpx import picmi
-
 import numpy as np
+
 import argparse
 import sys
 

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -1,6 +1,8 @@
-from pywarpx import picmi
-import numpy as np
+#!/usr/bin/env python3
 
+from pywarpx import picmi
+
+import numpy as np
 import argparse
 import sys
 

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Input file to test the saving of old particle positions
 
 import numpy as np

--- a/Examples/Tests/ParticleDataPython/analysis.py
+++ b/Examples/Tests/ParticleDataPython/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 Modern Electron
 #

--- a/Examples/Tests/PythonWrappers/PICMI_inputs_2d.py
+++ b/Examples/Tests/PythonWrappers/PICMI_inputs_2d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable

--- a/Examples/Tests/RepellingParticles/analysis_repelling.py
+++ b/Examples/Tests/RepellingParticles/analysis_repelling.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2021 Remi Lehe
 #

--- a/Examples/Tests/SilverMueller/analysis_silver_mueller.py
+++ b/Examples/Tests/SilverMueller/analysis_silver_mueller.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021
 #

--- a/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
+++ b/Examples/Tests/SingleParticle/analysis_bilinear_filter.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Maxence Thevenet
 #

--- a/Examples/Tests/boundaries/analysis.py
+++ b/Examples/Tests/boundaries/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 David Grote
 #

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Yinjian Zhao
 #

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Yinjian Zhao
 #

--- a/Examples/Tests/collision/analysis_collision_rz.py
+++ b/Examples/Tests/collision/analysis_collision_rz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2021 Yinjian Zhao
 #

--- a/Examples/Tests/divb_cleaning/analysis.py
+++ b/Examples/Tests/divb_cleaning/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019
 #

--- a/Examples/Tests/embedded_circle/analysis.py
+++ b/Examples/Tests/embedded_circle/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/Examples/Tests/galilean/analysis_2d.py
+++ b/Examples/Tests/galilean/analysis_2d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is used to test the results of the Galilean PSATD method and
 averaged Galilean PSATD method in WarpX.

--- a/Examples/Tests/galilean/analysis_3d.py
+++ b/Examples/Tests/galilean/analysis_3d.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is used to test the results of the Galilean PSATD method and
 averaged Galilean PSATD method in WarpX.

--- a/Examples/Tests/initial_distribution/analysis_distribution.py
+++ b/Examples/Tests/initial_distribution/analysis_distribution.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Yinjian Zhao
 #

--- a/Examples/Tests/initial_plasma_profile/analysis.py
+++ b/Examples/Tests/initial_plasma_profile/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 Michael Rowan
 #

--- a/Examples/Tests/particle_pusher/analysis_pusher.py
+++ b/Examples/Tests/particle_pusher/analysis_pusher.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Yinjian Zhao
 #

--- a/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
+++ b/Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Luca Fedeli, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # --- Test if MPI_communicator is correctly passed from Python to CPP
 # --- This test should be run with MPI enabled
 # --- Inputs taken from langmuir_2d. Runs 10 steps, and will check

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a script that analyses the simulation results from
 # the script `PICMI_inputs_2d`.

--- a/Examples/Tests/photon_pusher/analysis_photon_pusher.py
+++ b/Examples/Tests/photon_pusher/analysis_photon_pusher.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Luca Fedeli, Maxence Thevenet, Weiqun Zhang
 #

--- a/Examples/Tests/plasma_lens/analysis.py
+++ b/Examples/Tests/plasma_lens/analysis.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2021 David Grote
 #

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019 Luca Fedeli, Maxence Thevenet, Remi Lehe
 #

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2021 Luca Fedeli, Yinjian Zhao
 #

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2021 Luca Fedeli, Yinjian Zhao
 #

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 Michael Rowan
 #

--- a/Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
+++ b/Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2021 Luca Fedeli, Yinjian Zhao
 #

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This is a script that adds particle components at runtime,
 # then performs checkpoint / restart and compares the result
 # to the original simulation.

--- a/Examples/Tests/restart/analysis_restart.py
+++ b/Examples/Tests/restart/analysis_restart.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 import yt


### PR DESCRIPTION
Make sure that all PICMI scripts and all analysis Python scripts in `Examples/` are:
- executable (`chmod a+x`)
- start with a shell-bang to `python3`

Now, all scripts can be run directly without a `python3 ...` prefix and also default to the only right executable of Python on older systems. (New systems always have a `python3` alias, too.)