### PR TITLE
For Python inputs, values with temporary variables are wrapped in quotes

### DIFF
--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -50,20 +50,24 @@ class Bucket(object):
             if value is None:
                 continue
             # --- repr is applied to value so that for floats, all of the digits are included.
-            # --- The strip is then needed when value is a string.
+            # --- The strip of "'" is then needed when value is a string.
             if isinstance(value, str):
-                rhs = value
+                if value.find('=') > -1:
+                    # --- Expressions with temporary variables need to be inside quotes
+                    rhs = f'"{value}"'
+                else:
+                    rhs = value
             elif np.iterable(value):
                 if len(value) == 0:
                     # --- Skip if empty
                     continue
                 # --- For lists, tuples, and arrays make a space delimited string of the values.
                 # --- The lambda is needed in case this is a list of strings.
-                rhs = ' '.join(map(lambda s : repr(s).strip("'\""), value))
+                rhs = ' '.join(map(lambda s : repr(s).strip("'"), value))
             elif isinstance(value, bool):
                 rhs = 1 if value else 0
             else:
                 rhs = value
-            attrstring = '{0}.{1} = {2}'.format(self.instancename, attr, repr(rhs).strip("'\""))
+            attrstring = '{0}.{1} = {2}'.format(self.instancename, attr, repr(rhs).strip("'"))
             result += [attrstring]
         return result


### PR DESCRIPTION
An expression like this `r2=x*x+y*y+z*z; r=sqrt(r2); r-0.1` needs to wrapped in quotes to be properly processed by the parser. Without the fix in this PR, an error would occur with expressions with temporary variables,

> ParmParse::addDefn(): no values for definition (input name)

Where `input name` is the value being set.