### PR TITLE
FFT of J: Use Correct Current w/ Current Centering

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -331,9 +331,7 @@ void WarpX::PSATDBackwardTransformJ ()
         idx_jy = static_cast<int>(Idx.Jy);
         idx_jz = static_cast<int>(Idx.Jz);
 
-        auto& current = (WarpX::do_current_centering) ? current_fp_nodal : current_fp;
-
-        BackwardTransformVect(lev, *spectral_solver_fp[lev], current[lev], idx_jx, idx_jy, idx_jz);
+        BackwardTransformVect(lev, *spectral_solver_fp[lev], current_fp[lev], idx_jx, idx_jy, idx_jz);
 
         if (spectral_solver_cp[lev])
         {
@@ -343,8 +341,6 @@ void WarpX::PSATDBackwardTransformJ ()
             idx_jy = static_cast<int>(Idx.Jy);
             idx_jz = static_cast<int>(Idx.Jz);
 
-            // Current centering is not implemented with mesh refinement, so we do not yet need to
-            // distinguish between current_cp and current_cp_nodal, as for the fine patch currents
             BackwardTransformVect(lev, *spectral_solver_cp[lev], current_cp[lev], idx_jx, idx_jy, idx_jz);
         }
     }


### PR DESCRIPTION
When the current centering option is activated, we deposit the current on the nodal MultiFab `current_fp_nodal` (using here the fine patch object, to fix the ideas) and interpolate the values on the staggered MultiFab `current_fp`, using finite-order centering. This staggered MultiFab is the current density used to push the fields (also defined on staggered grids) in spectral space, so it is the one that we perform forward and backward FFTs on. The old code was performing the forward FFT of `current_fp` and the backward FFT of `current_fp_nodal`, which I think is inconsistent. The inconsistency was introduced in #2839. Not sure whether to flag this as a proper bug, though: it's more of an inconsistency that can possibly show up in the diagnostics, in my opinion. Let me know if you agree with this change,