### PR TITLE
Implement some clang-tidy suggestions

### DIFF
--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -254,9 +254,8 @@ void BeamRelevant::ComputeDiags (int step)
 
         if (w_sum < std::numeric_limits<Real>::min() )
         {
-            for (int i = 0; i < static_cast<int>(m_data.size()); ++i){
-                m_data[i] = 0.0_rt;
-            }
+            for (auto& item: m_data) item = 0.0_rt;
+
             return;
         }
 

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -107,11 +107,8 @@ void ReducedDiags::WriteToFile (int step) const
     ofs << WarpX::GetInstance().gett_new(0);
 
     // loop over data size and write
-    for (int i = 0; i < static_cast<int>(m_data.size()); ++i)
-    {
-        ofs << m_sep;
-        ofs << m_data[i];
-    }
+    for (const auto& item : m_data) ofs << m_sep << item;
+
     // end loop over data size
 
     // end line

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -82,8 +82,7 @@ public:
      * Constructor does nothing because optical depth initialization
      * does not require control parameters or lookup tables.
      */
-    BreitWheelerGetOpticalDepth ()
-    {}
+    BreitWheelerGetOpticalDepth () = default;
 
     /**
      * () operator is just a thin wrapper around a very simple function to
@@ -112,7 +111,7 @@ public:
     /**
      * Default constructor: it leaves the functor in a non-initialized state.
      */
-    BreitWheelerEvolveOpticalDepth (){}
+    BreitWheelerEvolveOpticalDepth () = default;
 
 
     /**
@@ -200,7 +199,7 @@ public:
     /**
      * Default constructor: it leaves the functor in a non-initialized state.
      */
-    BreitWheelerGeneratePairs (){}
+    BreitWheelerGeneratePairs () = default;
 
     /**
      * Constructor acquires pointers to control parameters and
@@ -297,7 +296,7 @@ public:
     /**
      * Constructor requires no arguments.
      */
-    BreitWheelerEngine ();
+    BreitWheelerEngine () = default;
 
     /**
      * Builds the functor to initialize the optical depth

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -33,8 +33,6 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 
 // Factory class =============================
 
-BreitWheelerEngine::BreitWheelerEngine (){}
-
 BreitWheelerGetOpticalDepth
 BreitWheelerEngine::build_optical_depth_functor () const
 {

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H
@@ -81,8 +81,7 @@ public:
      * Constructor does nothing because optical depth initialization
      * does not require control parameters or lookup tables.
      */
-    QuantumSynchrotronGetOpticalDepth ()
-    {}
+    QuantumSynchrotronGetOpticalDepth () = default;
 
     /**
      * () operator is just a thin wrapper around a very simple function to
@@ -111,7 +110,7 @@ public:
     /**
      * Default constructor: it leaves the functor in a non-initialized state.
      */
-    QuantumSynchrotronEvolveOpticalDepth (){}
+    QuantumSynchrotronEvolveOpticalDepth () = default;
 
     /**
      * Constructor to be used to initialize the functor.
@@ -184,7 +183,7 @@ public:
     /**
      * Default constructor: it leaves the functor in a non-initialized state.
      */
-    QuantumSynchrotronPhotonEmission (){}
+    QuantumSynchrotronPhotonEmission () = default;
 
     /**
      * Constructor acquires pointers to control parameters and
@@ -277,7 +276,7 @@ public:
     /**
      * Constructor requires no arguments.
      */
