### PR TITLE
Updated documentation for predefined_profile_params for parabolic_channel

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -815,7 +815,7 @@ Particle initialization
 
       .. math::
 
-          n = n_0 n(x,y) n(z)
+          n = n_0 n(x,y) n(z-z_0)
 
       with
 
@@ -824,7 +824,7 @@ Particle initialization
           n(x,y) = 1 + 4\frac{x^2+y^2}{k_p^2 R_c^4}
 
       where :math:`k_p` is the plasma wavenumber associated with density :math:`n_0`.
-      Here, :math:`n(z)` is a cosine-like up-ramp from :math:`0` to :math:`L_{ramp,up}`,
+      Here, with :math:`z_0` as the start of the plasma, :math:`n(z-z_0)` is a cosine-like up-ramp from :math:`0` to :math:`L_{ramp,up}`,
       constant to :math:`1` from :math:`L_{ramp,up}` to :math:`L_{ramp,up} + L_{plateau}`
       and a cosine-like down-ramp from :math:`L_{ramp,up} + L_{plateau}` to
       :math:`L_{ramp,up} + L_{plateau}+L_{ramp,down}`. All parameters are given
@@ -835,7 +835,7 @@ Particle initialization
 
     * If ``species_name.predefined_profile_name`` is ``parabolic_channel``,
       ``predefined_profile_params`` contains a space-separated list of the
-      following parameters, in this order: :math:`L_{ramp,up}` :math:`L_{plateau}`
+      following parameters, in this order: :math:`z_0` :math:`L_{ramp,up}` :math:`L_{plateau}`
       :math:`L_{ramp,down}` :math:`R_c` :math:`n_0`
 
 * ``<species_name>.do_backward_propagation`` (`bool`)


### PR DESCRIPTION
The `z_0` parameter, the starting point of the plasma profile, was left out of the documentation. This adds it.