### PR TITLE
Apply clang-tidy suggestions to MsgLogger and WarnManager

### DIFF
--- a/Source/Utils/MsgLogger/MsgLogger.H
+++ b/Source/Utils/MsgLogger/MsgLogger.H
@@ -280,10 +280,9 @@ namespace MsgLogger{
 
 #endif
 
-        int m_rank = 0                          /*! MPI rank of the current process*/;
-        int m_num_procs = 0                     /*! Number of MPI ranks*/;
-        int m_io_rank = 0                       /*! Rank of the I/O process*/;
-        [[maybe_unused]] bool m_am_i_io = false /*! Flag to store if the process is responsible for I/O*/;
+        const int m_rank       /*! MPI rank of the current process*/;
+        const int m_num_procs  /*! Number of MPI ranks*/;
+        const int m_io_rank    /*! Rank of the I/O process*/;
 
         std::map<Msg, std::int64_t> m_messages /*! This stores a map to associate warning messages with the corresponding counters*/;
     };

--- a/Source/Utils/MsgLogger/MsgLogger.H
+++ b/Source/Utils/MsgLogger/MsgLogger.H
@@ -280,10 +280,10 @@ namespace MsgLogger{
 
 #endif
 
-        int m_rank = 0         /*! MPI rank of the current process*/;
-        int m_num_procs = 0    /*! Number of MPI ranks*/;
-        int m_io_rank = 0      /*! Rank of the I/O process*/;
-        bool m_am_i_io = false /*! Flag to store if the process is responsible for I/O*/;
+        int m_rank = 0                          /*! MPI rank of the current process*/;
+        int m_num_procs = 0                     /*! Number of MPI ranks*/;
+        int m_io_rank = 0                       /*! Rank of the I/O process*/;
+        [[maybe_unused]] bool m_am_i_io = false /*! Flag to store if the process is responsible for I/O*/;
 
         std::map<Msg, std::int64_t> m_messages /*! This stores a map to associate warning messages with the corresponding counters*/;
     };

--- a/Source/Utils/MsgLogger/MsgLogger.cpp
+++ b/Source/Utils/MsgLogger/MsgLogger.cpp
@@ -209,8 +209,7 @@ MsgWithCounterAndRanks::deserialize (std::vector<char>::const_iterator&& it)
 Logger::Logger() :
     m_rank{amrex::ParallelDescriptor::MyProc()},
     m_num_procs{amrex::ParallelDescriptor::NProcs()},
-    m_io_rank{amrex::ParallelDescriptor::IOProcessorNumber()},
-    m_am_i_io{m_rank == m_io_rank}
+    m_io_rank{amrex::ParallelDescriptor::IOProcessorNumber()}
 {}
 
 void Logger::record_msg(Msg msg)
@@ -323,6 +322,7 @@ std::pair<int,int> Logger::find_gather_rank_and_its_msgs(int how_many_msgs) cons
     const auto num_msg =
         amrex::ParallelDescriptor::Gather(how_many_msgs, m_io_rank);
 
+    const auto m_am_i_io = (m_rank == m_io_rank);
     if (m_am_i_io){
         const auto it_max = std::max_element(num_msg.begin(), num_msg.end());
         max_items = *it_max;

--- a/Source/Utils/MsgLogger/MsgLogger.cpp
+++ b/Source/Utils/MsgLogger/MsgLogger.cpp
@@ -206,12 +206,12 @@ MsgWithCounterAndRanks::deserialize (std::vector<char>::const_iterator&& it)
     return MsgWithCounterAndRanks::deserialize(it);
 }
 
