### PR TITLE
Multi-J: J Always Linear in Time

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1563,7 +1563,7 @@ Numerics and algorithms
     https://ieeexplore.ieee.org/document/8659392.
 
 * ``warpx.do_multi_J`` (`0` or `1`; default: `0`)
-    Whether to use the multi-J algorithm, where current deposition and field update are performed multiple times within each time step. The number of sub-steps is determined by the input parameter ``warpx.do_multi_J_n_depositions``. Unlike sub-cycling, field gathering is performed only once per time step, as in regular PIC cycles. For simulations with strong numerical Cherenkov instability (NCI), it is recommended to use the multi-J algorithm in combination with ``psatd.do_time_averaging = 1``.
+    Whether to use the multi-J algorithm, where current deposition and field update are performed multiple times within each time step. The number of sub-steps is determined by the input parameter ``warpx.do_multi_J_n_depositions``. Unlike sub-cycling, field gathering is performed only once per time step, as in regular PIC cycles. When ``warpx.do_multi_J = 1``, we perform linear interpolation of two distinct currents deposited at the beginning and the end of the time step, instead of using one single current deposited at half time. For simulations with strong numerical Cherenkov instability (NCI), it is recommended to use the multi-J algorithm in combination with ``psatd.do_time_averaging = 1``.
 
 * ``warpx.do_multi_J_n_depositions`` (integer)
     Number of sub-steps to use with the multi-J algorithm, when ``warpx.do_multi_J = 1``.
@@ -1696,9 +1696,6 @@ Numerics and algorithms
 
 * ``psatd.do_time_averaging`` (`0` or `1`; default: 0)
     Whether to use an averaged Galilean PSATD algorithm or standard Galilean PSATD.
-
-* ``psatd.J_linear_in_time`` (`0` or `1`; default: `0`)
-    Whether to perform linear interpolation of two distinct currents deposited at the beginning and the end of the time step (``psatd.J_linear_in_time = 1``), instead of using one single current deposited at half time (``psatd.J_linear_in_time = 0``), for the field update in Fourier space. Currently requires ``psatd.update_with_rho = 1``, ``warpx.do_dive_cleaning = 1``, and ``warpx.do_divb_cleaning = 1``.
 
 * ``warpx.override_sync_intervals`` (`string`) optional (default `1`)
     Using the `Intervals parser`_ syntax, this string defines the timesteps at which

--- a/Examples/Tests/multi_J/inputs_2d
+++ b/Examples/Tests/multi_J/inputs_2d
@@ -39,7 +39,6 @@ warpx.moving_window_v = 1.
 
 # Spectral solver
 psatd.do_time_averaging = 1
-psatd.J_linear_in_time = 1
 psatd.update_with_rho = 1
 
 # Multi-J scheme

--- a/Examples/Tests/multi_J/inputs_2d_pml
+++ b/Examples/Tests/multi_J/inputs_2d_pml
@@ -39,7 +39,6 @@ warpx.moving_window_v = 1.
 
 # Spectral solver
 psatd.do_time_averaging = 0
-psatd.J_linear_in_time = 1
 psatd.update_with_rho = 1
 
 # Multi-J scheme

--- a/Examples/Tests/multi_J/inputs_rz
+++ b/Examples/Tests/multi_J/inputs_rz
@@ -37,7 +37,6 @@ warpx.do_dive_cleaning = 1
 warpx.do_divb_cleaning = 1
 warpx.do_multi_J = 1
 warpx.do_multi_J_n_depositions = 2
-psatd.J_linear_in_time = 1
 psatd.do_time_averaging = 1
 
 # PSATD

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -115,7 +115,7 @@ public:
          int ncell, int delta, amrex::IntVect ref_ratio,
          amrex::Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
          int do_moving_window, int pml_has_particles, int do_pml_in_domain,
-         const bool J_linear_in_time,
+         const bool do_multi_J,
          const bool do_pml_dive_cleaning, const bool do_pml_divb_cleaning,
          int max_guard_EB,
          const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -477,7 +477,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
           int ncell, int delta, amrex::IntVect ref_ratio,
           Real dt, int nox_fft, int noy_fft, int noz_fft, bool do_nodal,
           int do_moving_window, int /*pml_has_particles*/, int do_pml_in_domain,
-          const bool J_linear_in_time,
+          const bool do_multi_J,
           const bool do_pml_dive_cleaning, const bool do_pml_divb_cleaning,
           int max_guard_EB,
           const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
@@ -669,7 +669,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
 
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
-        amrex::ignore_unused(lev, dt, J_linear_in_time);
+        amrex::ignore_unused(lev, dt, do_multi_J);
 #   if(AMREX_SPACEDIM!=3)
         amrex::ignore_unused(noy_fft);
 #   endif
