### PR TITLE
[WIP] Maxwell Solver: Default Yee -> CKC

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1540,7 +1540,7 @@ Numerics and algorithms
                 IEEE Antennas and Propagation Society International Symposium (2005),
                 <https://ieeexplore.ieee.org/document/1551259>)
 
-     If ``algo.maxwell_solver`` is not specified, ``yee`` is the default.
+     If ``algo.maxwell_solver`` is not specified, then ``ckc`` is the default for Cartesian and ``yee`` is the default for RZ simulations.
 
 * ``algo.em_solver_medium`` (`string`, optional)
     The medium for evaluating the Maxwell solver. Available options are :

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -27,7 +27,11 @@ const std::map<std::string, int> maxwell_solver_algo_to_int = {
     {"ckc",     MaxwellSolverAlgo::CKC },
     {"psatd",   MaxwellSolverAlgo::PSATD },
     {"ect",     MaxwellSolverAlgo::ECT },
+#if defined(WARPX_DIM_RZ)
     {"default", MaxwellSolverAlgo::Yee }
+#else
+    {"default", MaxwellSolverAlgo::CKC }
+#endif
 };
 
 const std::map<std::string, int> electrostatic_solver_algo_to_int = {


### PR DESCRIPTION
As discussed in our developer meeting today:
Change the default of `algo.maxwell_solver` from Yee to CKC.

- [x] decide on RZ: keep Yee
- [ ] merge in #2940?
- [ ] potentially reset checks that use the "default" MW solver