### PR TITLE
Add `local` flag to `warpx_getNumParticles`

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -625,7 +625,7 @@ class LibWarpX():
             x, y, z, ux, uy, uz, nattr, attr, unique_particles
         )
 
-    def get_particle_count(self, species_name):
+    def get_particle_count(self, species_name, local=False):
         '''
 
         This returns the number of particles of the specified species in the
@@ -635,6 +635,8 @@ class LibWarpX():
         ----------
 
             species_name : the species name that the number will be returned for
+            local        : If True the particle count on this processor will
+                           be returned.
 
         Returns
         -------
@@ -643,7 +645,7 @@ class LibWarpX():
 
         '''
         return self.libwarpx_so.warpx_getNumParticles(
-            ctypes.c_char_p(species_name.encode('utf-8'))
+            ctypes.c_char_p(species_name.encode('utf-8')), local
         )
 
     def get_particle_structs(self, species_name, level):

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -78,7 +78,7 @@ extern "C" {
 
     amrex::Real warpx_getCellSize(int dir, int lev);
 
-    long warpx_getNumParticles(const char* char_species_name);
+    long warpx_getNumParticles(const char* char_species_name, const bool local);
 
     amrex::ParticleReal** warpx_getParticleStructs(
         const char* char_species_name, int lev, int* num_tiles,

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -240,11 +240,12 @@ namespace
         return dx[dir];
     }
 
-    long warpx_getNumParticles(const char* char_species_name) {
+    long warpx_getNumParticles(const char* char_species_name, const bool local) {
         const auto & mypc = WarpX::GetInstance().GetPartContainer();
         const std::string species_name(char_species_name);
         auto & myspc = mypc.GetParticleContainerFromName(species_name);
-        return myspc.TotalNumberOfParticles();
+        // the first argument below is to only count valid particles
+        return myspc.TotalNumberOfParticles(true, local);
     }
 
 #define WARPX_GET_FIELD(FIELD, GETTER) \


### PR DESCRIPTION
This PR allows a user to get the number of particles of a given species on this processor instead of only being able to access the total number of particles in the whole simulation.