### PR TITLE
Make error and info messages visually uniform

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -13,6 +13,7 @@
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -583,7 +584,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     IntVect ngf = IntVect(AMREX_D_DECL(ngf_int, ngf_int, ngf_int));
 
     if (do_moving_window) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lev <= 1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(lev <= 1,
             "The number of grow cells for the moving window currently assumes 2 levels max.");
         int rr = ref_ratio[WarpX::moving_window_dir];
         nge[WarpX::moving_window_dir] = std::max(nge[WarpX::moving_window_dir], rr);
@@ -723,8 +724,8 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
 #   if(AMREX_SPACEDIM!=3)
         amrex::ignore_unused(noy_fft);
 #   endif
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
-                                         "PML: PSATD solver selected but not built.");
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+            "PML: PSATD solver selected but not built.");
 #else
         // Flags passed to the spectral solver constructor
         const amrex::IntVect fill_guards = amrex::IntVect(0);
@@ -843,8 +844,8 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
             amrex::ignore_unused(dt);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
-                                             "PML: PSATD solver selected but not built.");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                "PML: PSATD solver selected but not built.");
 #else
             // Flags passed to the spectral solver constructor
             const amrex::IntVect fill_guards = amrex::IntVect(0);
@@ -946,7 +947,7 @@ PML::MakeBoxArray_multiple (const amrex::Geometry& geom, const amrex::BoxArray& 
             // The check is only needed along the axis where PMLs are being used.
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         grid_bx.length(idim) > ncell[idim],
                         "Consider using larger amr.blocking_factor with PMLs");
                 }

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -6,6 +6,7 @@
  */
 #include "BTD_Plotfile_Header_Impl.H"
 
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX.H>
@@ -108,7 +109,7 @@ void
 BTDPlotfileHeaderImpl::WriteHeader ()
 {
     if ( amrex::FileExists(m_Header_path) ) {
-        amrex::Print() << " removing this file : " << m_Header_path << "\n";
+        amrex::Print() << Utils::TextMsg::Info(" removing this file : " + m_Header_path);
         amrex::FileSystem::Remove(m_Header_path);
     }
     std::ofstream HeaderFile;
@@ -257,7 +258,7 @@ void
 BTDMultiFabHeaderImpl::WriteMultiFabHeader ()
 {
     if ( amrex::FileExists(m_Header_path) ) {
-        amrex::Print() << " removing this file : " << m_Header_path << "\n";
+        amrex::Print() << Utils::TextMsg::Info(" removing this file : " + m_Header_path);
         amrex::FileSystem::Remove(m_Header_path);
     }
     std::ofstream FabHeaderFile;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -16,6 +16,7 @@
 #include "Parallelization/WarpXCommUtil.H"
 #include "ComputeDiagFunctors/BackTransformParticleFunctor.H"
 #include "Utils/CoarsenIO.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
@@ -120,23 +121,23 @@ BTDiagnostics::ReadParameters ()
     BaseReadParameters();
     auto & warpx = WarpX::GetInstance();
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.gamma_boost > 1.0_rt,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.gamma_boost > 1.0_rt,
         "gamma_boost must be > 1 to use the back-transformed diagnostics");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.boost_direction[2] == 1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.boost_direction[2] == 1,
         "The back transformed diagnostics currently only works if the boost is in the z-direction");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.do_moving_window,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.do_moving_window,
            "The moving window should be on if using the boosted frame diagnostic.");
     // The next two asserts could be relaxed with respect to check to current step
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.end_moving_window_step < 0,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.end_moving_window_step < 0,
         "The moving window must not stop when using the boosted frame diagnostic.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.start_moving_window_step == 0,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.start_moving_window_step == 0,
         "The moving window must start at step zero for the boosted frame diagnostic.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.moving_window_dir == WARPX_ZINDEX,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( warpx.moving_window_dir == WARPX_ZINDEX,
            "The boosted frame diagnostic currently only works if the moving window is in the z direction.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_format == "plotfile" || m_format == "openpmd",
         "<diag>.format must be plotfile or openpmd for back transformed diagnostics");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_crse_ratio == amrex::IntVect(1),
         "Only support for coarsening ratio of 1 in all directions is included for BTD\n"
         );
@@ -149,7 +150,7 @@ BTDiagnostics::ReadParameters ()
     pp_diag_name.query("do_back_transformed_fields", m_do_back_transformed_fields);
     pp_diag_name.query("do_back_transformed_particles", m_do_back_transformed_particles);
     AMREX_ALWAYS_ASSERT(m_do_back_transformed_fields or m_do_back_transformed_particles);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_back_transformed_fields, " fields must be turned on for the new back-transformed diagnostics");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_back_transformed_fields, " fields must be turned on for the new back-transformed diagnostics");
     if (m_do_back_transformed_fields == false) m_varnames.clear();
 
     getWithParser(pp_diag_name, "num_snapshots_lab", m_num_snapshots_lab);
