### PR TITLE
Update parsing of FieldProbe in 2D and 1D

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2158,7 +2158,7 @@ Reduced Diagnostics
         **Plane**: probe a 2 dimensional plane of points to create a square plane detector.
         Initial input parameters ``x_probe``, ``y_probe``, and ``z_probe`` designate the center of the detector.
         The detector plane is normal to a vector specified by ``<reduced_diags_name>.target_normal_x``, ``<reduced_diags_name>.target_normal_y``, and ``<reduced_diags_name>.target_normal_z``.
-        Note that it is not necessary to specify the ``target_normal`` vector in a 2D simulation.
+        Note that it is not necessary to specify the ``target_normal`` vector in a 2D simulation (the only supported normal is in ``y``).
         The top of the plane is perpendicular to an "up" vector denoted by ``<reduced_diags_name>.target_up_x``, ``<reduced_diags_name>.target_up_y``, and ``<reduced_diags_name>.target_up_z``.
         The detector has a square radius to be determined by ``<reduced_diags_name>.detector_radius``.
         Similarly to the line detector, the plane detector requires a resolution ``<reduced_diags_name>.resolution``, which denotes the number of detector particles along each side of the square detector.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2158,6 +2158,7 @@ Reduced Diagnostics
         **Plane**: probe a 2 dimensional plane of points to create a square plane detector.
         Initial input parameters ``x_probe``, ``y_probe``, and ``z_probe`` designate the center of the detector.
         The detector plane is normal to a vector specified by ``<reduced_diags_name>.target_normal_x``, ``<reduced_diags_name>.target_normal_y``, and ``<reduced_diags_name>.target_normal_z``.
+        Note that it is not necessary to specify the ``target_normal`` vector in a 2D simulation.
         The top of the plane is perpendicular to an "up" vector denoted by ``<reduced_diags_name>.target_up_x``, ``<reduced_diags_name>.target_up_y``, and ``<reduced_diags_name>.target_up_z``.
         The detector has a square radius to be determined by ``<reduced_diags_name>.detector_radius``.
         Similarly to the line detector, the plane detector requires a resolution ``<reduced_diags_name>.resolution``, which denotes the number of detector particles along each side of the square detector.

--- a/Examples/Tests/FieldProbe/inputs_2d
+++ b/Examples/Tests/FieldProbe/inputs_2d
@@ -73,10 +73,8 @@ FP_line.intervals = 100
 FP_line.integrate = 1
 FP_line.probe_geometry = Line
 FP_line.x_probe = -1.5e-6
-FP_line.y_probe = 0.
 FP_line.z_probe = 1.7e-6
 FP_line.x1_probe = 1.5e-6
