### PR TITLE
Fix override default particle tiling

### DIFF
--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 7314e78fecda4080f6bd3a1857d033545f7d8a56
+branch = 812836f08a758ef6f65caf7eea477bfc6423e72b
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 7314e78fecda4080f6bd3a1857d033545f7d8a56
+branch = 812836f08a758ef6f65caf7eea477bfc6423e72b
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -22,8 +22,7 @@ namespace {
 
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
-        pp_amrex.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
-        pp_amrex.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        pp_amrex.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
         // Work-around:
         // If warpx.numprocs is used for the domain decomposition, we will not use blocking factor
@@ -47,7 +46,7 @@ namespace {
 #else
             bool do_tiling = true;
 #endif
-            pp_particles.add("do_tiling", do_tiling);
+            pp_particles.queryAdd("do_tiling", do_tiling);
         }
     }
 }

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -13,7 +13,7 @@
 namespace {
     /** Overwrite defaults in AMReX Inputs
      *
-     * This overwrites defaults in amrex::ParamParse for inputs.
+     * This overwrites defaults in amrex::ParmParse for inputs.
      */
     void
     overwrite_amrex_parser_defaults()

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -40,7 +40,7 @@ namespace {
         // "false" in AMReX, to "false" if compiling for GPU execution and "true"
         // if compiling for CPU.
         {
-            ParmParse pp_particles("particles");
+            amrex::ParmParse pp_particles("particles");
 #ifdef AMREX_USE_GPU
             bool do_tiling = false; // By default, tiling is off on GPU
 #else

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -36,6 +36,19 @@ namespace {
             amrex::ParmParse pp_amr("amr");
             pp_amr.add("blocking_factor", 1);
         }
+
+        // Here we override the default tiling option for particles, which is always
+        // "false" in AMReX, to "false" if compiling for GPU execution and "true"
+        // if compiling for CPU.
+        {
+            ParmParse pp_particles("particles");
+#ifdef AMREX_USE_GPU
+            bool do_tiling = false; // By default, tiling is off on GPU
+#else
+            bool do_tiling = true;
+#endif
+            pp_particles.add("do_tiling", do_tiling);
+        }
     }
 }
 

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -16,7 +16,7 @@ namespace {
      * This overwrites defaults in amrex::ParmParse for inputs.
      */
     void
-    overwrite_amrex_parser_defaults()
+    overwrite_amrex_parser_defaults ()
     {
         amrex::ParmParse pp_amrex("amrex");
 
@@ -53,7 +53,7 @@ namespace {
 }
 
 amrex::AMReX*
-warpx_amrex_init(int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
+warpx_amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
 {
     return amrex::Initialize(
         argc,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -131,14 +131,7 @@ WarpXParticleContainer::ReadParameters ()
     if (!initialized)
     {
         ParmParse pp_particles("particles");
-
-#ifdef AMREX_USE_GPU
-        do_tiling = false; // By default, tiling is off on GPU
-#else
-        do_tiling = true;
-#endif
         pp_particles.query("do_tiling", do_tiling);
-
         initialized = true;
     }
 }

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -237,7 +237,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "7314e78fecda4080f6bd3a1857d033545f7d8a56"
+set(WarpX_amrex_branch "812836f08a758ef6f65caf7eea477bfc6423e72b"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -70,7 +70,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 7314e78fecda4080f6bd3a1857d033545f7d8a56 && cd -
+cd amrex && git checkout --detach 812836f08a758ef6f65caf7eea477bfc6423e72b && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 


### PR DESCRIPTION
When we want to override an AMReX default, we need to make sure we add it to the ParmParse table prior to the construction of the WarpX object. 

This was exposed by this PR to AMReX: https://github.com/AMReX-Codes/amrex/pull/2573