### PR TITLE
CI: Azure Cache Ignore Errors

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -49,6 +49,7 @@ jobs:
   # - once stored under a key, they become immutable (even if cache content changes)
   # - for a refresh the key has to change, e.g., hash of a tracked file in the key
   - task: Cache@2
+    continueOnError: true
     inputs:
       key: 'Ccache | "$(System.JobName)" | .azure-pipelines.yml | cmake/dependencies/AMReX.cmake | run_test.sh'
       restoreKeys: |
@@ -60,6 +61,7 @@ jobs:
     displayName: Cache Ccache Objects
 
   - task: Cache@2
+    continueOnError: true
     inputs:
       key: 'Python3 | "$(System.JobName)" | .azure-pipelines.yml | run_test.sh'
       restoreKeys: |


### PR DESCRIPTION
Sometimes, the Azure Pipelines Cache tasks fail because the service is not available, either for download or upload after a successful job.

This marks the cache restore and upload steps as allowed to fail.