### PR TITLE
Clean Pip Staging Directory

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2946,7 +2946,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=ON
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2965,6 +2965,8 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_1d.py --test
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
+target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.command.build import build
+from distutils.command.clean import clean
 from distutils.version import LooseVersion
 import os
 import platform
@@ -14,13 +15,23 @@ from setuptools.command.build_ext import build_ext
 class CopyPreBuild(build):
     def initialize_options(self):
         build.initialize_options(self)
-        # We just overwrite this because the default "build/lib" clashes with
-        # directories many developers have in their source trees;
+        # We just overwrite this because the default "build" (and "build/lib")
+        # clashes with directories many developers have in their source trees;
         # this can create confusing results with "pip install .", which clones
         # the whole source tree by default
-        self.build_lib = '_tmppythonbuild'
+        self.build_base = '_tmppythonbuild'
 
     def run(self):
+        # remove existing build directory
+        #   by default, this stays around. we want to make sure generated
+        #   files like libwarpx.(2d|3d|rz).(so|pyd) are always only the
+        #   ones we want to package and not ones from an earlier wheel's stage
+        c = clean(self.distribution)
+        c.all = True
+        c.finalize_options()
+        c.run()
+
+        # call superclass
         build.run(self)
 
         # matches: libwarpx.(2d|3d|rz).(so|pyd)


### PR DESCRIPTION
The distutils staging (`build` -> `_tmppythonbuild`) directory that pip uses to collect build artifacts is not by default cleaned between multiple `pip` runs.

This can be confusing when we recompile, because old `libwarpx*` files can be still in it that are not present in our own `build/lib/`.

This cleans that staging directory before builds now. It also sets the whole `build_base` so that no artifact lands in the default, which was `build/`. So far, `bdist.linux-x86_64/` still was out-of-tree.

First reported by @RTSandberg :pray: 