### PR TITLE
Docs: Cori Python & Testing

### DIFF
--- a/Docs/source/install/hpc/cori.rst
+++ b/Docs/source/install/hpc/cori.rst
@@ -78,7 +78,17 @@ For PICMI and Python workflows, also install a virtual environment:
    source $HOME/sw/venvs/knl_warpx/bin/activate
 
    python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade wheel
+   python3 -m pip install --upgrade cython
+   python3 -m pip install --upgrade numpy
+   python3 -m pip install --upgrade pandas
+   python3 -m pip install --upgrade scipy
    MPICC="cc -shared" python3 -m pip install -U --no-cache-dir -v mpi4py
+   python3 -m pip install --upgrade openpmd-api
+   python3 -m pip install --upgrade matplotlib
+   python3 -m pip install --upgrade yt
+   # optional: for libEnsemble
+   #python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
 Haswell
 ^^^^^^^
@@ -131,7 +141,17 @@ For PICMI and Python workflows, also install a virtual environment:
    source $HOME/sw/venvs/haswell_warpx/bin/activate
 
    python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade wheel
+   python3 -m pip install --upgrade cython
+   python3 -m pip install --upgrade numpy
+   python3 -m pip install --upgrade pandas
+   python3 -m pip install --upgrade scipy
    MPICC="cc -shared" python3 -m pip install -U --no-cache-dir -v mpi4py
+   python3 -m pip install --upgrade openpmd-api
+   python3 -m pip install --upgrade matplotlib
+   python3 -m pip install --upgrade yt
+   # optional: for libEnsemble
+   #python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
 GPU (V100)
 ^^^^^^^^^^
@@ -173,7 +193,17 @@ For PICMI and Python workflows, also install a virtual environment:
    source $HOME/sw/venvs/gpu_warpx/bin/activate
 
    python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade wheel
+   python3 -m pip install --upgrade cython
+   python3 -m pip install --upgrade numpy
+   python3 -m pip install --upgrade pandas
+   python3 -m pip install --upgrade scipy
    python3 -m pip install -U --no-cache-dir -v mpi4py
+   python3 -m pip install --upgrade openpmd-api
+   python3 -m pip install --upgrade matplotlib
+   python3 -m pip install --upgrade yt
+   # optional: for libEnsemble
+   #python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
 Building WarpX
 --------------
@@ -220,7 +250,31 @@ The general :ref:`cmake compile-time options and instructions for Python (PICMI)
    cd $HOME/src/warpx
 
    # compile parallel PICMI interfaces with openPMD support and 3D, 2D and RZ
-   WARPX_MPI=ON BUILD_PARALLEL=16 python3 -m pip install --force-reinstall -v .
+   WARPX_MPI=ON BUILD_PARALLEL=16 python3 -m pip install --force-reinstall --no-deps -v .
+
+
+.. _building-cori-tests:
+
+Testing
+-------
+
+To run all tests (here on KNL), do:
+
+* change in ``Regressions/WarpX-tests.ini`` from ``mpiexec`` to ``srun``: ``MPIcommand = srun -n @nprocs@ @command@``
+
+.. code-block:: bash
+
+   # set test directory to a shared directory available on all nodes
+   #   note: the tests will create the directory automatically
+   export WARPX_CI_TMP="$HOME/warpx-regression-tests"
+
+   # compile with more cores
+   export WARPX_CI_NUM_MAKE_JOBS=16
+
+   # run all integration tests
+   #   note: we set MPICC as a build-setting for mpi4py on KNL/Haswell
+   MPICC="cc -shared" ./run_test.sh
+
 
 .. _running-cpp-cori:
 


### PR DESCRIPTION
- improve the `--force-reinstall` logic to not trigger a forced re-install of WarpX Python dependencies
- install WarpX Python dependencies upfront
- add a first "testing" section to show how to run `./run_tests.sh` on Cori