### PR TITLE
FieldProbe: Fixed Assert Typo

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -298,7 +298,7 @@ void FieldProbe::InitData ()
     }
     else
     {
-    amrex::Abort("ERROR: Invalid probe geometry. Valid geometries are point (0) and line (1).");
+    amrex::Abort("ERROR: Invalid probe geometry. Valid geometries are Point, Line, and Plane.");
     }
 }
 


### PR DESCRIPTION
Fixes an assert message overlooked when adding plane diagnostic