### PR TITLE
WIP Add TERM signal handler to checkpoint interupted simulation before exiting

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -47,16 +47,26 @@
 
 #include <algorithm>
 #include <array>
+#include <csignal>
 #include <memory>
 #include <ostream>
 #include <vector>
 
 using namespace amrex;
 
+void exitSignalHandler(int param)
+{
+    WarpX::GetInstance().setTerminateFlag(param);
+    Print() << "SIGTERM registered" << std::endl;
+}
+
 void
 WarpX::Evolve (int numsteps)
 {
     WARPX_PROFILE("WarpX::Evolve()");
+
+    // register handling of SIGTERM signal
+    signal(SIGTERM, exitSignalHandler);
 
     Real cur_time = t_new[0];
 
@@ -348,7 +358,7 @@ WarpX::Evolve (int numsteps)
                       << " s; Avg. per step = " << evolve_time/(step-step_begin+1) << " s\n";
         }
 
-        if (cur_time >= stop_time - 1.e-3*dt[0]) {
+        if ((cur_time >= stop_time - 1.e-3*dt[0]) || terminate_flag) {
             break;
         }
 

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -142,6 +142,7 @@ extern "C" {
 
   int warpx_maxStep ();
   amrex::Real warpx_stopTime ();
+  int warpx_terminateFlag ();
 
   int warpx_finestLevel ();
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -714,6 +714,10 @@ namespace
         WarpX& warpx = WarpX::GetInstance();
         return warpx.stopTime();
     }
+    int warpx_terminateFlag() {
+        WarpX& warpx = WarpX::GetInstance();
+        return warpx.terminateFlag();
+    }
 
     int warpx_finestLevel () {
         WarpX& warpx = WarpX::GetInstance();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -618,6 +618,8 @@ public:
 
     int maxStep () const {return max_step;}
     amrex::Real stopTime () const {return stop_time;}
+    void setTerminateFlag (int val) {terminate_flag = val;}
+    int terminateFlag () {return terminate_flag;}
 
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,
         amrex::Vector<amrex::MultiFab>& mf_avg, const amrex::IntVect ngrow) const;
@@ -1197,6 +1199,7 @@ private:
 
     int max_step   = std::numeric_limits<int>::max();
     amrex::Real stop_time = std::numeric_limits<amrex::Real>::max();
+    int terminate_flag = 0;
 
     int regrid_int = -1;
 


### PR DESCRIPTION
The idea here is to gracefully exit the simulation (possibly checkpointing at the current step) when a `SIGTERM` signal is sent to the simulation process. This is useful, for example, on SLURM systems where a terminate signal is sent to job steps some time before a job is killed (when exceeding time limits, memory limits, etc.).

I have tested locally that this works with several MPI processes as well as a single test on Perlmutter running on multiple GPUs. I'm not sure if there could be problems depending on where in the PIC loop the `SIGTERM` is captured though. 
I'm curious what others think about this approach.