### PR TITLE
Updated documentation regarding MCC collisions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1318,7 +1318,7 @@ External fields
 Collision initialization
 ------------------------
 
-WarpX provides a relativistic elastic Monte Carlo binary collision model,
+WarpX provides a relativistic elastic Monte Carlo binary Coulomb collision model,
 following the algorithm given by `Perez et al. (Phys. Plasmas 19, 083104, 2012) <https://doi.org/10.1063/1.4742167>`_.
 When the RZ mode is used, `warpx.n_rz_azimuthal_modes` must be set to 1 at the moment,
 since the current implementation of the collision module assumes axisymmetry.
@@ -1374,6 +1374,11 @@ Plasma Science, vol. 19, no. 2, pp. 65-85, 1991) <https://ieeexplore.ieee.org/do
     Only for ``background_mcc``. The MCC scattering processes that should be
     included. Available options are ``elastic``, ``back`` & ``charge_exchange``
     for ions and ``elastic``, ``excitationX`` & ``ionization`` for electrons.
+    The ``elastic`` option uses hard-sphere scattering, with a differential
+    cross section that is independent of angle.
+    With ``charge_exchange``, the ion velocity is replaced with the neutral
+    velocity, chosen from a Maxwellian based on the value of
+    ``<collision_name>.background_temperature``.
     Multiple excitation events can be included for electrons corresponding to
     excitation to different levels, the ``X`` above can be changed to a unique
     identifier for each excitation process. For each scattering process specified


### PR DESCRIPTION
Makes small changes to the documentation to give more explicit detail about the collision algorithms.

I'm working on an application that needs ion-neutral collisions and wanted to make sure I understood what the algorithms are in WarpX. Hopefully, the changes will be helpful to other users.