### PR TITLE
RigidInjection_BTD: Specify H5 Backend

### DIFF
--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -59,6 +59,7 @@ btd_openpmd.num_snapshots_lab = 2
 btd_openpmd.dt_snapshots_lab = 1.8679589331096515e-13
 btd_openpmd.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
 btd_openpmd.format = openpmd
+btd_openpmd.openpmd_backend = h5
 btd_openpmd.buffer_size = 32
 
 btd_pltfile.diag_type = BackTransformed
@@ -66,7 +67,7 @@ btd_pltfile.do_back_transformed_fields = 1
 btd_pltfile.num_snapshots_lab = 2
 btd_pltfile.dt_snapshots_lab = 1.8679589331096515e-13
 btd_pltfile.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
-btd_pltfile.format = openpmd
+btd_pltfile.format = plotfile
 btd_pltfile.buffer_size = 32
 
 # old BTD diagnostics


### PR DESCRIPTION
For openPMD, we default to ADIOS `.bp` files when available.
This results for this test in:
```
amrex::Abort::0:: Currently BackTransformed diagnostics type does not support species output for ADIOS backend. Please select h5 as openpmd backend !!!
```
as seen by @PhilMiller.

Similar to #2661

Also fixes the format for `btd_pltfile` to be `btd_pltfile.format = plotfile`.