### PR TITLE
Change _libwarpx.py functions to LibWarpX class methods

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -856,7 +856,7 @@ Particle initialization
     species that impact the embedded boundary.
     The scraped particle buffer can be used to track particle fluxes out of the
     simulation but is currently only accessible via the Python interface. The
-    ``pywarpx`` function ``get_particle_boundary_buffer()`` can be
+    ``pywarpx.libwarpx`` function ``get_particle_boundary_buffer()`` can be
     used to access the scraped particle buffer. An entry is included for every
     particle in the buffer of the timestep at which the particle was scraped.
     This can be accessed by passing the argument ``comp_name="step_scraped"`` to

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -856,7 +856,9 @@ Particle initialization
     species that impact the embedded boundary.
     The scraped particle buffer can be used to track particle fluxes out of the
     simulation but is currently only accessible via the Python interface. The
-    ``pywarpx.libwarpx`` function ``get_particle_boundary_buffer()`` can be
+    function ``get_particle_boundary_buffer``, found in the
+    ``picmi.Simulation`` class as
+    ``sim.extension.get_particle_boundary_buffer()``, can be
     used to access the scraped particle buffer. An entry is included for every
     particle in the buffer of the timestep at which the particle was scraped.
     This can be accessed by passing the argument ``comp_name="step_scraped"`` to

--- a/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
+++ b/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
@@ -2,7 +2,7 @@
 #
 # --- Input file to test particle reflection off an absorbing boundary
 
-from pywarpx import libwarpx, picmi
+from pywarpx import picmi
 
 constants = picmi.constants
 
@@ -114,20 +114,20 @@ sim.step(max_steps)
 # buffer functions as intended
 ################################################
 
-n = libwarpx.get_particle_boundary_buffer_size("electrons", 'z_hi')
+n = sim.extension.get_particle_boundary_buffer_size("electrons", 'z_hi')
 print("Number of electrons in upper buffer:", n)
 assert n == 63
 
-n = libwarpx.get_particle_boundary_buffer_size("electrons", 'z_lo')
+n = sim.extension.get_particle_boundary_buffer_size("electrons", 'z_lo')
 print("Number of electrons in lower buffer:", n)
 assert n == 67
 
-scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'z_hi', 'step_scraped', 0)
+scraped_steps = sim.extension.get_particle_boundary_buffer("electrons", 'z_hi', 'step_scraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 4)
 
-scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'z_lo', 'step_scraped', 0)
+scraped_steps = sim.extension.get_particle_boundary_buffer("electrons", 'z_lo', 'step_scraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 8)

--- a/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
+++ b/Examples/Modules/ParticleBoundaryProcess/PICMI_inputs_reflection.py
@@ -2,8 +2,7 @@
 #
 # --- Input file to test particle reflection off an absorbing boundary
 
-import pywarpx
-from pywarpx import picmi
+from pywarpx import libwarpx, picmi
 
 constants = picmi.constants
 
@@ -115,20 +114,20 @@ sim.step(max_steps)
 # buffer functions as intended
 ################################################
 
-n = pywarpx.get_particle_boundary_buffer_size("electrons", 'z_hi')
+n = libwarpx.get_particle_boundary_buffer_size("electrons", 'z_hi')
 print("Number of electrons in upper buffer:", n)
 assert n == 63
 
-n = pywarpx.get_particle_boundary_buffer_size("electrons", 'z_lo')
+n = libwarpx.get_particle_boundary_buffer_size("electrons", 'z_lo')
 print("Number of electrons in lower buffer:", n)
 assert n == 67
 
-scraped_steps = pywarpx.get_particle_boundary_buffer("electrons", 'z_hi', 'step_scraped', 0)
+scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'z_hi', 'step_scraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 4)
 
-scraped_steps = pywarpx.get_particle_boundary_buffer("electrons", 'z_lo', 'step_scraped', 0)
+scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'z_lo', 'step_scraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 8)

--- a/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
@@ -3,7 +3,7 @@
 # --- Input file to test the particle scraper and the Python wrappers
 # --- to access the buffer of scraped particles.
 
-from pywarpx import libwarpx, picmi
+from pywarpx import picmi
 
 ##########################
 # numerics parameters
@@ -116,25 +116,25 @@ sim.step(max_steps)
 
 from mpi4py import MPI as mpi
 
-my_id = libwarpx.getMyProc()
+my_id = sim.extension.getMyProc()
 
-n = libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
+n = sim.extension.get_particle_boundary_buffer_size("electrons", 'eb')
 print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 612
 
-scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
+scraped_steps = sim.extension.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
 for arr in scraped_steps:
     assert all(arr > 40)
 
-weights = libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
+weights = sim.extension.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
 n = sum(len(arr) for arr in weights)
 print(f"Number of electrons in this proc's buffer (proc #{my_id}): {n}")
 n_sum =  mpi.COMM_WORLD.allreduce(n, op=mpi.SUM)
 assert n_sum == 612
 
 # clear the particle buffer
-libwarpx.clearParticleBoundaryBuffer()
+sim.extension.clearParticleBoundaryBuffer()
 # confirm that the buffer was cleared
-n = libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
+n = sim.extension.get_particle_boundary_buffer_size("electrons", 'eb')
 print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 0

--- a/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
+++ b/Examples/Modules/ParticleBoundaryScrape/PICMI_inputs_scrape.py
@@ -3,8 +3,7 @@
 # --- Input file to test the particle scraper and the Python wrappers
 # --- to access the buffer of scraped particles.
 
-import pywarpx
-from pywarpx import picmi
+from pywarpx import libwarpx, picmi
 
 ##########################
 # numerics parameters
@@ -117,25 +116,25 @@ sim.step(max_steps)
 
 from mpi4py import MPI as mpi
 
-my_id = pywarpx.getMyProc()
+my_id = libwarpx.getMyProc()
 
-n = pywarpx.get_particle_boundary_buffer_size("electrons", 'eb')
+n = libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
 print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 612
 
-scraped_steps = pywarpx.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
+scraped_steps = libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
 for arr in scraped_steps:
     assert all(arr > 40)
 
-weights = pywarpx.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
+weights = libwarpx.get_particle_boundary_buffer("electrons", 'eb', 'w', 0)
 n = sum(len(arr) for arr in weights)
 print(f"Number of electrons in this proc's buffer (proc #{my_id}): {n}")
 n_sum =  mpi.COMM_WORLD.allreduce(n, op=mpi.SUM)
 assert n_sum == 612
 
 # clear the particle buffer
-pywarpx.clearParticleBoundaryBuffer()
+libwarpx.clearParticleBoundaryBuffer()
 # confirm that the buffer was cleared
-n = pywarpx.get_particle_boundary_buffer_size("electrons", 'eb')
+n = libwarpx.get_particle_boundary_buffer_size("electrons", 'eb')
 print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 0

--- a/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
+++ b/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
-from pywarpx import fields, libwarpx, picmi
+from pywarpx import fields, picmi
 
 max_steps = 1
 unit = 1e-3
@@ -83,10 +83,10 @@ sim.initialize_inputs()
 
 sim.step(1)
 
-print("======== Testing libwarpx.get_mesh_edge_lengths =========")
+print("======== Testing sim.extension.get_mesh_edge_lengths =========")
 
-ly_slice_x = np.array(libwarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[int(nx/2),:,:]
-lz_slice_x = np.array(libwarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[int(nx/2),:,:]
+ly_slice_x = np.array(sim.extension.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[int(nx/2),:,:]
+lz_slice_x = np.array(sim.extension.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[int(nx/2),:,:]
 
 n_edge_y_lo = int((ny - 30)/2)
 n_edge_y_hi = int(ny - (ny - 30)/2)
@@ -104,8 +104,8 @@ print("Perimeter of the middle x-slice:", perimeter_slice_x)
 assert np.isclose(perimeter_slice_x, perimeter_slice_x_true, rtol=1e-05, atol=1e-08)
 
 
-lx_slice_y = np.array(libwarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,int(ny/2),:]
-lz_slice_y = np.array(libwarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[:,int(ny/2),:]
+lx_slice_y = np.array(sim.extension.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,int(ny/2),:]
+lz_slice_y = np.array(sim.extension.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[:,int(ny/2),:]
 
 n_edge_x_lo = int((nx - 30)/2)
 n_edge_x_hi = int(nx - (nx - 30)/2)
@@ -124,8 +124,8 @@ print("Perimeter of the middle y-slice:", perimeter_slice_y)
 assert np.isclose(perimeter_slice_y, perimeter_slice_y_true, rtol=1e-05, atol=1e-08)
 
 
-lx_slice_z = np.array(libwarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,:,int(nz/2)]
-ly_slice_z = np.array(libwarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[:,:,int(nz/2)]
+lx_slice_z = np.array(sim.extension.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,:,int(nz/2)]
+ly_slice_z = np.array(sim.extension.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[:,:,int(nz/2)]
 
 n_edge_x_lo = int((nx - 30)/2)
 n_edge_x_hi = int(nx - (nx - 30)/2)
@@ -142,9 +142,9 @@ perimeter_slice_z_true = L_cavity*4
 print("Perimeter of the middle z-slice:", perimeter_slice_z)
 assert np.isclose(perimeter_slice_z, perimeter_slice_z_true, rtol=1e-05, atol=1e-08)
 
-print("======== Testing libwarpx.get_mesh_face_areas =========")
+print("======== Testing sim.extension.get_mesh_face_areas =========")
 
-Sx_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,0,include_ghosts=False)[0])[int(nx/2),:,:])
+Sx_slice = np.sum(np.array(sim.extension.get_mesh_face_areas(0,0,include_ghosts=False)[0])[int(nx/2),:,:])
 dx = (xmax-xmin)/nx
 Ax = dx*dx
 Sx_slice_true = L_cavity*L_cavity - 2*Ax
@@ -152,7 +152,7 @@ print("Area of the middle x-slice:", Sx_slice)
 assert np.isclose(Sx_slice, Sx_slice_true, rtol=1e-05, atol=1e-08)
 
 
-Sy_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,1,include_ghosts=False)[0])[:,int(ny/2),:])
+Sy_slice = np.sum(np.array(sim.extension.get_mesh_face_areas(0,1,include_ghosts=False)[0])[:,int(ny/2),:])
 dy = (ymax-ymin)/ny
 Ay = dy*dy
 Sy_slice_true = L_cavity*L_cavity - 2*Ay
@@ -160,7 +160,7 @@ print("Area of the middle y-slice:", Sx_slice)
 assert np.isclose(Sy_slice, Sy_slice_true, rtol=1e-05, atol=1e-08)
 
 
-Sz_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,2,include_ghosts=False)[0])[:,:,int(nz/2)])
+Sz_slice = np.sum(np.array(sim.extension.get_mesh_face_areas(0,2,include_ghosts=False)[0])[:,:,int(nz/2)])
 dz = (zmax-zmin)/nz
 Az = dz*dz
 Sz_slice_true = L_cavity*L_cavity - 2*Az

--- a/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
+++ b/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
-import pywarpx
-from pywarpx import fields, picmi
+from pywarpx import fields, libwarpx, picmi
 
 max_steps = 1
 unit = 1e-3
@@ -84,10 +83,10 @@ sim.initialize_inputs()
 
 sim.step(1)
 
-print("======== Testing pywarpx.get_mesh_edge_lengths =========")
+print("======== Testing libwarpx.get_mesh_edge_lengths =========")
 
-ly_slice_x = np.array(pywarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[int(nx/2),:,:]
-lz_slice_x = np.array(pywarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[int(nx/2),:,:]
+ly_slice_x = np.array(libwarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[int(nx/2),:,:]
+lz_slice_x = np.array(libwarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[int(nx/2),:,:]
 
 n_edge_y_lo = int((ny - 30)/2)
 n_edge_y_hi = int(ny - (ny - 30)/2)
@@ -105,8 +104,8 @@ print("Perimeter of the middle x-slice:", perimeter_slice_x)
 assert np.isclose(perimeter_slice_x, perimeter_slice_x_true, rtol=1e-05, atol=1e-08)
 
 
-lx_slice_y = np.array(pywarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,int(ny/2),:]
-lz_slice_y = np.array(pywarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[:,int(ny/2),:]
+lx_slice_y = np.array(libwarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,int(ny/2),:]
+lz_slice_y = np.array(libwarpx.get_mesh_edge_lengths(0,2,include_ghosts=False)[0])[:,int(ny/2),:]
 
 n_edge_x_lo = int((nx - 30)/2)
 n_edge_x_hi = int(nx - (nx - 30)/2)
@@ -125,8 +124,8 @@ print("Perimeter of the middle y-slice:", perimeter_slice_y)
 assert np.isclose(perimeter_slice_y, perimeter_slice_y_true, rtol=1e-05, atol=1e-08)
 
 
-lx_slice_z = np.array(pywarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,:,int(nz/2)]
-ly_slice_z = np.array(pywarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[:,:,int(nz/2)]
+lx_slice_z = np.array(libwarpx.get_mesh_edge_lengths(0,0,include_ghosts=False)[0])[:,:,int(nz/2)]
+ly_slice_z = np.array(libwarpx.get_mesh_edge_lengths(0,1,include_ghosts=False)[0])[:,:,int(nz/2)]
 
 n_edge_x_lo = int((nx - 30)/2)
 n_edge_x_hi = int(nx - (nx - 30)/2)
@@ -143,9 +142,9 @@ perimeter_slice_z_true = L_cavity*4
 print("Perimeter of the middle z-slice:", perimeter_slice_z)
 assert np.isclose(perimeter_slice_z, perimeter_slice_z_true, rtol=1e-05, atol=1e-08)
 
-print("======== Testing pywarpx.get_mesh_face_areas =========")
+print("======== Testing libwarpx.get_mesh_face_areas =========")
 
-Sx_slice = np.sum(np.array(pywarpx.get_mesh_face_areas(0,0,include_ghosts=False)[0])[int(nx/2),:,:])
+Sx_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,0,include_ghosts=False)[0])[int(nx/2),:,:])
 dx = (xmax-xmin)/nx
 Ax = dx*dx
 Sx_slice_true = L_cavity*L_cavity - 2*Ax
@@ -153,7 +152,7 @@ print("Area of the middle x-slice:", Sx_slice)
 assert np.isclose(Sx_slice, Sx_slice_true, rtol=1e-05, atol=1e-08)
 
 
-Sy_slice = np.sum(np.array(pywarpx.get_mesh_face_areas(0,1,include_ghosts=False)[0])[:,int(ny/2),:])
+Sy_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,1,include_ghosts=False)[0])[:,int(ny/2),:])
 dy = (ymax-ymin)/ny
 Ay = dy*dy
 Sy_slice_true = L_cavity*L_cavity - 2*Ay
@@ -161,7 +160,7 @@ print("Area of the middle y-slice:", Sx_slice)
 assert np.isclose(Sy_slice, Sy_slice_true, rtol=1e-05, atol=1e-08)
 
 
-Sz_slice = np.sum(np.array(pywarpx.get_mesh_face_areas(0,2,include_ghosts=False)[0])[:,:,int(nz/2)])
+Sz_slice = np.sum(np.array(libwarpx.get_mesh_face_areas(0,2,include_ghosts=False)[0])[:,:,int(nz/2)])
 dz = (zmax-zmin)/nz
 Az = dz*dz
 Sz_slice_true = L_cavity*L_cavity - 2*Az

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -6,8 +6,7 @@
 # --- used for the field solve step.
 
 import numpy as np
-import pywarpx
-from pywarpx import callbacks, fields, picmi
+from pywarpx import callbacks, fields, libwarpx, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
 
@@ -177,7 +176,7 @@ class PoissonSolverPseudo1D(picmi.ElectrostaticSolver):
         calculating phi from rho."""
         right_voltage = eval(
             self.right_voltage,
-            {'t':pywarpx.gett_new(0), 'sin':np.sin, 'pi':np.pi}
+            {'t':libwarpx.gett_new(0), 'sin':np.sin, 'pi':np.pi}
         )
         left_voltage = 0.0
 

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -6,7 +6,7 @@
 # --- used for the field solve step.
 
 import numpy as np
-from pywarpx import callbacks, fields, libwarpx, picmi
+from pywarpx import callbacks, fields, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
 
@@ -176,7 +176,7 @@ class PoissonSolverPseudo1D(picmi.ElectrostaticSolver):
         calculating phi from rho."""
         right_voltage = eval(
             self.right_voltage,
-            {'t':libwarpx.gett_new(0), 'sin':np.sin, 'pi':np.pi}
+            {'t':sim.extension.gett_new(0), 'sin':np.sin, 'pi':np.pi}
         )
         left_voltage = 0.0
 

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -9,8 +9,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
-import pywarpx
-from pywarpx import fields, picmi
+from pywarpx import fields, libwarpx, picmi
 
 constants = picmi.constants
 