@@ -690,7 +690,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         spectral_solver_fp = std::make_unique<SpectralSolver>(lev, realspace_ba, dm,
             nox_fft, noy_fft, noz_fft, do_nodal, WarpX::fill_guards, v_galilean_zero,
             v_comoving_zero, dx, dt, in_pml, periodic_single_box, update_with_rho,
-            fft_do_time_averaging, J_linear_in_time, m_dive_cleaning, m_divb_cleaning);
+            fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif
     }
 
@@ -808,7 +808,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             spectral_solver_cp = std::make_unique<SpectralSolver>(lev, realspace_cba, cdm,
                 nox_fft, noy_fft, noz_fft, do_nodal, WarpX::fill_guards, v_galilean_zero,
                 v_comoving_zero, cdx, dt, in_pml, periodic_single_box, update_with_rho,
-                fft_do_time_averaging, J_linear_in_time, m_dive_cleaning, m_divb_cleaning);
+                fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif
         }
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -578,21 +578,11 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
             // Forward FFT of J
             PSATDForwardTransformJ();
 
-            // Deposit mid rho and new rho
+            // Deposit new rho
             if (WarpX::update_with_rho)
             {
                 // Move rho deposited previously, from new to old
                 PSATDMoveRhoNewToRhoOld();
-
-                // Deposit rho at relative time t_depose - 0.5 * sub_dt
-                mypc->DepositCharge(rho_fp, t_depose - 0.5 * sub_dt);
-                // Filter, exchange boundary, and interpolate across levels
-                SyncRho();
-                // Forward FFT of rho_new
-                PSATDForwardTransformRho(0, 1);
-
-                // Move rho deposited previously, from new to mid
-                PSATDMoveRhoNewToRhoMid();
 
                 // Deposit rho at relative time t_depose
                 mypc->DepositCharge(rho_fp, t_depose);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -43,8 +43,9 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * \param[in] dt time step of the simulation
          * \param[in] update_with_rho whether the update equation for E uses rho or not
          * \param[in] time_averaging whether to use time averaging for large time steps
-         * \param[in] J_linear_in_time whether to use two currents computed at the beginning and the end
-         *            of the time interval (instead of using one current computed at half time)
+         * \param[in] do_multi_J whether the multi-J algorithm is used (hence two currents
+         *                       computed at the beginning and the end of the time interval
+         *                       instead of one current computed at half time)
          * \param[in] dive_cleaning Update F as part of the field update, so that errors in divE=rho propagate away at the speed of light
          * \param[in] divb_cleaning Update G as part of the field update, so that errors in divB=0 propagate away at the speed of light
          */
@@ -61,7 +62,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const amrex::Real dt,
             const bool update_with_rho,
             const bool time_averaging,
-            const bool J_linear_in_time,
+            const bool do_multi_J,
             const bool dive_cleaning,
             const bool divb_cleaning);
 
@@ -171,7 +172,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         amrex::Real m_dt;
         bool m_update_with_rho;
         bool m_time_averaging;
-        bool m_J_linear_in_time;
+        bool m_do_multi_J;
         bool m_dive_cleaning;
         bool m_divb_cleaning;
         bool m_is_galilean;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -169,8 +169,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients X5_coef, X6_coef;
 
         // These real coefficients are allocated only with the multi-J algorithm
