### PR TITLE
Refactor Vay Deposition Functions

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -385,13 +385,6 @@ WarpX::OneStep_nosub (Real cur_time)
     SyncCurrent();
     SyncRho();
 
-    // Apply current correction in Fourier space: for periodic single-box global FFTs
-    // without guard cells, apply this after calling SyncCurrent
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
-        if (fft_periodic_single_box && (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay))
-            VayDeposition();
-    }
-
     // At this point, J is up-to-date inside the domain, and E and B are
     // up-to-date including enough guard cells for first step of the field
     // solve.
@@ -932,26 +925,4 @@ WarpX::applyMirrors(Real time){
             }
         }
     }
-}
-
-// Compute current from Vay deposition in Fourier space
-void
-WarpX::VayDeposition ()
-{
-#ifdef WARPX_USE_PSATD
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
-    {
-        for (int lev = 0; lev <= finest_level; ++lev)
-        {
-            spectral_solver_fp[lev]->VayDeposition(lev, current_fp[lev]);
-            if (spectral_solver_cp[lev]) spectral_solver_cp[lev]->VayDeposition(lev, current_cp[lev]);
-        }
-    } else {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
-            "WarpX::VayDeposition: only implemented for spectral solver.");
-    }
-#else
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
-    "WarpX::CurrentCorrection: requires WarpX build with spectral solver support.");
-#endif
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -112,15 +112,9 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (
-            const int lev,
-            SpectralFieldData& field_data,
-            std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldData& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -832,24 +832,12 @@ void PsatdAlgorithm::CurrentCorrection (SpectralFieldData& field_data)
 }
 
 void
-PsatdAlgorithm::VayDeposition (
-    const int lev,
-    SpectralFieldData& field_data,
-    std::array<std::unique_ptr<amrex::MultiFab>,3>& current)
+PsatdAlgorithm::VayDeposition (SpectralFieldData& field_data)
 {
     // Profiling
     BL_PROFILE("PsatdAlgorithm::VayDeposition()");
 
     const SpectralFieldIndex& Idx = m_spectral_index;
-
-    // Forward Fourier transform of D (temporarily stored in current):
-    // D is nodal and does not match the staggering of J, therefore we pass the
-    // actual staggering of D (IntVect(1)) to the ForwardTransform function
-    field_data.ForwardTransform(lev, *current[0], Idx.Jx, 0, IntVect(1));
-    field_data.ForwardTransform(lev, *current[1], Idx.Jy, 0, IntVect(1));
-    field_data.ForwardTransform(lev, *current[2], Idx.Jz, 0, IntVect(1));
-
-    const amrex::IntVect& fill_guards = m_fill_guards;
 
     // Loop over boxes
     for (amrex::MFIter mfi(field_data.fields); mfi.isValid(); ++mfi)
@@ -903,11 +891,6 @@ PsatdAlgorithm::VayDeposition (
             else                 fields(i,j,k,Idx.Jz) = 0._rt;
         });
     }
-
-    // Backward Fourier transform of J
-    field_data.BackwardTransform(lev, *current[0], Idx.Jx, 0, fill_guards);
-    field_data.BackwardTransform(lev, *current[1], Idx.Jy, 0, fill_guards);
-    field_data.BackwardTransform(lev, *current[2], Idx.Jz, 0, fill_guards);
 }
 
 #endif // WARPX_USE_PSATD

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.H
@@ -65,14 +65,9 @@ class PsatdAlgorithmComoving : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldData& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldData& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
@@ -498,9 +498,7 @@ void PsatdAlgorithmComoving::CurrentCorrection (SpectralFieldData& field_data)
 }
 
 void
-PsatdAlgorithmComoving::VayDeposition (const int /*lev*/,
-                                       SpectralFieldData& /*field_data*/,
-                                       std::array<std::unique_ptr<amrex::MultiFab>,3>& /*current*/)
+PsatdAlgorithmComoving::VayDeposition (SpectralFieldData& /*field_data*/)
 {
     amrex::Abort("Vay deposition not implemented for comoving PSATD");
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.H
@@ -45,13 +45,9 @@ class PsatdAlgorithmGalileanRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev, SpectralFieldDataRZ& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldDataRZ& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.cpp
@@ -360,9 +360,7 @@ PsatdAlgorithmGalileanRZ::CurrentCorrection (SpectralFieldDataRZ& field_data)
 }
 
 void
