### PR TITLE
Allow flux injection in the out-of-plane direction for RZ/2D geometry

### DIFF
--- a/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
+++ b/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
@@ -7,26 +7,28 @@
 # License: BSD-3-Clause-LBNL
 
 """
-This script tests the continuous injection of particles in 
+This script tests the continuous injection of particles in
 the azimuthal direction, in RZ geometry.
 
-In this tests, relativistic electrons are continuously injected 
-in a uniform Bz field, at a radius that corresponds to their 
-Larmor radius. Therefore, throughout the simulations, these 
-electrons always stay at the same radius, while gyrating 
+In this tests, relativistic electrons are continuously injected
+in a uniform Bz field, at a radius that corresponds to their
+Larmor radius. Therefore, throughout the simulations, these
+electrons always stay at the same radius, while gyrating
 around the z axis.
 
 This script tests that:
-- At the end of the simulation, the electrons are all at 
-  the correct radius. (This indirectly checks that the 
+- At the end of the simulation, the electrons are all at
+  the correct radius. (This indirectly checks that the
   electrons were injected with the correct velocity
   throughout the simulation, and in particular that this
   velocity was along the azimuthal direction.)
 - The total number of electrons corresponds to the expected flux.
 """
 import sys
+
 import numpy as np
 import yt
+
 yt.funcs.mylog.setLevel(0)
 
 # Open plotfile specified in command line
@@ -36,14 +38,14 @@ t_max = ds.current_time.item()  # time of simulation
 
 # Total number of electrons expected:
 flux = 1. # in m^-2.s^-1, from the input script
-emission_surface = 0.8 # in m^2, 
+emission_surface = 0.8 # in m^2,
 # given that xmin = 1.5, xmax = 1.9, zmin = -1.0, zmax = 1.
 n_tot = flux * emission_surface * t_max
 
 # Read particle data
 ad = ds.all_data()
 r = ad['particle_position_x'].to_ndarray() # Corresponds to the radial coordinate in RZ
-w = ad['particle_weight'].to_ndarray() 
+w = ad['particle_weight'].to_ndarray()
 
 # Check that the number of particles matches the expected one
 assert np.allclose( w.sum(), n_tot, rtol=0.05 )

--- a/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
+++ b/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+"""
+This script tests the continuous injection of particles in 
+the azimuthal direction, in RZ geometry.
+
+In this tests, relativistic electrons are continuously injected 
+in a uniform Bz field, at a radius that corresponds to their 
+Larmor radius. Therefore, throughout the simulations, these 
+electrons always stay at the same radius, while gyrating 
+around the z axis.
+
+This script tests that:
+- At the end of the simulation, the electrons are all at 
+  the correct radius. (This indirectly checks that the 
+  electrons were injected with the correct velocity
+  throughout the simulation, and in particular that this
+  velocity was along the azimuthal direction.)
+- The total number of electrons corresponds to the expected flux.
+"""
+import sys
+import numpy as np
+import yt
+yt.funcs.mylog.setLevel(0)
+
+# Open plotfile specified in command line
+fn = sys.argv[1]
+ds = yt.load( fn )
+t_max = ds.current_time.item()  # time of simulation
+
+# Total number of electrons expected:
+flux = 1. # in m^-2.s^-1, from the input script
+emission_surface = 0.8 # in m^2, 
+# given that xmin = 1.5, xmax = 1.9, zmin = -1.0, zmax = 1.
+n_tot = flux * emission_surface * t_max
+
+# Read particle data
+ad = ds.all_data()
+r = ad['particle_position_x'].to_ndarray() # Corresponds to the radial coordinate in RZ
+w = ad['particle_weight'].to_ndarray() 
+
+# Check that the number of particles matches the expected one
+assert np.allclose( w.sum(), n_tot, rtol=0.05 )
+# Check that the particles are at the right radius
+assert np.all( (r >= 1.5) && (r <=1.9) )
+
+test_name = os.path.split(os.getcwd())[1]
+
+if re.search( 'single_precision', fn ):
+    checksumAPI.evaluate_checksum(test_name, fn, rtol=1.e-3)
+else:
+    checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
+++ b/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
@@ -24,10 +24,13 @@ This script tests that:
   velocity was along the azimuthal direction.)
 - The total number of electrons corresponds to the expected flux.
 """
+import os
+import re
 import sys
-import os, re
+
 import numpy as np
 import yt
+
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 

--- a/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
+++ b/Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
@@ -25,9 +25,11 @@ This script tests that:
 - The total number of electrons corresponds to the expected flux.
 """
 import sys
