### PR TITLE
openPMD: Add ADIOS2 Engine Parameter Control

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1892,15 +1892,15 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
         <diag_name>.adios2_operator.type = zfp
         <diag_name>.adios2_operator.parameters.precision = 3
 
-* ``<diag_name>.adios2_engine.type`` (``BP*``, ``SST``, ``SSC``, ``DataMan``) optional,
+* ``<diag_name>.adios2_engine.type`` (``bp4``, ``sst``, ``ssc``, ``dataman``) optional,
     `ADIOS2 Engine type <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
-    See full list of engines at `ADIOS readthedocs <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
+    See full list of engines at `ADIOS2 readthedocs <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
 
 * ``<diag_name>.adios2_engine.parameters.*`` optional,
     `ADIOS2 Engine parameters <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
 
-    An example for parameters for the BP engine are setting the number of writers (NumAggregators), transparently redirecting data to burst buffers etc.
-    A detailed list of engine-specific parameters are available at the official `ADIOS documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
+    An example for parameters for the BP engine are setting the number of writers (``NumAggregators``), transparently redirecting data to burst buffers etc.
+    A detailed list of engine-specific parameters are available at the official `ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
 
     .. code-block:: text
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1892,6 +1892,21 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
         <diag_name>.adios2_operator.type = zfp
         <diag_name>.adios2_operator.parameters.precision = 3
 
+* ``<diag_name>.adios2_engine.type`` (``BP4``, ``BP5``, ``SST``, ``SSC``, ``DataMan``) optional,
+    `ADIOS2 Engine type <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
+    See full list of engines at `ADIOS readthedocs <https://adios2.readthedocs.io/en/latest/engines/engines.html>`
+
+* ``<diag_name>.adios2_engine.parameters.*`` optional,
+    `ADIOS2 Engine parameters <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
+
+    An example for parameters for the BP engine are setting the number of writers (NumAggregators), transparently redirecting data to burst buffers etc.
+    A detailed list of engine-specific parameters are available at the official `ADIOS documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`
+
+    .. code-block:: text
+
+        <diag_name>.adios2_engine.parameter.NumAggregators = 2048
+        <diag_name>.adios2_engine.parameters.BurstBufferPath="/mnt/bb/username"
+
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
     Possible values: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz`` ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1892,15 +1892,15 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
         <diag_name>.adios2_operator.type = zfp
         <diag_name>.adios2_operator.parameters.precision = 3
 
-* ``<diag_name>.adios2_engine.type`` (``BP4``, ``BP5``, ``SST``, ``SSC``, ``DataMan``) optional,
+* ``<diag_name>.adios2_engine.type`` (``BP*``, ``SST``, ``SSC``, ``DataMan``) optional,
     `ADIOS2 Engine type <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
-    See full list of engines at `ADIOS readthedocs <https://adios2.readthedocs.io/en/latest/engines/engines.html>`
+    See full list of engines at `ADIOS readthedocs <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
 
 * ``<diag_name>.adios2_engine.parameters.*`` optional,
     `ADIOS2 Engine parameters <https://openpmd-api.readthedocs.io/en/0.14.0/details/backendconfig.html#adios2>`__ for `openPMD <https://www.openPMD.org>`_ data dumps.
 
     An example for parameters for the BP engine are setting the number of writers (NumAggregators), transparently redirecting data to burst buffers etc.
-    A detailed list of engine-specific parameters are available at the official `ADIOS documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`
+    A detailed list of engine-specific parameters are available at the official `ADIOS documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`__
 
     .. code-block:: text
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -66,6 +66,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
   std::string const prefix = diag_name + ".adios2_operator.parameters";
   ParmParse pp;
   auto entr = pp.getEntries(prefix);
+
   std::map< std::string, std::string > operator_parameters;
   auto const prefix_len = prefix.size() + 1;
   for (std::string k : entr) {
@@ -81,6 +82,7 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
   std::string const engine_prefix = diag_name + ".adios2_engine.parameters";
   ParmParse ppe;
   auto eng_entr = ppe.getEntries(engine_prefix);
+
   std::map< std::string, std::string > engine_parameters;
   auto const prefixlen = engine_prefix.size() + 1;
   for (std::string k : eng_entr) {

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -66,7 +66,6 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
   std::string const prefix = diag_name + ".adios2_operator.parameters";
   ParmParse pp;
   auto entr = pp.getEntries(prefix);
-
   std::map< std::string, std::string > operator_parameters;
   auto const prefix_len = prefix.size() + 1;
   for (std::string k : entr) {
@@ -76,10 +75,26 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
     operator_parameters.insert({k, v});
   }
 
+  // ADIOS2 engine type & parameters
+  std::string engine_type;
+  pp_diag_name.query("adios2_engine.type", engine_type);
+  std::string const engine_prefix = diag_name + ".adios2_engine.parameters";
+  ParmParse ppe;
+  auto eng_entr = ppe.getEntries(engine_prefix);
+  std::map< std::string, std::string > engine_parameters;
+  auto const prefixlen = engine_prefix.size() + 1;
+  for (std::string k : eng_entr) {
+    std::string v;
+    ppe.get(k.c_str(), v);
+    k.erase(0, prefixlen);
+    engine_parameters.insert({k, v});
+  }
+
   auto & warpx = WarpX::GetInstance();
   m_OpenPMDPlotWriter = std::make_unique<WarpXOpenPMDPlot>(
     encoding, openpmd_backend,
     operator_type, operator_parameters,
+    engine_type, engine_parameters,
     warpx.getPMLdirections()
   );
 

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -110,6 +110,8 @@ public:
                     std::string filetype,
                     std::string operator_type,
                     std::map< std::string, std::string > operator_parameters,
+                    std::string engine_type,
+                    std::map< std::string, std::string > engine_parameters,
                     std::vector<bool> fieldPMLdirections);
 
   ~WarpXOpenPMDPlot ();

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -157,7 +157,7 @@ namespace detail
   "adios2": {)END";
 
         end_block = R"END(
-  }    
+  }
 })END";
 
         // add the operator string block
