### PR TITLE
CMake: Add More Pip Helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ __pycache__
 Python/build/
 Python/dist/
 Python/pywarpx.egg-info/
+_tmppythonbuild/
+pywarpx.egg-info/
 
 ##########
 # Sphinx #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,23 +391,42 @@ endif()
 #)
 
 
-# CI Helper ###################################################################
+# pip helpers for the pywarpx package #########################################
 #
+if(WarpX_LIB)
+    set(PYINSTALLOPTIONS "" CACHE STRING
+        "Additional parameters to pass to `pip install`")
 
-# calling `python -m pip wheel .` and install re-using the build directory
-# note: this is mainly for our CI Python regression scripts, users and package
-#       managers should just use `python -m pip wheel .` and `... install *whl`
-#       directly
-set(PYINSTALLOPTIONS "" CACHE STRING "Additional parameters to pass to `pip install`")
-add_custom_target(install_pip
-    ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY} python3 -m pip wheel -v --use-feature=in-tree-build ${WarpX_SOURCE_DIR}
-    COMMAND
-        python3 -m pip install --force-reinstall --no-deps -v ${PYINSTALLOPTIONS} ${CMAKE_BINARY_DIR}/*whl
-    WORKING_DIRECTORY
-        ${CMAKE_BINARY_DIR}
-    DEPENDS
-        shared
-)
+    # build the wheel by re-using the shared library we build
+    add_custom_target(pip_wheel
+        ${CMAKE_COMMAND} -E rm -f ${WarpX_BINARY_DIR}/pywarpx*whl
+        COMMAND
+            ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+                python3 -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${WarpX_SOURCE_DIR}
+        WORKING_DIRECTORY
+            ${WarpX_BINARY_DIR}
+        DEPENDS
+            shared
+    )
+
+    # this will also upgrade/downgrade dependencies, e.g., when the version of picmistandard changes
+    add_custom_target(pip_install_requirements
+        python3 -m pip install -r ${WarpX_SOURCE_DIR}/requirements.txt
+        WORKING_DIRECTORY
+            ${WarpX_BINARY_DIR}
+    )
+
+    # We force-install because in development, it is likely that the version of
+    # the package does not change, but the code did change. We need --no-deps,
+    # because otherwise pip would also force reinstall all dependencies.
+    add_custom_target(pip_install
+        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} ${WarpX_BINARY_DIR}/pywarpx*whl
+        WORKING_DIRECTORY
+            ${WarpX_BINARY_DIR}
+        DEPENDS
+            shared pip_wheel pip_install_requirements
+    )
+endif()
 
 
 # Tests #######################################################################

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -213,7 +213,7 @@ Developers could now change the WarpX source code and then call the build line a
 
 .. note::
 
-   These commands builds one ``-DWarpX_DIMS=...`` dimensionality (default: ``3``) at a time.
+   These commands build one ``-DWarpX_DIMS=...`` dimensionality (default: ``3``) at a time.
    If your ``build/lib*/`` directory contains previously built ``libwarpx*`` libraries, then ``--target pip_install`` picks them up as well.
    A new call to ``cmake --build build ...`` will only rebuild *one* dimensionality, as set via ``WarpX_DIMS``.
 
@@ -278,7 +278,7 @@ Environment Variable          Default & Values                             Descr
 ``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built WarpX C++ libraries (see below)
 ============================= ============================================ ================================================================
 
-Note that we currently change the ``WARPX_MPI`` default intentionally to ``OFF``, to simplify a first install form source.
+Note that we currently change the ``WARPX_MPI`` default intentionally to ``OFF``, to simplify a first install from source.
 
 Some hints and workflows follow.
 Developers, that want to test a change of the source code but did not change the ``pywarpx`` version number, can force a reinstall via:

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -46,8 +46,9 @@ From the base of the WarpX source directory, execute:
    # compile, here we use four threads
    cmake --build build -j 4
 
-That's all! WarpX binaries are now in ``build/bin/``.
-Most people execute these binaries directly or copy them out.
+**That's it!**
+A 3D WarpX binary is now in ``build/bin/`` and :ref:`can be run <usage_run>` with a :ref:`3D example inputs file <usage-examples>`.
+Most people execute the binary directly or copy it out.
 
 If you want to install the executables in a programmatic way, run this:
 
@@ -62,7 +63,8 @@ You can inspect and modify build options after running ``cmake -S . -B build`` w
 
    ccmake build
 
-or by adding arguments with ``-D<OPTION>=<VALUE>`` to the first CMake call, e.g.:
+or by adding arguments with ``-D<OPTION>=<VALUE>`` to the first CMake call.
+For example, this builds WarpX in 2D geometry and enables Nvidia GPU (CUDA) support:
 
 .. code-block:: bash
 
