### PR TITLE
Crusher: CMake 3.22.1

### DIFF
--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -2,7 +2,7 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cmake/3.21.3
+module load cmake/3.22.1
 module load craype-accel-amd-gfx90a
 module load rocm/4.5.2
 module load cray-mpich


### PR DESCRIPTION
Update to the lastest available CMake on Crusher.
This one includes
  https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6264
in case we need to build directly with `hipcc` to work-around some internal compiler errors with the Cray wrappers.