### PR TITLE
RZ correction in 2d RZ Poisson slver

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -323,6 +323,8 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
     // Define the linear operator (Poisson operator)
     MLNodeLaplacian linop( geom_scaled, boxArray(), DistributionMap() );
 
+    linop.setRZCorrection(true);
+
     for (int lev = 0; lev <= max_level; ++lev) {
         linop.setSigma( lev, *sigma[lev] );
     }


### PR DESCRIPTION
Call MLNodeLaplacian::setRZCorrect, even when it's redundant when the
coordinate system is 2d rz, so that the solver does not depend on the
coordinate system set in amrex::Geometry.