### PR TITLE
Measure time taken in the moving window

### DIFF
--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -80,6 +80,8 @@ WarpX::UpdatePlasmaInjectionPosition (amrex::Real a_dt)
 int
 WarpX::MoveWindow (const int step, bool move_j)
 {
+    WARPX_PROFILE("WarpX::MoveWindow");
+
     if (step == start_moving_window_step) {
         amrex::Print() << Utils::TextMsg::Info("Starting moving window");
     }


### PR DESCRIPTION
This adds a timer of the function `MoveWindow`. 
By looking at the corresponding **inclusive** time in the Tiny profiler report, one should be able to see the cost associated with moving the window.