### PR TITLE
openPMD: Only Write up to Finest Level

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -32,7 +32,7 @@ public:
         const amrex::Vector<amrex::MultiFab>& mf,
         amrex::Vector<amrex::Geometry>& geom,
         const amrex::Vector<int> iteration, const double time,
-        const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/,
+        const amrex::Vector<ParticleDiag>& particle_diags, int output_levels,
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -128,7 +128,7 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<amrex::MultiFab>& mf,
     amrex::Vector<amrex::Geometry>& geom,
     const amrex::Vector<int> iteration, const double time,
-    const amrex::Vector<ParticleDiag>& particle_diags, int /*nlev*/,
+    const amrex::Vector<ParticleDiag>& particle_diags, int output_levels,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
     bool isBTD, int snapshotID, const amrex::Geometry& full_BTD_snapshot,
@@ -152,7 +152,7 @@ FlushFormatOpenPMD::WriteToFile (
 
     // fields: only dumped for coarse level
     m_OpenPMDPlotWriter->WriteOpenPMDFieldsAll(
-        varnames, mf, geom, output_iteration, time, isBTD, full_BTD_snapshot);
+        varnames, mf, geom, output_levels, output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
     m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, isBTD, totalParticlesFlushedAlready);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -137,11 +137,25 @@ public:
               const bool isBTD = false,
               const amrex::Vector<int>& totalParticlesFlushedAlready = amrex::Vector<int>());
 
+  /** Write out all openPMD fields for all active MR levels
+   *
+   * @param varnames variable names in each multifab
+   * @param mf multifab for each level
+   * @param geometry for each level
+   * @param output_levels the finest level to output, <= maxLevel
+   * @param iteration the current iteration or reconstructed labframe station number
+   * @param time the current simulation time in the lab frame
+   * @param isBTD true if this is part of a back-transformed diagnostics (BTD) station flush;
+                  in BTD, we write multiple times to the same iteration
+   * @param full_BTD_snapshot the geometry of the full lab frame for BTD
+   */
   void WriteOpenPMDFieldsAll (
               const std::vector<std::string>& varnames,
               const amrex::Vector<amrex::MultiFab>& mf,
               amrex::Vector<amrex::Geometry>& geom,
-              const int iteration, const double time,
+              int output_levels,
+              const int iteration,
+              const double time,
               bool isBTD = false,
               const amrex::Geometry& full_BTD_snapshot=amrex::Geometry() ) const;
 


### PR DESCRIPTION
With #2948, now that we support "dynamic" levels, we need to differentiate between the maximum allowed refinement level (maxLevel) and the currently maximum used level (finestLevel) of a simulation.

This should fix https://github.com/openPMD/openPMD-api/issues/1212