### PR TITLE
BTD : Redistribute Particles in buffer to lab frame box array and copy with (local=true)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -106,7 +106,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd amrex && git checkout --detach 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7 && cd -
+        cd amrex && git checkout --detach e213d767baab66574b2f29daf23e7288e6f1a8df && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-9-nvcc:

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7
+branch = e213d767baab66574b2f29daf23e7288e6f1a8df
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -353,6 +353,8 @@ private:
     void ResetTotalParticlesInBuffer(int i_buffer);
     /** Clear particle data stored in the particle buffer */
     void ClearParticleBuffer(int i_buffer);
+    /** Redistributes particles to the buffer box array in the lab-frame */
+    void RedistributeParticleBuffer (const int i_buffer);
 
 };
 #endif // WARPX_BTDIAGNOSTICS_H_

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -708,6 +708,10 @@ BTDiagnostics::Flush (int i_buffer)
     bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 ) ? true : false;
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];
+
+    // Redistribute particles in the lab frame box arrays that correspond to the buffer
+    RedistributeParticleBuffer(i_buffer);
+
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         labtime, m_output_species[i_buffer], nlev_output, file_name, m_file_min_digits,
@@ -727,6 +731,13 @@ BTDiagnostics::Flush (int i_buffer)
         UpdateTotalParticlesFlushed(i_buffer);
         ResetTotalParticlesInBuffer(i_buffer);
         ClearParticleBuffer(i_buffer);
+    }
+}
+
+void BTDiagnostics::RedistributeParticleBuffer (const int i_buffer)
+{
+    for (int isp = 0; isp < m_particles_buffer[i_buffer].size(); ++isp) {
+        m_particles_buffer[i_buffer][isp]->Redistribute();
     }
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -736,7 +736,7 @@ BTDiagnostics::Flush (int i_buffer)
 
 void BTDiagnostics::RedistributeParticleBuffer (const int i_buffer)
 {
-    for (int isp = 0; isp < m_particles_buffer[i_buffer].size(); ++isp) {
+    for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
         m_particles_buffer[i_buffer][isp]->Redistribute();
     }
 }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -367,7 +367,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
             }, true);
         } else {
             PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
-            tmp.copyParticles(*pinned_pc);
+            tmp.copyParticles(*pinned_pc, true);
         }
         // real_names contains a list of all particle attributes.
         // real_flags & int_flags are 1 or 0, whether quantity is dumped or not.

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -721,6 +721,16 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
         SetConstParticleRecordsEDPIC(currSpecies, NewParticleVectorSize, charge, mass);
     }
 
+
+    amrex::Print() << "isBTD=" << isBTD << std::endl;
+    amrex::Print() << "iteration=" << iteration << std::endl;
+    amrex::Print() << "num_dump_particles=" << num_dump_particles << std::endl;
+    amrex::Print() << "ParticleFlushOffset=" << ParticleFlushOffset << std::endl;
+    amrex::Print() << "doParticleSetup=" << doParticleSetup << std::endl;
+    amrex::Print() << "is_resizing_flush=" << is_resizing_flush << std::endl;
+    amrex::Print() << "is_last_flush_and_never_particles=" << is_last_flush_and_never_particles << std::endl;
+    amrex::Print() << "is_last_flush_to_step=" << is_last_flush_to_step << std::endl;
+
     // open files from all processors, in case some will not contribute below
     m_Series->flush();
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -619,7 +619,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
           tmp.SetParticleGeometry(0,pinned_pc->Geom(0));
           tmp.SetParticleBoxArray(0,pinned_pc->ParticleBoxArray(0));
           tmp.SetParticleDistributionMap(0, pinned_pc->ParticleDistributionMap(0));
-          tmp.copyParticles(*pinned_pc);
+          tmp.copyParticles(*pinned_pc, true);
       }
 
     // real_names contains a list of all real particle attributes.

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -721,16 +721,6 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
         SetConstParticleRecordsEDPIC(currSpecies, NewParticleVectorSize, charge, mass);
     }
 
-
-    amrex::Print() << "isBTD=" << isBTD << std::endl;
-    amrex::Print() << "iteration=" << iteration << std::endl;
-    amrex::Print() << "num_dump_particles=" << num_dump_particles << std::endl;
-    amrex::Print() << "ParticleFlushOffset=" << ParticleFlushOffset << std::endl;
-    amrex::Print() << "doParticleSetup=" << doParticleSetup << std::endl;
-    amrex::Print() << "is_resizing_flush=" << is_resizing_flush << std::endl;
-    amrex::Print() << "is_last_flush_and_never_particles=" << is_last_flush_and_never_particles << std::endl;
-    amrex::Print() << "is_last_flush_to_step=" << is_last_flush_to_step << std::endl;
-
     // open files from all processors, in case some will not contribute below
     m_Series->flush();
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -237,7 +237,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7"
+set(WarpX_amrex_branch "e213d767baab66574b2f29daf23e7288e6f1a8df"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -70,7 +70,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7 && cd -
+cd amrex && git checkout --detach e213d767baab66574b2f29daf23e7288e6f1a8df && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 


### PR DESCRIPTION
When copy particles before we flush the data with plotfile format, we set local=true. 
Otherwise before writing the data, the cell-indices of the particles are determined and are mapped to the box array. 
This is not required when we flush the particle data for BTD, similar to the regular full diagnostics.


Without this change, sometimes, a segfault is generated with 
`amrex::Abort::0::ParticleContainer::locateParticle(): invalid particle. !!!`

Here is the input file I used to test this
[inputs_test1.txt](https://github.com/ECP-WarpX/WarpX/files/8337830/inputs_test1.txt)

Update : 
This PR also Redistributes particles in the lab-frame buffer before copying them to tmp particle containers that are flushed out