@@ -178,7 +177,7 @@ def calcEz( z, r, k0, w0, wp, t, epsilons) :
     return( Ez_array )
 
 # Current time of the simulation
-t0 = pywarpx.gett_new(0)
+t0 = libwarpx.gett_new(0)
 
 # Get the raw field data. Note that these are the real and imaginary
 # parts of the fields for each azimuthal mode.

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -9,7 +9,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
-from pywarpx import fields, libwarpx, picmi
+from pywarpx import fields, picmi
 
 constants = picmi.constants
 
@@ -177,7 +177,7 @@ def calcEz( z, r, k0, w0, wp, t, epsilons) :
     return( Ez_array )
 
 # Current time of the simulation
-t0 = libwarpx.gett_new(0)
+t0 = sim.extension.gett_new(0)
 
 # Get the raw field data. Note that these are the real and imaginary
 # parts of the fields for each azimuthal mode.

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -3,8 +3,7 @@ import argparse
 import sys
 
 import numpy as np
-import pywarpx
-from pywarpx import callbacks, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 # Create the parser and add the argument
 parser = argparse.ArgumentParser()
@@ -107,9 +106,9 @@ sim.initialize_warpx()
 ##########################
 
 
-pywarpx.add_real_comp('electrons', 'newPid')
+libwarpx.add_real_comp('electrons', 'newPid')
 
-my_id = pywarpx.getMyProc()
+my_id = libwarpx.getMyProc()
 
 def add_particles():
 
