### PR TITLE
Rename `serialize_ics` as `serialize_initial_conditions`

### DIFF
--- a/Docs/source/developers/warning_logger.rst
+++ b/Docs/source/developers/warning_logger.rst
@@ -150,7 +150,7 @@ For instance, the following inputfile
    #################################
    ############ NUMERICS ###########
    #################################
-   warpx.serialize_ics = 1
+   warpx.serialize_initial_conditions = 1
    warpx.verbose = 1
    warpx.cfl = 1.0
    warpx.use_filter = 0

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -920,7 +920,7 @@ Particle initialization
     boosted frame, whether or not to plot back-transformed diagnostics for
     this species.
 
-* ``warpx.serialize_ics`` (`0` or `1`) optional (default `0`)
+* ``warpx.serialize_initial_conditions`` (`0` or `1`) optional (default `0`)
     Serialize the initial conditions for reproducible testing.
     Mainly whether or not to use OpenMP threading for particle initialization.
 

--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -20,7 +20,7 @@ warpx.cfl = .999
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Modules/RigidInjection/inputs_2d_LabFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_LabFrame
@@ -15,7 +15,7 @@ warpx.cfl = .999
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.use_filter = 0
 
 # Order of particle shape factors

--- a/Examples/Modules/boosted_diags/inputs_3d_slice
+++ b/Examples/Modules/boosted_diags/inputs_3d_slice
@@ -33,7 +33,7 @@ algo.particle_shape = 3
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 warpx.gamma_boost = 10.
 warpx.boost_direction = z

--- a/Examples/Modules/laser_injection/inputs_1d_rt
+++ b/Examples/Modules/laser_injection/inputs_1d_rt
@@ -19,7 +19,7 @@ geometry.prob_hi     =  15.e-6
 boundary.field_lo = pec
 boundary.field_hi = pec
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Modules/laser_injection/inputs_2d_rt
+++ b/Examples/Modules/laser_injection/inputs_2d_rt
@@ -19,7 +19,7 @@ geometry.prob_hi     =  20.e-6     15.e-6
 boundary.field_lo = pec periodic
 boundary.field_hi = pec periodic
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Modules/laser_injection/inputs_3d_rt
+++ b/Examples/Modules/laser_injection/inputs_3d_rt
@@ -20,7 +20,7 @@ geometry.prob_hi     =  20.e-6    20.e-6    12.e-6
 boundary.field_lo = periodic periodic pec
 boundary.field_hi = periodic periodic pec
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
+++ b/Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
@@ -10,7 +10,7 @@ geometry.dims = 2
 geometry.prob_lo     = -25.e-6  -25.0e-6     # physical domain
 geometry.prob_hi     =  25.e-6   25.e-6
 warpx.verbose = 1
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 #################################
 ####### Boundary condition ######

--- a/Examples/Modules/nci_corrector/inputs_2d
+++ b/Examples/Modules/nci_corrector/inputs_2d
@@ -30,7 +30,7 @@ algo.current_deposition = esirkepov
 # Order of particle shape factors
 algo.particle_shape = 3
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.cfl = 1.0
 warpx.do_subcycling = 1
 

--- a/Examples/Modules/qed/breit_wheeler/inputs_2d
+++ b/Examples/Modules/qed/breit_wheeler/inputs_2d
@@ -27,7 +27,7 @@ warpx.verbose = 1
 warpx.do_dive_cleaning = 0
 warpx.use_filter = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Modules/qed/breit_wheeler/inputs_3d
+++ b/Examples/Modules/qed/breit_wheeler/inputs_3d
@@ -27,7 +27,7 @@ warpx.verbose = 1
 warpx.do_dive_cleaning = 0
 warpx.use_filter = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Modules/qed/quantum_synchrotron/inputs_2d
+++ b/Examples/Modules/qed/quantum_synchrotron/inputs_2d
@@ -27,7 +27,7 @@ warpx.verbose = 1
 warpx.do_dive_cleaning = 0
 warpx.use_filter = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Modules/qed/quantum_synchrotron/inputs_3d
+++ b/Examples/Modules/qed/quantum_synchrotron/inputs_3d
@@ -27,7 +27,7 @@ warpx.verbose = 1
 warpx.do_dive_cleaning = 0
 warpx.use_filter = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Modules/qed/schwinger/inputs_3d_schwinger
