### PR TITLE
Re-order all particle quantities when doing MR partition

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -162,11 +162,7 @@ public:
                         WarpXParIter& pti,
                         int const lev,
                         amrex::iMultiFab const* current_masks,
-                        amrex::iMultiFab const* gather_masks,
-                        RealVector& uxp,
-                        RealVector& uyp,
-                        RealVector& uzp,
-                        RealVector& wp );
+                        amrex::iMultiFab const* gather_masks );
 
     virtual void PostRestart () final {}
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1744,8 +1744,8 @@ PhysicalParticleContainer::Evolve (int lev,
 
             const Box& box = pti.validbox();
 
+            // Extract particle data
             auto& attribs = pti.GetAttribs();
-
             auto&  wp = attribs[PIdx::w];
             auto& uxp = attribs[PIdx::ux];
             auto& uyp = attribs[PIdx::uy];
@@ -1790,7 +1790,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 //    and (thus) the `np-nfine_current`/`np-nfine_gather` last particles
                 //    deposit/gather in the buffer
                 PartitionParticlesInBuffers( nfine_current, nfine_gather, np,
-                    pti, lev, current_masks, gather_masks, uxp, uyp, uzp, wp );
+                    pti, lev, current_masks, gather_masks );
             }
 
             const long np_current = (cjx) ? nfine_current : np;

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -48,16 +48,13 @@ using namespace amrex;
  *       in the deposition buffers or in the interior of the fine patch
  * \param gather_masks indicates, for each cell, whether that cell is
  *       in the gather buffers or in the interior of the fine patch
- * \param uxp, uyp, uzp, wp references to the particle momenta and weight
- *         (modified by this function)
  */
 void
 PhysicalParticleContainer::PartitionParticlesInBuffers(
     long& nfine_current, long& nfine_gather, long const np,
     WarpXParIter& pti, int const lev,
     iMultiFab const* current_masks,
-    iMultiFab const* gather_masks,
-    RealVector& uxp, RealVector& uyp, RealVector& uzp, RealVector& wp)
+    iMultiFab const* gather_masks )
 {
     WARPX_PROFILE("PhysicalParticleContainer::PartitionParticlesInBuffers");
 
@@ -134,31 +131,17 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     // Reorder the actual particle array, using the `pid` indices
     if (nfine_current != np || nfine_gather != np)
     {
-        // Temporary array for particle AoS
-        ParticleVector particle_tmp;
-        particle_tmp.resize(np);
+        // Prepare temporary particle tile to copy to
+        ParticleTileType ptile_tmp;
+        ptile_tmp.define(m_num_runtime_real, m_num_runtime_int);
+        ptile_tmp.resize(np);
 
-        // Copy particle AoS
-        auto& aos = pti.GetArrayOfStructs();
-        amrex::ParallelFor( np,
-            copyAndReorder<ParticleType>( aos(), particle_tmp, pid ) );
-        std::swap(aos(), particle_tmp);
+        // Copy and re-order the data of the current particle tile
+        ParticleTileType& ptile = pti.GetParticleTile();
+        amrex::gatherParticles(ptile_tmp, ptile, np, pid.dataPtr());
+        ptile.swap(ptile_tmp)
 
-        // Temporary array for particle individual attributes
-        RealVector tmp;
-        tmp.resize(np);
-
-        // Copy individual attributes
-        amrex::ParallelFor( np, copyAndReorder<Real>( wp, tmp, pid ) );
-        std::swap(wp, tmp);
-        amrex::ParallelFor( np, copyAndReorder<Real>( uxp, tmp, pid ) );
-        std::swap(uxp, tmp);
-        amrex::ParallelFor( np, copyAndReorder<Real>( uyp, tmp, pid ) );
-        std::swap(uyp, tmp);
-        amrex::ParallelFor( np, copyAndReorder<Real>( uzp, tmp, pid ) );
-        std::swap(uzp, tmp);
-
-        // Make sure that the temporary arrays are not destroyed before
+        // Make sure that the temporary particle tile is not destroyed before
         // the GPU kernels finish running
         Gpu::streamSynchronize();
     }

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -133,13 +133,13 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     {
         // Prepare temporary particle tile to copy to
         ParticleTileType ptile_tmp;
-        ptile_tmp.define(m_num_runtime_real, m_num_runtime_int);
+        ptile_tmp.define(NumRuntimeRealComps(), NumRuntimeIntComps());
         ptile_tmp.resize(np);
 
         // Copy and re-order the data of the current particle tile
         ParticleTileType& ptile = pti.GetParticleTile();
         amrex::gatherParticles(ptile_tmp, ptile, np, pid.dataPtr());
-        ptile.swap(ptile_tmp)
+        ptile.swap(ptile_tmp);
 
         // Make sure that the temporary particle tile is not destroyed before
         // the GPU kernels finish running


### PR DESCRIPTION
When running with mesh refinement, we re-order to particle arrays in order to separate the particles that are close to the boundaries (i.e. in the "gather" and "deposition" buffer). 

However, when doing so, we were only reordering some fixed quantities (weight, momentum), but we were not taking into account the run-time components, or even some compile-time components (e.g. the angle `theta` when running with RZ). This resulted in some particles quantities being effectively "shuffled" among particles.

The new code is much more generic and re-orders all particle quantities.