-
+import os, re
 import numpy as np
 import yt
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import checksumAPI
 
 yt.funcs.mylog.setLevel(0)
 

--- a/Examples/Tests/FluxInjection/inputs_rz
+++ b/Examples/Tests/FluxInjection/inputs_rz
@@ -15,7 +15,7 @@ amr.max_grid_size = 16
 amr.max_level = 0
 
 # Geometry
-geometry.dims = rz
+geometry.dims = RZ
 geometry.prob_lo     =  0.0  -2.0        # physical domain
 geometry.prob_hi     =  3.0   2.0
 
@@ -36,13 +36,13 @@ warpx.use_filter = 0
 warpx.cfl = 1.0
 
 # particles
-particles.species_names = electron positron
+particles.species_names = electron
 
 electron.charge = -q_e
 electron.mass = m_e
 electron.injection_style = "SingleParticle"
 electron.single_particle_pos = 0.0  -1.7  0.0
-electron.single_particle_vel = -10.  0.0  0.0   # gamma*beta
+electron.single_particle_vel = 10.  0.0  0.0   # gamma*beta
 electron.single_particle_weight = 1.0
 
 # Order of particle shape factors

--- a/Examples/Tests/FluxInjection/inputs_rz
+++ b/Examples/Tests/FluxInjection/inputs_rz
@@ -65,8 +65,6 @@ warpx.do_dive_cleaning = 1
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 10
-diag1.write_particles = 1
+diag1.intervals = 1::10
 diag1.diag_type = Full
 diag1.fields_to_plot = Bz
-diag1.format = openpmd

--- a/Examples/Tests/FluxInjection/inputs_rz
+++ b/Examples/Tests/FluxInjection/inputs_rz
@@ -1,0 +1,62 @@
+# Maximum number of time steps
+max_step = 120
+
+# number of grid points
+amr.n_cell =  16  32
+
+# The lo and hi ends of grids are multipliers of blocking factor
+amr.blocking_factor = 16
+
+# Maximum allowable size of each subdomain in the problem domain;
+#    this is used to decompose the domain for parallel calculations.
+amr.max_grid_size = 16
+
+# Maximum level in hierarchy (for now must be 0, i.e., one level in total)
+amr.max_level = 0
+
+# Geometry
+geometry.dims = rz
+geometry.prob_lo     =  0.0  -2.0        # physical domain
+geometry.prob_hi     =  3.0   2.0
+
+# Boundary condition
+boundary.field_lo = none pec
+boundary.field_hi = pec pec
+
+particles.B_ext_particle_init_style = "constant"
+particles.B_external_particle = 0.  0.  1.e-2
+
+# Verbosity
+warpx.verbose = 1
+
+# Algorithms
+warpx.use_filter = 0
+
+# CFL
+warpx.cfl = 1.0
+
+# particles
+particles.species_names = electron positron
+
+electron.charge = -q_e
+electron.mass = m_e
+electron.injection_style = "SingleParticle"
+electron.single_particle_pos = 0.0  -1.7  0.0
+electron.single_particle_vel = -10.  0.0  0.0   # gamma*beta
+electron.single_particle_weight = 1.0
+
+# Order of particle shape factors
+algo.particle_shape = 3
+
+# Moving window
+warpx.do_moving_window = 0
+
+warpx.do_dive_cleaning = 1
+
+# Diagnostics
+diagnostics.diags_names = diag1
+diag1.intervals = 10
+diag1.write_particles = 1
+diag1.diag_type = Full
+diag1.fields_to_plot = Bz
+diag1.format = openpmd

