### PR TITLE
openPMD: ED-PIC in Runtime Attributes

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -208,6 +208,7 @@ private:
 
   /** This function sets up the entries for particle properties
    *
+   * @param[in] pc The particle container of the species
    * @param[in] currSpecies The openPMD species
    * @param[in] write_real_comp The real attribute ids, from WarpX
    * @param[in] real_comp_names The real attribute names, from WarpX
@@ -215,7 +216,8 @@ private:
    * @param[in] int_comp_names The int attribute names, from WarpX
    * @param[in] np  Number of particles
    */
-  void SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
+  void SetupRealProperties (ParticleContainer const * pc,
+               openPMD::ParticleSpecies& currSpecies,
                const amrex::Vector<int>& write_real_comp,
                const amrex::Vector<std::string>& real_comp_names,
                const amrex::Vector<int>& write_int_comp,
@@ -293,12 +295,6 @@ private:
 
   int m_MPIRank = 0;
   int m_MPISize = 1;
-
-  int m_NumSoARealAttributes = PIdx::nattribs; //! WarpX' additional real particle attributes in SoA
-  int m_NumAoSRealAttributes = 0; //! WarpX definition: no additional real attributes in particle AoS
-
-  //int m_NumSoAIntAttributes = PIdx::nattribs; //! WarpX' additional int particle attributes in SoA
-  int m_NumAoSIntAttributes = 0; //! WarpX definition: no additional int attributes in particle AoS
 
   openPMD::IterationEncoding m_Encoding = openPMD::IterationEncoding::fileBased;
   std::string m_OpenPMDFileType = "bp"; //! MPI-parallel openPMD backend: bp or h5

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -913,7 +913,8 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
   auto const& soa = pti.GetStructOfArrays();
   // first we concatinate the AoS into contiguous arrays
   {
-    for( auto idx=0; idx<ParticleIter::ContainerType::NStructReal; idx++ ) {
+    // note: WarpX does not yet use extra AoS Real attributes
+    for( auto idx=0; idx<ParticleIter::ContainerType::NStructReal; idx++ ) {  // lgtm [cpp/constant-comparison]
       if( write_real_comp[idx] ) {
           // handle scalar and non-scalar records by name
           const auto [record_name, component_name] = detail::name2openPMD(real_comp_names[idx]);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -719,7 +719,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
       m_doParticleSetUp = true;
   }
   SetupPos(currSpecies, NewParticleVectorSize, charge, mass, isBTD);
-  SetupRealProperties(currSpecies, write_real_comp, real_comp_names, write_int_comp, int_comp_names, NewParticleVectorSize, isBTD);
+  SetupRealProperties(pc, currSpecies, write_real_comp, real_comp_names, write_int_comp, int_comp_names, NewParticleVectorSize, isBTD);
   // open files from all processors, in case some will not contribute below
   m_Series->flush();
   for (auto currentLevel = 0; currentLevel <= pc->finestLevel(); currentLevel++)
@@ -816,7 +816,8 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
 }
 
 void
-WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
+WarpXOpenPMDPlot::SetupRealProperties (ParticleContainer const * pc,
+                      openPMD::ParticleSpecies& currSpecies,
                       const amrex::Vector<int>& write_real_comp,
                       const amrex::Vector<std::string>& real_comp_names,
                       const amrex::Vector<int>& write_int_comp,
@@ -851,9 +852,10 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
 
     // attributes need to be set only the first time BTD flush is called for a snapshot
     if (isBTD and m_doParticleSetUp == false) return;
+
     std::set< std::string > addedRecords; // add meta-data per record only once
-    for (auto idx=0; idx<m_NumSoARealAttributes; idx++) {
-        auto ii = m_NumAoSRealAttributes + idx; // jump over AoS names
+    for (auto idx=0; idx<pc->NumRealComps(); idx++) {
+        auto ii = ParticleContainer::NStructReal + idx; // jump over extra AoS names
         if (write_real_comp[ii]) {
             // handle scalar and non-scalar records by name
             const auto [record_name, component_name] = detail::name2openPMD(real_comp_names[ii]);
@@ -875,7 +877,7 @@ WarpXOpenPMDPlot::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
         }
     }
     for (auto idx=0; idx<int_counter; idx++) {
-        auto ii = m_NumAoSIntAttributes + idx; // jump over AoS names
+        auto ii = ParticleContainer::NStructInt + idx; // jump over extra AoS names
         if (write_int_comp[ii]) {
             // handle scalar and non-scalar records by name
             const auto [record_name, component_name] = detail::name2openPMD(int_comp_names[ii]);
@@ -905,20 +907,13 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
                        amrex::Vector<std::string> const& int_comp_names) const
 
 {
-  int numOutputReal = 0;
-  int const totalRealAttrs = m_NumAoSRealAttributes + m_NumSoARealAttributes;
-
-  for( int i = 0; i < totalRealAttrs; ++i )
-    if( write_real_comp[i] )
-      ++numOutputReal;
-
   auto const numParticleOnTile = pti.numParticles();
   uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
   auto const& aos = pti.GetArrayOfStructs();  // size =  numParticlesOnTile
   auto const& soa = pti.GetStructOfArrays();
   // first we concatinate the AoS into contiguous arrays
   {
-    for( auto idx=0; idx<m_NumAoSRealAttributes; idx++ ) {
+    for( auto idx=0; idx<ParticleIter::ContainerType::NStructReal; idx++ ) {
       if( write_real_comp[idx] ) {
           // handle scalar and non-scalar records by name
           const auto [record_name, component_name] = detail::name2openPMD(real_comp_names[idx]);
@@ -949,7 +944,7 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
   {
     auto const real_counter = std::min(write_real_comp.size(), real_comp_names.size());
     for (auto idx=0; idx<real_counter; idx++) {
-      auto ii = m_NumAoSRealAttributes + idx;
+      auto ii = ParticleIter::ContainerType::NStructReal + idx;  // jump over extra AoS names
       if (write_real_comp[ii]) {
         getComponentRecord(real_comp_names[ii]).storeChunk(openPMD::shareRaw(soa.GetRealData(idx)),
           {offset}, {numParticleOnTile64});
@@ -960,7 +955,7 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
   {
     auto const int_counter = std::min(write_int_comp.size(), int_comp_names.size());
     for (auto idx=0; idx<int_counter; idx++) {
-      auto ii = m_NumAoSIntAttributes + idx; // jump over AoS names
+      auto ii = ParticleIter::ContainerType::NStructInt + idx;  // jump over extra AoS names
       if (write_int_comp[ii]) {
         getComponentRecord(int_comp_names[ii]).storeChunk(openPMD::shareRaw(soa.GetIntData(idx)),
           {offset}, {numParticleOnTile64});


### PR DESCRIPTION
Add the ED-PIC extension attributes (weighting by macro or real particle) to runtime attributes.

Fix #2901