### PR TITLE
AMREX_ALWAYS_ASSERT -> AMREX_ASSERT for deposition bounds checks

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -353,7 +353,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     const amrex::IntVect range = jx->nGrowVect() - shape_extent;
 #endif
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for current deposition");
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -352,7 +352,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     // Jx, Jy and Jz have the same number of guard cells, hence it is sufficient to check for Jx
     const amrex::IntVect range = jx->nGrowVect() - shape_extent;
 #endif
-#if (!(AMREX_DEBUG || AMREX_USE_ASSERTION))
+#if !(defined(AMREX_DEBUG) || defined(AMREX_USE_ASSERTION))
     amrex::ignore_unused(range);
 #endif
     AMREX_ASSERT_WITH_MESSAGE(

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -352,9 +352,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     // Jx, Jy and Jz have the same number of guard cells, hence it is sufficient to check for Jx
     const amrex::IntVect range = jx->nGrowVect() - shape_extent;
 #endif
-#if !(defined(AMREX_DEBUG) || defined(AMREX_USE_ASSERTION))
-    amrex::ignore_unused(range);
-#endif
+    amrex::ignore_unused(range); // for release builds
     AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for current deposition");

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -352,7 +352,9 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     // Jx, Jy and Jz have the same number of guard cells, hence it is sufficient to check for Jx
     const amrex::IntVect range = jx->nGrowVect() - shape_extent;
 #endif
-
+#if (!(AMREX_DEBUG || AMREX_USE_ASSERTION))
+    amrex::ignore_unused(range);
+#endif
     AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for current deposition");

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -103,7 +103,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
 #else
     const amrex::IntVect range = rho->nGrowVect() - shape_extent;
 #endif
-#if !defined(AMREX_DEBUG) && !defined(AMREX_USE_ASSERTION)
+#if !(defined(AMREX_DEBUG) || defined(AMREX_USE_ASSERTION))
     amrex::ignore_unused(range);
 #endif
     AMREX_ASSERT_WITH_MESSAGE(

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -103,7 +103,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
 #else
     const amrex::IntVect range = rho->nGrowVect() - shape_extent;
 #endif
-#if (!(AMREX_DEBUG || AMREX_USE_ASSERTION))
+#if !defined(AMREX_DEBUG) && !defined(AMREX_USE_ASSERTION)
     amrex::ignore_unused(range);
 #endif
     AMREX_ASSERT_WITH_MESSAGE(

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -104,7 +104,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
     const amrex::IntVect range = rho->nGrowVect() - shape_extent;
 #endif
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for charge deposition");
 

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -103,7 +103,9 @@ deposit_charge (typename T_PC::ParIterType& pti,
 #else
     const amrex::IntVect range = rho->nGrowVect() - shape_extent;
 #endif
-
+#if (!(AMREX_DEBUG || AMREX_USE_ASSERTION))
+    amrex::ignore_unused(range);
+#endif
     AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for charge deposition");

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -103,9 +103,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
 #else
     const amrex::IntVect range = rho->nGrowVect() - shape_extent;
 #endif
-#if !(defined(AMREX_DEBUG) || defined(AMREX_USE_ASSERTION))
-    amrex::ignore_unused(range);
-#endif
+    amrex::ignore_unused(range); // for release builds
     AMREX_ASSERT_WITH_MESSAGE(
         amrex::numParticlesOutOfRange(pti, range) == 0,
         "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for charge deposition");


### PR DESCRIPTION
This check iterates the particle list, which is not for free.

We don't want to do this in release builds, but should keep doing it in CI. This change will make this happen.