--- a/Examples/Tests/FluxInjection/inputs_rz
+++ b/Examples/Tests/FluxInjection/inputs_rz
@@ -40,10 +40,20 @@ particles.species_names = electron
 
 electron.charge = -q_e
 electron.mass = m_e
-electron.injection_style = "SingleParticle"
-electron.single_particle_pos = 0.0  -1.7  0.0
-electron.single_particle_vel = 10.  0.0  0.0   # gamma*beta
-electron.single_particle_weight = 1.0
+electron.injection_style = NFluxPerCell
+electron.num_particles_per_cell = 1
+electron.surface_flux_pos = 0.
+electron.flux_normal_axis = t
+electron.flux_direction = +1
+electron.xmin = 1.5
+electron.xmax = 1.9
+electron.zmin = -1.0
+electron.zmax = 1.0
+electron.profile = constant
+electron.density = 1.
+electron.momentum_distribution_type = gaussianflux
+electron.uy_th = 0.
+electron.uy_m = 10.
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Regression/Checksum/benchmarks_json/FluxInjection.json
+++ b/Regression/Checksum/benchmarks_json/FluxInjection.json
@@ -1,0 +1,16 @@
+{
+  "electron": {
+    "particle_cpu": 0.0,
+    "particle_id": 17809220.0,
+    "particle_momentum_x": 1.771047564726242e-42,
+    "particle_momentum_y": 1.8010429574237632e-42,
+    "particle_momentum_z": 4.5894275602576847e-41,
+    "particle_position_x": 7013.28660219901,
+    "particle_position_y": 2072.97851839119,
+    "particle_theta": 6506.69168348596,
+    "particle_weight": 3.248107653772486e-08
+  },
+  "lev=0": {
+    "Bz": 2.206631903949293e-47
+  }
+}

