### PR TITLE
Minimum digits for plotfile cell and particle data is 5

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -217,6 +217,7 @@ BTDiagnostics::DoComputeAndPack (int step, bool force_flush)
 void
 BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
 {
+    lev = 0;
     auto & warpx = WarpX::GetInstance();
     // Lab-frame time for the i^th snapshot
     m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab;
@@ -505,7 +506,6 @@ BTDiagnostics::PrepareFieldDataForOutput ()
     }
 
     int num_BT_functors = 1;
-
     for (int lev = 0; lev < nlev_output; ++lev)
     {
         for (int i = 0; i < num_BT_functors; ++i)
@@ -741,6 +741,10 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
     auto & warpx = WarpX::GetInstance();
     const amrex::Vector<int> iteration = warpx.getistep();
+    // Minimum number of digits for plotfile containing multifab data (Cell_H_XXXXX)
+    const int amrex_fabfile_min_digits = 5;
+    // Minimum number of digits for plotfile containing particle data (DATA_XXXXX)
+    const int amrex_partfile_min_digits = 5;
     if (amrex::ParallelContext::IOProcessorSub()) {
         // Path to final snapshot plotfiles
         std::string snapshot_path = amrex::Concatenate(m_file_prefix, i_snapshot, m_file_min_digits);
@@ -786,10 +790,13 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
             std::string recent_Buffer_FabFilename = recent_Buffer_Level0_path + "/"
                                                   + Buffer_FabHeader.FabName(0);
             // Existing snapshot Fab Header Filename
+            // Cell_D_<number> is padded with 5 zeros as that is the default AMReX output
+            // The number is the multifab ID here.
             std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
-            std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], m_file_min_digits);
+            std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], amrex_fabfile_min_digits);
             // Name of the newly appended fab in the snapshot
-            std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],m_file_min_digits);
+            // Cell_D_<number> is padded with 5 zeros as that is the default AMReX output
+            std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],amrex_fabfile_min_digits);
 
             if ( m_buffer_flush_counter[i_snapshot] == 0) {
                 std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
@@ -821,10 +828,11 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
                                                      m_output_species_names[i]);
             BufferSpeciesHeader.ReadHeader();
             // only one box is flushed out at a time
+            // DATA_<number> is padded with 5 zeros as that is the default AMReX output for plotfile
+            // The number is the ID of the multifab that the particles belong to.
             std::string recent_ParticleDataFilename = amrex::Concatenate(
                 recent_species_prefix + "/Level_0/DATA_",
-                BufferSpeciesHeader.m_which_data[0][0],
-                m_file_min_digits);
+                BufferSpeciesHeader.m_which_data[0][0],amrex_partfile_min_digits);
             // Path to snapshot particle files
             std::string snapshot_species_path = snapshot_path + "/" + m_output_species_names[i];
             std::string snapshot_species_Level0path = snapshot_species_path + "/Level_0";
