### PR TITLE
[WIP] Increase default digit number for diagnostic files

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1943,7 +1943,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 * ``<diag_name>.file_prefix`` (`string`) optional (default `diags/<diag_name>`)
     Root for output file names. Supports sub-directories.
 
-* ``<diag_name>.file_min_digits`` (`int`) optional (default `5`)
+* ``<diag_name>.file_min_digits`` (`int`) optional (default `9`)
     The minimum number of digits used for the iteration number appended to the diagnostic file names.
 
 * ``<diag_name>.diag_lo`` (list `float`, 1 per dimension) optional (default `-infinity -infinity -infinity`)

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -130,7 +130,7 @@ protected:
     /** Prefix for output directories */
     std::string m_file_prefix;
     /** Minimum number of digits to iteration number in file name */
-    int m_file_min_digits = 5;
+    int m_file_min_digits = 9;
     /** Index of diagnostics in MultiDiagnostics::alldiags */
     int m_diag_index;
     /** Names of  each component requested by the user.


### PR DESCRIPTION
@ax3l Is there any harm in increasing the default number of digits for the output files?
It seems that various users are hitting this limit recently (which causes issue later for postprocessing of the timeseries). On the other hand, it is unlikely that we will reach simulations with 10^9 iterations soon...