### PR TITLE
Rigid Injection: Serialize RNG

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -201,7 +201,7 @@ analysisRoutine = Examples/Tests/SilverMueller/analysis_silver_mueller.py
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
-runtime_params =
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -218,7 +218,7 @@ analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFr
 [RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
-runtime_params =
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON


### PR DESCRIPTION
These tests use a temperature in the particle beam. Thus, we need to serialize the RNG for reproducible results / checksums.