@@ -123,7 +122,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    pywarpx.add_particles(
+    libwarpx.add_particles(
         species_name='electrons', x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
         w=w, newPid=newPid, unique_particles=args.unique
     )
@@ -141,11 +140,11 @@ sim.step(max_steps - 1)
 # are properly set
 ##########################
 
-assert (pywarpx.get_particle_count('electrons') == 270 / (2 - args.unique))
-assert (pywarpx.get_particle_comp_index('electrons', 'w') == 0)
-assert (pywarpx.get_particle_comp_index('electrons', 'newPid') == 4)
+assert (libwarpx.get_particle_count('electrons') == 270 / (2 - args.unique))
+assert (libwarpx.get_particle_comp_index('electrons', 'w') == 0)
+assert (libwarpx.get_particle_comp_index('electrons', 'newPid') == 4)
 
-new_pid_vals = pywarpx.get_particle_arrays(
+new_pid_vals = libwarpx.get_particle_arrays(
     'electrons', 'newPid', 0
 )
 for vals in new_pid_vals:

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 
 import numpy as np
-from pywarpx import callbacks, libwarpx, picmi
+from pywarpx import callbacks, picmi
 
 # Create the parser and add the argument
 parser = argparse.ArgumentParser()
@@ -106,9 +106,9 @@ sim.initialize_warpx()
 ##########################
 
 
-libwarpx.add_real_comp('electrons', 'newPid')
+sim.extension.add_real_comp('electrons', 'newPid')
 
-my_id = libwarpx.getMyProc()
+my_id = sim.extension.getMyProc()
 
 def add_particles():
 
@@ -122,7 +122,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    libwarpx.add_particles(
+    sim.extension.add_particles(
         species_name='electrons', x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
         w=w, newPid=newPid, unique_particles=args.unique
     )
@@ -140,11 +140,11 @@ sim.step(max_steps - 1)
 # are properly set
 ##########################
 
-assert (libwarpx.get_particle_count('electrons') == 270 / (2 - args.unique))
-assert (libwarpx.get_particle_comp_index('electrons', 'w') == 0)
-assert (libwarpx.get_particle_comp_index('electrons', 'newPid') == 4)
+assert (sim.extension.get_particle_count('electrons') == 270 / (2 - args.unique))
+assert (sim.extension.get_particle_comp_index('electrons', 'w') == 0)
+assert (sim.extension.get_particle_comp_index('electrons', 'newPid') == 4)
 
-new_pid_vals = libwarpx.get_particle_arrays(
+new_pid_vals = sim.extension.get_particle_arrays(
     'electrons', 'newPid', 0
 )
 for vals in new_pid_vals:

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
@@ -3,8 +3,7 @@
 # --- Input file to test the saving of old particle positions
 
 import numpy as np
-import pywarpx
-from pywarpx import picmi
+from pywarpx import libwarpx, picmi
 
 constants = picmi.constants
 
@@ -110,10 +109,10 @@ sim.step(max_steps - 1)
 # exist
 ##########################
 
-assert (pywarpx.get_particle_comp_index('electrons', 'prev_x') > 0)
-assert (pywarpx.get_particle_comp_index('electrons', 'prev_z') > 0)
+assert (libwarpx.get_particle_comp_index('electrons', 'prev_x') > 0)
+assert (libwarpx.get_particle_comp_index('electrons', 'prev_z') > 0)
 
-prev_z_vals = pywarpx.get_particle_arrays(
+prev_z_vals = libwarpx.get_particle_arrays(
     'electrons', 'prev_z', 0
 )
 for z_vals in prev_z_vals:

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
@@ -3,7 +3,7 @@
 # --- Input file to test the saving of old particle positions
 
 import numpy as np
-from pywarpx import libwarpx, picmi
+from pywarpx import picmi
 
 constants = picmi.constants
 
@@ -109,10 +109,10 @@ sim.step(max_steps - 1)
 # exist
 ##########################
 
-assert (libwarpx.get_particle_comp_index('electrons', 'prev_x') > 0)
-assert (libwarpx.get_particle_comp_index('electrons', 'prev_z') > 0)
+assert (sim.extension.get_particle_comp_index('electrons', 'prev_x') > 0)
+assert (sim.extension.get_particle_comp_index('electrons', 'prev_z') > 0)
 
-prev_z_vals = libwarpx.get_particle_arrays(
+prev_z_vals = sim.extension.get_particle_arrays(
     'electrons', 'prev_z', 0
 )
 for z_vals in prev_z_vals:

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -6,8 +6,7 @@
 # --- if the correct amount of processors are initialized in AMReX.
 
 from mpi4py import MPI
-import pywarpx
-from pywarpx import picmi
+from pywarpx import libwarpx, picmi
 
 constants = picmi.constants
 
@@ -128,14 +127,14 @@ new_comm_size = new_comm.size
 
 if color == 0:
     # verify that communicator contains correct number of procs (1)
-    assert pywarpx.getNProcs() == comm_world_size - 1
-    assert pywarpx.getNProcs() == new_comm_size
+    assert libwarpx.getNProcs() == comm_world_size - 1
+    assert libwarpx.getNProcs() == new_comm_size
 
 else:
     # verify that amrex initialized with 1 fewer proc than comm world
-    assert pywarpx.getNProcs() == comm_world_size - 1
-    assert pywarpx.getNProcs() == new_comm_size
+    assert libwarpx.getNProcs() == comm_world_size - 1
+    assert libwarpx.getNProcs() == new_comm_size
 
     # verify that amrex proc ranks are offset by -1 from
     # world comm proc ranks
-    assert pywarpx.getMyProc() == rank - 1
+    assert libwarpx.getMyProc() == rank - 1

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -6,7 +6,7 @@
 # --- if the correct amount of processors are initialized in AMReX.
 
 from mpi4py import MPI
-from pywarpx import libwarpx, picmi
+from pywarpx import picmi
 
 constants = picmi.constants
 
@@ -127,14 +127,14 @@ new_comm_size = new_comm.size
 
 if color == 0:
     # verify that communicator contains correct number of procs (1)
-    assert libwarpx.getNProcs() == comm_world_size - 1
-    assert libwarpx.getNProcs() == new_comm_size
+    assert sim.extension.getNProcs() == comm_world_size - 1
+    assert sim.extension.getNProcs() == new_comm_size
 
 else:
     # verify that amrex initialized with 1 fewer proc than comm world
-    assert libwarpx.getNProcs() == comm_world_size - 1
-    assert libwarpx.getNProcs() == new_comm_size
+    assert sim.extension.getNProcs() == comm_world_size - 1
+    assert sim.extension.getNProcs() == new_comm_size
 
     # verify that amrex proc ranks are offset by -1 from
     # world comm proc ranks
-    assert libwarpx.getMyProc() == rank - 1
+    assert sim.extension.getMyProc() == rank - 1

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -7,8 +7,7 @@
 import sys
 
 import numpy as np
-import pywarpx
-from pywarpx import callbacks, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 ##########################
 # physics parameters
@@ -113,7 +112,7 @@ sim.initialize_warpx()
 ##########################
 
 
-pywarpx.add_real_comp('electrons', 'newPid')
+libwarpx.add_real_comp('electrons', 'newPid')
 
 def add_particles():
 
@@ -127,7 +126,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    pywarpx.add_particles(
+    libwarpx.add_particles(
         species_name='electrons', x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
         w=w, newPid=newPid
     )
@@ -138,18 +137,18 @@ callbacks.installbeforestep(add_particles)
 # simulation run
 ##########################
 
-step_number = pywarpx.getistep(0)
+step_number = libwarpx.getistep(0)
 sim.step(max_steps - 1 - step_number)
 
 ##########################
 # check that the new PIDs are properly set
 ##########################
 
-assert(pywarpx.get_particle_count('electrons') == 90)
-assert (pywarpx.get_particle_comp_index('electrons', 'w') == 0)
-assert (pywarpx.get_particle_comp_index('electrons', 'newPid') == 4)
+assert(libwarpx.get_particle_count('electrons') == 90)
+assert (libwarpx.get_particle_comp_index('electrons', 'w') == 0)
+assert (libwarpx.get_particle_comp_index('electrons', 'newPid') == 4)
 
-new_pid_vals = pywarpx.get_particle_arrays(
+new_pid_vals = libwarpx.get_particle_arrays(
     'electrons', 'newPid', 0
 )
 for vals in new_pid_vals:

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -7,7 +7,7 @@
 import sys
 
 import numpy as np
-from pywarpx import callbacks, libwarpx, picmi
+from pywarpx import callbacks, picmi
 
 ##########################
 # physics parameters
@@ -112,7 +112,7 @@ sim.initialize_warpx()
 ##########################
 
 
-libwarpx.add_real_comp('electrons', 'newPid')
+sim.extension.add_real_comp('electrons', 'newPid')
 
 def add_particles():
 
@@ -126,7 +126,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    libwarpx.add_particles(
+    sim.extension.add_particles(
         species_name='electrons', x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
         w=w, newPid=newPid
     )
@@ -137,18 +137,18 @@ callbacks.installbeforestep(add_particles)
 # simulation run
 ##########################
 
-step_number = libwarpx.getistep(0)
+step_number = sim.extension.getistep(0)
 sim.step(max_steps - 1 - step_number)
 
 ##########################
 # check that the new PIDs are properly set
 ##########################
 
-assert(libwarpx.get_particle_count('electrons') == 90)
-assert (libwarpx.get_particle_comp_index('electrons', 'w') == 0)
-assert (libwarpx.get_particle_comp_index('electrons', 'newPid') == 4)
+assert(sim.extension.get_particle_count('electrons') == 90)
+assert (sim.extension.get_particle_comp_index('electrons', 'w') == 0)
+assert (sim.extension.get_particle_comp_index('electrons', 'newPid') == 4)
 
-new_pid_vals = libwarpx.get_particle_arrays(
+new_pid_vals = sim.extension.get_particle_arrays(
     'electrons', 'newPid', 0
 )
 for vals in new_pid_vals:

--- a/Python/pywarpx/PGroup.py
+++ b/Python/pywarpx/PGroup.py
@@ -6,7 +6,8 @@
 
 import numpy as np
 
-from . import _libwarpx
+from ._libwarpx import libwarpx
+from ._picmi import constants
 
 
 class PGroup(object):
@@ -65,7 +66,7 @@ class PGroup(object):
         pass
 
     def getnpid(self):
-        return _libwarpx.get_nattr()
+        return libwarpx.get_nattr()
     npid = property(getnpid)
 
     def getnps(self):
@@ -85,45 +86,45 @@ class PGroup(object):
     npmax = property(getnpmax)
 
     def getxp(self):
-        return _libwarpx.get_particle_x(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_x(self.ispecie, self.level)[self.igroup]
     xp = property(getxp)
 
     def getyp(self):
-        return _libwarpx.get_particle_y(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_y(self.ispecie, self.level)[self.igroup]
     yp = property(getyp)
 
     def getrp(self):
-        return _libwarpx.get_particle_r(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_r(self.ispecie, self.level)[self.igroup]
     rp = property(getrp)
 
     def getzp(self):
-        return _libwarpx.get_particle_z(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_z(self.ispecie, self.level)[self.igroup]
     zp = property(getzp)
 
     def getuxp(self):
-        return _libwarpx.get_particle_ux(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_ux(self.ispecie, self.level)[self.igroup]
     uxp = property(getuxp)
 
     def getuyp(self):
-        return _libwarpx.get_particle_uy(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_uy(self.ispecie, self.level)[self.igroup]
     uyp = property(getuyp)
 
     def getuzp(self):
-        return _libwarpx.get_particle_uz(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_uz(self.ispecie, self.level)[self.igroup]
     uzp = property(getuzp)
 
     def getw(self):
-        return _libwarpx.get_particle_weight(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_weight(self.ispecie, self.level)[self.igroup]
 
     def getpid(self, id):
-        pid = _libwarpx.get_particle_arrays(self.ispecie, id, self.level)[self.igroup]
+        pid = libwarpx.get_particle_arrays(self.ispecie, id, self.level)[self.igroup]
         return np.array([pid]).T
 
     def getgaminv(self):
         uxp = self.getuxp()
         uyp = self.getuyp()
         uzp = self.getuzp()
-        return np.sqrt(1. - (uxp**2 + uyp**2 + uzp**2)/_libwarpx.clight**2)
+        return np.sqrt(1. - (uxp**2 + uyp**2 + uzp**2)/constants.c**2)
     gaminv = property(getgaminv)
 
     def getex(self):
@@ -151,7 +152,7 @@ class PGroup(object):
     bz = property(getbz)
 
     def gettheta(self):
-        return _libwarpx.get_particle_theta(self.ispecie, self.level)[self.igroup]
+        return libwarpx.get_particle_theta(self.ispecie, self.level)[self.igroup]
     theta = property(gettheta)
 
 class PGroups(object):
@@ -160,7 +161,7 @@ class PGroups(object):
         self.level = level
 
     def setuppgroups(self):
-        xall = _libwarpx.get_particle_x(self.ispecie, self.level)
+        xall = libwarpx.get_particle_x(self.ispecie, self.level)
         self.ngroups = len(xall)
 
         self._pgroups = []

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -5,7 +5,8 @@
 #
 # License: BSD-3-Clause-LBNL
 
-from . import Particles, _libwarpx
+from . import Particles
+from ._libwarpx import libwarpx
 from .Algo import algo
 from .Amr import amr
 from .Boundary import boundary
@@ -75,19 +76,19 @@ class WarpX(Bucket):
 
     def init(self, mpi_comm=None):
         argv = ['warpx'] + self.create_argv_list()
-        _libwarpx.initialize(argv, mpi_comm=mpi_comm)
+        libwarpx.initialize(argv, mpi_comm=mpi_comm)
 
     def evolve(self, nsteps=-1):
-        _libwarpx.evolve(nsteps)
+        libwarpx.evolve(nsteps)
 
     def finalize(self, finalize_mpi=1):
-        _libwarpx.finalize(finalize_mpi)
+        libwarpx.finalize(finalize_mpi)
 
     def getProbLo(self, direction):
-        return _libwarpx.libwarpx.libwarpx_so.warpx_getProbLo(direction)
+        return libwarpx.libwarpx.libwarpx_so.warpx_getProbLo(direction)
 
     def getProbHi(self, direction):
-        return _libwarpx.libwarpx.libwarpx_so.warpx_getProbHi(direction)
+        return libwarpx.libwarpx.libwarpx_so.warpx_getProbHi(direction)
 
     def write_inputs(self, filename='inputs', **kw):
         argv = self.create_argv_list()

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -85,10 +85,10 @@ class WarpX(Bucket):
         libwarpx.finalize(finalize_mpi)
 
     def getProbLo(self, direction):
-        return libwarpx.libwarpx.libwarpx_so.warpx_getProbLo(direction)
+        return libwarpx.libwarpx_so.warpx_getProbLo(direction)
 
     def getProbHi(self, direction):
-        return libwarpx.libwarpx.libwarpx_so.warpx_getProbHi(direction)
+        return libwarpx.libwarpx_so.warpx_getProbHi(direction)
 
     def write_inputs(self, filename='inputs', **kw):
         argv = self.create_argv_list()

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -6,7 +6,6 @@
 # License: BSD-3-Clause-LBNL
 
 from . import Particles
-from ._libwarpx import libwarpx
 from .Algo import algo
 from .Amr import amr
 from .Boundary import boundary
@@ -20,6 +19,7 @@ from .Langmuirwave import langmuirwave
 from .Lasers import lasers, lasers_list
 from .PSATD import psatd
 from .Particles import particles, particles_list
+from ._libwarpx import libwarpx
 
 
 class WarpX(Bucket):

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -17,4 +17,4 @@ from .Lasers import lasers
 from .PSATD import psatd
 from .Particles import electrons, newspecies, particles, positrons, protons
 from .WarpX import warpx
-from ._libwarpx import *  # noqa
+from ._libwarpx import libwarpx

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -40,12 +40,15 @@ _libc = ctypes.CDLL(_path_libc)
 _LP_c_int = ctypes.POINTER(ctypes.c_int)
 _LP_c_char = ctypes.POINTER(ctypes.c_char)
 
+
 class LibWarpX():
+
     """This class manages the warpx shared object, the library from the compiled C++ code.
     It will only load the library when it is referenced, and this can only be done after
     the geometry is defined so that the version of the library that is needed can be determined.
     Once loaded, all of the setting of function call interfaces is setup.
     """
+
     def __init__(self):
 
         # Track whether amrex and warpx have been initialized
@@ -424,7 +427,6 @@ class LibWarpX():
 
         self.initialized = True
 
-
     @atexit.register
     def finalize(self, finalize_mpi=1):
         '''
@@ -473,22 +475,18 @@ class LibWarpX():
 
         self.libwarpx_so.warpx_evolve(num_steps);
 
-
     def getProbLo(self, direction):
         assert 0 <= direction < self.dim, 'Inappropriate direction specified'
         return self.libwarpx_so.warpx_getProbLo(direction)
-
 
     def getProbHi(self, direction):
         assert 0 <= direction < self.dim, 'Inappropriate direction specified'
         return self.libwarpx_so.warpx_getProbHi(direction)
 
-
     def getCellSize(self, direction, level=0):
         assert 0 <= direction < 3, 'Inappropriate direction specified'
         assert 0 <= level and level <= self.libwarpx_so.warpx_finestLevel(), 'Inappropriate level specified'
         return self.libwarpx_so.warpx_getCellSize(direction, level)
-
 
     #def get_sigma(self, direction):
     #    '''
@@ -628,7 +626,6 @@ class LibWarpX():
             x, y, z, ux, uy, uz, nattr, attr, unique_particles
         )
 
-
     def get_particle_count(self, species_name):
         '''
 
@@ -649,7 +646,6 @@ class LibWarpX():
         return self.libwarpx_so.warpx_getNumParticles(
             ctypes.c_char_p(species_name.encode('utf-8'))
         )
-
 
     def get_particle_structs(self, species_name, level):
         '''
@@ -690,7 +686,6 @@ class LibWarpX():
         _libc.free(particles_per_tile)
         _libc.free(data)
         return particle_data
-
 
     def get_particle_arrays(self, species_name, comp_name, level):
         '''
@@ -740,7 +735,6 @@ class LibWarpX():
         _libc.free(data)
         return particle_data
 
-
     def get_particle_x(self, species_name, level=0):
         '''
 
@@ -754,7 +748,6 @@ class LibWarpX():
         elif self.geometry_dim == 'rz':
             return [struct['x']*np.cos(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
 
-
     def get_particle_y(self, species_name, level=0):
         '''
 
@@ -767,7 +760,6 @@ class LibWarpX():
             return [struct['y'] for struct in structs]
         elif self.geometry_dim == 'rz':
             return [struct['x']*np.sin(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
-
 
     def get_particle_r(self, species_name, level=0):
         '''
@@ -784,7 +776,6 @@ class LibWarpX():
         elif self.geometry_dim == '2d':
             raise Exception('get_particle_r: There is no r coordinate with 2D Cartesian')
 
-
     def get_particle_z(self, species_name, level=0):
         '''
 
@@ -798,7 +789,6 @@ class LibWarpX():
         elif self.geometry_dim == 'rz' or self.geometry_dim == '2d':
             return [struct['y'] for struct in structs]
 
-
     def get_particle_id(self, species_name, level=0):
         '''
 
@@ -808,7 +798,6 @@ class LibWarpX():
         '''
         structs = self.get_particle_structs(species_name, level)
         return [struct['id'] for struct in structs]
-
 
     def get_particle_cpu(self, species_name, level=0):
         '''
@@ -820,7 +809,6 @@ class LibWarpX():
         structs = self.get_particle_structs(species_name, level)
         return [struct['cpu'] for struct in structs]
 
-
     def get_particle_weight(self, species_name, level=0):
         '''
 
@@ -830,7 +818,6 @@ class LibWarpX():
         '''
 
         return self.get_particle_arrays(species_name, 'w', level)
-
 
     def get_particle_ux(self, species_name, level=0):
         '''
@@ -842,7 +829,6 @@ class LibWarpX():
 
         return self.get_particle_arrays(species_name, 'ux', level)
 
-
     def get_particle_uy(self, species_name, level=0):
         '''
 
@@ -853,7 +839,6 @@ class LibWarpX():
 
         return self.get_particle_arrays(species_name, 'uy', level)
 
-
     def get_particle_uz(self, species_name, level=0):
         '''
 
@@ -863,7 +848,6 @@ class LibWarpX():
         '''
 
         return self.get_particle_arrays(species_name, 'uz', level)
-
 
     def get_particle_theta(self, species_name, level=0):
         '''
@@ -880,7 +864,6 @@ class LibWarpX():
             return [np.arctan2(struct['y'], struct['x']) for struct in structs]
         elif self.geometry_dim == '2d':
             raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
-
 
     def get_particle_comp_index(self, species_name, pid_name):
         '''
@@ -906,7 +889,6 @@ class LibWarpX():
             ctypes.c_char_p(pid_name.encode('utf-8'))
         )
 
-
     def add_real_comp(self, species_name, pid_name, comm=True):
         '''
 
@@ -924,7 +906,6 @@ class LibWarpX():
             ctypes.c_char_p(species_name.encode('utf-8')),
             ctypes.c_char_p(pid_name.encode('utf-8')), comm
         )
-
 
     def get_particle_boundary_buffer_size(self, species_name, boundary):
         '''
@@ -949,7 +930,6 @@ class LibWarpX():
             ctypes.c_char_p(species_name.encode('utf-8')),
             self.get_boundary_number(boundary)
         )
-
 
     def get_particle_boundary_buffer_structs(self, species_name, boundary, level):
         '''
@@ -995,7 +975,6 @@ class LibWarpX():
         _libc.free(particles_per_tile)
         _libc.free(data)
         return particle_data
-
 
     def get_particle_boundary_buffer(self, species_name, boundary, comp_name, level):
         '''
@@ -1058,7 +1037,6 @@ class LibWarpX():
         _libc.free(data)
         return particle_data
 
-
     def clearParticleBoundaryBuffer(self):
         '''
 
@@ -1066,7 +1044,6 @@ class LibWarpX():
 
         '''
         self.libwarpx_so.warpx_clearParticleBoundaryBuffer()
-
 
     def _get_mesh_field_list(self, warpx_func, level, direction, include_ghosts):
         """
@@ -1114,7 +1091,6 @@ class LibWarpX():
         _libc.free(data)
         return grid_data
 
-
     def get_mesh_electric_field(self, level, direction, include_ghosts=True):
         '''
 
@@ -1142,7 +1118,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfield, level, direction, include_ghosts)
 
-
     def get_mesh_electric_field_cp(self, level, direction, include_ghosts=True):
         '''
 
@@ -1169,7 +1144,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldCP, level, direction, include_ghosts)
 
-
     def get_mesh_electric_field_fp(self, level, direction, include_ghosts=True):
         '''
 
@@ -1195,7 +1169,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldFP, level, direction, include_ghosts)
-
 
     def get_mesh_electric_field_cp_pml(self, level, direction, include_ghosts=True):
         '''
@@ -1226,7 +1199,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_electric_field_fp_pml(self, level, direction, include_ghosts=True):
         '''
 
@@ -1256,7 +1228,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_magnetic_field(self, level, direction, include_ghosts=True):
         '''
 
@@ -1284,7 +1255,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfield, level, direction, include_ghosts)
 
-
     def get_mesh_magnetic_field_cp(self, level, direction, include_ghosts=True):
         '''
 
@@ -1311,7 +1281,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldCP, level, direction, include_ghosts)
 
-
     def get_mesh_magnetic_field_fp(self, level, direction, include_ghosts=True):
         '''
 
@@ -1337,7 +1306,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldFP, level, direction, include_ghosts)
-
 
     def get_mesh_magnetic_field_cp_pml(self, level, direction, include_ghosts=True):
         '''
@@ -1368,7 +1336,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_magnetic_field_fp_pml(self, level, direction, include_ghosts=True):
         '''
 
@@ -1398,7 +1365,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_current_density(self, level, direction, include_ghosts=True):
         '''
 
@@ -1423,7 +1389,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensity, level, direction, include_ghosts)
-
 
     def get_mesh_current_density_cp(self, level, direction, include_ghosts=True):
         '''
@@ -1451,7 +1416,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityCP, level, direction, include_ghosts)
 
-
     def get_mesh_current_density_fp(self, level, direction, include_ghosts=True):
         '''
 
@@ -1477,7 +1441,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityFP, level, direction, include_ghosts)
-
 
     def get_mesh_current_density_cp_pml(self, level, direction, include_ghosts=True):
         '''
@@ -1508,7 +1471,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_current_density_fp_pml(self, level, direction, include_ghosts=True):
         '''
 
@@ -1538,7 +1500,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_charge_density_cp(self, level, include_ghosts=True):
         '''
 
@@ -1563,7 +1524,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getChargeDensityCP, level, None, include_ghosts)
-
 
     def get_mesh_charge_density_fp(self, level, include_ghosts=True):
         '''
@@ -1590,7 +1550,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getChargeDensityFP, level, None, include_ghosts)
 
-
     def get_mesh_phi_fp(self, level, include_ghosts=True):
         '''
 
@@ -1614,7 +1573,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getPhiFP, level, None, include_ghosts)
-
 
     def get_mesh_F_cp(self, level, include_ghosts=True):
         '''
@@ -1641,7 +1599,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldCP, level, None, include_ghosts)
 
-
     def get_mesh_F_fp(self, level, include_ghosts=True):
         '''
 
@@ -1666,7 +1623,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldFP, level, None, include_ghosts)
-
 
     def get_mesh_F_fp_pml(self, level, include_ghosts=True):
         '''
@@ -1695,7 +1651,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_F_cp_pml(self, level, include_ghosts=True):
         '''
 
@@ -1723,7 +1678,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_G_cp(self, level, include_ghosts=True):
         '''
 
@@ -1749,7 +1703,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldCP, level, None, include_ghosts)
 
-
     def get_mesh_G_fp(self, level, include_ghosts=True):
         '''
 
@@ -1774,7 +1727,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldFP, level, None, include_ghosts)
-
 
     def get_mesh_G_cp_pml(self, level, include_ghosts=True):
         '''
@@ -1803,7 +1755,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_G_fp_pml(self, level, include_ghosts=True):
         '''
 
@@ -1831,7 +1782,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_edge_lengths(self, level, direction, include_ghosts=True):
         '''
 
@@ -1858,7 +1808,6 @@ class LibWarpX():
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getEdgeLengths, level, direction, include_ghosts)
 
-
     def get_mesh_face_areas(self, level, direction, include_ghosts=True):
         '''
 
@@ -1884,7 +1833,6 @@ class LibWarpX():
         '''
 
         return self._get_mesh_field_list(self.libwarpx_so.warpx_getFaceAreas, level, direction, include_ghosts)
-
 
     def _get_mesh_array_lovects(self, level, direction, include_ghosts=True, getlovectsfunc=None):
         assert(0 <= level and level <= self.libwarpx_so.warpx_finestLevel())
@@ -1918,7 +1866,6 @@ class LibWarpX():
         _libc.free(data)
         return lovects, ng
 
-
     def get_mesh_electric_field_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -1942,7 +1889,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldLoVects)
 
-
     def get_mesh_electric_field_cp_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -1964,7 +1910,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldCPLoVects)
 
-
     def get_mesh_electric_field_fp_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -1985,7 +1930,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldFPLoVects)
-
 
     def get_mesh_electric_field_cp_lovects_pml(self, level, direction, include_ghosts=True):
         '''
@@ -2011,7 +1955,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_electric_field_fp_lovects_pml(self, level, direction, include_ghosts=True):
         '''
 
@@ -2036,7 +1979,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_magnetic_field_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -2060,7 +2002,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldLoVects)
 
-
     def get_mesh_magnetic_field_cp_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -2082,7 +2023,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldCPLoVects)
 
-
     def get_mesh_magnetic_field_fp_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -2103,7 +2043,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldFPLoVects)
-
 
     def get_mesh_magnetic_field_cp_lovects_pml(self, level, direction, include_ghosts=True):
         '''
@@ -2129,7 +2068,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_magnetic_field_fp_lovects_pml(self, level, direction, include_ghosts=True):
         '''
 
@@ -2154,7 +2092,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_current_density_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -2175,7 +2112,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityLoVects)
-
 
     def get_mesh_current_density_cp_lovects(self, level, direction, include_ghosts=True):
         '''
@@ -2218,7 +2154,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityFPLoVects)
-
 
     def get_mesh_current_density_cp_lovects_pml(self, level, direction, include_ghosts=True):
         '''
@@ -2268,7 +2203,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_charge_density_cp_lovects(self, level, include_ghosts=True):
         '''
 
@@ -2288,7 +2222,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getChargeDensityCPLoVects)
-
 
     def get_mesh_charge_density_fp_lovects(self, level, include_ghosts=True):
         '''
@@ -2310,7 +2243,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getChargeDensityFPLoVects)
 
-
     def get_mesh_phi_fp_lovects(self, level, include_ghosts=True):
         '''
 
@@ -2330,7 +2262,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getPhiFPLoVects)
-
 
     def get_mesh_F_cp_lovects(self, level, include_ghosts=True):
         '''
@@ -2352,7 +2283,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldCPLoVects)
 
-
     def get_mesh_F_fp_lovects(self, level, include_ghosts=True):
         '''
 
@@ -2372,7 +2302,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldFPLoVects)
-
 
     def get_mesh_F_cp_lovects_pml(self, level, include_ghosts=True):
         '''
@@ -2397,7 +2326,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_F_fp_lovects_pml(self, level, include_ghosts=True):
         '''
 
@@ -2421,7 +2349,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_G_cp_lovects(self, level, include_ghosts=True):
         '''
 
@@ -2442,7 +2369,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldCPLoVects)
 
-
     def get_mesh_G_fp_lovects(self, level, include_ghosts=True):
         '''
 
@@ -2462,7 +2388,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldFPLoVects)
-
 
     def get_mesh_G_cp_lovects_pml(self, level, include_ghosts=True):
         '''
@@ -2487,7 +2412,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_G_fp_lovects_pml(self, level, include_ghosts=True):
         '''
 
@@ -2511,7 +2435,6 @@ class LibWarpX():
         except ValueError:
             raise Exception('PML not initialized')
 
-
     def get_mesh_edge_lengths_lovects(self, level, direction, include_ghosts=True):
         '''
 
@@ -2532,7 +2455,6 @@ class LibWarpX():
 
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEdgeLengthsLoVects)
-
 
     def get_mesh_face_areas_lovects(self, level, direction, include_ghosts=True):
         '''
@@ -2555,7 +2477,6 @@ class LibWarpX():
         '''
         return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getFaceAreasLoVects)
 
-
     def _get_nodal_flag(self, getdatafunc):
         data = getdatafunc()
         if not data:
@@ -2570,13 +2491,11 @@ class LibWarpX():
         _libc.free(data)
         return nodal_flag
 
-
     def get_Ex_nodal_flag(self):
         '''
         This returns a 1d array of the nodal flags for Ex along each direction. A 1 means node centered, and 0 cell centered.
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getEx_nodal_flag)
-
 
     def get_Ey_nodal_flag(self):
         '''
@@ -2584,13 +2503,11 @@ class LibWarpX():
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getEy_nodal_flag)
 
-
     def get_Ez_nodal_flag(self):
         '''
         This returns a 1d array of the nodal flags for Ez along each direction. A 1 means node centered, and 0 cell centered.
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getEz_nodal_flag)
-
 
     def get_Bx_nodal_flag(self):
         '''
@@ -2598,13 +2515,11 @@ class LibWarpX():
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getBx_nodal_flag)
 
-
     def get_By_nodal_flag(self):
         '''
         This returns a 1d array of the nodal flags for By along each direction. A 1 means node centered, and 0 cell centered.
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getBy_nodal_flag)
-
 
     def get_Bz_nodal_flag(self):
         '''
@@ -2612,13 +2527,11 @@ class LibWarpX():
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getBz_nodal_flag)
 
-
     def get_Jx_nodal_flag(self):
         '''
         This returns a 1d array of the nodal flags for Jx along each direction. A 1 means node centered, and 0 cell centered.
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getJx_nodal_flag)
-
 
     def get_Jy_nodal_flag(self):
         '''
@@ -2626,13 +2539,11 @@ class LibWarpX():
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getJy_nodal_flag)
 
-
     def get_Jz_nodal_flag(self):
         '''
         This returns a 1d array of the nodal flags for Jz along each direction. A 1 means node centered, and 0 cell centered.
         '''
         return self._get_nodal_flag(self.libwarpx_so.warpx_getJz_nodal_flag)
-
 
     def get_Rho_nodal_flag(self):
         '''

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -52,6 +52,7 @@ class LibWarpX():
     def __init__(self):
         # Track whether amrex and warpx have been initialized
         self.initialized = False
+        atexit.register(self.finalize)
 
     def __getattr__(self, attribute):
         if attribute == 'libwarpx_so':
@@ -428,12 +429,10 @@ class LibWarpX():
 
         self.initialized = True
 
-    @atexit.register
     def finalize(self, finalize_mpi=1):
         '''
 
-        Call finalize for WarpX and AMReX. Must be called at
-        the end of your script.
+        Call finalize for WarpX and AMReX. Registered to run at program exit.
 
         '''
         if self.initialized:

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -50,7 +50,6 @@ class LibWarpX():
     """
 
     def __init__(self):
-
         # Track whether amrex and warpx have been initialized
         self.initialized = False
 
@@ -341,9 +340,11 @@ class LibWarpX():
 
         return boundary_num
 
-    # this is a function for converting a ctypes pointer to a numpy array
     @staticmethod
     def _array1d_from_pointer(pointer, dtype, size):
+        '''
+        Function for converting a ctypes pointer to a numpy array
+        '''
         if not pointer:
             raise Exception(f'_array1d_from_pointer: pointer is a nullptr')
         if sys.version_info.major >= 3:

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -2619,6 +2619,3 @@ class LibWarpX():
 
 
 libwarpx = LibWarpX()
-
-# --- Is there a better way of handling constants?
-clight = 2.99792458e+8 # m/s

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -876,6 +876,7 @@ class LibWarpX():
         if self.geometry_dim == 'rz':
             return self.get_particle_arrays(species_name, 'theta', level)
         elif self.geometry_dim == '3d':
+            structs = self.get_particle_structs(species_name, level)
             return [np.arctan2(struct['y'], struct['x']) for struct in structs]
         elif self.geometry_dim == '2d':
             raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -338,2374 +338,2375 @@ class LibWarpX():
 
         return boundary_num
 
+    # this is a function for converting a ctypes pointer to a numpy array
+    @staticmethod
+    def _array1d_from_pointer(pointer, dtype, size):
+        if not pointer:
+            raise Exception(f'_array1d_from_pointer: pointer is a nullptr')
+        if sys.version_info.major >= 3:
+            # from where do I import these? this might only work for CPython...
+            #PyBuf_READ  = 0x100
+            PyBUF_WRITE = 0x200
+            buffer_from_memory = ctypes.pythonapi.PyMemoryView_FromMemory
+            buffer_from_memory.argtypes = (ctypes.c_void_p, ctypes.c_int, ctypes.c_int)
+            buffer_from_memory.restype = ctypes.py_object
+            buf = buffer_from_memory(pointer, dtype.itemsize*size, PyBUF_WRITE)
+        else:
+            buffer_from_memory = ctypes.pythonapi.PyBuffer_FromReadWriteMemory
+            buffer_from_memory.restype = ctypes.py_object
+            buf = buffer_from_memory(pointer, dtype.itemsize*size)
+        return np.frombuffer(buf, dtype=dtype, count=size)
+
+    def getNProcs(self):
+        '''
+
+        Get the number of processors
+
+        '''
+        return self.libwarpx_so.warpx_getNProcs()
+
+    def getMyProc(self):
+        '''
+
+        Get the number of the processor
+
+        '''
+        return self.libwarpx_so.warpx_getMyProc()
+
+    def get_nattr(self):
+        '''
+
+        Get the number of extra attributes.
+
+        '''
+        # --- The -3 is because the comps include the velocites
+        return self.libwarpx_so.warpx_nComps() - 3
+
+    def get_nattr_species(self, species_name):
+        '''
+
+        Get the number of real attributes for the given species.
+
+        '''
+        return self.libwarpx_so.warpx_nCompsSpecies(
+            ctypes.c_char_p(species_name.encode('utf-8')))
+
+    def amrex_init(self, argv, mpi_comm=None):
+        # --- Construct the ctype list of strings to pass in
+        argc = len(argv)
+        argvC = (_LP_c_char * (argc+1))()
+        for i, arg in enumerate(argv):
+            enc_arg = arg.encode('utf-8')
+            argvC[i] = ctypes.create_string_buffer(enc_arg)
+
+        if mpi_comm is None or MPI is None:
+            self.libwarpx_so.amrex_init(argc, argvC)
+        else:
+            comm_ptr = MPI._addressof(mpi_comm)
+            comm_val = _MPI_Comm_type.from_address(comm_ptr)
+            self.libwarpx_so.amrex_init_with_inited_mpi(argc, argvC, comm_val)
+
+    def initialize(self, argv=None, mpi_comm=None):
+        '''
+
+        Initialize WarpX and AMReX. Must be called before
+        doing anything else.
+
+        '''
+        if argv is None:
+            argv = sys.argv
+        self.amrex_init(argv, mpi_comm)
+        self.libwarpx_so.warpx_ConvertLabParamsToBoost()
+        self.libwarpx_so.warpx_ReadBCParams()
+        if self.geometry_dim == 'rz':
+            self.libwarpx_so.warpx_CheckGriddingForRZSpectral()
+        self.libwarpx_so.warpx_init()
+
+        self.initialized = True
+
+
+    @atexit.register
+    def finalize(self, finalize_mpi=1):
+        '''
+
+        Call finalize for WarpX and AMReX. Must be called at
+        the end of your script.
+
+        '''
+        if self.initialized:
+            self.libwarpx_so.warpx_finalize()
+            self.libwarpx_so.amrex_finalize(finalize_mpi)
+
+    def getistep(self, level=0):
+        '''
+
+        Get the current time step number for the specified level
+
+        Parameter
+        ---------
+
+        level : the refinement level to reference
+        '''
+        return self.libwarpx_so.warpx_getistep(level)
+
+    def gett_new(self, level=0):
+        '''
+
+        Get the next time for the specified level
+
+        '''
+        return self.libwarpx_so.warpx_gett_new(level)
+
+    def evolve(self, num_steps=-1):
+        '''
+
+        Evolve the simulation for num_steps steps. If num_steps=-1,
+        the simulation will be run until the end as specified in the
+        inputs file.
+
+        Parameters
+        ----------
+
+        num_steps: int, the number of steps to take
+
+        '''
+
+        self.libwarpx_so.warpx_evolve(num_steps);
+
+
+    def getProbLo(self, direction):
+        assert 0 <= direction < self.dim, 'Inappropriate direction specified'
+        return self.libwarpx_so.warpx_getProbLo(direction)
+
+
+    def getProbHi(self, direction):
+        assert 0 <= direction < self.dim, 'Inappropriate direction specified'
+        return self.libwarpx_so.warpx_getProbHi(direction)
+
+
+    def getCellSize(self, direction, level=0):
+        assert 0 <= direction < 3, 'Inappropriate direction specified'
+        assert 0 <= level and level <= self.libwarpx_so.warpx_finestLevel(), 'Inappropriate level specified'
+        return self.libwarpx_so.warpx_getCellSize(direction, level)
+
+
+    #def get_sigma(self, direction):
+    #    '''
+    #
+    #    Return the 'sigma' PML coefficients for the electric field
+    #    in a given direction.
+    #
+    #    '''
+    #
+    #    size = ctypes.c_int(0)
+    #    data = self.libwarpx_so.warpx_getPMLSigma(direction, ctypes.byref(size))
+    #    arr = np.ctypeslib.as_array(data, (size.value,))
+    #    arr.setflags(write=1)
+    #    return arr
+    #
+    #
+    #def get_sigma_star(self, direction):
+    #    '''
+    #
+    #    Return the 'sigma*' PML coefficients for the magnetic field
+    #    in the given direction.
+    #
+    #    '''
+    #
+    #    size = ctypes.c_int(0)
+    #    data = self.libwarpx_so.warpx_getPMLSigmaStar(direction, ctypes.byref(size))
+    #    arr = np.ctypeslib.as_array(data, (size.value,))
+    #    arr.setflags(write=1)
+    #    return arr
+    #
+    #
+    #def compute_pml_factors(self, lev, dt):
+    #    '''
+    #
+    #    This recomputes the PML coefficients for a given level, using the
+    #    time step dt. This needs to be called after modifying the coefficients
+    #    from Python.
+    #
+    #    '''
+    #
+    #    self.libwarpx_so.warpx_ComputePMLFactors(lev, dt)
+
+    def add_particles(self, species_name, x=None, y=None, z=None, ux=None, uy=None, uz=None, w=None,
+                    unique_particles=True, **kwargs):
+        '''
+
+        A function for adding particles to the WarpX simulation.
+
+        Parameters
+        ----------
+
+        species_name     : the species to add the particle to
+        x, y, z          : arrays or scalars of the particle positions (default = 0.)
+        ux, uy, uz       : arrays or scalars of the particle momenta (default = 0.)
+        w                : array or scalar of particle weights (default = 0.)
+        unique_particles : whether the particles are unique or duplicated on
+                        several processes. (default = True)
+        kwargs           : dictionary containing an entry for all the extra particle
+                        attribute arrays. If an attribute is not given it will be
+                        set to 0.
+
+        '''
+
+        # --- Get length of arrays, set to one for scalars
+        lenx = np.size(x)
+        leny = np.size(y)
+        lenz = np.size(z)
+        lenux = np.size(ux)
+        lenuy = np.size(uy)
+        lenuz = np.size(uz)
+        lenw = np.size(w)
+
+        # --- Find the max length of the parameters supplied
+        maxlen = 0
+        if x is not None:
+            maxlen = max(maxlen, lenx)
+        if y is not None:
+            maxlen = max(maxlen, leny)
+        if z is not None:
+            maxlen = max(maxlen, lenz)
+        if ux is not None:
+            maxlen = max(maxlen, lenux)
+        if uy is not None:
+            maxlen = max(maxlen, lenuy)
+        if uz is not None:
+            maxlen = max(maxlen, lenuz)
+        if w is not None:
+            maxlen = max(maxlen, lenw)
+
+        # --- Make sure that the lengths of the input parameters are consistent
+        assert x is None or lenx==maxlen or lenx==1, "Length of x doesn't match len of others"
+        assert y is None or leny==maxlen or leny==1, "Length of y doesn't match len of others"
+        assert z is None or lenz==maxlen or lenz==1, "Length of z doesn't match len of others"
+        assert ux is None or lenux==maxlen or lenux==1, "Length of ux doesn't match len of others"
+        assert uy is None or lenuy==maxlen or lenuy==1, "Length of uy doesn't match len of others"
+        assert uz is None or lenuz==maxlen or lenuz==1, "Length of uz doesn't match len of others"
+        assert w is None or lenw==maxlen or lenw==1, "Length of w doesn't match len of others"
+        for key, val in kwargs.items():
+            assert np.size(val)==1 or len(val)==maxlen, f"Length of {key} doesn't match len of others"
+
+        # --- If the length of the input is zero, then quietly return
+        # --- This is not an error - it just means that no particles are to be injected.
+        if maxlen == 0:
+            return
+
+        # --- Broadcast scalars into appropriate length arrays
+        # --- If the parameter was not supplied, use the default value
+        if lenx == 1:
+            x = np.full(maxlen, (x or 0.), float)
+        if leny == 1:
+            y = np.full(maxlen, (y or 0.), float)
+        if lenz == 1:
+            z = np.full(maxlen, (z or 0.), float)
+        if lenux == 1:
+            ux = np.full(maxlen, (ux or 0.), float)
+        if lenuy == 1:
+            uy = np.full(maxlen, (uy or 0.), float)
+        if lenuz == 1:
+            uz = np.full(maxlen, (uz or 0.), float)
+        if lenw == 1:
+            w = np.full(maxlen, (w or 0.), float)
+        for key, val in kwargs.items():
+            if np.size(val) == 1:
+                kwargs[key] = np.full(maxlen, val, float)
+
+        # --- The -3 is because the comps include the velocites
+        nattr = self.get_nattr_species(species_name) - 3
+        attr = np.zeros((maxlen, nattr))
+        attr[:,0] = w
+
+        for key, vals in kwargs.items():
+            # --- The -3 is because components 1 to 3 are velocities
+            attr[:,self.get_particle_comp_index(species_name, key)-3] = vals
+
+        self.libwarpx_so.warpx_addNParticles(
+            ctypes.c_char_p(species_name.encode('utf-8')), x.size,
+            x, y, z, ux, uy, uz, nattr, attr, unique_particles
+        )
+
+
+    def get_particle_count(self, species_name):
+        '''
+
+        This returns the number of particles of the specified species in the
+        simulation.
+
+        Parameters
+        ----------
+
+            species_name : the species name that the number will be returned for
+
+        Returns
+        -------
+
+            An integer count of the number of particles
+
+        '''
+        return self.libwarpx_so.warpx_getNumParticles(
+            ctypes.c_char_p(species_name.encode('utf-8'))
+        )
+
+
+    def get_particle_structs(self, species_name, level):
+        '''
+
+        This returns a list of numpy arrays containing the particle struct data
+        on each tile for this process. The particle data is represented as a structured
+        numpy array and contains the particle 'x', 'y', 'z', 'id', and 'cpu'.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            species_name : the species name that the data will be returned for
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        particles_per_tile = _LP_c_int()
+        num_tiles = ctypes.c_int(0)
+        data = self.libwarpx_so.warpx_getParticleStructs(
+            ctypes.c_char_p(species_name.encode('utf-8')), level,
+            ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
+        )
+
+        particle_data = []
+        for i in range(num_tiles.value):
+            if particles_per_tile[i] == 0:
+                continue
+            arr = self._array1d_from_pointer(data[i], self._p_dtype, particles_per_tile[i])
+            particle_data.append(arr)
+
+        _libc.free(particles_per_tile)
+        _libc.free(data)
+        return particle_data
+
+
+    def get_particle_arrays(self, species_name, comp_name, level):
+        '''
+
+        This returns a list of numpy arrays containing the particle array data
+        on each tile for this process.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            species_name   : the species name that the data will be returned for
+            comp_name      : the component of the array data that will be returned.
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        particles_per_tile = _LP_c_int()
+        num_tiles = ctypes.c_int(0)
+        data = self.libwarpx_so.warpx_getParticleArrays(
+            ctypes.c_char_p(species_name.encode('utf-8')),
+            ctypes.c_char_p(comp_name.encode('utf-8')),
+            level, ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
+        )
+
+        particle_data = []
+        for i in range(num_tiles.value):
+            if particles_per_tile[i] == 0:
+                continue
+            if not data[i]:
+                raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
+            arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
+            try:
+                # This fails on some versions of numpy
+                arr.setflags(write=1)
+            except ValueError:
+                pass
+            particle_data.append(arr)
+
+        _libc.free(particles_per_tile)
+        _libc.free(data)
+        return particle_data
+
+
+    def get_particle_x(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'x'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        if self.geometry_dim == '3d' or self.geometry_dim == '2d':
+            return [struct['x'] for struct in structs]
+        elif self.geometry_dim == 'rz':
+            return [struct['x']*np.cos(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
+
+
+    def get_particle_y(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'y'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        if self.geometry_dim == '3d' or self.geometry_dim == '2d':
+            return [struct['y'] for struct in structs]
+        elif self.geometry_dim == 'rz':
+            return [struct['x']*np.sin(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
+
+
+    def get_particle_r(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'r'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        if self.geometry_dim == 'rz':
+            return [struct['x'] for struct in structs]
+        elif self.geometry_dim == '3d':
+            return [np.sqrt(struct['x']**2 + struct['y']**2) for struct in structs]
+        elif self.geometry_dim == '2d':
+            raise Exception('get_particle_r: There is no r coordinate with 2D Cartesian')
+
+
+    def get_particle_z(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'z'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        if self.geometry_dim == '3d':
+            return [struct['z'] for struct in structs]
+        elif self.geometry_dim == 'rz' or self.geometry_dim == '2d':
+            return [struct['y'] for struct in structs]
+
+
+    def get_particle_id(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'id'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        return [struct['id'] for struct in structs]
+
+
+    def get_particle_cpu(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle 'cpu'
+        positions on each tile.
+
+        '''
+        structs = self.get_particle_structs(species_name, level)
+        return [struct['cpu'] for struct in structs]
+
+
+    def get_particle_weight(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle
+        weight on each tile.
+
+        '''
+
+        return self.get_particle_arrays(species_name, 'w', level)
+
+
+    def get_particle_ux(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle
+        x momentum on each tile.
+
+        '''
+
+        return self.get_particle_arrays(species_name, 'ux', level)
+
+
+    def get_particle_uy(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle
+        y momentum on each tile.
+
+        '''
+
+        return self.get_particle_arrays(species_name, 'uy', level)
+
+
+    def get_particle_uz(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle
+        z momentum on each tile.
+
+        '''
+
+        return self.get_particle_arrays(species_name, 'uz', level)
+
+
+    def get_particle_theta(self, species_name, level=0):
+        '''
+
+        Return a list of numpy arrays containing the particle
+        theta on each tile.
+
+        '''
+
+        if self.geometry_dim == 'rz':
+            return self.get_particle_arrays(species_name, 'theta', level)
+        elif self.geometry_dim == '3d':
+            return [np.arctan2(struct['y'], struct['x']) for struct in structs]
+        elif self.geometry_dim == '2d':
+            raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
+
+
+    def get_particle_comp_index(self, species_name, pid_name):
+        '''
+
+        Get the component index for a given particle attribute. This is useful
+        to get the corrent ordering of attributes when adding new particles using
+        `add_particles()`.
+
+        Parameters
+        ----------
+
+            species_name   : the species name that the data will be returned for
+            pid_name       : string that is used to identify the new component
+
+        Returns
+        -------
+
+            Integer corresponding to the index of the requested attribute
+
+        '''
+        return self.libwarpx_so.warpx_getParticleCompIndex(
+            ctypes.c_char_p(species_name.encode('utf-8')),
+            ctypes.c_char_p(pid_name.encode('utf-8'))
+        )
+
+
+    def add_real_comp(self, species_name, pid_name, comm=True):
+        '''
+
+        Add a real component to the particle data array.
+
+        Parameters
+        ----------
+
+            species_name   : the species name for which the new component will be added
+            pid_name       : string that is used to identify the new component
+            comm           : should the component be communicated
+
+        '''
+        self.libwarpx_so.warpx_addRealComp(
+            ctypes.c_char_p(species_name.encode('utf-8')),
+            ctypes.c_char_p(pid_name.encode('utf-8')), comm
+        )
+
+
+    def get_particle_boundary_buffer_size(self, species_name, boundary):
+        '''
+
+        This returns the number of particles that have been scraped so far in the simulation
+        from the specified boundary and of the specified species.
+
+        Parameters
+        ----------
+
+            species_name   : return the number of scraped particles of this species
+            boundary       : the boundary from which to get the scraped particle data.
+                            In the form x/y/z_hi/lo
+
+        Returns
+        -------
+
+            The number of particles scraped so far from a boundary and of a species.
+
+        '''
+        return self.libwarpx_so.warpx_getParticleBoundaryBufferSize(
+            ctypes.c_char_p(species_name.encode('utf-8')),
+            self.get_boundary_number(boundary)
+        )
+
+
+    def get_particle_boundary_buffer_structs(self, species_name, boundary, level):
+        '''
+
+        This returns a list of numpy arrays containing the particle struct data
+        for a species that has been scraped by a specific simulation boundary. The
+        particle data is represented as a structured numpy array and contains the
+        particle 'x', 'y', 'z', 'id', and 'cpu'.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            species_name : the species name that the data will be returned for
+            boundary     : the boundary from which to get the scraped particle data.
+                        In the form x/y/z_hi/lo or eb.
+            level        : Which AMR level to retrieve scraped particle data from.
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        particles_per_tile = _LP_c_int()
+        num_tiles = ctypes.c_int(0)
+        data = self.libwarpx_so.warpx_getParticleBoundaryBufferStructs(
+                ctypes.c_char_p(species_name.encode('utf-8')),
+                self.get_boundary_number(boundary), level,
+                ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
+        )
+
+        particle_data = []
+        for i in range(num_tiles.value):
+            if particles_per_tile[i] == 0:
+                continue
+            arr = self._array1d_from_pointer(data[i], self._p_dtype, particles_per_tile[i])
+            particle_data.append(arr)
+
+        _libc.free(particles_per_tile)
+        _libc.free(data)
+        return particle_data
+
+
+    def get_particle_boundary_buffer(self, species_name, boundary, comp_name, level):
+        '''
+
+        This returns a list of numpy arrays containing the particle array data
+        for a species that has been scraped by a specific simulation boundary.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            species_name   : the species name that the data will be returned for.
+            boundary       : the boundary from which to get the scraped particle data.
+                            In the form x/y/z_hi/lo or eb.
+            comp_name      : the component of the array data that will be returned.
+                            If "step_scraped" the special attribute holding the
+                            timestep at which a particle was scraped will be
+                            returned.
+            level          : Which AMR level to retrieve scraped particle data from.
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        particles_per_tile = _LP_c_int()
+        num_tiles = ctypes.c_int(0)
+        if comp_name == 'step_scraped':
+            data = self.libwarpx_so.warpx_getParticleBoundaryBufferScrapedSteps(
+                ctypes.c_char_p(species_name.encode('utf-8')),
+                self.get_boundary_number(boundary), level,
+                ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
+            )
+        else:
+            data = self.libwarpx_so.warpx_getParticleBoundaryBuffer(
+                ctypes.c_char_p(species_name.encode('utf-8')),
+                self.get_boundary_number(boundary), level,
+                ctypes.byref(num_tiles), ctypes.byref(particles_per_tile),
+                ctypes.c_char_p(comp_name.encode('utf-8'))
+            )
+
+        particle_data = []
+        for i in range(num_tiles.value):
+            if particles_per_tile[i] == 0:
+                continue
+            if not data[i]:
+                raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
+            arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
+            try:
+                # This fails on some versions of numpy
+                arr.setflags(write=1)
+            except ValueError:
+                pass
+            particle_data.append(arr)
+
+        _libc.free(particles_per_tile)
+        _libc.free(data)
+        return particle_data
+
+
+    def clearParticleBoundaryBuffer(self):
+        '''
+
+        Clear the buffer that holds the particles lost at the boundaries.
+
+        '''
+        self.libwarpx_so.warpx_clearParticleBoundaryBuffer()
+
+
+    def _get_mesh_field_list(self, warpx_func, level, direction, include_ghosts):
+        """
+        Generic routine to fetch the list of field data arrays.
+        """
+        shapes = _LP_c_int()
+        size = ctypes.c_int(0)
+        ncomps = ctypes.c_int(0)
+        ngrowvect = _LP_c_int()
+        if direction is None:
+            data = warpx_func(level,
+                            ctypes.byref(size), ctypes.byref(ncomps),
+                            ctypes.byref(ngrowvect), ctypes.byref(shapes))
+        else:
+            data = warpx_func(level, direction,
+                            ctypes.byref(size), ctypes.byref(ncomps),
+                            ctypes.byref(ngrowvect), ctypes.byref(shapes))
+        if not data:
+            raise Exception('object was not initialized')
+
+        ngvect = [ngrowvect[i] for i in range(self.dim)]
+        grid_data = []
+        shapesize = self.dim
+        if ncomps.value > 1:
+            shapesize += 1
+        for i in range(size.value):
+            shape = tuple([shapes[shapesize*i + d] for d in range(shapesize)])
+            # --- The data is stored in Fortran order, hence shape is reversed and a transpose is taken.
+            if shape[::-1] == 0:
+                continue
+            if not data[i]:
+                raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
+            arr = np.ctypeslib.as_array(data[i], shape[::-1]).T
+            try:
+                # This fails on some versions of numpy
+                arr.setflags(write=1)
+            except ValueError:
+                pass
+            if include_ghosts:
+                grid_data.append(arr)
+            else:
+                grid_data.append(arr[tuple([slice(ngvect[d], -ngvect[d]) for d in range(self.dim)])])
+
+        _libc.free(shapes)
+        _libc.free(data)
+        return grid_data
+
+
+    def get_mesh_electric_field(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electric field
+        data on each grid for this process.
+
+        This version is for the full "auxiliary" solution on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfield, level, direction, include_ghosts)
+
+
+    def get_mesh_electric_field_cp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electric field
+        data on each grid for this process. This version returns the field on
+        the coarse patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldCP, level, direction, include_ghosts)
+
+
+    def get_mesh_electric_field_fp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electric field
+        data on each grid for this process. This version returns the field on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldFP, level, direction, include_ghosts)
+
+
+    def get_mesh_electric_field_cp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electric field
+        data on each grid for this process. This version returns the field on
+        the coarse patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldCP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_electric_field_fp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electric field
+        data on each grid for this process. This version returns the field on
+        the fine patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getEfieldFP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_magnetic_field(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh magnetic field
+        data on each grid for this process.
+
+        This version is for the full "auxiliary" solution on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfield, level, direction, include_ghosts)
+
+
+    def get_mesh_magnetic_field_cp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh magnetic field
+        data on each grid for this process. This version returns the field on
+        the coarse patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldCP, level, direction, include_ghosts)
+
+
+    def get_mesh_magnetic_field_fp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh magnetic field
+        data on each grid for this process. This version returns the field on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldFP, level, direction, include_ghosts)
+
+
+    def get_mesh_magnetic_field_cp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh magnetic field
+        data on each grid for this process. This version returns the field on
+        the coarse patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldCP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_magnetic_field_fp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh magnetic field
+        data on each grid for this process. This version returns the field on
+        the fine patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getBfieldFP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_current_density(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh current density
+        data on each grid for this process.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensity, level, direction, include_ghosts)
+
+
+    def get_mesh_current_density_cp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh current density
+        data on each grid for this process. This version returns the density for
+        the coarse patch on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityCP, level, direction, include_ghosts)
+
+
+    def get_mesh_current_density_fp(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh current density
+        data on each grid for this process. This version returns the density on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityFP, level, direction, include_ghosts)
+
+
+    def get_mesh_current_density_cp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh current density
+        data on each grid for this process. This version returns the density for
+        the coarse patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityCP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_current_density_fp_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh current density
+        data on each grid for this process. This version returns the density on
+        the fine patch for the PML for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getCurrentDensityFP_PML, level, direction, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_charge_density_cp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh charge density
+        data on each grid for this process. This version returns the density for
+        the coarse patch on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getChargeDensityCP, level, None, include_ghosts)
+
+
+    def get_mesh_charge_density_fp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh charge density
+        data on each grid for this process. This version returns the density on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getChargeDensityFP, level, None, include_ghosts)
+
+
+    def get_mesh_phi_fp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh electrostatic
+        potential data on each grid for this process. This version returns the
+        potential on the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getPhiFP, level, None, include_ghosts)
+
+
+    def get_mesh_F_cp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh F field
+        data on each grid for this process. This version returns the F field for
+        the coarse patch on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldCP, level, None, include_ghosts)
+
+
+    def get_mesh_F_fp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh F field
+        data on each grid for this process. This version returns the F field on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldFP, level, None, include_ghosts)
+
+
+    def get_mesh_F_fp_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh F field
+        data on each grid for this process. This version returns the F field on
+        the fine patch for the PML on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldFP_PML, level, None, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_F_cp_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh F field
+        data on each grid for this process. This version returns the F field on
+        the coarse patch for the PML on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getFfieldCP_PML, level, None, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_G_cp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh G field
+        data on each grid for this process. This version returns the G field for
+        the coarse patch on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldCP, level, None, include_ghosts)
+
+
+    def get_mesh_G_fp(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh G field
+        data on each grid for this process. This version returns the G field on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldFP, level, None, include_ghosts)
+
+
+    def get_mesh_G_cp_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh G field
+        data on each grid for this process. This version returns the G field on
+        the coarse patch for the PML on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldCP_PML, level, None, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_G_fp_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh G field
+        data on each grid for this process. This version returns the G field on
+        the fine patch for the PML on the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+        try:
+            return self._get_mesh_field_list(self.libwarpx_so.warpx_getGfieldFP_PML, level, None, include_ghosts)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_edge_lengths(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh edge lengths
+        data on each grid for this process. This version returns the density on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getEdgeLengths, level, direction, include_ghosts)
+
+
+    def get_mesh_face_areas(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of numpy arrays containing the mesh face areas
+        data on each grid for this process. This version returns the density on
+        the fine patch for the given level.
+
+        The data for the numpy arrays are not copied, but share the underlying
+        memory buffer with WarpX. The numpy arrays are fully writeable.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A List of numpy arrays.
+
+        '''
+
+        return self._get_mesh_field_list(self.libwarpx_so.warpx_getFaceAreas, level, direction, include_ghosts)
+
+
+    def _get_mesh_array_lovects(self, level, direction, include_ghosts=True, getlovectsfunc=None):
+        assert(0 <= level and level <= self.libwarpx_so.warpx_finestLevel())
+
+        size = ctypes.c_int(0)
+        ngrowvect = _LP_c_int()
+        if direction is None:
+            data = getlovectsfunc(level, ctypes.byref(size), ctypes.byref(ngrowvect))
+        else:
+            data = getlovectsfunc(level, direction, ctypes.byref(size), ctypes.byref(ngrowvect))
+
+        if not data:
+            raise Exception('object was not initialized')
+
+        lovects_ref = np.ctypeslib.as_array(data, (size.value, self.dim))
+
+        # --- Make a copy of the data to avoid memory problems
+        # --- Also, take the transpose to give shape (dims, number of grids)
+        lovects = lovects_ref.copy().T
+
+        ng = []
+        if include_ghosts:
+            for d in range(self.dim):
+                ng.append(ngrowvect[d])
+        else:
+            for d in range(self.dim):
+                ng.append(0)
+                lovects[d,:] += ngrowvect[d]
+
+        del lovects_ref
+        _libc.free(data)
+        return lovects, ng
+
+
+    def get_mesh_electric_field_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        This version is for the full "auxiliary" solution on the given level.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldLoVects)
+
+
+    def get_mesh_electric_field_cp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldCPLoVects)
+
+
+    def get_mesh_electric_field_fp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldFPLoVects)
+
+
+    def get_mesh_electric_field_cp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldCPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_electric_field_fp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEfieldFPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_magnetic_field_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        This version is for the full "auxiliary" solution on the given level.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldLoVects)
+
+
+    def get_mesh_magnetic_field_cp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldCPLoVects)
+
+
+    def get_mesh_magnetic_field_fp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldFPLoVects)
+
+
+    def get_mesh_magnetic_field_cp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldCPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_magnetic_field_fp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getBfieldFPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_current_density_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityLoVects)
+
+
+    def get_mesh_current_density_cp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityCPLoVects)
+
+    def get_mesh_current_density_fp_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityFPLoVects)
+
+
+    def get_mesh_current_density_cp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityCPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+    def get_mesh_current_density_fp_lovects_pml(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getCurrentDensityFPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_charge_density_cp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh electric field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getChargeDensityCPLoVects)
+
+
+    def get_mesh_charge_density_fp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh
+        charge density data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getChargeDensityFPLoVects)
+
+
+    def get_mesh_phi_fp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh
+        electrostatic potential data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getPhiFPLoVects)
+
+
+    def get_mesh_F_cp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh F field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldCPLoVects)
+
+
+    def get_mesh_F_fp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh F field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldFPLoVects)
+
+
+    def get_mesh_F_cp_lovects_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh F field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldCPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_F_fp_lovects_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh F field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getFfieldFPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_G_cp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh G field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldCPLoVects)
+
+
+    def get_mesh_G_fp_lovects(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh G field
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldFPLoVects)
+
+
+    def get_mesh_G_cp_lovects_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh G field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldCPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_G_fp_lovects_pml(self, level, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh G field
+        data on each PML grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        try:
+            return self._get_mesh_array_lovects(level, None, include_ghosts, self.libwarpx_so.warpx_getGfieldFPLoVects_PML)
+        except ValueError:
+            raise Exception('PML not initialized')
+
+
+    def get_mesh_edge_lengths_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh edge lengths
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getEdgeLengthsLoVects)
+
+
+    def get_mesh_face_areas_lovects(self, level, direction, include_ghosts=True):
+        '''
+
+        This returns a list of the lo vectors of the arrays containing the mesh face areas
+        data on each grid for this process.
+
+        Parameters
+        ----------
+
+            level          : the AMR level to get the data for
+            direction      : the component of the data you want
+            include_ghosts : whether to include ghost zones or not
+
+        Returns
+        -------
+
+            A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
+
+        '''
+        return self._get_mesh_array_lovects(level, direction, include_ghosts, self.libwarpx_so.warpx_getFaceAreasLoVects)
+
+
+    def _get_nodal_flag(self, getdatafunc):
+        data = getdatafunc()
+        if not data:
+            raise Exception('object was not initialized')
+
+        nodal_flag_ref = np.ctypeslib.as_array(data, (self.dim,))
+
+        # --- Make a copy of the data to avoid memory problems
+        nodal_flag = nodal_flag_ref.copy()
+
+        del nodal_flag_ref
+        _libc.free(data)
+        return nodal_flag
+
+
+    def get_Ex_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Ex along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getEx_nodal_flag)
+
+
+    def get_Ey_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Ey along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getEy_nodal_flag)
+
+
+    def get_Ez_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Ez along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getEz_nodal_flag)
+
+
+    def get_Bx_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Bx along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getBx_nodal_flag)
+
+
+    def get_By_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for By along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getBy_nodal_flag)
+
+
+    def get_Bz_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Bz along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getBz_nodal_flag)
+
+
+    def get_Jx_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Jx along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getJx_nodal_flag)
+
+
+    def get_Jy_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Jy along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getJy_nodal_flag)
+
+
+    def get_Jz_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Jz along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getJz_nodal_flag)
+
+
+    def get_Rho_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Rho along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getRho_nodal_flag)
+
+    def get_Phi_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for Phi along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getPhi_nodal_flag)
+
+    def get_F_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for F along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getF_nodal_flag)
+
+    def get_G_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for G along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getG_nodal_flag)
+
+    def get_edge_lengths_x_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the x edge lengths along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_edge_lengths_x_nodal_flag)
+
+    def get_edge_lengths_y_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the y edge lengths along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_edge_lengths_y_nodal_flag)
+
+    def get_edge_lengths_z_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the z edge lengths along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_edge_lengths_z_nodal_flag)
+
+    def get_face_areas_x_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the x face areas along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_face_areas_x_nodal_flag)
+
+    def get_face_areas_y_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the y face areas along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_face_areas_y_nodal_flag)
+
+    def get_face_areas_z_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for the z face areas along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_get_face_areas_z_nodal_flag)
+
+    def get_F_pml_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for F in the PML along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getF_pml_nodal_flag)
+
+    def get_G_pml_nodal_flag(self):
+        '''
+        This returns a 1d array of the nodal flags for G in the PML along each direction. A 1 means node centered, and 0 cell centered.
+        '''
+        return self._get_nodal_flag(self.libwarpx_so.warpx_getG_pml_nodal_flag)
+
 
 libwarpx = LibWarpX()
 
 # --- Is there a better way of handling constants?
 clight = 2.99792458e+8 # m/s
