### PR TITLE
Clean-up in ElectrostaticSolver.cpp

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -196,35 +196,6 @@ WarpX::AddSpaceChargeFieldLabFrame ()
    a source, assuming that the source moves at a constant speed \f$\vec{\beta}\f$.
    This uses the amrex solver.
 
-   \param[in] rho The charge density a given species
-   \param[out] phi The potential to be computed by this function
-   \param[in] beta Represents the velocity of the source of `phi`
-*/
-void
-WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-                   amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                   std::array<Real, 3> const beta,
-                   Real const required_precision,
-                   Real const absolute_tolerance,
-                   int const max_iters,
-                   int const verbosity) const
-{
-#ifdef WARPX_DIM_RZ
-    computePhiRZ( rho, phi, beta, required_precision, absolute_tolerance,
-                  max_iters, verbosity );
-#else
-    computePhiCartesian( rho, phi, beta, required_precision, absolute_tolerance,
-                         max_iters, verbosity );
-#endif
-
-}
-
-#ifdef WARPX_DIM_RZ
-/* Compute the potential `phi` in cylindrical geometry by solving the Poisson equation
-   with `rho` as a source, assuming that the source moves at a constant
-   speed \f$\vec{\beta}\f$.
-   This uses the amrex solver.
-
    More specifically, this solves the equation
    \f[
        \vec{\nabla}^2 r \phi - (\vec{\beta}\cdot\vec{\nabla})^2 r \phi = -\frac{r \rho}{\epsilon_0}
@@ -233,9 +204,13 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
    \param[in] rho The charge density a given species
    \param[out] phi The potential to be computed by this function
    \param[in] beta Represents the velocity of the source of `phi`
+   \param[in] required_precision The relative convergence threshold for the MLMG solver
+   \param[in] absolute_tolerance The absolute convergence threshold for the MLMG solver
+   \param[in] max_iters The maximum number of iterations allowed for the MLMG solver
+   \param[in] verbosity The verbosity setting for the MLMG solver
 */
 void
-WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
+WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
@@ -243,6 +218,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
                    int const max_iters,
                    int const verbosity) const
 {
+#ifdef WARPX_DIM_RZ
     // Create a new geometry with the z coordinate scaled by gamma
     amrex::Real const gamma = std::sqrt(1._rt/(1._rt - beta[2]*beta[2]));
 
@@ -260,108 +236,9 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
         amrex::RealBox rb = RealBox(scaled_lo, scaled_hi);
         geom_scaled[lev].define(geom_lev.Domain(), &rb);
     }
-
-    // get the potential at the current time
-    amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_lo;
-    amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_hi;
-    phi_bc_values_lo[1] = field_boundary_handler.potential_zlo(gett_new(0));
-    phi_bc_values_hi[1] = field_boundary_handler.potential_zhi(gett_new(0));
-
-    // set the boundary potential values if needed
-    setPhiBC(phi, phi_bc_values_lo, phi_bc_values_hi);
-
-    amrex::Real max_norm_b = 0.0;
-    for (int lev=0; lev < rho.size(); lev++){
-        rho[lev]->mult(-1._rt/PhysConst::ep0);
-        max_norm_b = amrex::max(max_norm_b, rho[lev]->norm0());
-    }
-    amrex::ParallelDescriptor::ReduceRealMax(max_norm_b);
-
-    bool always_use_bnorm = (max_norm_b > 0);
-    if (!always_use_bnorm) {
-        if (absolute_tolerance == 0.0) absolute_tolerance = amrex::Real(1e-6);
-        WarpX::GetInstance().RecordWarning(
-            "ElectrostaticSolver", "Max norm of rho is 0", WarnPriority::low
-        );
-    }
-
-    LPInfo info;
-
-#ifndef AMREX_USE_EB
-    // Define the linear operator (Poisson operator)
-    MLEBNodeFDLaplacian linop( geom_scaled, boxArray(), DistributionMap(), info );
-#else
-    // With embedded boundary: extract EB info
-    Vector<EBFArrayBoxFactory const*> eb_factory;
-    eb_factory.resize(max_level+1);
-    for (int lev = 0; lev <= max_level; ++lev) {
-        eb_factory[lev] = &WarpX::fieldEBFactory(lev);
-    }
-    MLEBNodeFDLaplacian linop( Geom(), boxArray(), DistributionMap(), info, eb_factory);
-    // if the EB potential only depends on time, the potential can be passed
-    // as a float instead of a callable
-    if (field_boundary_handler.phi_EB_only_t) {
-        linop.setEBDirichlet(field_boundary_handler.potential_eb_t(gett_new(0)));
-    }
-    else linop.setEBDirichlet(field_boundary_handler.getPhiEB(gett_new(0)));
-
 #endif
 
