### PR TITLE
Fix some bugprone-narrowing-conversions issues

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -434,7 +434,7 @@ SigmaBox::ComputePMLFactorsB (const Real* a_dx, Real dt)
         p_sigma_star_cumsum_fac[idim] = sigma_star_cumsum_fac[idim].data();
         p_sigma_star[idim] = sigma_star[idim].data();
         p_sigma_star_cumsum[idim] = sigma_star_cumsum[idim].data();
-        N[idim] = sigma_star[idim].size();
+        N[idim] = static_cast<int>(sigma_star[idim].size());
         dx[idim] = a_dx[idim];
     }
     amrex::ParallelFor(
@@ -468,7 +468,7 @@ SigmaBox::ComputePMLFactorsE (const Real* a_dx, Real dt)
         p_sigma_cumsum_fac[idim] = sigma_cumsum_fac[idim].data();
         p_sigma[idim] = sigma[idim].data();
         p_sigma_cumsum[idim] = sigma_cumsum[idim].data();
-        N[idim] = sigma[idim].size();
+        N[idim] = static_cast<int>(sigma[idim].size());
         dx[idim] = a_dx[idim];
     }
     amrex::ParallelFor(

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -589,7 +589,7 @@ BackTransformedDiagnostic (Real zmin_lab, Real zmax_lab, Real v_window_lab,
 
     m_dz_lab_ = PhysConst::c * m_dt_boost_ * m_inv_beta_boost_ * m_inv_gamma_boost_;
     m_inv_dz_lab_ = 1.0_rt / m_dz_lab_;
-    int Nz_lab = static_cast<unsigned>((zmax_lab - zmin_lab) * m_inv_dz_lab_);
+    int Nz_lab = static_cast<int>((zmax_lab - zmin_lab) * m_inv_dz_lab_);
 #if (AMREX_SPACEDIM >= 2)
     int Nx_lab = geom.Domain().length(0);
 #endif
@@ -620,7 +620,7 @@ BackTransformedDiagnostic (Real zmin_lab, Real zmax_lab, Real v_window_lab,
         map_actual_fields_to_dump.push_back(i);
 
     if (do_user_fields){
-        m_ncomp_to_dump = user_fields_to_dump.size();
+        m_ncomp_to_dump = static_cast<int>(user_fields_to_dump.size());
         map_actual_fields_to_dump.resize(m_ncomp_to_dump);
         m_mesh_field_names.resize(m_ncomp_to_dump);
         for (int i=0; i<m_ncomp_to_dump; i++){
@@ -752,7 +752,7 @@ void BackTransformedDiagnostic::Flush (const Geometry& /*geom*/)
     for (auto& lf_diags : m_LabFrameDiags_) {
 
         Real zmin_lab = lf_diags->m_prob_domain_lab_.lo(WARPX_ZINDEX);
-        auto i_lab = static_cast<unsigned>(
+        auto i_lab = static_cast<int>(
             (lf_diags->m_current_z_lab - zmin_lab) / m_dz_lab_);
 
         if (lf_diags->m_buff_counter_ != 0) {
@@ -1382,7 +1382,7 @@ LabFrameSnapShot::
 AddDataToBuffer( MultiFab& tmp, int k_lab,
                  amrex::Vector<int> const& map_actual_fields_to_dump)
 {
-    const int ncomp_to_dump = map_actual_fields_to_dump.size();
+    const int ncomp_to_dump = static_cast<int>(map_actual_fields_to_dump.size());
     MultiFab& buf = *m_data_buffer_;
 #ifdef AMREX_USE_GPU
     Gpu::DeviceVector<int> d_map_actual_fields_to_dump(ncomp_to_dump);
@@ -1422,7 +1422,7 @@ LabFrameSlice::
 AddDataToBuffer( MultiFab& tmp, int k_lab,
                  amrex::Vector<int> const& map_actual_fields_to_dump)
 {
-    const int ncomp_to_dump = map_actual_fields_to_dump.size();
+    const int ncomp_to_dump = static_cast<int>(map_actual_fields_to_dump.size());
     MultiFab& buf = *m_data_buffer_;
 #ifdef AMREX_USE_GPU
     Gpu::DeviceVector<int> d_map_actual_fields_to_dump(ncomp_to_dump);
@@ -1462,13 +1462,13 @@ AddPartDataToParticleBuffer(
     Vector<WarpXParticleContainer::DiagnosticParticleData> const& tmp_particle_buffer,
     int nspeciesBoostedFrame) {
     for (int isp = 0; isp < nspeciesBoostedFrame; ++isp) {
-        auto np = tmp_particle_buffer[isp].GetRealData(DiagIdx::w).size();
+        auto np = static_cast<int>(tmp_particle_buffer[isp].GetRealData(DiagIdx::w).size());
         if (np == 0) continue;
 
         // allocate size of particle buffer array to np
         // This is a growing array. Each time we add np elements
         // to the existing array which has size = init_size
-        const int init_size = m_particles_buffer_[isp].GetRealData(DiagIdx::w).size();
+        const int init_size = static_cast<int>(m_particles_buffer_[isp].GetRealData(DiagIdx::w).size());
         const int total_size = init_size + np;
         m_particles_buffer_[isp].resize(total_size);
 
@@ -1588,7 +1588,8 @@ AddPartDataToParticleBuffer(
         // flag values. These location indices are used to copy data
         // from src to dst when the copy-flag is set to 1.
         const int copy_size = amrex::Scan::ExclusiveSum(np, Flag, IndexLocation);
-        const int init_size = m_particles_buffer_[isp].GetRealData(DiagIdx::w).size();
+        const auto init_size = static_cast<int>(
+            m_particles_buffer_[isp].GetRealData(DiagIdx::w).size());
         const int total_reducedDiag_size = copy_size + init_size;
 
         // allocate array size for reduced diagnostic buffer array

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -328,7 +328,8 @@ Diagnostics::ComputeAndPack ()
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         for(int lev=0; lev<nlev_output; lev++){
             int icomp_dst = 0;
-            for (int icomp=0, n=m_all_field_functors[lev].size(); icomp<n; icomp++){
+            const auto n = static_cast<int>(m_all_field_functors[lev].size());
+            for (int icomp=0; icomp<n; icomp++){
                 // Call all functors in m_all_field_functors[lev]. Each of them computes
                 // a diagnostics and writes in one or more components of the output
                 // multifab m_mf_output[lev].

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -361,7 +361,7 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
             diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
                 ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
             diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-                (ba.getCellCenteredBox( ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+                (ba.getCellCenteredBox( static_cast<int>(ba.size())-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
         }
     }
 
@@ -375,7 +375,7 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
     // Allocate output MultiFab for diagnostics. The data will be stored at cell-centers.
     int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
     // The zero is hard-coded since the number of output buffers = 1 for FullDiagnostics
-    m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, m_varnames.size(), ngrow);
+    m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, static_cast<int>(m_varnames.size()), ngrow);
 
 
     if (lev == 0) {
@@ -409,7 +409,8 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
 
     m_all_field_functors[lev].resize( m_varnames.size() );
     // Fill vector of functors for all components except individual cylindrical modes.
-    for (int comp=0, n=m_all_field_functors[lev].size(); comp<n; comp++){
+    const auto n = static_cast<int>(m_all_field_functors[lev].size());
+    for (int comp=0; comp<n; comp++){
         if        ( m_varnames[comp] == "Ex" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Efield_aux(lev, 0), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "Ey" ){

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -55,7 +55,7 @@ MultiDiagnostics::ReadParameters ()
     pp_diagnostics.query("enable", enable_diags);
     if (enable_diags == 1) {
         pp_diagnostics.queryarr("diags_names", diags_names);
-        ndiags = diags_names.size();
+        ndiags = static_cast<int>(diags_names.size());
     }
 
     diags_types.resize( ndiags );

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -66,7 +66,7 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
 
     Vector<int> slice_ncells(AMREX_SPACEDIM);
     int nghost = 1;
-    int nlevels = dom_geom.size();
+    auto nlevels = static_cast<int>(dom_geom.size());
     int ncomp = (mf).nComp();
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nlevels==1,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2324,7 +2324,7 @@ WarpX::getPMLdirections() const
 #endif
     if( do_pml )
     {
-        for( unsigned int i = 0u; i < dirsWithPML.size() / 2u; ++i )
+        for( int i = 0; i < static_cast<int>(dirsWithPML.size()) / 2; ++i )
         {
             dirsWithPML.at( 2u*i      ) = bool(do_pml_Lo[i]);
             dirsWithPML.at( 2u*i + 1u ) = bool(do_pml_Hi[i]);


### PR DESCRIPTION
This PR fixes some issues found using `clang-tidy` and performing the check `bugprone-narrowing-conversions`