### PR TITLE
ABLASTR: particle weights `const`

### DIFF
--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -93,7 +93,7 @@ public:
 
     // DepositCharge should do nothing for photons
     virtual void DepositCharge (WarpXParIter& /*pti*/,
-                                RealVector& /*wp*/,
+                                RealVector const & /*wp*/,
                                 const int * const /*ion_lev*/,
                                 amrex::MultiFab* /*rho*/,
                                 int /*icomp*/,

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -206,7 +206,7 @@ public:
     std::unique_ptr<amrex::MultiFab> GetChargeDensity(int lev, bool local = false);
 
     virtual void DepositCharge (WarpXParIter& pti,
-                               RealVector& wp,
+                               RealVector const & wp,
                                const int * const ion_lev,
                                amrex::MultiFab* rho,
                                int icomp,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -586,7 +586,7 @@ WarpXParticleContainer::DepositCurrent (
  * \param depos_lev   : Level on which particles deposit (if buffers are used)
  */
 void
-WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector& wp,
+WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                                        const int * const ion_lev,
                                        amrex::MultiFab* rho, int icomp,
                                        const long offset, const long np_to_depose,
@@ -681,7 +681,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             const long np = pti.numParticles();
-            auto& wp = pti.GetAttribs(PIdx::w);
+            auto const & wp = pti.GetAttribs(PIdx::w);
 
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization)

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -57,7 +57,7 @@ namespace particles {
 template< typename T_PC >
 static void
 deposit_charge (typename T_PC::ParIterType& pti,
-                typename T_PC::RealVector& wp,
+                typename T_PC::RealVector const& wp,
                 const int * const ion_lev,
                 amrex::MultiFab* rho, const int icomp, const int nc,
                 const long offset, const long np_to_depose,


### PR DESCRIPTION
We can declare the particle weights `const` because we don't change values in them during deposition.