@@ -162,7 +163,7 @@ BTDiagnostics::ReadParameters ()
         m_dt_snapshots_lab = m_dz_snapshots_lab/PhysConst::c;
         snapshot_interval_is_specified = true;
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(snapshot_interval_is_specified,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(snapshot_interval_is_specified,
         "For back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab");
 
     if (queryWithParser(pp_diag_name, "buffer_size", m_buffer_size)) {
@@ -266,7 +267,7 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
         // if hi<=lo, then hi = lo + 1, to ensure one cell in that dimension
         if ( hi[idim] <= lo[idim] ) {
              hi[idim]  = lo[idim] + 1;
-             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 m_crse_ratio[idim]==1, "coarsening ratio in reduced dimension must be 1."
              );
         }

--- a/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
@@ -1,6 +1,7 @@
 #include "CellCenterFunctor.H"
 
 #include "Utils/CoarsenIO.H"
+#include "Utils/TextMsg.H"
 #ifdef WARPX_DIM_RZ
 #   include "WarpX.H"
 #endif
@@ -23,7 +24,7 @@ CellCenterFunctor::operator()(amrex::MultiFab& mf_dst, int dcomp, const int /*i_
     if (m_convertRZmodes2cartesian) {
         // In cylindrical geometry, sum real part of all modes of m_mf_src in
         // temporary multifab mf_dst_stag, and cell-center it to mf_dst.
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             nComp()==1,
             "The RZ averaging over modes must write into 1 single component");
         auto& warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -1,6 +1,7 @@
 #include "DivEFunctor.H"
 
 #include "Utils/CoarsenIO.H"
+#include "Utils/TextMsg.H"
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpXAlgorithmSelection.H"
 #endif
@@ -44,7 +45,7 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const int /*i_
     if (m_convertRZmodes2cartesian) {
         // In cylindrical geometry, sum real part of all modes of divE in
         // temporary multifab mf_dst_stag, and cell-center it to mf_dst.
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             nComp()==1,
             "The RZ averaging over modes must write into 1 single component");
         amrex::MultiFab mf_dst_stag(divE.boxArray(), warpx.DistributionMap(m_lev), 1, divE.nGrowVect());

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -9,6 +9,7 @@
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/CoarsenIO.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX.H>
@@ -72,7 +73,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
     if (m_convertRZmodes2cartesian) {
         // In cylindrical geometry, sum real part of all modes of rho in
         // temporary MultiFab mf_dst_stag, and cell-center it to mf_dst
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             nComp()==1,
             "The RZ averaging over modes must write into one single component");
         amrex::MultiFab mf_dst_stag( rho->boxArray(), warpx.DistributionMap(m_lev), 1, rho->nGrowVect() );

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -13,6 +13,7 @@
 #include "FlushFormats/FlushFormatSensei.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Parallelization/WarpXCommUtil.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
@@ -62,14 +63,14 @@ Diagnostics::BaseReadParameters ()
 
     // Sanity check if user requests to plot phi
     if (WarpXUtilStr::is_in(m_varnames, "phi")){
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             warpx.do_electrostatic==ElectrostaticSolverAlgo::LabFrame,
             "plot phi only works if do_electrostatic = labframe");
     }
 
     // Sanity check if user requests to plot F
     if (WarpXUtilStr::is_in(m_varnames, "F")){
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             warpx.do_dive_cleaning,
             "plot F only works if warpx.do_dive_cleaning = 1");
     }
@@ -77,7 +78,7 @@ Diagnostics::BaseReadParameters ()
     // G can be written to file only if WarpX::do_divb_cleaning = 1
     if (WarpXUtilStr::is_in(m_varnames, "G"))
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             warpx.do_divb_cleaning, "G can be written to file only if warpx.do_divb_cleaning = 1");
     }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -1,6 +1,7 @@
 #include "FlushFormatAscent.H"
 
 #include "WarpX.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
 #include <AMReX.H>
@@ -96,7 +97,7 @@ FlushFormatAscent::WriteParticles(const amrex::Vector<ParticleDiag>& particle_di
             for (; rvn_it != real_comps_map.end(); ++rvn_it)
                 if (rvn_it->second == j)
                     break;
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 rvn_it != real_comps_map.end(),
                 "Ascent: SoA real attribute not found");
             std::string varname = rvn_it->first;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
@@ -47,7 +48,8 @@ FlushFormatCheckpoint::WriteToFile (
 
     const std::string& checkpointname = amrex::Concatenate(prefix, iteration[0], file_min_digits);
 
-    amrex::Print() << "  Writing checkpoint " << checkpointname << "\n";
+    amrex::Print() << Utils::TextMsg::Info(
+        "Writing checkpoint " + checkpointname);
 
     // const int nlevels = finestLevel()+1;
     amrex::PreBuildDirectorHierarchy(checkpointname, default_level_prefix, nlev, true);

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -1,5 +1,6 @@
 #include "FlushFormatOpenPMD.H"
 
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
@@ -135,7 +136,7 @@ FlushFormatOpenPMD::WriteToFile (
 {
     WARPX_PROFILE("FlushFormatOpenPMD::WriteToFile()");
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !plot_raw_fields && !plot_raw_fields_guards,
         "Cannot plot raw data with OpenPMD output format. Use plotfile instead.");
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -5,6 +5,7 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Particles/PinnedMemoryParticleContainer.H"
 #include "Utils/Interpolate.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
@@ -64,7 +65,7 @@ FlushFormatPlotfile::WriteToFile (
     WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);
-    amrex::Print() << "  Writing plotfile " << filename << "\n";
+    amrex::Print() << Utils::TextMsg::Info("Writing plotfile " + filename);
 
     Vector<std::string> rfs;
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -77,7 +77,7 @@ FullDiagnostics::ReadParameters ()
     // Read list of full diagnostics fields requested by the user.
     bool checkpoint_compatibility = BaseReadParameters();
     amrex::ParmParse pp_diag_name(m_diag_name);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_format == "plotfile" || m_format == "openpmd" ||
         m_format == "checkpoint" || m_format == "ascent" ||
         m_format == "sensei",
@@ -95,7 +95,7 @@ FullDiagnostics::ReadParameters ()
 #endif
 
     if (m_format == "checkpoint"){
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             raw_specified == false &&
             checkpoint_compatibility == true,
             "For a checkpoint output, cannot specify these parameters as all data must be dumped "
@@ -289,13 +289,13 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
     // Check if warpx BoxArray is coarsenable.
     if (warpx.get_numprocs() == 0)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE (
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE (
             ba.coarsenable(m_crse_ratio), "Invalid coarsening ratio for field diagnostics."
             "Must be an integer divisor of the blocking factor.");
     }
     else
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE (
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE (
             ba.coarsenable(m_crse_ratio), "Invalid coarsening ratio for field diagnostics."
             "The total number of cells must be a multiple of the coarsening ratio multiplied by numprocs.");
     }
@@ -317,7 +317,7 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
         // removed if warpx.numprocs is used for the domain decomposition.
         if (warpx.get_numprocs() == 0)
         {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( blockingFactor[idim] % m_crse_ratio[idim]==0,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( blockingFactor[idim] % m_crse_ratio[idim]==0,
                            " coarsening ratio must be integer divisor of blocking factor");
         }
     }
@@ -339,7 +339,7 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
             // if hi<=lo, then hi = lo + 1, to ensure one cell in that dimension
             if ( hi[idim] <= lo[idim] ) {
                  hi[idim]  = lo[idim] + 1;
-                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                 WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     m_crse_ratio[idim]==1, "coarsening ratio in reduced dimension must be 1."
                  );
             }
@@ -366,7 +366,7 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
         }
     }
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_crse_ratio.min() > 0, "Coarsening ratio must be non-zero.");
     // The BoxArray is coarsened based on the user-defined coarsening ratio.
     ba.coarsen(m_crse_ratio);

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -10,6 +10,7 @@
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "FlushFormats/FlushFormat.H"
 #include "Particles/MultiParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "WarpX.H"
 

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -45,11 +45,10 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
             // of the species' PIdx variables.
             if (var != "rho") {
                 // Return error if var not in PIdx.
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     ParticleStringNames::to_index.count(var),
-                    Utils::TextMsg::Err("variables argument '" + var
-                        +"' not in ParticleStringNames")
-                    );
+                    "variables argument '" + var
+                    +"' not in ParticleStringNames");
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }
         }

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -2,6 +2,7 @@
 
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
@@ -44,10 +45,10 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
             // of the species' PIdx variables.
             if (var != "rho") {
                 // Return error if var not in PIdx.
-                WarpXUtilMsg::AlwaysAssert(
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                     ParticleStringNames::to_index.count(var),
-                    "ERROR: variables argument '" + var +
-                    "' not in ParticleStringNames"
+                    Utils::TextMsg::Err("variables argument '" + var
+                        +"' not in ParticleStringNames")
                     );
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -14,6 +14,7 @@
 #include "Particles/RigidInjectedParticleContainer.H"
 #include "Particles/SpeciesPhysicalProperties.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
@@ -119,6 +120,8 @@ PhysicalParticleContainer::WriteHeader (std::ostream& os) const
 void
 MultiParticleContainer::Restart (const std::string& dir)
 {
+    auto& warpx = WarpX::GetInstance();
+
     // note: all containers is sorted like this
     // - species_names
     // - lasers_names
@@ -151,10 +154,11 @@ MultiParticleContainer::Restart (const std::string& dir)
         for (auto const& comp : pc->getParticleRuntimeComps()) {
             auto search = std::find(real_comp_names.begin(), real_comp_names.end(), comp.first);
             if (search == real_comp_names.end()) {
-                std::stringstream ss;
-                ss << "Species " << species_names[i] << "needs runtime real component " << comp.first;
-                ss << ", but it was not found in the checkpoint file. \n";
-                amrex::Abort(ss.str());
+                amrex::Abort(Utils::TextMsg::Err(
+                    "Species " + species_names[i]
+                    + "needs runtime real component " +  comp.first
+                    + ", but it was not found in the checkpoint file."
+                ));
             }
         }
 
@@ -163,9 +167,11 @@ MultiParticleContainer::Restart (const std::string& dir)
             auto current_comp_names = pc->getParticleComps();
             auto search = current_comp_names.find(comp_name);
             if (search == current_comp_names.end()) {
-                amrex::Print() << "Runtime real component " << comp_name
-                               << " was found in the checkpoint file, but it has not been added yet. "
-                               << " Adding it now. \n";
+                amrex::Print() << Utils::TextMsg::Info(
+                    "Runtime real component " + comp_name
+                    + " was found in the checkpoint file, but it has not been added yet. "
+                    + " Adding it now."
+                );
                 pc->AddRealComp(comp_name);
             }
         }
@@ -195,9 +201,11 @@ MultiParticleContainer::Restart (const std::string& dir)
             auto current_comp_names = pc->getParticleiComps();
             auto search = current_comp_names.find(comp_name);
             if (search == current_comp_names.end()) {
-                amrex::Print() << "Runtime int component " << comp_name
-                               << " was found in the checkpoint file, but it has not been added yet. "
-                               << " Adding it now. \n";
+                amrex::Print(Utils::TextMsg::Info(
+                    "Runtime int component " + comp_name
+                    + " was found in the checkpoint file, but it has not been added yet. "
+                    + " Adding it now."
+                ));
                 pc->AddIntComp(comp_name);
             }
         }

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -120,8 +120,6 @@ PhysicalParticleContainer::WriteHeader (std::ostream& os) const
 void
 MultiParticleContainer::Restart (const std::string& dir)
 {
-    auto& warpx = WarpX::GetInstance();
-
     // note: all containers is sorted like this
     // - species_names
     // - lasers_names
@@ -201,11 +199,11 @@ MultiParticleContainer::Restart (const std::string& dir)
             auto current_comp_names = pc->getParticleiComps();
             auto search = current_comp_names.find(comp_name);
             if (search == current_comp_names.end()) {
-                amrex::Print(Utils::TextMsg::Info(
+                amrex::Print()<< Utils::TextMsg::Info(
                     "Runtime int component " + comp_name
                     + " was found in the checkpoint file, but it has not been added yet. "
                     + " Adding it now."
-                ));
+                );
                 pc->AddIntComp(comp_name);
             }
         }

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -9,6 +9,7 @@
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
 
@@ -31,7 +32,7 @@ FieldEnergy::FieldEnergy (std::string rd_name)
 {
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldEnergy reduced diagnostics does not work for RZ coordinate.");
 #endif
 

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -9,6 +9,7 @@
 
 #include "Utils/CoarsenIO.H"
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX_Algorithm.H>
@@ -44,7 +45,7 @@ FieldMaximum::FieldMaximum (std::string rd_name)
 {
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldMaximum reduced diagnostics does not work for RZ coordinate.");
 #endif
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -10,6 +10,7 @@
 #include "Particles/Gather/FieldGather.H"
 
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
@@ -49,7 +50,7 @@ FieldProbe::FieldProbe (std::string rd_name)
 
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldProbe reduced diagnostics does not work for RZ coordinate.");
 #endif
 
@@ -155,7 +156,7 @@ FieldProbe::FieldProbe (std::string rd_name)
             WarnPriority::low);
     }
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(interp_order <= WarpX::nox ,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(interp_order <= WarpX::nox ,
                                      "Field probe interp_order should be less than or equal to algo.particle_shape");
     if (ParallelDescriptor::IOProcessor())
     {

--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
@@ -13,6 +13,7 @@
 #include "Particles/Pusher/UpdatePosition.H"
 #include "Particles/ParticleBoundaries_K.H"
 #include "Utils/CoarsenMR.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -71,7 +72,7 @@ FieldProbeParticleContainer::AddNParticles (int lev,
                                             amrex::Vector<amrex::ParticleReal> const & y,
                                             amrex::Vector<amrex::ParticleReal> const & z)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lev == 0, "AddNParticles: only lev=0 is supported yet.");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(lev == 0, "AddNParticles: only lev=0 is supported yet.");
     AMREX_ALWAYS_ASSERT(x.size() == y.size());
     AMREX_ALWAYS_ASSERT(x.size() == z.size());
 

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -8,6 +8,7 @@
 #include "FieldReduction.H"
 
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXUtil.H"
 
@@ -29,7 +30,7 @@ FieldReduction::FieldReduction (std::string rd_name)
 
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldReduction reduced diagnostics does not work for RZ coordinate.");
 #endif
 
@@ -37,7 +38,7 @@ FieldReduction::FieldReduction (std::string rd_name)
     int nLevel = 0;
     amrex::ParmParse pp_amr("amr");
     pp_amr.query("max_level", nLevel);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nLevel == 0,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nLevel == 0,
         "FieldReduction reduced diagnostics does not work with mesh refinement.");
 
     constexpr int noutputs = 1; // A single output in the Field reduction diagnostic

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -12,6 +12,7 @@
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX_BoxArray.H>
@@ -34,7 +35,7 @@ RhoMaximum::RhoMaximum (std::string rd_name)
 {
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "RhoMaximum reduced diagnostics does not work for RZ coordinate.");
 #endif
 

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -8,6 +8,7 @@
 #include "SliceDiagnostic.H"
 
 #include "WarpX.H"
+#include "Utils/TextMsg.H"
 #include "Parallelization/WarpXCommUtil.H"
 
 #include <AMReX.H>
@@ -69,7 +70,7 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
     auto nlevels = static_cast<int>(dom_geom.size());
     int ncomp = (mf).nComp();
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( nlevels==1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( nlevels==1,
        "Slice diagnostics does not work with mesh refinement yet (TO DO).");
 
     const auto conversionType = (mf).ixType();

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -13,8 +13,9 @@
 #endif
 #include "FieldIO.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Utils/CoarsenIO.H"
 #include "Parallelization/WarpXCommUtil.H"
+#include "Utils/CoarsenIO.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
@@ -93,7 +94,8 @@ WarpX::InitFromCheckpoint ()
 {
     WARPX_PROFILE("WarpX::InitFromCheckpoint()");
 
-    amrex::Print() << "  Restart from checkpoint " << restart_chkfile << "\n";
+    amrex::Print(Utils::TextMsg::Info(
+        "  Restart from checkpoint " + restart_chkfile));;
 
     // Header
     {

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -94,8 +94,8 @@ WarpX::InitFromCheckpoint ()
 {
     WARPX_PROFILE("WarpX::InitFromCheckpoint()");
 
-    amrex::Print(Utils::TextMsg::Info(
-        "  Restart from checkpoint " + restart_chkfile));;
+    amrex::Print()<< Utils::TextMsg::Info(
+        "restart from checkpoint " + restart_chkfile);
 
     // Header
     {

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -10,6 +10,7 @@
 
 #include "Particles/WarpXParticleContainer.H"
 #include "Diagnostics/FlushFormats/FlushFormat.H"
+#include "Utils/TextMsg.H"
 
 #include "Diagnostics/ParticleDiag/ParticleDiag_fwd.H"
 
@@ -45,7 +46,8 @@ public:
   ~Timer () {
       m_End = amrex::second();
       amrex::ParallelDescriptor::ReduceRealMax(m_End, amrex::ParallelDescriptor::IOProcessorNumber());
-      amrex::Print()<<m_Tag<<" took:"<<m_End - m_Start<<" seconds\n";
+      amrex::Print() << Utils::TextMsg::Info(
+        m_Tag + " took: "+ std::to_string(m_End - m_Start) + " seconds");
   }
 private:
   amrex::Real m_Start;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -9,6 +9,7 @@
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "FieldIO.H"
 #include "Particles/Filter/FilterFunctors.H"
+#include "Utils/TextMsg.H"
 #include "Utils/RelativeCellPosition.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -443,7 +444,7 @@ WarpXOpenPMDPlot::GetFileName (std::string& filepath)
 void WarpXOpenPMDPlot::SetStep (int ts, const std::string& dirPrefix, int file_min_digits,
                                 bool isBTD)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(ts >= 0 , "openPMD iterations are unsigned");
 
     m_dirPrefix = dirPrefix;
     m_file_min_digits = file_min_digits;
@@ -664,7 +665,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
                     amrex::ParticleReal const mass, const bool isBTD,
                     int ParticleFlushOffset)
 {
-  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD: series must be initialized");
+  WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD: series must be initialized");
 
   AMREX_ALWAYS_ASSERT(write_real_comp.size() == pc->NumRealComps());
   AMREX_ALWAYS_ASSERT( write_int_comp.size() == pc->NumIntComps());
@@ -762,8 +763,8 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
            //   reconstruct x and y from polar coordinates r, theta
            auto const& soa = pti.GetStructOfArrays();
            amrex::ParticleReal const* theta = soa.GetRealData(PIdx::theta).dataPtr();
-           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(theta != nullptr, "openPMD: invalid theta pointer.");
-           AMREX_ALWAYS_ASSERT_WITH_MESSAGE(int(soa.GetRealData(PIdx::theta).size()) == numParticleOnTile,
+           WARPX_ALWAYS_ASSERT_WITH_MESSAGE(theta != nullptr, "openPMD: invalid theta pointer.");
+           WARPX_ALWAYS_ASSERT_WITH_MESSAGE(int(soa.GetRealData(PIdx::theta).size()) == numParticleOnTile,
                                             "openPMD: theta and tile size do not match");
            {
                std::shared_ptr< amrex::ParticleReal > x(
@@ -1186,7 +1187,7 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
   //This is AMReX's tiny profiler. Possibly will apply it later
   WARPX_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDFields()");
 
-  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD series must be initialized");
+  WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_Series != nullptr, "openPMD series must be initialized");
 
   // is this either a regular write (true) or the first write in a
   // backtransformed diagnostic (BTD):

--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "WarpX.H"
+
+#include "Utils/TextMsg.H"
+
 #include <AMReX_Scan.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_MultiFab.H>
@@ -174,15 +177,16 @@ WarpX::CountExtFaces() {
     return sums;
 }
 
-
 void
 WarpX::ComputeFaceExtensions(){
 #ifdef AMREX_USE_EB
     if(WarpX::verbose) {
         amrex::Array1D<int, 0, 2> N_ext_faces = CountExtFaces();
-        amrex::Print() << "Faces to be extended in x:\t" << N_ext_faces(0) << std::endl;
-        amrex::Print() << "Faces to be extended in y:\t" << N_ext_faces(1) << std::endl;
-        amrex::Print() << "Faces to be extended in z:\t" << N_ext_faces(2) << std::endl;
+        amrex::Print() << Utils::TextMsg::Info(
+            "Faces to be extended in x:\t" + std::to_string(N_ext_faces(0)) + "\n"
+            +"Faces to be extended in y:\t" + std::to_string(N_ext_faces(1)) + "\n"
+            +"Faces to be extended in z:\t" + std::to_string(N_ext_faces(2))
+        );
     }
 
     InitBorrowing();
@@ -190,12 +194,14 @@ WarpX::ComputeFaceExtensions(){
 
     if(WarpX::verbose) {
         amrex::Array1D<int, 0, 2> N_ext_faces_after_one_way = CountExtFaces();
-        amrex::Print() << "Faces to be extended after one way extension in x:\t" <<
-                       N_ext_faces_after_one_way(0) << std::endl;
-        amrex::Print() << "Faces to be extended after one way extension in y:\t" <<
-                       N_ext_faces_after_one_way(1) << std::endl;
-        amrex::Print() << "Faces to be extended after one way extension in z:\t" <<
-                       N_ext_faces_after_one_way(2) << std::endl;
+        amrex::Print() << Utils::TextMsg::Info(
+            "Faces to be extended after one way extension in x:\t"
+            + std::to_string(N_ext_faces_after_one_way(0)) + "\n"
+            +"Faces to be extended after one way extension in y:\t"
+            + std::to_string(N_ext_faces_after_one_way(1)) + "\n"
+            +"Faces to be extended after one way extension in z:\t"
+            + std::to_string(N_ext_faces_after_one_way(2))
+        );
     }
 
     ComputeEightWaysExtensions();
@@ -203,21 +209,23 @@ WarpX::ComputeFaceExtensions(){
 
     amrex::Array1D<int, 0, 2> N_ext_faces_after_eight_ways = CountExtFaces();
     if(WarpX::verbose) {
-        amrex::Print() << "Faces to be extended after eight ways extension in x:\t" <<
-                       N_ext_faces_after_eight_ways(0) << std::endl;
-        amrex::Print() << "Faces to be extended after eight ways extension in y:\t" <<
-                       N_ext_faces_after_eight_ways(1) << std::endl;
-        amrex::Print() << "Faces to be extended after eight ways extension ins z:\t" <<
-                       N_ext_faces_after_eight_ways(2) << std::endl;
+        amrex::Print() << Utils::TextMsg::Info(
+            "Faces to be extended after eight ways extension in x:\t"
+            + std::to_string(N_ext_faces_after_eight_ways(0)) + "\n"
+            +"Faces to be extended after eight ways extension in y:\t"
+            + std::to_string(N_ext_faces_after_eight_ways(1)) + "\n"
+            +"Faces to be extended after eight ways extension in z:\t"
+            + std::to_string(N_ext_faces_after_eight_ways(2))
+        );
     }
     if (N_ext_faces_after_eight_ways(0) > 0) {
-        amrex::Abort("Some x faces could not be extended");
+        amrex::Abort(Utils::TextMsg::Err("Some x faces could not be extended"));
     }
     if (N_ext_faces_after_eight_ways(1) > 0) {
-        amrex::Abort("Some y faces could not be extended");
+        amrex::Abort(Utils::TextMsg::Err("Some y faces could not be extended"));
     }
     if (N_ext_faces_after_eight_ways(2) > 0) {
-        amrex::Abort("Some z faces could not be extended");
+        amrex::Abort(Utils::TextMsg::Err("Some z faces could not be extended"));
     }
 #endif
 }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -653,7 +653,7 @@ WarpX::OneStep_sub1 (Real curtime)
 
     // TODO: we could save some charge depositions
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level == 1, "Must have exactly two levels");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level == 1, "Must have exactly two levels");
     const int fine_lev = 1;
     const int coarse_lev = 0;
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -298,7 +298,7 @@ WarpX::Evolve (int numsteps)
 
         if (sort_intervals.contains(step+1)) {
             if (verbose) {
-                Utils::Msg::print_info("re-sorting particles");
+                amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
             }
             mypc->SortParticlesByBin(sort_bin_size);
         }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -27,6 +27,7 @@
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Python/WarpX_py.H"
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -195,8 +196,9 @@ WarpX::Evolve (int numsteps)
         }
         else
         {
-            amrex::Print() << "Error: do_subcycling = " << do_subcycling << std::endl;
-            amrex::Abort("Unsupported do_subcycling type");
+            amrex::Abort(Utils::TextMsg::Err(
+                "do_subcycling = " + std::to_string(do_subcycling)
+                + " is an unsupported do_subcycling type."));
         }
 
         // Resample particles
@@ -296,7 +298,7 @@ WarpX::Evolve (int numsteps)
 
         if (sort_intervals.contains(step+1)) {
             if (verbose) {
-                amrex::Print() << "re-sorting particles \n";
+                Utils::Msg::print_info("re-sorting particles");
             }
             mypc->SortParticlesByBin(sort_bin_size);
         }

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -13,6 +13,7 @@
 #include "Python/WarpX_py.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Parallelization/WarpXCommUtil.H"
@@ -144,7 +145,7 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
 
 #ifdef WARPX_DIM_RZ
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
                                      "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
@@ -194,7 +195,7 @@ WarpX::AddSpaceChargeFieldLabFrame ()
     if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
 
 #ifdef WARPX_DIM_RZ
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
                                      "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
@@ -790,7 +791,7 @@ void ElectrostaticSolver::BoundaryHandler::definePhiBCs ( )
                 dirichlet_flag[idim*2] = false;
             }
             else {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
                     "Field boundary conditions have to be either periodic, PEC or none "
                     "when using the electrostatic solver"
                 );
@@ -805,7 +806,7 @@ void ElectrostaticSolver::BoundaryHandler::definePhiBCs ( )
                 dirichlet_flag[idim*2+1] = false;
             }
             else {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
                     "Field boundary conditions have to be either periodic, PEC or none "
                     "when using the electrostatic solver"
                 );

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -1,5 +1,6 @@
 #include "MacroscopicProperties.H"
 
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
@@ -116,7 +117,7 @@ MacroscopicProperties::ReadParameters ()
 void
 MacroscopicProperties::InitData ()
 {
-    amrex::Print() << "we are in init data of macro \n";
+    amrex::Print() << Utils::TextMsg::Info("we are in init data of macro");
     auto & warpx = WarpX::GetInstance();
 
     // Get BoxArray and DistributionMap of warpx instance.

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -154,7 +154,7 @@ MacroscopicProperties::InitData ()
     // In the Maxwell solver, `epsilon` is used in the denominator.
     // Therefore, it needs to be strictly positive
     bool const local=true;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_eps_mf->min(0,0,local) > 0,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_eps_mf->min(0,0,local) > 0,
     "WarpX encountered zero or negative values for the relative permittivity `epsilon`. Please check the initialization of `epsilon`.");
 
     // Initialize mu

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -7,6 +7,7 @@
 #include "HankelTransform.H"
 
 #include "BesselRoots.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
 
@@ -23,7 +24,7 @@ HankelTransform::HankelTransform (int const hankel_order,
 {
 
     // Check that azimuthal_mode has a valid value
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(hankel_order-1 <= azimuthal_mode && azimuthal_mode <= hankel_order+1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(hankel_order-1 <= azimuthal_mode && azimuthal_mode <= hankel_order+1,
                                      "azimuthal_mode must be either hankel_order-1, hankel_order or hankel_order+1");
 
     amrex::Vector<amrex::Real> alphas;

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -7,6 +7,7 @@
  */
 #include "SpectralKSpace.H"
 
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_BLassert.H>
@@ -38,7 +39,7 @@ SpectralKSpace::SpectralKSpace( const BoxArray& realspace_ba,
                                 const RealVect realspace_dx )
     : dx(realspace_dx)  // Store the cell size as member `dx`
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         realspace_ba.ixType()==IndexType::TheCellType(),
         "SpectralKSpace expects a cell-centered box.");
 
@@ -104,9 +105,9 @@ SpectralKSpace::getKComponent( const DistributionMapping& dm,
         // Fill the k vector
         IntVect fft_size = realspace_ba[mfi].length();
         const Real dk = 2*MathConst::pi/(fft_size[i_dim]*dx[i_dim]);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( bx.smallEnd(i_dim) == 0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( bx.smallEnd(i_dim) == 0,
             "Expected box to start at 0, in spectral space.");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( bx.bigEnd(i_dim) == N-1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( bx.bigEnd(i_dim) == N-1,
             "Expected different box end index in spectral space.");
         if (only_positive_k){
             // Fill the full axis with positive k values
@@ -280,7 +281,7 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
 Vector<Real>
 getFornbergStencilCoefficients(const int n_order, const bool nodal)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_order % 2 == 0, "n_order must be even");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_order % 2 == 0, "n_order must be even");
 
     const int m = n_order / 2;
     Vector<Real> coefs;

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpaceRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpaceRZ.cpp
@@ -4,6 +4,7 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "SpectralKSpaceRZ.H"
 
@@ -22,7 +23,7 @@ SpectralKSpaceRZ::SpectralKSpaceRZ (const amrex::BoxArray& realspace_ba,
 {
     dx = realspace_dx;  // Store the cell size as member `dx`
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         realspace_ba.ixType() == amrex::IndexType::TheCellType(),
         "SpectralKSpaceRZ expects a cell-centered box.");
 

--- a/Source/FieldSolver/SpectralSolver/WrapCuFFT.cpp
+++ b/Source/FieldSolver/SpectralSolver/WrapCuFFT.cpp
@@ -7,6 +7,8 @@
 
 #include "AnyFFT.H"
 
+#include "Utils/TextMsg.H"
+
 namespace AnyFFT
 {
 
@@ -35,7 +37,7 @@ namespace AnyFFT
                 result = cufftPlan2d(
                     &(fft_plan.m_plan), real_size[1], real_size[0], VendorR2C);
             } else {
-                amrex::Abort("only dim=2 and dim=3 have been implemented");
+                amrex::Abort(Utils::TextMsg::Err("only dim=2 and dim=3 have been implemented"));
             }
         } else {
             if (dim == 3) {
@@ -45,13 +47,14 @@ namespace AnyFFT
                 result = cufftPlan2d(
                     &(fft_plan.m_plan), real_size[1], real_size[0], VendorC2R);
             } else {
-                amrex::Abort("only dim=2 and dim=3 have been implemented");
+                amrex::Abort(Utils::TextMsg::Err("only dim=2 and dim=3 have been implemented"));
             }
         }
 
         if ( result != CUFFT_SUCCESS ) {
-            amrex::Print() << " cufftplan failed! Error: " <<
-                cufftErrorToString(result) << "\n";
+            amrex::Print() << Utils::TextMsg::Err(
+                    "cufftplan failed! Error: "
+                    + cufftErrorToString(result));
         }
 
         // Store meta-data in fft_plan
@@ -89,8 +92,9 @@ namespace AnyFFT
             amrex::Abort("direction must be AnyFFT::direction::R2C or AnyFFT::direction::C2R");
         }
         if ( result != CUFFT_SUCCESS ) {
-            amrex::Print() << " forward transform using cufftExec failed ! Error: " <<
-                cufftErrorToString(result) << "\n";
+            amrex::Print() << Utils::TextMsg::Err(
+                "forward transform using cufftExec failed ! Error: "
+                +cufftErrorToString(result));
         }
     }
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -20,6 +20,7 @@
 #       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif
 #endif
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -994,7 +995,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     const Real dr = dx[0];
 
     constexpr int NODE = amrex::IndexType::NODE;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().toIntVect()[0] != NODE,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().toIntVect()[0] != NODE,
         "Jr should never node-centered in r");
 
 

