### PR TITLE
[WIP] Azure: Compile with `-g`

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     CEI_SUDO: 'sudo'
     CEI_TMP: '/tmp/cei'
     CMAKE_GENERATOR: 'Ninja'
+    CXXFLAGS: '-g'
     FFTW_HOME: '/usr'
     LAPACKPP_HOME: '/usr/local'
     OMP_NUM_THREADS: 1

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
         openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pandas python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
-      ccache --set-config=max_size=2.0G
+      ccache --set-config=max_size=5.0G
       python3 -m pip install --upgrade pip
       python3 -m pip install --upgrade setuptools
       python3 -m pip install --upgrade wheel

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
         WARPX_CI_EB: 'TRUE'
 
   # default: 60; maximum: 360
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
 
   steps:
   # set up caches:
@@ -82,7 +82,7 @@ jobs:
         openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pandas python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
-      ccache --set-config=max_size=10.0G
+      ccache --set-config=max_size=2.0G
       python3 -m pip install --upgrade pip
       python3 -m pip install --upgrade setuptools
       python3 -m pip install --upgrade wheel


### PR DESCRIPTION
Uses default compilation type (`Release`) which implies `-O3`, but adds `-g` debug symbols (just larger binaries) for more useful backtraces.

First seen in #2878.