### PR TITLE
Expose WarpXParticleContainer::sumParticleCharge to Python

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -224,6 +224,7 @@ class LibWarpX():
         self.libwarpx_so.warpx_getFaceAreas.restype = _LP_LP_c_real
         self.libwarpx_so.warpx_getFaceAreasLoVects.restype = _LP_c_int
 
+        self.libwarpx_so.warpx_sumParticleCharge.restype = c_real
         self.libwarpx_so.warpx_getParticleBoundaryBufferSize.restype = ctypes.c_int
         self.libwarpx_so.warpx_getParticleBoundaryBufferStructs.restype = _LP_LP_c_particlereal
         self.libwarpx_so.warpx_getParticleBoundaryBuffer.restype = _LP_LP_c_particlereal
@@ -908,6 +909,22 @@ class LibWarpX():
         self.libwarpx_so.warpx_addRealComp(
             ctypes.c_char_p(species_name.encode('utf-8')),
             ctypes.c_char_p(pid_name.encode('utf-8')), comm
+        )
+
+    def get_species_charge_sum(self, species_name, local=False):
+        '''
+
+        Returns the total charge in the simulation due to the given species.
+
+        Parameters
+        ----------
+
+            species_name   : the species name for which charge will be summed
+            local          : If True return total charge per processor
+
+        '''
+        return self.libwarpx_so.warpx_sumParticleCharge(
+            ctypes.c_char_p(species_name.encode('utf-8')), local
         )
 
     def get_particle_boundary_buffer_size(self, species_name, boundary):

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -798,7 +798,7 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
     amrex::Real total_charge = 0.0;
 
     const int nLevels = finestLevel();
-    for (int lev = 0; lev < nLevels; ++lev)
+    for (int lev = 0; lev <= nLevels; ++lev)
     {
 
 #ifdef AMREX_USE_OMP

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -94,6 +94,8 @@ extern "C" {
     void warpx_addRealComp(
         const char* char_species_name, const char* char_comp_name, bool comm);
 
+    amrex::Real warpx_sumParticleCharge(const char* char_species_name, const bool local);
+
     int warpx_getParticleBoundaryBufferSize(const char* species_name, int boundary);
 
     int** warpx_getParticleBoundaryBufferScrapedSteps(

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -516,6 +516,14 @@ namespace
         mypc.defineAllParticleTiles();
     }
 
+    amrex::Real warpx_sumParticleCharge(const char* char_species_name, const bool local)
+    {
+        auto & mypc = WarpX::GetInstance().GetPartContainer();
+        const std::string species_name(char_species_name);
+        auto & myspc = mypc.GetParticleContainerFromName(species_name);
+        return myspc.sumParticleCharge(local);
+    }
+
     int warpx_getParticleBoundaryBufferSize(const char* species_name, int boundary)
     {
         const std::string name(species_name);


### PR DESCRIPTION
Also fixes a bug in `WarpXParticleContainer::sumParticleCharge` where the loop over levels should include the `finestLevel`.

This functionality is useful to us in order to get the summed weight of a given species.