### PR TITLE
Add Coulomb collision installation to picmi.py

### DIFF
--- a/Examples/Tests/collision/PICMI_inputs_2d.py
+++ b/Examples/Tests/collision/PICMI_inputs_2d.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+#
+# --- Input file for binary Coulomb collision testing. This input scripts
+# --- runs the same test as inputs_2d but via Python.
+
+from pywarpx import picmi
+
+constants = picmi.constants
+
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+
+max_steps = 150
+
+max_grid_size = 8
+max_level = 0
+nx = max_grid_size
+ny = max_grid_size
+
+xmin = 0
+xmax = 4.154046151855669e2
+ymin = xmin
+ymax = xmax
+
+plasma_density = 1e21
+elec_rms_velocity = 0.044237441120300*constants.c
+ion_rms_velocity = 0.006256118919701*constants.c
+number_per_cell = 200
+
+#################################
+############ NUMERICS ###########
+#################################
+serialize_ics = 1
+verbose = 1
+cfl = 1.0
+
+# Order of particle shape factors
+particle_shape = 1
+
+#################################
+############ PLASMA #############
+#################################
+
+elec_dist = picmi.UniformDistribution(
+    density=plasma_density,
+    rms_velocity=[elec_rms_velocity]*3,
+    directed_velocity=[elec_rms_velocity, 0., 0.]
+)
+
+ion_dist = picmi.UniformDistribution(
+    density=plasma_density,
+    rms_velocity=[ion_rms_velocity]*3,
+)
+
+electrons = picmi.Species(
+    particle_type='electron', name='electron',
+    warpx_do_not_deposit=1,
+    initial_distribution=elec_dist,
+)
+ions = picmi.Species(
+    particle_type='H',
+    name='ion', charge='q_e',
+    mass="5*m_e",
+    warpx_do_not_deposit=1,
+    initial_distribution=ion_dist
+)
+
+#################################
+########## COLLISIONS ###########
+#################################
+
+collision1 = picmi.CoulombCollisions(
+    name='collisions1',
+    species=[electrons, ions],
+    CoulombLog=15.9
+)
+collision2 = picmi.CoulombCollisions(
+    name='collisions2',
+    species=[electrons, electrons],
+    CoulombLog=15.9
+)
+collision3 = picmi.CoulombCollisions(
+    name='collisions3',
+    species=[ions, ions],
+    CoulombLog=15.9
+)
+
+#################################
+###### GRID AND SOLVER ##########
+#################################
+
+grid = picmi.Cartesian2DGrid(
+    number_of_cells=[nx, ny],
+    warpx_max_grid_size=max_grid_size,
+    warpx_blocking_factor=max_grid_size,
+    lower_bound=[xmin, ymin],
+    upper_bound=[xmax, ymax],
+    lower_boundary_conditions=['periodic', 'periodic'],
+    upper_boundary_conditions=['periodic', 'periodic'],
+)
+solver = picmi.ElectromagneticSolver(grid=grid, cfl=cfl)
+
+#################################
+######### DIAGNOSTICS ###########
+#################################
+
+field_diag = picmi.FieldDiagnostic(
+    name='diag1',
+    grid=grid,
+    period=10,
+    data_list=[],
+    write_dir='.',
+    warpx_file_prefix='Python_collisionXZ_plt'
+)
+
+#################################
+####### SIMULATION SETUP ########
+#################################
+
+sim = picmi.Simulation(
+    solver=solver,
+    max_steps=max_steps,
+    verbose=verbose,
+    warpx_serialize_ics=serialize_ics,
+    warpx_collisions=[collision1, collision2, collision3]
+)
+
+sim.add_species(
+    electrons,
+    layout=picmi.PseudoRandomLayout(
+        n_macroparticles_per_cell=number_per_cell, grid=grid
+    )
+)
+sim.add_species(
+    ions,
+    layout=picmi.PseudoRandomLayout(
+        n_macroparticles_per_cell=number_per_cell, grid=grid
+    )
+)
+
+sim.add_diagnostic(field_diag)
+
+#################################
+##### SIMULATION EXECUTION ######
+#################################
+
+#sim.write_input_file('PICMI_inputs_2d')
+sim.step(max_steps)

