### PR TITLE
Docs: Crusher Load `cce` module

### DIFF
--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -2,6 +2,7 @@
 #export proj=<yourProject>
 
 # required dependencies
+module load cce
 module load cmake/3.21.3
 module load craype-accel-amd-gfx90a
 module load rocm/4.5.2

--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -2,7 +2,7 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cce
+module load cce/13.0.1
 module load cmake/3.21.3
 module load craype-accel-amd-gfx90a
 module load rocm/4.5.2

--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -2,11 +2,11 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cce/13.0.1
 module load cmake/3.21.3
 module load craype-accel-amd-gfx90a
 module load rocm/4.5.2
 module load cray-mpich
+module load cce/13.0.1  # must be loaded after rocm
 
 # optional: faster builds
 module load ccache


### PR DESCRIPTION
Without that compiler module in the `PrgEnv-cray` (default), HIP **RDC** builds do not work.
```
ld.lld: error: undefined symbol: __hip_fatbin
```

X-Ref:
- https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#compilers
- https://github.com/AMReX-Codes/amrex/pull/2584
- OLCFHELP-5465