### PR TITLE
Lassen: Fix Chunked HDF5 with MPI

### DIFF
--- a/Tools/machines/lassen-llnl/lassen.bsub
+++ b/Tools/machines/lassen-llnl/lassen.bsub
@@ -18,5 +18,9 @@
 #BSUB -o WarpXo.%J
 #BSUB -e WarpXe.%J
 
+# Work-around OpenMPI bug with chunked HDF5
+#   https://github.com/open-mpi/ompi/issues/7795
+export OMPI_MCA_io=ompio
+
 export OMP_NUM_THREADS=1
 jsrun -r 4 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs -M "-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
Try to work-around segfaults with HDF5 when running on more than one node.

- [x] testing

I think that is caused by: https://github.com/open-mpi/ompi/issues/7795

```
=== If no file names and line numbers are shown below, one can run
            addr2line -Cpfie my_exefile my_line_address
    to convert `my_line_address` (e.g., 0x4a6b) into file name and line number.
    Or one can use amrex/Tools/Backtrace/parse_bt.py.

=== Please note that the line number reported by addr2line may not be accurate.
    One can use
            readelf -wl my_exefile | grep my_line_address'
    to find out the offset for that line.

 0: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x1051b690]
    amrex::BLBackTrace::print_backtrace_info(_IO_FILE*)
??:0

 1: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x1051d774]
    amrex::BLBackTrace::handler(int)
??:0

 2: [0x2000000504d8]
    __kernel_sigtramp_rt64
arch/powerpc/kernel/vdso64/sigtramp.S:30

 3: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(ADIOI_Flatten+0xbc4) [0x20001e01488c]
    ADIOI_Flatten
??:0

 4: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(ADIOI_Flatten_datatype+0x1d8) [0x20001e013c8c]
    ADIOI_Flatten_datatype
??:0

 5: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(ADIOI_Flatten_and_find+0x28) [0x20001e017c28]
    ADIOI_Flatten_and_find
??:0

 6: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(+0x2ee70) [0x20001dfcee70]
    ADIOI_Exch_and_write
??:0

 7: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(ADIOI_GPFS_WriteStridedColl+0x1bfc) [0x20001dfce428]
    ADIOI_GPFS_WriteStridedColl
??:0

 8: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(MPIOI_File_write_all+0x610) [0x20001dfbfb84]
    MPIOI_File_write_all
??:0

 9: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(mca_io_romio_dist_MPI_File_write_at_all+0x68) [0x20001dfc07f0]
    mca_io_romio_dist_MPI_File_write_at_all
??:0

10: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/container/../lib/spectrum_mpi/mca_io_romio321.so(mca_io_romio321_file_write_at_all+0x3c) [0x20001dfb1d7c]
    mca_io_romio321_file_write_at_all
??:0

11: /usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/lib/libmpi_ibm.so.3(PMPI_File_write_at_all+0x124) [0x2000001993b4]
    PMPI_File_write_at_all
??:0

12: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0x3aff10) [0x20000061ff10]
    H5FD_mpio_write
/builddir/build/BUILD/hdf5-1.10.4/src/H5FDmpio.c:1801:43

13: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5FD_write+0xcc) [0x2000003dac1c]
    H5FD_write
/builddir/build/BUILD/hdf5-1.10.4/src/H5FDint.c:257:18

14: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5F__accum_write+0x1b8) [0x2000003ae2d8]
    H5F__accum_write
/builddir/build/BUILD/hdf5-1.10.4/src/H5Faccum.c:825:12

15: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5PB_write+0xa68) [0x200000503e48]
    H5PB_write
/builddir/build/BUILD/hdf5-1.10.4/src/H5PB.c:1027:12

16: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5F_block_write+0x68) [0x2000003bc3c8]
    H5F_block_write
/builddir/build/BUILD/hdf5-1.10.4/src/H5Fio.c:164:8

17: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5D__chunk_allocate+0x12b0) [0x200000354dc0]
    H5D__chunk_collective_fill inlined at /builddir/build/BUILD/hdf5-1.10.4/src/H5Dchunk.c:4383:12 in H5D__chunk_allocate
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dchunk.c:4702:8
H5D__chunk_allocate
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dchunk.c:4383:12

18: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0xf6e48) [0x200000366e48]
    H5D__init_storage
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:2242:20

19: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5D__alloc_storage+0x200) [0x20000036d9c0]
    H5D__alloc_storage
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:2155:23

20: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5D__layout_oh_create+0x4a8) [0x2000003760e8]
    H5D__layout_oh_create
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dlayout.c:507:12

21: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5D__create+0x20e0) [0x20000036a630]
    H5D__update_oh_info inlined at /builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:1098:8 in H5D__create
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:797:8
H5D__create
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:1098:8

22: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0x1074fc) [0x2000003774fc]
    H5O__dset_create
/builddir/build/BUILD/hdf5-1.10.4/src/H5Doh.c:299:24

23: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5O_obj_create+0x13c) [0x20000049b9ec]
    H5O_obj_create
/builddir/build/BUILD/hdf5-1.10.4/src/H5Oint.c:2644:37

24: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0x1e63e4) [0x2000004563e4]
    H5L__link_cb
/builddir/build/BUILD/hdf5-1.10.4/src/H5L.c:1618:53

25: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0x1afb68) [0x20000041fb68]
    H5G__traverse_real
/builddir/build/BUILD/hdf5-1.10.4/src/H5Gtraverse.c:626:16

26: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5G_traverse+0xc0) [0x200000420060]
    H5G_traverse
/builddir/build/BUILD/hdf5-1.10.4/src/H5Gtraverse.c:851:9

27: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(+0x1e2e60) [0x200000452e60]
    H5L__create_real
/builddir/build/BUILD/hdf5-1.10.4/src/H5L.c:1812:8

28: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5L_link_object+0x5c) [0x2000004580fc]
    H5L_link_object
/builddir/build/BUILD/hdf5-1.10.4/src/H5L.c:1571:7

29: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5D__create_named+0x74) [0x200000367fa4]
    H5D__create_named
/builddir/build/BUILD/hdf5-1.10.4/src/H5Dint.c:325:8

30: /usr/tce/packages/hdf5/hdf5-parallel-1.10.4-gcc-8.3.1-spectrum-mpi-rolling-release/lib/libhdf5.so.103(H5Dcreate2+0x284) [0x20000033e734]
    H5Dcreate2
/builddir/build/BUILD/hdf5-1.10.4/src/H5D.c:144:24

31: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x106a5cf0]
    openPMD::HDF5IOHandlerImpl::createDataset(openPMD::Writable*, openPMD::Parameter<(openPMD::Operation)9> const&)
??:0

32: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x106aa554]
    openPMD::AbstractIOHandlerImpl::flush()
??:0

33: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x106b1bd4]
    openPMD::ParallelHDF5IOHandler::flush()
??:0

34: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x105ee570]
    openPMD::Mesh::flush_impl(std::string const&)
??:0

35: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x1011c0ac]
    openPMD::BaseRecord<openPMD::MeshRecordComponent>::flush(std::string const&)
??:0

36: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x105ddb0c]
    openPMD::Iteration::flush()
??:0

37: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x105ddef4]
    openPMD::Iteration::flushFileBased(std::string const&, unsigned long)
??:0

38: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x10631a04]
    openPMD::SeriesInterface::flushFileBased(std::_Rb_tree_iterator<std::pair<unsigned long const, openPMD::Iteration> >, std::_Rb_tree_iterator<std::pair<unsigned long const, openPMD::Iteration> >)
??:0

39: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x10632920]
    openPMD::SeriesInterface::flush_impl(std::_Rb_tree_iterator<std::pair<unsigned long const, openPMD::Iteration> >, std::_Rb_tree_iterator<std::pair<unsigned long const, openPMD::Iteration> >, openPMD::FlushLevel, bool)
??:0

40: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x106329c4]
    openPMD::SeriesInterface::flush()
??:0

41: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x10111f60]
    WarpXOpenPMDPlot::WriteOpenPMDFieldsAll(std::vector<std::string, std::allocator<std::string> > const&, amrex::Vector<amrex::MultiFab, std::allocator<amrex::MultiFab> > const&, amrex::Vector<amrex::Geometry, std::allocator<amrex::Geometry> >&, int, double, bool, amrex::Geometry const&) const
??:0

42: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x10189f50]
    FlushFormatOpenPMD::WriteToFile(amrex::Vector<std::string, std::allocator<std::string> >, amrex::Vector<amrex::MultiFab, std::allocator<amrex::MultiFab> > const&, amrex::Vector<amrex::Geometry, std::allocator<amrex::Geometry> >&, amrex::Vector<int, std::allocator<int> >, double, amrex::Vector<ParticleDiag, std::allocator<ParticleDiag> > const&, int, std::string, int, bool, bool, bool, int, amrex::Geometry const&, bool) const
??:0

43: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x100c5c30]
    FullDiagnostics::Flush(int)
??:0

44: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x100bf9ac]
    Diagnostics::FilterComputePackFlush(int, bool)
??:0

45: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x100ca5d0]
    MultiDiagnostics::FilterComputePackFlush(int, bool)
??:0

46: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x10287c9c]
    WarpX::InitData()
??:0

47: src/warpx/build/bin/warpx.2d.MPI.CUDA.DP.OPMD.QED() [0x1001d3f4]
    main
??:0

48: /lib64/libc.so.6(+0x25300) [0x200000b35300]
    generic_start_main
../csu/libc-start.c:266

49: /lib64/libc.so.6(__libc_start_main+0xc4) [0x200000b354f4]
    __libc_start_main
../sysdeps/unix/sysv/linux/powerpc/libc-start.c:81


===== TinyProfilers ======
main()
WarpX::InitData()
Diagnostics::FilterComputePackFlush()
FlushFormatOpenPMD::WriteToFile()
WarpXOpenPMDPlot::WriteOpenPMDFields()
```