### PR TITLE
Python_restart_eb: Add CMake Options

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -916,6 +916,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_restart_eb.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = pip_install
 restartTest = 1
 restartFileNum = 30
 useMPI = 1


### PR DESCRIPTION
Add missing CMake options in `WarpX-tests.ini` for the `Python_restart_eb` test.

This must have been merged in parallel to when we modernized our regression tests end of last year. #2556 