### PR TITLE
Delete check on "legacy parameter" coord_sys, since it is automatically set by AMReX

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1393,13 +1393,6 @@ WarpX::BackwardCompatibility ()
             "lasers.nlasers is ignored. Just use lasers.names please.",
             WarnPriority::low);
     }
-    ParmParse pp_geometry("geometry");
-    std::string coord_sys;
-    if (pp_geometry.query("coord_sys", coord_sys)){
-        this->RecordWarning("Geometry",
-            "geometry.coord_sys is ignored. Please use the new geometry.dims parameter.",
-            WarnPriority::low);
-    }
 }
 
 // This is a virtual function.


### PR DESCRIPTION
`coord_sys` is now always automatically set by AMReX (https://github.com/AMReX-Codes/amrex/blob/3a2a74fc4b383fdda1d85abb7cd34fe8a6888362/Src/Base/AMReX_Geometry.cpp#L123 ) ! Therefore, if we keep this check we will always have a warning message, even if the inputfile does not contain `coord_sys` ...