### PR TITLE
Bug Fix : BTD + MR, initialize output buffer only for the level in the output

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -261,9 +261,17 @@ Diagnostics::InitData ()
     // loop over all buffers
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         // loop over all levels
+        // This includes full diagnostics and BTD as well as cell-center functors for BTD.
+        // Note that the cell-centered data for BTD is computed for all levels and hence
+        // the corresponding functor is also initialized for all the levels
         for (int lev = 0; lev < nmax_lev; ++lev) {
             // allocate and initialize m_all_field_functors depending on diag type
             InitializeFieldFunctors(lev);
+        }
+        // loop over the levels selected for output
+        // This includes all the levels for full diagnostics
+        // and only the coarse level (mother grid) for BTD
+        for (int lev = 0; lev < nlev_output; ++lev) {
             // Initialize buffer data required for particle and/or fields
             InitializeBufferData(i_buffer, lev);
         }


### PR DESCRIPTION
When visualizing BTD output from simulations run with MR, the results looked skewed (see figure below)
![Screenshot from 2022-03-14 15-09-44](https://user-images.githubusercontent.com/41089244/158269734-fb2da7bd-8ca3-407f-b416-f131c243ee9b.png)

BTD output is only generated for the coarse grid, i.e., the mother grid.
When running with more than one level, the extent of the buffer multifab, (the multifab that stores the back-transformed data), is updated with level 1 grid, which is inconsistent since the buffer multifab is only generated for the coarsest level in the simulation.

This PR fixes this issue by ensuring that the buffer data is initialized only for the levels in the output, which for BTD is 1.
The input file used is 
[inputs_2d.txt](https://github.com/ECP-WarpX/WarpX/files/8248827/inputs_2d.txt)
This should fix one of the errors observed in Issue #2746. Other bug-fixes for this Issue to follow



On a related note. 
In this line (link below ), I had initialized the nlev_output to be 1 and don't update it (on purpose because we want there to be only one level for BTD output, at-least for now)
Any suggestions on a better approach? if yes, let me know, and I will add that as a separate mini-PR
https://github.com/ECP-WarpX/WarpX/blob/f3fecb3324ed42be8985c0ff495597f70d21f317/Source/Diagnostics/BTDiagnostics.cpp#L61 