--- a/Regression/Checksum/benchmarks_json/FluxInjection.json
+++ b/Regression/Checksum/benchmarks_json/FluxInjection.json
@@ -1,16 +1,16 @@
 {
   "electron": {
-    "particle_cpu": 0.0,
-    "particle_id": 17809220.0,
-    "particle_momentum_x": 1.771047564726242e-42,
-    "particle_momentum_y": 1.8010429574237632e-42,
-    "particle_momentum_z": 4.5894275602576847e-41,
-    "particle_position_x": 7013.28660219901,
-    "particle_position_y": 2072.97851839119,
-    "particle_theta": 6506.69168348596,
-    "particle_weight": 3.248107653772486e-08
+    "particle_cpu": 2060.0,
+    "particle_id": 8893516.0,
+    "particle_momentum_x": 1.7856085576594427e-42,
+    "particle_momentum_y": 1.7883824545080506e-42,
+    "particle_momentum_z": 4.565443974152731e-41,
+    "particle_position_x": 6992.343661648445,
+    "particle_position_y": 2049.9517671725316,
+    "particle_theta": 6536.38847902292,
+    "particle_weight": 3.240227722540627e-08
   },
   "lev=0": {
-    "Bz": 2.206631903949293e-47
+    "Bz": 2.20886367779576e-47
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -812,6 +812,24 @@ analysisRoutine = Examples/Tests/Langmuir/analysis_langmuir_multi_rz.py
 analysisOutputImage = Langmuir_multi_rz_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
+[FluxInjection]
+buildDir = .
+inputFile = Examples/Tests/FluxInjection/inputs_rz
+runtime_params = 
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron
+analysisRoutine = Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
+
 [Langmuir_multi_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -815,7 +815,7 @@ aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 [FluxInjection]
 buildDir = .
 inputFile = Examples/Tests/FluxInjection/inputs_rz
-runtime_params = 
+runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -131,7 +131,7 @@ struct InjectorMomentumGaussianFlux
         amrex::ignore_unused( x, y );
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
         amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
-#endif        
+#endif
         amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
 
         return amrex::XDim3{ux, uy, uz};

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -131,7 +131,7 @@ struct InjectorMomentumGaussianFlux
         amrex::ignore_unused( x, y );
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
         amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
-#endif
+#endif        
         amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
 
         return amrex::XDim3{ux, uy, uz};

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -114,7 +114,9 @@ struct InjectorMomentumGaussianFlux
         amrex::Real ur = std::sqrt(2._rt*std::log(1._rt/urand));
         if (m_flux_direction < 0) ur = -ur;
 
-        // Note that in 2D, with m_flux_normal_axis == 1, uy is out of the plane and so Gaussian and uz is v*Gaussian
+        // Note: Here, in RZ geometry, the variables `ux` and `uy` actually
+        // correspond to the radial and azimuthal component of the momentum
+        // (and e.g.`m_flux_normal_axis==1` corresponds to v*Gaussian along theta)
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
         amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
         amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -561,9 +561,10 @@ struct InjectorMomentum
         }
     }
 
-private:
     enum struct Type { constant, custom, gaussian, gaussianflux, boltzmann, juttner, radial_expansion, parser};
     Type type;
+
+private:
 
     // An instance of union Object constructs and stores any one of
     // the objects declared (constant or custom or gaussian or

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -105,7 +105,7 @@ struct InjectorMomentumGaussianFlux
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real /*z*/,
+    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
                  amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
@@ -114,26 +114,10 @@ struct InjectorMomentumGaussianFlux
         amrex::Real ur = std::sqrt(2._rt*std::log(1._rt/urand));
         if (m_flux_direction < 0) ur = -ur;
 
-#if (defined WARPX_DIM_RZ)
-        amrex::Real const u_r = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
-        amrex::Real const u_t = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
-        amrex::Real const r = std::sqrt( x*x + y*y );
-        amrex::Real ux, uy;
-        if (r > 0){
-          amrex::Real const inv_r = 1./r;
-          ux = (x*inv_r)*u_r - (y*inv_r)*u_t;
-          uy = (y*inv_r)*u_r + (x*inv_r)*u_t;
-        } else {
-          ux = u_r;
-          uy = u_t;
-        }
-#else
-        amrex::ignore_unused( x, y );
+        // Note that in 2D, with m_flux_normal_axis == 1, uy is out of the plane and so Gaussian and uz is v*Gaussian
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
         amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
-#endif        
         amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
-
         return amrex::XDim3{ux, uy, uz};
     }
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -105,7 +105,7 @@ struct InjectorMomentumGaussianFlux
 
     AMREX_GPU_HOST_DEVICE
     amrex::XDim3
-    getMomentum (amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+    getMomentum (amrex::Real x, amrex::Real y, amrex::Real /*z*/,
                  amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
@@ -114,10 +114,26 @@ struct InjectorMomentumGaussianFlux
         amrex::Real ur = std::sqrt(2._rt*std::log(1._rt/urand));
         if (m_flux_direction < 0) ur = -ur;
 
-        // Note that in 2D, with m_flux_normal_axis == 1, uy is out of the plane and so Gaussian and uz is v*Gaussian
+#if (defined WARPX_DIM_RZ)
+        amrex::Real const u_r = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
+        amrex::Real const u_t = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
+        amrex::Real const r = std::sqrt( x*x + y*y );
+        amrex::Real ux, uy;
+        if (r > 0){
+          amrex::Real const inv_r = 1./r;
+          ux = (x*inv_r)*u_r - (y*inv_r)*u_t;
+          uy = (y*inv_r)*u_r + (x*inv_r)*u_t;
+        } else {
+          ux = u_r;
+          uy = u_t;
+        }
+#else
+        amrex::ignore_unused( x, y );
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
         amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
+#endif        
         amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
+
         return amrex::XDim3{ux, uy, uz};
     }
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -116,8 +116,8 @@ struct InjectorMomentumGaussianFlux
 
         // Note that in 2D, with m_flux_normal_axis == 1, uy is out of the plane and so Gaussian and uz is v*Gaussian
         amrex::Real const ux = (m_flux_normal_axis == 0 ? m_ux_th*ur : amrex::RandomNormal(m_ux_m, m_ux_th, engine));
-        amrex::Real const uy = (m_flux_normal_axis == 1 && AMREX_SPACEDIM==3 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
-        amrex::Real const uz = (m_flux_normal_axis == WARPX_ZINDEX ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
+        amrex::Real const uy = (m_flux_normal_axis == 1 ? m_uy_th*ur : amrex::RandomNormal(m_uy_m, m_uy_th, engine));
+        amrex::Real const uz = (m_flux_normal_axis == 2 ? m_uz_th*ur : amrex::RandomNormal(m_uz_m, m_uz_th, engine));
         return amrex::XDim3{ux, uy, uz};
     }
 

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -46,12 +46,12 @@ struct InjectorPositionRandomPlane
         else          return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt};
 #elif (defined(WARPX_DIM_XZ))
         // In 2D, the 2 first components of the `XDim3` vector below correspond to x and z
-        if (dir == 0) return amrex::XDim3{0._rt, amrex::Random(engine), 0._rt)};
+        if (dir == 0) return amrex::XDim3{0._rt, amrex::Random(engine), 0._rt};
         if (dir == 1) return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt};
         else          return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
 #elif (defined(WARPX_DIM_1D_Z))
         // In 2D, the first components of the `XDim3` vector below correspond to z
