### PR TITLE
Allow `_libwarpx.add_particles` to be called with empty numpy arrays

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -591,11 +591,6 @@ class LibWarpX():
         for key, val in kwargs.items():
             assert np.size(val)==1 or len(val)==maxlen, f"Length of {key} doesn't match len of others"
 
-        # --- If the length of the input is zero, then quietly return
-        # --- This is not an error - it just means that no particles are to be injected.
-        if maxlen == 0:
-            return
-
         # --- Broadcast scalars into appropriate length arrays
         # --- If the parameter was not supplied, use the default value
         if lenx == 1:


### PR DESCRIPTION
The early return in `_libwarpx.add_particles` when no particles are being added causes the simulation to hang in the case that some processors inject particles while others don't. This is presumably due to the `Redistribute();` call at the end of `WarpXParticleContainer::AddNParticles()` which is not reached by the processors that returned early.

I did test that with this change the above mentioned problem is avoided.

Another fix would be to expose `Redistribute()` to Python and call it before the early return.