-PsatdAlgorithmGalileanRZ::VayDeposition (const int /*lev*/,
-                                         SpectralFieldDataRZ& /*field_data*/,
-                                         std::array<std::unique_ptr<amrex::MultiFab>,3>& /*current*/)
+PsatdAlgorithmGalileanRZ::VayDeposition (SpectralFieldDataRZ& /*field_data*/)
 {
     amrex::Abort("Vay deposition not implemented in RZ geometry");
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
@@ -111,15 +111,9 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (
-            const int lev,
-            SpectralFieldData& field_data,
-            std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldData& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.cpp
@@ -433,15 +433,12 @@ void PsatdAlgorithmJLinearInTime::CurrentCorrection (SpectralFieldData& field_da
 }
 
 void
-PsatdAlgorithmJLinearInTime::VayDeposition (
-    const int lev,
-    SpectralFieldData& field_data,
-    std::array<std::unique_ptr<amrex::MultiFab>,3>& current)
+PsatdAlgorithmJLinearInTime::VayDeposition (SpectralFieldData& field_data)
 {
     // Profiling
     BL_PROFILE("PsatdAlgorithmJLinearInTime::VayDeposition()");
 
-    amrex::ignore_unused(lev, field_data, current);
+    amrex::ignore_unused(field_data);
     amrex::Abort("Vay deposition not implemented for multi-J PSATD algorithm");
 }
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.H
@@ -63,14 +63,9 @@ class PsatdAlgorithmPml : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldData& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldData& field_data) override final;
 
     private:
         SpectralFieldIndex m_spectral_index;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.cpp
@@ -408,9 +408,7 @@ PsatdAlgorithmPml::CurrentCorrection (SpectralFieldData& /*field_data*/)
 }
 
 void
-PsatdAlgorithmPml::VayDeposition (const int /*lev*/,
-                                  SpectralFieldData& /*field_data*/,
-                                  std::array<std::unique_ptr<amrex::MultiFab>,3>& /*current*/)
+PsatdAlgorithmPml::VayDeposition (SpectralFieldData& /*field_data*/)
 {
     amrex::Abort("Vay deposition not implemented for PML PSATD");
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.H
@@ -46,12 +46,8 @@ class PsatdAlgorithmPmlRZ : public SpectralBaseAlgorithmRZ
          * derived classes.
          *
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldDataRZ& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldDataRZ& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.cpp
@@ -166,9 +166,7 @@ PsatdAlgorithmPmlRZ::CurrentCorrection (SpectralFieldDataRZ& /* field_data */)
 }
 
 void
-PsatdAlgorithmPmlRZ::VayDeposition (const int /* lev */,
-                                    SpectralFieldDataRZ& /*field_data*/,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& /*current*/)
+PsatdAlgorithmPmlRZ::VayDeposition (SpectralFieldDataRZ& /*field_data*/)
 {
     amrex::Abort("Vay deposition not implemented in RZ geometry PML");
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
@@ -49,14 +49,9 @@ class PsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ and cannot be overridden by further
          * derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldDataRZ& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) override final;
+        virtual void VayDeposition (SpectralFieldDataRZ& field_data) override final;
 
     private:
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -479,9 +479,7 @@ PsatdAlgorithmRZ::CurrentCorrection (SpectralFieldDataRZ& field_data)
 }
 
 void
-PsatdAlgorithmRZ::VayDeposition (const int /* lev */,
-                                 SpectralFieldDataRZ& /*field_data*/,
-                                 std::array<std::unique_ptr<amrex::MultiFab>,3>& /*current*/)
+PsatdAlgorithmRZ::VayDeposition (SpectralFieldDataRZ& /*field_data*/)
 {
     amrex::Abort("Vay deposition not implemented in RZ geometry");
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
@@ -57,14 +57,9 @@ class SpectralBaseAlgorithm
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldData& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) = 0;
+        virtual void VayDeposition (SpectralFieldData& field_data) = 0;
 
         /**
          * \brief Compute spectral divergence of E

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.H
@@ -50,14 +50,9 @@ class SpectralBaseAlgorithmRZ
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
-         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
-         * \param[in,out] current    Array of unique pointers to \c MultiFab storing
-         *                           the three components of the current density
          */