+++ b/Examples/Modules/qed/schwinger/inputs_3d_schwinger
@@ -25,7 +25,7 @@ algo.field_gathering = momentum-conserving
 algo.particle_pusher = boris
 warpx.verbose = 1
 warpx.cfl = 1. # if 1., the time step is set to its CFL limit
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.use_filter = 0
 
 # Order of particle shape factors

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
@@ -94,7 +94,7 @@ sim = picmi.Simulation(
     verbose = 1,
     particle_shape = 'cubic',
     warpx_use_filter = 1,
-    warpx_serialize_ics = 1,
+    warpx_serialize_initial_conditions = 1,
     warpx_do_dynamic_scheduling = 0)
 
 # Add plasma electrons

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
@@ -127,7 +127,7 @@ sim = picmi.Simulation(
     verbose = 1,
     particle_shape = 'cubic',
     warpx_use_filter = 1,
-    warpx_serialize_ics = 1)
+    warpx_serialize_initial_conditions = 1)
 
 # Add plasma electrons
 sim.add_species(

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
@@ -125,7 +125,7 @@ sim = picmi.Simulation(
     verbose = 1,
     particle_shape = 'cubic',
     warpx_use_filter = 1,
-    warpx_serialize_ics = 1,
+    warpx_serialize_initial_conditions = 1,
     warpx_do_dynamic_scheduling = 0)
 
 # Add plasma electrons

--- a/Examples/Physics_applications/laser_acceleration/inputs_1d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_1d
@@ -27,7 +27,7 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z # Only z is supported for the moment
 warpx.moving_window_v = 1.0 # units of speed of light
 warpx.do_dynamic_scheduling = 0
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d
@@ -28,7 +28,7 @@ warpx.cfl = 1. # if 1., the time step is set to its CFL limit
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z # Only z is supported for the moment
 warpx.moving_window_v = 1.0 # units of speed of light
-warpx.serialize_ics = 1 # for production, set this to 0 (default)
+warpx.serialize_initial_conditions = 1 # for production, set this to 0 (default)
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Physics_applications/laser_acceleration/inputs_2d_boost
+++ b/Examples/Physics_applications/laser_acceleration/inputs_2d_boost
@@ -34,7 +34,7 @@ warpx.cfl = 1.
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1.0 # in units of the speed of light
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Physics_applications/laser_acceleration/inputs_3d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_3d
@@ -29,7 +29,7 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z # Only z is supported for the moment
 warpx.moving_window_v = 1.0 # units of speed of light
 warpx.do_dynamic_scheduling = 0 # for production, set this to 1 (default)
-warpx.serialize_ics = 1         # for production, set this to 0 (default)
+warpx.serialize_initial_conditions = 1         # for production, set this to 0 (default)
 
 # Order of particle shape factors
 algo.particle_shape = 3

--- a/Examples/Physics_applications/plasma_mirror/inputs_2d
+++ b/Examples/Physics_applications/plasma_mirror/inputs_2d
@@ -10,7 +10,7 @@ geometry.dims = 2
 geometry.prob_lo = -100.e-6   0.     # physical domain
 geometry.prob_hi =  100.e-6   100.e-6
 warpx.verbose = 1
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 #################################
 ####### Boundary condition ######

--- a/Examples/Physics_applications/uniform_plasma/inputs_2d
+++ b/Examples/Physics_applications/uniform_plasma/inputs_2d
@@ -19,7 +19,7 @@ boundary.field_hi = periodic periodic
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
 warpx.use_filter = 0

--- a/Examples/Physics_applications/uniform_plasma/inputs_3d
+++ b/Examples/Physics_applications/uniform_plasma/inputs_3d
@@ -19,7 +19,7 @@ boundary.field_hi = periodic periodic periodic
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
 

--- a/Examples/Tests/Langmuir/inputs_1d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_1d_multi_rt
@@ -20,7 +20,7 @@ geometry.prob_hi     =  20.e-6
 boundary.field_lo = periodic
 boundary.field_hi = periodic
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rt
@@ -20,7 +20,7 @@ geometry.prob_hi     =  20.e-6    20.e-6
 boundary.field_lo = periodic periodic
 boundary.field_hi = periodic periodic
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
+++ b/Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
@@ -29,7 +29,7 @@ geometry.prob_hi     =  20.e-6    20.e-6
 boundary.field_lo = none periodic
 boundary.field_hi = none periodic
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/Langmuir/inputs_3d_multi_rt
+++ b/Examples/Tests/Langmuir/inputs_3d_multi_rt
@@ -33,7 +33,7 @@ geometry.prob_hi     =  lx/2.    lx/2.    lx/2.
 boundary.field_lo = periodic periodic periodic
 boundary.field_hi = periodic periodic periodic
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/PEC/inputs_field_PEC_3d
+++ b/Examples/Tests/PEC/inputs_field_PEC_3d
@@ -23,7 +23,7 @@ geometry.prob_hi     =   8.e-6  8.e-6  4.e-6
 boundary.field_lo = periodic periodic pec
 boundary.field_hi = periodic periodic pec
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/PEC/inputs_field_PEC_mr_3d
+++ b/Examples/Tests/PEC/inputs_field_PEC_mr_3d
@@ -23,7 +23,7 @@ warpx.fine_tag_hi     =  4.e-6   4.e-6   2.e-6      # physical domain
 boundary.field_lo = periodic periodic pec
 boundary.field_hi = periodic periodic pec
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Verbosity
 warpx.verbose = 1

--- a/Examples/Tests/collision/PICMI_inputs_2d.py
+++ b/Examples/Tests/collision/PICMI_inputs_2d.py
@@ -32,7 +32,7 @@ number_per_cell = 200
 #################################
 ############ NUMERICS ###########
 #################################
-serialize_ics = 1
+serialize_initial_conditions = 1
 verbose = 1
 cfl = 1.0
 
@@ -123,7 +123,7 @@ sim = picmi.Simulation(
     solver=solver,
     max_steps=max_steps,
     verbose=verbose,
-    warpx_serialize_ics=serialize_ics,
+    warpx_serialize_initial_conditions=serialize_initial_conditions,
     warpx_collisions=[collision1, collision2, collision3]
 )
 

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -19,7 +19,7 @@ boundary.field_hi = periodic periodic
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
 

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -19,7 +19,7 @@ boundary.field_hi = periodic periodic periodic
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
 

--- a/Examples/Tests/collision/inputs_rz
+++ b/Examples/Tests/collision/inputs_rz
@@ -19,7 +19,7 @@ boundary.field_hi = none periodic
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = 1.0
 

--- a/Examples/Tests/comoving/inputs_2d_hybrid
+++ b/Examples/Tests/comoving/inputs_2d_hybrid
@@ -38,7 +38,7 @@ warpx.moving_window_v = 1.0
 
 warpx.use_filter = 1
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 
 interpolation.field_centering_nox = 8

--- a/Examples/Tests/galilean/inputs_2d_hybrid
+++ b/Examples/Tests/galilean/inputs_2d_hybrid
@@ -36,7 +36,7 @@ warpx.moving_window_v = 1.0
 
 warpx.use_filter = 1
 
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 
 interpolation.field_centering_nox = 8

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
@@ -173,7 +173,7 @@ def generate():
         f.write("algo.charge_deposition = standard\n")
         f.write("algo.field_gathering = energy-conserving\n")
         f.write("warpx.cfl = 1.0\n")
-        f.write("warpx.serialize_ics = 1\n")
+        f.write("warpx.serialize_initial_conditions = 1\n")
 
         f.write("particles.species_names = ")
         for cc in cases:

--- a/Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
+++ b/Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
@@ -13,7 +13,7 @@ geometry.prob_hi = 8e-07 8e-07 8e-07
 algo.charge_deposition = standard
 algo.field_gathering = energy-conserving
 warpx.cfl = 1.0
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 
 # Boundary condition
 boundary.field_lo = periodic periodic periodic

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -967,7 +967,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.field_gathering_algo = kw.pop('warpx_field_gathering_algo', None)
         self.particle_pusher_algo = kw.pop('warpx_particle_pusher_algo', None)
         self.use_filter = kw.pop('warpx_use_filter', None)
-        self.serialize_ics = kw.pop('warpx_serialize_ics', None)
+        self.serialize_initial_conditions = kw.pop('warpx_serialize_initial_conditions', None)
         self.do_dynamic_scheduling = kw.pop('warpx_do_dynamic_scheduling', None)
         self.load_balance_intervals = kw.pop('warpx_load_balance_intervals', None)
         self.load_balance_efficiency_ratio_threshold = kw.pop('warpx_load_balance_efficiency_ratio_threshold', None)
@@ -1013,7 +1013,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         pywarpx.algo.costs_heuristic_cells_wt = self.costs_heuristic_cells_wt
 
         pywarpx.warpx.use_filter = self.use_filter
-        pywarpx.warpx.serialize_ics = self.serialize_ics
+        pywarpx.warpx.serialize_initial_conditions = self.serialize_initial_conditions
 
         pywarpx.warpx.do_dynamic_scheduling = self.do_dynamic_scheduling
 

--- a/Regression/TestFillBoundary/inputs.2d
+++ b/Regression/TestFillBoundary/inputs.2d
@@ -13,7 +13,7 @@ geometry.prob_hi     =  20.e-6    20.e-6
 #################################
 ############ NUMERICS ###########
 #################################
-warpx.serialize_ics = 1
+warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.cfl = .9999
 amr.plot_int = 1000

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -527,14 +527,14 @@ useOMP = 0
 numthreads = 1
 compileTest = 0
 doVis = 0
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 compareParticles = 0
 
 #xxxxx
 #[LaserAcceleration]
 #buildDir = .
 #inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
-#runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_ics=1
+#runtime_params = warpx.do_dynamic_scheduling=0 amr.n_cell=32 32 256 max_step=100 electrons.zmin=0.e-6 warpx.serialize_initial_conditions=1
 #dim = 3
 #addToCompileString = USE_GPU=TRUE
 #restartTest = 0
@@ -550,7 +550,7 @@ compareParticles = 0
 [subcyclingMR]
 buildDir = .
 inputFile = Examples/Tests/subcycling/inputs_2d
-runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+runtime_params = warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -565,7 +565,7 @@ compareParticles = 0
 [LaserAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
-runtime_params = amr.max_level=1 max_step=200 warpx.serialize_ics=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
+runtime_params = amr.max_level=1 max_step=200 warpx.serialize_initial_conditions=1 warpx.fine_tag_lo=-5.e-6 -35.e-6 warpx.fine_tag_hi=5.e-6 -25.e-6
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0
@@ -581,7 +581,7 @@ particleTypes = electrons beam
 [PlasmaAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_GPU=TRUE
 restartTest = 0

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -137,7 +137,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [pml_psatd_rz]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -201,7 +201,7 @@ analysisRoutine = Examples/Tests/SilverMueller/analysis_silver_mueller.py
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_LabFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -218,7 +218,7 @@ analysisRoutine = Examples/Modules/RigidInjection/analysis_rigid_injection_LabFr
 [RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
@@ -951,7 +951,7 @@ analysisOutputImage = laser_analysis.png
 [LaserInjection_2d]
 buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs_2d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -968,7 +968,7 @@ analysisRoutine = Examples/Modules/laser_injection/analysis_2d.py
 [LaserInjection_1d]
 buildDir = .
 inputFile = Examples/Modules/laser_injection/inputs_1d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 1
 addToCompileString = USE_OPENPMD=TRUE QED=FALSE
 cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
@@ -1079,7 +1079,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [subcyclingMR]
 buildDir = .
 inputFile = Examples/Tests/subcycling/inputs_2d
-runtime_params = warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+runtime_params = warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1152,7 +1152,7 @@ analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_refi
 [PlasmaAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1723,7 +1723,7 @@ analysisRoutine =
 [PlasmaAccelerationBoost2d]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 256 max_step=20
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 256 max_step=20
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1799,7 +1799,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [PlasmaAccelerationBoost3d]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 64 128 max_step=5
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=5
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -1815,7 +1815,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [PlasmaMirror]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_mirror/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=256 128 max_step=20
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=256 128 max_step=20
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1831,7 +1831,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [LaserIonAcc2d]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_ion/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=384 512 max_step=100
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=384 512 max_step=100
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
@@ -1847,7 +1847,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [momentum-conserving-gather]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_ics=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1987,7 +1987,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [LaserAccelerationBoost]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 amr.n_cell=64 512 max_step=20
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 512 max_step=20
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2113,7 +2113,7 @@ analysisRoutine = Examples/Tests/Maxwell_Hybrid_QED/analysis_Maxwell_QED_Hybrid.
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs
 aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2131,7 +2131,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs
 aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
@@ -2148,7 +2148,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
 [reduced_diags_loadbalancecosts_timers]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2165,7 +2165,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 [reduced_diags_loadbalancecosts_timers_psatd]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Timers
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2182,7 +2182,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 [reduced_diags_loadbalancecosts_heuristic]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Heuristic
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Heuristic
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2271,7 +2271,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [galilean_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 electrons.random_theta=0 ions.random_theta=0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2451,7 +2451,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [multi_J_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/multi_J/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2643,7 +2643,7 @@ analysisRoutine = Examples/Tests/embedded_circle/analysis.py
 [initial_distribution]
 buildDir = .
 inputFile = Examples/Tests/initial_distribution/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -791,7 +791,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
     }
 #ifdef AMREX_USE_OMP
     info.SetDynamic(true);
-#pragma omp parallel if (not WarpX::serialize_ics)
+#pragma omp parallel if (not WarpX::serialize_initial_conditions)
 #endif
     for (MFIter mfi = MakeMFIter(lev, info); mfi.isValid(); ++mfi)
     {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -286,7 +286,7 @@ public:
     static bool use_filter_compensation;
 
     //! If true, the initial conditions from random number generators are serialized (useful for reproducible testing with OpenMP)
-    static bool serialize_ics;
+    static bool serialize_initial_conditions;
 
     // Back transformation diagnostic
     static bool do_back_transformed_diagnostics;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1326,16 +1326,19 @@ WarpX::ReadParameters ()
 void
 WarpX::BackwardCompatibility ()
 {
-    ParmParse pp_amr("amr");
+    // Auxiliary variables
     int backward_int;
+    bool backward_bool;
+    std::string backward_str;
+    amrex::Real backward_Real;
+
+    ParmParse pp_amr("amr");
     if (pp_amr.query("plot_int", backward_int)){
         amrex::Abort("amr.plot_int is not supported anymore. Please use the new syntax for diagnostics:\n"
             "diagnostics.diags_names = my_diag\n"
             "my_diag.intervals = 10\n"
             "for output every 10 iterations. See documentation for more information");
     }
-
-    std::string backward_str;
     if (pp_amr.query("plot_file", backward_str)){
         amrex::Abort("amr.plot_file is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
@@ -1364,7 +1367,6 @@ WarpX::BackwardCompatibility ()
                      "Please use the renamed option algo.load_balance_intervals instead.");
     }
 
-    amrex::Real backward_Real;
     if (pp_warpx.query("load_balance_efficiency_ratio_threshold", backward_Real)){
         amrex::Abort("warpx.load_balance_efficiency_ratio_threshold is not supported anymore. "
                      "Please use the renamed option algo.load_balance_efficiency_ratio_threshold.");
@@ -1392,6 +1394,11 @@ WarpX::BackwardCompatibility ()
     if ( pp_warpx.query("do_pml", backward_int) ) {
         amrex::Abort( "do_pml is not supported anymore. Please use boundary.field_lo and boundary.field_hi to set the boundary conditions.");
     }
+    if (pp_warpx.query("serialize_ics", backward_bool)) {
+        amrex::Abort("warpx.serialize_ics is no longer a valid option. "
+                     "Please use the renamed option warpx.serialize_initial_conditions instead.");
+    }
+
     ParmParse pp_interpolation("interpolation");
     if (pp_interpolation.query("nox", backward_int) ||
         pp_interpolation.query("noy", backward_int) ||
@@ -1415,6 +1422,7 @@ WarpX::BackwardCompatibility ()
             "particles.nspecies is ignored. Just use particles.species_names please.",
             WarnPriority::low);
     }
+
     ParmParse pp_collisions("collisions");
     int ncollisions;
     if (pp_collisions.query("ncollisions", ncollisions)){
@@ -1422,6 +1430,7 @@ WarpX::BackwardCompatibility ()
             "collisions.ncollisions is ignored. Just use particles.collision_names please.",
             WarnPriority::low);
     }
+
     ParmParse pp_lasers("lasers");
     int nlasers;
     if (pp_lasers.query("nlasers", nlasers)){

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -154,7 +154,7 @@ bool WarpX::use_filter = true;
 bool WarpX::use_kspace_filter       = true;
 bool WarpX::use_filter_compensation = false;
 
-bool WarpX::serialize_ics     = false;
+bool WarpX::serialize_initial_conditions = false;
 bool WarpX::refine_plasma     = false;
 
 int WarpX::num_mirrors = 0;
@@ -751,7 +751,7 @@ WarpX::ReadParameters ()
         }
 #endif
 
-        pp_warpx.query("serialize_ics", serialize_ics);
+        pp_warpx.query("serialize_initial_conditions", serialize_initial_conditions);
         pp_warpx.query("refine_plasma", refine_plasma);
         pp_warpx.query("do_dive_cleaning", do_dive_cleaning);
         pp_warpx.query("do_divb_cleaning", do_divb_cleaning);


### PR DESCRIPTION
As discussed in the comments of #2921, let's rename `warpx.serialize_ics` as `warpx.serialize_initial_conditions`, which is more self-explanatory.