### PR TITLE
RZ: Do Not Add geometry.coord_sys

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -547,11 +547,6 @@ void CheckGriddingForRZSpectral ()
     // Ensure that geometry.dims is set properly.
     CheckDims();
 
-    // Ensure that AMReX geometry.coord_sys is set properly
-    int coord_sys = 1;
-    ParmParse pp_geometry("geometry");
-    pp_geometry.add("coord_sys", coord_sys);
-
     ParmParse pp_algo("algo");
     int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
 


### PR DESCRIPTION
It seems like we were still adding by hand `geometry.coord_sys = 1` in RZ geometry, which in turn triggered the warning
https://github.com/ECP-WarpX/WarpX/blob/4e9d98c528dfebf05aa9d07edf451eff29f37f65/Source/WarpX.cpp#L1392-L1396
as reported in #2751.