-Logger::Logger(){
-    m_rank = amrex::ParallelDescriptor::MyProc();
-    m_num_procs = amrex::ParallelDescriptor::NProcs();
-    m_io_rank = amrex::ParallelDescriptor::IOProcessorNumber();
-    m_am_i_io = (m_rank == m_io_rank);
-}
+Logger::Logger() :
+    m_rank{amrex::ParallelDescriptor::MyProc()},
+    m_num_procs{amrex::ParallelDescriptor::NProcs()},
+    m_io_rank{amrex::ParallelDescriptor::IOProcessorNumber()},
+    m_am_i_io{m_rank == m_io_rank}
+{}
 
 void Logger::record_msg(Msg msg)
 {
@@ -250,7 +250,7 @@ Logger::collective_gather_msgs_with_counter_and_ranks() const
 
     // Find out who is the "gather rank" and how many messages it has
     const auto my_msgs = get_msgs();
-    const auto how_many_msgs = my_msgs.size();
+    const auto how_many_msgs = static_cast<int>(my_msgs.size());
     const auto [gather_rank, gather_rank_how_many_msgs] =
         find_gather_rank_and_its_msgs(how_many_msgs);
 
@@ -329,7 +329,7 @@ std::pair<int,int> Logger::find_gather_rank_and_its_msgs(int how_many_msgs) cons
 
         //In case of an "ex aequo" the I/O rank should be the gather rank
         max_rank = (max_items == how_many_msgs) ?
-            m_io_rank : it_max - num_msg.begin();
+            m_io_rank : static_cast<int>(it_max - num_msg.begin());
     }
 
     auto package = std::array<int,2>{max_rank, max_items};