-        // TODO Rename this consistently
-        SpectralRealCoefficients X9_coef;
+        SpectralRealCoefficients X7_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -112,6 +112,19 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const amrex::Real dt);
 
         /**
+         * \brief Initializes additional coefficients used in \c pushSpectralFields to update the E and B fields,
+         *        required only when using the multi-J algorithm
+         *
+         * \param[in] spectral_kspace spectral space
+         * \param[in] dm distribution mapping
+         * \param[in] dt time step of the simulation
+         */
+        void InitializeSpectralCoefficientsMultiJ (
+            const SpectralKSpace& spectral_kspace,
+            const amrex::DistributionMapping& dm,
+            const amrex::Real dt);
+
+        /**
          * \brief Virtual function for current correction in Fourier space
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This function overrides the virtual function \c CurrentCorrection in the
@@ -154,6 +167,11 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients T2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 
         SpectralComplexCoefficients X5_coef, X6_coef;
+
+        // These real coefficients are allocated only with the multi-J algorithm
+        SpectralRealCoefficients X7_coef;
+        SpectralRealCoefficients X8_coef;
+        SpectralRealCoefficients X9_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -169,8 +169,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients X5_coef, X6_coef;
 
         // These real coefficients are allocated only with the multi-J algorithm
-        SpectralRealCoefficients X7_coef;
-        SpectralRealCoefficients X8_coef;
+        // TODO Rename this consistently
         SpectralRealCoefficients X9_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -169,7 +169,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients X5_coef, X6_coef;
 
         // These real coefficients are allocated only with the multi-J algorithm
-        SpectralRealCoefficients X7_coef, X8_coef, X9_coef, X10_coef;
+        SpectralRealCoefficients X7_coef, X8_coef, X9_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -169,7 +169,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients X5_coef, X6_coef;
 
         // These real coefficients are allocated only with the multi-J algorithm
-        SpectralRealCoefficients X7_coef;
+        SpectralRealCoefficients X7_coef, X8_coef, X9_coef, X10_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -112,19 +112,6 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const amrex::Real dt);
 
         /**
-         * \brief Initializes additional coefficients used in \c pushSpectralFields to update the E and B fields,
-         *        required only when using the multi-J algorithm
-         *
-         * \param[in] spectral_kspace spectral space
-         * \param[in] dm distribution mapping
-         * \param[in] dt time step of the simulation
-         */
-        void InitializeSpectralCoefficientsMultiJ (
-            const SpectralKSpace& spectral_kspace,
-            const amrex::DistributionMapping& dm,
-            const amrex::Real dt);
-
-        /**
          * \brief Virtual function for current correction in Fourier space
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This function overrides the virtual function \c CurrentCorrection in the
@@ -167,9 +154,6 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
         SpectralComplexCoefficients T2_coef, X1_coef, X2_coef, X3_coef, X4_coef;
 
         SpectralComplexCoefficients X5_coef, X6_coef;
-
-        // These real coefficients are allocated only with the multi-J algorithm
-        SpectralRealCoefficients X7_coef, X8_coef, X9_coef;
 
         // These real and complex coefficients are allocated only with averaged Galilean PSATD
         SpectralComplexCoefficients Psi1_coef, Psi2_coef, Y1_coef, Y2_coef, Y3_coef, Y4_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -39,7 +39,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     const amrex::Real dt,
     const bool update_with_rho,
     const bool time_averaging,
-    const bool J_linear_in_time,
+    const bool do_multi_J,
     const bool dive_cleaning,
     const bool divb_cleaning)
     // Initializer list
@@ -59,7 +59,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     m_dt(dt),
     m_update_with_rho(update_with_rho),
     m_time_averaging(time_averaging),
-    m_J_linear_in_time(J_linear_in_time),
+    m_do_multi_J(do_multi_J),
     m_dive_cleaning(dive_cleaning),
     m_divb_cleaning(divb_cleaning)
 {
@@ -84,7 +84,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     InitializeSpectralCoefficients(spectral_kspace, dm, dt);
 
     // Allocate these coefficients only with time averaging
-    if (time_averaging && !J_linear_in_time)
+    if (time_averaging && !do_multi_J)
     {
         Psi1_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
         Psi2_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
@@ -96,7 +96,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     }
     // Allocate these coefficients only with time averaging
     // and with the assumption that J is linear in time
-    else if (time_averaging && J_linear_in_time)
+    else if (time_averaging && do_multi_J)
     {
         X5_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
         X6_coef = SpectralComplexCoefficients(ba, dm, 1, 0);
@@ -123,7 +123,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
 {
     const bool update_with_rho  = m_update_with_rho;
     const bool time_averaging   = m_time_averaging;
-    const bool J_linear_in_time = m_J_linear_in_time;
+    const bool do_multi_J = m_do_multi_J;
     const bool dive_cleaning    = m_dive_cleaning;
     const bool divb_cleaning    = m_divb_cleaning;
     const bool is_galilean      = m_is_galilean;
@@ -163,7 +163,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
         amrex::Array4<const Complex> Y3_arr;
         amrex::Array4<const Complex> Y4_arr;
 
-        if (time_averaging && !J_linear_in_time)
+        if (time_averaging && !do_multi_J)
         {
             Psi1_arr = Psi1_coef[mfi].array();
             Psi2_arr = Psi2_coef[mfi].array();
@@ -175,7 +175,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
 
         Array4<const Complex> X5_arr;
         Array4<const Complex> X6_arr;
-        if (time_averaging && J_linear_in_time)
+        if (time_averaging && do_multi_J)
         {
             X5_arr = X5_coef[mfi].array();
             X6_arr = X6_coef[mfi].array();
@@ -320,7 +320,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
                 fields(i,j,k,Idx.G) = C * G_old + I * c2 * S_ck * k_dot_B;
             }
 
-            if (J_linear_in_time)
+            if (do_multi_J)
             {
                 const Complex Jx_new = fields(i,j,k,Idx.Jx_new);
                 const Complex Jy_new = fields(i,j,k,Idx.Jy_new);
@@ -391,7 +391,7 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
             }
 
             // Additional update equations for averaged Galilean algorithm
-            if (time_averaging && !J_linear_in_time)
+            if (time_averaging && !do_multi_J)
             {
                 // These coefficients are initialized in the function InitializeSpectralCoefficients below
                 const Complex Psi1 = Psi1_arr(i,j,k);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -587,7 +587,7 @@ void PsatdAlgorithm::InitializeSpectralCoefficients (
                 }
                 else
                 {
-                    X2(i,j,k) = - c2 / ep0 * dt2 / 6._rt;
+                    X2(i,j,k) = 0._rt;
                 }
             }
             else // standard or Galilean PSATD
@@ -628,7 +628,7 @@ void PsatdAlgorithm::InitializeSpectralCoefficients (
                 }
                 else
                 {
-                    X3(i,j,k) = 0._rt;
+                    X3(i,j,k) = - c2 * dt2 / (6._rt * ep0);
                 }
             }
             else // standard or Galilean PSATD
@@ -996,7 +996,7 @@ void PsatdAlgorithm::InitializeSpectralCoefficientsMultiJ (
             }
             else
             {
-                X7(i,j,k) = - c2 / ep0 * dt2 / 6._rt;
+                X7(i,j,k) = c2 * dt2 / (6._rt * ep0);
             }
         });
     }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -274,15 +274,15 @@ PsatdAlgorithm::pushSpectralFields (SpectralFieldData& f) const
             {
                 fields(i,j,k,Idx.Ex) = T2 * C * Ex_old
                                        + I * c2 * T2 * S_ck * (ky * Bz_old - kz * By_old)
-                                       + X4 * Jx + I * T2 * X3 * rho_old * kx - I * X2 * rho_new * kx;
+                                       + X4 * Jx - I * (X2 * rho_new - T2 * X3 * rho_old) * kx;
 
                 fields(i,j,k,Idx.Ey) = T2 * C * Ey_old
                                        + I * c2 * T2 * S_ck * (kz * Bx_old - kx * Bz_old)
-                                       + X4 * Jy + I * T2 * X3 * rho_old * ky - I * X2 * rho_new * ky;
+                                       + X4 * Jy - I * (X2 * rho_new - T2 * X3 * rho_old) * ky;
 
                 fields(i,j,k,Idx.Ez) = T2 * C * Ez_old
                                        + I * c2 * T2 * S_ck * (kx * By_old - ky * Bx_old)
-                                       + X4 * Jz + I * T2 * X3 * rho_old * kz - I * X2 * rho_new * kz;
+                                       + X4 * Jz - I * (X2 * rho_new - T2 * X3 * rho_old) * kz;
             }
 
             // Update equations for E in the formulation without rho

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
@@ -23,7 +23,7 @@ class PsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
                          bool const nodal, amrex::Real const dt_step,
                          bool const update_with_rho,
                          const bool time_averaging,
-                         const bool J_linear_in_time,
+                         const bool do_multi_J,
                          const bool dive_cleaning,
                          const bool divb_cleaning);
         // Redefine functions from base class
@@ -74,7 +74,7 @@ class PsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
         amrex::Real m_dt;
         bool m_update_with_rho;
         bool m_time_averaging;
-        bool m_J_linear_in_time;
+        bool m_do_multi_J;
         bool m_dive_cleaning;
         bool m_divb_cleaning;
         SpectralRealCoefficients C_coef, S_ck_coef, X1_coef, X2_coef, X3_coef;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -22,7 +22,7 @@ PsatdAlgorithmRZ::PsatdAlgorithmRZ (SpectralKSpaceRZ const & spectral_kspace,
                                     bool const nodal, amrex::Real const dt,
                                     bool const update_with_rho,
                                     const bool time_averaging,
-                                    const bool J_linear_in_time,
+                                    const bool do_multi_J,
                                     const bool dive_cleaning,
                                     const bool divb_cleaning)
      // Initialize members of base class
@@ -31,7 +31,7 @@ PsatdAlgorithmRZ::PsatdAlgorithmRZ (SpectralKSpaceRZ const & spectral_kspace,
        m_dt(dt),
        m_update_with_rho(update_with_rho),
        m_time_averaging(time_averaging),
-       m_J_linear_in_time(J_linear_in_time),
+       m_do_multi_J(do_multi_J),
        m_dive_cleaning(dive_cleaning),
        m_divb_cleaning(divb_cleaning)
 {
@@ -46,25 +46,25 @@ PsatdAlgorithmRZ::PsatdAlgorithmRZ (SpectralKSpaceRZ const & spectral_kspace,
 
     coefficients_initialized = false;
 
-    if (time_averaging && J_linear_in_time)
+    if (time_averaging && do_multi_J)
     {
         X5_coef = SpectralRealCoefficients(ba, dm, n_rz_azimuthal_modes, 0);
         X6_coef = SpectralRealCoefficients(ba, dm, n_rz_azimuthal_modes, 0);
     }
 
-    if (time_averaging && !J_linear_in_time)
+    if (time_averaging && !do_multi_J)
     {
-        amrex::Abort("RZ PSATD: psatd.do_time_averaging = 1 implemented only with psatd.J_linear_in_time = 1");
+        amrex::Abort("RZ PSATD: psatd.do_time_averaging = 1 implemented only with warpx.do_multi_J = 1");
     }
 
-    if (dive_cleaning && !J_linear_in_time)
+    if (dive_cleaning && !do_multi_J)
     {
-        amrex::Abort("RZ PSATD: warpx.do_dive_cleaning = 1 implemented only with psatd.J_linear_in_time = 1");
+        amrex::Abort("RZ PSATD: warpx.do_dive_cleaning = 1 implemented only with warpx.do_multi_J = 1");
     }
 
-    if (divb_cleaning && !J_linear_in_time)
+    if (divb_cleaning && !do_multi_J)
     {
-        amrex::Abort("RZ PSATD: warpx.do_divb_cleaning = 1 implemented only with psatd.J_linear_in_time = 1");
+        amrex::Abort("RZ PSATD: warpx.do_divb_cleaning = 1 implemented only with warpx.do_multi_J = 1");
     }
 }
 
@@ -76,7 +76,7 @@ PsatdAlgorithmRZ::pushSpectralFields(SpectralFieldDataRZ & f)
 
     const bool update_with_rho = m_update_with_rho;
     const bool time_averaging = m_time_averaging;
-    const bool J_linear_in_time = m_J_linear_in_time;
+    const bool do_multi_J = m_do_multi_J;
     const bool dive_cleaning = m_dive_cleaning;
     const bool divb_cleaning = m_divb_cleaning;
 
@@ -105,7 +105,7 @@ PsatdAlgorithmRZ::pushSpectralFields(SpectralFieldDataRZ & f)
 
         amrex::Array4<const amrex::Real> X5_arr;
         amrex::Array4<const amrex::Real> X6_arr;
-        if (time_averaging && J_linear_in_time)
+        if (time_averaging && do_multi_J)
         {
             X5_arr = X5_coef[mfi].array();
             X6_arr = X6_coef[mfi].array();
@@ -231,7 +231,7 @@ PsatdAlgorithmRZ::pushSpectralFields(SpectralFieldDataRZ & f)
                 G_old = fields(i,j,k,G_m);
             }
 
-            if (J_linear_in_time)
+            if (do_multi_J)
             {
                 const int Jp_m_new = Idx.Jx_new + Idx.n_fields*mode;
                 const int Jm_m_new = Idx.Jy_new + Idx.n_fields*mode;
@@ -328,7 +328,7 @@ PsatdAlgorithmRZ::pushSpectralFields(SpectralFieldDataRZ & f)
 void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const & f)
 {
     const bool time_averaging = m_time_averaging;
-    const bool J_linear_in_time = m_J_linear_in_time;
+    const bool do_multi_J = m_do_multi_J;
 
     // Fill them with the right values:
     // Loop over boxes and allocate the corresponding coefficients
@@ -349,7 +349,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
 
         amrex::Array4<amrex::Real> X5;
         amrex::Array4<amrex::Real> X6;
-        if (time_averaging && J_linear_in_time)
+        if (time_averaging && do_multi_J)
         {
             X5 = X5_coef[mfi].array();
             X6 = X6_coef[mfi].array();
@@ -388,7 +388,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
                 X3(i,j,k,mode) = - c*c * dt*dt / (3._rt*ep0);
             }
 
-            if (time_averaging && J_linear_in_time)
+            if (time_averaging && do_multi_J)
             {
                 constexpr amrex::Real c2 = PhysConst::c;
                 const amrex::Real dt3 = dt * dt * dt;

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -86,7 +86,8 @@ class SpectralFieldIndex
     int Ex_avg = -1, Ey_avg = -1, Ez_avg = -1;
     int Bx_avg = -1, By_avg = -1, Bz_avg = -1;
 
-    // J linear in time
+    // Multi-J, div(E) and div(B) cleaning
+    int rho_mid = -1;
     int Jx_new = -1, Jy_new = -1, Jz_new = -1;
     int F = -1, G = -1;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -39,21 +39,21 @@ class SpectralFieldIndex
          * Set integer indices to access data in spectral space
          * and total number of fields to be stored.
          *
-         * \param[in] update_with_rho   whether rho is used in the field update equations
-         * \param[in] time_averaging    whether the time averaging algorithm is used
-         * \param[in] J_linear_in_time  whether to use two currents computed at the beginning and
-         *                              the end of the time interval (instead of using one current
-         *                              computed at half time)
-         * \param[in] dive_cleaning     whether to use div(E) cleaning to account for errors in
-         *                              Gauss law (new field F in the update equations)
-         * \param[in] divb_cleaning     whether to use div(B) cleaning to account for errors in
-         *                              div(B) = 0 law (new field G in the update equations)
-         * \param[in] pml               whether the indices are used to access spectral data
-         *                              for the PML spectral solver
+         * \param[in] update_with_rho whether rho is used in the field update equations
+         * \param[in] time_averaging  whether the time averaging algorithm is used
+         * \param[in] do_multi_J      whether the multi-J algorithm is used (hence two currents
+         *                            computed at the beginning and the end of the time interval
+         *                            instead of one current computed at half time)
+         * \param[in] dive_cleaning   whether to use div(E) cleaning to account for errors in
+         *                            Gauss law (new field F in the update equations)
+         * \param[in] divb_cleaning   whether to use div(B) cleaning to account for errors in
+         *                            div(B) = 0 law (new field G in the update equations)
+         * \param[in] pml             whether the indices are used to access spectral data
+         *                            for the PML spectral solver
          */
         SpectralFieldIndex (const bool update_with_rho,
                             const bool time_averaging,
-                            const bool J_linear_in_time,
+                            const bool do_multi_J,
                             const bool dive_cleaning,
                             const bool divb_cleaning,
                             const bool pml);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -87,7 +87,6 @@ class SpectralFieldIndex
     int Bx_avg = -1, By_avg = -1, Bz_avg = -1;
 
     // Multi-J, div(E) and div(B) cleaning