-    // Solve the Poisson equation
-    linop.setDomainBC( field_boundary_handler.lobc, field_boundary_handler.hibc );
-    linop.setRZ(true);
-    MLMG mlmg(linop);
-    mlmg.setVerbose(verbosity);
-    mlmg.setMaxIter(max_iters);
-    mlmg.setAlwaysUseBNorm(always_use_bnorm);
-    mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho),
-                required_precision, absolute_tolerance );
-
-#ifdef AMREX_USE_EB
-    // use amrex to directly calculate the electric field since with EB's the
-    // simple finite difference scheme in WarpX::computeE sometimes fails
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
-    {
-        for (int lev = 0; lev <= max_level; ++lev) {
-            mlmg.getGradSolution(
-                {amrex::Array<amrex::MultiFab*,2>{
-                    get_pointer_Efield_fp(lev, 0),get_pointer_Efield_fp(lev, 2)
-                    }}
-            );
-            get_pointer_Efield_fp(lev, 0)->mult(-1._rt);
-            get_pointer_Efield_fp(lev, 2)->mult(-1._rt);
-        }
-    }
-#endif
-
-}
-
-#else
-
-/* Compute the potential `phi` in Cartesian geometry by solving the Poisson equation
-   with `rho` as a source, assuming that the source moves at a constant
-   speed \f$\vec{\beta}\f$.
-   This uses the amrex solver.
-
-   More specifically, this solves the equation
-   \f[
-       \vec{\nabla}^2\phi - (\vec{\beta}\cdot\vec{\nabla})^2\phi = -\frac{\rho}{\epsilon_0}
-   \f]
-
-   \param[in] rho The charge density a given species
-   \param[out] phi The potential to be computed by this function
-   \param[in] beta Represents the velocity of the source of `phi`
-*/
-void
-WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-                            amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                            std::array<Real, 3> const beta,
-                            Real const required_precision,
-                            Real absolute_tolerance,
-                            int const max_iters,
-                            int const verbosity) const
-{
-    // get the potential at the current time
+    // get the boundary potentials at the current time
     amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_lo;
     amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_hi;
     phi_bc_values_lo[WARPX_ZINDEX] = field_boundary_handler.potential_zlo(gett_new(0));
@@ -378,49 +255,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
 
     setPhiBC(phi, phi_bc_values_lo, phi_bc_values_hi);
 
-#ifndef AMREX_USE_EB
-    // Define the linear operator (Poisson operator)
-    MLNodeTensorLaplacian linop( Geom(), boxArray(), DistributionMap() );
-
-    // Set the value of beta
-    amrex::Array<amrex::Real,AMREX_SPACEDIM> beta_solver =
-#   if defined(WARPX_DIM_1D_Z)
-        {{ beta[2] }};  // beta_x and beta_z
-#   elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        {{ beta[0], beta[2] }};  // beta_x and beta_z
-#   else
-        {{ beta[0], beta[1], beta[2] }};
-#   endif
-    linop.setBeta( beta_solver );
-
-#else
-
-    // With embedded boundary: extract EB info
-    LPInfo info;
-    Vector<EBFArrayBoxFactory const*> eb_factory;
-    eb_factory.resize(max_level+1);
-    for (int lev = 0; lev <= max_level; ++lev) {
-      eb_factory[lev] = &WarpX::fieldEBFactory(lev);
-    }
-    MLEBNodeFDLaplacian linop( Geom(), boxArray(), DistributionMap(), info, eb_factory);
-
-    // Note: this assumes that the beam is propagating along
-    // one of the axes of the grid, i.e. that only *one* of the Cartesian
-    // components of `beta` is non-negligible.
-    linop.setSigma({AMREX_D_DECL(
-        1._rt-beta[0]*beta[0], 1._rt-beta[1]*beta[1], 1._rt-beta[2]*beta[2])});
-
-    // if the EB potential only depends on time, the potential can be passed
-    // as a float instead of a callable
-    if (field_boundary_handler.phi_EB_only_t) {
-        linop.setEBDirichlet(field_boundary_handler.potential_eb_t(gett_new(0)));
-    }
-    else linop.setEBDirichlet(field_boundary_handler.getPhiEB(gett_new(0)));
-#endif
-
-    // Solve the Poisson equation
-    linop.setDomainBC( field_boundary_handler.lobc, field_boundary_handler.hibc );
-
+    // scale rho appropriately; also determine if rho is zero everywhere
     amrex::Real max_norm_b = 0.0;
     for (int lev=0; lev < rho.size(); lev++){
         rho[lev]->mult(-1._rt/PhysConst::ep0);
@@ -436,6 +271,59 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
         );
     }
 
