### PR TITLE
[WIP] Macroscopic solver in the pml region

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -140,6 +140,14 @@ public:
     amrex::MultiFab* GetG_fp ();
     amrex::MultiFab* GetG_cp ();
 
+    // When macroscopic solver is used with pml boundaries
+    amrex::MultiFab* Geteps_fp();
+    amrex::MultiFab* Geteps_cp();
+    amrex::MultiFab* Getmu_fp();
+    amrex::MultiFab* Getmu_cp();
+    amrex::MultiFab* Getsigma_fp();
+    amrex::MultiFab* Getsigma_cp();
+
     const MultiSigmaBox& GetMultiSigmaBox_fp () const
         { return *sigba_fp; }
 
@@ -220,6 +228,14 @@ private:
 
     std::unique_ptr<MultiSigmaBox> sigba_fp;
     std::unique_ptr<MultiSigmaBox> sigba_cp;
+
+    // macroscopic properties in PML, permittivity (epsilon), permeability (mu), conductivity (sigma)
+    std::unique_ptr<amrex::MultiFab> pml_eps_fp;
+    std::unique_ptr<amrex::MultiFab> pml_mu_fp;
+    std::unique_ptr<amrex::MultiFab> pml_sigma_fp;
+    std::unique_ptr<amrex::MultiFab> pml_eps_cp;
+    std::unique_ptr<amrex::MultiFab> pml_mu_cp;
+    std::unique_ptr<amrex::MultiFab> pml_sigma_cp;
 
 #ifdef WARPX_USE_PSATD
     std::unique_ptr<SpectralSolver> spectral_solver_fp;

--- a/Source/FieldSolver/FiniteDifferenceSolver/CMakeLists.txt
+++ b/Source/FieldSolver/FiniteDifferenceSolver/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(WarpX
     EvolveG.cpp
     FiniteDifferenceSolver.cpp
     MacroscopicEvolveE.cpp
+    MacroscopicEvolveEPML.cpp
     ApplySilverMuellerBoundary.cpp
 )
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -148,7 +148,7 @@ class FiniteDifferenceSolver
                       amrex::MultiFab* const eps_mf,
                       amrex::MultiFab* const mu_mf,
                       amrex::MultiFab* const sigma_mf);
-       
+
     private:
 
         int m_fdtd_algo;

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -123,6 +123,32 @@ class FiniteDifferenceSolver
                      std::array< amrex::MultiFab*, 3 > const Efield,
                      amrex::Real const dt );
 
+        /**
+          * \brief Macroscopic E-update in the pml region for non-vacuum medium using the user-selected
+          * finite-difference algorithm and macroscopic sigma-method defined in
+          * WarpXAlgorithmSelection.H
+          *
+          * \param[out] Efield                vector of electric field MultiFabs updated at a given level
+          * \param[in] Bfield                 vector of magnetic field MultiFabs at a given level
+          * \param[in] Jfield                 vector of current density MultiFabs at a given level
+          * \param[in] sigba                  PML factors used to damp current in the pml-region
+          * \param[in] dt                     timestep of the simulation
+          * \param[in] pml_has_particles      whether particle current-deposition and damping is on in the pml
+          * \param[in] macroscopic_properties contains user-defined properties of the medium.
+          * \param[in] eps_mf                 permittivity multifab in the pml region at a given level
+          * \param[in] mu_mf                  permeability multifab in the pml region at a given level
+          * \param[in] sigma_mf               conductivity multifab in the pml region at a given level
+          */
+       void MacroscopicEvolveEPML ( std::array< amrex::MultiFab*, 3 > Efield,
+                      std::array< amrex::MultiFab*, 3 > const Bfield,
+                      std::array< amrex::MultiFab*, 3 > const Jfield,
+                      MultiSigmaBox const& sigba,
+                      amrex::Real const dt, bool pml_has_particles,
+                      std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+                      amrex::MultiFab* const eps_mf,
+                      amrex::MultiFab* const mu_mf,
+                      amrex::MultiFab* const sigma_mf);
+       
     private:
 
         int m_fdtd_algo;