--- a/Source/Filter/NCIGodfreyFilter.cpp
+++ b/Source/Filter/NCIGodfreyFilter.cpp
@@ -7,6 +7,7 @@
 #include "NCIGodfreyFilter.H"
 
 #include "Utils/NCIGodfreyTables.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX.H>
 #include <AMReX_Algorithm.H>
@@ -48,10 +49,10 @@ void NCIGodfreyFilter::ComputeStencils(){
 
     // Sanity checks: filter length shoulz be 5 in z
 #if  defined(WARPX_DIM_3D)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         slen.z==5,"ERROR: NCI filter requires 5 points in z");
 #else
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         slen.y==5,"ERROR: NCI filter requires 5 points in z");
 #endif
     // Interpolate coefficients from the table, and store into prestencil.

--- a/Source/Initialization/CustomDensityProb.H
+++ b/Source/Initialization/CustomDensityProb.H
@@ -7,6 +7,7 @@
 #ifndef CUSTOM_DENSITY_PROB_H_
 #define CUSTOM_DENSITY_PROB_H_
 
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 
 #include <AMReX_Arena.H>
@@ -25,7 +26,7 @@ struct InjectorDensityCustom
         // Read parameters for custom density profile from file
         amrex::ParmParse pp_species_name(species_name);
         std::vector<amrex::Real> v;
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
                                          "Too many parameters for InjectorDensityCustom");
         getArrWithParser(pp_species_name, "custom_profile_params", v);
         for (int i = 0; i < static_cast<int>(v.size()); ++i) {

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -8,6 +8,7 @@
 #include "InjectorDensity.H"
 
 #include "Initialization/CustomDensityProb.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 
 #include <AMReX_BLassert.H>
@@ -51,7 +52,7 @@ InjectorDensityPredefined::InjectorDensityPredefined (
     std::vector<amrex::Real> v;
     // Read parameters for the predefined plasma profile.
     getArrWithParser(pp_species_name, "predefined_profile_params", v);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
                                      "Too many parameters for InjectorDensityPredefined");
     for (int i = 0; i < static_cast<int>(v.size()); ++i) {
         p[i] = v[i];
@@ -64,7 +65,7 @@ InjectorDensityPredefined::InjectorDensityPredefined (
                    which_profile_s.begin(), ::tolower);
     if (which_profile_s == "parabolic_channel"){
         profile = Profile::parabolic_channel;
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() > 5,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() > 5,
             "InjectorDensityPredefined::parabolic_channel: not enough parameters");
     }
 }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -15,6 +15,7 @@
 #include "Initialization/InjectorMomentum.H"
 #include "Initialization/InjectorPosition.H"
 #include "Particles/SpeciesPhysicalProperties.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
@@ -69,7 +70,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 #endif
 
     pp_species_name.query("radially_weighted", radially_weighted);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(radially_weighted, "ERROR: Only radially_weighted=true is supported");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(radially_weighted, "ERROR: Only radially_weighted=true is supported");
 
     // Unlimited boundaries
     xmin = std::numeric_limits<amrex::Real>::lowest();
@@ -185,7 +186,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         getArrWithParser(pp_species_name, "multiple_particles_vel_y", multiple_particles_vel_y);
         getArrWithParser(pp_species_name, "multiple_particles_vel_z", multiple_particles_vel_z);
         getArrWithParser(pp_species_name, "multiple_particles_weight", multiple_particles_weight);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             ((multiple_particles_pos_x.size() == multiple_particles_pos_y.size()) &&
              (multiple_particles_pos_x.size() == multiple_particles_pos_z.size()) &&
              (multiple_particles_pos_x.size() == multiple_particles_vel_x.size()) &&
@@ -214,14 +215,14 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         gaussian_beam = true;
         parseMomentum(pp_species_name);
 #if defined(WARPX_DIM_XZ)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
         "Error: Gaussian beam y_rms must be strictly greater than 0 in 2D "
         "(it is used when computing the particles' weights from the total beam charge)");
 #elif defined(WARPX_DIM_1D_Z)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( x_rms > 0._rt,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( x_rms > 0._rt,
         "Error: Gaussian beam x_rms must be strictly greater than 0 in 1D "
         "(it is used when computing the particles' weights from the total beam charge)");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( y_rms > 0._rt,
         "Error: Gaussian beam y_rms must be strictly greater than 0 in 1D "
         "(it is used when computing the particles' weights from the total beam charge)");
 #endif
@@ -234,7 +235,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell);
 #if WARPX_DIM_RZ
         if (WarpX::n_rz_azimuthal_modes > 1) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             num_particles_per_cell>=2*WarpX::n_rz_azimuthal_modes,
             "Error: For accurate use of WarpX cylindrical gemoetry the number "
             "of particles should be at least two times n_rz_azimuthal_modes "
@@ -252,7 +253,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell_real);
 #ifdef WARPX_DIM_RZ
         if (WarpX::n_rz_azimuthal_modes > 1) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             num_particles_per_cell_real>=2*WarpX::n_rz_azimuthal_modes,
             "Error: For accurate use of WarpX cylindrical geometry the number "
             "of particles should be at least two times n_rz_azimuthal_modes "
@@ -298,10 +299,10 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         std::string flux_normal_axis_help = "'z'.";
 #    endif
 #endif
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(flux_normal_axis >= 0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(flux_normal_axis >= 0,
             "Error: Invalid value for flux_normal_axis. It must be " + flux_normal_axis_help);
         pp_species_name.get("flux_direction", flux_direction);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(flux_direction == +1 || flux_direction == -1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(flux_direction == +1 || flux_direction == -1,
             "Error: flux_direction must be -1 or +1.");
         // Construct InjectorPosition with InjectorPositionRandom.
         h_inj_pos = std::make_unique<InjectorPosition>(
@@ -332,7 +333,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
 #endif
 #if WARPX_DIM_RZ
         if (WarpX::n_rz_azimuthal_modes > 1) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             num_particles_per_cell_each_dim[1]>=2*WarpX::n_rz_azimuthal_modes,
             "Error: For accurate use of WarpX cylindrical geometry the number "
             "of particles in the theta direction should be at least two times "
@@ -368,23 +369,23 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
             m_openpmd_input_series = std::make_unique<openPMD::Series>(
                 str_injection_file, openPMD::Access::READ_ONLY);
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 m_openpmd_input_series->iterations.size() == 1u,
                 "External file should contain only 1 iteration\n");
             openPMD::Iteration it = m_openpmd_input_series->iterations.begin()->second;
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 it.particles.size() == 1u,
                 "External file should contain only 1 species\n");
             std::string const ps_name = it.particles.begin()->first;
             openPMD::ParticleSpecies ps = it.particles.begin()->second;
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ps.contains("charge") || charge_is_specified || species_is_specified,
                 std::string("'") + ps_name +
                 ".injection_file' does not contain a 'charge' species record. "
                 "Please specify '" + ps_name + ".charge' or "
                 "'" + ps_name + ".species_type' in your input file!\n");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ps.contains("mass") || mass_is_specified || species_is_specified,
                 std::string("'") + ps_name +
                 ".injection_file' does not contain a 'mass' species record. "
