### PR TITLE
Do Not Fill PML Guard Cells w/ Inverse FFTs

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -727,6 +727,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
                                          "PML: PSATD solver selected but not built.");
 #else
         // Flags passed to the spectral solver constructor
+        const amrex::IntVect fill_guards = amrex::IntVect(0);
         const bool in_pml = true;
         const bool periodic_single_box = false;
         const bool update_with_rho = false;
@@ -738,7 +739,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         amrex::Vector<amrex::Real> const v_comoving_zero = {0., 0., 0.};
         realspace_ba.enclosedCells().grow(nge); // cell-centered + guard cells
         spectral_solver_fp = std::make_unique<SpectralSolver>(lev, realspace_ba, dm,
-            nox_fft, noy_fft, noz_fft, do_nodal, WarpX::fill_guards, v_galilean_zero,
+            nox_fft, noy_fft, noz_fft, do_nodal, fill_guards, v_galilean_zero,
             v_comoving_zero, dx, dt, in_pml, periodic_single_box, update_with_rho,
             fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif
@@ -846,6 +847,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
                                              "PML: PSATD solver selected but not built.");
 #else
             // Flags passed to the spectral solver constructor
+            const amrex::IntVect fill_guards = amrex::IntVect(0);
             const bool in_pml = true;
             const bool periodic_single_box = false;
             const bool update_with_rho = false;
@@ -857,7 +859,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             amrex::Vector<amrex::Real> const v_comoving_zero = {0., 0., 0.};
             realspace_cba.enclosedCells().grow(nge); // cell-centered + guard cells
             spectral_solver_cp = std::make_unique<SpectralSolver>(lev, realspace_cba, cdm,
-                nox_fft, noy_fft, noz_fft, do_nodal, WarpX::fill_guards, v_galilean_zero,
+                nox_fft, noy_fft, noz_fft, do_nodal, fill_guards, v_galilean_zero,
                 v_comoving_zero, cdx, dt, in_pml, periodic_single_box, update_with_rho,
                 fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif


### PR DESCRIPTION
`WarpX::fill_guards` controls whether the guard cells are filled when we compute the inverse FFTs of the various fields with the PSATD solver, and it is currently set to `true` with `damped` boundary conditions and `false` otherwise by default:
https://github.com/ECP-WarpX/WarpX/blob/fe971e82a49a1c5101e5ef48cce849460dcb598d/Source/WarpX.cpp#L1266-L1276

`WarpX::fill_guards` was also used to control the behavior in the PML, and not just in the regular grid. However, filling the guard cells in the PML with inverse FFTs, when `damped` boundary conditions are used for the coarse level of a simulation with mesh refinement, can lead to discontinuities that are reflected in the regular grid, because of the exchange of data between the regular grid and the PML itself.

Thus, in this PR we enforce that `false` is passed to the constructor of the spectral solver in the PML, so that the guard cells are not filled. We want to see if this plays a role in the instabilities reported in #2795.

**Update** As reported in https://github.com/ECP-WarpX/WarpX/issues/2795#issuecomment-1043209710, this fixes #2795. Credit to @RemiLehe for suggesting that this could solve the issue.