### PR TITLE
Load-balancing heuristic weights: not negative by default

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1260,13 +1260,13 @@ private:
      * The problem setup for these tests is an empty (i.e. no particles) domain
      * of size 256 by 256 by 256 cells, from which the average time per iteration
      * per cell is computed. */
-    amrex::Real costs_heuristic_cells_wt = amrex::Real(-1);
+    amrex::Real costs_heuristic_cells_wt = amrex::Real(0);
     /** Weight factor for particles in `Heuristic` costs update.
      * Default values on GPU are determined from single-GPU tests on Summit.
      * The problem setup for these tests is a high-ppc (27 particles per cell)
      * uniform plasma on a domain of size 128 by 128 by 128, from which the approximate
      * time per iteration per particle is computed. */
-    amrex::Real costs_heuristic_particles_wt = amrex::Real(-1);
+    amrex::Real costs_heuristic_particles_wt = amrex::Real(0);
 
     // Determines timesteps for override sync
     IntervalsParser override_sync_intervals;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -340,7 +340,7 @@ WarpX::WarpX ()
     // Set default values for particle and cell weights for costs update;
     // Default values listed here for the case AMREX_USE_GPU are determined
     // from single-GPU tests on Summit.
-    if (costs_heuristic_cells_wt<0. && costs_heuristic_particles_wt<0.
+    if (costs_heuristic_cells_wt<=0. && costs_heuristic_particles_wt<=0.
         && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
     {
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
If the user uses the heuristic load-balancing cost, passes only e.g. the weight on the cells (and omits the weight on the particles like this):
```
algo.load_balance_costs_update = heuristic
algo.costs_heuristic_cells_wt = 0.4
# Users says nothing about `algo.costs_heuristic_particles_wt`
```
then the current WarpX default is that the particles are counted **negatively** (!!).
In other words, the load-balancing algorithm will try to stack boxes that have a lot of particles together on the same rank, while spreading out boxes that do not have any particle across the other ranks. (I did encounter this in practice!)

This PR avoids this issue by setting the default weights to 0. 