@@ -581,7 +582,7 @@ void PlasmaInjector::parseMomentum (amrex::ParmParse& pp)
         h_inj_mom.reset(new InjectorMomentum((InjectorMomentumGaussian*)nullptr,
                                              ux_m, uy_m, uz_m, ux_th, uy_th, uz_th));
     } else if (mom_dist_s == "gaussianflux") {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(surface_flux,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(surface_flux,
             "Error: gaussianflux can only be used with injection_style = NFluxPerCell");
         amrex::Real ux_m = 0._rt;
         amrex::Real uy_m = 0._rt;

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -23,6 +23,7 @@
 #include "Particles/MultiParticleContainer.H"
 #include "Parallelization/WarpXCommUtil.H"
 #include "Utils/MPIInitHelpers.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -556,16 +557,16 @@ void
 WarpX::computeMaxStepBoostAccelerator(const amrex::Geometry& a_geom){
     // Sanity checks: can use zmax_plasma_to_compute_max_step only if
     // the moving window and the boost are all in z direction.
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         WarpX::moving_window_dir == WARPX_ZINDEX,
-        "Can use zmax_plasma_to_compute_max_step only if " +
+        "Can use zmax_plasma_to_compute_max_step only if "
         "moving window along z. TODO: all directions.");
     if (gamma_boost > 1){
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             (WarpX::boost_direction[0]-0)*(WarpX::boost_direction[0]-0) +
             (WarpX::boost_direction[1]-0)*(WarpX::boost_direction[1]-0) +
             (WarpX::boost_direction[2]-1)*(WarpX::boost_direction[2]-1) < 1.e-12,
-            "Can use zmax_plasma_to_compute_max_step in boosted frame only if " +
+            "Can use zmax_plasma_to_compute_max_step in boosted frame only if "
             "warpx.boost_direction = z. TODO: all directions.");
     }
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -6,6 +6,7 @@
  */
 #include "Laser/LaserProfiles.H"
 
+#include "Utils/InfoMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpX_Complex.H"
 #include "WarpX.H"
@@ -275,9 +276,9 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::find_left_right_time_indices(amrex
 void
 WarpXLaserProfiles::FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int t_end)
 {
-    amrex::Print() <<
-        "Reading [" << t_begin << ", " << t_end <<
-        ") data chunk from " << m_params.txye_file_name << "\n";
+    Utils::Msg::print_info(
+        "Reading [" + std::to_string(t_begin) + ", " + std::to_string(t_end) +
+        ") data chunk from " + m_params.txye_file_name);
 
     //Indices of the first and last timestep to read
     auto i_first = max(0, t_begin);

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -6,7 +6,7 @@
  */
 #include "Laser/LaserProfiles.H"
 
-#include "Utils/InfoMsg.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpX_Complex.H"
 #include "WarpX.H"
@@ -276,7 +276,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::find_left_right_time_indices(amrex
 void
 WarpXLaserProfiles::FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int t_end)
 {
-    Utils::Msg::print_info(
+    amrex::Print() << Utils::TextMsg::Info(
         "Reading [" + std::to_string(t_begin) + ", " + std::to_string(t_end) +
         ") data chunk from " + m_params.txye_file_name);
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -7,6 +7,7 @@
  */
 #include "Laser/LaserProfiles.H"
 
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpX_Complex.H"
@@ -62,7 +63,7 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
             m_common_params.nvec.begin(),
             m_common_params.nvec.end(),
             m_params.stc_direction.begin(), 0.0);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < 1.0e-14,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < 1.0e-14,
         "stc_direction is not perpendicular to the laser plane vector");
 
     // Get angle between p_X and stc_direction

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -15,6 +15,7 @@
 #    include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
 #endif
 #include "Filter/NCIGodfreyFilter.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
@@ -99,7 +100,7 @@ guardCellManager::Init (
     // the fine grid by a number of cells equal to the ref_ratio in the moving
     // window direction.
     if (do_moving_window) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(ref_ratios.size() <= 1,
             "The number of grow cells for the moving window currently assumes 2 levels max.");
         const int nlevs = ref_ratios.size()+1;
         int max_r = (nlevs > 1) ? ref_ratios[0][moving_window_dir] : 2;

--- a/Source/Parallelization/KernelTimer.H
+++ b/Source/Parallelization/KernelTimer.H
@@ -7,6 +7,7 @@
 #ifndef KERNELTIMER_H_
 #define KERNELTIMER_H_
 
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX.H>

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -15,6 +15,7 @@
 #include "Filter/BilinearFilter.H"
 #include "Utils/CoarsenMR.H"
 #include "Utils/IntervalsParser.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpXComm_K.H"
@@ -65,7 +66,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 {
 #ifndef WARPX_USE_PSATD
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
             "WarpX::UpdateAuxilaryDataStagToNodal: PSATD solver requires "
             "WarpX build with spectral solver support.");
     }
@@ -587,7 +588,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
     // Fill guard cells in valid domain
     for (int i = 0; i < 3; ++i)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             ng <= mf[i]->nGrowVect(),
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
@@ -644,7 +645,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
     // Fill guard cells in valid domain
     for (int i = 0; i < 3; ++i)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             ng <= mf[i]->nGrowVect(),
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
@@ -675,7 +676,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             Vector<MultiFab*> mf{Efield_avg_fp[lev][0].get(),Efield_avg_fp[lev][1].get(),Efield_avg_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
         } else {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
             WarpXCommUtil::FillBoundary(*Efield_avg_fp[lev][0], ng, period);
@@ -696,7 +697,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             WarpXCommUtil::FillBoundary(mf, cperiod);
 
         } else {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
             WarpXCommUtil::FillBoundary(*Efield_avg_cp[lev][0], ng, cperiod);
@@ -728,7 +729,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             Vector<MultiFab*> mf{Bfield_avg_fp[lev][0].get(),Bfield_avg_fp[lev][1].get(),Bfield_avg_fp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, period);
         } else {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
             WarpXCommUtil::FillBoundary(*Bfield_avg_fp[lev][0], ng, period);
@@ -748,7 +749,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             Vector<MultiFab*> mf{Bfield_avg_cp[lev][0].get(),Bfield_avg_cp[lev][1].get(),Bfield_avg_cp[lev][2].get()};
             WarpXCommUtil::FillBoundary(mf, cperiod);
         } else {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
             WarpXCommUtil::FillBoundary(*Bfield_avg_cp[lev][0], ng, cperiod);

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -240,7 +240,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
 
         amrex::Print() << Utils::TextMsg::Info(
             "Setting up collisions for " + m_species_names[0] + " with total "
-            + "collision probability: " <<
+            + "collision probability: "
             + std::to_string(m_total_collision_prob) + " "
             + std::to_string(m_total_collision_prob_ioniz)
         );

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -8,6 +8,7 @@
 #include "MCCScattering.H"
 #include "Particles/ParticleCreation/FilterCopyTransform.H"
 #include "Particles/ParticleCreation/SmartCopy.H"
+#include "Utils/TextMsg.H"
 #include "Utils/ParticleUtils.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -237,10 +238,12 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
             m_background_mass = species1.getMass();
         }
 
-        amrex::Print() <<
-            "Setting up collisions for " << m_species_names[0] << " with total "
-            "collision probability: " <<
-            m_total_collision_prob + m_total_collision_prob_ioniz << "\n";
+        amrex::Print() << Utils::TextMsg::Info(
+            "Setting up collisions for " + m_species_names[0] + " with total "
+            + "collision probability: " <<
+            + std::to_string(m_total_collision_prob) + " "
+            + std::to_string(m_total_collision_prob_ioniz)
+        );
 
         init_flag = true;
     }

--- a/Source/Particles/Collision/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCCCollision.cpp
@@ -23,14 +23,14 @@
 BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name)
     : CollisionBase(collision_name)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_species_names.size() == 1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_species_names.size() == 1,
                                      "Background MCC must have exactly one species.");
 
     amrex::ParmParse pp_collision_name(collision_name);
 
     amrex::Real background_density = 0;
     if (queryWithParser(pp_collision_name, "background_density", background_density)) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             (background_density > 0), "The background density must be greater than 0."
         );
         m_background_density_parser = makeParser(std::to_string(background_density), {"x", "y", "z", "t"});
@@ -43,7 +43,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
 
     amrex::Real background_temperature;
     if (queryWithParser(pp_collision_name, "background_temperature", background_temperature)) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             (background_temperature >= 0), "The background temperature must be positive."
         );
         m_background_temperature_parser = makeParser(std::to_string(background_temperature), {"x", "y", "z", "t"});
@@ -65,7 +65,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
     if (m_max_background_density == 0 && background_density != 0) {
         m_max_background_density = background_density;
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         (m_max_background_density > 0),
         "The maximum background density must be greater than 0."
     );
@@ -100,7 +100,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
 
         MCCProcess process(scattering_process, cross_section_file, energy);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != MCCProcessType::INVALID,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != MCCProcessType::INVALID,
                                          "Cannot add an unknown MCC process type");
 
         // if the scattering process is ionization get the secondary species
@@ -109,7 +109,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const collision_name
         // the maximum collision frequency with the same function used for
         // particle conserving processes
         if (process.type() == MCCProcessType::IONIZATION) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!ionization_flag,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!ionization_flag,
                                              "Background MCC only supports a single ionization process");
             ionization_flag = true;
 
@@ -211,7 +211,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
         // dt has to be small enough that a linear expansion of the collision
         // probability is sufficiently accurately, otherwise the MCC results
         // will be very heavily affected by small changes in the timestep
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coll_n < 0.1_rt,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(coll_n < 0.1_rt,
             "dt is too large to ensure accurate MCC results"
         );
 
@@ -223,7 +223,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, MultiParticleContain
             auto coll_n_ioniz = m_nu_max_ioniz * m_ndt * dt;
             m_total_collision_prob_ioniz = 1.0_rt - std::exp(-coll_n_ioniz);
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coll_n_ioniz < 0.1_rt,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(coll_n_ioniz < 0.1_rt,
                 "dt is too large to ensure accurate MCC results"
             );
 

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -14,6 +14,7 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
@@ -69,11 +70,11 @@ public:
 
         if (m_fusion_type == NuclearFusionType::ProtonBoron)
         {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 product_species_name.size() == 1,
                 "ERROR: Proton-boron must contain exactly one product species");
             auto& product_species = mypc->GetParticleContainerFromName(product_species_name[0]);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 product_species.AmIA<PhysicalSpecies::helium>(),
                 "ERROR: Product species of proton-boron fusion must be of type helium");
         }

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -11,6 +11,7 @@
 #include "Particles/Collision/BinaryCollision/BinaryCollision.H"
 #include "Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H"
 #include "Particles/Collision/BinaryCollision/ParticleCreationFunc.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 
@@ -30,7 +31,7 @@ CollisionHandler::CollisionHandler(MultiParticleContainer const * const mypc)
     for (int i = 0; i < static_cast<int>(ncollisions); ++i) {
         amrex::ParmParse pp_collision_name(collision_names[i]);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::n_rz_azimuthal_modes==1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::n_rz_azimuthal_modes==1,
         "RZ mode `warpx.n_rz_azimuthal_modes` must be 1 when using the binary collision module.");
 
         // For legacy, pairwisecoulomb is the default

--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -60,7 +60,7 @@ MCCProcess::init (const std::string& scattering_process, const amrex::Real energ
     // cost is > 0 - this is to prevent the possibility of negative left
     // over energy after a collision event
     if (m_exe_h.m_energy_penalty > 0) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             (getCrossSection(m_exe_h.m_energy_penalty) == 0),
             "Cross-section > 0 at energy cost for collision."
         );
@@ -121,7 +121,7 @@ MCCProcess::sanityCheckEnergyGrid (
     // confirm that the input data for the cross-section was provided with
     // equal energy steps, otherwise the linear interpolation will fail
     for (unsigned i = 1; i < energies.size(); i++) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                                          (std::abs(energies[i] - energies[i-1] - dE) < dE / 100.0),
                                          "Energy grid not evenly spaced."
                                          );

--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -5,6 +5,8 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "MCCProcess.H"
+
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 MCCProcess::MCCProcess (
@@ -12,8 +14,9 @@ MCCProcess::MCCProcess (
                         const std::string& cross_section_file,
                         const amrex::Real energy )
 {
-    amrex::Print() << "Reading file " << cross_section_file << " for "
-                   << scattering_process << " scattering cross-sections.\n";
+    amrex::Print() << Utils::TextMsg::Info(
+        "Reading file " + cross_section_file + " for "
+        + scattering_process + " scattering cross-sections.");
 
     // read the cross-section data file into memory
     readCrossSectionFile(cross_section_file, m_energies, m_sigmas_h);

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -2,6 +2,7 @@
 
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX_Vector.H>
@@ -83,7 +84,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, int a_offset)
         m_repeated_plasma_lens_strengths_B = mypc.d_repeated_plasma_lens_strengths_B.data();
     }
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Etype != Unknown, "Unknown E_ext_particle_init_style");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_Btype != Unknown, "Unknown B_ext_particle_init_style");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_Etype != Unknown, "Unknown E_ext_particle_init_style");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_Btype != Unknown, "Unknown B_ext_particle_init_style");
 
 }

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -13,6 +13,7 @@
 #include "Particles/LaserParticleContainer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -495,7 +496,7 @@ LaserParticleContainer::InitData (int lev)
     amrex::Vector<amrex::Real> particle_uy(np, 0.0);
     amrex::Vector<amrex::Real> particle_uz(np, 0.0);
 
-    if (Verbose()) amrex::Print() << "Adding laser particles\n";
+    if (Verbose()) amrex::Print() << Utils::TextMsg::Info("Adding laser particles");
     // Add particles on level 0. They will be redistributed afterwards
     AddNParticles(0,
                   np, particle_x.dataPtr(), particle_y.dataPtr(), particle_z.dataPtr(),

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -20,6 +20,7 @@
 #   include "Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper_fwd.H"
 #endif
 #include "PhysicalParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpXParticleContainer.H"
@@ -513,7 +514,7 @@ private:
                              First const& pc_dst, Args const&... others) const noexcept
     {
         if (pc_src.do_tiling && amrex::Gpu::notInLaunchRegion()) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_dst.do_tiling,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(pc_dst.do_tiling,
                 "For particle creation processes, either all or none of the "
                 "particle species must use tiling.");
         }

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -77,12 +77,7 @@ public:
     GetParticleContainerPtr (int ispecies) const {return allcontainers[ispecies].get();}
 
     WarpXParticleContainer&