-    int rho_mid = -1;
     int Jx_new = -1, Jy_new = -1, Jz_new = -1;
     int F = -1, G = -1;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -68,7 +68,10 @@ SpectralFieldIndex::SpectralFieldIndex (const bool update_with_rho,
 
         if (do_multi_J)
         {
-            Jx_new = c++; Jy_new = c++; Jz_new = c++;
+            rho_mid = c++;
+            Jx_new = c++;
+            Jy_new = c++;
+            Jz_new = c++;
         }
     }
     else // PML

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -34,7 +34,7 @@ using namespace amrex;
 
 SpectralFieldIndex::SpectralFieldIndex (const bool update_with_rho,
                                         const bool time_averaging,
-                                        const bool J_linear_in_time,
+                                        const bool do_multi_J,
                                         const bool dive_cleaning,
                                         const bool divb_cleaning,
                                         const bool pml)
@@ -66,7 +66,7 @@ SpectralFieldIndex::SpectralFieldIndex (const bool update_with_rho,
 
         if (divb_cleaning) G = c++;
 
-        if (J_linear_in_time)
+        if (do_multi_J)
         {
             Jx_new = c++; Jy_new = c++; Jz_new = c++;
         }

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -68,7 +68,6 @@ SpectralFieldIndex::SpectralFieldIndex (const bool update_with_rho,
 
         if (do_multi_J)
         {
-            rho_mid = c++;
             Jx_new = c++;
             Jy_new = c++;
             Jz_new = c++;

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -59,9 +59,9 @@ class SpectralSolver
          *                                (no domain decomposition)
          * \param[in] update_with_rho whether rho is used in the field update equations
          * \param[in] fft_do_time_averaging whether the time averaging algorithm is used
-         * \param[in] J_linear_in_time whether to use two currents computed at the beginning and
-         *                             the end of the time interval (instead of using one current
-         *                             computed at half time)
+         * \param[in] do_multi_J whether the multi-J algorithm is used (hence two currents
+         *                       computed at the beginning and the end of the time interval
+         *                       instead of one current computed at half time)
          * \param[in] dive_cleaning whether to use div(E) cleaning to account for errors in
          *                          Gauss law (new field F in the update equations)
          * \param[in] divb_cleaning whether to use div(B) cleaning to account for errors in
@@ -81,7 +81,7 @@ class SpectralSolver
                         const bool periodic_single_box,
                         const bool update_with_rho,
                         const bool fft_do_time_averaging,
-                        const bool J_linear_in_time,
+                        const bool do_multi_J,
                         const bool dive_cleaning,
                         const bool divb_cleaning);
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -30,7 +30,7 @@ SpectralSolver::SpectralSolver(
                 const bool pml, const bool periodic_single_box,
                 const bool update_with_rho,
                 const bool fft_do_time_averaging,
-                const bool J_linear_in_time,
+                const bool do_multi_J,
                 const bool dive_cleaning,
                 const bool divb_cleaning)
 {
@@ -42,7 +42,7 @@ SpectralSolver::SpectralSolver(
     const SpectralKSpace k_space= SpectralKSpace(realspace_ba, dm, dx);
 
     m_spectral_index = SpectralFieldIndex(update_with_rho, fft_do_time_averaging,
-                                          J_linear_in_time, dive_cleaning, divb_cleaning, pml);
+                                          do_multi_J, dive_cleaning, divb_cleaning, pml);
 
     // - Select the algorithm depending on the input parameters
     //   Initialize the corresponding coefficients over k space
@@ -63,7 +63,7 @@ SpectralSolver::SpectralSolver(
         else {
             algorithm = std::make_unique<PsatdAlgorithm>(
                 k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal, fill_guards,
-                v_galilean, dt, update_with_rho, fft_do_time_averaging, J_linear_in_time,
+                v_galilean, dt, update_with_rho, fft_do_time_averaging, do_multi_J,
                 dive_cleaning, divb_cleaning);
         }
     }

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
@@ -36,7 +36,7 @@ class SpectralSolverRZ
                           amrex::RealVect const dx, amrex::Real const dt,
                           bool const update_with_rho,
                           const bool fft_do_time_averaging,
-                          const bool J_linear_in_time,
+                          const bool do_multi_J,
                           const bool dive_cleaning,
                           const bool divb_cleaning);
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
@@ -34,7 +34,7 @@ SpectralSolverRZ::SpectralSolverRZ (const int lev,
                                     amrex::RealVect const dx, amrex::Real const dt,
                                     bool const update_with_rho,
                                     const bool fft_do_time_averaging,
-                                    const bool J_linear_in_time,
+                                    const bool do_multi_J,
                                     const bool dive_cleaning,
                                     const bool divb_cleaning)
     : k_space(realspace_ba, dm, dx)
@@ -47,7 +47,7 @@ SpectralSolverRZ::SpectralSolverRZ (const int lev,
 
     const bool pml = false;
     m_spectral_index = SpectralFieldIndex(update_with_rho, fft_do_time_averaging,
-                                          J_linear_in_time, dive_cleaning, divb_cleaning, pml);
+                                          do_multi_J, dive_cleaning, divb_cleaning, pml);
 
     // - Select the algorithm depending on the input parameters
     //   Initialize the corresponding coefficients over k space
@@ -56,7 +56,7 @@ SpectralSolverRZ::SpectralSolverRZ (const int lev,
          // v_galilean is 0: use standard PSATD algorithm
         algorithm = std::make_unique<PsatdAlgorithmRZ>(
             k_space, dm, m_spectral_index, n_rz_azimuthal_modes, norder_z, nodal, dt,
-            update_with_rho, fft_do_time_averaging, J_linear_in_time, dive_cleaning, divb_cleaning);
+            update_with_rho, fft_do_time_averaging, do_multi_J, dive_cleaning, divb_cleaning);
     } else {
         // Otherwise: use the Galilean algorithm
         algorithm = std::make_unique<GalileanPsatdAlgorithmRZ>(

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -317,6 +317,22 @@ WarpX::PSATDPushSpectralFields ()
 }
 
 void
+WarpX::PSATDMoveRhoNewToRhoMid ()
+{
+    const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
+
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        spectral_solver_fp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
+
+        if (spectral_solver_cp[lev])
+        {
+            spectral_solver_cp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
+        }
+    }
+}
+
+void
 WarpX::PSATDMoveRhoNewToRhoOld ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -236,12 +236,9 @@ WarpX::PSATDForwardTransformJ ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
-    const int idx_jx = (WarpX::J_linear_in_time) ? static_cast<int>(Idx.Jx_new)
-                                                 : static_cast<int>(Idx.Jx);
-    const int idx_jy = (WarpX::J_linear_in_time) ? static_cast<int>(Idx.Jy_new)
-                                                 : static_cast<int>(Idx.Jy);
-    const int idx_jz = (WarpX::J_linear_in_time) ? static_cast<int>(Idx.Jz_new)
-                                                 : static_cast<int>(Idx.Jz);
+    const int idx_jx = static_cast<int>(Idx.Jx_new);
+    const int idx_jy = static_cast<int>(Idx.Jy_new);
+    const int idx_jz = static_cast<int>(Idx.Jz_new);
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -236,9 +236,9 @@ WarpX::PSATDForwardTransformJ ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
-    const int idx_jx = static_cast<int>(Idx.Jx_new);
-    const int idx_jy = static_cast<int>(Idx.Jy_new);
-    const int idx_jz = static_cast<int>(Idx.Jz_new);
+    const int idx_jx = (WarpX::do_multi_J) ? static_cast<int>(Idx.Jx_new) : static_cast<int>(Idx.Jx);
+    const int idx_jy = (WarpX::do_multi_J) ? static_cast<int>(Idx.Jy_new) : static_cast<int>(Idx.Jy);
+    const int idx_jz = (WarpX::do_multi_J) ? static_cast<int>(Idx.Jz_new) : static_cast<int>(Idx.Jz);
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -317,22 +317,6 @@ WarpX::PSATDPushSpectralFields ()
 }
 
 void
