### PR TITLE
Docs: Add Missing Default for warpx.serialize_ics

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -874,7 +874,7 @@ Particle initialization
     boosted frame, whether or not to plot back-transformed diagnostics for
     this species.
 
-* ``warpx.serialize_ics`` (`0 or 1`)
+* ``warpx.serialize_ics`` (`0` or `1`) optional (default `0`)
     Serialize the initial conditions for reproducible testing.
     Mainly whether or not to use OpenMP threading for particle initialization.
 


### PR DESCRIPTION
The default value of `warpx.serialize_ics` was missing from our documentation. It seems to me like the default value is `0`/`false`, based on the code here:
https://github.com/ECP-WarpX/WarpX/blob/011241af1c8feac1e1f8c726ac729a1216bd5d83/Source/WarpX.cpp#L156