### PR TITLE
CI: Run `initial_distribution` on 1 MPI Process

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2575,7 +2575,7 @@ addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
-numprocs = 2
+numprocs = 1
 useOMP = 1
 numthreads = 1
 compileTest = 0


### PR DESCRIPTION
This CI test has 1 grid only, so it should run on 1 MPI process only. Thank you @lucafedeli88 for reporting this in #2751. 