### PR TITLE
Add const auto to for range loops whenever possible

### DIFF
--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -44,7 +44,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
 
     // create a vector of MCCProcess objects from each scattering
     // process name
-    for (auto scattering_process : scattering_process_names) {
+    for (const auto& scattering_process : scattering_process_names) {
         std::string kw_cross_section = scattering_process + "_cross_section";
         std::string cross_section_file;
         pp_collision_name.query(kw_cross_section.c_str(), cross_section_file);

--- a/Source/Utils/MsgLogger/MsgLogger.cpp
+++ b/Source/Utils/MsgLogger/MsgLogger.cpp
@@ -621,7 +621,7 @@ std::vector<char> serialize_msgs(
     const auto how_many = static_cast<int> (msgs.size());
     put_in (how_many, serialized);
 
-    for (auto msg : msgs){
+    for (const auto& msg : msgs){
         put_in_vec(msg.serialize(), serialized);
     }
     return serialized;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -728,7 +728,7 @@ namespace WarpXUtilStr
                const std::vector<std::string>& elems)
     {
         bool value = false;
-        for (auto elem : elems){
+        for (const auto& elem : elems){
             if (is_in(vect, elem)) value = true;
         }
         return value;


### PR DESCRIPTION
This PR fixes all the ~three~ two issues found with the [performance-for-range-copy](https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html) check by `clang-tidy`