### PR TITLE
Docs: Spack Dev - Relax MPL Pin

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -74,7 +74,7 @@ If you also want to run runtime tests and added Python (``spack add python`` and
 
 .. code-block:: bash
 
-   python3 -m pip install matplotlib==3.2.2 yt scipy numpy openpmd-api virtualenv
+   python3 -m pip install matplotlib yt scipy numpy openpmd-api virtualenv
 
 If you want to run the ``./run_test.sh`` :ref:`test script <developers-testing>`, which uses our legacy GNUmake build system, you need to set the following environment hints after ``spack env activate warpx-dev`` for dependent software:
 


### PR DESCRIPTION
Relax the pinned version of `matplotlib`, documented in our Spack developer enviornment documentation. This caused problems (tried to re-compile and did not find freetype) on Ubuntu 20.04. We pinned this earlier, since yt was incompatible.