### PR TITLE
Lassen: Work-Around MPI Allgatherv

### DIFF
--- a/Docs/source/install/hpc/lassen.rst
+++ b/Docs/source/install/hpc/lassen.rst
@@ -88,3 +88,20 @@ regime), the following set of parameters provided good performance:
   node)
 
 * **Two `128x128x128` grids per GPU**, or **one `128x128x256` grid per GPU**.
+
+
+.. _building-lassen-issues:
+
+Known System Issues
+-------------------
+
+.. warning::
+
+   Feb 17th, 2022 (INC0211698):
+   The implementation of AllGatherv in IBM's MPI optimization library "libcollectives" is broken and leads to HDF5 crashes for multi-node runs.
+
+   Our batch script templates above `apply this work-around <https://github.com/ECP-WarpX/WarpX/pull/2874>`__ *before* the call to ``jsrun``, which avoids the broken routines from IBM and trades them for an OpenMPI implementation of collectives:
+
+   .. code-block:: bash
+
+      export OMPI_MCA_coll_ibm_skip_allgatherv=true

--- a/Docs/source/install/hpc/lassen.rst
+++ b/Docs/source/install/hpc/lassen.rst
@@ -97,7 +97,7 @@ Known System Issues
 
 .. warning::
 
-   Feb 17th, 2022 (INC0211698):
+   Feb 17th, 2022 (INC0278922):
    The implementation of AllGatherv in IBM's MPI optimization library "libcollectives" is broken and leads to HDF5 crashes for multi-node runs.
 
    Our batch script templates above `apply this work-around <https://github.com/ECP-WarpX/WarpX/pull/2874>`__ *before* the call to ``jsrun``, which avoids the broken routines from IBM and trades them for an OpenMPI implementation of collectives:

--- a/Tools/machines/lassen-llnl/lassen.bsub
+++ b/Tools/machines/lassen-llnl/lassen.bsub
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Axel Huebl
+# Copyright 2020-2022 Axel Huebl
 #
 # This file is part of WarpX.
 #
@@ -21,6 +21,10 @@
 # Work-around OpenMPI bug with chunked HDF5
 #   https://github.com/open-mpi/ompi/issues/7795
 export OMPI_MCA_io=ompio
+
+# Work-around for broken IBM "libcollectives" MPI_Allgatherv
+#   https://github.com/ECP-WarpX/WarpX/pull/2874
+export OMPI_MCA_coll_ibm_skip_allgatherv=true
 
 export OMP_NUM_THREADS=1
 jsrun -r 4 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs -M "-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
The implementation of AllGatherv in IBM's MPI optimization library "libcollectives" is broken and leads to HDF5 crashes for multi-node runs.

IBM Spectrum MPI, Version 10 Release 1, User's Guide:
  https://www.ibm.com/docs/en/SSZTET_EOS/eos/guide_101.pdf

See:
https://github.com/ECP-WarpX/WarpX/pull/2863#issuecomment-1043623849