### PR TITLE
Make moving window dimensionality consistent in PICMI

### DIFF
--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
@@ -29,7 +29,7 @@ grid = picmi.Cartesian1DGrid(
     upper_boundary_conditions = ['dirichlet'],
     lower_boundary_conditions_particles = ['absorbing'],
     upper_boundary_conditions_particles = ['absorbing'],
-    moving_window_velocity = [0., 0., c],
+    moving_window_velocity = [c],
     warpx_max_grid_size = max_grid_size,
     warpx_blocking_factor = blocking_factor)
 

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_rz.py
@@ -33,7 +33,7 @@ grid = picmi.CylindricalGrid(
     upper_boundary_conditions = ['dirichlet', 'dirichlet'],
     lower_boundary_conditions_particles = ['absorbing', 'absorbing'],
     upper_boundary_conditions_particles = ['absorbing', 'absorbing'],
-    moving_window_zvelocity = c,
+    moving_window_velocity = [0., c],
     warpx_max_grid_size = max_grid_size,
     warpx_blocking_factor = blocking_factor)
 

--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
@@ -11,7 +11,7 @@ nz = 64
 zmin = -200.e-6
 zmax = +200.e-6
 
-moving_window_velocity = [0., 0., constants.c]
+moving_window_velocity = [constants.c]
 
 number_per_cell_each_dim = [10]
 

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -91,7 +91,7 @@ grid = picmi.CylindricalGrid(number_of_cells = [nr, nz],
                              upper_boundary_conditions = ['none', 'periodic'],
                              lower_boundary_conditions_particles = ['absorbing', 'periodic'],
                              upper_boundary_conditions_particles = ['absorbing', 'periodic'],
-                             moving_window_zvelocity = 0.,
+                             moving_window_velocity = [0.,0.],
                              warpx_max_grid_size=64)
 
 solver = picmi.ElectromagneticSolver(grid=grid, cfl=1.)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -444,14 +444,14 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         pywarpx.boundary.particle_lo = [self.bc_rmin_particles, self.bc_zmin_particles]
         pywarpx.boundary.particle_hi = [self.bc_rmax_particles, self.bc_zmax_particles]
 
-        if self.moving_window_zvelocity is not None:
-            if np.isscalar(self.moving_window_zvelocity):
-                if self.moving_window_zvelocity !=0:
-                    pywarpx.warpx.do_moving_window = 1
-                    pywarpx.warpx.moving_window_dir = 'z'
-                    pywarpx.warpx.moving_window_v = self.moving_window_zvelocity/constants.c  # in units of the speed of light
-            else:
-                raise Exception('RZ PICMI moving_window_velocity (only available in z direction) should be a scalar')
+        if self.moving_window_velocity is not None and np.any(np.not_equal(self.moving_window_velocity, 0.)):
+            pywarpx.warpx.do_moving_window = 1
+            if self.moving_window_velocity[0] != 0.:
+                pywarpx.warpx.moving_window_dir = 'r'
+                pywarpx.warpx.moving_window_v = self.moving_window_velocity[0]/constants.c  # in units of the speed of light
+            if self.moving_window_velocity[1] != 0.:
+                pywarpx.warpx.moving_window_dir = 'z'
+                pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -501,9 +501,9 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
 
         if self.moving_window_velocity is not None and np.any(np.not_equal(self.moving_window_velocity, 0.)):
             pywarpx.warpx.do_moving_window = 1
-            if self.moving_window_velocity[2] != 0.:
+            if self.moving_window_velocity[0] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
-                pywarpx.warpx.moving_window_v = self.moving_window_velocity[2]/constants.c  # in units of the speed of light
+                pywarpx.warpx.moving_window_v = self.moving_window_velocity[0]/constants.c  # in units of the speed of light
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -59,7 +59,7 @@ setup(name = 'pywarpx',
       package_dir = {'pywarpx': 'pywarpx'},
       description = """Wrapper of WarpX""",
       package_data = package_data,
-      install_requires = ['numpy', 'picmistandard==0.0.18', 'periodictable'],
+      install_requires = ['numpy', 'picmistandard==0.0.19', 'periodictable'],
       python_requires = '>=3.6',
       zip_safe=False
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy~=1.15
 periodictable~=1.5
 
 # PICMI
-picmistandard==0.0.18
+picmistandard==0.0.19
 #   for development against an unreleased PICMI version, use:
 #picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 


### PR DESCRIPTION
This PR makes moving window velocity dimensions consistent with the code's dimensions (cf Issue #2702 ). Now, we need to use (assuming moving window direction is "z")

moving_window_velocity = [0., 0., c] in 3D
moving_window_velocity = [0., c] in 2D
moving_window_velocity = [c] in 1D

This closes #2702.