### PR TITLE
Replace deprecated header <ctype.h> with <cctype>

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -56,7 +56,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
-#include <ctype.h>
+#include <cctype>
 #include <functional>
 #include <limits>
 #include <map>

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -15,7 +15,7 @@
 
 #include <algorithm>
 #include <cstring>
-#include <ctype.h>
+#include <cctype>
 #include <map>
 #include <utility>
 


### PR DESCRIPTION
This PR fixes the only two issues found enabling [modernize-deprecated-headers](https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html) check in `clang-tidy`