-    GetParticleContainerFromName (std::string name) const {
-        auto it = std::find(species_names.begin(), species_names.end(), name);
-        WarpXUtilMsg::AlwaysAssert(it != species_names.end(), "ERROR: Unknown species name");
-        int i = std::distance(species_names.begin(), it);
-        return *allcontainers[i];
-    }
+    GetParticleContainerFromName (const std::string& name) const;
 
 #ifdef WARPX_USE_OPENPMD
     std::unique_ptr<WarpXParticleContainer>& GetUniqueContainer(int ispecies) {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -279,10 +279,10 @@ MultiParticleContainer::ReadParameters ()
             pp_particles.queryarr("deposit_on_main_grid", tmp);
             for (auto const& name : tmp) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
-                WarpXUtilMsg::AlwaysAssert(
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                     it != species_names.end(),
-                    "ERROR: species '" + name
-                    + "' in particles.deposit_on_main_grid must be part of particles.species_names"
+                    Utils::TextMsg::Err("species '" + name
+                        + "' in particles.deposit_on_main_grid must be part of particles.species_names")
                 );
                 int i = std::distance(species_names.begin(), it);
                 m_deposit_on_main_grid[i] = true;
@@ -293,10 +293,10 @@ MultiParticleContainer::ReadParameters ()
             pp_particles.queryarr("gather_from_main_grid", tmp_gather);
             for (auto const& name : tmp_gather) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
-                WarpXUtilMsg::AlwaysAssert(
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                     it != species_names.end(),
-                    "ERROR: species '" + name
-                    + "' in particles.gather_from_main_grid must be part of particles.species_names"
+                    Utils::TextMsg::Err("species '" + name
+                        + "' in particles.gather_from_main_grid must be part of particles.species_names")
                 );
                 int i = std::distance(species_names.begin(), it);
                 m_gather_from_main_grid.at(i) = true;
@@ -310,10 +310,10 @@ MultiParticleContainer::ReadParameters ()
             if (!rigid_injected_species.empty()) {
                 for (auto const& name : rigid_injected_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
-                    WarpXUtilMsg::AlwaysAssert(
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                         it != species_names.end(),
-                        "ERROR: species '" + name
-                        + "' in particles.rigid_injected_species must be part of particles.species_names"
+                        Utils::TextMsg::Err("species '" + name
+                        + "' in particles.rigid_injected_species must be part of particles.species_names")
                     );
                     int i = std::distance(species_names.begin(), it);
                     species_types[i] = PCTypes::RigidInjected;
@@ -325,10 +325,10 @@ MultiParticleContainer::ReadParameters ()
             if (!photon_species.empty()) {
                 for (auto const& name : photon_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
-                    WarpXUtilMsg::AlwaysAssert(
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                         it != species_names.end(),
-                        "ERROR: species '" + name
-                        + "' in particles.photon_species must be part of particles.species_names"
+                        Utils::TextMsg::Err("species '" + name
+                        + "' in particles.photon_species must be part of particles.species_names")
                     );
                     int i = std::distance(species_names.begin(), it);
                     species_types[i] = PCTypes::Photon;
@@ -374,6 +374,18 @@ MultiParticleContainer::ReadParameters ()
 #endif
         initialized = true;
     }
+}
+
+WarpXParticleContainer&
+MultiParticleContainer::GetParticleContainerFromName (const std::string& name) const
+{
+    auto it = std::find(species_names.begin(), species_names.end(), name);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        it != species_names.end(),
+        Utils::TextMsg::Err("unknown species name");
+    );
+    int i = std::distance(species_names.begin(), it);
+    return *allcontainers[i];
 }
 
 void
@@ -837,11 +849,10 @@ MultiParticleContainer::getSpeciesID (std::string product_str) const
         }
     }
 
-    WarpXUtilMsg::AlwaysAssert(
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         found != 0,
-        "ERROR: could not find the ID of product species '"
-        + product_str + "'" + ". Wrong name?"
-    );
+        Utils::TextMsg::Err("could not find the ID of product species '"
+        + product_str + "'" + ". Wrong name?"));
 
     return i_product;
 }
@@ -864,11 +875,10 @@ MultiParticleContainer::SetDoBackTransformedParticles (std::string species_name,
            pc->SetDoBackTransformedParticles(do_back_transformed_particles);
         }
     }
-    WarpXUtilMsg::AlwaysAssert(
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         found != 0,
-        "ERROR: could not find the ID of product species '"
-        + species_name + "'" + ". Wrong name?"
-    );
+        Utils::TextMsg("ERROR: could not find the ID of product species '"
+        + species_name + "'" + ". Wrong name?"));
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -230,7 +230,7 @@ MultiParticleContainer::ReadParameters ()
         if (m_E_ext_particle_s == "repeated_plasma_lens" ||
             m_B_ext_particle_s == "repeated_plasma_lens") {
             getWithParser(pp_particles, "repeated_plasma_lens_period", m_repeated_plasma_lens_period);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_repeated_plasma_lens_period > 0._rt,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_repeated_plasma_lens_period > 0._rt,
                                              "The period of the repeated plasma lens must be greater than zero");
             getArrWithParser(pp_particles, "repeated_plasma_lens_starts", h_repeated_plasma_lens_starts);
             getArrWithParser(pp_particles, "repeated_plasma_lens_lengths", h_repeated_plasma_lens_lengths);
@@ -279,11 +279,10 @@ MultiParticleContainer::ReadParameters ()
             pp_particles.queryarr("deposit_on_main_grid", tmp);
             for (auto const& name : tmp) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     it != species_names.end(),
-                    Utils::TextMsg::Err("species '" + name
-                        + "' in particles.deposit_on_main_grid must be part of particles.species_names")
-                );
+                    "species '" + name
+                    + "' in particles.deposit_on_main_grid must be part of particles.species_names");
                 int i = std::distance(species_names.begin(), it);
                 m_deposit_on_main_grid[i] = true;
             }
@@ -293,11 +292,10 @@ MultiParticleContainer::ReadParameters ()
             pp_particles.queryarr("gather_from_main_grid", tmp_gather);
             for (auto const& name : tmp_gather) {
                 auto it = std::find(species_names.begin(), species_names.end(), name);
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     it != species_names.end(),
-                    Utils::TextMsg::Err("species '" + name
-                        + "' in particles.gather_from_main_grid must be part of particles.species_names")
-                );
+                    "species '" + name
+                        + "' in particles.gather_from_main_grid must be part of particles.species_names");
                 int i = std::distance(species_names.begin(), it);
                 m_gather_from_main_grid.at(i) = true;
             }
@@ -310,11 +308,10 @@ MultiParticleContainer::ReadParameters ()
             if (!rigid_injected_species.empty()) {
                 for (auto const& name : rigid_injected_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         it != species_names.end(),
-                        Utils::TextMsg::Err("species '" + name
-                        + "' in particles.rigid_injected_species must be part of particles.species_names")
-                    );
+                        "species '" + name
+                        + "' in particles.rigid_injected_species must be part of particles.species_names");
                     int i = std::distance(species_names.begin(), it);
                     species_types[i] = PCTypes::RigidInjected;
                 }
@@ -325,11 +322,10 @@ MultiParticleContainer::ReadParameters ()
             if (!photon_species.empty()) {
                 for (auto const& name : photon_species) {
                     auto it = std::find(species_names.begin(), species_names.end(), name);
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         it != species_names.end(),
-                        Utils::TextMsg::Err("species '" + name
-                        + "' in particles.photon_species must be part of particles.species_names")
-                    );
+                        "species '" + name
+                        + "' in particles.photon_species must be part of particles.species_names");
                     int i = std::distance(species_names.begin(), it);
                     species_types[i] = PCTypes::Photon;
                 }
@@ -338,11 +334,11 @@ MultiParticleContainer::ReadParameters ()
         }
         pp_particles.query("use_fdtd_nci_corr", WarpX::use_fdtd_nci_corr);
 #ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
                             "ERROR: use_fdtd_nci_corr is not supported in RZ");
 #endif
 #ifdef WARPX_DIM_1D_Z
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::use_fdtd_nci_corr==0,
                             "ERROR: use_fdtd_nci_corr is not supported in 1D");
 #endif
 
@@ -380,10 +376,9 @@ WarpXParticleContainer&
 MultiParticleContainer::GetParticleContainerFromName (const std::string& name) const
 {
     auto it = std::find(species_names.begin(), species_names.end(), name);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         it != species_names.end(),
-        Utils::TextMsg::Err("unknown species name");
-    );
+        "unknown species name");
     int i = std::distance(species_names.begin(), it);
     return *allcontainers[i];
 }
@@ -849,10 +844,10 @@ MultiParticleContainer::getSpeciesID (std::string product_str) const
         }
     }
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         found != 0,
-        Utils::TextMsg::Err("could not find the ID of product species '"
-        + product_str + "'" + ". Wrong name?"));
+        "could not find the ID of product species '"
+        + product_str + "'" + ". Wrong name?");
 
     return i_product;
 }
@@ -875,10 +870,10 @@ MultiParticleContainer::SetDoBackTransformedParticles (std::string species_name,
            pc->SetDoBackTransformedParticles(do_back_transformed_particles);
         }
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         found != 0,
-        Utils::TextMsg("ERROR: could not find the ID of product species '"
-        + species_name + "'" + ". Wrong name?"));
+        "ERROR: could not find the ID of product species '"
+        + species_name + "'" + ". Wrong name?");
 }
 
 void
@@ -969,7 +964,7 @@ void MultiParticleContainer::CheckIonizationProductSpecies()
 {
     for (int i=0; i < static_cast<int>(species_names.size()); i++){
         if (allcontainers[i]->do_field_ionization){
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != allcontainers[i]->ionization_product,
                 "ERROR: ionization product cannot be the same species");
         }
@@ -1313,14 +1308,14 @@ MultiParticleContainer::doQEDSchwinger ()
 
     auto & warpx = WarpX::GetInstance();
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(warpx.do_nodal ||
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(warpx.do_nodal ||
        warpx.field_gathering_algo == GatheringAlgo::MomentumConserving,
           "ERROR: Schwinger process only implemented for warpx.do_nodal = 1"
                                  "or algo.field_gathering = momentum-conserving");
 
     constexpr int level_0 = 0;
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(warpx.maxLevel() == level_0,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(warpx.maxLevel() == level_0,
         "ERROR: Schwinger process not implemented with mesh refinement");
 
 #ifdef WARPX_DIM_RZ
@@ -1655,15 +1650,15 @@ void MultiParticleContainer::CheckQEDProductSpecies()
     for (int i=0; i<nspecies; i++){
         const auto& pc = allcontainers[i];
         if (pc->has_breit_wheeler()){
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != pc->m_qed_breit_wheeler_ele_product,
                 "ERROR: Breit Wheeler product cannot be the same species");
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != pc->m_qed_breit_wheeler_pos_product,
                 "ERROR: Breit Wheeler product cannot be the same species");
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 allcontainers[pc->m_qed_breit_wheeler_ele_product]->
                     AmIA<PhysicalSpecies::electron>()
                 &&
@@ -1673,11 +1668,11 @@ void MultiParticleContainer::CheckQEDProductSpecies()
         }
 
         if(pc->has_quantum_sync()){
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 i != pc->m_qed_quantum_sync_phot_product,
                 "ERROR: Quantum Synchrotron product cannot be the same species");
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 allcontainers[pc->m_qed_quantum_sync_phot_product]->
                     AmIA<PhysicalSpecies::photon>(),
                 "ERROR: Quantum Synchrotron product species is of wrong type");
@@ -1685,7 +1680,7 @@ void MultiParticleContainer::CheckQEDProductSpecies()
     }
 
     if (m_do_qed_schwinger) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 allcontainers[m_qed_schwinger_ele_product]->
                     AmIA<PhysicalSpecies::electron>()
                 &&

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -10,6 +10,7 @@
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/Gather/ScalarFieldGather.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX_Geometry.H>
 #include <AMReX_ParmParse.H>
@@ -100,9 +101,11 @@ void ParticleBoundaryBuffer::printNumParticles () const {
             for (int i = 0; i < numSpecies(); ++i)
             {
                 int np = buffer[i].isDefined() ? buffer[i].TotalNumberOfParticles(false) : 0;
-                amrex::Print() << "Species " << getSpeciesNames()[i] << " has "
-                               << np << " particles in the boundary buffer "
-                               << "for side " << iside << " of dim " << idim << "\n";
+                amrex::Print() << Utils::TextMsg::Info(
+                    "Species " + getSpeciesNames()[i] + " has "
+                    + std::to_string(np) + " particles in the boundary buffer "
+                    + "for side " + std::to_string(iside) + " of dim " + std::to_string(idim)
+                );
             }
         }
     }
