### PR TITLE
Check that the relative permittivity epsilon is always strictly positive

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -150,6 +150,12 @@ MacroscopicProperties::InitData ()
         InitializeMacroMultiFabUsingParser(m_eps_mf.get(), m_epsilon_parser->compile<3>(), lev);
 
     }
+    // In the Maxwell solver, `epsilon` is used in the denominator.
+    // Therefore, it needs to be strictly positive
+    bool const local=true;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_eps_mf->min(0,0,local) > 0,
+    "WarpX encountered zero or negative values for the relative permittivity `epsilon`. Please check the initialization of `epsilon`.");
+
     // Initialize mu
     if (m_mu_s == "constant") {
 


### PR DESCRIPTION
When initializing the relative permittivity epsilon, users can create a zero permittivity by accident. In that case, they will probably get a confusing error message (due to a division by zero in the Maxwell equation). This PR makes the error message more explicitly.

@atmyers Am I correct that, by using `local = true` here, the performance impact of this change should be minimal (even if we had to re-evaluate `epsilon` at each timestep)?