@@ -80,14 +82,15 @@ CMake Option                  Default & Values                             Descr
 ``CMAKE_BUILD_TYPE``          RelWithDebInfo/**Release**/Debug             Type of build, symbols & optimizations
 ``CMAKE_INSTALL_PREFIX``      system-dependent path                        Install path prefix
 ``CMAKE_VERBOSE_MAKEFILE``    ON/**OFF**                                   Print all compiler commands to the terminal during build
+``PYINSTALLOPTIONS``                                                       Additional options for ``pip install``, e.g., ``-v --user``
 ``WarpX_APP``                 **ON**/OFF                                   Build the WarpX executable application
 ``WarpX_ASCENT``              ON/**OFF**                                   Ascent in situ visualization
 ``WarpX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
-``WarpX_DIMS``                **3**/2/RZ                                   Simulation dimensionality
+``WarpX_DIMS``                **3**/2/1/RZ                                 Simulation dimensionality
 ``WarpX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
 ``WarpX_GPUCLOCK``            **ON**/OFF                                   Add GPU kernel timers (cost function, +4 registers/kernel)
 ``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO)
-``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a shared library
+``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a shared library, e.g., for PICMI Python
 ``WarpX_MPI``                 **ON**/OFF                                   Multi-node support (message-passing)
 ``WarpX_MPI_THREAD_MULTIPLE`` **ON**/OFF                                   MPI thread-multiple support, i.e. for ``async_io``
 ``WarpX_OPENPMD``             **ON**/OFF                                   openPMD I/O (HDF5, ADIOS)
@@ -173,21 +176,79 @@ Run
 ---
 
 An executable WarpX binary with the current compile-time options encoded in its file name will be created in ``build/bin/``.
+Note that you need separate binaries to run 1D, 2D, 3D, and RZ geometry inputs scripts.
+Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`__ named ``warpx`` can be found in that directory, which points to the last built WarpX executable.
 
-Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`_ named ``warpx`` can be found in that directory, which points to the last built WarpX executable.
+More details on running simulations are in the section :ref:`Run WarpX <usage_run>`.
+Alternatively, read on and also build our PICMI Python interface.
 
 
 .. _building-cmake-python:
 
-Python Bindings
----------------
+PICMI Python Bindings
+---------------------
 
-Build and install ``pywarpx`` from the root of the WarpX source tree:
+.. note::
+
+   Preparation: make sure you work with up-to-date Python tooling.
+
+   .. code-block:: bash
+
+      python3 -m pip install -U pip setuptools wheel
+
+For PICMI Python bindings, configure WarpX to produce a library and call our ``pip_install`` *CMake target*:
+
+.. code-block:: bash
+
+   # find dependencies & configure
+   cmake -S . -B build -DWarpX_LIB=ON
+
+   # build and then call "python3 -m pip install ..."
+   cmake --build build --target pip_install -j 4
+
+**That's it!**
+You can now :ref:`run a first 3D PICMI script <usage-picmi>` from our :ref:`examples <usage-examples>`.
+
+Developers could now change the WarpX source code and then call the build line again to refresh the Python installation.
+
+.. note::
+
+   These commands builds one ``-DWarpX_DIMS=...`` dimensionality (default: ``3``) at a time.
+   If your ``build/lib*/`` directory contains previously built ``libwarpx*`` libraries, then ``--target pip_install`` picks them up as well.
+   A new call to ``cmake --build build ...`` will only rebuild *one* dimensionality, as set via ``WarpX_DIMS``.
+
+If you like to build a WarpX Python package that supports *all* dimensionalities, you can run this:
+
+.. code-block:: bash
+
+   for d in 1 2 3 RZ; do
+       cmake -S . -B build -DWarpX_DIMS=$d -DWarpX_LIB=ON
+       cmake --build build -j 4
+   done
+   cmake --build build --target pip_install
+
+.. tip::
+
+   If you do *not* develop with :ref:`a user-level package manager <install-dependencies>`, e.g., because you rely on a HPC system's environment modules, then consider to set up a virtual environment via `Python venv <https://docs.python.org/3/library/venv.html>`__.
+   Otherwise, without a virtual environment, you likely need to add the CMake option ``-DPYINSTALLOPTIONS="--user"``.
+
+
+.. _building-pip-python:
+
+Python Bindings (Package Management)
+------------------------------------
+
+This section is relevant for Python package management, mainly for maintainers or people that rather like to interact only with ``pip``.
+
+One can build and install ``pywarpx`` from the root of the WarpX source tree:
 
 .. code-block:: bash
 
    python3 -m pip wheel -v .
-   python3 -m pip install *whl
+   python3 -m pip install pywarpx*whl
+
+This will call the CMake logic above implicitly.
+Using this workflow has the advantage that it can build and package up multiple libraries with varying ``WarpX_DIMS`` into one ``pywarpx`` package.
 
 Environment variables can be used to control the build step:
 
