### PR TITLE
Don't cut all particles in a Gaussian beam when x_rms=0

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -451,9 +451,9 @@ PhysicalParticleContainer::AddGaussianBeam (
             const Real z = amrex::RandomNormal(z_m, z_rms);
 #endif
             if (plasma_injector->insideBounds(x, y, z)  &&
-                std::abs( x - x_m ) < x_cut * x_rms     &&
-                std::abs( y - y_m ) < y_cut * y_rms     &&
-                std::abs( z - z_m ) < z_cut * z_rms   ) {
+                std::abs( x - x_m ) <= x_cut * x_rms     &&
+                std::abs( y - y_m ) <= y_cut * y_rms     &&
+                std::abs( z - z_m ) <= z_cut * z_rms   ) {
                 XDim3 u = plasma_injector->getMomentum(x, y, z);
                 u.x *= PhysConst::c;
                 u.y *= PhysConst::c;


### PR DESCRIPTION
Currently it is not possible to inject particles with `gaussian_beam` injection style when the rms in one of the spatial direction is exactly 0, which is slightly inconvenient. Not using strict inequalities when cutting the beam with `x_cut`, `y_cut` and `z_cut` should be enough to fix the issue.