### PR TITLE
Fix unstable Python_particle_attr_access CI tests

### DIFF
--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -115,9 +115,9 @@ my_id = sim.extension.getMyProc()
 def add_particles():
 
     nps = 10 * (my_id + 1)
-    x = np.random.rand(nps) * 0.03
+    x = np.linspace(0.005, 0.025, nps)
     y = np.zeros(nps)
-    z = np.random.random(nps) * 0.03
+    z = np.linspace(0.005, 0.025, nps)
     ux = np.random.normal(loc=0, scale=1e3, size=nps)
     uy = np.random.normal(loc=0, scale=1e3, size=nps)
     uz = np.random.normal(loc=0, scale=1e3, size=nps)

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -36,7 +36,6 @@ xmax = 0.03
 ymin = 0
 ymax = 0.03
 
-
 ##########################
 # numerics components
 ##########################
@@ -105,6 +104,9 @@ sim.initialize_warpx()
 # python particle data access
 ##########################
 
+# set numpy random seed so that the particle properties generated
+# below will be reproducible from run to run
+np.random.seed(30025025)
 
 sim.extension.add_real_comp('electrons', 'newPid')
 

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -111,15 +111,18 @@ sim.initialize_warpx()
 # python particle data access
 ##########################
 
+# set numpy random seed so that the particle properties generated
+# below will be reproducible from run to run
+np.random.seed(30025025)
 
 sim.extension.add_real_comp('electrons', 'newPid')
 
 def add_particles():
 
     nps = 10
-    x = np.random.rand(nps) * 0.03
+    x = np.linspace(0.005, 0.025, nps)
     y = np.zeros(nps)
-    z = np.random.random(nps) * 0.03
+    z = np.linspace(0.005, 0.025, nps)
     ux = np.random.normal(loc=0, scale=1e3, size=nps)
     uy = np.random.normal(loc=0, scale=1e3, size=nps)
     uz = np.random.normal(loc=0, scale=1e3, size=nps)


### PR DESCRIPTION
The `numpy` random seed is now explicitly set in order to ensure that the particles injected during the test are the same from run to run. This will avoid the issue with these tests not consistently passing. Fixes #2764.