### PR TITLE
[WIP] Output More Versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ if(WarpX_APP)
     target_sources(app PRIVATE Source/main.cpp)
 endif()
 
-#add_subdirectory(Source/ablastr)
+add_subdirectory(Source/ablastr)
 add_subdirectory(Source/BoundaryConditions)
 add_subdirectory(Source/Diagnostics)
 add_subdirectory(Source/EmbeddedBoundary)
@@ -315,6 +315,19 @@ endif()
 if(WIN32)
     target_compile_definitions(ablastr PUBLIC _USE_MATH_DEFINES)
 endif()
+
+# additional defines for version outputs
+#   CMake
+target_compile_definitions(ablastr PUBLIC CMAKE_VERSION=${CMAKE_VERSION})
+target_compile_definitions(ablastr PUBLIC CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+
+#   OS & Host Architecture
+target_compile_definitions(ablastr PUBLIC CMAKE_SYSTEM=${CMAKE_SYSTEM})
+target_compile_definitions(ablastr PUBLIC CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR})
+
+#   Compiler
+target_compile_definitions(ablastr PUBLIC CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID})
+target_compile_definitions(ablastr PUBLIC CMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION})
 
 
 # Warnings ####################################################################

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -23,6 +23,7 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
+#include "ablastr/version/VersionFormat.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrCore.H>
@@ -110,9 +111,7 @@ WarpX::InitData ()
 {
     WARPX_PROFILE("WarpX::InitData()");
     Print() << "WarpX (" << WarpX::Version() << ")\n";
-#ifdef WARPX_QED
-    Print() << "PICSAR (" << WarpX::PicsarVersion() << ")\n";
-#endif
+    ablastr::version::printSoftwareVersions();
 
     if (restart_chkfile.empty())
     {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -106,7 +106,6 @@ public:
     ~WarpX ();
 
     static std::string Version (); //!< Version of WarpX executable
-    static std::string PicsarVersion (); //!< Version of PICSAR dependency
 
     int Verbose () const { return verbose; }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2498,19 +2498,6 @@ WarpX::Version ()
         return version;
 }
 
-std::string
-WarpX::PicsarVersion ()
-{
-    std::string version;
-#ifdef PICSAR_GIT_VERSION
-    version = std::string(PICSAR_GIT_VERSION);
-#endif
-    if( version.empty() )
-        return std::string("Unknown");
-    else
-        return version;
-}
-
 bool
 WarpX::isAnyBoundaryPML()
 {

--- a/Source/ablastr/CMakeLists.txt
+++ b/Source/ablastr/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(version)

--- a/Source/ablastr/Make.package
+++ b/Source/ablastr/Make.package
@@ -1,5 +1,4 @@
-#CEXE_sources += ParticleBoundaries.cpp
-
 include $(WARPX_HOME)/Source/ablastr/particles/Make.package
+include $(WARPX_HOME)/Source/ablastr/version/Make.package
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr

--- a/Source/ablastr/particles/Make.package
+++ b/Source/ablastr/particles/Make.package
@@ -1,3 +1,3 @@
-#CEXE_sources += ParticleBoundaries.cpp
+#CEXE_sources += ParticleMoments.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/particles

--- a/Source/ablastr/profiler/Make.package
+++ b/Source/ablastr/profiler/Make.package
@@ -1,3 +1,3 @@
-#CEXE_sources += ParticleBoundaries.cpp
+#CEXE_sources += ProfilerWrapper.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/profiler

--- a/Source/ablastr/version/CMakeLists.txt
+++ b/Source/ablastr/version/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(ablastr
+  PRIVATE
+    VersionFormat.cpp
+)

--- a/Source/ablastr/version/Make.package
+++ b/Source/ablastr/version/Make.package
@@ -1,0 +1,3 @@
+CEXE_sources += VersionFormat.cpp
+
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/version

--- a/Source/ablastr/version/VersionFormat.H
+++ b/Source/ablastr/version/VersionFormat.H
@@ -1,0 +1,23 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef ABLASTR_VERSION_FORMAT
+#define ABLASTR_VERSION_FORMAT
+
+
+namespace ablastr::version {
+
+    /** Collect software dependencies of ABLASTR/WarpX
+     *
+     * amrex::Print() the versions of dependent software in ABLASTR/WarpX
+     * for output and reproducibility.
+     */
+    void
+    printSoftwareVersions();
+
+} // namespace ablastr::version
+
+#endif // ABLASTR_VERSION_FORMAT

--- a/Source/ablastr/version/VersionFormat.cpp
+++ b/Source/ablastr/version/VersionFormat.cpp
@@ -1,0 +1,209 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "VersionFormat.H"
+#include "WarpX.H"
+
+#include <AMReX_Print.H>
+
+#ifdef __CUDACC_VER_MAJOR__
+#   include <cuda.h>
+#endif
+#ifdef WARPX_USE_OPENPMD
+#   include "openPMD/openPMD.hpp"
+#endif
+#if defined(AMREX_USE_MPI)
+#   include <mpi.h>
+#endif
+
+#include <map>
+#include <string>
+#include <sstream>
+
+// Stringizes arguments after they have been expanded.
+#define ABLASTR_STRINGIZE(...) ABLASTR_STRINGIZE2(__VA_ARGS__)
+#define ABLASTR_STRINGIZE2(...) #__VA_ARGS__
+
+
+void
+ablastr::version::printSoftwareVersions()
+{
+    std::string const versionNotFound("unknown");
+    std::string const versionDisabled("disabled");
+
+    std::stringstream warpxCompute;
+#if defined(AMREX_USE_CUDA)
+    warpxCompute << "CUDA";
+#elif defined(AMREX_USE_HIP)
+    warpxCompute << "HIP";
+#elif defined(AMREX_USE_DPCPP)
+    warpxCompute << "SYCL/DPC++";
+#elif defined(AMREX_USE_OMP)
+    warpxCompute << "OpenMP";
+#else
+    warpxCompute << "NOACC";
+#endif
+
+    std::stringstream picsar;
+#ifdef PICSAR_GIT_VERSION
+    picsar << std::string(PICSAR_GIT_VERSION);
+#elif !defined(WARPX_QED)
+    picsar << versionDisabled;
+#endif
+    if( picsar.str().empty() )
+        picsar << versionNotFound;
+
+    std::stringstream picsarTableGen;
+#if defined(WARPX_QED_TABLE_GEN)
+    picsarTableGen << " (with table generation)";
+#endif
+
+#if 0 && defined(WARPX_QED_TABLE_GEN)
+    // commented, since only transitively from PICSAR
+    std::stringstream boost;
+    boost << int(BOOST_VERSION / 100000) << "." << int(BOOST_VERSION / 100 % 1000) << "."
+          << int(BOOST_VERSION % 100);
+#endif
+
+    std::stringstream buildType;
+#ifdef CMAKE_BUILD_TYPE
+    buildType << ABLASTR_STRINGIZE(CMAKE_BUILD_TYPE);
+#else
+    buildType << versionNotFound;
+#endif
+
+    std::stringstream os;
+#ifdef CMAKE_SYSTEM
+    os << ABLASTR_STRINGIZE(CMAKE_SYSTEM);
+#else
+    os << versionNotFound;
+#endif
+
+    std::stringstream arch;
+#ifdef CMAKE_SYSTEM_PROCESSOR
+    arch << ABLASTR_STRINGIZE(CMAKE_SYSTEM_PROCESSOR);
+#else
+    arch << versionNotFound;
+#endif
+
+    std::stringstream cxx;
+#ifdef CMAKE_CXX_COMPILER_ID
+    cxx << ABLASTR_STRINGIZE(CMAKE_CXX_COMPILER_ID);
+#else
+    cxx << versionNotFound;
+#endif
+
+    std::stringstream cxxVersion;
+#ifdef CMAKE_CXX_COMPILER_VERSION
+    cxxVersion << ABLASTR_STRINGIZE(CMAKE_CXX_COMPILER_VERSION);
+#else
+    cxxVersion << versionNotFound;
+#endif
+
+    std::stringstream cmake;
+#ifdef CMAKE_VERSION
+    cmake << ABLASTR_STRINGIZE(CMAKE_VERSION);
+#else
+    cmake << versionNotFound;
+#endif
+
+    std::stringstream computeVersion;
+#ifdef __CUDACC_VER_MAJOR__
+    computeVersion << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__ << "." << __CUDACC_VER_BUILD__;
+#endif
+
+#if defined(AMREX_USE_OMP)
+    std::map< int, std::string > mapOpenMP = {
+        {200505, "2.5"},
+        {200805, "3.0"},
+        {201107, "3.1"},
+        {201307, "4.0"},
+        {201511, "4.5"},
+        {201811, "5.0"}
+    };
+
+    if (mapOpenMP.count(_OPENMP) == 1u)
+        computeVersion << mapOpenMP[_OPENMP];
+    else
+        computeVersion << _OPENMP;
+#endif
+
+    // TODO: HIP, SYCL
+
+    std::stringstream mpiStandard;
+    std::stringstream mpiFlavor;
+    std::stringstream mpiFlavorVersion;
+#if defined(AMREX_USE_MPI)
+    mpiStandard << MPI_VERSION << "." << MPI_SUBVERSION;
+#   if defined(OMPI_MAJOR_VERSION)
+    // includes derivatives such as Bull MPI, Sun, ...
+    mpiFlavor << "OpenMPI";
+    mpiFlavorVersion << OMPI_MAJOR_VERSION << "." << OMPI_MINOR_VERSION << "." << OMPI_RELEASE_VERSION;
+#   elif defined(MPICH_VERSION)
+    /* includes MPICH2 and MPICH3 and
+     * derivates such as IBM, Cray, MS, Intel, MVAPICH(2), ... */
+    mpiFlavor << "MPICH";
+    mpiFlavorVersion << MPICH_VERSION;
+#   else
+    mpiFlavor << versionNotFound;
+    mpiFlavorVersion << versionNotFound;
+#   endif
+#else
+    mpiStandard << versionDisabled;
+    mpiFlavor << versionDisabled;
+    mpiFlavorVersion << versionDisabled;
+#endif
+
+#ifdef WARPX_USE_OPENPMD
+    std::string openPMD = openPMD::getVersion();
+    std::string openPMDstandard = openPMD::getStandard();
+    std::string openPMDext;
+    auto const openPMDextVec = openPMD::getFileExtensions();
+    for (auto it = openPMDextVec.cbegin();
+         it != openPMDextVec.cend(); it++)
+    {
+        openPMDext.append(*it);
+
+        if (openPMDextVec.size() > 1)
+            if (openPMDextVec.end() - 1 != it)
+                openPMDext.append(",");
+    }
+#else
+    std::string openPMD = versionDisabled;
+    std::string openPMDstandard = versionDisabled;
+    std::string openPMDext = versionDisabled;
+#endif
+
+    // TODO: FFTW
+    // TODO: BLAS++/LAPACK++
+    // TODO: Ascent
+    // TODO: SENSEI
+
+    // command-line output
+    //   AMReX: automatically printed
+    //   app: add manually before this call
+    amrex::Print() << "Build options:" << "\n";
+    amrex::Print() << "  Build type: " << buildType.str() << "\n";
+    amrex::Print() << "  OS:         " << os.str() << "\n";
+    amrex::Print() << "  arch:       " << arch.str() << "\n";
+    amrex::Print() << "  CXX:        " << cxx.str() << " (" << cxxVersion.str() << ")" << "\n";
+    amrex::Print() << "  compute:    " << warpxCompute.str() << " (" << computeVersion.str() << ")" << "\n";
+    amrex::Print() << "Third party:" << std::endl;
+    amrex::Print() << "  CMake:      " << cmake.str() << "\n";
+    amrex::Print() << "  MPI:        " << std::endl
+                   << "    standard: " << mpiStandard.str() << "\n"
+                   << "    flavor:   " << mpiFlavor.str() << " (" << mpiFlavorVersion.str() << ")\n";
+    amrex::Print() << "  PICSAR:     " << picsar.str() << picsarTableGen.str() << "\n";
+    amrex::Print() << "  openPMD:    " << openPMD
+                   << " (standard: " << openPMDstandard
+                   << "; files: " << openPMDext << ")\n";
+    // only transitive in PICSAR QED with tables
+    // amrex::Print() << "  Boost:      " << boost.str() << "\n";
+    // TODO: FFTW
+    // TODO: BLAS++/LAPACK++
+    // TODO: Ascent
+    // TODO: SENSEI
+}


### PR DESCRIPTION
Add more build information and dependency information to our output on startup. This increases reproducibility by tracking more software dependencies and build options.

Example output when built with CMake:
```
MPI initialized with 1 MPI processes
MPI initialized with thread support level 3
OMP initialized with 8 OMP threads
AMReX (22.01-16-g7314e78fecda) initialized
WarpX (22.01-27-g73858579e907-dirty)
Build options:
  Build type: Release
  OS:         Linux-5.4.0-56-generic
  arch:       x86_64
  CXX:        GNU (9.3.0)
  accelerate: OpenMP (4.5)
Third party:
  CMake:      3.22.1
  MPI:        
    standard: 3.1
    flavor:   OpenMPI (4.1.2)
  PICSAR:     7b5449f92a4b
  openPMD:    0.14.3 (standard: 1.1.0; files: json,bp,sst,ssc,h5)
```
