### PR TITLE
Add Python callbacks before and after collisions

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -250,9 +250,9 @@ class CallbackFunctions(object):
 
 # --- Now create the actual instances.
 _afterinit = CallbackFunctions('afterinit')
-_beforeEsolve = CallbackFunctions('beforeEsolve')
 _beforecollisions = CallbackFunctions('beforecollisions')
 _aftercollisions = CallbackFunctions('aftercollisions')
+_beforeEsolve = CallbackFunctions('beforeEsolve')
 _poissonsolver = CallbackFunctions('poissonsolver')
 _afterEsolve = CallbackFunctions('afterEsolve')
 _beforedeposition = CallbackFunctions('beforedeposition')

--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -251,6 +251,8 @@ class CallbackFunctions(object):
 # --- Now create the actual instances.
 _afterinit = CallbackFunctions('afterinit')
 _beforeEsolve = CallbackFunctions('beforeEsolve')
+_beforecollisions = CallbackFunctions('beforecollisions')
+_aftercollisions = CallbackFunctions('aftercollisions')
 _poissonsolver = CallbackFunctions('poissonsolver')
 _afterEsolve = CallbackFunctions('afterEsolve')
 _beforedeposition = CallbackFunctions('beforedeposition')
@@ -312,6 +314,34 @@ def uninstallafterinit(f):
 def isinstalledafterinit(f):
     "Checks if the function is called after a init"
     return _afterinit.isinstalledfuncinlist(f)
+
+# ----------------------------------------------------------------------------
+def callfrombeforecollisions(f):
+    installbeforecollisions(f)
+    return f
+def installbeforecollisions(f):
+    "Adds a function to the list of functions called before collisions"
+    _beforecollisions.installfuncinlist(f)
+def uninstallbeforecollisions(f):
+    "Removes the function from the list of functions called before collisions"
+    _beforecollisions.uninstallfuncinlist(f)
+def isinstalledbeforecollisions(f):
+    "Checks if the function is called before collisions"
+    return _beforecollisions.isinstalledfuncinlist(f)
+
+# ----------------------------------------------------------------------------
+def callfromaftercollisions(f):
+    installaftercollisions(f)
+    return f
+def installaftercollisions(f):
+    "Adds a function to the list of functions called after collisions"
+    _aftercollisions.installfuncinlist(f)
+def uninstallaftercollisions(f):
+    "Removes the function from the list of functions called after collisions"
+    _aftercollisions.uninstallfuncinlist(f)
+def isinstalledaftercollisions(f):
+    "Checks if the function is called after collisions"
+    return _aftercollisions.isinstalledfuncinlist(f)
 
 # ----------------------------------------------------------------------------
 def callfrombeforeEsolve(f):

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -156,7 +156,9 @@ WarpX::Evolve (int numsteps)
         // Run multi-physics modules:
         // ionization, Coulomb collisions, QED
         doFieldIonization();
+        ExecutePythonCallback("beforecollisions");
         mypc->doCollisions( cur_time );
+        ExecutePythonCallback("aftercollisions");
 #ifdef WARPX_QED
         doQEDEvents();
         mypc->doQEDSchwinger();

--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -19,9 +19,10 @@
  *
  * The keys of the map describe at what point in the simulation the python
  * functions will be called. Currently supported keys (callback points) are
- * afterinit, beforeEsolve, poissonsolver, afterEsolve, beforedeposition,
- * afterdeposition, particlescraper, particleloader, beforestep, afterstep,
- * afterrestart, particleinjection and appliedfields.
+ * afterinit, beforecollisions, aftercollisions, beforeEsolve, poissonsolver,
+ * afterEsolve, beforedeposition, afterdeposition, particlescraper,
+ * particleloader, beforestep, afterstep, afterrestart, particleinjection and
+ * appliedfields.
 */
 extern std::map< std::string, WARPX_CALLBACK_PY_FUNC_0 > warpx_callback_py_map;
 


### PR DESCRIPTION
We will use this for a routine to track the total number of particles injected by the MCC routine. But it might be useful to others at some point as well.