### PR TITLE
Read species size correctly

### DIFF
--- a/Examples/Tests/FieldProbe/inputs_2d
+++ b/Examples/Tests/FieldProbe/inputs_2d
@@ -62,6 +62,7 @@ diag1.intervals = 100
 diag1.diag_type = Full
 #diag1.format = openpmd
 diag1.fields_to_plot = Ex Ey Ez Bx By Bz
+diag1.write_species = 0
 
 #################################
 ## Reduced Diagnostics

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -110,7 +110,6 @@ void BTDiagnostics::DerivedInitData ()
         mpc.SetDoBackTransformedParticles(species, m_do_back_transformed_particles);
     }
     m_particles_buffer.resize(m_num_buffers);
-    m_output_species.resize(m_num_buffers);
     m_totalParticles_flushed_already.resize(m_num_buffers);
     m_totalParticles_in_buffer.resize(m_num_buffers);
 }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -232,8 +232,9 @@ Diagnostics::InitData ()
             // Note that the filter is set for every ith snapshot, and the number of snapshots
             // for full diagnostics is 1, while for BTD it is user-defined.
             for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-                for (auto& v : m_output_species.at(i_buffer))
+                for (auto& v : m_output_species.at(i_buffer)) {
                     v.m_do_geom_filter = true;
+                }
                 // Disabling particle-io for reduced domain diagnostics by reducing
                 // the particle-diag vector to zero.
                 // This is a temporary fix until particle_buffer is supported in diagnostics.
@@ -303,6 +304,8 @@ Diagnostics::InitBaseData ()
         m_geom_output[i].resize( nmax_lev );
     }
 
+    // allocate vector of particle buffers
+    m_output_species.resize(m_num_buffers);
 }
 
 void

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -223,7 +223,7 @@ Diagnostics::InitData ()
             m_output_species.at(i_buffer).clear();
         }
         m_output_species_names.clear();
-    } else { 
+    } else {
         amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
         if ( queryArrWithParser(pp_diag_name, "diag_lo", dummy_val, 0, AMREX_SPACEDIM) ||
              queryArrWithParser(pp_diag_name, "diag_hi", dummy_val, 0, AMREX_SPACEDIM) ) {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -222,7 +222,7 @@ Diagnostics::InitData ()
         // Note that the filter is set for every ith snapshot, and the number of snapshots
         // for full diagnostics is 1, while for BTD it is user-defined.
         for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-            for (int i = 0; i < m_output_species.size(); ++i) {
+            for (int i = 0; i < m_output_species[i_buffer].size(); ++i) {
                 m_output_species[i_buffer][i].m_do_geom_filter = true;
             }
             // Disabling particle-io for reduced domain diagnostics by reducing

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -233,7 +233,7 @@ Diagnostics::InitData ()
             // for full diagnostics is 1, while for BTD it is user-defined.
             for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
                 for (int i = 0; i < m_output_species.at(i_buffer).size(); ++i) {
-                    m_output_species[i_buffer][i].m_do_geom_filter = true;
+                    m_output_species.at(i_buffer).at(i).m_do_geom_filter = true;
                 }
                 // Disabling particle-io for reduced domain diagnostics by reducing
                 // the particle-diag vector to zero.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -219,9 +219,8 @@ Diagnostics::InitData ()
             amrex::Abort("For checkpoint format, write_species flag must be 1.");
         }
         // if user-defined value for write_species == 0, then clear species vector
-        for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-            m_output_species.at(i_buffer).clear();
-        }
+        for (auto& v : m_output_species)
+            m_output_species.clear();
         m_output_species_names.clear();
     } else {
         amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
@@ -232,9 +231,8 @@ Diagnostics::InitData ()
             // Note that the filter is set for every ith snapshot, and the number of snapshots
             // for full diagnostics is 1, while for BTD it is user-defined.
             for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-                for (int i = 0; i < m_output_species.at(i_buffer).size(); ++i) {
-                    m_output_species.at(i_buffer).at(i).m_do_geom_filter = true;
-                }
+                for (auto& v : m_output_species.at(i_buffer))
+                    v.m_do_geom_filter = true;
                 // Disabling particle-io for reduced domain diagnostics by reducing
                 // the particle-diag vector to zero.
                 // This is a temporary fix until particle_buffer is supported in diagnostics.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -240,7 +240,10 @@ Diagnostics::InitData ()
                 // This is a temporary fix until particle_buffer is supported in diagnostics.
                 m_output_species.at(i_buffer).clear();
             }
-            amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+            std::string warnMsg = "For full diagnostics on a reduced domain, particle I/O is not ";
+            warnMsg += "supported, yet! Therefore, particle I/O is disabled for this diagnostics: ";
+            warnMsg += m_diag_name;
+            WarpX::GetInstance().RecordWarning("Diagnostics", warnMsg);
         }
     }
 }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -219,30 +219,30 @@ Diagnostics::InitData ()
             amrex::Abort("For checkpoint format, write_species flag must be 1.");
         }
         // if user-defined value for write_species == 0, then clear species vector
