### PR TITLE
NVCC 11.0-11.4.1: Silence Warning in ShapeFactors

### DIFF
--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -65,8 +65,8 @@ struct Compute_shape_factor
         else{
             amrex::Abort("Unknown particle shape selected in Compute_shape_factor");
             amrex::ignore_unused(sx, xmid);
-            return 0;
         }
+        return 0;
     }
 };
 
@@ -119,8 +119,8 @@ struct Compute_shifted_shape_factor
         else{
             amrex::Abort("Unknown particle shape selected in Compute_shifted_shape_factor");
             amrex::ignore_unused(sx, x_old, i_new);
-            return 0;
         }
+        return 0;
     }
 };
 


### PR DESCRIPTION
Silence a warning about a missing return type when building with GCC 11.2 & CUDA NVCC 11.4.100.
```
warning #940-D: missing return statement at end of non-void function
```

First seen on Perlmutter (NERSC).

This is a false-positive from NVCC and also shows up in: `Source/Utils/MsgLogger/MsgLoggerSerialization.H` lines 110, 146

It looks like this is fixed in NVCC 11.5 and present in all earlier NVCC versions (11.0-11.4.1) that support C++17:
https://cuda.godbolt.org/z/K4s6KvM6T