### PR TITLE
WarpX/PICSAR Version Define: File

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -106,7 +106,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd amrex && git checkout --detach 6bbcbbb7829902e9038bee8c28be09800b22aab2 && cd -
+        cd amrex && git checkout --detach 806f2373b68efa37120c393264647178304720b7 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-9-nvcc:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ endif()
 # own headers
 target_include_directories(WarpX PUBLIC
     $<BUILD_INTERFACE:${WarpX_SOURCE_DIR}/Source>
+    $<BUILD_INTERFACE:${WarpX_BINARY_DIR}/Source>
 )
 target_include_directories(ablastr PUBLIC
     # future: own directory root
@@ -276,12 +277,6 @@ set_warpx_binary_name()
 
 # Defines #####################################################################
 #
-get_source_version(WarpX ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_definitions(ablastr PUBLIC WARPX_GIT_VERSION="${WarpX_GIT_VERSION}")
-if(WarpX_QED)
-    target_compile_definitions(ablastr PUBLIC PICSAR_GIT_VERSION="${PXRMP_QED_GIT_VERSION}")
-endif()
-
 if(WarpX_DIMS STREQUAL 3)
     target_compile_definitions(ablastr PUBLIC WARPX_DIM_3D WARPX_ZINDEX=2)
 elseif(WarpX_DIMS STREQUAL 2)
@@ -324,6 +319,13 @@ set_cxx_warnings()
 
 # Generate Configuration and .pc Files ########################################
 #
+get_source_version(WarpX ${WarpX_SOURCE_DIR})
+configure_file(
+    ${WarpX_SOURCE_DIR}/Source/Utils/WarpXVersion.H.in
+    ${WarpX_BINARY_DIR}/Source/Utils/WarpXVersion.H
+    @ONLY
+)
+
 # these files are used if WarpX is installed and picked up by a downstream
 # project (not needed yet)
 

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 6bbcbbb7829902e9038bee8c28be09800b22aab2
+branch = 806f2373b68efa37120c393264647178304720b7
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 6bbcbbb7829902e9038bee8c28be09800b22aab2
+branch = 806f2373b68efa37120c393264647178304720b7
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -136,8 +136,7 @@ endif
 
 WARPX_GIT_VERSION := $(shell cd $(WARPX_HOME); git describe --abbrev=12 --dirty --always --tags)
 PICSAR_GIT_VERSION := $(shell cd $(PICSAR_HOME); git describe --abbrev=12 --dirty --always --tags)
-DEFINES += -DWARPX_GIT_VERSION=\"$(WARPX_GIT_VERSION)\"
-DEFINES += -DPICSAR_GIT_VERSION=\"$(PICSAR_GIT_VERSION)\"
+WARPX_DEFINES = -DWARPX_GIT_VERSION=\"$(WARPX_GIT_VERSION)\" -DPICSAR_GIT_VERSION=\"$(PICSAR_GIT_VERSION)\"
 
 DEFINES += -DPICSAR_NO_ASSUMED_ALIGNMENT
 DEFINES += -DWARPX
@@ -291,6 +290,18 @@ AMReX_buildInfo.cpp:
           --F_comp_name "$(F90)" --F_flags "$(F90FLAGS)" \
           --link_flags "$(LDFLAGS)" --libraries "$(libraries)" \
           --GIT ". $(AMREX_HOME) $(PICSAR_HOME)"
+
+vpath WarpXVersion.H $(srcTempDir)/Utils
+
+AUTO_BUILD_SOURCES += $(srcTempDir)/Utils/WarpXVersion.H
+
+$(srcTempDir)/Utils/WarpXVersion.H:
+	@echo Generating WarpXVersion.H ...
+	@if [ ! -d $(srcTempDir)/Utils ]; then mkdir -p $(srcTempDir)/Utils; fi
+	@ $(MKVERSIONHEADER) --code="WARPX" --defines="$(WARPX_DEFINES)" > $@
+
+cleanconfig::
+	$(SILENT) $(RM) -r $(srcTempDir)/Utils
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.rules
 

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(WarpX
     WarpXMovingWindow.cpp
     WarpXTagging.cpp
     WarpXUtil.cpp
+    WarpXVersion.cpp
 )
 
 add_subdirectory(MsgLogger)

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -1,6 +1,7 @@
 CEXE_sources += WarpXMovingWindow.cpp
 CEXE_sources += WarpXTagging.cpp
 CEXE_sources += WarpXUtil.cpp
+CEXE_sources += WarpXVersion.cpp
 CEXE_sources += WarpXAlgorithmSelection.cpp
 CEXE_sources += CoarsenIO.cpp
 CEXE_sources += CoarsenMR.cpp

--- a/Source/Utils/WarpXVersion.H.in
+++ b/Source/Utils/WarpXVersion.H.in
@@ -1,0 +1,18 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_VERSION_H_
+#define WARPX_VERSION_H_
+
+#ifndef WARPX_GIT_VERSION
+#   define WARPX_GIT_VERSION "@WarpX_GIT_VERSION@"
+#endif
+
+#ifndef PICSAR_GIT_VERSION
+#   define PICSAR_GIT_VERSION "@PXRMP_QED_GIT_VERSION@"
+#endif
+
+#endif // WARPX_VERSION_H_

--- a/Source/Utils/WarpXVersion.cpp
+++ b/Source/Utils/WarpXVersion.cpp
@@ -1,0 +1,37 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "WarpX.H"
+#include "Utils/WarpXVersion.H"
+
+#include <string>
+
+
+std::string
+WarpX::Version ()
+{
+    std::string version;
+#ifdef WARPX_GIT_VERSION
+    version = std::string(WARPX_GIT_VERSION);
+#endif
+    if( version.empty() )
+        return std::string("Unknown");
+    else
+        return version;
+}
+
+std::string
+WarpX::PicsarVersion ()
+{
+    std::string version;
+#ifdef PICSAR_GIT_VERSION
+    version = std::string(PICSAR_GIT_VERSION);
+#endif
+    if( version.empty() )
+        return std::string("Unknown");
+    else
+        return version;
+}

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -37,7 +37,6 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
-#include "Utils/WarpXVersion.H"
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
@@ -2566,32 +2565,6 @@ WarpX::RestoreCurrent (int lev)
             std::swap(current_fp[lev][idim], current_store[lev][idim]);
         }
     }
-}
-
-std::string
-WarpX::Version ()
-{
-    std::string version;
-#ifdef WARPX_GIT_VERSION
-    version = std::string(WARPX_GIT_VERSION);
-#endif
-    if( version.empty() )
-        return std::string("Unknown");
-    else
-        return version;
-}
-
-std::string
-WarpX::PicsarVersion ()
-{
-    std::string version;
-#ifdef PICSAR_GIT_VERSION
-    version = std::string(PICSAR_GIT_VERSION);
-#endif
-    if( version.empty() )
-        return std::string("Unknown");
-    else
-        return version;
 }
 
 bool

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -37,6 +37,7 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
+#include "Utils/WarpXVersion.H"
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -237,7 +237,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "6bbcbbb7829902e9038bee8c28be09800b22aab2"
+set(WarpX_amrex_branch "806f2373b68efa37120c393264647178304720b7"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -70,7 +70,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 6bbcbbb7829902e9038bee8c28be09800b22aab2 && cd -
+cd amrex && git checkout --detach 806f2373b68efa37120c393264647178304720b7 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 


### PR DESCRIPTION
Move the `-D` defines that contain the latest WarpX commit to a config file. Using always the latest commit counteracts `ccache` since the signature of the compilation call changes every commit.

- [x] CMake
- [x] GNUmake