### PR TITLE
ionization_level -> ionizationLevel

### DIFF
--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -122,7 +122,7 @@ Attribute name        ``int``/``real``  Description                         Wher
                                         was created.
 ``id``                ``int``           CPU-local particle index            AoS   CT
                                         where the particle was created.
-``ionization_level``  ``int``           Ion ionization level                SoA   RT   Added when ionization
+``ionizationLevel``   ``int``           Ion ionization level                SoA   RT   Added when ionization
                                                                                        physics is used.
 ``opticalDepthQSR``   ``real``          QED: optical depth of the Quantum-  SoA   RT   Added when PICSAR QED
                                         Synchrotron process                            physics is used.

--- a/Examples/Modules/ionization/analysis_ionization.py
+++ b/Examples/Modules/ionization/analysis_ionization.py
@@ -32,7 +32,7 @@ import checksumAPI
 filename = sys.argv[1]
 ds = yt.load( filename )
 ad = ds.all_data()
-ilev = ad['ions', 'particle_ionization_level'].v
+ilev = ad['ions', 'particle_ionizationLevel'].v
 
 # Fraction of Nitrogen ions that are N5+.
 N5_fraction = ilev[ilev == 5].size/float(ilev.size)
@@ -55,7 +55,7 @@ if do_plot:
     species = 'ions';
     xi = ad[species, 'particle_position_x'].v
     zi = ad[species, 'particle_position_y'].v
-    ii = ad[species, 'particle_ionization_level'].v
+    ii = ad[species, 'particle_ionizationLevel'].v
     plt.figure(figsize=(10,10))
     plt.subplot(211)
     plt.imshow(np.abs(F), extent=extent, aspect='auto',

--- a/Regression/Checksum/benchmarks_json/ionization_boost.json
+++ b/Regression/Checksum/benchmarks_json/ionization_boost.json
@@ -12,7 +12,7 @@
   "ions": {
     "particle_cpu": 0.0,
     "particle_id": 88079424.0,
-    "particle_ionization_level": 52741.0,
+    "particle_ionizationLevel": 52741.0,
     "particle_momentum_x": 3.63061972838759e-18,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 1.0432995297946715e-13,

--- a/Regression/Checksum/benchmarks_json/ionization_lab.json
+++ b/Regression/Checksum/benchmarks_json/ionization_lab.json
@@ -12,7 +12,7 @@
   "ions": {
     "particle_cpu": 5888.0,
     "particle_id": 42547456.0,
-    "particle_ionization_level": 72897.0,
+    "particle_ionizationLevel": 72897.0,
     "particle_momentum_x": 1.761324005206226e-18,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 3.618696690270335e-23,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -952,7 +952,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
         int* pi = nullptr;
         if (do_field_ionization) {
-            pi = soa.GetIntData(particle_icomps["ionization_level"]).data() + old_size;
+            pi = soa.GetIntData(particle_icomps["ionizationLevel"]).data() + old_size;
         }
 
 #ifdef WARPX_QED
@@ -1448,7 +1448,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
         int* p_ion_level = nullptr;
         if (do_field_ionization) {
-            p_ion_level = soa.GetIntData(particle_icomps["ionization_level"]).data() + old_size;
+            p_ion_level = soa.GetIntData(particle_icomps["ionizationLevel"]).data() + old_size;
         }
 
 #ifdef WARPX_QED
@@ -1799,7 +1799,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 // Deposit charge before particle push, in component 0 of MultiFab rho.
                 int* AMREX_RESTRICT ion_lev;
                 if (do_field_ionization){
-                    ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                    ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
                 } else {
                     ion_lev = nullptr;
                 }
@@ -1870,7 +1870,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 if (! skip_deposition) {
                     int* AMREX_RESTRICT ion_lev;
                     if (do_field_ionization){
-                        ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                        ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
                     } else {
                         ion_lev = nullptr;
                     }
@@ -1893,7 +1893,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 if (WarpX::do_electrostatic == ElectrostaticSolverAlgo::None) {
                     int* AMREX_RESTRICT ion_lev;
                     if (do_field_ionization){
-                        ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                        ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
                     } else {
                         ion_lev = nullptr;
                     }
@@ -2255,7 +2255,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
 
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization) {
-                ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
             }
 
             // Loop over the particles and update their momentum
@@ -2621,7 +2621,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
     int* AMREX_RESTRICT ion_lev = nullptr;
     if (do_field_ionization) {
-        ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr() + offset;
+        ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr() + offset;
     }
 
     const bool save_previous_position = m_save_previous_position;
@@ -2733,7 +2733,7 @@ PhysicalParticleContainer::InitIonizationModule ()
     pp_species_name.get("ionization_product_species", ionization_product_name);
     pp_species_name.get("physical_element", physical_element);
     // Add runtime integer component for ionization level
-    AddIntComp("ionization_level");
+    AddIntComp("ionizationLevel");
     // Get atomic number and ionization energies from file
     int const ion_element_id = ion_map_ids.at(physical_element);
     ion_atomic_number = ion_atomic_numbers[ion_element_id];
@@ -2802,7 +2802,7 @@ PhysicalParticleContainer::getIonizationFunc (const WarpXParIter& pti,
                                 adk_prefactor.dataPtr(),
                                 adk_exp_prefactor.dataPtr(),
                                 adk_power.dataPtr(),
-                                particle_icomps["ionization_level"],
+                                particle_icomps["ionizationLevel"],
                                 ion_atomic_number);
 }
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -388,7 +388,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
 
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization) {
-                ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
             }
 
             // Save the position and momenta, making copies

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -554,7 +554,7 @@ WarpXParticleContainer::DepositCurrent (
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization)
             {
-                ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
             }
 
             DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev,
@@ -696,7 +696,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization)
             {
-                ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
             }
 
             DepositCharge(pti, wp, ion_lev, rho[lev].get(), icomp, 0, np, thread_num, lev, lev);
@@ -781,7 +781,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 
             int* AMREX_RESTRICT ion_lev;
             if (do_field_ionization){
-                ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
+                ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();
             } else {
                 ion_lev = nullptr;
             }


### PR DESCRIPTION
Rename to follow the naming conventions we use for I/O for scalar and vector/tensor attributes.

Notes:
- needed breaking change. This will only be a problem if you try to restart from a checkpoint file before & after the change.

References:
- https://warpx.readthedocs.io/en/latest/developers/particles.html#particle-attributes
- https://github.com/ECP-WarpX/WarpX/issues/1652#issuecomment-1036604849
- https://github.com/ECP-WarpX/WarpX/pull/2735#discussion_r804991858