### PR TITLE
CI: mpi4py breaking setuptools API

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -18,6 +18,10 @@ jobs:
     env:
       CXXFLAGS: "-Werror"
       CMAKE_GENERATOR: Ninja
+      # setuptools/mp4py work-around, see
+      #   https://github.com/mpi4py/mpi4py/pull/159
+      #   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
@@ -60,9 +64,13 @@ jobs:
     name: NVHPC@21.9 NVCC/NVC++ Release [tests]
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
-    # For NVHPC, Ninja is slower than the default:
-    #env:
-    #  CMAKE_GENERATOR: Ninja
+    env:
+      # For NVHPC, Ninja is slower than the default:
+      #CMAKE_GENERATOR: Ninja
+      # setuptools/mp4py work-around, see
+      #   https://github.com/mpi4py/mpi4py/pull/159
+      #   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,14 +7,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_gcc9:
+  build_appleclang:
     name: AppleClang
     runs-on: macos-latest
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror -Wno-error=pass-failed"
-    # For macOS, Ninja is slower than the default:
-    #  CMAKE_GENERATOR: Ninja
+      # For macOS, Ninja is slower than the default:
+      #CMAKE_GENERATOR: Ninja
+      # setuptools/mp4py work-around, see
+      #   https://github.com/mpi4py/mpi4py/pull/159
+      #   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -59,9 +59,13 @@ jobs:
     name: Clang pywarpx
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
-    # On CI for this test, Ninja is slower than the default:
-    #env:
-    #  CMAKE_GENERATOR: Ninja
+    env:
+      # On CI for this test, Ninja is slower than the default:
+      #CMAKE_GENERATOR: Ninja
+      # setuptools/mp4py work-around, see
+      #   https://github.com/mpi4py/mpi4py/pull/159
+      #   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies

--- a/run_test.sh
+++ b/run_test.sh
@@ -62,6 +62,10 @@ rm -rf py-venv
 python3 -m venv py-venv
 source py-venv/bin/activate
 python3 -m pip install --upgrade pip setuptools wheel
+# setuptools/mp4py work-around, see
+#   https://github.com/mpi4py/mpi4py/pull/159
+#   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+export SETUPTOOLS_USE_DISTUTILS="stdlib"
 python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone PICSAR, AMReX and warpx-data


### PR DESCRIPTION
setuptools keeps breaking its API, which currently breaks `mpi4py` installs. Until a new mpi4py release is cut, this will serve as a work-around.

X-ref:
- https://github.com/mpi4py/mpi4py/pull/159
- https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274