@@ -168,7 +168,7 @@ namespace detail
         {
           "type": ")END";
             op_block += operator_type + "\"";
-        
+
             if (!op_parameters.empty()) {
                 op_block += R"END(,
           "parameters": {
@@ -181,7 +181,7 @@ namespace detail
     })END";
         if (!engine_type.empty())
             op_block += ",";
-        
+
         }  // end operator string block
 
         // add the engine string block
@@ -190,26 +190,26 @@ namespace detail
     "engine": {
       "type": ")END";
             en_block += engine_type + "\"";
-        
+
             if (!en_parameters.empty()) {
                 en_block += R"END(,
       "parameters": {
 )END";
-            en_block += en_parameters + "}"; 
+            en_block += en_parameters + "}";
             }
-            
+
             en_block += R"END(
     })END";
-            
+
         }  // end engine string block
-        
+
         options = top_block + op_block + en_block + end_block;
 
         int rank;
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         if (rank == 0)
             std::cout << options << std::endl;
-        
+
         return options;
     }
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -204,12 +204,6 @@ namespace detail
         }  // end engine string block
 
         options = top_block + op_block + en_block + end_block;
-
-        int rank;
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-        if (rank == 0)
-            std::cout << options << std::endl;
-
         return options;
     }
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -122,9 +122,18 @@ namespace detail
      */
     inline std::string
     getSeriesOptions (std::string const & operator_type,
-                      std::map< std::string, std::string > const & operator_parameters)
+                      std::map< std::string, std::string > const & operator_parameters,
+                      std::string const & engine_type,
+                      std::map< std::string, std::string > const & engine_parameters)
     {
+        if (operator_type.empty() && engine_type.empty())
+            return "{}";
+
         std::string options;
+        std::string top_block;
+        std::string end_block;
+        std::string op_block;
+        std::string en_block;
 
         std::string op_parameters;
         for (const auto& kv : operator_parameters) {
@@ -133,31 +142,74 @@ namespace detail
                     .append("\"").append(kv.first).append("\": ")    /* key */
                     .append("\"").append(kv.second).append("\""); /* value (as string) */
         }
-        if (!operator_type.empty()) {
-            options = R"END(
+
+        std::string en_parameters;
+        for (const auto& kv : engine_parameters) {
+            if (!en_parameters.empty()) en_parameters.append(",\n");
+            en_parameters.append(std::string(12, ' '))         /* just pretty alignment */
+                    .append("\"").append(kv.first).append("\": ")    /* key */
+                    .append("\"").append(kv.second).append("\""); /* value (as string) */
+        }
+
+        // create the outer-level blocks
+        top_block = R"END(
 {
-  "adios2": {
+  "adios2": {)END";
+
+        end_block = R"END(
+  }    
+})END";
+
+        // add the operator string block
+        if (!operator_type.empty()) {
+            op_block = R"END(
     "dataset": {
       "operators": [
         {
           "type": ")END";
-            options += operator_type + "\"";
-        }
-        if (!operator_type.empty() && !op_parameters.empty()) {
-            options += R"END(
-         ,"parameters": {
+            op_block += operator_type + "\"";
+        
+            if (!op_parameters.empty()) {
+                op_block += R"END(,
+          "parameters": {
 )END";
-            options += op_parameters + "}";
+            op_block += op_parameters + "}";
         }
-        if (!operator_type.empty())
-            options += R"END(
+            op_block += R"END(
         }
       ]
-    }
-  }
-}
+    })END";
+        if (!engine_type.empty())
+            op_block += ",";
+        
+        }  // end operator string block
+
+        // add the engine string block
+        if (!engine_type.empty()) {
+            en_block = R"END(
+    "engine": {
+      "type": ")END";
+            en_block += engine_type + "\"";
+        
+            if (!en_parameters.empty()) {
+                en_block += R"END(,
+      "parameters": {
 )END";
-        if (options.empty()) options = "{}";
+            en_block += en_parameters + "}"; 
+            }
+            
+            en_block += R"END(
+    })END";
+            
+        }  // end engine string block
+        
+        options = top_block + op_block + en_block + end_block;
+
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if (rank == 0)
+            std::cout << options << std::endl;
+        
         return options;
     }
 
@@ -337,6 +389,8 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot (
     std::string openPMDFileType,
     std::string operator_type,
     std::map< std::string, std::string > operator_parameters,
+    std::string engine_type,
+    std::map< std::string, std::string > engine_parameters,
     std::vector<bool> fieldPMLdirections)
   :m_Series(nullptr),
    m_Encoding(ie),
@@ -355,7 +409,8 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot (
     m_OpenPMDFileType = "json";
 #endif
 
-    m_OpenPMDoptions = detail::getSeriesOptions(operator_type, operator_parameters);
+    m_OpenPMDoptions = detail::getSeriesOptions(operator_type, operator_parameters,
+                                                engine_type, engine_parameters);
 }
 
 WarpXOpenPMDPlot::~WarpXOpenPMDPlot ()


### PR DESCRIPTION
Add support for setting ADIOS engine types and their parameters for openPMD. Similar to how ADIOS operators are setup.
Addresses #2866 