-
-# this is a function for converting a ctypes pointer to a numpy array
-def _array1d_from_pointer(pointer, dtype, size):
-    if not pointer:
-        raise Exception(f'_array1d_from_pointer: pointer is a nullptr')
-    if sys.version_info.major >= 3:
-        # from where do I import these? this might only work for CPython...
-        #PyBuf_READ  = 0x100
-        PyBUF_WRITE = 0x200
-        buffer_from_memory = ctypes.pythonapi.PyMemoryView_FromMemory
-        buffer_from_memory.argtypes = (ctypes.c_void_p, ctypes.c_int, ctypes.c_int)
-        buffer_from_memory.restype = ctypes.py_object
-        buf = buffer_from_memory(pointer, dtype.itemsize*size, PyBUF_WRITE)
-    else:
-        buffer_from_memory = ctypes.pythonapi.PyBuffer_FromReadWriteMemory
-        buffer_from_memory.restype = ctypes.py_object
-        buf = buffer_from_memory(pointer, dtype.itemsize*size)
-    return np.frombuffer(buf, dtype=dtype, count=size)
-
-def getNProcs():
-    '''
-
-    Get the number of processors
-
-    '''
-    return libwarpx.libwarpx_so.warpx_getNProcs()
-
-def getMyProc():
-    '''
-
-    Get the number of the processor
-
-    '''
-    return libwarpx.libwarpx_so.warpx_getMyProc()
-
-def get_nattr():
-    '''
-
-    Get the number of extra attributes.
-
-    '''
-    # --- The -3 is because the comps include the velocites
-    return libwarpx.libwarpx_so.warpx_nComps() - 3
-
-def get_nattr_species(species_name):
-    '''
-
-    Get the number of real attributes for the given species.
-
-    '''
-    return libwarpx.libwarpx_so.warpx_nCompsSpecies(
-        ctypes.c_char_p(species_name.encode('utf-8')))
-
-def amrex_init(argv, mpi_comm=None):
-    # --- Construct the ctype list of strings to pass in
-    argc = len(argv)
-    argvC = (_LP_c_char * (argc+1))()
-    for i, arg in enumerate(argv):
-        enc_arg = arg.encode('utf-8')
-        argvC[i] = ctypes.create_string_buffer(enc_arg)
-
-    if mpi_comm is None or MPI is None:
-        libwarpx.libwarpx_so.amrex_init(argc, argvC)
-    else:
-        comm_ptr = MPI._addressof(mpi_comm)
-        comm_val = _MPI_Comm_type.from_address(comm_ptr)
-        libwarpx.libwarpx_so.amrex_init_with_inited_mpi(argc, argvC, comm_val)
-
-def initialize(argv=None, mpi_comm=None):
-    '''
-
-    Initialize WarpX and AMReX. Must be called before
-    doing anything else.
-
-    '''
-    if argv is None:
-        argv = sys.argv
-    amrex_init(argv, mpi_comm)
-    libwarpx.libwarpx_so.warpx_ConvertLabParamsToBoost()
-    libwarpx.libwarpx_so.warpx_ReadBCParams()
-    if libwarpx.geometry_dim == 'rz':
-        libwarpx.libwarpx_so.warpx_CheckGriddingForRZSpectral()
-    libwarpx.libwarpx_so.warpx_init()
-
-    libwarpx.initialized = True
-
-
-@atexit.register
-def finalize(finalize_mpi=1):
-    '''
-
-    Call finalize for WarpX and AMReX. Must be called at
-    the end of your script.
-
-    '''
-    if libwarpx.initialized:
-        libwarpx.libwarpx_so.warpx_finalize()
-        libwarpx.libwarpx_so.amrex_finalize(finalize_mpi)
-
-def getistep(level=0):
-    '''
-
-    Get the current time step number for the specified level
-
-    Parameter
-    ---------
-
-    level : the refinement level to reference
-    '''
-    return libwarpx.libwarpx_so.warpx_getistep(level)
-
-def gett_new(level=0):
-    '''
-
-    Get the next time for the specified level
-
-    '''
-    return libwarpx.libwarpx_so.warpx_gett_new(level)
-
-def evolve(num_steps=-1):
-    '''
-
-    Evolve the simulation for num_steps steps. If num_steps=-1,
-    the simulation will be run until the end as specified in the
-    inputs file.
-
-    Parameters
-    ----------
-
-    num_steps: int, the number of steps to take
-
-    '''
-
-    libwarpx.libwarpx_so.warpx_evolve(num_steps);
-
-
-def getProbLo(direction):
-    assert 0 <= direction < libwarpx.dim, 'Inappropriate direction specified'
-    return libwarpx.libwarpx_so.warpx_getProbLo(direction)
-
-
-def getProbHi(direction):
-    assert 0 <= direction < libwarpx.dim, 'Inappropriate direction specified'
-    return libwarpx.libwarpx_so.warpx_getProbHi(direction)
-
-
-def getCellSize(direction, level=0):
-    assert 0 <= direction < 3, 'Inappropriate direction specified'
-    assert 0 <= level and level <= libwarpx.libwarpx_so.warpx_finestLevel(), 'Inappropriate level specified'
-    return libwarpx.libwarpx_so.warpx_getCellSize(direction, level)
-
-
-#def get_sigma(direction):
-#    '''
-#
-#    Return the 'sigma' PML coefficients for the electric field
-#    in a given direction.
-#
-#    '''
-#
-#    size = ctypes.c_int(0)
-#    data = libwarpx.libwarpx_so.warpx_getPMLSigma(direction, ctypes.byref(size))
-#    arr = np.ctypeslib.as_array(data, (size.value,))
-#    arr.setflags(write=1)
-#    return arr
-#
-#
-#def get_sigma_star(direction):
-#    '''
-#
-#    Return the 'sigma*' PML coefficients for the magnetic field
-#    in the given direction.
-#
-#    '''
-#
-#    size = ctypes.c_int(0)
-#    data = libwarpx.libwarpx_so.warpx_getPMLSigmaStar(direction, ctypes.byref(size))
-#    arr = np.ctypeslib.as_array(data, (size.value,))
-#    arr.setflags(write=1)
-#    return arr
-#
-#
-#def compute_pml_factors(lev, dt):
-#    '''
-#
-#    This recomputes the PML coefficients for a given level, using the
-#    time step dt. This needs to be called after modifying the coefficients
-#    from Python.
-#
-#    '''
-#
-#    libwarpx.libwarpx_so.warpx_ComputePMLFactors(lev, dt)
-
-def add_particles(species_name, x=None, y=None, z=None, ux=None, uy=None, uz=None, w=None,
-                  unique_particles=True, **kwargs):
-    '''
-
-    A function for adding particles to the WarpX simulation.
-
-    Parameters
-    ----------
-
-    species_name     : the species to add the particle to
-    x, y, z          : arrays or scalars of the particle positions (default = 0.)
-    ux, uy, uz       : arrays or scalars of the particle momenta (default = 0.)
-    w                : array or scalar of particle weights (default = 0.)
-    unique_particles : whether the particles are unique or duplicated on
-                       several processes. (default = True)
-    kwargs           : dictionary containing an entry for all the extra particle
-                       attribute arrays. If an attribute is not given it will be
-                       set to 0.
-
-    '''
-
-    # --- Get length of arrays, set to one for scalars
-    lenx = np.size(x)
-    leny = np.size(y)
-    lenz = np.size(z)
-    lenux = np.size(ux)
-    lenuy = np.size(uy)
-    lenuz = np.size(uz)
-    lenw = np.size(w)
-
-    # --- Find the max length of the parameters supplied
-    maxlen = 0
-    if x is not None:
-        maxlen = max(maxlen, lenx)
-    if y is not None:
-        maxlen = max(maxlen, leny)
-    if z is not None:
-        maxlen = max(maxlen, lenz)
-    if ux is not None:
-        maxlen = max(maxlen, lenux)
-    if uy is not None:
-        maxlen = max(maxlen, lenuy)
-    if uz is not None:
-        maxlen = max(maxlen, lenuz)
-    if w is not None:
-        maxlen = max(maxlen, lenw)
-
-    # --- Make sure that the lengths of the input parameters are consistent
-    assert x is None or lenx==maxlen or lenx==1, "Length of x doesn't match len of others"
-    assert y is None or leny==maxlen or leny==1, "Length of y doesn't match len of others"
-    assert z is None or lenz==maxlen or lenz==1, "Length of z doesn't match len of others"
-    assert ux is None or lenux==maxlen or lenux==1, "Length of ux doesn't match len of others"
-    assert uy is None or lenuy==maxlen or lenuy==1, "Length of uy doesn't match len of others"
-    assert uz is None or lenuz==maxlen or lenuz==1, "Length of uz doesn't match len of others"
-    assert w is None or lenw==maxlen or lenw==1, "Length of w doesn't match len of others"
-    for key, val in kwargs.items():
-        assert np.size(val)==1 or len(val)==maxlen, f"Length of {key} doesn't match len of others"
-
-    # --- If the length of the input is zero, then quietly return
-    # --- This is not an error - it just means that no particles are to be injected.
-    if maxlen == 0:
-        return
-
-    # --- Broadcast scalars into appropriate length arrays
-    # --- If the parameter was not supplied, use the default value
-    if lenx == 1:
-        x = np.full(maxlen, (x or 0.), float)
-    if leny == 1:
-        y = np.full(maxlen, (y or 0.), float)
-    if lenz == 1:
-        z = np.full(maxlen, (z or 0.), float)
-    if lenux == 1:
-        ux = np.full(maxlen, (ux or 0.), float)
-    if lenuy == 1:
-        uy = np.full(maxlen, (uy or 0.), float)
-    if lenuz == 1:
-        uz = np.full(maxlen, (uz or 0.), float)
-    if lenw == 1:
-        w = np.full(maxlen, (w or 0.), float)
-    for key, val in kwargs.items():
-        if np.size(val) == 1:
-            kwargs[key] = np.full(maxlen, val, float)
-
-    # --- The -3 is because the comps include the velocites
-    nattr = get_nattr_species(species_name) - 3
-    attr = np.zeros((maxlen, nattr))
-    attr[:,0] = w
-
-    for key, vals in kwargs.items():
-        # --- The -3 is because components 1 to 3 are velocities
-        attr[:,get_particle_comp_index(species_name, key)-3] = vals
-
-    libwarpx.libwarpx_so.warpx_addNParticles(
-        ctypes.c_char_p(species_name.encode('utf-8')), x.size,
-        x, y, z, ux, uy, uz, nattr, attr, unique_particles
-    )
-
-
-def get_particle_count(species_name):
-    '''
-
-    This returns the number of particles of the specified species in the
-    simulation.
-
-    Parameters
-    ----------
-
-        species_name : the species name that the number will be returned for
-
-    Returns
-    -------
-
-        An integer count of the number of particles
-
-    '''
-    return libwarpx.libwarpx_so.warpx_getNumParticles(
-        ctypes.c_char_p(species_name.encode('utf-8'))
-    )
-
-
-def get_particle_structs(species_name, level):
-    '''
-
-    This returns a list of numpy arrays containing the particle struct data
-    on each tile for this process. The particle data is represented as a structured
-    numpy array and contains the particle 'x', 'y', 'z', 'id', and 'cpu'.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        species_name : the species name that the data will be returned for
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    particles_per_tile = _LP_c_int()
-    num_tiles = ctypes.c_int(0)
-    data = libwarpx.libwarpx_so.warpx_getParticleStructs(
-        ctypes.c_char_p(species_name.encode('utf-8')), level,
-        ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
-    )
-
-    particle_data = []
-    for i in range(num_tiles.value):
-        if particles_per_tile[i] == 0:
-            continue
-        arr = _array1d_from_pointer(data[i], libwarpx._p_dtype, particles_per_tile[i])
-        particle_data.append(arr)
-
-    _libc.free(particles_per_tile)
-    _libc.free(data)
-    return particle_data
-
-
-def get_particle_arrays(species_name, comp_name, level):
-    '''
-
-    This returns a list of numpy arrays containing the particle array data
-    on each tile for this process.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        species_name   : the species name that the data will be returned for
-        comp_name      : the component of the array data that will be returned.
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    particles_per_tile = _LP_c_int()
-    num_tiles = ctypes.c_int(0)
-    data = libwarpx.libwarpx_so.warpx_getParticleArrays(
-        ctypes.c_char_p(species_name.encode('utf-8')),
-        ctypes.c_char_p(comp_name.encode('utf-8')),
-        level, ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
-    )
-
-    particle_data = []
-    for i in range(num_tiles.value):
-        if particles_per_tile[i] == 0:
-            continue
-        if not data[i]:
-            raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
-        arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
-        try:
-            # This fails on some versions of numpy
-            arr.setflags(write=1)
-        except ValueError:
-            pass
-        particle_data.append(arr)
-
-    _libc.free(particles_per_tile)
-    _libc.free(data)
-    return particle_data
-
-
-def get_particle_x(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'x'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    if libwarpx.geometry_dim == '3d' or libwarpx.geometry_dim == '2d':
-        return [struct['x'] for struct in structs]
-    elif libwarpx.geometry_dim == 'rz':
-        return [struct['x']*np.cos(theta) for struct, theta in zip(structs, get_particle_theta(species_name))]
-
-
-def get_particle_y(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'y'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    if libwarpx.geometry_dim == '3d' or libwarpx.geometry_dim == '2d':
-        return [struct['y'] for struct in structs]
-    elif libwarpx.geometry_dim == 'rz':
-        return [struct['x']*np.sin(theta) for struct, theta in zip(structs, get_particle_theta(species_name))]
-
-
-def get_particle_r(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'r'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    if libwarpx.geometry_dim == 'rz':
-        return [struct['x'] for struct in structs]
-    elif libwarpx.geometry_dim == '3d':
-        return [np.sqrt(struct['x']**2 + struct['y']**2) for struct in structs]
-    elif libwarpx.geometry_dim == '2d':
-        raise Exception('get_particle_r: There is no r coordinate with 2D Cartesian')
-
-
-def get_particle_z(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'z'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    if libwarpx.geometry_dim == '3d':
-        return [struct['z'] for struct in structs]
-    elif libwarpx.geometry_dim == 'rz' or libwarpx.geometry_dim == '2d':
-        return [struct['y'] for struct in structs]
-
-
-def get_particle_id(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'id'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    return [struct['id'] for struct in structs]
-
-
-def get_particle_cpu(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle 'cpu'
-    positions on each tile.
-
-    '''
-    structs = get_particle_structs(species_name, level)
-    return [struct['cpu'] for struct in structs]
-
-
-def get_particle_weight(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle
-    weight on each tile.
-
-    '''
-
-    return get_particle_arrays(species_name, 'w', level)
-
-
-def get_particle_ux(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle
-    x momentum on each tile.
-
-    '''
-
-    return get_particle_arrays(species_name, 'ux', level)
-
-
-def get_particle_uy(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle
-    y momentum on each tile.
-
-    '''
-
-    return get_particle_arrays(species_name, 'uy', level)
-
-
-def get_particle_uz(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle
-    z momentum on each tile.
-
-    '''
-
-    return get_particle_arrays(species_name, 'uz', level)
-
-
-def get_particle_theta(species_name, level=0):
-    '''
-
-    Return a list of numpy arrays containing the particle
-    theta on each tile.
-
-    '''
-
-    if libwarpx.geometry_dim == 'rz':
-        return get_particle_arrays(species_name, 'theta', level)
-    elif libwarpx.geometry_dim == '3d':
-        return [np.arctan2(struct['y'], struct['x']) for struct in structs]
-    elif libwarpx.geometry_dim == '2d':
-        raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
-
-
-def get_particle_comp_index(species_name, pid_name):
-    '''
-
-    Get the component index for a given particle attribute. This is useful
-    to get the corrent ordering of attributes when adding new particles using
-    `add_particles()`.
-
-    Parameters
-    ----------
-
-        species_name   : the species name that the data will be returned for
-        pid_name       : string that is used to identify the new component
-
-    Returns
-    -------
-
-        Integer corresponding to the index of the requested attribute
-
-    '''
-    return libwarpx.libwarpx_so.warpx_getParticleCompIndex(
-        ctypes.c_char_p(species_name.encode('utf-8')),
-        ctypes.c_char_p(pid_name.encode('utf-8'))
-    )
-
-
-def add_real_comp(species_name, pid_name, comm=True):
-    '''
-
-    Add a real component to the particle data array.
-
-    Parameters
-    ----------
-
-        species_name   : the species name for which the new component will be added
-        pid_name       : string that is used to identify the new component
-        comm           : should the component be communicated
-
-    '''
-    libwarpx.libwarpx_so.warpx_addRealComp(
-        ctypes.c_char_p(species_name.encode('utf-8')),
-        ctypes.c_char_p(pid_name.encode('utf-8')), comm
-    )
-
-
-def get_particle_boundary_buffer_size(species_name, boundary):
-    '''
-
-    This returns the number of particles that have been scraped so far in the simulation
-    from the specified boundary and of the specified species.
-
-    Parameters
-    ----------
-
-        species_name   : return the number of scraped particles of this species
-        boundary       : the boundary from which to get the scraped particle data.
-                         In the form x/y/z_hi/lo
-
-    Returns
-    -------
-
-        The number of particles scraped so far from a boundary and of a species.
-
-    '''
-    return libwarpx.libwarpx_so.warpx_getParticleBoundaryBufferSize(
-        ctypes.c_char_p(species_name.encode('utf-8')),
-        libwarpx.get_boundary_number(boundary)
-    )
-
-
-def get_particle_boundary_buffer_structs(species_name, boundary, level):
-    '''
-
-    This returns a list of numpy arrays containing the particle struct data
-    for a species that has been scraped by a specific simulation boundary. The
-    particle data is represented as a structured numpy array and contains the
-    particle 'x', 'y', 'z', 'id', and 'cpu'.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        species_name : the species name that the data will be returned for
-        boundary     : the boundary from which to get the scraped particle data.
-                       In the form x/y/z_hi/lo or eb.
-        level        : Which AMR level to retrieve scraped particle data from.
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    particles_per_tile = _LP_c_int()
-    num_tiles = ctypes.c_int(0)
-    data = libwarpx.libwarpx_so.warpx_getParticleBoundaryBufferStructs(
-            ctypes.c_char_p(species_name.encode('utf-8')),
-            libwarpx.get_boundary_number(boundary), level,
-            ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
-    )
-
-    particle_data = []
-    for i in range(num_tiles.value):
-        if particles_per_tile[i] == 0:
-            continue
-        arr = _array1d_from_pointer(data[i], libwarpx._p_dtype, particles_per_tile[i])
-        particle_data.append(arr)
-
-    _libc.free(particles_per_tile)
-    _libc.free(data)
-    return particle_data
-
-
-def get_particle_boundary_buffer(species_name, boundary, comp_name, level):
-    '''
-
-    This returns a list of numpy arrays containing the particle array data
-    for a species that has been scraped by a specific simulation boundary.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        species_name   : the species name that the data will be returned for.
-        boundary       : the boundary from which to get the scraped particle data.
-                         In the form x/y/z_hi/lo or eb.
-        comp_name      : the component of the array data that will be returned.
-                         If "step_scraped" the special attribute holding the
-                         timestep at which a particle was scraped will be
-                         returned.
-        level          : Which AMR level to retrieve scraped particle data from.
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    particles_per_tile = _LP_c_int()
-    num_tiles = ctypes.c_int(0)
-    if comp_name == 'step_scraped':
-        data = libwarpx.libwarpx_so.warpx_getParticleBoundaryBufferScrapedSteps(
-            ctypes.c_char_p(species_name.encode('utf-8')),
-            libwarpx.get_boundary_number(boundary), level,
-            ctypes.byref(num_tiles), ctypes.byref(particles_per_tile)
-        )
-    else:
-        data = libwarpx.libwarpx_so.warpx_getParticleBoundaryBuffer(
-            ctypes.c_char_p(species_name.encode('utf-8')),
-            libwarpx.get_boundary_number(boundary), level,
-            ctypes.byref(num_tiles), ctypes.byref(particles_per_tile),
-            ctypes.c_char_p(comp_name.encode('utf-8'))
-        )
-
-    particle_data = []
-    for i in range(num_tiles.value):
-        if particles_per_tile[i] == 0:
-            continue
-        if not data[i]:
-            raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
-        arr = np.ctypeslib.as_array(data[i], (particles_per_tile[i],))
-        try:
-            # This fails on some versions of numpy
-            arr.setflags(write=1)
-        except ValueError:
-            pass
-        particle_data.append(arr)
-
-    _libc.free(particles_per_tile)
-    _libc.free(data)
-    return particle_data
-
-
-def clearParticleBoundaryBuffer():
-    '''
-
-    Clear the buffer that holds the particles lost at the boundaries.
-
-    '''
-    libwarpx.libwarpx_so.warpx_clearParticleBoundaryBuffer()
-
-
-def _get_mesh_field_list(warpx_func, level, direction, include_ghosts):
-    """
-     Generic routine to fetch the list of field data arrays.
-    """
-    shapes = _LP_c_int()
-    size = ctypes.c_int(0)
-    ncomps = ctypes.c_int(0)
-    ngrowvect = _LP_c_int()
-    if direction is None:
-        data = warpx_func(level,
-                          ctypes.byref(size), ctypes.byref(ncomps),
-                          ctypes.byref(ngrowvect), ctypes.byref(shapes))
-    else:
-        data = warpx_func(level, direction,
-                          ctypes.byref(size), ctypes.byref(ncomps),
-                          ctypes.byref(ngrowvect), ctypes.byref(shapes))
-    if not data:
-        raise Exception('object was not initialized')
-
-    ngvect = [ngrowvect[i] for i in range(libwarpx.dim)]
-    grid_data = []
-    shapesize = libwarpx.dim
-    if ncomps.value > 1:
-        shapesize += 1
-    for i in range(size.value):
-        shape = tuple([shapes[shapesize*i + d] for d in range(shapesize)])
-        # --- The data is stored in Fortran order, hence shape is reversed and a transpose is taken.
-        if shape[::-1] == 0:
-            continue
-        if not data[i]:
-            raise Exception(f'get_particle_arrays: data[i] for i={i} was not initialized')
-        arr = np.ctypeslib.as_array(data[i], shape[::-1]).T
-        try:
-            # This fails on some versions of numpy
-            arr.setflags(write=1)
-        except ValueError:
-            pass
-        if include_ghosts:
-            grid_data.append(arr)
-        else:
-            grid_data.append(arr[tuple([slice(ngvect[d], -ngvect[d]) for d in range(libwarpx.dim)])])
-
-    _libc.free(shapes)
-    _libc.free(data)
-    return grid_data
-
-
-def get_mesh_electric_field(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electric field
-    data on each grid for this process.
-
-    This version is for the full "auxiliary" solution on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEfield, level, direction, include_ghosts)
-
-
-def get_mesh_electric_field_cp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electric field
-    data on each grid for this process. This version returns the field on
-    the coarse patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEfieldCP, level, direction, include_ghosts)
-
-
-def get_mesh_electric_field_fp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electric field
-    data on each grid for this process. This version returns the field on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEfieldFP, level, direction, include_ghosts)
-
-
-def get_mesh_electric_field_cp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electric field
-    data on each grid for this process. This version returns the field on
-    the coarse patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEfieldCP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_electric_field_fp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electric field
-    data on each grid for this process. This version returns the field on
-    the fine patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEfieldFP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_magnetic_field(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh magnetic field
-    data on each grid for this process.
-
-    This version is for the full "auxiliary" solution on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getBfield, level, direction, include_ghosts)
-
-
-def get_mesh_magnetic_field_cp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh magnetic field
-    data on each grid for this process. This version returns the field on
-    the coarse patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getBfieldCP, level, direction, include_ghosts)
-
-
-def get_mesh_magnetic_field_fp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh magnetic field
-    data on each grid for this process. This version returns the field on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getBfieldFP, level, direction, include_ghosts)
-
-
-def get_mesh_magnetic_field_cp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh magnetic field
-    data on each grid for this process. This version returns the field on
-    the coarse patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getBfieldCP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_magnetic_field_fp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh magnetic field
-    data on each grid for this process. This version returns the field on
-    the fine patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getBfieldFP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_current_density(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh current density
-    data on each grid for this process.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getCurrentDensity, level, direction, include_ghosts)
-
-
-def get_mesh_current_density_cp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh current density
-    data on each grid for this process. This version returns the density for
-    the coarse patch on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getCurrentDensityCP, level, direction, include_ghosts)
-
-
-def get_mesh_current_density_fp(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh current density
-    data on each grid for this process. This version returns the density on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getCurrentDensityFP, level, direction, include_ghosts)
-
-
-def get_mesh_current_density_cp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh current density
-    data on each grid for this process. This version returns the density for
-    the coarse patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getCurrentDensityCP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_current_density_fp_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh current density
-    data on each grid for this process. This version returns the density on
-    the fine patch for the PML for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getCurrentDensityFP_PML, level, direction, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_charge_density_cp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh charge density
-    data on each grid for this process. This version returns the density for
-    the coarse patch on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getChargeDensityCP, level, None, include_ghosts)
-
-
-def get_mesh_charge_density_fp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh charge density
-    data on each grid for this process. This version returns the density on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getChargeDensityFP, level, None, include_ghosts)
-
-
-def get_mesh_phi_fp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh electrostatic
-    potential data on each grid for this process. This version returns the
-    potential on the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getPhiFP, level, None, include_ghosts)
-
-
-def get_mesh_F_cp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh F field
-    data on each grid for this process. This version returns the F field for
-    the coarse patch on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getFfieldCP, level, None, include_ghosts)
-
-
-def get_mesh_F_fp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh F field
-    data on each grid for this process. This version returns the F field on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getFfieldFP, level, None, include_ghosts)
-
-
-def get_mesh_F_fp_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh F field
-    data on each grid for this process. This version returns the F field on
-    the fine patch for the PML on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getFfieldFP_PML, level, None, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_F_cp_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh F field
-    data on each grid for this process. This version returns the F field on
-    the coarse patch for the PML on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getFfieldCP_PML, level, None, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_G_cp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh G field
-    data on each grid for this process. This version returns the G field for
-    the coarse patch on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getGfieldCP, level, None, include_ghosts)
-
-
-def get_mesh_G_fp(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh G field
-    data on each grid for this process. This version returns the G field on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getGfieldFP, level, None, include_ghosts)
-
-
-def get_mesh_G_cp_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh G field
-    data on each grid for this process. This version returns the G field on
-    the coarse patch for the PML on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getGfieldCP_PML, level, None, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_G_fp_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh G field
-    data on each grid for this process. This version returns the G field on
-    the fine patch for the PML on the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-    try:
-        return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getGfieldFP_PML, level, None, include_ghosts)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_edge_lengths(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh edge lengths
-    data on each grid for this process. This version returns the density on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getEdgeLengths, level, direction, include_ghosts)
-
-
-def get_mesh_face_areas(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of numpy arrays containing the mesh face areas
-    data on each grid for this process. This version returns the density on
-    the fine patch for the given level.
-
-    The data for the numpy arrays are not copied, but share the underlying
-    memory buffer with WarpX. The numpy arrays are fully writeable.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A List of numpy arrays.
-
-    '''
-
-    return _get_mesh_field_list(libwarpx.libwarpx_so.warpx_getFaceAreas, level, direction, include_ghosts)
-
-
-def _get_mesh_array_lovects(level, direction, include_ghosts=True, getlovectsfunc=None):
-    assert(0 <= level and level <= libwarpx.libwarpx_so.warpx_finestLevel())
-
-    size = ctypes.c_int(0)
-    ngrowvect = _LP_c_int()
-    if direction is None:
-        data = getlovectsfunc(level, ctypes.byref(size), ctypes.byref(ngrowvect))
-    else:
-        data = getlovectsfunc(level, direction, ctypes.byref(size), ctypes.byref(ngrowvect))
-
-    if not data:
-        raise Exception('object was not initialized')
-
-    lovects_ref = np.ctypeslib.as_array(data, (size.value, libwarpx.dim))
-
-    # --- Make a copy of the data to avoid memory problems
-    # --- Also, take the transpose to give shape (dims, number of grids)
-    lovects = lovects_ref.copy().T
-
-    ng = []
-    if include_ghosts:
-        for d in range(libwarpx.dim):
-            ng.append(ngrowvect[d])
-    else:
-        for d in range(libwarpx.dim):
-            ng.append(0)
-            lovects[d,:] += ngrowvect[d]
-
-    del lovects_ref
-    _libc.free(data)
-    return lovects, ng
-
-
-def get_mesh_electric_field_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    This version is for the full "auxiliary" solution on the given level.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEfieldLoVects)
-
-
-def get_mesh_electric_field_cp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEfieldCPLoVects)
-
-
-def get_mesh_electric_field_fp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEfieldFPLoVects)
-
-
-def get_mesh_electric_field_cp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEfieldCPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_electric_field_fp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEfieldFPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_magnetic_field_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    This version is for the full "auxiliary" solution on the given level.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getBfieldLoVects)
-
-
-def get_mesh_magnetic_field_cp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getBfieldCPLoVects)
-
-
-def get_mesh_magnetic_field_fp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getBfieldFPLoVects)
-
-
-def get_mesh_magnetic_field_cp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getBfieldCPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_magnetic_field_fp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getBfieldFPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_current_density_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getCurrentDensityLoVects)
-
-
-def get_mesh_current_density_cp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getCurrentDensityCPLoVects)
-
-def get_mesh_current_density_fp_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getCurrentDensityFPLoVects)
-
-
-def get_mesh_current_density_cp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getCurrentDensityCPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-def get_mesh_current_density_fp_lovects_pml(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getCurrentDensityFPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_charge_density_cp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh electric field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getChargeDensityCPLoVects)
-
-
-def get_mesh_charge_density_fp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh
-    charge density data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getChargeDensityFPLoVects)
-
-
-def get_mesh_phi_fp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh
-    electrostatic potential data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getPhiFPLoVects)
-
-
-def get_mesh_F_cp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh F field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getFfieldCPLoVects)
-
-
-def get_mesh_F_fp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh F field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getFfieldFPLoVects)
-
-
-def get_mesh_F_cp_lovects_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh F field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getFfieldCPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_F_fp_lovects_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh F field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getFfieldFPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_G_cp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh G field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getGfieldCPLoVects)
-
-
-def get_mesh_G_fp_lovects(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh G field
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getGfieldFPLoVects)
-
-
-def get_mesh_G_cp_lovects_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh G field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getGfieldCPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_G_fp_lovects_pml(level, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh G field
-    data on each PML grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    try:
-        return _get_mesh_array_lovects(level, None, include_ghosts, libwarpx.libwarpx_so.warpx_getGfieldFPLoVects_PML)
-    except ValueError:
-        raise Exception('PML not initialized')
-
-
-def get_mesh_edge_lengths_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh edge lengths
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getEdgeLengthsLoVects)
-
-
-def get_mesh_face_areas_lovects(level, direction, include_ghosts=True):
-    '''
-
-    This returns a list of the lo vectors of the arrays containing the mesh face areas
-    data on each grid for this process.
-
-    Parameters
-    ----------
-
-        level          : the AMR level to get the data for
-        direction      : the component of the data you want
-        include_ghosts : whether to include ghost zones or not
-
-    Returns
-    -------
-
-        A 2d numpy array of the lo vector for each grid with the shape (dims, number of grids)
-
-    '''
-    return _get_mesh_array_lovects(level, direction, include_ghosts, libwarpx.libwarpx_so.warpx_getFaceAreasLoVects)
-
-
-def _get_nodal_flag(getdatafunc):
-    data = getdatafunc()
-    if not data:
-        raise Exception('object was not initialized')
-
-    nodal_flag_ref = np.ctypeslib.as_array(data, (libwarpx.dim,))
-
-    # --- Make a copy of the data to avoid memory problems
-    nodal_flag = nodal_flag_ref.copy()
-
-    del nodal_flag_ref
-    _libc.free(data)
-    return nodal_flag
-
-
-def get_Ex_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Ex along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getEx_nodal_flag)
-
-
-def get_Ey_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Ey along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getEy_nodal_flag)
-
-
-def get_Ez_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Ez along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getEz_nodal_flag)
-
-
-def get_Bx_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Bx along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getBx_nodal_flag)
-
-
-def get_By_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for By along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getBy_nodal_flag)
-
-
-def get_Bz_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Bz along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getBz_nodal_flag)
-
-
-def get_Jx_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Jx along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getJx_nodal_flag)
-
-
-def get_Jy_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Jy along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getJy_nodal_flag)
-
-
-def get_Jz_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Jz along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getJz_nodal_flag)
-
-
-def get_Rho_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Rho along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getRho_nodal_flag)
-
-def get_Phi_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for Phi along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getPhi_nodal_flag)
-
-def get_F_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for F along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getF_nodal_flag)
-
-def get_G_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for G along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getG_nodal_flag)
-
-def get_edge_lengths_x_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the x edge lengths along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_edge_lengths_x_nodal_flag)
-
-def get_edge_lengths_y_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the y edge lengths along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_edge_lengths_y_nodal_flag)
-
-def get_edge_lengths_z_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the z edge lengths along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_edge_lengths_z_nodal_flag)
-
-def get_face_areas_x_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the x face areas along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_face_areas_x_nodal_flag)
-
-def get_face_areas_y_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the y face areas along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_face_areas_y_nodal_flag)
-
-def get_face_areas_z_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for the z face areas along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_get_face_areas_z_nodal_flag)
-
-def get_F_pml_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for F in the PML along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getF_pml_nodal_flag)
-
-def get_G_pml_nodal_flag():
-    '''
-    This returns a 1d array of the nodal flags for G in the PML along each direction. A 1 means node centered, and 0 cell centered.
-    '''
-    return _get_nodal_flag(libwarpx.libwarpx_so.warpx_getG_pml_nodal_flag)

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     npes = 1
 