-FP_line.y1_probe = 0.
 FP_line.z1_probe = 1.7e-6
 FP_line.resolution = 201
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -82,23 +82,39 @@ FieldProbe::FieldProbe (std::string rd_name)
     if (m_probe_geometry_str == "Point")
     {
         m_probe_geometry = DetectorGeometry::Point;
+        x_probe = 0._rt;
+        y_probe = 0._rt;
+#if !defined(WARPX_DIM_1D_Z)
         getWithParser(pp_rd_name, "x_probe", x_probe);
+#endif
+#if defined(WARPX_DIM_3D)
         getWithParser(pp_rd_name, "y_probe", y_probe);
+#endif
         getWithParser(pp_rd_name, "z_probe", z_probe);
     }
     else if (m_probe_geometry_str == "Line")
     {
+#if defined(WARPX_DIM_1D_Z)
+        amrex::Abort("ERROR: Line probe should be used in a 2D or 3D simulation only");
+#endif
         m_probe_geometry = DetectorGeometry::Line;
-        getWithParser(pp_rd_name, "x_probe", x_probe);
+        y_probe = 0._rt;
+        y1_probe = 0._rt;
+#if defined(WARPX_DIM_3D)
         getWithParser(pp_rd_name, "y_probe", y_probe);
-        getWithParser(pp_rd_name, "z_probe", z_probe);
-        getWithParser(pp_rd_name, "x1_probe", x1_probe);
         getWithParser(pp_rd_name, "y1_probe", y1_probe);
+#endif
+        getWithParser(pp_rd_name, "x_probe", x_probe);
+        getWithParser(pp_rd_name, "x1_probe", x1_probe);
+        getWithParser(pp_rd_name, "z_probe", z_probe);
         getWithParser(pp_rd_name, "z1_probe", z1_probe);
         getWithParser(pp_rd_name, "resolution", m_resolution);
     }
     else if (m_probe_geometry_str == "Plane")
     {
+#if !defined(WARPX_DIM_3D)
+        amrex::Abort("ERROR: Plane probe should be used in a 3D simulation only");
+#endif
         m_probe_geometry = DetectorGeometry::Plane;
         getWithParser(pp_rd_name, "x_probe", x_probe);
         getWithParser(pp_rd_name, "y_probe", y_probe);

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -94,36 +94,44 @@ FieldProbe::FieldProbe (std::string rd_name)
     }
     else if (m_probe_geometry_str == "Line")
     {
-#if defined(WARPX_DIM_1D_Z)
-        amrex::Abort("ERROR: Line probe should be used in a 2D or 3D simulation only");
-#endif
         m_probe_geometry = DetectorGeometry::Line;
+        x_probe = 0._rt;
+        x1_probe = 0._rt;
         y_probe = 0._rt;
         y1_probe = 0._rt;
+#if !defined(WARPX_DIM_1D_Z)
+        getWithParser(pp_rd_name, "x_probe", x_probe);
+        getWithParser(pp_rd_name, "x1_probe", x1_probe);
+#endif
 #if defined(WARPX_DIM_3D)
         getWithParser(pp_rd_name, "y_probe", y_probe);
         getWithParser(pp_rd_name, "y1_probe", y1_probe);
 #endif
-        getWithParser(pp_rd_name, "x_probe", x_probe);
-        getWithParser(pp_rd_name, "x1_probe", x1_probe);
         getWithParser(pp_rd_name, "z_probe", z_probe);
         getWithParser(pp_rd_name, "z1_probe", z1_probe);
         getWithParser(pp_rd_name, "resolution", m_resolution);
     }
     else if (m_probe_geometry_str == "Plane")
     {
-#if !defined(WARPX_DIM_3D)
-        amrex::Abort("ERROR: Plane probe should be used in a 3D simulation only");
+#if defined(WARPX_DIM_1D_Z)
+        amrex::Abort("ERROR: Plane probe should be used in a 2D or 3D simulation only");
 #endif
         m_probe_geometry = DetectorGeometry::Plane;
-        getWithParser(pp_rd_name, "x_probe", x_probe);
+        y_probe = 0._rt;
+        target_normal_x = 0._rt;
+        target_normal_y = 1._rt;
+        target_normal_z = 0._rt;
+        target_up_y = 0._rt;
+#if defined(WARPX_DIM_3D)
         getWithParser(pp_rd_name, "y_probe", y_probe);
-        getWithParser(pp_rd_name, "z_probe", z_probe);
         getWithParser(pp_rd_name, "target_normal_x", target_normal_x);
         getWithParser(pp_rd_name, "target_normal_y", target_normal_y);
         getWithParser(pp_rd_name, "target_normal_z", target_normal_z);
-        getWithParser(pp_rd_name, "target_up_x", target_up_x);
         getWithParser(pp_rd_name, "target_up_y", target_up_y);
+#endif
+        getWithParser(pp_rd_name, "x_probe", x_probe);
+        getWithParser(pp_rd_name, "z_probe", z_probe);
+        getWithParser(pp_rd_name, "target_up_x", target_up_x);
         getWithParser(pp_rd_name, "target_up_z", target_up_z);
         getWithParser(pp_rd_name, "detector_radius", detector_radius);
         getWithParser(pp_rd_name, "resolution", m_resolution);


### PR DESCRIPTION
I'm in the process of adding a ci test for reduced diags in 2D and I noticed a couple of things concerning the `FieldProbe` reduced diag in 2D.

1. Even in 2D, it is required to specify `y_probe` in the input file. Should we just set it to zero in 2D sims?
2. Does it make sense to add a plane detector in a 2D sim? Or a line detector in a 1D sim? Should we abort the runs in these cases? A plane detector in a 2D sim could make sense if it's in the plane of the simulation, but it feels like it's not what this diag was intended for, am I correct? (e.g. we don't have a volume probe for 3D sims)

I've implemented these suggestions in this PR, let me know if that sounds good to you.