### PR TITLE
Relativistic ES - only add the E-field due to boundary potentials once

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2461,7 +2461,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [ElectrostaticSphere]
 buildDir = .
 inputFile = Examples/Tests/ElectrostaticSphere/inputs_3d
-runtime_params =
+runtime_params = warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -64,43 +64,48 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
         AddSpaceChargeFieldLabFrame();
     }
     else {
-        // Calculate the E and B components due to boundary potentials alone
-        // Allocate fields for charge and potential
-        const int num_levels = max_level + 1;
-        Vector<std::unique_ptr<MultiFab> > rho(num_levels);
-        Vector<std::unique_ptr<MultiFab> > phi(num_levels);
-        // Use number of guard cells used for local deposition of rho
-        const amrex::IntVect ng = guard_cells.ng_depos_rho;
-        for (int lev = 0; lev <= max_level; lev++) {
-            BoxArray nba = boxArray(lev);
-            nba.surroundingNodes();
-            rho[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, ng);
-            rho[lev]->setVal(0.);
-            phi[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, 1);
-            phi[lev]->setVal(0.);
-        }
-        // Set the boundary potentials appropriately
-        setPhiBC(phi);
-
-        // beta is zero for boundaries
-        std::array<Real, 3> beta = {0._rt};
-
-        // Compute the potential phi, by solving the Poisson equation
-        computePhi( rho, phi, beta, self_fields_required_precision,
-                    self_fields_absolute_tolerance, self_fields_max_iters,
-                    self_fields_verbosity );
-
-        // Compute the corresponding electric and magnetic field, from the potential phi
-        computeE( Efield_fp, phi, beta );
-        computeB( Bfield_fp, phi, beta );
-
+        bool calculate_background_field = false;
         // Loop over the species and add their space-charge contribution to E and B
         for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
             WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
             if (species.initialize_self_fields ||
                 (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
                 AddSpaceChargeField(species);
+                calculate_background_field = true;
             }
+        }
+
+        if (calculate_background_field){
+            // Calculate the E and B components due to boundary potentials alone
+            // Allocate fields for charge and potential
+            const int num_levels = max_level + 1;
+            Vector<std::unique_ptr<MultiFab> > rho(num_levels);
+            Vector<std::unique_ptr<MultiFab> > phi(num_levels);
+            // Use number of guard cells used for local deposition of rho
+            const amrex::IntVect ng = guard_cells.ng_depos_rho;
+            for (int lev = 0; lev <= max_level; lev++) {
+                BoxArray nba = boxArray(lev);
+                nba.surroundingNodes();
+                rho[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, ng);
+                rho[lev]->setVal(0.);
+                phi[lev] = std::make_unique<MultiFab>(nba, DistributionMap(lev), 1, 1);
+                phi[lev]->setVal(0.);
+            }
+
+            // Set the boundary potentials appropriately
+            setPhiBC(phi);
+
+            // beta is zero for boundaries
+            std::array<Real, 3> beta = {0._rt};
+
+            // Compute the potential phi, by solving the Poisson equation
+            computePhi( rho, phi, beta, self_fields_required_precision,
+                        self_fields_absolute_tolerance, self_fields_max_iters,
+                        self_fields_verbosity );
+
+            // Compute the corresponding electric and magnetic field, from the potential phi
+            computeE( Efield_fp, phi, beta );
+            computeB( Bfield_fp, phi, beta );
         }
     }
     // Transfer fields from 'fp' array to 'aux' array.

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -101,7 +101,6 @@ WarpX::AddBoundaryField ()
     // stored yet
     if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
 
-    // Calculate the E and B components due to boundary potentials alone
     // Allocate fields for charge and potential
     const int num_levels = max_level + 1;
     Vector<std::unique_ptr<MultiFab> > rho(num_levels);

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -595,6 +595,9 @@ WarpX::computeB (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >
                  const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                  std::array<amrex::Real, 3> const beta ) const
 {
+    // return early if beta is 0 since there will be no B-field
+    if ((beta[0] == 0._rt) && (beta[1] == 0._rt) && (beta[2] == 0._rt)) return;
+
     for (int lev = 0; lev <= max_level; lev++) {
 
         const Real* dx = Geom(lev).CellSize();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -694,6 +694,7 @@ public:
 
     ElectrostaticSolver::BoundaryHandler field_boundary_handler;
     void ComputeSpaceChargeField (bool const reset_fields);
+    void AddBoundaryField ();
     void AddSpaceChargeField (WarpXParticleContainer& pc);
     void AddSpaceChargeFieldLabFrame ();
     void computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -704,9 +704,7 @@ public:
                      const int max_iters=200,
                      const int verbosity=2) const;
 
-    void setPhiBC (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
-                   amrex::Array<amrex::Real,AMREX_SPACEDIM>& phi_bc_values_lo,
-                   amrex::Array<amrex::Real,AMREX_SPACEDIM>& phi_bc_values_hi ) const;
+    void setPhiBC (amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi ) const;
 
     void computeE (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >& E,
                    const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,


### PR DESCRIPTION
This PR addresses the second point of #2708. The E-field due to boundary potentials is now calculated in a separate step from the E-fields due to particles. 
It was necessary to add a check that the E-field is only calculated if there is at least one species for which self-fields are calculated, otherwise several tests crash (such as `silver_mueller_2d_x`).