### PR TITLE
Binary Collisions: Const & Restrict

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ComputeTemperature.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ComputeTemperature.H
@@ -13,8 +13,9 @@
 template <typename T_index, typename T_R>
 AMREX_GPU_HOST_DEVICE
 T_R ComputeTemperature (
-    T_index const Is, T_index const Ie, T_index const *I,
-    T_R const *ux, T_R const *uy, T_R const *uz, T_R const m )
+    T_index const Is, T_index const Ie, T_index const * AMREX_RESTRICT I,
+    T_R const * AMREX_RESTRICT ux, T_R const * AMREX_RESTRICT uy, T_R const * AMREX_RESTRICT uz,
+    T_R const m )
 {
 
     T_R constexpr inv_c2 = T_R(1.0) / ( PhysConst::c * PhysConst::c );

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -42,7 +42,8 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ElasticCollisionPerez (
     T_index const I1s, T_index const I1e,
     T_index const I2s, T_index const I2e,
-    T_index *I1,       T_index *I2,
+    T_index const* AMREX_RESTRICT I1,
+    T_index const* AMREX_RESTRICT I2,
     SoaData_type soa_1, SoaData_type soa_2,
     T_R const  q1, T_R const  q2,
     T_R const  m1, T_R const  m2,

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
@@ -70,7 +70,8 @@ public:
     void operator() (
         index_type const I1s, index_type const I1e,
         index_type const I2s, index_type const I2e,
-        index_type* I1,       index_type* I2,
+        index_type const* AMREX_RESTRICT I1,
+        index_type const* AMREX_RESTRICT I2,
         SoaData_type soa_1, SoaData_type soa_2,
         GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
         amrex::Real const  q1, amrex::Real const  q2,

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -131,7 +131,8 @@ public:
     void operator() (
         index_type const I1s, index_type const I1e,
         index_type const I2s, index_type const I2e,
-        index_type* I1,       index_type* I2,
+        index_type const* AMREX_RESTRICT I1,
+        index_type const* AMREX_RESTRICT I2,
         SoaData_type soa_1, SoaData_type soa_2,
         GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
         amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,


### PR DESCRIPTION
`const`-ifying and `restrict`-ing pointers to index arrays for binary collision routines.
This should allow the compiler to do more optimizations.