### PR TITLE
CI: Do Not Set `diag1.file_prefix` in `runtime_params`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -71,7 +71,7 @@ cmakeSetupOpts = -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON
 [pml_x_yee]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee diag1.file_prefix=pml_x_yee_plt chk.file_prefix=pml_x_yee_chk
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_chk
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1345,7 +1345,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2 diag1.file_prefix=dive_cleaning_2d_plt
+runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
 analysisRoutine = Examples/Modules/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -1363,7 +1363,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 diag1.file_prefix=dive_cleaning_3d_plt
+runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Modules/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -1440,7 +1440,7 @@ analysisRoutine = Examples/Tests/particles_in_PML/analysis_particles_in_pml.py
 [photon_pusher]
 buildDir = .
 inputFile = Examples/Tests/photon_pusher/inputs_3d
-runtime_params = diag1.file_prefix=photon_pusher_plt
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3


### PR DESCRIPTION
I noticed that a few CI tests were setting `diag1.file_prefix` in the `runtime_params` field in WarpX-tests.ini, but that should not be necessary.