-    QuantumSynchrotronEngine ();
+    QuantumSynchrotronEngine () = default;
 
     /**
      * Builds the functor to initialize the optical depth

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
@@ -33,8 +33,6 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 
 // Factory class =============================
 
-QuantumSynchrotronEngine::QuantumSynchrotronEngine (){}
-
 QuantumSynchrotronGetOpticalDepth
 QuantumSynchrotronEngine::build_optical_depth_functor ()
 {

--- a/Source/Utils/IntervalsParser.cpp
+++ b/Source/Utils/IntervalsParser.cpp
@@ -70,9 +70,9 @@ IntervalsParser::IntervalsParser (const std::vector<std::string>& instr_vec)
 
     auto insplit = WarpXUtilStr::split<std::vector<std::string>>(inconcatenated, m_separator);
 
-    for(int i=0; i<static_cast<int>(insplit.size()); i++)
+    for(const auto& inslc : insplit)
     {
-        SliceParser temp_slice(insplit[i]);
+        SliceParser temp_slice(inslc);
         m_slices.push_back(temp_slice);
         if ((temp_slice.getPeriod() > 0) &&
                (temp_slice.getStop() >= temp_slice.getStart())) m_activated = true;
@@ -81,17 +81,15 @@ IntervalsParser::IntervalsParser (const std::vector<std::string>& instr_vec)
 
 bool IntervalsParser::contains (const int n) const
 {
-    for(int i=0; i<static_cast<int>(m_slices.size()); i++){
-        if (m_slices[i].contains(n)) return true;
-    }
-    return false;
+    return std::any_of(m_slices.begin(), m_slices.end(),
+        [&](const auto& slice){return slice.contains(n);});
 }
 
 int IntervalsParser::nextContains (const int n) const
 {
     int next = std::numeric_limits<int>::max();
-    for(int i=0; i<static_cast<int>(m_slices.size()); i++){
-        next = std::min(m_slices[i].nextContains(n),next);
+    for(const auto& slice: m_slices){
+        next = std::min(slice.nextContains(n),next);
     }
     return next;
 }
@@ -99,8 +97,8 @@ int IntervalsParser::nextContains (const int n) const
 int IntervalsParser::previousContains (const int n) const
 {
     int previous = 0;
-    for(int i=0; i<static_cast<int>(m_slices.size()); i++){
-        previous = std::max(m_slices[i].previousContains(n),previous);
+    for(const auto& slice: m_slices){
+        previous = std::max(slice.previousContains(n),previous);
     }
     return previous;
 }

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -288,7 +288,7 @@ int safeCastToInt(const amrex::Real x, const std::string& real_name) {
     std::string assert_msg;
     // (2.0*(numeric_limits<int>::max()/2+1)) converts numeric_limits<int>::max()+1 to a real ensuring accuracy to all digits
     // This accepts x = 2**31-1 but rejects 2**31.
-    if (x < (2.0*(std::numeric_limits<int>::max()/2+1))) {
+    if (x < (2.0*static_cast<double>(std::numeric_limits<int>::max()/2+1))) {
         if (std::ceil(x) >= std::numeric_limits<int>::min()) {
             result = static_cast<int>(x);
         } else {

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -288,7 +288,9 @@ int safeCastToInt(const amrex::Real x, const std::string& real_name) {
     std::string assert_msg;
     // (2.0*(numeric_limits<int>::max()/2+1)) converts numeric_limits<int>::max()+1 to a real ensuring accuracy to all digits
     // This accepts x = 2**31-1 but rejects 2**31.
-    if (x < (2.0*static_cast<double>(std::numeric_limits<int>::max()/2+1))) {
+    using namespace amrex::literals;
+    constexpr amrex::Real max_range = (2.0_rt*static_cast<amrex::Real>(std::numeric_limits<int>::max()/2+1));
+    if (x < max_range) {
         if (std::ceil(x) >= std::numeric_limits<int>::min()) {
             result = static_cast<int>(x);
         } else {


### PR DESCRIPTION
Inspired by @ax3l , I've used [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) on WarpX enabling the following checks:

- 	[[modernize-use-equals-default]](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html)
- 	[[modernize-loop-convert]](https://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html)
- 	[[bugprone-integer-division]](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-integer-division.html)

In practice, I've used this command to compile:
`CXX=clang++ CC=clang ccmake ../. -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-checks=-*,modernize-use-equals-default, modernize-loop-convert, bugprone-integer-division"`

This PR fixes all the issues found with `modernize-loop-convert`, some of the issues found with `modernize-use-equals-default` (there are some subtleties related to unique pointers that I need to understand before fixing them all in another PR), and one of the two issues found with `bugprone-integer-division`.

Concerning the other issue found with `bugprone-integer-division`, I left it as it was since I don't know if the integer division there
is intentional or not:
```
/home/luca/Projects/WarpX/Source/Filter/NCIGodfreyFilter.cpp:61:36: warning: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division]
    Real weight_right = m_cdtodz - index/tab_length;
```