-WarpX::PSATDMoveRhoNewToRhoMid ()
-{
-    const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
-
-    for (int lev = 0; lev <= finest_level; ++lev)
-    {
-        spectral_solver_fp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
-
-        if (spectral_solver_cp[lev])
-        {
-            spectral_solver_cp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
-        }
-    }
-}
-
-void
 WarpX::PSATDMoveRhoNewToRhoOld ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -243,7 +243,7 @@ WarpX::InitPML ()
                              pml_ncell, pml_delta, amrex::IntVect::TheZeroVector(),
                              dt[0], nox_fft, noy_fft, noz_fft, do_nodal,
                              do_moving_window, pml_has_particles, do_pml_in_domain,
-                             J_linear_in_time,
+                             do_multi_J,
                              do_pml_dive_cleaning, do_pml_divb_cleaning,
                              guard_cells.ng_FieldSolver.max(),
                              do_pml_Lo_corrected, do_pml_Hi);
@@ -274,7 +274,7 @@ WarpX::InitPML ()
                                    pml_ncell, pml_delta, refRatio(lev-1),
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
                                    do_moving_window, pml_has_particles, do_pml_in_domain,
-                                   J_linear_in_time, do_pml_dive_cleaning, do_pml_divb_cleaning,
+                                   do_multi_J, do_pml_dive_cleaning, do_pml_divb_cleaning,
                                    guard_cells.ng_FieldSolver.max(),
                                    do_pml_Lo_MR, do_pml_Hi_MR);
         }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1351,6 +1351,11 @@ private:
     void PSATDForwardTransformRho (const int icomp, const int dcomp);
 
     /**
+     * \brief Copy rho_new to rho_mid in spectral space
+     */
+    void PSATDMoveRhoNewToRhoMid ();
+
+    /**
      * \brief Copy rho_new to rho_old in spectral space
      */
     void PSATDMoveRhoNewToRhoOld ();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1351,11 +1351,6 @@ private:
     void PSATDForwardTransformRho (const int icomp, const int dcomp);
 
     /**
-     * \brief Copy rho_new to rho_mid in spectral space
-     */
-    void PSATDMoveRhoNewToRhoMid ();
-
-    /**
      * \brief Copy rho_new to rho_old in spectral space
      */
     void PSATDMoveRhoNewToRhoOld ();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -270,7 +270,6 @@ public:
     static int do_subcycling;
     static int do_multi_J;
     static int do_multi_J_n_depositions;
