### PR TITLE
Add profile region for Evolve

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -57,6 +57,7 @@ using namespace amrex;
 void
 WarpX::Evolve (int numsteps)
 {
+    WARPX_PROFILE_REGION("WarpX::Evolve()");
     WARPX_PROFILE("WarpX::Evolve()");
 
     Real cur_time = t_new[0];


### PR DESCRIPTION
It turns out that this is needed in order for WarpX to work with the AMRVis visualization of the profiling timeline.