### PR TITLE
Perlmutter: Set CRAY_ACCEL_TARGET for GPU-Enabled MPI

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -62,6 +62,9 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
    # GPU-aware MPI
    export MPICH_GPU_SUPPORT_ENABLED=1
 
+   #Necessary to use CUDA-Aware MPI and run a job
+   export CRAY_ACCEL_TARGET=nvidia80
+
    # optimize CUDA compilation for A100
    export AMREX_CUDA_ARCH=8.0
 

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -62,7 +62,7 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
    # GPU-aware MPI
    export MPICH_GPU_SUPPORT_ENABLED=1
 
-   #Necessary to use CUDA-Aware MPI and run a job
+   # necessary to use CUDA-Aware MPI and run a job
    export CRAY_ACCEL_TARGET=nvidia80
 
    # optimize CUDA compilation for A100


### PR DESCRIPTION
When I try to run a job on Perlmutter i obtain the following error:
```
MPIDI_CRAY_init: GPU_SUPPORT_ENABLED is requested, but GTL library is not linked
```
And in order to run the job it is necessary to add the line: 
`export CRAY_ACCEL_TARGET=nvidia80` in the `warpx.profile` document.
As it is said in the Perlmutter documentation: https://docs.nersc.gov/systems/perlmutter/
