### PR TITLE
Gaussian particle beam: add error message when using y_rms = 0 in 2D

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -55,6 +55,8 @@ PlasmaInjector::PlasmaInjector () {}
 PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     : species_id(ispecies), species_name(name)
 {
+    using namespace amrex::literals;
+
     amrex::ParmParse pp_species_name(species_name);
 
 #ifdef AMREX_USE_GPU
@@ -211,6 +213,19 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         pp_species_name.query("do_symmetrize", do_symmetrize);
         gaussian_beam = true;
         parseMomentum(pp_species_name);
+#if defined(WARPX_DIM_XZ)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
+        "Error: Gaussian beam y_rms must be strictly greater than 0 in 2D "
+        "(it is used when computing the particles' weights from the total beam charge)");
+#elif defined(WARPX_DIM_1D_Z)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( x_rms > 0._rt,
+        "Error: Gaussian beam x_rms must be strictly greater than 0 in 1D "
+        "(it is used when computing the particles' weights from the total beam charge)");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
+        "Error: Gaussian beam y_rms must be strictly greater than 0 in 1D "
+        "(it is used when computing the particles' weights from the total beam charge)");
+#endif
+
     }
     // Depending on injection type at runtime, initialize inj_pos
     // so that inj_pos->getPositionUnitBox calls


### PR DESCRIPTION
I tried to set `beam.y_rms = 0` when adding a gaussian particle beam in a 2D simulation. This actually should not be done because it results in a division by 0 in the computation of the weights of the beam particles:
https://github.com/ECP-WarpX/WarpX/blob/455c8cdfda44962e18a0476afa52e9337cfbbc99/Source/Particles/PhysicalParticleContainer.cpp#L469
This eventually leads to a segfault.

In this PR, I add error messages in case someone does the same thing as me in the future.
