### PR TITLE
Add amrex REPO and BRANCH flags for python builds

### DIFF
--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -269,6 +269,8 @@ Environment Variable          Default & Values                             Descr
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)
 ``ADIOS_USE_STATIC_LIBS``     ON/**OFF**                                   Prefer static libraries for ADIOS1 dependency (openPMD)
 ``WARPX_AMREX_SRC``           *None*                                       Absolute path to AMReX source directory (preferred if set)
+``WARPX_AMREX_REPO``          *None (uses cmake default)*                  Repository URI to pull and build AMReX from
+``WARPX_AMREX_BRANCH``        *None (uses cmake default)*                  Repository branch for ``WARPX_AMREX_REPO``
 ``WARPX_AMREX_INTERNAL``      **ON**/OFF                                   Needs a pre-installed AMReX library if set to ``OFF``
 ``WARPX_OPENPMD_SRC``         *None*                                       Absolute path to openPMD-api source directory (preferred if set)
 ``WARPX_OPENPMD_INTERNAL``    **ON**/OFF                                   Needs a pre-installed openPMD-api library if set to ``OFF``

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,10 @@ class CMakeBuild(build_ext):
         # further dependency control (developers & package managers)
         if WARPX_AMREX_SRC:
             cmake_args.append('-DWarpX_amrex_src=' + WARPX_AMREX_SRC)
+        if WARPX_AMREX_REPO:
+            cmake_args.append('-DWarpX_amrex_repo=' + WARPX_AMREX_REPO)
+        if WARPX_AMREX_BRANCH:
+            cmake_args.append('-DWarpX_amrex_branch=' + WARPX_AMREX_BRANCH)
         if WARPX_OPENPMD_SRC:
             cmake_args.append('-DWarpX_openpmd_src=' + WARPX_OPENPMD_SRC)
         if WARPX_PICSAR_SRC:
@@ -202,6 +206,8 @@ HDF5_USE_STATIC_LIBRARIES = env.pop('HDF5_USE_STATIC_LIBRARIES', 'OFF')
 ADIOS_USE_STATIC_LIBS = env.pop('ADIOS_USE_STATIC_LIBS', 'OFF')
 # CMake dependency control (developers & package managers)
 WARPX_AMREX_SRC = env.pop('WARPX_AMREX_SRC', '')
+WARPX_AMREX_REPO = env.pop('WARPX_AMREX_REPO', '')
+WARPX_AMREX_BRANCH = env.pop('WARPX_AMREX_BRANCH', '')
 WARPX_AMREX_INTERNAL = env.pop('WARPX_AMREX_INTERNAL', 'ON')
 WARPX_OPENPMD_SRC = env.pop('WARPX_OPENPMD_SRC', '')
 WARPX_OPENPMD_INTERNAL = env.pop('WARPX_OPENPMD_INTERNAL', 'ON')


### PR DESCRIPTION
I needed these to build an image with Andrew's AMReX PR https://github.com/AMReX-Codes/amrex/pull/2624 to test the bug reported in https://github.com/ECP-WarpX/WarpX/issues/2785 , and thought I would add them for others to use.