-        virtual void VayDeposition (const int lev,
-                                    SpectralFieldDataRZ& field_data,
-                                    std::array<std::unique_ptr<amrex::MultiFab>,3>& current) = 0;
+        virtual void VayDeposition (SpectralFieldDataRZ& field_data) = 0;
 
     protected: // Meant to be used in the subclasses
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -89,10 +89,40 @@ class SpectralSolver
          * \brief Transform the component `i_comp` of MultiFab `mf`
          *  to spectral space, and store the corresponding result internally
          *  (in the spectral field specified by `field_index`) */
-        void ForwardTransform( const int lev,
+        void ForwardTransform (const int lev,
                                const amrex::MultiFab& mf,
                                const int field_index,
-                               const int i_comp=0 );
+                               const int i_comp,
+                               const amrex::IntVect& stag);
+
+        // This overload is used if stag is not passed
+        AMREX_FORCE_INLINE
+        void ForwardTransform (const int lev,
+                               const amrex::MultiFab& mf,
+                               const int field_index,
+                               const int i_comp)
+        {
+            ForwardTransform(lev, mf, field_index, i_comp, mf.ixType().toIntVect());
+        }
+
+        // This overload is used if i_comp is not passed
+        AMREX_FORCE_INLINE
+        void ForwardTransform (const int lev,
+                               const amrex::MultiFab& mf,
+                               const int field_index,
+                               const amrex::IntVect& stag)
+        {
+            ForwardTransform(lev, mf, field_index, 0, stag);
+        }
+
+        // This overload is used if i_comp and stag are not passed
+        AMREX_FORCE_INLINE
+        void ForwardTransform (const int lev,
+                               const amrex::MultiFab& mf,
+                               const int field_index)
+        {
+            ForwardTransform(lev, mf, field_index, 0, mf.ixType().toIntVect());
+        }
 
         /**
          * \brief Transform spectral field specified by `field_index` back to
@@ -139,9 +169,9 @@ class SpectralSolver
          * \param[in,out] current Array of unique pointers to \c MultiFab storing
          *                        the three components of the current density
          */
-        void VayDeposition (const int lev, std::array<std::unique_ptr<amrex::MultiFab>,3>& current)
+        void VayDeposition ()
         {
-            algorithm->VayDeposition(lev, field_data, current);
+            algorithm->VayDeposition(field_data);
         }
 
         /**

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -86,16 +86,24 @@ class SpectralSolver
                         const bool divb_cleaning);
 
         /**
-         * \brief Transform the component `i_comp` of MultiFab `mf`
-         *  to spectral space, and store the corresponding result internally
-         *  (in the spectral field specified by `field_index`) */
+         * \brief Transform the component i_comp of the MultiFab mf to Fourier space,
+         * and store the result internally (in the spectral field specified by field_index)
+         *
+         * \param[in] lev mesh refinement level
+         * \param[in] mf MultiFab that is transformed to Fourier space (component i_comp)
+         * \param[in] field_index index of the spectral field that stores the FFT result
+         * \param[in] i_comp component of the MultiFab mf that is transformed to Fourier space
+         * \param[in] stag index type that needs to be used to perform the FFT operation
+         */
         void ForwardTransform (const int lev,
                                const amrex::MultiFab& mf,
                                const int field_index,
                                const int i_comp,
                                const amrex::IntVect& stag);
 
-        // This overload is used if stag is not passed
+        /**
+         * \brief Overload of ForwardTransform used if stag is not passed
+         */
         AMREX_FORCE_INLINE
         void ForwardTransform (const int lev,
                                const amrex::MultiFab& mf,
@@ -105,7 +113,9 @@ class SpectralSolver
             ForwardTransform(lev, mf, field_index, i_comp, mf.ixType().toIntVect());
         }
 
-        // This overload is used if i_comp is not passed
+        /**
+         * \brief Overload of ForwardTransform used if i_comp is not passed
+         */
         AMREX_FORCE_INLINE
         void ForwardTransform (const int lev,
                                const amrex::MultiFab& mf,
@@ -115,7 +125,9 @@ class SpectralSolver
             ForwardTransform(lev, mf, field_index, 0, stag);
         }
 
