### PR TITLE
CI: Newer CCache for HIP

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -85,6 +85,16 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/nvcc11.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-
+          ccache-cuda-gnumake-
     - name: build WarpX
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -25,10 +25,11 @@ sudo apt-get update
 # other: rocm-dev rocm-utils
 sudo apt-get install -y --no-install-recommends \
     build-essential \
-    ccache          \
     gfortran        \
+    libhiredis-dev  \
     libnuma-dev     \
     libopenmpi-dev  \
+    libzstd-dev     \
     ninja-build     \
     openmpi-bin     \
     rocm-dev        \
@@ -48,3 +49,13 @@ which clang++
 sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"
+
+# ccache 4.2+
+#
+cmake-easyinstall --prefix=/usr/local \
+    git+https://github.com/ccache/ccache.git@v4.6 \
+    -DCMAKE_BUILD_TYPE=Release        \
+    -DENABLE_DOCUMENTATION=OFF        \
+    -DENABLE_TESTING=OFF              \
+    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -53,7 +53,7 @@ export CEI_TMP="/tmp/cei"
 
 # ccache 4.2+
 #
-cmake-easyinstall --prefix=/usr/local \
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
     git+https://github.com/ccache/ccache.git@v4.6 \
     -DCMAKE_BUILD_TYPE=Release        \
     -DENABLE_DOCUMENTATION=OFF        \

--- a/.github/workflows/dependencies/nvcc11.sh
+++ b/.github/workflows/dependencies/nvcc11.sh
@@ -55,7 +55,7 @@ export CEI_TMP="/tmp/cei"
 
 # ccache 4.2+
 #
-cmake-easyinstall --prefix=/usr/local \
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
     git+https://github.com/ccache/ccache.git@v4.6 \
     -DCMAKE_BUILD_TYPE=Release        \
     -DENABLE_DOCUMENTATION=OFF        \

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -40,7 +40,7 @@ export CEI_TMP="/tmp/cei"
 
 # ccache 4.2+
 #
-cmake-easyinstall --prefix=/usr/local \
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
     git+https://github.com/ccache/ccache.git@v4.6 \
     -DCMAKE_BUILD_TYPE=Release        \
     -DENABLE_DOCUMENTATION=OFF        \


### PR DESCRIPTION
`ccache` for HIP did only produce a 1MB artifact, which seems to small. Upgrade `ccache` to see if this achieves better results (as in #2927)

Follow-up to #2920  #2927

Also adds: missing CCache entry for GNUmake CUDA build