-from . import _libwarpx
+from ._libwarpx import libwarpx
 
 
 class _MultiFABWrapper(object):
@@ -43,7 +43,7 @@ class _MultiFABWrapper(object):
         self.level = level
         self.include_ghosts = include_ghosts
 
-        self.dim = _libwarpx.libwarpx.dim
+        self.dim = libwarpx.dim
 
         # overlaps is one along the axes where the grid boundaries overlap the neighboring grid,
         # which is the case with node centering.
@@ -86,16 +86,16 @@ class _MultiFABWrapper(object):
         """
 
         try:
-            if _libwarpx.libwarpx.geometry_dim == '3d':
+            if libwarpx.geometry_dim == '3d':
                 idir = ['x', 'y', 'z'].index(direction)
                 celldir = idir
-            elif _libwarpx.libwarpx.geometry_dim == '2d':
+            elif libwarpx.geometry_dim == '2d':
                 idir = ['x', 'z'].index(direction)
                 celldir = 2*idir
-            elif _libwarpx.libwarpx.geometry_dim == 'rz':
+            elif libwarpx.geometry_dim == 'rz':
                 idir = ['r', 'z'].index(direction)
                 celldir = 2*idir
-            elif _libwarpx.geometry_dim == '1d':
+            elif libwarpx.geometry_dim == '1d':
                 idir = ['z'].index(direction)
                 celldir = idir
         except ValueError:
@@ -108,7 +108,7 @@ class _MultiFABWrapper(object):
             nn = comm_world.allreduce(nn, op=mpi.MAX)
 
         # --- Cell size in the direction
-        dd = _libwarpx.getCellSize(celldir, self.level)
+        dd = libwarpx.getCellSize(celldir, self.level)
 
         # --- Get the nodal flag along direction
         nodal_flag = self.get_nodal_flag()[idir]
@@ -300,7 +300,7 @@ class _MultiFABWrapper(object):
         if ncomps > 1 and ic is None:
             sss = tuple(list(sss) + [ncomps])
         # --- Create the array to be returned.
-        resultglobal = np.zeros(sss, dtype=_libwarpx.libwarpx._numpy_real_dtype)
+        resultglobal = np.zeros(sss, dtype=libwarpx._numpy_real_dtype)
 
         datalist = []
         for i in range(len(fields)):
@@ -435,457 +435,457 @@ class _MultiFABWrapper(object):
 
 def ExWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_electric_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field,
-                            get_nodal_flag=_libwarpx.get_Ex_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field,
+                            get_nodal_flag=libwarpx.get_Ex_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_electric_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field,
-                            get_nodal_flag=_libwarpx.get_Ey_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field,
+                            get_nodal_flag=libwarpx.get_Ey_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_electric_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field,
-                            get_nodal_flag=_libwarpx.get_Ez_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field,
+                            get_nodal_flag=libwarpx.get_Ez_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field,
-                            get_nodal_flag=_libwarpx.get_Bx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field,
+                            get_nodal_flag=libwarpx.get_Bx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ByWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field,
-                            get_nodal_flag=_libwarpx.get_By_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field,
+                            get_nodal_flag=libwarpx.get_By_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field,
-                            get_nodal_flag=_libwarpx.get_Bz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field,
+                            get_nodal_flag=libwarpx.get_Bz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_current_density_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density,
-                            get_nodal_flag=_libwarpx.get_Jx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density,
+                            get_nodal_flag=libwarpx.get_Jx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_current_density_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density,
-                            get_nodal_flag=_libwarpx.get_Jy_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density,
+                            get_nodal_flag=libwarpx.get_Jy_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_current_density_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density,
-                            get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density,
+                            get_nodal_flag=libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ExCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp,
-                            get_nodal_flag=_libwarpx.get_Ex_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp,
+                            get_nodal_flag=libwarpx.get_Ex_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EyCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp,
-                            get_nodal_flag=_libwarpx.get_Ey_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp,
+                            get_nodal_flag=libwarpx.get_Ey_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EzCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp,
-                            get_nodal_flag=_libwarpx.get_Ez_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp,
+                            get_nodal_flag=libwarpx.get_Ez_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BxCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp,
-                            get_nodal_flag=_libwarpx.get_Bx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp,
+                            get_nodal_flag=libwarpx.get_Bx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ByCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp,
-                            get_nodal_flag=_libwarpx.get_By_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp,
+                            get_nodal_flag=libwarpx.get_By_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BzCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp,
-                            get_nodal_flag=_libwarpx.get_Bz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp,
+                            get_nodal_flag=libwarpx.get_Bz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JxCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp,
-                            get_nodal_flag=_libwarpx.get_Jx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_cp,
+                            get_nodal_flag=libwarpx.get_Jx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JyCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp,
-                            get_nodal_flag=_libwarpx.get_Jy_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_cp,
+                            get_nodal_flag=libwarpx.get_Jy_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JzCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp,
-                            get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_cp,
+                            get_nodal_flag=libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def RhoCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_charge_density_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_charge_density_cp,
-                            get_nodal_flag=_libwarpx.get_Rho_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_charge_density_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_charge_density_cp,
+                            get_nodal_flag=libwarpx.get_Rho_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_F_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_F_cp,
-                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_F_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_F_cp,
+                            get_nodal_flag=libwarpx.get_F_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GCPWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_G_cp_lovects,
-                            get_fabs=_libwarpx.get_mesh_G_cp,
-                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_G_cp_lovects,
+                            get_fabs=libwarpx.get_mesh_G_cp,
+                            get_nodal_flag=libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ExFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp,
-                            get_nodal_flag=_libwarpx.get_Ex_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp,
+                            get_nodal_flag=libwarpx.get_Ex_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EyFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp,
-                            get_nodal_flag=_libwarpx.get_Ey_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp,
+                            get_nodal_flag=libwarpx.get_Ey_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp,
-                            get_nodal_flag=_libwarpx.get_Ez_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp,
+                            get_nodal_flag=libwarpx.get_Ez_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BxFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp,
-                            get_nodal_flag=_libwarpx.get_Bx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp,
+                            get_nodal_flag=libwarpx.get_Bx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ByFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp,
-                            get_nodal_flag=_libwarpx.get_By_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp,
+                            get_nodal_flag=libwarpx.get_By_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp,
-                            get_nodal_flag=_libwarpx.get_Bz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp,
+                            get_nodal_flag=libwarpx.get_Bz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JxFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp,
-                            get_nodal_flag=_libwarpx.get_Jx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_fp,
+                            get_nodal_flag=libwarpx.get_Jx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JyFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp,
-                            get_nodal_flag=_libwarpx.get_Jy_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_fp,
+                            get_nodal_flag=libwarpx.get_Jy_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp,
-                            get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_current_density_fp,
+                            get_nodal_flag=libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def RhoFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_charge_density_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_charge_density_fp,
-                            get_nodal_flag=_libwarpx.get_Rho_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_charge_density_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_charge_density_fp,
+                            get_nodal_flag=libwarpx.get_Rho_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def PhiFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_phi_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_phi_fp,
-                            get_nodal_flag=_libwarpx.get_Phi_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_phi_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_phi_fp,
+                            get_nodal_flag=libwarpx.get_Phi_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_F_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_F_fp,
-                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_F_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_F_fp,
+                            get_nodal_flag=libwarpx.get_F_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_G_fp_lovects,
-                            get_fabs=_libwarpx.get_mesh_G_fp,
-                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_G_fp_lovects,
+                            get_fabs=libwarpx.get_mesh_G_fp,
+                            get_nodal_flag=libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EdgeLengthsxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_edge_lengths_lovects,
-                            get_fabs=_libwarpx.get_mesh_edge_lengths,
-                            get_nodal_flag=_libwarpx.get_edge_lengths_x_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_edge_lengths_lovects,
+                            get_fabs=libwarpx.get_mesh_edge_lengths,
+                            get_nodal_flag=libwarpx.get_edge_lengths_x_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EdgeLengthsyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_edge_lengths_lovects,
-                            get_fabs=_libwarpx.get_mesh_edge_lengths,
-                            get_nodal_flag=_libwarpx.get_edge_lengths_y_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_edge_lengths_lovects,
+                            get_fabs=libwarpx.get_mesh_edge_lengths,
+                            get_nodal_flag=libwarpx.get_edge_lengths_y_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EdgeLengthszWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_edge_lengths_lovects,
-                            get_fabs=_libwarpx.get_mesh_edge_lengths,
-                            get_nodal_flag=_libwarpx.get_edge_lengths_z_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_edge_lengths_lovects,
+                            get_fabs=libwarpx.get_mesh_edge_lengths,
+                            get_nodal_flag=libwarpx.get_edge_lengths_z_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FaceAreasxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_face_areas_lovects,
-                            get_fabs=_libwarpx.get_mesh_face_areas,
-                            get_nodal_flag=_libwarpx.get_face_areas_x_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_face_areas_lovects,
+                            get_fabs=libwarpx.get_mesh_face_areas,
+                            get_nodal_flag=libwarpx.get_face_areas_x_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FaceAreasyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_face_areas_lovects,
-                            get_fabs=_libwarpx.get_mesh_face_areas,
-                            get_nodal_flag=_libwarpx.get_face_areas_y_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_face_areas_lovects,
+                            get_fabs=libwarpx.get_mesh_face_areas,
+                            get_nodal_flag=libwarpx.get_face_areas_y_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FaceAreaszWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_face_areas_lovects,
-                            get_fabs=_libwarpx.get_mesh_face_areas,
-                            get_nodal_flag=_libwarpx.get_face_areas_z_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_face_areas_lovects,
+                            get_fabs=libwarpx.get_mesh_face_areas,
+                            get_nodal_flag=libwarpx.get_face_areas_z_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ExCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Ex_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_Ex_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EyCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Ey_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_Ey_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EzCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_electric_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Ez_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_Ez_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BxCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Bx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_Bx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ByCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_By_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_By_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BzCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Bz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_cp_pml,
+                            get_nodal_flag=libwarpx.get_Bz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JxCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Jx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_cp_pml,
+                            get_nodal_flag=libwarpx.get_Jx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JyCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Jy_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_cp_pml,
+                            get_nodal_flag=libwarpx.get_Jy_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JzCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_current_density_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_cp_pml,
-                            get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_cp_pml,
+                            get_nodal_flag=libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_F_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_F_cp_pml,
-                            get_nodal_flag=_libwarpx.get_F_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_F_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_F_cp_pml,
+                            get_nodal_flag=libwarpx.get_F_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GCPPMLWrapper(level=1, include_ghosts=False):
     assert level>0, Exception('Coarse patch only available on levels > 0')
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_G_cp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_G_cp_pml,
-                            get_nodal_flag=_libwarpx.get_G_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_G_cp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_G_cp_pml,
+                            get_nodal_flag=libwarpx.get_G_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ExFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Ex_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_Ex_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EyFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Ey_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_Ey_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def EzFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_electric_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_electric_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Ez_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_electric_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_electric_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_Ez_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BxFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Bx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_Bx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def ByFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_By_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_By_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def BzFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_magnetic_field_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Bz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_magnetic_field_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_magnetic_field_fp_pml,
+                            get_nodal_flag=libwarpx.get_Bz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JxFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=0,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Jx_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_fp_pml,
+                            get_nodal_flag=libwarpx.get_Jx_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JyFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=1,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Jy_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_fp_pml,
+                            get_nodal_flag=libwarpx.get_Jy_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def JzFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=2,
-                            get_lovects=_libwarpx.get_mesh_current_density_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_current_density_fp_pml,
-                            get_nodal_flag=_libwarpx.get_Jz_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_current_density_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_current_density_fp_pml,
+                            get_nodal_flag=libwarpx.get_Jz_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def FFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_F_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_F_fp_pml,
-                            get_nodal_flag=_libwarpx.get_F_pml_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_F_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_F_fp_pml,
+                            get_nodal_flag=libwarpx.get_F_pml_nodal_flag,
                             level=level, include_ghosts=include_ghosts)
 
 def GFPPMLWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(direction=None,
-                            get_lovects=_libwarpx.get_mesh_G_fp_lovects_pml,
-                            get_fabs=_libwarpx.get_mesh_G_fp_pml,
-                            get_nodal_flag=_libwarpx.get_G_pml_nodal_flag,
+                            get_lovects=libwarpx.get_mesh_G_fp_lovects_pml,
+                            get_fabs=libwarpx.get_mesh_G_fp_pml,
+                            get_nodal_flag=libwarpx.get_G_pml_nodal_flag,
                             level=level, include_ghosts=include_ghosts)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -924,6 +924,12 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
 
 
 class Simulation(picmistandard.PICMI_Simulation):
+
+    # Set the C++ WarpX interface (see _libwarpx.LibWarpX) as an extension to
+    # Simulation objects. In the future, LibWarpX objects may actually be owned
+    # by Simulation objects to permit multiple WarpX runs simultaneously.
+    extension = pywarpx.libwarpx
+
     def init(self, kw):
 
         self.current_deposition_algo = kw.pop('warpx_current_deposition_algo', None)


### PR DESCRIPTION
This implements the next refactor discussed in #2637 , which is that functions previously in _libwarpx.py are now member functions of LibWarpX. This avoids an `import *` in `pywarpx`, and makes all functions accessing code in `_libwarpx.py` access the `libwarpx` namespace, which I think enhances readability. Two other notable things:

* `clight` was removed from `_libwarpx.py`. It duplicated `picmi.constants.c`.
* `get_particle_theta`'s 3D clause did not fetch `structs` before using them. That's fixed. Obviously it wasn't being CI tested... I'm not sure what CI test is appropriate/useful though. This is a separate commit at present if you want to find it quickly.