### PR TITLE
CI: Cache for GitHub Actions

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -27,6 +27,18 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/nvcc11.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-
+          ccache-cuda-nvcc-
+    - name: install openPMD-api
+      run: |
         export CEI_SUDO="sudo"
         cmake-easyinstall --prefix=/usr/local \
           git+https://github.com/openPMD/openPMD-api.git@0.14.3 \
@@ -96,6 +108,16 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dependencies
       run: .github/workflows/dependencies/nvhpc.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-
+          ccache-cuda-nvhpc-
     - name: Build & Install
       run: |
         source /etc/profile.d/modules.sh

--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -21,6 +21,7 @@ df -h
 # https://github.com/ECP-WarpX/WarpX/pull/1566#issuecomment-790934878
 sudo apt-get install -y --no-install-recommends \
     build-essential \
+    ccache          \
     cmake           \
     intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
     g++ gfortran    \

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -11,6 +11,7 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    ccache              \
     cmake               \
     gnupg               \
     ninja-build         \

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -25,6 +25,7 @@ sudo apt-get update
 # other: rocm-dev rocm-utils
 sudo apt-get install -y --no-install-recommends \
     build-essential \
+    ccache          \
     gfortran        \
     libnuma-dev     \
     libopenmpi-dev  \

--- a/.github/workflows/dependencies/icc.sh
+++ b/.github/workflows/dependencies/icc.sh
@@ -11,8 +11,9 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt-get -qqq update
 sudo apt-get install -y \
   build-essential \
-  cmake           \
   ca-certificates \
+  ccache          \
+  cmake           \
   gnupg           \
   pkg-config      \
   wget

--- a/.github/workflows/dependencies/nvcc11.sh
+++ b/.github/workflows/dependencies/nvcc11.sh
@@ -11,6 +11,7 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    ccache              \
     cmake               \
     gnupg               \
     libopenmpi-dev      \

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -10,6 +10,7 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    ccache              \
     cmake               \
     environment-modules \
     gnupg               \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,6 +19,16 @@ jobs:
     - name: install dependencies
       shell: bash
       run: .github/workflows/dependencies/hip.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-
+          ccache-hip-3dsp-
     - name: build WarpX
       shell: bash
       run: |
@@ -62,6 +72,16 @@ jobs:
     - name: install dependencies
       shell: bash
       run: .github/workflows/dependencies/hip.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-
+          ccache-hip-2ddp-
     - name: build WarpX
       shell: bash
       run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -21,6 +21,16 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/icc.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-
+          ccache-intel-icc-
     - name: build WarpX
       run: |
         set +eu
@@ -64,6 +74,16 @@ jobs:
       shell: bash
       run: |
         .github/workflows/dependencies/dpcpp.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-
+          ccache-intel-icpx-
     - name: build WarpX
       shell: bash
       run: |
@@ -110,6 +130,16 @@ jobs:
       shell: bash
       run: |
         .github/workflows/dependencies/dpcpp.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-
+          ccache-intel-dpcc-
     - name: build WarpX
       shell: bash
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,7 @@ jobs:
         set +e
         rm -rf /usr/local/bin/2to3
         brew update
+        brew install ccache
         brew install fftw
         brew install libomp
         brew install ninja
@@ -34,6 +35,16 @@ jobs:
         set -e
         brew tap openpmd/openpmd
         brew install openpmd-api
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-
+          ccache-macos-appleclang-
     - name: build WarpX
       run: |
         cmake -S . -B build_dp         \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,6 +18,16 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
+          ccache-openmp-cxxminimal-
     - name: build WarpX
       run: |
         cmake -S . -B build_3D         \
@@ -47,6 +57,16 @@ jobs:
       run: |
         .github/workflows/dependencies/gcc.sh
         sudo apt-get install -y libopenmpi-dev openmpi-bin
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
+          ccache-openmp-gccablastr-
     - name: build WarpX
       run: |
         cmake -S . -B build            \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         cmake -S . -B build               `
               -DCMAKE_BUILD_TYPE=Debug    `
-              -DCMAKE_CXX_STANDARD=17     `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DWarpX_COMPUTE=NOACC       `
               -DWarpX_OPENPMD=ON          `
@@ -39,10 +38,9 @@ jobs:
         $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
-
-# -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121
-# and can be removed with openPMD-api 0.14.3+
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
+# JSON writes are currently very slow (50min) with MSVC
+#  --diagformat=openpmd
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -69,7 +67,6 @@ jobs:
               -G "Ninja"      ^
               -DCMAKE_C_COMPILER=clang-cl   ^
               -DCMAKE_CXX_COMPILER=clang-cl ^
-              -DCMAKE_CXX_STANDARD=17       ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
@@ -84,6 +81,3 @@ jobs:
         python3 -m pip install . -vv --no-build-isolation
 
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
-
-# -DCMAKE_CXX_STANDARD=17 is set due to https://github.com/openPMD/openPMD-api/pull/1121
-# and can be removed with openPMD-api 0.14.3+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,16 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
+          ccache-windows-winmsvc-
     - name: Build & Install
       run: |
         cmake -S . -B build               `
@@ -40,6 +50,16 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}-
+          ccache-windows-winclang-
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build & Install
       shell: cmd


### PR DESCRIPTION
Use caches for `ccache` on GitHub actions.

Similar to the cache logic added for Azure Pipelines in #2615