### PR TITLE
MCC: allow background density and temperature to be functions of space and time

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1396,9 +1396,15 @@ Plasma Science, vol. 19, no. 2, pp. 65-85, 1991) <https://ieeexplore.ieee.org/do
 
 * ``<collision_name>.background_density`` (`float`)
     Only for ``background_mcc``. The density of the neutral background gas in :math:`m^{-3}`.
+    Can also provide ``<collision_name>.background_density(x,y,z,t)`` using the parser
+    initialization style for spatially and temporally varying density. If a function
+    is used for the background density, the input parameter ``<collision_name>.max_background_density``
+    must also be provided to calculate the maximum collision probability.
 
 * ``<collision_name>.background_temperature`` (`float`)
     Only for ``background_mcc``. The temperature of the neutral background gas in Kelvin.
+    Can also provide ``<collision_name>.background_temperature(x,y,z,t)`` using the parser
+    initialization style for spatially and temporally varying temperature.
 
 * ``<collision_name>.background_mass`` (`float`) optional
     Only for ``background_mcc``. The mass of the background gas in kg. If not

--- a/Source/Particles/Collision/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCCCollision.H
@@ -11,6 +11,7 @@
 #include "CollisionBase.H"
 #include "MCCProcess.H"
 
+#include <AMReX_Parser.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_GpuContainers.H>
@@ -41,7 +42,7 @@ public:
      * @param pti particle iterator
      *
      */
-    void doBackgroundCollisionsWithinTile ( WarpXParIter& pti );
+    void doBackgroundCollisionsWithinTile ( WarpXParIter& pti, amrex::Real t);
 
     /** Perform MCC ionization interactions
      *
@@ -55,7 +56,8 @@ public:
                                  int lev,
                                  amrex::LayoutData<amrex::Real>* cost,
                                  WarpXParticleContainer& species1,
-                                 WarpXParticleContainer& species2
+                                 WarpXParticleContainer& species2,
+                                 amrex::Real t
                                  );
 
 private:
@@ -70,13 +72,18 @@ private:
 
     amrex::Real m_mass1;
 
-    amrex::Real m_background_temperature;
-    amrex::Real m_background_density;
+    amrex::Real m_max_background_density = 0;
     amrex::Real m_background_mass;
     amrex::Real m_total_collision_prob;
     amrex::Real m_total_collision_prob_ioniz = 0;
     amrex::Real m_nu_max;
     amrex::Real m_nu_max_ioniz;
+
+    amrex::Parser m_background_density_parser;
+    amrex::Parser m_background_temperature_parser;
+
+    amrex::ParserExecutor<4> m_background_density_func;
+    amrex::ParserExecutor<4> m_background_temperature_func;
 };
 
 #endif // WARPX_PARTICLES_COLLISION_BACKGROUNDMCCCOLLISION_H_

--- a/Source/Particles/Collision/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCCCollision.H
@@ -40,6 +40,7 @@ public:
     /** Perform particle conserving MCC collisions within a tile
      *
      * @param pti particle iterator
+     * @param t current time
      *
      */
     void doBackgroundCollisionsWithinTile ( WarpXParIter& pti, amrex::Real t);
@@ -50,6 +51,7 @@ public:
      * @param[in,out] cost pointer to (load balancing) cost corresponding to box where present particles are ionized.
      * @param[in,out] species1,species2 reference to species container used to inject
      * new particles