@@ -111,8 +114,10 @@ void ParticleBoundaryBuffer::printNumParticles () const {
     for (int i = 0; i < numSpecies(); ++i)
     {
         int np = buffer[i].isDefined() ? buffer[i].TotalNumberOfParticles(false) : 0;
-        amrex::Print() << "Species " << getSpeciesNames()[i] << " has "
-                       << np << " particles in the EB boundary buffer \n";
+        amrex::Print() << Utils::TextMsg::Info(
+            "Species " + getSpeciesNames()[i] + " has "
+            + std::to_string(np) + " particles in the EB boundary buffer"
+        );
     }
 #endif
 }

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -274,10 +274,10 @@ ParticleBoundaryBuffer::getParticleBuffer(const std::string species_name, int bo
     auto& buffer = m_particle_containers[boundary];
     auto index = WarpX::GetInstance().GetPartContainer().getSpeciesID(species_name);
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_boundary_buffer[boundary][index],
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_boundary_buffer[boundary][index],
                                      "Attempted to get particle buffer for boundary "
-                                     + boundary + ", which is not used!");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(buffer[index].isDefined(),
+                                     + std::to_string(boundary) + ", which is not used!");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(buffer[index].isDefined(),
                                      "Tried to get a buffer that is not defined!");
 
     return buffer[index];

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -17,6 +17,7 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Pusher/UpdatePositionPhoton.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX_Array.H>
@@ -62,7 +63,7 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core, int ispecie
         //Check for processes which do not make sense for photons
         bool test_quantum_sync = false;
         pp_species_name.query("do_qed_quantum_sync", test_quantum_sync);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         test_quantum_sync == 0,
         "ERROR: do_qed_quantum_sync can be 1 for species NOT listed in particles.photon_species only!");
         //_________________________________________________________

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -32,6 +32,7 @@
 #include "Particles/SpeciesPhysicalProperties.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/IonizationEnergiesTable.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -2822,7 +2823,7 @@ void PhysicalParticleContainer::resample (const int timestep)
     WARPX_PROFILE_VAR_START(blp_resample_actual);
     if (m_resampler.triggered(timestep, global_numparts))
     {
-        amrex::Print() << "Resampling " << species_name << ".\n";
+        amrex::Print() << Utils::TextMsg::Info("Resampling " + species_name);
         for (int lev = 0; lev <= maxLevel(); lev++)
         {
             for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -258,12 +258,12 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp_species_name.query("do_classical_radiation_reaction", do_classical_radiation_reaction);
     //if the species is not a lepton, do_classical_radiation_reaction
     //should be false
-    WarpXUtilMsg::AlwaysAssert(
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         !(do_classical_radiation_reaction &&
         !(AmIA<PhysicalSpecies::electron>() ||
         AmIA<PhysicalSpecies::positron>() )),
-        "ERROR: can't enable classical radiation reaction for non lepton species '"
-        + species_name + "'."
+        Utils::TextMsg::Err("can't enable classical radiation reaction for non lepton species '"
+            + species_name + "'.")
     );
 
     //Only Boris pusher is compatible with radiation reaction
@@ -897,8 +897,9 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
             pid = ParticleType::NextID();
             ParticleType::NextID(pid+max_new_particles);
         }
-        WarpXUtilMsg::AlwaysAssert(static_cast<Long>(pid + max_new_particles) < LastParticleID,
-                                   "ERROR: overflow on particle id numbers");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            static_cast<Long>(pid + max_new_particles) < LastParticleID,
+            Utils::TextMsg::Err("ERROR: overflow on particle id numbers"));
 
         const int cpuid = ParallelDescriptor::MyProc();
 
@@ -1428,8 +1429,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
             pid = ParticleType::NextID();
             ParticleType::NextID(pid+max_new_particles);
         }
-        WarpXUtilMsg::AlwaysAssert(static_cast<Long>(pid + max_new_particles) < LastParticleID,
-                                   "ERROR: overflow on particle id numbers");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            static_cast<Long>(pid + max_new_particles) < LastParticleID,
+            Utils::TextMsg::Err("overflow on particle id numbers"));
 
         const int cpuid = ParallelDescriptor::MyProc();
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -258,16 +258,15 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp_species_name.query("do_classical_radiation_reaction", do_classical_radiation_reaction);
     //if the species is not a lepton, do_classical_radiation_reaction
     //should be false
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !(do_classical_radiation_reaction &&
         !(AmIA<PhysicalSpecies::electron>() ||
         AmIA<PhysicalSpecies::positron>() )),
-        Utils::TextMsg::Err("can't enable classical radiation reaction for non lepton species '"
-            + species_name + "'.")
-    );
+        "can't enable classical radiation reaction for non lepton species '"
+            + species_name + "'.");
 
     //Only Boris pusher is compatible with radiation reaction
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !(do_classical_radiation_reaction &&
         WarpX::particle_pusher_algo != ParticlePusherAlgo::Boris),
         "Radiation reaction can be enabled only if Boris pusher is used");
@@ -536,7 +535,7 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
 #ifdef WARPX_USE_OPENPMD
     //TODO: Make changes for read/write in multiple MPI ranks
     if (ParallelDescriptor::IOProcessor()) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(plasma_injector,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(plasma_injector,
                                          "AddPlasmaFromFile: plasma injector not initialized.\n");
         // take ownership of the series and close it when done
         auto series = std::move(plasma_injector->m_openpmd_input_series);
@@ -897,9 +896,9 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
             pid = ParticleType::NextID();
             ParticleType::NextID(pid+max_new_particles);
         }
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             static_cast<Long>(pid + max_new_particles) < LastParticleID,
-            Utils::TextMsg::Err("ERROR: overflow on particle id numbers"));
+            "ERROR: overflow on particle id numbers");
 
         const int cpuid = ParallelDescriptor::MyProc();
 
@@ -1429,9 +1428,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
             pid = ParticleType::NextID();
             ParticleType::NextID(pid+max_new_particles);
         }
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             static_cast<Long>(pid + max_new_particles) < LastParticleID,
-            Utils::TextMsg::Err("overflow on particle id numbers"));
+            "overflow on particle id numbers");
 
         const int cpuid = ParallelDescriptor::MyProc();
 
@@ -2549,7 +2548,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
                                    amrex::Real dt, ScaleFields scaleFields,
                                    DtType a_dt_type)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE((gather_lev==(lev-1)) ||
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE((gather_lev==(lev-1)) ||
                                      (gather_lev==(lev  )),
                                      "Gather buffers only work for lev-1");
     // If no particles, do not do anything

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -8,6 +8,7 @@
 
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/ParticleUtils.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
@@ -33,7 +34,7 @@ LevelingThinning::LevelingThinning (const std::string species_name)
 
     amrex::ParmParse pp_species_name(species_name);
     queryWithParser(pp_species_name, "resampling_algorithm_target_ratio", m_target_ratio);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_target_ratio > 0._rt,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_target_ratio > 0._rt,
                                     "Resampling target ratio should be strictly greater than 0");
     if (m_target_ratio <= 1._rt)
     {
@@ -44,7 +45,7 @@ LevelingThinning::LevelingThinning (const std::string species_name)
     }
 
     queryWithParser(pp_species_name, "resampling_algorithm_min_ppc", m_min_ppc);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_min_ppc >= 1,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_min_ppc >= 1,
                                      "Resampling min_ppc should be greater than or equal to 1");
 }
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -15,6 +15,7 @@
 #include "Evolve/WarpXDtType.H"
 #include "Particles/ParticleBoundaries.H"
 #include "SpeciesPhysicalProperties.H"
+#include "Utils/TextMsg.H"
 
 #ifdef WARPX_QED
 #    include "ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H"
@@ -300,7 +301,8 @@ public:
             particle_runtime_comps[name] = NumRealComps() - PIdx::nattribs;
             AddRealComp(comm);
         } else {
-            amrex::Print() << name << " already exists in particle_comps, not adding. \n";
+            amrex::Print() << Utils::TextMsg::Info(
+                name + " already exists in particle_comps, not adding.");
         }
     }
 
@@ -312,7 +314,8 @@ public:
             particle_runtime_icomps[name] = NumIntComps() - 0;
             AddIntComp(comm);
         } else {
-            amrex::Print() << name << " already exists in particle_icomps, not adding. \n";
+            amrex::Print() << Utils::TextMsg::Info(
+                name + " already exists in particle_icomps, not adding.");
         }
     }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -17,6 +17,7 @@
 #include "Parallelization/WarpXCommUtil.H"
 #include "ParticleBoundaries_K.H"
 #include "Utils/CoarsenMR.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -305,7 +306,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                                         int const thread_num, const int lev, int const depos_lev,
                                         amrex::Real const dt, amrex::Real const relative_time)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev==(lev-1)) ||
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev==(lev-1)) ||
                                      (depos_lev==(lev  )),
                                      "Deposition buffers only work for lev-1");
 

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(WarpX
   PRIVATE
     CoarsenIO.cpp
     CoarsenMR.cpp
+    TextMsg.cpp
     Interpolate.cpp
     IntervalsParser.cpp
     ParticleUtils.cpp

--- a/Source/Utils/CoarsenIO.cpp
+++ b/Source/Utils/CoarsenIO.cpp
@@ -1,5 +1,7 @@
 #include "CoarsenIO.H"
 
+#include "Utils/TextMsg.H"
+
 #include <AMReX_BLProfiler.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Box.H>
@@ -29,10 +31,10 @@ CoarsenIO::Loop ( MultiFab& mf_dst,
     const IntVect stag_src = mf_src.boxArray().ixType().toIntVect();
     const IntVect stag_dst = mf_dst.boxArray().ixType().toIntVect();
 
-    if ( crse_ratio > IntVect(1) ) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( ngrowvect == IntVect(0),
+    if ( crse_ratio > IntVect(1) ) WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ngrowvect == IntVect(0),
         "option of filling guard cells of destination MultiFab with coarsening not supported for this interpolation" );
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.nGrowVect() >= stag_dst-stag_src+ngrowvect,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.nGrowVect() >= stag_dst-stag_src+ngrowvect,
         "source fine MultiFab does not have enough guard cells for this interpolation" );
 
     // Auxiliary integer arrays (always 3D)
@@ -127,7 +129,7 @@ CoarsenIO::Coarsen ( MultiFab& mf_dst,
 
     // Convert BoxArray of source MultiFab to staggering of destination MultiFab and coarsen it
     BoxArray ba_tmp = amrex::convert( mf_src.boxArray(), mf_dst.ixType().toIntVect() );
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( ba_tmp.coarsenable( crse_ratio ),
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ba_tmp.coarsenable( crse_ratio ),
         "source MultiFab converted to staggering of destination MultiFab is not coarsenable" );
     ba_tmp.coarsen( crse_ratio );
 

--- a/Source/Utils/CoarsenMR.cpp
+++ b/Source/Utils/CoarsenMR.cpp
@@ -1,5 +1,7 @@
 #include "CoarsenMR.H"
 
+#include "Utils/TextMsg.H"
+
 #include <AMReX_BLProfiler.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_BoxArray.H>
@@ -91,7 +93,7 @@ CoarsenMR::Coarsen ( MultiFab& mf_dst,
 {
     BL_PROFILE("CoarsenMR::Coarsen()");
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.ixType() == mf_dst.ixType(),
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.ixType() == mf_dst.ixType(),
         "source MultiFab and destination MultiFab have different IndexType" );
 
     // Number of guard cells to fill on coarse patch and number of components

--- a/Source/Utils/IntervalsParser.cpp
+++ b/Source/Utils/IntervalsParser.cpp
@@ -23,10 +23,9 @@ SliceParser::SliceParser (const std::string& instr)
     }
     else // 2 colons in input string. The input is start:stop:period
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             insplit.size() == 3,
-            Utils::TextMsg::Err(instr + "' is not a valid syntax for a slice.")
-        );
+            instr + "' is not a valid syntax for a slice.");
         if (!insplit[0].empty()){
             m_start = parseStringtoInt(insplit[0], "interval start");}
         if (!insplit[1].empty()){

--- a/Source/Utils/IntervalsParser.cpp
+++ b/Source/Utils/IntervalsParser.cpp
@@ -1,4 +1,5 @@
 #include "IntervalsParser.H"
+#include "TextMsg.H"
 #include "WarpXUtil.H"
 
 #include <AMReX_Utility.H>
@@ -8,8 +9,6 @@
 
 SliceParser::SliceParser (const std::string& instr)
 {
-    const std::string assert_msg = "ERROR: '" + instr + "' is not a valid syntax for a slice.";
-
     // split string and trim whitespaces
     auto insplit = WarpXUtilStr::split<std::vector<std::string>>(instr, m_separator, true);
 
@@ -24,7 +23,10 @@ SliceParser::SliceParser (const std::string& instr)
     }
     else // 2 colons in input string. The input is start:stop:period
     {
-        WarpXUtilMsg::AlwaysAssert(insplit.size() == 3,assert_msg);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            insplit.size() == 3,
+            Utils::TextMsg::Err(instr + "' is not a valid syntax for a slice.")
+        );
         if (!insplit[0].empty()){
             m_start = parseStringtoInt(insplit[0], "interval start");}
         if (!insplit[1].empty()){

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -4,6 +4,7 @@ CEXE_sources += WarpXUtil.cpp
 CEXE_sources += WarpXAlgorithmSelection.cpp
 CEXE_sources += CoarsenIO.cpp
 CEXE_sources += CoarsenMR.cpp
+CEXE_sources += TextMsg.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += IntervalsParser.cpp
 CEXE_sources += MPIInitHelpers.cpp

--- a/Source/Utils/TextMsg.H
+++ b/Source/Utils/TextMsg.H
@@ -10,6 +10,8 @@
 
 #include <string>
 
+#define WARPX_ALWAYS_ASSERT_WITH_MESSAGE(EX,MSG) (EX)?((void)0):Utils::TextMsg::Assert( # EX , __FILE__, __LINE__ , MSG)
+
 namespace Utils
 {
 namespace TextMsg
@@ -45,6 +47,8 @@ namespace TextMsg
     * @return the formatted message
     */
     std::string Warn(const std::string& msg, const bool do_text_wrapping = true);
+
+    void Assert(const char* ex, const char* file, const int line, const std::string& msg);
 }
 }
 

--- a/Source/Utils/TextMsg.H
+++ b/Source/Utils/TextMsg.H
@@ -1,0 +1,51 @@
+/* Copyright 2022 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_TEXT_MSG_H_
+#define WARPX_TEXT_MSG_H_
+
+#include <string>
+
+namespace Utils
+{
+namespace TextMsg
+{
+    /** \brief This function formats a text message as an error message,
+    *   adding the '### ERROR: ' prefix and (by default) performing text wrapping
+    *
+    * @param[in] msg the string to be formatterd
+    * @param[in] do_text_wrapping if true, the message is automatically
+    *
+    * @return the formatted message
+    */
+    std::string Err(const std::string& msg, const bool do_text_wrapping = true);
+
+    /** \brief This function formats a text message as an info message,
+    *   adding the '### INFO: ' prefix and (by default) performing text wrapping
+    *
+    * @param[in] msg the string to be formatterd
+    * @param[in] do_text_wrapping if true, the message is automatically
+    *
+    * @return the formatted message
+    */
+    std::string Info(const std::string& msg, const bool do_text_wrapping = true);
+
+    /** \brief This function formats a text message as a warning message,
+    *   adding the '### WARN: ' prefix and (by default) performing text wrapping.
+    *   Warning: this format is not used by the WarningLogger, which has an internal,
+    *   dedicated, formatter.
+    *
+    * @param[in] msg the string to be formatterd
+    * @param[in] do_text_wrapping if true, the message is automatically
+    *
+    * @return the formatted message
+    */
+    std::string Warn(const std::string& msg, const bool do_text_wrapping = true);
+}
+}
+
+#endif //WARPX_TEXT_MSG_H_

