### PR TITLE
Allow Dirichlet BCs on r boundaries in RZ (electrostatic)

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -312,12 +312,10 @@ class LibWarpX():
         '''
         if self.geometry_dim == '3d':
             dimensions = {'x' : 0, 'y' : 1, 'z' : 2}
-        elif self.geometry_dim == '2d':
+        elif self.geometry_dim == '2d' or self.geometry_dim == 'rz':
             dimensions = {'x' : 0, 'z' : 1}
         elif self.geometry_dim == '1d':
             dimensions = {'z' : 0}
-        elif self.geometry_dim == 'rz':
-            dimensions = {'r': 0, 'z': 1}
         else:
             raise RuntimeError(f"Unknown simulation geometry: {self.geometry_dim}")
 
@@ -334,7 +332,7 @@ class LibWarpX():
         else:
             if self.geometry_dim == '3d':
                 boundary_num = 6
-            elif self.geometry_dim == '2d':
+            elif self.geometry_dim == '2d' or self.geometry_dim == 'rz':
                 boundary_num = 4
             elif self.geometry_dim == '1d':
                 boundary_num = 2

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -410,8 +410,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         self.blocking_factor_x = kw.pop('warpx_blocking_factor_x', None)
         self.blocking_factor_y = kw.pop('warpx_blocking_factor_y', None)
 
-        self.potential_xmin = None
-        self.potential_xmax = None
+        self.potential_xmin = kw.pop('warpx_potential_lo_r', None)
+        self.potential_xmax = kw.pop('warpx_potential_hi_r', None)
         self.potential_ymin = None
         self.potential_ymax = None
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -666,12 +666,20 @@ void ElectrostaticSolver::BoundaryHandler::definePhiBCs ( )
 #ifdef WARPX_DIM_RZ
     WarpX& warpx = WarpX::GetInstance();
     auto geom = warpx.Geom(0);
-    if (geom.ProbLo() == 0){
+    if (geom.ProbLo(0) == 0){
         lobc[0] = LinOpBCType::Neumann;
-        hibc[0] = LinOpBCType::Dirichlet;
         dirichlet_flag[0] = false;
-        dirichlet_flag[1] = true;
         dim_start = 1;
+
+        // handle the r_max boundary explicity
+        if (WarpX::field_boundary_hi[0] == FieldBoundaryType::PEC) {
+            hibc[0] = LinOpBCType::Dirichlet;
+            dirichlet_flag[1] = true;
+        }
+        else if (WarpX::field_boundary_hi[0] == FieldBoundaryType::None) {
+            hibc[0] = LinOpBCType::Neumann;
+            dirichlet_flag[1] = false;
+        }
     }
 #endif
     for (int idim=dim_start; idim<AMREX_SPACEDIM; idim++){

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -698,11 +698,6 @@ void ReadBCParams ()
             }
         }
     }
-#ifdef WARPX_DIM_RZ
-    // Ensure code aborts if PEC is specified at r=0 for RZ
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( WarpX::field_boundary_lo[0] == FieldBoundaryType::None,
-        "Error : Field boundary at r=0 must be ``none``. \n");
-#endif
 
     // Appending periodicity information to input so that it can be used by amrex
     // to set parameters necessary to define geometry and perform communication

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -891,6 +891,13 @@ WarpX::ReadParameters ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(0) == 0,
             "The problem must not be periodic in the radial direction");
 
+        // Ensure code aborts if PEC is specified at r=0 for RZ
+        if (Geom(0).ProbLo(0) == 0){
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WarpX::field_boundary_lo[0] == FieldBoundaryType::None,
+                "Error : Field boundary at r=0 must be ``none``. \n");
+        }
+
         if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
             // Force do_nodal=true (that is, not staggered) and
             // use same shape factors in all directions, for gathering


### PR DESCRIPTION
Currently in electrostatic `RZ` simulations the `rmin` boundary is hard coded to use a Neumann boundary condition. This makes sense if `rmin == 0` but not otherwise. This PR allows the user to set a Dirichlet boundary condition (and boundary potential) if `rmin != 0`.
A use case for the added functionality can be seen in https://github.com/ModernElectron/WarpX/pull/131 where a cylindrical vacuum thermionic diode was simulated. The test shown in that PR also provides evidence that the `rmin != 0` case works as expected (at least for electrostatic simulations).