@@ -195,7 +256,7 @@ Environment variables can be used to control the build step:
 Environment Variable          Default & Values                             Description
 ============================= ============================================ ================================================================
 ``WARPX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
-``WARPX_DIMS``                ``"2;3;RZ"``                                 Simulation dimensionalities (semicolon-separated list)
+``WARPX_DIMS``                ``"1;2;3;RZ"``                               Simulation dimensionalities (semicolon-separated list)
 ``WARPX_EB``                  ON/**OFF**                                   Embedded boundary support (not supported in RZ yet)
 ``WARPX_MPI``                 ON/**OFF**                                   Multi-node support (message-passing)
 ``WARPX_OPENPMD``             **ON**/OFF                                   openPMD I/O (HDF5, ADIOS)
@@ -217,11 +278,10 @@ Environment Variable          Default & Values                             Descr
 ``PYWARPX_LIB_DIR``           *None*                                       If set, search for pre-built WarpX C++ libraries (see below)
 ============================= ============================================ ================================================================
 
+Note that we currently change the ``WARPX_MPI`` default intentionally to ``OFF``, to simplify a first install form source.
 
-Python Bindings (Developers)
-----------------------------
-
-**Developers** might have all Python dependencies already installed and want to just overwrite an already installed ``pywarpx`` package:
+Some hints and workflows follow.
+Developers, that want to test a change of the source code but did not change the ``pywarpx`` version number, can force a reinstall via:
 
 .. code-block:: bash
 
@@ -250,7 +310,7 @@ If the C++ libraries are already pre-compiled, we can pick them up in the Python
 .. code-block:: bash
 
    # build WarpX executables and libraries
-   for d in 2 3 RZ; do
+   for d in 1 2 3 RZ; do
      cmake -S . -B build -DWarpX_DIMS=$d -DWarpX_LIB=ON
      cmake --build build -j 4
    done

--- a/Docs/source/usage/how_to_run.rst
+++ b/Docs/source/usage/how_to_run.rst
@@ -34,6 +34,11 @@ Try it like this:
 
 Hitting the ``<TAB>`` key will suggest available WarpX executables as found in your ``PATH`` `environment variable <https://en.wikipedia.org/wiki/PATH_(variable)>`__.
 
+.. note::
+
+   WarpX needs separate binaries to run in dimensionality of 1D, 2D, 3D, and RZ.
+   We encode the supported dimensionality in the binary file name.
+
 If you :ref:`compiled the code yourself <install-developers>`, the WarpX executable is stored in the source folder under ``build/bin``.
 We also create a symbolic link that is just called ``warpx`` that points to the last executable you built, which can be copied, too.
 Copy the **executable** to this directory:

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -859,7 +859,7 @@ customRunCmd = python3 PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -879,7 +879,7 @@ customRunCmd = python3 PICMI_inputs_runtime_component_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 1
 restartFileNum = 5
 useMPI = 1
@@ -988,7 +988,7 @@ customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1026,7 +1026,7 @@ customRunCmd = python3 PICMI_inputs_1d.py
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1099,7 +1099,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1155,7 +1155,7 @@ customRunCmd = python3 PICMI_inputs_langmuir_rt.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -1668,7 +1668,7 @@ runtime_params =
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1688,7 +1688,7 @@ runtime_params =
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1724,7 +1724,7 @@ customRunCmd = python3 PICMI_inputs_plasma_acceleration.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1744,7 +1744,7 @@ customRunCmd = python3 PICMI_inputs_plasma_acceleration_mr.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1764,7 +1764,7 @@ customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1868,7 +1868,7 @@ customRunCmd = python3 PICMI_inputs_rz.py
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1888,7 +1888,7 @@ customRunCmd = python3 PICMI_inputs_langmuir2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2469,7 +2469,7 @@ customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2728,7 +2728,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2799,7 +2799,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2873,7 +2873,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=ON
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2945,7 +2945,7 @@ customRunCmd = python3 PICMI_inputs_scrape.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2965,7 +2965,7 @@ customRunCmd = python3 PICMI_inputs_reflection.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -2983,7 +2983,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -3001,7 +3001,7 @@ customRunCmd = python3 PICMI_inputs_2d.py --unique
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -3019,7 +3019,7 @@ customRunCmd = python3 PICMI_inputs_prev_pos_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -3146,7 +3146,7 @@ customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PSATD=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -3165,7 +3165,7 @@ customRunCmd = python PICMI_inputs_EB_API.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
-target = install_pip
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 1


### PR DESCRIPTION
Add and document more helpers to quickly and iteratively install our PICMI Python bindings with a one-liner from CMake:
(after one has _once_ run the configuration one-liner)
```console
cmake --build build --target pip_install -j 4
```

This should accelerate development cycles.