### PR TITLE
Only set modified k to 0 for even number of points

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -266,7 +266,7 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
                     } else {
                         // The other axes contains both positive and negative k ;
                         // the Nyquist frequency is in the middle of the array.
-                        if ( (N%2==0) & (i == N/2) ){
+                        if ( (N%2==0) && (i == N/2) ){
                             p_modified_k[i] = 0.0_rt;
                         }
                     }

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -266,7 +266,7 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
                     } else {
                         // The other axes contains both positive and negative k ;
                         // the Nyquist frequency is in the middle of the array.
-                        if (i == N/2) {
+                        if ( (N%2==0) & (i == N/2) ){
                             p_modified_k[i] = 0.0_rt;
                         }
                     }


### PR DESCRIPTION
In the code that computes the modified k vectors, we explicitly set the modified vector to 0 at the Nyquist frequency. 

However, we failed to notice that the Nyquist frequency is part of the set of discrete k vectors **only when** the number of grid points is even. (This is because the discrete `k` values are of the form `2*pi*i / (N*dx)`, with `i` an integer and `N` the number of grid points. The Nyquist frequency is `2*pi / (2*dx)` ; it can only be reached when `N` is even.)

Fix #2850