### PR TITLE
Fix PML with anisotropic refinement ratio

### DIFF
--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_anisotropic.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_MR_anisotropic.json
@@ -2,43 +2,43 @@
   "electrons": {
     "particle_cpu": 32768.0,
     "particle_id": 1123057664.0,
-    "particle_momentum_x": 4.2441494210115385e-20,
+    "particle_momentum_x": 4.241333654356747e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 4.2429971697106366e-20,
-    "particle_position_x": 0.6553605498557016,
-    "particle_position_y": 0.655360420612517,
+    "particle_momentum_z": 4.243147160194918e-20,
+    "particle_position_x": 0.6553604355411431,
+    "particle_position_y": 0.6553604252756429,
     "particle_weight": 3200000000000000.5
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 32.13899895667297,
+    "By": 31.85950148151796,
     "Bz": 0.0,
-    "Ex": 7573285869190.605,
+    "Ex": 7575288819909.899,
     "Ey": 0.0,
-    "Ez": 7572536902181.709,
-    "jx": 7302040020242814.0,
+    "Ez": 7572601899574.373,
+    "jx": 7297234592450874.0,
     "jy": 0.0,
-    "jz": 7302892615117250.0
+    "jz": 7303113293544192.0
   },
   "lev=1": {
     "Bx": 0.0,
-    "By": 74.04987113513879,
+    "By": 75.34189668301649,
     "Bz": 0.0,
-    "Ex": 4601660582425.954,
+    "Ex": 4601932334532.539,
     "Ey": 0.0,
-    "Ez": 7012131128423.561,
-    "jx": 4495212217937750.0,
+    "Ez": 7011970862051.691,
+    "jx": 4494391278293099.5,
     "jy": 0.0,
-    "jz": 6848672875762947.0
+    "jz": 6848792132928508.0
   },
   "positrons": {
     "particle_cpu": 32768.0,
     "particle_id": 3371204608.0,
-    "particle_momentum_x": 4.2436090244998326e-20,
+    "particle_momentum_x": 4.2408343046906606e-20,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 4.2430343380944015e-20,
-    "particle_position_x": 0.6553600813503462,
-    "particle_position_y": 0.6553595861949815,
+    "particle_momentum_z": 4.243183197977201e-20,
+    "particle_position_x": 0.6553601964895763,
+    "particle_position_y": 0.6553595823177,
     "particle_weight": 3200000000000000.5
   }
 }

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -42,11 +42,13 @@ struct Sigma : amrex::Gpu::DeviceVector<amrex::Real>
 struct SigmaBox
 {
     SigmaBox (const amrex::Box& box, const amrex::BoxArray& grids,
-              const amrex::Real* dx, int ncell, int delta, const amrex::Box& regdomain);
+              const amrex::Real* dx, const amrex::IntVect& ncell, const amrex::IntVect& delta,
+              const amrex::Box& regdomain);
 
-    void define_single (const amrex::Box& regdomain, int ncell,
+    void define_single (const amrex::Box& regdomain, const amrex::IntVect& ncell,
                         const amrex::Array<amrex::Real,AMREX_SPACEDIM>& fac);
-    void define_multiple (const amrex::Box& box, const amrex::BoxArray& grids, int ncell,
+    void define_multiple (const amrex::Box& box, const amrex::BoxArray& grids,
+                          const amrex::IntVect& ncell,
                           const amrex::Array<amrex::Real,AMREX_SPACEDIM>& fac);
 
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
@@ -69,7 +71,8 @@ class SigmaBoxFactory
     : public amrex::FabFactory<SigmaBox>
 {
 public:
-    SigmaBoxFactory (const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta,
+    SigmaBoxFactory (const amrex::BoxArray& grid_ba, const amrex::Real* dx,
+                     const amrex::IntVect& ncell, const amrex::IntVect& delta,
                      const amrex::Box& regular_domain)
         : m_grids(grid_ba), m_dx(dx), m_ncell(ncell), m_delta(delta), m_regdomain(regular_domain) {}
     virtual ~SigmaBoxFactory () = default;
@@ -93,8 +96,8 @@ public:
 private:
     const amrex::BoxArray& m_grids;
     const amrex::Real* m_dx;
-    int m_ncell;
-    int m_delta;
+    amrex::IntVect m_ncell;
+    amrex::IntVect m_delta;
     amrex::Box m_regdomain;
 };
 
@@ -103,7 +106,8 @@ class MultiSigmaBox
 {
 public:
     MultiSigmaBox(const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-                  const amrex::BoxArray& grid_ba, const amrex::Real* dx, int ncell, int delta,
+                  const amrex::BoxArray& grid_ba, const amrex::Real* dx,
+                  const amrex::IntVect& ncell, const amrex::IntVect& delta,
                   const amrex::Box& regular_domain);
     void ComputePMLFactorsB (const amrex::Real* dx, amrex::Real dt);
     void ComputePMLFactorsE (const amrex::Real* dx, amrex::Real dt);
@@ -250,20 +254,23 @@ private:
                                          const amrex::Box& regular_domain,
                                          const amrex::Geometry& geom,
                                          const amrex::BoxArray& grid_ba,
-                                         int ncell, int do_pml_in_domain,
-                                         const amrex::IntVect do_pml_Lo,
-                                         const amrex::IntVect do_pml_Hi);
+                                         const amrex::IntVect& ncell,
+                                         int do_pml_in_domain,
+                                         const amrex::IntVect& do_pml_Lo,
+                                         const amrex::IntVect& do_pml_Hi);
 
     static amrex::BoxArray MakeBoxArray_single (const amrex::Box& regular_domain,
                                                 const amrex::BoxArray& grid_ba,
-                                                int ncell, const amrex::IntVect do_pml_Lo,
-                                                const amrex::IntVect do_pml_Hi);
+                                                const amrex::IntVect& ncell,
+                                                const amrex::IntVect& do_pml_Lo,
+                                                const amrex::IntVect& do_pml_Hi);
 
     static amrex::BoxArray MakeBoxArray_multiple (const amrex::Geometry& geom,
                                                   const amrex::BoxArray& grid_ba,
-                                                  int ncell, int do_pml_in_domain,
-                                                  const amrex::IntVect do_pml_Lo,
-                                                  const amrex::IntVect do_pml_Hi);
+                                                  const amrex::IntVect& ncell,
+                                                  int do_pml_in_domain,
+                                                  const amrex::IntVect& do_pml_Lo,
+                                                  const amrex::IntVect& do_pml_Hi);
 
     static void CopyToPML (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom);
 };


### PR DESCRIPTION
Use IntVect instead of int for the number of cells in PML so that
anisotropic refinement ratio can be properly handled.