### PR TITLE
Crusher (OLCF): New ROCm module

### DIFF
--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -4,7 +4,7 @@
 # required dependencies
 module load cmake/3.22.1
 module load craype-accel-amd-gfx90a
-module load rocm/4.5.2
+module load rocm/5.0.0
 module load cray-mpich
 module load cce/13.0.1  # must be loaded after rocm
 


### PR DESCRIPTION
Document using the latest `rocm/5.0.0` module on Crusher.