-        if (dir == 0) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt)};
+        if (dir == 0) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
         if (dir == 1) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
         else          return amrex::XDim3{0._rt, 0._rt, 0._rt};
 #endif

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -39,9 +39,22 @@ struct InjectorPositionRandomPlane
                         amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
+#if ((defined WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+        // In RZ, the 3 components of the `XDim3` vector below correspond to r, theta, z respectively
         if (dir == 0) return amrex::XDim3{0._rt, amrex::Random(engine), amrex::Random(engine)};
         if (dir == 1) return amrex::XDim3{amrex::Random(engine), 0._rt, amrex::Random(engine)};
         else          return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt};
+#elif (defined(WARPX_DIM_XZ))
+        // In 2D, the 2 first components of the `XDim3` vector below correspond to x and z
+        if (dir == 0) return amrex::XDim3{0._rt, amrex::Random(engine), 0._rt)};
+        if (dir == 1) return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt};
+        else          return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
+#elif (defined(WARPX_DIM_1D_Z))
+        // In 2D, the first components of the `XDim3` vector below correspond to z
+        if (dir == 0) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt)};
+        if (dir == 1) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
+        else          return amrex::XDim3{0._rt, 0._rt, 0._rt};
+#endif
     }
 private:
     int dir;

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -40,11 +40,7 @@ struct InjectorPositionRandomPlane
     {
         using namespace amrex::literals;
         if (dir == 0) return amrex::XDim3{0._rt, amrex::Random(engine), amrex::Random(engine)};
-#if (defined WARPX_DIM_RZ)
-        if (dir == 1) return amrex::XDim3{amrex::Random(engine), 0._rt, 0._rt};
-#else
         if (dir == 1) return amrex::XDim3{amrex::Random(engine), 0._rt, amrex::Random(engine)};
-#endif
         else          return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt};
     }
 private:

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -107,6 +107,9 @@ public:
 
     bool surface_flux = false; // inject from a surface
     amrex::Real surface_flux_pos; // surface location
+    // Flux normal axis represents the direction in which to emit particles
+    // When compiled in Cartesian geometry, 0 = x, 1 = y, 2 = z
+    // When compiled in cylindrical geometry, 0 = radial, 1 = azimuthal, 2 = z
     int flux_normal_axis;
     int flux_direction; // -1 for left, +1 for right
 

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -252,6 +252,9 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         if      (flux_normal_axis_string == "r" || flux_normal_axis_string == "R") {
             flux_normal_axis = 0;
         }