@@ -239,6 +265,18 @@ class FiniteDifferenceSolver
             std::array< std::unique_ptr< amrex::MultiFab>, 3> const& Jfield,
             amrex::Real const dt,
             std::unique_ptr<MacroscopicProperties> const& macroscopic_properties);
+
+        template< typename T_Algo, typename T_MacroAlgo>
+        void MacroscopicEvolveEPMLCartesian (
+            std::array< amrex::MultiFab*, 3> Efield,
+            std::array< amrex::MultiFab*, 3> Bfield,
+            std::array< amrex::MultiFab*, 3> Jfield,
+            MultiSigmaBox const& sigba,
+            amrex::Real const dt, bool pml_has_particles,
+            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+            amrex::MultiFab* const eps_mf,
+            amrex::MultiFab* const mu_mf,
+            amrex::MultiFab* const sigma_mf);
 
         template< typename T_Algo >
         void EvolveBPMLCartesian (

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -1,0 +1,250 @@
+/* Copyright 2022 Revathi Jambunathan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
+#ifdef WARPX_DIM_RZ
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
+#else
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H"
+#endif
+#include "BoundaryConditions/PML.H"
+#include "BoundaryConditions/PML_current.H"
+#include "BoundaryConditions/PMLComponent.H"
+#include "Utils/CoarsenIO.H"
+#include "Utils/WarpXConst.H"
+#include <AMReX_Gpu.H>
+#include <AMReX.H>
+
+using namespace amrex;
+
+void FiniteDifferenceSolver::MacroscopicEvolveEPML (
+    std::array< amrex::MultiFab*, 3 > Efield,
+    std::array< amrex::MultiFab*, 3 > const Bfield,
+    std::array< amrex::MultiFab*, 3 > const Jfield,
+    MultiSigmaBox const& sigba,
+    amrex::Real const dt, bool pml_has_particles,
+    std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+    amrex::MultiFab* const eps_mf,
+    amrex::MultiFab* const mu_mf,
+    amrex::MultiFab* const sigma_mf)
+{
+
+#ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Efield, Bfield, Jfield, sigba, dt, pml_has_particles, macroscopic_properties, eps_mf, mu_mf, sigma_mf);
+    amrex::Abort("macroscopic PML is not implemented in cylindrical geometry.");
+#else
+    if (m_do_nodal) {
+        amrex::Abort("Macroscopic Efield-push and pml is not implemented for nodal solver, yet");
+    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+        if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, LaxWendroffAlgo>
+                (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,
+                 macroscopic_properties, eps_mf, mu_mf, sigma_mf);
+        
+        } else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, BackwardEulerAlgo>
+                (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,
+                 macroscopic_properties, eps_mf, mu_mf, sigma_mf);
+        }
+    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+        if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, LaxWendroffAlgo>
+                (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,
+                 macroscopic_properties, eps_mf, mu_mf, sigma_mf);
+        } else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, BackwardEulerAlgo>
+                (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,
+                 macroscopic_properties, eps_mf, mu_mf, sigma_mf);
+        }
+    } else {
+        amrex::Abort("Unknown algorithm");
+    }
+#endif
+}
+
+#ifndef WARPX_DIM_RZ
+template<typename T_Algo, typename T_MacroAlgo>
+void FiniteDifferenceSolver::MacroscopicEvolveEPMLCartesian (
+    std::array< amrex::MultiFab*, 3> Efield,
+    std::array< amrex::MultiFab*, 3> Bfield,
+    std::array< amrex::MultiFab*, 3> Jfield,
+    MultiSigmaBox const& sigba,
+    amrex::Real const dt, bool pml_has_particles,
+    std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+    amrex::MultiFab* const eps_mf,
+    amrex::MultiFab* const mu_mf,
+    amrex::MultiFab* const sigma_mf)
+{
+    // Index type required for calling CoarsenIO::Interp to interpolate macroscopic
+    // properties from their respective staggering to the Ex, Ey, Ez locations
+    amrex::GpuArray<int, 3> const& sigma_stag = macroscopic_properties->sigma_IndexType;
+    amrex::GpuArray<int, 3> const& epsilon_stag = macroscopic_properties->epsilon_IndexType;
+    amrex::GpuArray<int, 3> const& macro_cr     = macroscopic_properties->macro_cr_ratio;
+    amrex::GpuArray<int, 3> const& Ex_stag = macroscopic_properties->Ex_IndexType;
+    amrex::GpuArray<int, 3> const& Ey_stag = macroscopic_properties->Ey_IndexType;
+    amrex::GpuArray<int, 3> const& Ez_stag = macroscopic_properties->Ez_IndexType;
+
+    // Loop through the grids, and over the tiles within each grid
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+        // Extract field data for this grid/tile
+        amrex::Array4<amrex::Real> const& Ex = Efield[0]->array(mfi);
+        amrex::Array4<amrex::Real> const& Ey = Efield[1]->array(mfi);
+        amrex::Array4<amrex::Real> const& Ez = Efield[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& Bx = Bfield[0]->array(mfi);
+        amrex::Array4<amrex::Real> const& By = Bfield[1]->array(mfi);
+        amrex::Array4<amrex::Real> const& Bz = Bfield[2]->array(mfi);
+        // Extract material properties
+        amrex::Array4<amrex::Real> const& sigma_arr = sigma_mf->array(mfi);
+        amrex::Array4<amrex::Real> const& eps_arr = eps_mf->array(mfi);
+        amrex::Array4<amrex::Real> const& mu_arr = mu_mf->array(mfi);
+        // Extract stencil coefficients
+        amrex::Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        int const n_coefs_x = m_stencil_coefs_x.size();
+        amrex::Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
+        int const n_coefs_y = m_stencil_coefs_y.size();
+        amrex::Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
+        int const n_coefs_z = m_stencil_coefs_z.size();
+
+        // This functor computes Hx = Bx/mu
+        // Note that mu is cell-centered here and will be interpolated/averaged
+        // to the location where the B-field and H-field are defined, i.e., at face-centers
+        FieldAccessorMacroscopic const Hx(Bx, mu_arr);
+        FieldAccessorMacroscopic const Hy(By, mu_arr);
+        FieldAccessorMacroscopic const Hz(Bz, mu_arr);
+
+        // Extract tileboxes for which to loop
+        amrex::Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
+        amrex::Box const& tey  = mfi.tilebox(Efield[1]->ixType().toIntVect());
+        amrex::Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
+        // starting component to interpolate macro properties to Ex, Ey, Ez locations
+        const int scomp = 0;
+        // Loop over the cells and update the fields
+        amrex::ParallelFor(tex, tey, tez,
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                // Interpolate conductivity, sigma, to Ex position on the grid
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ex_stag, macro_cr, i, j, k, scomp);
+                // Interpolated permittivity, epsilon, to Ex position on the grid
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ex_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ex(i, j, k, PMLComp::xz) = alpha * Ex(i, j, k, PMLComp::xz) - beta * (
+                    T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k, PMLComp::yx)
+                  + T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k, PMLComp::yz) );
+                Ex(i, j, k, PMLComp::xy) = alpha * Ex(i, j, k, PMLComp::xy) + beta * (
+                    T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k, PMLComp::zx)
+                  + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k, PMLComp::zy) );
+            },
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                // Interpolate conductivity, sigma, to Ey position on the grid
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ey_stag, macro_cr, i, j, k, scomp);
+                // Interpolated permittivity, epsilon, to Ey position on the grid
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ey_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ey(i, j, k, PMLComp::yx) = alpha * Ey(i, j, k, PMLComp::yx) - beta * (
+                    T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k, PMLComp::zx)
+                  + T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k, PMLComp::zy) );
+                Ey(i, j, k, PMLComp::yz) = alpha * Ey(i, j, k, PMLComp::yz) + beta * (
+                    T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k, PMLComp::xy)
+                  + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k, PMLComp::xz) );
+            },
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                // Interpolate conductivity, sigma, to Ez position on the grid
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ez_stag, macro_cr, i, j, k, scomp);
+                // Interpolated permittivity, epsilon, to Ez position on the grid
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ez_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ez(i, j, k, PMLComp::zy) = alpha * Ez(i, j, k, PMLComp::zy) - beta * (
+                    T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k, PMLComp::xy)
+                  + T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k, PMLComp::xz) );
+                Ez(i, j, k, PMLComp::zx) = alpha * Ez(i, j, k, PMLComp::zx) + beta * (
+                    T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k, PMLComp::yx)
+                  + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k, PMLComp::yz) );
+            }
+        );
+
+        // Update the E field in the PML, using the current
+        // deposited by the particles in the PML
+        if (pml_has_particles) {
+
+            // Extract field data for this grid/tile
+            Array4<Real> const& Jx = Jfield[0]->array(mfi);
+            Array4<Real> const& Jy = Jfield[1]->array(mfi);
+            Array4<Real> const& Jz = Jfield[2]->array(mfi);
+            const Real* sigmaj_x = sigba[mfi].sigma[0].data();
+            const Real* sigmaj_y = sigba[mfi].sigma[1].data();
+            const Real* sigmaj_z = sigba[mfi].sigma[2].data();
+            int const x_lo = sigba[mfi].sigma[0].lo();
+#if defined(WARPX_DIM_3D)
+            int const y_lo = sigba[mfi].sigma[1].lo();
+            int const z_lo = sigba[mfi].sigma[2].lo();
+#else
+            int const y_lo = 0;
+            int const z_lo = sigba[mfi].sigma[1].lo();
+#endif
+            amrex::ParallelFor( tex, tey, tez,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    // Interpolate conductivity, sigma, to Ex position on the grid
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ex_stag, macro_cr, i, j, k, scomp);
+                    // Interpolated permittivity, epsilon, to Ex position on the grid
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ex_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ex_pml_current(i, j, k, Ex, Jx,
+                        sigmaj_y, sigmaj_z, y_lo, z_lo, beta);
+                },
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    // Interpolate conductivity, sigma, to Ey position on the grid
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ey_stag, macro_cr, i, j, k, scomp);
+                    // Interpolated permittivity, epsilon, to Ey position on the grid
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ey_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ey_pml_current(i, j, k, Ey, Jy,
+                        sigmaj_x, sigmaj_z, x_lo, z_lo, beta);
+                },
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    // Interpolate conductivity, sigma, to Ez position on the grid
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ez_stag, macro_cr, i, j, k, scomp);
+                    // Interpolated permittivity, epsilon, to Ez position on the grid
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ez_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ez_pml_current(i, j, k, Ez, Jz,
+                        sigmaj_x, sigmaj_y, x_lo, y_lo, beta);
+                }
+            );
+        }
+    }
+}
+#endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -47,7 +47,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveEPML (
             MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, LaxWendroffAlgo>
                 (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,
                  macroscopic_properties, eps_mf, mu_mf, sigma_mf);
-        
+
         } else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
             MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, BackwardEulerAlgo>
                 (Efield, Bfield, Jfield, sigba, dt, pml_has_particles,

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -66,27 +66,18 @@ public:
      /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
      amrex::GpuArray<int, 3> macro_cr_ratio;
 
-private:
-
-     /** Conductivity, sigma, of the medium */
-     amrex::Real m_sigma = 0.0;
-     /** Permittivity, epsilon, of the medium */
-     amrex::Real m_epsilon = PhysConst::ep0;
-     /** Permeability, mu, of the medium */
-     amrex::Real m_mu = PhysConst::mu0;
-     /** Multifab for m_sigma */
-     std::unique_ptr<amrex::MultiFab> m_sigma_mf;
-     /** Multifab for m_epsilon */
-     std::unique_ptr<amrex::MultiFab> m_eps_mf;
-     /** Multifab for m_mu */
-     std::unique_ptr<amrex::MultiFab> m_mu_mf;
-
      /** Stores initialization type for conductivity : constant or parser */
      std::string m_sigma_s = "constant";
      /** Stores initialization type for permittivity : constant or parser */
      std::string m_epsilon_s = "constant";
      /** Stores initialization type for permeability : constant or parser */
      std::string m_mu_s = "constant";
+     /** Conductivity, sigma, of the medium */
+     amrex::Real m_sigma = 0.0;
+     /** Permittivity, epsilon, of the medium */
+     amrex::Real m_epsilon = PhysConst::ep0;
+     /** Permeability, mu, of the medium */
+     amrex::Real m_mu = PhysConst::mu0;
 
      /** string for storing parser function */
      std::string m_str_sigma_function;
@@ -96,6 +87,16 @@ private:
      std::unique_ptr<amrex::Parser> m_sigma_parser;
      std::unique_ptr<amrex::Parser> m_epsilon_parser;
      std::unique_ptr<amrex::Parser> m_mu_parser;
+
+private:
+
+     /** Multifab for m_sigma */
+     std::unique_ptr<amrex::MultiFab> m_sigma_mf;
+     /** Multifab for m_epsilon */
+     std::unique_ptr<amrex::MultiFab> m_eps_mf;
+     /** Multifab for m_mu */
+     std::unique_ptr<amrex::MultiFab> m_mu_mf;
+
 
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/Make.package
+++ b/Source/FieldSolver/FiniteDifferenceSolver/Make.package
@@ -9,6 +9,7 @@ CEXE_sources += EvolveBPML.cpp
 CEXE_sources += EvolveEPML.cpp
 CEXE_sources += EvolveFPML.cpp
 CEXE_sources += ApplySilverMuellerBoundary.cpp
+CEXE_sources += MacroscopicEvolveEPML.cpp
 
 include $(WARPX_HOME)/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/Make.package
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -676,19 +676,19 @@ WarpX::MacroscopicEvolveE (int lev, PatchType patch_type, amrex::Real a_dt) {
     }
     if (do_pml && pml[lev]->ok()) {
         if (patch_type == PatchType::fine) {
-            m_fdtd_solver_fp[lev]->EvolveEPML(
+            m_fdtd_solver_fp[lev]->MacroscopicEvolveEPML(
                 pml[lev]->GetE_fp(), pml[lev]->GetB_fp(),
-                pml[lev]->Getj_fp(), pml[lev]->Get_edge_lengths(),
-                pml[lev]->GetF_fp(),
-                pml[lev]->GetMultiSigmaBox_fp(),
-                a_dt, pml_has_particles );
+                pml[lev]->Getj_fp(), pml[lev]->GetMultiSigmaBox_fp(),
+                a_dt, pml_has_particles, m_macroscopic_properties,
+                pml[lev]->Geteps_fp(), pml[lev]->Getmu_fp(),
+                pml[lev]->Getsigma_fp());
         } else {
-            m_fdtd_solver_cp[lev]->EvolveEPML(
+            m_fdtd_solver_fp[lev]->MacroscopicEvolveEPML(
                 pml[lev]->GetE_cp(), pml[lev]->GetB_cp(),
-                pml[lev]->Getj_cp(), pml[lev]->Get_edge_lengths(),
-                pml[lev]->GetF_cp(),
-                pml[lev]->GetMultiSigmaBox_cp(),
-                a_dt, pml_has_particles );
+                pml[lev]->Getj_cp(), pml[lev]->GetMultiSigmaBox_cp(),
+                a_dt, pml_has_particles, m_macroscopic_properties,
+                pml[lev]->Geteps_cp(), pml[lev]->Getmu_cp(),
+                pml[lev]->Getsigma_cp());
         }
     }
 


### PR DESCRIPTION
In this PR, the macroscopic solver is extended to the E-field defined in the pml region. 
The input file used to test this is attached below
[inputs_laser_3d.txt](https://github.com/ECP-WarpX/WarpX/files/7841806/inputs_laser_3d.txt)


The test-case includes eps_r=4 for the material on the right side of the image below, and a laser in injected at an angle in the vacuum region. 

With the development branch, after entering the material and reaching the pml boundary, the signal is reflected, unlike what we expect at the pml boundary. 
![nomacroinpml](https://user-images.githubusercontent.com/41089244/148839558-702e449a-0baf-4af3-a6d8-ca599fa8687c.gif)

With this PR, the reflection is now fixed.
![with_macroinpml](https://user-images.githubusercontent.com/41089244/148841532-ad434cc4-2ff3-4a9d-b731-809831e1d2ad.gif)