--- a/Source/Utils/TextMsg.cpp
+++ b/Source/Utils/TextMsg.cpp
@@ -1,0 +1,69 @@
+/* Copyright 2022 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "TextMsg.H"
+
+#include "WarpXUtil.H"
+
+#include <AMReX_Print.H>
+
+#include <sstream>
+
+using namespace Utils::TextMsg;
+
+namespace
+{
+    constexpr auto err_prefix       = "### ERROR   : ";
+    constexpr auto warn_prefix      = "!!! WARNING : ";
+    constexpr auto info_prefix      = "--- INFO    : ";
+    constexpr auto err_line_prefix  = "#            ";
+    constexpr auto line_prefix      = "             ";
+    constexpr auto line_length   = 66;
+
+    std::string Msg(
+        const std::string& msg,
+        const std::string& msg_prefix,
+        const std::string& msg_line_prefix,
+        const int msg_line_length,
+        const bool do_text_wrapping)
+    {
+        if(!do_text_wrapping){
+            return msg_prefix + msg + "\n";
+        }
+
+        const auto wrapped_text = WarpXUtilStr::automatic_text_wrap(
+            msg, msg_line_length);
+
+        std::stringstream ss_out;
+
+        std::for_each(std::begin(wrapped_text), std::end(wrapped_text),
+            [&,ln=0](const auto& line) mutable {
+                ss_out << ((ln++ == 0) ? msg_prefix : msg_line_prefix);
+                ss_out << line << "\n";
+            });
+
+        return ss_out.str();
+    }
+}
+
+std::string Err(const std::string& msg, const bool do_text_wrapping = true)
+{
+    return ::Msg(
+        msg, ::err_prefix, ::err_line_prefix, ::line_length, do_text_wrapping);
+}
+
+std::string Info(const std::string& msg, const bool do_text_wrapping = true)
+{
+    return ::Msg(
+        msg, ::info_prefix, ::line_prefix, ::line_length, do_text_wrapping);
+}
+
+std::string Warn(const std::string& msg, const bool do_text_wrapping = true)
+{
+    return ::Msg(
+        msg, ::warn_prefix, ::line_prefix, ::line_length, do_text_wrapping);
+}

--- a/Source/Utils/TextMsg.cpp
+++ b/Source/Utils/TextMsg.cpp
@@ -13,8 +13,6 @@
 
 #include <sstream>
 
-using namespace Utils::TextMsg;
-
 namespace
 {
     constexpr auto err_prefix       = "### ERROR   : ";
@@ -50,20 +48,26 @@ namespace
     }
 }
 
-std::string Err(const std::string& msg, const bool do_text_wrapping = true)
+std::string Utils::TextMsg::Err(const std::string& msg, const bool do_text_wrapping)
 {
     return ::Msg(
         msg, ::err_prefix, ::err_line_prefix, ::line_length, do_text_wrapping);
 }
 
-std::string Info(const std::string& msg, const bool do_text_wrapping = true)
+std::string Utils::TextMsg::Info(const std::string& msg, const bool do_text_wrapping)
 {
     return ::Msg(
         msg, ::info_prefix, ::line_prefix, ::line_length, do_text_wrapping);
 }
 
-std::string Warn(const std::string& msg, const bool do_text_wrapping = true)
+std::string Utils::TextMsg::Warn(const std::string& msg, const bool do_text_wrapping)
 {
     return ::Msg(
         msg, ::warn_prefix, ::line_prefix, ::line_length, do_text_wrapping);
+}
+
+void Utils::TextMsg::Assert(const char* ex, const char* file, const int line, const std::string& msg)
+{
+    const auto n_msg = "\n" + Err(msg);
+    amrex::Assert(ex , file, line , n_msg.c_str());
 }

--- a/Source/Utils/WarnManager.cpp
+++ b/Source/Utils/WarnManager.cpp
@@ -8,6 +8,7 @@
 #include "WarnManager.H"
 
 #include "MsgLogger/MsgLogger.H"
+#include "WarpXUtil.H"
 
 #include <AMReX_ParallelDescriptor.H>
 
@@ -201,39 +202,12 @@ WarnManager::msg_formatter(
     const auto prefix = "*" + std::string(tab_size, ' ');
     const auto prefix_length = static_cast<int>(prefix.length());
 
+    const auto wrapped_text = WarpXUtilStr::automatic_text_wrap(
+        msg, line_size-prefix_length);
+
     std::stringstream ss_out;
-    std::stringstream ss_msg{msg};
-
-    std::string line;
-    std::string word;
-
-    while(std::getline(ss_msg, line,'\n')){
-        ss_out << prefix;
-
-        std::stringstream ss_line{line};
-        int counter = prefix_length;
-
-        while (ss_line >> word){
-            const auto wlen = static_cast<int>(word.length());
-
-            if(counter == prefix_length){
-                ss_out << word;
-                counter += wlen;
-            }
-            else{
-                if (counter + wlen < line_size){
-                    ss_out << " " << word;
-                    counter += (wlen+1);
-                }
-                else{
-                    ss_out << "\n" << prefix << word;
-                    counter = prefix_length + wlen;
-                }
-            }
-        }
-
-        ss_out << '\n';
-    }
+    for (const auto& line : wrapped_text)
+        ss_out << prefix << line << "\n";
 
     return ss_out.str();
 }

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "Particles/MultiParticleContainer.H"
 #include "Parallelization/WarpXCommUtil.H"
+#include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
@@ -80,10 +81,10 @@ int
 WarpX::MoveWindow (const int step, bool move_j)
 {
     if (step == start_moving_window_step) {
-        amrex::Print() << "Starting moving window\n";
+        amrex::Print() << Utils::TextMsg::Info("Starting moving window");
     }
     if (step == end_moving_window_step) {
-        amrex::Print() << "Stopping moving window\n";
+        amrex::Print() << Utils::TextMsg::Info("Stopping moving window");
     }
     if (moving_window_active(step) == false) return 0;
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -333,17 +333,6 @@ void getArrWithParser (const amrex::ParmParse& a_pp, char const * const str, std
                        const int start_ix = amrex::ParmParse::FIRST,
                        const int num_val = amrex::ParmParse::LAST);
 
-namespace WarpXUtilMsg{
-
-/** \brief If is_expression_true is false, this function prints msg and calls amrex::abort()
- *
- * @param[in] is_expression_true
- * @param[in] msg the string to be printed if is_expression_true is false (default value is "ERROR!")
- */
-void AlwaysAssert(bool is_expression_true, const std::string& msg);
-
-}
-
 namespace WarpXUtilStr
 {
     /** Return true if elem is in vect, false otherwise
@@ -397,6 +386,17 @@ namespace WarpXUtilStr
             cont.push_back(instr.substr(previous, current - previous));}
         return cont;
     }
+
+    /** \brief This function performs automatic text wrapping on a string,
+     *  returning an array of strings each not exceeding the maximum line length
+     *  (unless the text contains a word exceeding the maximum line length).
+     *
+     * @param[in] text the string containing the text to be wrapped
+     * @param[in] max_line_length the maximum line length
+     * @return an std::vector containing the lines of the wrapped text
+     */
+    std::vector<std::string> automatic_text_wrap(
+        const std::string& text, const int max_line_length);
 
 }
 

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -7,6 +7,7 @@
  */
 #include "WarpX.H"
 
+#include "TextMsg.H"
 #include "WarpXAlgorithmSelection.H"
 #include "WarpXConst.H"
 #include "WarpXProfilerWrapper.H"
@@ -74,12 +75,12 @@ void ParseGeometryInput()
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
-            "Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero");
+            Utils::TextMsg::Err("Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero"));
     }
     else
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
-            "Lower bound of radial coordinate (prob_lo[0]) with RZ FDTD solver must be non-negative");
+            Utils::TextMsg::Err("Lower bound of radial coordinate (prob_lo[0]) with RZ FDTD solver must be non-negative"));
     }
 #endif
 
@@ -124,12 +125,11 @@ void ReadBoostedFrameParameters(Real& gamma_boost, Real& beta_boost,
             boost_direction[2] = 1;
         }
         else {
-            const std::string msg = "Unknown boost_dir: "+s;
-            Abort(msg.c_str());
+            Abort(Utils::TextMsg::Err("Unknown boost_dir: "+s));
         }
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( s == "z" || s == "Z" ,
-                                          "The boost must be in the z direction.");
+            Utils::TextMsg::Err("The boost must be in the z direction."));
     }
 }
 
@@ -295,16 +295,16 @@ int safeCastToInt(const amrex::Real x, const std::string& real_name) {
             result = static_cast<int>(x);
         } else {
             error_detected = true;
-            assert_msg = "Error: Negative overflow detected when casting " + real_name + " = " + std::to_string(x) + " to int";
+            assert_msg = "Negative overflow detected when casting " + real_name + " = " + std::to_string(x) + " to int";
         }
     } else if (x > 0) {
         error_detected = true;
-        assert_msg =  "Error: Overflow detected when casting " + real_name + " = " + std::to_string(x) + " to int";
+        assert_msg =  "Overflow detected when casting " + real_name + " = " + std::to_string(x) + " to int";
     } else {
         error_detected = true;
-        assert_msg =  "Error: NaN detected when casting " + real_name + " to int";
+        assert_msg =  "NaN detected when casting " + real_name + " to int";
     }
-    WarpXUtilMsg::AlwaysAssert(!error_detected, assert_msg);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!error_detected, Utils::TextMsg::Err(assert_msg));
     return result;
 }
 
@@ -349,7 +349,9 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         // user's expressions because of the limited range of exponentials in single precision
         double v;
 
-        WarpXUtilMsg::AlwaysAssert(recursive_symbols.count(*it)==0, "Expressions contains recursive symbol "+*it);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            recursive_symbols.count(*it)==0,
+            Utils::TextMsg::Err("Expressions contains recursive symbol "+*it));
         recursive_symbols.insert(*it);
         const bool is_input = queryWithParser(pp_my_constants, it->c_str(), v);
         recursive_symbols.erase(*it);
@@ -370,7 +372,7 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         ++it;
     }
     for (auto const& s : symbols) {
-        amrex::Abort("makeParser::Unknown symbol "+s);
+        amrex::Abort(Utils::TextMsg::Err("makeParser::Unknown symbol "+s));
     }
     return parser;
 }
@@ -536,11 +538,11 @@ void CheckDims ()
     ParmParse pp_geometry("geometry");
     std::string dims;
     pp_geometry.get("dims", dims);
-    std::string dims_error = "ERROR: The selected WarpX executable was built as '";
+    std::string dims_error = "The selected WarpX executable was built as '";
     dims_error.append(dims_compiled).append("'-dimensional, but the ");
     dims_error.append("inputs file declares 'geometry.dims = ").append(dims).append("'.\n");
     dims_error.append("Please re-compile with a different WarpX_DIMS option or select the right executable name.");
-    WarpXUtilMsg::AlwaysAssert(dims == dims_compiled, dims_error);
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(dims == dims_compiled, dims_error);
 }
 
 void CheckGriddingForRZSpectral ()

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -703,17 +703,6 @@ void ReadBCParams ()
     pp_geometry.addarr("is_periodic", geom_periodicity);
 }
 
-namespace WarpXUtilMsg{
-
-void AlwaysAssert(bool is_expression_true, const std::string& msg = "ERROR!")
-{
-    if(is_expression_true) return;
-
-    amrex::Abort(msg);
-}
-
-}
-
 namespace WarpXUtilStr
 {
     bool is_in(const std::vector<std::string>& vect,
@@ -729,6 +718,45 @@ namespace WarpXUtilStr
             [&](const auto elem){return is_in(vect, elem);});
     }
 
+    std::vector<std::string> automatic_text_wrap(
+        const std::string& text, const int max_line_length){
+
+        auto ss_text = std::stringstream{text};
+        auto wrapped_text_lines = std::vector<std::string>{};
+
+        std::string line;
+        while(std::getline(ss_text, line,'\n')){
+
+            auto ss_line = std::stringstream{line};
+            int counter = 0;
+            std::stringstream ss_line_out;
+            std::string word;
+
+            while (ss_line >> word){
+                const auto wlen = static_cast<int>(word.length());
+
+                if(counter == 0){
+                    ss_line_out << word;
+                    counter += wlen;
+                }
+                else{
+                    if (counter + wlen < max_line_length){
+                        ss_line_out << " " << word;
+                        counter += (wlen+1);
+                    }
+                    else{
+                        wrapped_text_lines.push_back(ss_line_out.str());
+                        ss_line_out = std::stringstream{word};
+                        counter = wlen;
+                    }
+                }
+            }
+
+            wrapped_text_lines.push_back(ss_line_out.str());
+        }
+
+        return wrapped_text_lines;
+    }
 }
 
 namespace WarpXUtilLoadBalance

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -74,13 +74,13 @@ void ParseGeometryInput()
     int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
     if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
-            Utils::TextMsg::Err("Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero"));
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
+            "Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero");
     }
     else
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
-            Utils::TextMsg::Err("Lower bound of radial coordinate (prob_lo[0]) with RZ FDTD solver must be non-negative"));
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] >= 0.,
+            "Lower bound of radial coordinate (prob_lo[0]) with RZ FDTD solver must be non-negative");
     }
 #endif
 
@@ -128,8 +128,8 @@ void ReadBoostedFrameParameters(Real& gamma_boost, Real& beta_boost,
             Abort(Utils::TextMsg::Err("Unknown boost_dir: "+s));
         }
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( s == "z" || s == "Z" ,
-            Utils::TextMsg::Err("The boost must be in the z direction."));
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( s == "z" || s == "Z" ,
+            "The boost must be in the z direction.");
     }
 }
 
@@ -304,7 +304,7 @@ int safeCastToInt(const amrex::Real x, const std::string& real_name) {
         error_detected = true;
         assert_msg =  "NaN detected when casting " + real_name + " to int";
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!error_detected, Utils::TextMsg::Err(assert_msg));
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!error_detected, assert_msg);
     return result;
 }
 
@@ -349,9 +349,9 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         // user's expressions because of the limited range of exponentials in single precision
         double v;
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             recursive_symbols.count(*it)==0,
-            Utils::TextMsg::Err("Expressions contains recursive symbol "+*it));
+            "Expressions contains recursive symbol "+*it);
         recursive_symbols.insert(*it);
         const bool is_input = queryWithParser(pp_my_constants, it->c_str(), v);
         recursive_symbols.erase(*it);
@@ -372,7 +372,7 @@ Parser makeParser (std::string const& parse_function, amrex::Vector<std::string>
         ++it;
     }
     for (auto const& s : symbols) {
-        amrex::Abort(Utils::TextMsg::Err("makeParser::Unknown symbol "+s));
+        amrex::Abort("makeParser::Unknown symbol "+s);
     }
     return parser;
 }