-        m_output_species.clear();
-        m_output_species_names.clear();
-    }
-
-    amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
-    if ( queryArrWithParser(pp_diag_name, "diag_lo", dummy_val, 0, AMREX_SPACEDIM) ||
-         queryArrWithParser(pp_diag_name, "diag_hi", dummy_val, 0, AMREX_SPACEDIM) ) {
-        // set geometry filter for particle-diags to true when the diagnostic domain-extent
-        // is specified by the user.
-        // Note that the filter is set for every ith snapshot, and the number of snapshots
-        // for full diagnostics is 1, while for BTD it is user-defined.
         for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
-            for (int i = 0; i < m_output_species[i_buffer].size(); ++i) {
-                m_output_species[i_buffer][i].m_do_geom_filter = true;
-            }
-            // Disabling particle-io for reduced domain diagnostics by reducing
-            // the particle-diag vector to zero.
-            // This is a temporary fix until particle_buffer is supported in diagnostics.
-            m_output_species[i_buffer].clear();
+            m_output_species.at(i_buffer).clear();
         }
-        m_output_species.clear();
-        amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+        m_output_species_names.clear();
+    } else { 
+        amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
+        if ( queryArrWithParser(pp_diag_name, "diag_lo", dummy_val, 0, AMREX_SPACEDIM) ||
+             queryArrWithParser(pp_diag_name, "diag_hi", dummy_val, 0, AMREX_SPACEDIM) ) {
+            // set geometry filter for particle-diags to true when the diagnostic domain-extent
+            // is specified by the user.
+            // Note that the filter is set for every ith snapshot, and the number of snapshots
+            // for full diagnostics is 1, while for BTD it is user-defined.
+            for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
+                for (int i = 0; i < m_output_species.at(i_buffer).size(); ++i) {
+                    m_output_species[i_buffer][i].m_do_geom_filter = true;
+                }
+                // Disabling particle-io for reduced domain diagnostics by reducing
+                // the particle-diag vector to zero.
+                // This is a temporary fix until particle_buffer is supported in diagnostics.
+                m_output_species.at(i_buffer).clear();
+            }
+            amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
+        }
     }
-
 }
 
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -219,8 +219,9 @@ Diagnostics::InitData ()
             amrex::Abort("For checkpoint format, write_species flag must be 1.");
         }
         // if user-defined value for write_species == 0, then clear species vector
-        for (auto& v : m_output_species)
-            m_output_species.clear();
+        for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
+            m_output_species.at(i_buffer).clear();
+        }
         m_output_species_names.clear();
     } else {
         amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -214,6 +214,15 @@ Diagnostics::InitData ()
         InitializeParticleFunctors();
     }
 
+    if (write_species == 0) {
+        if (m_format == "checkpoint"){
+            amrex::Abort("For checkpoint format, write_species flag must be 1.");
+        }
+        // if user-defined value for write_species == 0, then clear species vector
+        m_output_species.clear();
+        m_output_species_names.clear();
+    }
+
     amrex::Vector <amrex::Real> dummy_val(AMREX_SPACEDIM);
     if ( queryArrWithParser(pp_diag_name, "diag_lo", dummy_val, 0, AMREX_SPACEDIM) ||
          queryArrWithParser(pp_diag_name, "diag_hi", dummy_val, 0, AMREX_SPACEDIM) ) {
@@ -234,14 +243,6 @@ Diagnostics::InitData ()
         amrex::Print() << " WARNING: For full diagnostics on a reduced domain, particle io is not supported, yet! Therefore, particle-io is disabled for this diag " << m_diag_name << "\n";
     }
 
-    if (write_species == 0) {
-        if (m_format == "checkpoint"){
-            amrex::Abort("For checkpoint format, write_species flag must be 1.");
-        }
-        // if user-defined value for write_species == 0, then clear species vector
-        m_output_species.clear();
-        m_output_species_names.clear();
-    }
 }
 
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -477,7 +477,7 @@ FullDiagnostics::PrepareFieldDataForOutput ()
     // The level is set to 0, because the whole physical domain of the simulation is used
     // to set the domain dimensions for the output particle container.
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
-        for (int i = 0; i < m_output_species[i_buffer].size(); ++i) {
+        for (int i = 0; i < m_output_species.at(i_buffer).size(); ++i) {
             m_output_species[i_buffer][i].m_diag_domain = m_geom_output[i_buffer][0].ProbDomain();
         }
     }

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -62,7 +62,6 @@ FullDiagnostics::InitializeParticleBuffer ()
         }
     }
     // Initialize one ParticleDiag per species requested
-    m_output_species.resize(m_num_buffers);
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         for (auto const& species : m_output_species_names){
             const int idx = mpc.getSpeciesID(species);


### PR DESCRIPTION
For diagnostics, 
when the user specifies `diag_lo` and `diag_hi`, we read geometry filter and we also temporarily disable particle-io for slices (or diags over a small region of the domain).

When doing so, we loop over number of species, but this was not done correctly for the 2D vector and is fixed in this PR.
```
        for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer ) {
            for (int i = 0; i < m_output_species[i_buffer].size(); ++i) {
                m_output_species[i_buffer][i].m_do_geom_filter = true;
            }
         ...
        }
``
```

We now access species size with `m_output_species[i_buffer].size()` instead of `m_output_species.size()` which would return the number of buffers, instead of number of species in a given buffer.

Thanks to Andy Nonaka (@ajnonaka ) for finding this issue!