@@ -832,8 +840,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
             std::string snapshot_ParticleHdrFilename = snapshot_species_Level0path + "/Particle_H";
             std::string snapshot_ParticleDataFilename = amrex::Concatenate(
                 snapshot_species_Level0path + "/DATA_",
-                m_buffer_flush_counter[i_snapshot],
-                m_file_min_digits);
+                m_buffer_flush_counter[i_snapshot],amrex_partfile_min_digits);
 
             if (m_buffer_flush_counter[i_snapshot] == 0) {
                 BufferSpeciesHeader.set_DataIndex(0,0,m_buffer_flush_counter[i_snapshot]);
@@ -1028,7 +1035,6 @@ BTDiagnostics::InitializeParticleBuffer ()
 void
 BTDiagnostics::PrepareParticleDataForOutput()
 {
-
     auto& warpx = WarpX::GetInstance();
     for (int lev = 0; lev < nlev_output; ++lev) {
         for (int i = 0; i < m_all_particle_functors.size(); ++i)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -740,7 +740,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
     auto & warpx = WarpX::GetInstance();
     const amrex::Vector<int> iteration = warpx.getistep();
-    // number of digits for plotfile containing multifab data (Cell_H_XXXXX)
+    // number of digits for plotfile containing multifab data (Cell_D_XXXXX)
     // the digits here are "multifab ids" (independent of the step) and thus always small
     const int amrex_fabfile_digits = 5;
     // number of digits for plotfile containing particle data (DATA_XXXXX)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -217,7 +217,6 @@ BTDiagnostics::DoComputeAndPack (int step, bool force_flush)
 void
 BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
 {
-    lev = 0;
     auto & warpx = WarpX::GetInstance();
     // Lab-frame time for the i^th snapshot
     m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab;
@@ -741,10 +740,12 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
 
     auto & warpx = WarpX::GetInstance();
     const amrex::Vector<int> iteration = warpx.getistep();
-    // Minimum number of digits for plotfile containing multifab data (Cell_H_XXXXX)
-    const int amrex_fabfile_min_digits = 5;
-    // Minimum number of digits for plotfile containing particle data (DATA_XXXXX)
-    const int amrex_partfile_min_digits = 5;
+    // number of digits for plotfile containing multifab data (Cell_H_XXXXX)
+    // the digits here are "multifab ids" (independent of the step) and thus always small
+    const int amrex_fabfile_digits = 5;
+    // number of digits for plotfile containing particle data (DATA_XXXXX)
+    // the digits here are "... ids" (independent of the step) and thus always small
+    const int amrex_partfile_digits = 5;
     if (amrex::ParallelContext::IOProcessorSub()) {
         // Path to final snapshot plotfiles
         std::string snapshot_path = amrex::Concatenate(m_file_prefix, i_snapshot, m_file_min_digits);
@@ -793,10 +794,10 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
             // Cell_D_<number> is padded with 5 zeros as that is the default AMReX output
             // The number is the multifab ID here.
             std::string snapshot_FabHeaderFilename = snapshot_Level0_path + "/Cell_H";
-            std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_",m_buffer_flush_counter[i_snapshot], amrex_fabfile_min_digits);
+            std::string snapshot_FabFilename = amrex::Concatenate(snapshot_Level0_path+"/Cell_D_", m_buffer_flush_counter[i_snapshot], amrex_fabfile_digits);
             // Name of the newly appended fab in the snapshot
             // Cell_D_<number> is padded with 5 zeros as that is the default AMReX output
-            std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_",m_buffer_flush_counter[i_snapshot],amrex_fabfile_min_digits);
+            std::string new_snapshotFabFilename = amrex::Concatenate("Cell_D_", m_buffer_flush_counter[i_snapshot], amrex_fabfile_digits);
 
             if ( m_buffer_flush_counter[i_snapshot] == 0) {
                 std::rename(recent_Header_filename.c_str(), snapshot_Header_filename.c_str());
@@ -832,7 +833,8 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
             // The number is the ID of the multifab that the particles belong to.
             std::string recent_ParticleDataFilename = amrex::Concatenate(
                 recent_species_prefix + "/Level_0/DATA_",
-                BufferSpeciesHeader.m_which_data[0][0],amrex_partfile_min_digits);
+                BufferSpeciesHeader.m_which_data[0][0],
+                amrex_partfile_digits);
             // Path to snapshot particle files
             std::string snapshot_species_path = snapshot_path + "/" + m_output_species_names[i];
             std::string snapshot_species_Level0path = snapshot_species_path + "/Level_0";
@@ -840,7 +842,8 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
             std::string snapshot_ParticleHdrFilename = snapshot_species_Level0path + "/Particle_H";
             std::string snapshot_ParticleDataFilename = amrex::Concatenate(
                 snapshot_species_Level0path + "/DATA_",
-                m_buffer_flush_counter[i_snapshot],amrex_partfile_min_digits);
+                m_buffer_flush_counter[i_snapshot],
+                amrex_partfile_digits);
 
             if (m_buffer_flush_counter[i_snapshot] == 0) {
                 BufferSpeciesHeader.set_DataIndex(0,0,m_buffer_flush_counter[i_snapshot]);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -744,7 +744,7 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
     // the digits here are "multifab ids" (independent of the step) and thus always small
     const int amrex_fabfile_digits = 5;
     // number of digits for plotfile containing particle data (DATA_XXXXX)
-    // the digits here are "... ids" (independent of the step) and thus always small
+    // the digits here are fab ids that the particles belong to (independent of the step) and thus always small
     const int amrex_partfile_digits = 5;
     if (amrex::ParallelContext::IOProcessorSub()) {
         // Path to final snapshot plotfiles


### PR DESCRIPTION
Plotfile output contains Cell_D_XXXXX with mutlifab data and DATA_XXXXX with particle data.
The digits here are multifab numbers and usually very small, so they cannot overflow. AMReX expects them to be exactly 5 digits in a couple of places right now.

For BTD, we merge buffers written in plotfile format so that we have one single plotfile (with merged buffer output) for a given lab-frame snapshot.
When ensuring that the file format for diagnostics contained default (6) or user-defined minimum digits, in PR #2910 , we also modified the files with 5 digits. This PR fixes this. 

A CI-test to catch this earlier is coming up in a follow-up PR. 
(Currently there is another bug with BTD and particle output)


