### PR TITLE
LaserAccelection_1d: Use same build as other 1D tests

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1025,8 +1025,8 @@ buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs_1d
 runtime_params =
 dim = 1
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=1
+addToCompileString = USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 2


### PR DESCRIPTION
This should cut ~6:30 off the 1D CI build/test, with no negative impact.