+    LPInfo info;
+
+#ifndef AMREX_USE_EB
+#   ifdef WARPX_DIM_RZ
+        // Define the linear operator (Poisson operator)
+        MLEBNodeFDLaplacian linop( geom_scaled, boxArray(), DistributionMap(), info );
+#   else
+        // Define the linear operator (Poisson operator)
+        MLNodeTensorLaplacian linop( Geom(), boxArray(), DistributionMap() );
+
+        // Set the value of beta
+        amrex::Array<amrex::Real,AMREX_SPACEDIM> beta_solver =
+#       if defined(WARPX_DIM_1D_Z)
+            {{ beta[2] }};  // beta_x and beta_z
+#       elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+            {{ beta[0], beta[2] }};  // beta_x and beta_z
+#       else
+            {{ beta[0], beta[1], beta[2] }};
+#       endif
+        linop.setBeta( beta_solver );
+        ignore_unused(info);
+#   endif
+#else
+    // With embedded boundary: extract EB info
+    Vector<EBFArrayBoxFactory const*> eb_factory;
+    eb_factory.resize(max_level+1);
+    for (int lev = 0; lev <= max_level; ++lev) {
+        eb_factory[lev] = &WarpX::fieldEBFactory(lev);
+    }
+    MLEBNodeFDLaplacian linop( Geom(), boxArray(), DistributionMap(), info, eb_factory);
+
+#   ifndef WARPX_DIM_RZ
+        // Note: this assumes that the beam is propagating along
+        // one of the axes of the grid, i.e. that only *one* of the Cartesian
+        // components of `beta` is non-negligible.
+        linop.setSigma({AMREX_D_DECL(
+            1._rt-beta[0]*beta[0], 1._rt-beta[1]*beta[1], 1._rt-beta[2]*beta[2])});
+#   endif
+
+    // if the EB potential only depends on time, the potential can be passed
+    // as a float instead of a callable
+    if (field_boundary_handler.phi_EB_only_t) {
+        linop.setEBDirichlet(field_boundary_handler.potential_eb_t(gett_new(0)));
+    }
+    else linop.setEBDirichlet(field_boundary_handler.getPhiEB(gett_new(0)));
+
+#endif
+
+    // Solve the Poisson equation
+    linop.setDomainBC( field_boundary_handler.lobc, field_boundary_handler.hibc );
+#ifdef WARPX_DIM_RZ
+    linop.setRZ(true);
+#endif
     MLMG mlmg(linop);
     mlmg.setVerbose(verbosity);
     mlmg.setMaxIter(max_iters);
@@ -476,7 +364,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     }
 #endif
 }
-#endif
+
 
 /* \brief Set Dirichlet boundary conditions for the electrostatic solver.
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -700,23 +700,9 @@ public:
                      amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                      std::array<amrex::Real, 3> const beta = {{0,0,0}},
                      amrex::Real const required_precision=amrex::Real(1.e-11),
-                     amrex::Real const absolute_tolerance=amrex::Real(0.0),
+                     amrex::Real absolute_tolerance=amrex::Real(0.0),
                      const int max_iters=200,
                      const int verbosity=2) const;
-    void computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-                       amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                       std::array<amrex::Real, 3> const beta,
-                       amrex::Real const required_precision,
-                       amrex::Real absolute_tolerance,
-                       int const max_iters,
-                       int const verbosity) const;
-    void computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
-                       amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                       std::array<amrex::Real, 3> const beta,
-                       amrex::Real const required_precision,
-                       amrex::Real absolute_tolerance,
-                       int const max_iters,
-                       int const verbosity) const;
 
     void setPhiBC (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    amrex::Array<amrex::Real,AMREX_SPACEDIM>& phi_bc_values_lo,


### PR DESCRIPTION
Removed distinct functions `computePhiRZ` and `computePhiCartesian` since after PR #2602 these function now share mostly the same code.
In the future it would be good to always calculate the E-field with `mlmg.getGradSolution` to avoid the need for separate routines when EBs are turned on versus off. This would require also using the `MLEBNodeFDLaplacian` linear operator when solving `phi` in Cartesian coordinates without EBs (instead of the `MLNodeTensorLaplacian`).