+        if      (flux_normal_axis_string == "t" || flux_normal_axis_string == "T") {
+            flux_normal_axis = 1;
+        }
 #else
 #    ifndef WARPX_DIM_1D_Z
         if      (flux_normal_axis_string == "x" || flux_normal_axis_string == "X") {
@@ -265,7 +268,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         }
 #endif
         if (flux_normal_axis_string == "z" || flux_normal_axis_string == "Z") {
-            flux_normal_axis = WARPX_ZINDEX;
+            flux_normal_axis = 2;
         }
 #ifdef WARPX_DIM_3D
         std::string flux_normal_axis_help = "'x', 'y', or 'z'.";

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1428,6 +1428,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
         bool loc_do_field_ionization = do_field_ionization;
         int loc_ionization_initial_level = ionization_initial_level;
+        int const loc_flux_normal_axis = plasma_injector->flux_normal_axis;
 
         // Loop over all new particles and inject them (creates too many
         // particles, in particular does not consider xmin, xmax etc.).
@@ -1558,7 +1559,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // For cylindrical emission (flux_normal_axis==0
                 // or flux_normal_axis==2), the emission surface depends on
                 // the radius ; thus, the calculation is finalized here
-                if (plasma_injector->flux_normal_axis != 1) {
+                if (loc_flux_normal_axis != 1) {
                     if (radially_weighted) {
                          weight *= 2._rt*MathConst::pi*xb;
                     } else {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1265,6 +1265,8 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
             // The above formula captures the following cases:
             // - flux_normal_axis=0 (emission along x/r) and dir=0
             // - flux_normal_axis=2 (emission along z) and dir=1
+#elif defined(WARPX_DIM_1D_Z)
+            if ( (dir==0) && (plasma_injector->flux_normal_axis==2) ) {
 #endif
                 if (plasma_injector->flux_direction > 0) {
                     if (plasma_injector->surface_flux_pos <  tile_realbox.lo(dir) ||
@@ -1497,7 +1499,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Rotate the position
                 pos.x = xb*cos_theta;
                 pos.y = xb*sin_theta;
-                // Rotate the position
+                // Rotate the momentum
                 {
                     Real ur = u.x;
                     Real ut = u.y;
@@ -1543,6 +1545,12 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Real weight = dens * scale_fac / (AMREX_D_TERM(fac, *fac, *fac));
                 Real weight = dens * scale_fac * dt;
 #ifdef WARPX_DIM_RZ
+                // The particle weight is proportional to the user-specified
+                // flux (denoted as `dens` here) and the emission surface within
+                // one cell (captured partially by `scale_fac`).
+                // For cylindrical emission (flux_normal_axis==0
+                // or flux_normal_axis==2), the emission surface depends on
+                // the radius ; thus, the calculation is finalized here
                 if (plasma_injector->flux_normal_axis != 1) {
                     if (radially_weighted) {
                          weight *= 2._rt*MathConst::pi*xb;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1483,8 +1483,18 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 } else {
                     theta = 2._rt*MathConst::pi*r.y;
                 }
-                pos.x = xb*std::cos(theta);
-                pos.y = xb*std::sin(theta);
+                Real const cos_theta = std::cos(theta);
+                Real const sin_theta = std::sin(theta);
+                // Rotate the position
+                pos.x = xb*cos_theta;
+                pos.y = xb*sin_theta;
+                // Rotate the position
+                {
+                    Real ur = u.x;
+                    Real ut = u.y;
+                    u.x = cos_theta*ur - sin_theta*ut;
+                    u.y = sin_theta*ur + cos_theta*ut;
+                }
 #endif
 
                 // Lab-frame simulation

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -948,7 +948,6 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const auto poffset = offset.data();
 #ifdef WARPX_DIM_RZ
         const bool rz_random_theta = m_rz_random_theta;
-        int const loc_flux_normal_axis = plasma_injector->flux_normal_axis;
 #endif
         amrex::ParallelForRNG(overlap_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::RandomEngine const& engine) noexcept
@@ -1429,6 +1428,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
         bool loc_do_field_ionization = do_field_ionization;
         int loc_ionization_initial_level = ionization_initial_level;
+#ifdef WARPX_DIM_RZ
+        int const loc_flux_normal_axis = plasma_injector->flux_normal_axis;
+#endif
 
         // Loop over all new particles and inject them (creates too many
         // particles, in particular does not consider xmin, xmax etc.).

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -948,6 +948,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const auto poffset = offset.data();
 #ifdef WARPX_DIM_RZ
         const bool rz_random_theta = m_rz_random_theta;
+        int const loc_flux_normal_axis = plasma_injector->flux_normal_axis;
 #endif
         amrex::ParallelForRNG(overlap_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::RandomEngine const& engine) noexcept
@@ -1428,7 +1429,6 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
         bool loc_do_field_ionization = do_field_ionization;
         int loc_ionization_initial_level = ionization_initial_level;
-        int const loc_flux_normal_axis = plasma_injector->flux_normal_axis;
 
         // Loop over all new particles and inject them (creates too many
         // particles, in particular does not consider xmin, xmax etc.).
@@ -1503,7 +1503,8 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Rotate the position
                 pos.x = xb*cos_theta;
                 pos.y = xb*sin_theta;
-                if (inj_mom->type == InjectorMomentum::Type::gaussianflux) {
+                if ( (inj_mom->type == InjectorMomentum::Type::gaussianflux) &&
+                     (loc_flux_normal_axis != 2) ) {
                     // Rotate the momentum
                     // This because, when the flux direction is e.g. "r"
                     // the `inj_mom` objects generates a v*Gaussian distribution

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1502,8 +1502,12 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Rotate the position
                 pos.x = xb*cos_theta;
                 pos.y = xb*sin_theta;
-                // Rotate the momentum
-                {
+                if (inj_mom->type == InjectorMomentum::Type::gaussianflux) {
+                    // Rotate the momentum
+                    // This because, when the flux direction is e.g. "r"
+                    // the `inj_mom` objects generates a v*Gaussian distribution
+                    // along the Cartesian "x" directionm by default. This
+                    // needs to be rotated along "r".
                     Real ur = u.x;
                     Real ut = u.y;
                     u.x = cos_theta*ur - sin_theta*ut;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1194,6 +1194,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
     if (plasma_injector->flux_normal_axis == 2) scale_fac /= dx[1];
     // When emission is in the theta direction (flux_normal_axis == 1),
     // the emitting surface is a rectangle, within the plane of the simulation
+#elif defined(WARPX_DIM_1D_Z)
+    scale_fac = dx[0]/num_ppc_real;
+    if (plasma_injector->flux_normal_axis == 2) scale_fac /= dx[0];
 #endif
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(0);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1534,13 +1534,15 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Real weight = dens * scale_fac / (AMREX_D_TERM(fac, *fac, *fac));
                 Real weight = dens * scale_fac * dt;
 #ifdef WARPX_DIM_RZ
-                if (radially_weighted) {
-                    weight *= 2._rt*MathConst::pi*xb;
-                } else {
-                    // This is not correct since it might shift the particle
-                    // out of the local grid
-                    pos.x = std::sqrt(xb*rmax);
-                    weight *= dx[0];
+                if (plasma_injector->flux_normal_axis != 1) {
+                    if (radially_weighted) {
+                         weight *= 2._rt*MathConst::pi*xb;
+                    } else {
+                         // This is not correct since it might shift the particle
+                         // out of the local grid
+                         pos.x = std::sqrt(xb*rmax);
+                         weight *= dx[0];
+                    }
                 }
 #endif
                 pa[PIdx::w ][ip] = weight;


### PR DESCRIPTION
In the current WarpX version, the `AddPlasmaFlux` function does not allow to emit particles in the out-of-plane direction in 2D (i.e. in the `y` direction) and RZ (i.e. in the `theta` direction). This PR overcomes this restriction.

Essentially, this is done by allowing `flux_normal_axis` to be `0`, `1` or `2` (instead of `0` or `1` only, as was the case up to now in 2D and RZ), so that:
- **in Cartesian**: `0` corresponds to `x`, `1` corresponds to `y`, `2` corresponds to `z`
- **in cylindrical**: `0` corresponds to `r`, `1` corresponds to `theta`, `2` corresponds to `z`.

TODO:
- [x] Cleanup code and add comments
- [x] Add automated tests in RZ
