### PR TITLE
Fix incorrect levels when reading raw data from a MR simulation

### DIFF
--- a/Tools/PostProcessing/read_raw_data.py
+++ b/Tools/PostProcessing/read_raw_data.py
@@ -38,7 +38,7 @@ def read_data(plt_file):
 
     '''
     all_data = []
-    raw_files = glob(plt_file + "/raw_fields/Level_*/")
+    raw_files = sorted(glob(plt_file + "/raw_fields/Level_*/"))
     for raw_file in raw_files:
         field_names = _get_field_names(raw_file)
 


### PR DESCRIPTION
read_data function of read_raw_data module was returning data from incorrect level when executing `my_field = data[level][field]` . This PR fixes that by reading the sorted plot file names.