--- a/Examples/Tests/collision/PICMI_inputs_2d.py
+++ b/Examples/Tests/collision/PICMI_inputs_2d.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 #
-# --- Input file for binary Coulomb collision testing. This input scripts
-# --- runs the same test as inputs_2d but via Python.
+# --- Input file for binary Coulomb collision testing. This input script
+# --- runs the same test as inputs_2d but via Python, therefore the input
+# --- values where directly copied from inputs_2d.
 
 from pywarpx import picmi
 

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -10,14 +10,14 @@
 # using electron-ion temperature relaxation in 2D.
 # Initially, electrons and ions are both in equilibrium
 # (gaussian) distributions, but have different temperatures.
-# Relaxation occurs to bring the two temperatures to be
-# a final same temperature through collisions.
+# Relaxation occurs to bring the two temperatures to the
+# same final temperature through collisions.
 # The code was tested to be valid, more detailed results
 # were used to obtain an exponential fit with
 # coefficients a and b.
 # This automated test compares the results with the fit.
-# Unrelated to the collision module, we also test the plotfile particle filter function in this
-# analysis script.
+# Unrelated to the collision module, we also test the plotfile
+# particle filter function in this analysis script.
 
 # Possible errors:
 # tolerance: 0.001
@@ -70,7 +70,7 @@ for fn in fn_list:
     # load file
     ds  = yt.load( fn )
     ad  = ds.all_data()
-    px  = ad['particle_momentum_x'].to_ndarray()
+    px  = ad[('all', 'particle_momentum_x')].to_ndarray()
     # get time index j
     j = int(fn[-5:])
     # compute error
@@ -87,6 +87,10 @@ print('error = ', error)
 print('tolerance = ', tolerance)
 assert(error < tolerance)
 
+# The second part of the analysis is not done for the Python test
+# since the particle filter function is not accessible from PICMI yet
+if "Python" in last_fn:
+    exit()
 
 ## In the second past of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -859,6 +859,27 @@ class Mirror(picmistandard.PICMI_Mirror):
         pywarpx.warpx.mirror_z_npoints.append(self.number_of_cells)
 
 
+class CoulombCollisions(picmistandard.base._ClassWithInit):
+    """Custom class to handle setup of binary Coulmb collisions in WarpX. If
+    collision initialization is added to picmistandard this can be changed to
+    inherit that functionality."""
+
+    def __init__(self, name, species, CoulombLog=None, ndt=None, **kw):
+        self.name = name
+        self.species = species
+        self.CoulombLog = CoulombLog
+        self.ndt = ndt
+
+        self.handle_init(kw)
+
+    def initialize_inputs(self):
+        collision = pywarpx.Collisions.newcollision(self.name)
+        collision.type = 'pairwisecoulomb'
+        collision.species = [species.name for species in self.species]
+        collision.CoulombLog = self.CoulombLog
+        collision.ndt = self.ndt
+
+
 class MCCCollisions(picmistandard.base._ClassWithInit):
     """Custom class to handle setup of MCC collisions in WarpX. If collision
     initialization is added to picmistandard this can be changed to inherit

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2053,6 +2053,26 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
+[Python_collisionXZ]
+buildDir = .
+inputFile = Examples/Tests/collision/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
 [collisionRZ]
 buildDir = .
 inputFile = Examples/Tests/collision/inputs_rz


### PR DESCRIPTION
Support was added to `picmi.py` to allow Coulomb collisions to be installed in simulations executed via Python.
A PICMI version of the existing 2d collisions test was also added to cover the new functionality in CI testing.