### PR TITLE
Add RZ support in libwarpx function _get_boundary_number

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -311,8 +311,10 @@ class LibWarpX():
             dimensions = {'x' : 0, 'z' : 1}
         elif self.geometry_dim == '1d':
             dimensions = {'z' : 0}
+        elif self.geometry_dim == 'rz':
+            dimensions = {'r': 0, 'z': 1}
         else:
-            raise NotImplementedError("RZ is not supported for particle scraping.")
+            raise RuntimeError(f"Unknown simulation geometry: {self.geometry_dim}")
 
         if boundary != 'eb':
             boundary_parts = boundary.split("_")


### PR DESCRIPTION
Based on the results shown in https://github.com/ModernElectron/WarpX/pull/121, all other functionality needed to track scraped particles in `RZ` works (`r` scraping not explicitly tested).