-        // This overload is used if i_comp and stag are not passed
+        /**
+         * Overload of ForwardTransform used if both i_comp and stag are not passed
+         */
         AMREX_FORCE_INLINE
         void ForwardTransform (const int lev,
                                const amrex::MultiFab& mf,

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -92,10 +92,11 @@ void
 SpectralSolver::ForwardTransform( const int lev,
                                   const amrex::MultiFab& mf,
                                   const int field_index,
-                                  const int i_comp )
+                                  const int i_comp,
+                                  const amrex::IntVect& stag )
 {
     WARPX_PROFILE("SpectralSolver::ForwardTransform");
-    field_data.ForwardTransform( lev, mf, field_index, i_comp );
+    field_data.ForwardTransform( lev, mf, field_index, i_comp, stag );
 }
 
 void

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
@@ -106,12 +106,8 @@ class SpectralSolverRZ
          * declared in the base class SpectralBaseAlgorithmRZ and defined in its
          * derived classes, from objects of class SpectralSolverRZ through the private
          * unique pointer \c algorithm.
-         *
-         * \param[in]     lev     The mesh refinement level
-         * \param[in,out] current Array of unique pointers to \c MultiFab storing
-         * the three components of the current density
          */
-        void VayDeposition (const int lev, std::array<std::unique_ptr<amrex::MultiFab>,3>& current);
+        void VayDeposition ();
 
         /**
          * \brief Copy spectral data from component \c src_comp to component \c dest_comp

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
@@ -157,7 +157,7 @@ SpectralSolverRZ::CurrentCorrection ()
 }
 
 void
-SpectralSolverRZ::VayDeposition (const int lev, std::array<std::unique_ptr<amrex::MultiFab>,3>& current)
+SpectralSolverRZ::VayDeposition ()
 {
-    algorithm->VayDeposition(lev, field_data, current);
+    algorithm->VayDeposition(field_data);
 }

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -263,18 +263,18 @@ WarpX::PSATDForwardTransformJ ()
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         // With Vay's deposition, J stores a temporary current (D) that is later modified
-        // in Fourier space: its staggering is always nodal and does not match that of J
+        // in Fourier space: its staggering matches that of rho and not J
         amrex::IntVect jx_stag =
             (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-            amrex::IntVect::TheNodeVector() : current_fp[lev][0]->ixType().toIntVect();
+            WarpX::m_rho_nodal_flag : current_fp[lev][0]->ixType().toIntVect();
 
         amrex::IntVect jy_stag =
             (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-            amrex::IntVect::TheNodeVector() : current_fp[lev][1]->ixType().toIntVect();
+            WarpX::m_rho_nodal_flag : current_fp[lev][1]->ixType().toIntVect();
 
         amrex::IntVect jz_stag =
             (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-            amrex::IntVect::TheNodeVector() : current_fp[lev][2]->ixType().toIntVect();
+            WarpX::m_rho_nodal_flag : current_fp[lev][2]->ixType().toIntVect();
 
         ForwardTransformVect(lev, *spectral_solver_fp[lev], current_fp[lev],
                              idx_jx, idx_jy, idx_jz, jx_stag, jy_stag, jz_stag);
@@ -282,18 +282,18 @@ WarpX::PSATDForwardTransformJ ()
         if (spectral_solver_cp[lev])
         {
             // With Vay's deposition, J stores a temporary current (D) that is later modified
-            // in Fourier space: its staggering is always nodal and does not match that of J
+            // in Fourier space: its staggering matches that of rho and not J
             jx_stag =
                 (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-                amrex::IntVect::TheNodeVector() : current_cp[lev][0]->ixType().toIntVect();
+                WarpX::m_rho_nodal_flag : current_cp[lev][0]->ixType().toIntVect();
 
             jy_stag =
                 (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-                amrex::IntVect::TheNodeVector() : current_cp[lev][1]->ixType().toIntVect();
+                WarpX::m_rho_nodal_flag : current_cp[lev][1]->ixType().toIntVect();
 
             jz_stag =
                 (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
-                amrex::IntVect::TheNodeVector() : current_cp[lev][2]->ixType().toIntVect();
+                WarpX::m_rho_nodal_flag : current_cp[lev][2]->ixType().toIntVect();
 
             ForwardTransformVect(lev, *spectral_solver_cp[lev], current_cp[lev],
                                  idx_jx, idx_jy, idx_jz, jx_stag, jy_stag, jz_stag);

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -55,8 +55,30 @@ using namespace amrex;
 #ifdef WARPX_USE_PSATD
 namespace {
 
-    void
-    ForwardTransformVect (
+    void ForwardTransformVect (
+        const int lev,
+#ifdef WARPX_DIM_RZ
+        SpectralSolverRZ& solver,
+#else
+        SpectralSolver& solver,
+#endif
+        std::array<std::unique_ptr<amrex::MultiFab>,3>& vector_field,
+        const int compx, const int compy, const int compz,
+        const amrex::IntVect& stag_x, const amrex::IntVect& stag_y, const amrex::IntVect& stag_z)
+    {
+#ifdef WARPX_DIM_RZ
+        amrex::ignore_unused(stag_x, stag_y, stag_z);
+        solver.ForwardTransform(lev, *vector_field[0], compx, *vector_field[1], compy);
+        solver.ForwardTransform(lev, *vector_field[2], compz);
+#else
+        solver.ForwardTransform(lev, *vector_field[0], compx, stag_x);
+        solver.ForwardTransform(lev, *vector_field[1], compy, stag_y);
+        solver.ForwardTransform(lev, *vector_field[2], compz, stag_z);
+#endif
+    }
+
+    AMREX_FORCE_INLINE
+    void ForwardTransformVect (
         const int lev,
 #ifdef WARPX_DIM_RZ
         SpectralSolverRZ& solver,
@@ -66,13 +88,10 @@ namespace {
         std::array<std::unique_ptr<amrex::MultiFab>,3>& vector_field,
         const int compx, const int compy, const int compz)
     {
-#ifdef WARPX_DIM_RZ
-        solver.ForwardTransform(lev, *vector_field[0], compx, *vector_field[1], compy);
-#else
-        solver.ForwardTransform(lev, *vector_field[0], compx);
-        solver.ForwardTransform(lev, *vector_field[1], compy);
-#endif
-        solver.ForwardTransform(lev, *vector_field[2], compz);
+        ForwardTransformVect(lev, solver, vector_field, compx, compy, compz,
+                             (*vector_field[0]).ixType().toIntVect(),
+                             (*vector_field[1]).ixType().toIntVect(),
+                             (*vector_field[2]).ixType().toIntVect());
     }
 
     void
@@ -243,11 +262,41 @@ WarpX::PSATDForwardTransformJ ()
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        ForwardTransformVect(lev, *spectral_solver_fp[lev], current_fp[lev], idx_jx, idx_jy, idx_jz);
+        // With Vay's deposition, J stores a temporary current (D) that is later modified
+        // in Fourier space: its staggering is always nodal and does not match that of J
+        amrex::IntVect jx_stag =
+            (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+            amrex::IntVect::TheNodeVector() : current_fp[lev][0]->ixType().toIntVect();
+
+        amrex::IntVect jy_stag =
+            (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+            amrex::IntVect::TheNodeVector() : current_fp[lev][1]->ixType().toIntVect();
+
+        amrex::IntVect jz_stag =
+            (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+            amrex::IntVect::TheNodeVector() : current_fp[lev][2]->ixType().toIntVect();
+
+        ForwardTransformVect(lev, *spectral_solver_fp[lev], current_fp[lev],
+                             idx_jx, idx_jy, idx_jz, jx_stag, jy_stag, jz_stag);
 
         if (spectral_solver_cp[lev])
         {
-            ForwardTransformVect(lev, *spectral_solver_cp[lev], current_cp[lev], idx_jx, idx_jy, idx_jz);
+            // With Vay's deposition, J stores a temporary current (D) that is later modified
+            // in Fourier space: its staggering is always nodal and does not match that of J
+            jx_stag =
+                (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+                amrex::IntVect::TheNodeVector() : current_cp[lev][0]->ixType().toIntVect();
+
+            jy_stag =
+                (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+                amrex::IntVect::TheNodeVector() : current_cp[lev][1]->ixType().toIntVect();
+
+            jz_stag =
+                (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) ?
+                amrex::IntVect::TheNodeVector() : current_cp[lev][2]->ixType().toIntVect();
+
+            ForwardTransformVect(lev, *spectral_solver_cp[lev], current_cp[lev],
+                                 idx_jx, idx_jy, idx_jz, jx_stag, jy_stag, jz_stag);
         }
     }
 
@@ -344,6 +393,19 @@ void WarpX::PSATDCurrentCorrection ()
         if (spectral_solver_cp[lev])
         {
             spectral_solver_cp[lev]->CurrentCorrection();
+        }
+    }
+}
+
+void WarpX::PSATDVayDeposition ()
+{
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        spectral_solver_fp[lev]->VayDeposition();
+
+        if (spectral_solver_cp[lev])
+        {
+            spectral_solver_cp[lev]->VayDeposition();
         }
     }
 }
@@ -473,6 +535,14 @@ WarpX::PushPSATD ()
     if (WarpX::current_correction)
     {
         PSATDCurrentCorrection();
+        PSATDBackwardTransformJ();
+    }
+
+    // Compute the current in Fourier space according to the Vay deposition scheme, and
+    // transform back to real space so that the Vay deposition is reflected in the diagnostics
+    if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
+    {
+        PSATDVayDeposition();
         PSATDBackwardTransformJ();
     }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -891,24 +891,6 @@ private:
     void AddRhoFromFineLevelandSumBoundary (int lev, int icomp, int ncomp);
     void NodalSyncRho (int lev, PatchType patch_type, int icomp, int ncomp);
 
-    /**
-     * \brief Private function for current correction in Fourier space
-     * (equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010):
-     * loops over the MR levels and applies the correction on the fine and coarse
-     * patches (calls the virtual method \c CurrentCorrection of the spectral
-     * algorithm in use, via the public interface defined in the class SpectralSolver).
-     */
-    void CurrentCorrection ();
-
-    /**
-     * \brief Private function for Vay deposition in Fourier space
-     * (equations (20)-(24) of https://doi.org/10.1016/j.jcp.2013.03.010):
-     * loops over the MR levels and applies the correction on the fine and coarse
-     * patches (calls the virtual method \c VayDeposition of the spectral
-     * algorithm in use, via the public interface defined in the class SpectralSolver).
-     */
-    void VayDeposition ();
-
     void ReadParameters ();
 
     /** This function queries deprecated input parameters and abort
@@ -1408,6 +1390,11 @@ private:
      * \brief Correct current in Fourier space so that the continuity equation is satisfied
      */
     void PSATDCurrentCorrection ();