-    static int J_linear_in_time;
 
     static bool do_device_synchronize;
     static bool safe_guard_cells;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -183,7 +183,6 @@ int WarpX::self_fields_verbosity = 2;
 int WarpX::do_subcycling = 0;
 int WarpX::do_multi_J = 0;
 int WarpX::do_multi_J_n_depositions;
-int WarpX::J_linear_in_time = 0;
 bool WarpX::safe_guard_cells = 0;
 
 IntVect WarpX::filter_npass_each_dir(1);
@@ -1088,7 +1087,6 @@ WarpX::ReadParameters ()
 
         pp_psatd.query("current_correction", current_correction);
         pp_psatd.query("do_time_averaging", fft_do_time_averaging);
-        pp_psatd.query("J_linear_in_time", J_linear_in_time);
 
         if (!fft_periodic_single_box && current_correction)
             amrex::Abort(
@@ -1200,12 +1198,9 @@ WarpX::ReadParameters ()
             {
                 amrex::Abort("Multi-J algorithm not implemented with Galilean PSATD");
             }
-        }
 
-        if (J_linear_in_time)
-        {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
-                "psatd.update_with_rho must be set to 1 when psatd.J_linear_in_time = 1");
+                "psatd.update_with_rho must be set to 1 when warpx.do_multi_J = 1");
         }
 
         for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
@@ -2016,7 +2011,7 @@ void WarpX::AllocLevelSpectralSolverRZ (amrex::Vector<std::unique_ptr<SpectralSo
                                                   solver_dt,
                                                   update_with_rho,
                                                   fft_do_time_averaging,
-                                                  J_linear_in_time,
+                                                  do_multi_J,
                                                   do_dive_cleaning,
                                                   do_divb_cleaning);
     spectral_solver[lev] = std::move(pss);
@@ -2072,7 +2067,7 @@ void WarpX::AllocLevelSpectralSolver (amrex::Vector<std::unique_ptr<SpectralSolv
                                                 fft_periodic_single_box,
                                                 update_with_rho,
                                                 fft_do_time_averaging,
-                                                J_linear_in_time,
+                                                do_multi_J,
                                                 do_dive_cleaning,
                                                 do_divb_cleaning);
     spectral_solver[lev] = std::move(pss);


### PR DESCRIPTION
Remove `WarpX::J_linear_in_time` (and corresponding input parameter): always `true` with multi-J algorithm, always `false` with standard and Galilean/comoving PSATD.

The implementation of the multi-J formulation with rho quadratic in time will follow in a separate PR.