### PR TITLE
[mini] Use parser to read laser spatio-temporal couplings direction

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -48,7 +48,7 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
     queryWithParser(ppl, "phi0", m_params.phi0);
 
     m_params.stc_direction = m_common_params.p_X;
-    ppl.queryarr("stc_direction", m_params.stc_direction);
+    queryArrWithParser(ppl, "stc_direction", m_params.stc_direction);
     auto const s = 1.0_rt / std::sqrt(
         m_params.stc_direction[0]*m_params.stc_direction[0] +
         m_params.stc_direction[1]*m_params.stc_direction[1] +


### PR DESCRIPTION
Looks like this parameter was missed when we added parser support for all real input parameters.