### PR TITLE
Properly initialize timestep, for electrostatic solver with mesh refinement

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -76,7 +76,9 @@ WarpX::ComputeDt ()
     }
 
     if (do_electrostatic != ElectrostaticSolverAlgo::None) {
-        dt[0] = const_dt;
+        for (int lev=0; lev<=max_level; lev++) {
+            dt[lev] = const_dt;
+        }
     }
 }
 


### PR DESCRIPTION
**PR description edited by @RemiLehe **

When running WarpX simulations with mesh refinement and the electrostatic solver, only the `lev=0` timestep was initialized properly. The timestep for the higher levels (`lev>0`) was initialized according the Maxwell CFL, which is irrelevant in the case of the electrostatic solver. 

This resulted in the different levels having different timesteps (without having subcycling!) and thus e.g. particles on different MR levels would move with a different `dt`!