### PR TITLE
Fix number of guard cell for coarse patch (for relativistic Poisson solver)

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -728,12 +728,11 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
             const DistributionMapping& fine_dm = rho[lev+1]->DistributionMap();
             BoxArray coarsened_fine_BA = rho[lev+1]->boxArray();
             coarsened_fine_BA.coarsen(m_gdb->refRatio(lev));
-            MultiFab coarsened_fine_data(coarsened_fine_BA, fine_dm, rho[lev+1]->nComp(), 0);
+            const IntVect ngrow = (rho[lev+1]->nGrowVect()+1)/m_gdb->refRatio(lev);
+            MultiFab coarsened_fine_data(coarsened_fine_BA, fine_dm, rho[lev+1]->nComp(), ngrow );
             coarsened_fine_data.setVal(0.0);
 
-            int const refinement_ratio = 2;
-
-            CoarsenMR::Coarsen( coarsened_fine_data, *rho[lev+1], IntVect(refinement_ratio) );
+            CoarsenMR::Coarsen( coarsened_fine_data, *rho[lev+1], m_gdb->refRatio(lev) );
             WarpXCommUtil::ParallelAdd(*rho[lev], coarsened_fine_data, 0, 0, rho[lev]->nComp(),
                                        amrex::IntVect::TheZeroVector(),
                                        amrex::IntVect::TheZeroVector(),


### PR DESCRIPTION
When using the relativistic Poisson solver with MR, we temporarily allocate a coarse patch for `rho` in order to propagate the charge from the fine patch to the level below (by coarsening the fine patch to the coarse patch, and then doing a `ParallelCopy` to the level below).

(In the case of the lab-frame Poisson solver as well as the Maxwell solver, we use the permanently stored `rho_cp`, instead of temporarily allocating a coarse patch.)

However, the number of guard cells that was allocated for this coarse patch was insufficient. More specifically, the guard cells of the coarse patch must be wide enough to contain the guard cells of the corresponding fine patch (because particles may deposit charge in the guard cells of the fine patch).