### PR TITLE
CI: Use new "archive_output = 0" mode

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -17,6 +17,7 @@ suiteName = WarpX-GPU
 COMP = g++
 add_to_c_make_command = TEST=TRUE USE_ASSERTION=TRUE WarpxBinDir=
 
+archive_output = 0
 purge_output = 1
 
 MAKE = make

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -14,6 +14,7 @@ sourceTree = C_Src
 # suiteName is the name prepended to all output directories
 suiteName = WarpX
 
+archive_output = 0
 purge_output = 1
 
 useCmake = 1


### PR DESCRIPTION
Avoid `.tgz`-ing the output files, so we can interact directly with plotfiles with our benchmark scripts.

Implementation proposed in:
https://github.com/AMReX-Codes/regression_testing/pull/117