### PR TITLE
CI: GNUmake

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -60,6 +60,27 @@ jobs:
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl
 
+  # make sure legacy build system continues to build, i.e., that we don't forget
+  # to add new .cpp files
+  build_nvcc_gnumake:
+    name: NVCC 11.0.2 GNUmake
+    runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        .github/workflows/dependencies/nvcc11.sh
+    - name: build WarpX
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
+
+        git clone https://github.com/AMReX-Codes/amrex.git ../amrex
+        cd amrex && git checkout --detach e3b1468b8f16d11eebf4b10cca32829c78fb5d35 && cd -
+        make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE -j 2
+
   build_nvhpc21-9-nvcc:
     name: NVHPC@21.9 NVCC/NVC++ Release [tests]
     runs-on: ubuntu-20.04

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -130,7 +130,9 @@ ifeq ($(USE_SINGLE_PRECISION_PARTICLES),TRUE)
   USERSuffix := $(USERSuffix).pSP
 endif
 
-include $(PICSAR_HOME)/src/Make.package
+ifeq ($(QED),TRUE)
+  include $(PICSAR_HOME)/src/Make.package
+endif
 
 WARPX_GIT_VERSION := $(shell cd $(WARPX_HOME); git describe --abbrev=12 --dirty --always --tags)
 PICSAR_GIT_VERSION := $(shell cd $(PICSAR_HOME); git describe --abbrev=12 --dirty --always --tags)

--- a/Tools/Release/updateAMReX.py
+++ b/Tools/Release/updateAMReX.py
@@ -118,6 +118,20 @@ with open(run_test_path, encoding='utf-8') as f:
 with open(run_test_path, "w", encoding='utf-8') as f:
     f.write(run_test_content)
 
+# CI: legacy build check in .github/workflows/cuda.yml
+ci_gnumake_path = str(REPO_DIR.joinpath(".github/workflows/cuda.yml"))
+with open(ci_gnumake_path, encoding='utf-8') as f:
+    ci_gnumake_content = f.read()
+    #   branch/commit/tag (git fetcher) version
+    #     cd amrex && git checkout COMMIT_TAG_OR_BRANCH && cd -
+    ci_gnumake_content = re.sub(
+        r'(.*cd\s+amrex.+git checkout\s+--detach\s+)(.+)(\s+&&\s.*)',
+        r'\g<1>{}\g<3>'.format(amrex_new_branch),
+        ci_gnumake_content, flags = re.MULTILINE)
+
+with open(ci_gnumake_path, "w", encoding='utf-8') as f:
+    f.write(ci_gnumake_content)
+
 if ConfigUpdater is not None:
     # WarpX-tests.ini
     tests_ini_path = str(REPO_DIR.joinpath("Regression/WarpX-tests.ini"))


### PR DESCRIPTION
Since we migrated also Azure regression tests to CMake now, we should add a GNUmake build to CI, so we don't accidentally lose this capability (we will not duplicate the whole CI matrix).
Does a standard CUDA build without dependencies but enabling PSATD.