### PR TITLE
Prepare for CI: Remove PGI

### DIFF
--- a/Regression/prepare_file_ci.py
+++ b/Regression/prepare_file_ci.py
@@ -48,8 +48,7 @@ text = re.sub( '\[(?P<name>.*)\]\nbuildDir = ',
 # Change compile options when running on GPU
 if arch == 'GPU':
     text = re.sub( 'addToCompileString =',
-                    'addToCompileString = USE_GPU=TRUE USE_OMP=FALSE USE_ACC=TRUE ', text)
-    text = re.sub( 'COMP\s*=.*', 'COMP = pgi', text )
+                   'addToCompileString = USE_GPU=TRUE USE_OMP=FALSE ', text)
 print('Compiling for %s' %arch)
 
 # Extra dependencies


### PR DESCRIPTION
Remove an outdated "COMP = PGI" setting that has not been used for years (likely not been used since OpenACC experiments in the Fortran times).