### PR TITLE
Summit: Fix Batch Template

### DIFF
--- a/Tools/machines/summit-olcf/summit_v100.bsub
+++ b/Tools/machines/summit-olcf/summit_v100.bsub
@@ -44,7 +44,7 @@ cat > romio-hints << EOL
    romio_ds_write enable
    cb_buffer_size 16777216
    cb_nodes ${NUM_HOSTS}
-   EOL
+EOL
 
 # OpenMP: 1 thread per MPI rank
 export OMP_NUM_THREADS=1


### PR DESCRIPTION
That EOL should be at the beginning of the line.

Thanks to @nckwcq for catching this! :tada: 