### PR TITLE
Fix ambiguity in reference to Parser

### DIFF
--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -82,7 +82,7 @@ struct GetExternalEBField
             Ey = m_Efield_value[1];
             Ez = m_Efield_value[2];
         }
-        else if (m_Etype == Parser)
+        else if (m_Etype == ExternalFieldInitType::Parser)
         {
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);
@@ -102,7 +102,7 @@ struct GetExternalEBField
             By = m_Bfield_value[1];
             Bz = m_Bfield_value[2];
         }
-        else if (m_Btype == Parser)
+        else if (m_Btype == ExternalFieldInitType::Parser)
         {
             amrex::ParticleReal x, y, z;
             m_get_position(i, x, y, z);

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -52,7 +52,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, int a_offset)
 
     if (mypc.m_E_ext_particle_s == "parse_e_ext_particle_function")
     {
-        m_Etype = Parser;
+        m_Etype = ExternalFieldInitType::Parser;
         m_Exfield_partparser = mypc.m_Ex_particle_parser->compile<4>();
         m_Eyfield_partparser = mypc.m_Ey_particle_parser->compile<4>();
         m_Ezfield_partparser = mypc.m_Ez_particle_parser->compile<4>();
@@ -60,7 +60,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, int a_offset)
 
     if (mypc.m_B_ext_particle_s == "parse_b_ext_particle_function")
     {
-        m_Btype = Parser;
+        m_Btype = ExternalFieldInitType::Parser;
         m_Bxfield_partparser = mypc.m_Bx_particle_parser->compile<4>();
         m_Byfield_partparser = mypc.m_By_particle_parser->compile<4>();
         m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<4>();


### PR DESCRIPTION
In assigning external fields to particles,  we have a Parser type.
The compiler sometimes triggers an error with a message that the `reference to "Parser" is ambiguous`

This PR fixes it by explicitly defining the enumerator `ExternalFieldInitType::Parser` to reference to the Parser-type.

Thanks to @atmyers for the offline discussion.