### PR TITLE
Switch test to use common build with openPMD enabled

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2008,7 +2008,7 @@ customRunCmd = ./analysis.py
 runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
 addToCompileString = USE_OPENPMD=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2007,7 +2007,7 @@ aux1File = Examples/Modules/laser_injection_from_file/inputs.2d_test_txye
 customRunCmd = ./analysis.py
 runtime_params = warpx.do_dynamic_scheduling=0
 dim = 2
-addToCompileString = USE_OPENPMD=FALSE
+addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1


### PR DESCRIPTION
This should cut a couple minutes off the `cartesian2d` CI build, since it's the only one in 2D that specifies ` -DWarpX_OPENPMD=OFF`