+
+    /**
+     * \brief Vay deposition in Fourier space (https://doi.org/10.1016/j.jcp.2013.03.010)
+     */
+    void PSATDVayDeposition ();
 
     /**
      * \brief Update all necessary fields in spectral space

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -283,6 +283,9 @@ public:
     // do nodal
     static int do_nodal;
 
+    // Global rho nodal flag to know about rho index type when rho MultiFab is not allocated
+    amrex::IntVect m_rho_nodal_flag;
+
     std::array<const amrex::MultiFab* const, 3>
     get_array_Bfield_aux  (const int lev) const {
         return {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -192,6 +192,7 @@ int WarpX::n_field_gather_buffer = -1;
 int WarpX::n_current_deposition_buffer = -1;
 
 int WarpX::do_nodal = false;
+amrex::IntVect m_rho_nodal_flag;
 
 int WarpX::do_similar_dm_pml = 1;
 
@@ -1649,6 +1650,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // Even components are the imaginary parts.
     ncomps = n_rz_azimuthal_modes*2 - 1;
 #endif
+
+    // Set global rho nodal flag to know about rho index type when rho MultiFab is not allocated
+    m_rho_nodal_flag = rho_nodal_flag;
 
     // set human-readable tag for each MultiFab
     auto const tag = [lev]( std::string tagname ) {


### PR DESCRIPTION
Same as #2839, but for Vay deposition. Needed for the implementation of Vay's deposition with the assumption of J linear in time.

With the Vay deposition we need to pass a non-trivial index type for the forward FFTs of the "current" D (to be modified in Fourier space), hence I had to add a few overloads of the functions that perform such FFTs:
- Overload of `ForwardTransformVect` in Source/FieldSolver/WarpXPushFieldsEM.cpp, which takes as additional inputs the index type of each vector component;
- Overloads of `ForwardTransform` in Source/FieldSolver/SpectralSolver/SpectralSolver.H (multiple overloads because both `i_comp` and the newly added argument `stag` can be optional, with default values given by `0` and the index type of the MultiFab `mf` passed as argument itself, respectively).