### PR TITLE
Set geometry earlier in picmi

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -417,6 +417,13 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        # Geometry
+        # Set these as soon as the information is available
+        # (since these are needed to determine which shard object is loaded)
+        pywarpx.geometry.dims = 'RZ'
+        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
+        pywarpx.geometry.prob_hi = self.upper_bound
+
     def initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
@@ -432,10 +439,6 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         assert self.lower_bound[0] >= 0., Exception('Lower radial boundary must be >= 0.')
         assert self.bc_rmin != 'periodic' and self.bc_rmax != 'periodic', Exception('Radial boundaries can not be periodic')
 
-        # Geometry
-        pywarpx.geometry.dims = 'RZ'
-        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
-        pywarpx.geometry.prob_hi = self.upper_bound
         pywarpx.warpx.n_rz_azimuthal_modes = self.n_azimuthal_modes
 
         # Boundary conditions
@@ -478,6 +481,13 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        # Geometry
+        # Set these as soon as the information is available
+        # (since these are needed to determine which shard object is loaded)
+        pywarpx.geometry.dims = '1'
+        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
+        pywarpx.geometry.prob_hi = self.upper_bound
+
     def initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
@@ -487,11 +497,6 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
         pywarpx.amr.max_grid_size_x = self.max_grid_size_x
         pywarpx.amr.blocking_factor = self.blocking_factor
         pywarpx.amr.blocking_factor_x = self.blocking_factor_x
-
-        # Geometry
-        pywarpx.geometry.dims = '1'
-        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
-        pywarpx.geometry.prob_hi = self.upper_bound
 
         # Boundary conditions
         pywarpx.boundary.field_lo = [BC_map[bc] for bc in [self.bc_xmin]]
@@ -531,6 +536,13 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        # Geometry
+        # Set these as soon as the information is available
+        # (since these are needed to determine which shard object is loaded)
+        pywarpx.geometry.dims = '2'
+        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
+        pywarpx.geometry.prob_hi = self.upper_bound
+
     def initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
@@ -542,11 +554,6 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         pywarpx.amr.blocking_factor = self.blocking_factor
         pywarpx.amr.blocking_factor_x = self.blocking_factor_x
         pywarpx.amr.blocking_factor_y = self.blocking_factor_y
-
-        # Geometry
-        pywarpx.geometry.dims = '2'
-        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
-        pywarpx.geometry.prob_hi = self.upper_bound
 
         # Boundary conditions
         pywarpx.boundary.field_lo = [BC_map[bc] for bc in [self.bc_xmin, self.bc_ymin]]
@@ -592,6 +599,13 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        # Geometry
+        # Set these as soon as the information is available
+        # (since these are needed to determine which shard object is loaded)
+        pywarpx.geometry.dims = '3'
+        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
+        pywarpx.geometry.prob_hi = self.upper_bound
+
     def initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
@@ -605,11 +619,6 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         pywarpx.amr.blocking_factor_x = self.blocking_factor_x
         pywarpx.amr.blocking_factor_y = self.blocking_factor_y
         pywarpx.amr.blocking_factor_z = self.blocking_factor_z
-
-        # Geometry
-        pywarpx.geometry.dims = '3'
-        pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
-        pywarpx.geometry.prob_hi = self.upper_bound
 
         # Boundary conditions
         pywarpx.boundary.field_lo = [BC_map[bc] for bc in [self.bc_xmin, self.bc_ymin, self.bc_zmin]]

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -419,7 +419,7 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
 
         # Geometry
         # Set these as soon as the information is available
-        # (since these are needed to determine which shard object is loaded)
+        # (since these are needed to determine which shared object to load)
         pywarpx.geometry.dims = 'RZ'
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
@@ -483,7 +483,7 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
 
         # Geometry
         # Set these as soon as the information is available
-        # (since these are needed to determine which shard object is loaded)
+        # (since these are needed to determine which shared object to load)
         pywarpx.geometry.dims = '1'
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
@@ -538,7 +538,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
         # Geometry
         # Set these as soon as the information is available
-        # (since these are needed to determine which shard object is loaded)
+        # (since these are needed to determine which shared object to load)
         pywarpx.geometry.dims = '2'
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
@@ -601,7 +601,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
         # Geometry
         # Set these as soon as the information is available
-        # (since these are needed to determine which shard object is loaded)
+        # (since these are needed to determine which shared object to load)
         pywarpx.geometry.dims = '3'
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound


### PR DESCRIPTION
This moves the lines setting the geometry so that they are called when the `Grid` class is setup, instead of waiting until the rest of the initialization is done. The geometry is needed to determine which version of the shared object should be loaded. This will allow more flexibility for users, allowing earlier use of routines from `libwarpx`.