@@ -596,7 +596,7 @@ void CheckGriddingForRZSpectral ()
     // The factor of 8 is there to make some room for higher order
     // shape factors and filtering.
     int nprocs = ParallelDescriptor::NProcs();
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_cell[1] >= 8*nprocs,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_cell[1] >= 8*nprocs,
                                      "With RZ spectral, there must be at least eight z-cells per processor so that there can be at least one block per processor.");
 
     // Get the longitudinal blocking factor in case it was set by the user.
@@ -675,12 +675,12 @@ void ReadBCParams ()
             WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Periodic ) {
             geom_periodicity[idim] = 1;
             // to ensure both lo and hi are set to periodic consistently for both field and particles.
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (WarpX::field_boundary_lo[idim]  == FieldBoundaryType::Periodic) &&
                 (WarpX::field_boundary_hi[idim]  == FieldBoundaryType::Periodic),
             "field boundary must be consistenly periodic in both lo and hi");
             if (particle_boundary_specified) {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     (WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Periodic) &&
                     (WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Periodic),
                "field and particle boundary must be periodic in both lo and hi");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -30,6 +30,7 @@
 #include "Filter/NCIGodfreyFilter.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
+#include "Utils/TextMsg.H"
 #include "Utils/MsgLogger/MsgLogger.H"
 #include "Utils/WarnManager.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -437,10 +438,15 @@ WarpX::RecordWarning(
         msg_priority = Utils::MsgLogger::Priority::medium;
 
     if(m_always_warn_immediately){
+
         amrex::Warning(
-            "!!!!!! WARNING: ["
-            + std::string(Utils::MsgLogger::PriorityToString(msg_priority))
-            + "][" + topic + "] " + text);
+            Utils::TextMsg::Warn(
+                "["
+                + std::string(Utils::MsgLogger::PriorityToString(msg_priority))
+                + "]["
+                + topic
+                + "] "
+                + text));
     }
 
 #ifdef AMREX_USE_OMP

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -409,7 +409,7 @@ WarpX::WarpX ()
     }
 
     if (WarpX::current_deposition_algo != CurrentDepositionAlgo::Esirkepov) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             use_fdtd_nci_corr == 0,
             "The NCI corrector should only be used with Esirkepov deposition");
     }
@@ -542,10 +542,10 @@ WarpX::ReadParameters ()
         std::vector<int> numprocs_in;
         queryArrWithParser(pp_warpx, "numprocs", numprocs_in, 0, AMREX_SPACEDIM);
         if (not numprocs_in.empty()) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE
                 (numprocs_in.size() == AMREX_SPACEDIM,
                  "warpx.numprocs, if specified, must have AMREX_SPACEDIM numbers");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE
                 (ParallelDescriptor::NProcs() == AMREX_D_TERM(numprocs_in[0],
                                                              *numprocs_in[1],
                                                              *numprocs_in[2]),
@@ -588,7 +588,7 @@ WarpX::ReadParameters ()
         pp_warpx.queryarr("override_sync_intervals", override_sync_intervals_string_vec);
         override_sync_intervals = IntervalsParser(override_sync_intervals_string_vec);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycling != 1 || max_level <= 1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycling != 1 || max_level <= 1,
                                          "Subcycling method 1 only works for 2 levels.");
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
@@ -624,7 +624,7 @@ WarpX::ReadParameters ()
                 amrex::Abort(msg.c_str());
             }
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(moving_window_dir) == 0,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(moving_window_dir) == 0,
                        "The problem must be non-periodic in the moving window direction");
 
             moving_window_x = geom[0].ProbLo(moving_window_dir);
@@ -636,14 +636,14 @@ WarpX::ReadParameters ()
         pp_warpx.query("do_back_transformed_diagnostics", do_back_transformed_diagnostics);
         if (do_back_transformed_diagnostics) {
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
                    "gamma_boost must be > 1 to use the boosted frame diagnostic.");
 
             pp_warpx.query("lab_data_directory", lab_data_directory);
 
             std::string s;
             pp_warpx.get("boost_direction", s);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
                    "The boosted frame diagnostic currently only works if the boost is in the z direction.");
 
             queryWithParser(pp_warpx, "num_snapshots_lab", num_snapshots_lab);
@@ -656,7 +656,7 @@ WarpX::ReadParameters ()
                 dt_snapshots_lab = dz_snapshots_lab/PhysConst::c;
                 snapshot_interval_is_specified = 1;
             }
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 snapshot_interval_is_specified,
                 "When using back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab.");
 
@@ -664,18 +664,18 @@ WarpX::ReadParameters ()
 
             pp_warpx.query("do_back_transformed_fields", do_back_transformed_fields);
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window,
                    "The moving window should be on if using the boosted frame diagnostic.");
 
             pp_warpx.get("moving_window_dir", s);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( (s == "z" || s == "Z"),
                    "The boosted frame diagnostic currently only works if the moving window is in the z direction.");
         }
 
         do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_electrostatic!=ElectrostaticSolverAlgo::None,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_electrostatic!=ElectrostaticSolverAlgo::None,
         "Currently, the embedded boundary in RZ only works for electrostatic solvers.");
 #endif
 
@@ -827,7 +827,7 @@ WarpX::ReadParameters ()
         // TODO Implement div(B) cleaning in PML with FDTD and remove ASSERT
         if (maxwell_solver_id != MaxwellSolverAlgo::PSATD)
         {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 do_pml_divb_cleaning == false,
                 "warpx.do_pml_divb_cleaning = true not implemented for FDTD solver");
         }
@@ -850,9 +850,9 @@ WarpX::ReadParameters ()
         }
 
 #ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( isAnyBoundaryPML() == false || maxwell_solver_id == MaxwellSolverAlgo::PSATD,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( isAnyBoundaryPML() == false || maxwell_solver_id == MaxwellSolverAlgo::PSATD,
             "PML are not implemented in RZ geometry with FDTD; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( field_boundary_lo[1] != FieldBoundaryType::PML && field_boundary_hi[1] != FieldBoundaryType::PML,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( field_boundary_lo[1] != FieldBoundaryType::PML && field_boundary_hi[1] != FieldBoundaryType::PML,
             "PML are not implemented in RZ geometry along z; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
 #endif
 
@@ -900,7 +900,7 @@ WarpX::ReadParameters ()
 #ifdef WARPX_DIM_RZ
         // Only needs to be set with WARPX_DIM_RZ, otherwise defaults to 1
         queryWithParser(pp_warpx, "n_rz_azimuthal_modes", n_rz_azimuthal_modes);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( n_rz_azimuthal_modes > 0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( n_rz_azimuthal_modes > 0,
             "The number of azimuthal modes (n_rz_azimuthal_modes) must be at least 1");
 #endif
 
@@ -923,24 +923,24 @@ WarpX::ReadParameters ()
         ParmParse pp_algo("algo");
 #ifdef WARPX_DIM_RZ
         if (maxwell_solver_id == MaxwellSolverAlgo::CKC) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
                 "algo.maxwell_solver = ckc is not (yet) available for RZ geometry");
         }
 #endif
 #ifndef WARPX_USE_PSATD
         if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
                                               "algo.maxwell_solver = psatd is not supported because WarpX was built without spectral solvers");
         }
 #endif
 
 #ifdef WARPX_DIM_RZ
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(0) == 0,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(0) == 0,
             "The problem must not be periodic in the radial direction");
 
         // Ensure code aborts if PEC is specified at r=0 for RZ
         if (Geom(0).ProbLo(0) == 0){
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 WarpX::field_boundary_lo[0] == FieldBoundaryType::None,
                 "Error : Field boundary at r=0 must be ``none``. \n");
         }
@@ -1076,7 +1076,7 @@ WarpX::ReadParameters ()
             // (note that when WarpX::do_nodal = 1 finite-order centering is not used anyways)
             if (maxLevel() > 0 && WarpX::do_nodal == 0)
             {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     field_centering_nox == 2 && field_centering_noy == 2 && field_centering_noz == 2,
                     "High-order centering of fields (order > 2) is not implemented with mesh refinement");
             }
@@ -1136,9 +1136,9 @@ WarpX::ReadParameters ()
 
 
         if (!fft_periodic_single_box) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
         }
 
         pp_psatd.query("current_correction", current_correction);
@@ -1244,7 +1244,7 @@ WarpX::ReadParameters ()
         }
 
         if (m_v_comoving[0] != 0. || m_v_comoving[1] != 0. || m_v_comoving[2] != 0.) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
                 "psatd.update_with_rho must be equal to 1 for comoving PSATD");
         }
 
@@ -1255,7 +1255,7 @@ WarpX::ReadParameters ()
                 amrex::Abort("Multi-J algorithm not implemented with Galilean PSATD");
             }
 
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(update_with_rho,
                 "psatd.update_with_rho must be set to 1 when warpx.do_multi_J = 1");
         }
 
@@ -1263,7 +1263,7 @@ WarpX::ReadParameters ()
         {
             if (WarpX::field_boundary_lo[dir] == FieldBoundaryType::Damped ||
                 WarpX::field_boundary_hi[dir] == FieldBoundaryType::Damped ) {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     WarpX::field_boundary_lo[dir] == WarpX::field_boundary_hi[dir],
                     "field boundary in both lo and hi must be set to Damped for PSATD"
                 );
@@ -1318,7 +1318,7 @@ WarpX::ReadParameters ()
        }
 
        if (do_back_transformed_diagnostics) {
-          AMREX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
+          WARPX_ALWAYS_ASSERT_WITH_MESSAGE(gamma_boost > 1.0,
                  "gamma_boost must be > 1 to use the boost frame diagnostic");
           queryWithParser(pp_slice, "num_slice_snapshots_lab", num_slice_snapshots_lab);
           if (num_slice_snapshots_lab > 0) {
@@ -1798,19 +1798,19 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     {
         // Allocate and initialize the spectral solver
 #ifndef WARPX_USE_PSATD
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
             "WarpX::AllocLevelMFs: PSATD solver requires WarpX build with spectral solver support.");
 #else
 
         // Check whether the option periodic, single box is valid here
         if (fft_periodic_single_box) {
 #   ifdef WARPX_DIM_RZ
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 geom[0].isPeriodic(1)          // domain is periodic in z
                 && ba.size() == 1 && lev == 0, // domain is decomposed in a single box
                 "The option `psatd.periodic_single_box_fft` can only be used for a periodic domain, decomposed in a single box");
 #   else
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 geom[0].isAllPeriodic()        // domain is periodic in all directions
                 && ba.size() == 1 && lev == 0, // domain is decomposed in a single box
                 "The option `psatd.periodic_single_box_fft` can only be used for a periodic domain, decomposed in a single box");
@@ -1959,7 +1959,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         {
             // Allocate and initialize the spectral solver
 #ifndef WARPX_USE_PSATD
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( false,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
                 "WarpX::AllocLevelMFs: PSATD solver requires WarpX build with spectral solver support.");
 #else
 
@@ -2225,7 +2225,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
                     const std::array<const amrex::MultiFab* const, 3>& B,
                     const std::array<amrex::Real,3>& dx)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!do_nodal,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!do_nodal,
         "ComputeDivB not implemented with do_nodal."
         "Shouldn't be too hard to make it general with class FiniteDifferenceSolver");
 
@@ -2263,7 +2263,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
                     const std::array<const amrex::MultiFab* const, 3>& B,
                     const std::array<amrex::Real,3>& dx, IntVect const ngrow)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!do_nodal,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!do_nodal,
         "ComputeDivB not implemented with do_nodal."
         "Shouldn't be too hard to make it general with class FiniteDifferenceSolver");
 

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -12,6 +12,7 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Particles/Deposition/ChargeDeposition.H"
+#include "Utils/TextMsg.H"
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"
 #endif
@@ -79,7 +80,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
     amrex::IntVect ng_rho = rho->nGrowVect();
     if (num_rho_deposition_guards.has_value())
         ng_rho = num_rho_deposition_guards.value();
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho <= rho->nGrowVect(),
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho <= rho->nGrowVect(),
                                      "num_rho_deposition_guards are larger than allocated!");
     // particle shape
     auto const[nox, noy, noz] = std::array<int, 3>{particle_shape, particle_shape, particle_shape};
@@ -88,17 +89,17 @@ deposit_charge (typename T_PC::ParIterType& pti,
     // current box; with offset, we start at a later particle index
     if (!np_to_depose.has_value())
         np_to_depose = pti.numParticles();
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(np_to_depose.value() + offset <= pti.numParticles(),
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(np_to_depose.value() + offset <= pti.numParticles(),
                                      "np_to_depose + offset are out-of-bounds for particle iterator");
 
     int const lev = pti.GetLevel();
     if (!depos_lev.has_value())
         depos_lev = lev;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev.value() == (lev-1)) ||
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev.value() == (lev-1)) ||
                                      (depos_lev.value() == (lev  )),
                                      "Deposition buffers only work for lev or lev-1");
     if (!rel_ref_ratio.has_value()) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lev == depos_lev,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(lev == depos_lev,
                                          "rel_ref_ratio must be set if lev != depos_lev");
         rel_ref_ratio = amrex::IntVect(AMREX_D_DECL(1, 1, 1));
     }


### PR DESCRIPTION
The goal of this PR is to make "info" messages and error messages visually uniform (i.e., using the same prefix, the same style...).
There may be better ways to do so, therefore I am completely open to suggestions for improvements!

Anyway, the message styles are implemented in the new files `Utils/TextMsg.H` , and they use a new "automatic text wrapping" method implemented in `WarpXUtil.H` . 

Ideally, an error message would be raised with something like:
`WARPX_ALWAYS_ASSERT_WITH_MESSAGE(condition, msg)` (`AMREX_ALWAYS_ASSERT_WITH_MESSAGE` does not allow for `std::string` for the message). The result would be something like:

```
0::Assertion `dims == dims_compiled' failed, file "/home/luca/Projects/WarpX/Source/Utils/WarpXUtil.cpp", line 545, Msg: 
### ERROR   : The selected WarpX executable was built as '3'-dimensional, but
#             inputs file declares 'geometry.dims = 2'.
#            Please re-compile with a different WarpX_DIMS option or select the
#             executable name.
 !!!
```

"info" messages would be generated with something like
`amrex::Print() << Utils::TextMsg::Info(msg)` and the result would be like:

```
--- INFO    : Writing plotfile diags/diag1000002
```

Warnings are normally collected with the warning logger, but their style in case we ask warpx to warn immediately is implemented in `Utils/TextMsg.H` 

What do you think?