+     * @param t current time
      *
      */
     void doBackgroundIonization (

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -291,7 +291,7 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
 
     // get neutral mass
     amrex::Real mass_a = m_background_mass;
-    // compile parsers for the background density and temperature
+    // get parsers for the background density and temperature
     auto n_a_func = m_background_density_func;
     auto T_a_func = m_background_temperature_func;
 

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -29,6 +29,9 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
 
     amrex::Real background_density = 0;
     if (queryWithParser(pp_collision_name, "background_density", background_density)) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            (background_density > 0), "The background density must be greater than 0."
+        );
         m_background_density_parser = makeParser(std::to_string(background_density), {"x", "y", "z", "t"});
     }
     else {
@@ -39,6 +42,9 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
 
     amrex::Real background_temperature;
     if (queryWithParser(pp_collision_name, "background_temperature", background_temperature)) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            (background_temperature >= 0), "The background temperature must be positive."
+        );
         m_background_temperature_parser = makeParser(std::to_string(background_temperature), {"x", "y", "z", "t"});
     }
     else {

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -154,10 +154,12 @@ public:
         if (Random(engine) > m_total_collision_prob) return false;
 
         // get references to the particle to get its position
-        auto& p = ptd.m_aos[i];
+        const auto& p = ptd.getSuperParticle(i);
+        ParticleReal x, y, z;
+        get_particle_position(p, x, y, z);
 
         // calculate neutral density at particle location
-        const Real n_a = m_n_a_func(p.pos(0), p.pos(1), p.pos(2), m_t);
+        const Real n_a = m_n_a_func(x, y, z, m_t);
 
         // get the particle velocity
         const ParticleReal ux = ptd.m_rdata[PIdx::ux][i];
@@ -244,13 +246,13 @@ public:
         using std::sqrt;
 
         // get references to the particle to get its position
-        auto& p = src.m_aos[i_src];
+        const auto& p = src.getSuperParticle(i_src);
+        ParticleReal x, y, z;
+        get_particle_position(p, x, y, z);
 
         // calculate standard deviation in neutral velocity distribution using
         // the local temperature
-        const Real ion_vel_std = (
-            m_sqrt_kb_m * sqrt(m_T_a_func(p.pos(0), p.pos(1), p.pos(2), m_t))
-        );
+        const Real ion_vel_std = m_sqrt_kb_m * sqrt(m_T_a_func(x, y, z, m_t));
 
         // get references to the original particle's velocity
         auto& ux = src.m_rdata[PIdx::ux][i_src];

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -116,17 +116,21 @@ public:
     * @param[in] mcc_process an MCCProcess object associated with the ionization
     * @param[in] mass colliding particle's mass (could also assume electron)
     * @param[in] total_collision_prob total probability for a collision to occur
-    * @param[in] nu_max_norm normalized maximum collision frequency, normalized
-    *            by the neutral density.
+    * @param[in] nu_max maximum collision frequency
+    * @param[in] n_a_func ParserExecutor<4> function to get the background
+                 density in m^-3 as a function of space and time
+    * @param[in] t the current simulation time
     */
     ImpactIonizationFilterFunc(
         MCCProcess const& mcc_process,
         amrex::Real const mass,
         amrex::Real const total_collision_prob,
-        amrex::Real const nu_max_norm
+        amrex::Real const nu_max,
+        amrex::ParserExecutor<4> const& n_a_func,
+        amrex::Real t
     ) : m_mcc_process(mcc_process.executor()), m_mass(mass),
         m_total_collision_prob(total_collision_prob),
-        m_nu_max_norm(nu_max_norm){ }
+        m_nu_max(nu_max), m_n_a_func(n_a_func), m_t(t) { }
 
     /**
     * \brief Functor call. This method determines if a given (electron) particle
@@ -149,6 +153,12 @@ public:
         // determine if this particle should collide
         if (Random(engine) > m_total_collision_prob) return false;
 
+        // get references to the particle to get its position
+        auto& p = ptd.m_aos[i];
+
+        // calculate neutral density at particle location
+        const Real n_a = m_n_a_func(p.pos(0), p.pos(1), p.pos(2), m_t);
+
         // get the particle velocity
         const ParticleReal ux = ptd.m_rdata[PIdx::ux][i];
         const ParticleReal uy = ptd.m_rdata[PIdx::uy][i];
@@ -163,7 +173,7 @@ public:
         const Real sigma_E = m_mcc_process.getCrossSection(E_coll);
 
         // calculate normalized collision frequency
-        const Real nu_i = sigma_E * v_coll / m_nu_max_norm;
+        const Real nu_i = n_a * sigma_E * v_coll / m_nu_max;
 
         // check if this collision should be performed
         return (Random(engine) <= nu_i);
@@ -173,7 +183,9 @@ private:
     MCCProcess::Executor m_mcc_process;
     amrex::Real m_mass;
     amrex::Real m_total_collision_prob = 0;
-    amrex::Real m_nu_max_norm;
+    amrex::Real m_nu_max;
+    amrex::ParserExecutor<4> m_n_a_func;
+    amrex::Real m_t;
 };
 
 
@@ -196,13 +208,17 @@ public:
     *
     * @param[in] energy_cost energy cost of ionization
     * @param[in] mass1 mass of the colliding species
-    * @param[in] standard deviation of ion velocity distribution for each velocity
-                 direction; for a Maxwellian distribution it should equal sqrt(kB*T/m)
+    * @param[in] sqrt_kb_m value of sqrt(kB/m), where kB is Boltzmann's constant
+                 and m is the background neutral mass
+    * @param[in] T_a_func ParserExecutor<4> function to get the background
+                 temperature in Kelvin as a function of space and time
+    * @param[in] t the current simulation time
     */
     ImpactIonizationTransformFunc(
-        amrex::Real energy_cost, amrex::Real mass1, amrex::Real ion_vel_std
+        amrex::Real energy_cost, amrex::Real mass1, amrex::Real sqrt_kb_m,
+        amrex::ParserExecutor<4> const& T_a_func, amrex::Real t
     ) :  m_energy_cost(energy_cost), m_mass1(mass1),
-         m_ion_vel_std(ion_vel_std) { }
+         m_sqrt_kb_m(sqrt_kb_m), m_T_a_func(T_a_func), m_t(t) { }
 
     /**
     * \brief Functor call. It determines the properties of the generated pair
@@ -226,6 +242,15 @@ public:
     {
         using namespace amrex;
         using std::sqrt;
+
+        // get references to the particle to get its position
+        auto& p = src.m_aos[i_src];
+
+        // calculate standard deviation in neutral velocity distribution using
+        // the local temperature
+        const Real ion_vel_std = (
+            m_sqrt_kb_m * sqrt(m_T_a_func(p.pos(0), p.pos(1), p.pos(2), m_t))
+        );
 
         // get references to the original particle's velocity
         auto& ux = src.m_rdata[PIdx::ux][i_src];
@@ -257,14 +282,16 @@ public:
         ParticleUtils::RandomizeVelocity(e_ux, e_uy, e_uz, vp, engine);
 
         // get velocities for the ion from a Maxwellian distribution
-        i_ux = m_ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
-        i_uy = m_ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
-        i_uz = m_ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+        i_ux = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+        i_uy = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+        i_uz = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
     }
 
 private:
     amrex::Real m_energy_cost;
     amrex::Real m_mass1;
-    amrex::Real m_ion_vel_std;
+    amrex::Real m_sqrt_kb_m;
+    amrex::ParserExecutor<4> m_T_a_func;
+    amrex::Real m_t;
 };
 #endif // WARPX_PARTICLES_COLLISION_MCC_SCATTERING_H_


### PR DESCRIPTION
As discussed during the 2/18 meeting, this PR extends the MCC module to accept a spatially and temporally varying function for the background density. The background temperature is also allowed to be a function now since in standard use cases the background pressure should be constant while the density and temperature changes.

In order to maintain backward compatibility arguments of the form `background_density` or `background_density(x,y,z,t)` are accepted with the former accepting a constant value.