@@ -575,7 +575,7 @@ gather_all_data(
             static_cast<int>(package_for_gather_rank.size()), gather_rank);
         amrex::ParallelDescriptor::Gatherv(
             package_for_gather_rank.data(),
-            package_for_gather_rank.size(),
+            static_cast<int>(package_for_gather_rank.size()),
             all_data.data(),
             package_lengths,
             displacements,

--- a/Source/Utils/WarnManager.H
+++ b/Source/Utils/WarnManager.H
@@ -80,19 +80,6 @@ namespace Utils
         private:
 
         /**
-        * \brief This function generates the header of the warning messages list
-        *
-        * @param[in] when a string to mark when the warnings are printed out (it appears in the warning list)
-        * @param[in] line_size maximum line length to be used in formatting warning list
-        * @param[in] is_global flag: true if the header is for a global warning list, false otherwise
-        * @return a string containing the header of the warning list
-        */
-        std::string get_header(
-            const std::string& when,
-            const int line_size,
-            const bool is_global) const;
-
-        /**
         * \brief This function generates a string for a single entry of the warning list
         * for a MessageWithCounter struct (i.e., a warning message paired with a counter storing
         * how many times the warning has been raised)
@@ -115,6 +102,19 @@ namespace Utils
             const MsgLogger::MsgWithCounterAndRanks& msg_with_counter_and_ranks) const;
 
         /**
+        * \brief This function generates the header of the warning messages list
+        *
+        * @param[in] when a string to mark when the warnings are printed out (it appears in the warning list)
+        * @param[in] line_size maximum line length to be used in formatting warning list
+        * @param[in] is_global flag: true if the header is for a global warning list, false otherwise
+        * @return a string containing the header of the warning list
+        */
+        static std::string get_header(
+            const std::string& when,
+            const int line_size,
+            const bool is_global);
+
+        /**
         * \brief This function formats each line of a warning message text
         *
         * @param[in] msg the warning message text
@@ -122,10 +122,10 @@ namespace Utils
         * @param[in] tab_size tabulation size to be used in formatting warning list
         * @return a string containing the formatted warning message text
         */
-        std::string msg_formatter(
+        static std::string msg_formatter(
             const std::string& msg,
             const int line_size,
-            const int tab_size) const;
+            const int tab_size);
 
         int m_rank = 0 /*! MPI rank (appears in the warning list)*/;
         std::unique_ptr<MsgLogger::Logger> m_p_logger /*! The Logger stores all the warning messages*/;

--- a/Source/Utils/WarnManager.cpp
+++ b/Source/Utils/WarnManager.cpp
@@ -18,7 +18,7 @@ using namespace Utils;
 using namespace Utils::MsgLogger;
 
 WarnManager::WarnManager():
-    m_rank{m_rank = amrex::ParallelDescriptor::MyProc()},
+    m_rank{amrex::ParallelDescriptor::MyProc()},
     m_p_logger{std::make_unique<Logger>()}
 {}
 

--- a/Source/Utils/WarnManager.cpp
+++ b/Source/Utils/WarnManager.cpp
@@ -17,10 +17,10 @@
 using namespace Utils;
 using namespace Utils::MsgLogger;
 
-WarnManager::WarnManager(){
-    m_rank = amrex::ParallelDescriptor::MyProc();
-    m_p_logger = std::make_unique<Logger>();
-}
+WarnManager::WarnManager():
+    m_rank{m_rank = amrex::ParallelDescriptor::MyProc()},
+    m_p_logger{std::make_unique<Logger>()}
+{}
 
 void WarnManager::record_warning(
             std::string topic,
@@ -38,9 +38,9 @@ std::string WarnManager::print_local_warnings(const std::string& when) const
 
     std::stringstream ss;
 
-    ss << "\n" << get_header(when, warn_line_size, false);
+    ss << "\n" << WarnManager::get_header(when, warn_line_size, false);
 
-    if(all_warnings.size() == 0){
+    if(all_warnings.empty()){
         ss << "* No recorded warnings.\n";
     }
     else{
@@ -69,9 +69,9 @@ std::string WarnManager::print_global_warnings(const std::string& when) const
 
     std::stringstream ss;
 
-    ss << "\n" << get_header(when, warn_line_size, true);
+    ss << "\n" << WarnManager::get_header(when, warn_line_size, true);
 
-    if(all_warnings.size() == 0){
+    if(all_warnings.empty()){
         ss << "* No recorded warnings.\n";
     }
     else{
@@ -106,7 +106,7 @@ void WarnManager::debug_read_warnings_from_input(amrex::ParmParse& params)
 
         int all_involved = 0;
         pp_warn.query("all_involved", all_involved);
-        if(all_involved){
+        if(all_involved != 0){
             this->record_warning(topic, msg, priority);
         }
         else{
@@ -119,30 +119,6 @@ void WarnManager::debug_read_warnings_from_input(amrex::ParmParse& params)
         }
     }
 
-}
-
-std::string WarnManager::get_header(
-    const std::string& when,
-    const int line_size,
-    const bool is_global) const
-{
-    const std::string warn_header{"**** WARNINGS "};
-
-    std::stringstream ss;
-
-    ss << warn_header <<
-        std::string(line_size - static_cast<int>(warn_header.length()), '*') << "\n" ;
-
-    if(is_global){
-        ss << "* GLOBAL warning list  after " << " [ " <<  when << " ]\n*\n";
-    }
-    else{
-        auto const mpi_rank = amrex::ParallelDescriptor::MyProc();
-        ss << "* LOCAL" << " ( rank # " << mpi_rank << " ) "
-            << " warning list  after " <<  when << "\n*\n";
-    }
-
-    return ss.str();
 }
 
 std::string WarnManager::print_warn_msg(
@@ -187,7 +163,31 @@ std::string WarnManager::print_warn_msg(
     else{
         raised_by += "ALL\n";
     }
-    ss << msg_formatter(raised_by, warn_line_size, warn_tab_size);
+    ss << WarnManager::msg_formatter(raised_by, warn_line_size, warn_tab_size);
+
+    return ss.str();
+}
+
+std::string WarnManager::get_header(
+    const std::string& when,
+    const int line_size,
+    const bool is_global)
+{
+    const std::string warn_header{"**** WARNINGS "};
+
+    std::stringstream ss;
+
+    ss << warn_header <<
+        std::string(line_size - static_cast<int>(warn_header.length()), '*') << "\n" ;
+
+    if(is_global){
+        ss << "* GLOBAL warning list  after " << " [ " <<  when << " ]\n*\n";
+    }
+    else{
+        auto const mpi_rank = amrex::ParallelDescriptor::MyProc();
+        ss << "* LOCAL" << " ( rank # " << mpi_rank << " ) "
+            << " warning list  after " <<  when << "\n*\n";
+    }
 
     return ss.str();
 }
@@ -196,7 +196,7 @@ std::string
 WarnManager::msg_formatter(
         const std::string& msg,
         const int line_size,
-        const int tab_size) const
+        const int tab_size)
 {
     const auto prefix = "*" + std::string(tab_size, ' ');
     const auto prefix_length = static_cast<int>(prefix.length());


### PR DESCRIPTION
I started using the tool `clang-tidy` on WarpX (https://clang.llvm.org/extra/clang-tidy/).
In this PR I've applied some changes suggested by this tool to MsgLogger and WarnManager. The suggested changes
are supposed to  improve readability and to comply with (some of) the c++ core guidelines.

In this case I added few `static_cast<int>`, I set few methods as `static` and I used initializer lists for member variables.