### PR TITLE
RZ: Add error message when using 0 order for azimuthal decomposition

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -172,6 +172,7 @@ Setting up the field mesh
 
 * ``geometry.n_rz_azimuthal_modes`` (`integer`; 1 by default)
     When using the RZ version, this is the number of azimuthal modes.
+    The default is ``1``, which corresponds to a perfectly axisymmetric simulation.
 
 * ``geometry.prob_lo`` and ``geometry.prob_hi`` (`2 floats in 2D`, `3 floats in 3D`; in meters)
     The extent of the full simulation box. This box is rectangular, and thus its

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -858,8 +858,12 @@ WarpX::ReadParameters ()
         // Use same shape factors in all directions, for gathering
         if (do_nodal) galerkin_interpolation = false;
 
+#ifdef WARPX_DIM_RZ
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
         queryWithParser(pp_warpx, "n_rz_azimuthal_modes", n_rz_azimuthal_modes);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_rz_azimuthal_modes > 0,
+            "The number of azimuthal modes (n_rz_azimuthal_modes) must be at least 1");
+#endif
 
         // If true, the current is deposited on a nodal grid and centered onto a staggered grid.
         // Setting warpx.do_current_centering = 1 makes sense only if warpx.do_nodal = 0. Instead,


### PR DESCRIPTION
In case someone in the future does the same as me and wrongly assumes that ``geometry.n_rz_azimuthal_modes = 0`` corresponds to an axisymmetric simulation, this will result in an clean error message instead of a segfault.