### PR TITLE
ABLASTR: Compute Phi

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -7,83 +7,101 @@
 #ifndef ELECTROSTATICSOLVER_H_
 #define ELECTROSTATICSOLVER_H_
 
-#include "Utils/WarpXUtil.H"
-
 #include <AMReX_Array.H>
-#include <AMReX_MLNodeTensorLaplacian.H>
-#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
-#    include <AMReX_MLEBNodeFDLaplacian.H>
-#endif
-#include <AMReX_Parser.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MLMG.H>
 #include <AMReX_REAL.H>
+#include <AMReX_Parser.H>
 
 namespace ElectrostaticSolver {
 
-struct PhiCalculatorEB {
+    struct PhiCalculatorEB {
 
-    amrex::Real t;
-    amrex::ParserExecutor<4> potential_eb;
+        amrex::Real t;
+        amrex::ParserExecutor<4> potential_eb;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    amrex::Real operator() (const amrex::Real x, const amrex::Real z) const noexcept
-    {
-        using namespace amrex::literals;
-        return potential_eb(x, 0.0_rt, z, t);
-    }
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::Real operator()(const amrex::Real x, const amrex::Real z) const noexcept {
+            using namespace amrex::literals;
+            return potential_eb(x, 0.0_rt, z, t);
+        }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    amrex::Real operator() (const amrex::Real x, const amrex::Real y, const amrex::Real z) const noexcept
-    {
-        return potential_eb(x, y, z, t);
-    }
-};
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::Real operator()(const amrex::Real x, const amrex::Real y, const amrex::Real z) const noexcept {
+            return potential_eb(x, y, z, t);
+        }
+    };
 
-class BoundaryHandler {
+    class PoissonBoundaryHandler {
+    public:
 
-public:
+        amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM> lobc, hibc;
+        bool bcs_set = false;
+        std::array<bool, AMREX_SPACEDIM * 2> dirichlet_flag;
+        bool has_non_periodic = false;
+        bool phi_EB_only_t = true;
 
-    amrex::Array<amrex::LinOpBCType,AMREX_SPACEDIM> lobc, hibc;
-    bool bcs_set = false;
-    std::array<bool,AMREX_SPACEDIM*2> dirichlet_flag;
-    bool has_non_periodic = false;
-    bool phi_EB_only_t = true;
+        void definePhiBCs ();
 
-    void definePhiBCs ();
-    void buildParsers ();
+        void buildParsers ();
 
-    PhiCalculatorEB getPhiEB (amrex::Real t) const noexcept
-    {
-        return PhiCalculatorEB{t, potential_eb};
-    }
+        PhiCalculatorEB getPhiEB(amrex::Real t) const noexcept {
+            return PhiCalculatorEB{t, potential_eb};
+        }
 
-    // set default potentials to zero in order for current tests to pass
-    // but forcing the user to specify a potential might be better
-    std::string potential_xlo_str = "0";
-    std::string potential_xhi_str = "0";
-    std::string potential_ylo_str = "0";
-    std::string potential_yhi_str = "0";
-    std::string potential_zlo_str = "0";
-    std::string potential_zhi_str = "0";
-    std::string potential_eb_str = "0";
+        // set default potentials to zero in order for current tests to pass
+        // but forcing the user to specify a potential might be better
+        std::string potential_xlo_str = "0";
+        std::string potential_xhi_str = "0";
+        std::string potential_ylo_str = "0";
+        std::string potential_yhi_str = "0";
+        std::string potential_zlo_str = "0";
+        std::string potential_zhi_str = "0";
+        std::string potential_eb_str = "0";
 
-    amrex::ParserExecutor<1> potential_xlo;
-    amrex::ParserExecutor<1> potential_xhi;
-    amrex::ParserExecutor<1> potential_ylo;
-    amrex::ParserExecutor<1> potential_yhi;
-    amrex::ParserExecutor<1> potential_zlo;
-    amrex::ParserExecutor<1> potential_zhi;
-    amrex::ParserExecutor<1> potential_eb_t;
-    amrex::ParserExecutor<4> potential_eb;
+        amrex::ParserExecutor<1> potential_xlo;
+        amrex::ParserExecutor<1> potential_xhi;
+        amrex::ParserExecutor<1> potential_ylo;
+        amrex::ParserExecutor<1> potential_yhi;
+        amrex::ParserExecutor<1> potential_zlo;
+        amrex::ParserExecutor<1> potential_zhi;
+        amrex::ParserExecutor<1> potential_eb_t;
+        amrex::ParserExecutor<4> potential_eb;
 
-private:
+    private:
 
-    amrex::Parser potential_xlo_parser;
-    amrex::Parser potential_xhi_parser;
-    amrex::Parser potential_ylo_parser;
-    amrex::Parser potential_yhi_parser;
-    amrex::Parser potential_zlo_parser;
-    amrex::Parser potential_zhi_parser;
-    amrex::Parser potential_eb_parser;
-};
-}
-#endif
+        amrex::Parser potential_xlo_parser;
+        amrex::Parser potential_xhi_parser;
+        amrex::Parser potential_ylo_parser;
+        amrex::Parser potential_yhi_parser;
+        amrex::Parser potential_zlo_parser;
+        amrex::Parser potential_zhi_parser;
+        amrex::Parser potential_eb_parser;
+    };
+
+    /** use amrex to directly calculate the electric field since with EB's the
+     *
+     * simple finite difference scheme in WarpX::computeE sometimes fails
+     */
+    class EBCalcEfromPhiPerLevel {
+      private:
+        amrex::Vector<
+            amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM>
+        > m_e_field;
+
+      public:
+        EBCalcEfromPhiPerLevel(amrex::Vector<amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> > e_field)
+                : m_e_field(e_field) {}
+
+        void operator()(amrex::MLMG & mlmg, int const lev) {
+            using namespace amrex::literals;
+
+            mlmg.getGradSolution({m_e_field[lev]});
+            for (auto &field: m_e_field[lev]) {
+                field->mult(-1._rt);
+            }
+        }
+    };
+} // namespace ElectrostaticSolver
+
+#endif // ELECTROSTATICSOLVER_H_

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -17,6 +17,7 @@
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
+#include <ablastr/fields/PoissonSolver.H>
 #include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
@@ -43,6 +44,9 @@
 #include <AMReX_SPACE.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MFInterp_C.H>
+#ifdef AMREX_USE_EB
+#   include <AMReX_EBFabFactory.H>
+#endif
 
 #include <array>
 #include <memory>
@@ -104,7 +108,7 @@ WarpX::AddBoundaryField ()
 
     // Store the boundary conditions for the field solver if they haven't been
     // stored yet
-    if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
+    if (!m_poisson_boundary_handler.bcs_set) m_poisson_boundary_handler.definePhiBCs();
 
     // Allocate fields for charge and potential
     const int num_levels = max_level + 1;
@@ -144,7 +148,7 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
 
     // Store the boundary conditions for the field solver if they haven't been
     // stored yet
-    if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
+    if (!m_poisson_boundary_handler.bcs_set) m_poisson_boundary_handler.definePhiBCs();
 
 #ifdef WARPX_DIM_RZ
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
@@ -195,7 +199,7 @@ WarpX::AddSpaceChargeFieldLabFrame ()
 
     // Store the boundary conditions for the field solver if they haven't been
     // stored yet
-    if (!field_boundary_handler.bcs_set) field_boundary_handler.definePhiBCs();
+    if (!m_poisson_boundary_handler.bcs_set) m_poisson_boundary_handler.definePhiBCs();
 
 #ifdef WARPX_DIM_RZ
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
@@ -276,184 +280,70 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    int const max_iters,
                    int const verbosity) const
 {
-    // scale rho appropriately; also determine if rho is zero everywhere
-    amrex::Real max_norm_b = 0.0;
-    for (int lev=0; lev < rho.size(); lev++){
-        rho[lev]->mult(-1._rt/PhysConst::ep0);
-        max_norm_b = amrex::max(max_norm_b, rho[lev]->norm0());
-    }
-    amrex::ParallelDescriptor::ReduceRealMax(max_norm_b);
-
-    bool always_use_bnorm = (max_norm_b > 0);
-    if (!always_use_bnorm) {
-        if (absolute_tolerance == 0.0) absolute_tolerance = amrex::Real(1e-6);
-        ablastr::warn_manager::WMRecordWarning(
-            "ElectrostaticSolver", "Max norm of rho is 0",
-            ablastr::warn_manager::WarnPriority::low
-        );
-    }
-
-    LPInfo info;
-
-    for (int lev=0; lev<=finest_level; lev++) {
-        // Set the value of beta
-        amrex::Array<amrex::Real,AMREX_SPACEDIM> beta_solver =
-#if defined(WARPX_DIM_1D_Z)
-            {{ beta[2] }};  // beta_x and beta_z
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-            {{ beta[0], beta[2] }};  // beta_x and beta_z
-#else
-            {{ beta[0], beta[1], beta[2] }};
-#endif
-
-#if !(defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ))
-        // Determine whether to use semi-coarsening
-        Array<Real,AMREX_SPACEDIM> dx_scaled
-            {AMREX_D_DECL(Geom(lev).CellSize(0)/std::sqrt(1._rt-beta_solver[0]*beta_solver[0]),
-                          Geom(lev).CellSize(1)/std::sqrt(1._rt-beta_solver[1]*beta_solver[1]),
-                          Geom(lev).CellSize(2)/std::sqrt(1._rt-beta_solver[2]*beta_solver[2]))};
-        int max_semicoarsening_level = 0;
-        int semicoarsening_direction = -1;
-        int min_dir = std::distance(dx_scaled.begin(),
-                                    std::min_element(dx_scaled.begin(),dx_scaled.end()));
-        int max_dir = std::distance(dx_scaled.begin(),
-                                    std::max_element(dx_scaled.begin(),dx_scaled.end()));
-        if (dx_scaled[max_dir] > dx_scaled[min_dir]) {
-            semicoarsening_direction = max_dir;
-            max_semicoarsening_level = static_cast<int>
-                (std::log2(dx_scaled[max_dir]/dx_scaled[min_dir]));
-        }
-        if (max_semicoarsening_level > 0) {
-            info.setSemicoarsening(true);
-            info.setMaxSemicoarseningLevel(max_semicoarsening_level);
-            info.setSemicoarseningDirection(semicoarsening_direction);
-        }
-#endif
-
-#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
-        // In the presence of EB or RZ: the solver assumes that the beam is
-        // propagating along  one of the axes of the grid, i.e. that only *one*
-        // of the components of `beta` is non-negligible.
-        MLEBNodeFDLaplacian linop( {Geom(lev)}, {boxArray(lev)}, {DistributionMap(lev)}, info
+    std::optional<ElectrostaticSolver::EBCalcEfromPhiPerLevel> post_phi_calculation;
 #if defined(AMREX_USE_EB)
-            , {&WarpX::fieldEBFactory(lev)}
-#endif
-        );
 
-        // Note: this assumes that the beam is propagating along
-        // one of the axes of the grid, i.e. that only *one* of the
-        // components of `beta` is non-negligible. // we use this
-#if defined(WARPX_DIM_RZ)
-        linop.setSigma({0._rt, 1._rt-beta_solver[1]*beta_solver[1]});
-#else
-        linop.setSigma({AMREX_D_DECL(
-            1._rt-beta_solver[0]*beta_solver[0],
-            1._rt-beta_solver[1]*beta_solver[1],
-            1._rt-beta_solver[2]*beta_solver[2])});
-#endif
-
-#if defined(AMREX_USE_EB)
-        // if the EB potential only depends on time, the potential can be passed
-        // as a float instead of a callable
-        if (field_boundary_handler.phi_EB_only_t) {
-            linop.setEBDirichlet(field_boundary_handler.potential_eb_t(gett_new(0)));
-        }
-        else linop.setEBDirichlet(field_boundary_handler.getPhiEB(gett_new(0)));
-#endif
-#else
-        // In the absence of EB and RZ: use a more generic solver
-        // that can handle beams propagating in any direction
-        MLNodeTensorLaplacian linop( {Geom(lev)}, {boxArray(lev)},
-            {DistributionMap(lev)}, info );
-        linop.setBeta( beta_solver ); // for the non-axis-aligned solver
-#endif
-
-        // Solve the Poisson equation
-        linop.setDomainBC( field_boundary_handler.lobc, field_boundary_handler.hibc );
-#ifdef WARPX_DIM_RZ
-        linop.setRZ(true);
-#endif
-        MLMG mlmg(linop); // actual solver defined here
-        mlmg.setVerbose(verbosity);
-        mlmg.setMaxIter(max_iters);
-        mlmg.setAlwaysUseBNorm(always_use_bnorm);
-
-        // Solve Poisson equation at lev
-        mlmg.solve( {phi[lev].get()}, {rho[lev].get()},
-                    required_precision, absolute_tolerance );
-
-        // needed for solving the levels by levels:
-        // - coarser level is initial guess for finer level
-        // - coarser level provides boundary varlues for finer level patch
-        // Interpolation from phi[lev] to phi[lev+1]
-        // (This provides both the boundary conditions and initial guess for phi[lev+1])
-        if (lev < finest_level) {
-
-            // Allocate phi_cp for lev+1
-            BoxArray ba = phi[lev+1]->boxArray();
-            const IntVect& refratio = refRatio(lev);
-            ba.coarsen(refratio);
-            const int ncomp = linop.getNComp();
-            MultiFab phi_cp(ba, phi[lev+1]->DistributionMap(), ncomp, 1);
-
-            // Copy from phi[lev] to phi_cp (in parallel)
-            const amrex::IntVect& ng = IntVect::TheUnitVector();
-            const amrex::Periodicity& crse_period = Geom(lev).periodicity();
-            ablastr::utils::communication::ParallelCopy(phi_cp, *phi[lev], 0, 0, 1, ng, ng,
-                                                        WarpX::do_single_precision_comms,
-                                                        crse_period);
-
-            // Local interpolation from phi_cp to phi[lev+1]
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-            for (MFIter mfi(*phi[lev+1],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-                Array4<Real> const& phi_fp_arr = phi[lev+1]->array(mfi);
-                Array4<Real> const& phi_cp_arr = phi_cp.array(mfi);
-
-                Box const& b = mfi.tilebox(phi[lev+1]->ixType().toIntVect());
-                amrex::ParallelFor( b,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    mf_nodebilin_interp(i, j, k, 0, phi_fp_arr, 0, phi_cp_arr, 0, refratio);
-                });
-            }
-
-        }
-
-#ifdef AMREX_USE_EB
-        // use amrex to directly calculate the electric field since with EB's the
-        // simple finite difference scheme in WarpX::computeE sometimes fails
-        if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
-        {
-#if defined(WARPX_DIM_1D_Z)
-            mlmg.getGradSolution(
-                {amrex::Array<amrex::MultiFab*,1>{
+    // EB: use AMReX to directly calculate the electric field since with EB's the
+    // simple finite difference scheme in WarpX::computeE sometimes fails
+    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
+    {
+        // TODO: maybe make this a helper function or pass Efield_fp directly
+        amrex::Vector<
+            amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM>
+        > e_field;
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            e_field.push_back(
+#   if defined(WARPX_DIM_1D_Z)
+                amrex::Array<amrex::MultiFab*, 1>{
                     get_pointer_Efield_fp(lev, 2)
-                    }}
-            );
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-            mlmg.getGradSolution(
-                {amrex::Array<amrex::MultiFab*,2>{
-                    get_pointer_Efield_fp(lev, 0),get_pointer_Efield_fp(lev, 2)
-                    }}
-            );
-#elif defined(WARPX_DIM_3D)
-            mlmg.getGradSolution(
-                {amrex::Array<amrex::MultiFab*,3>{
-                    get_pointer_Efield_fp(lev, 0),get_pointer_Efield_fp(lev, 1),
+                }
+#   elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                amrex::Array<amrex::MultiFab*, 2>{
+                    get_pointer_Efield_fp(lev, 0),
                     get_pointer_Efield_fp(lev, 2)
-                    }}
+                }
+#   elif defined(WARPX_DIM_3D)
+                amrex::Array<amrex::MultiFab *, 3>{
+                    get_pointer_Efield_fp(lev, 0),
+                    get_pointer_Efield_fp(lev, 1),
+                    get_pointer_Efield_fp(lev, 2)
+                }
+#   endif
             );
-            get_pointer_Efield_fp(lev, 1)->mult(-1._rt);
-#endif
-            get_pointer_Efield_fp(lev, 0)->mult(-1._rt);
-            get_pointer_Efield_fp(lev, 2)->mult(-1._rt);
         }
-#endif
-
+        post_phi_calculation = ElectrostaticSolver::EBCalcEfromPhiPerLevel(e_field);
     }
+
+    std::optional<amrex::Vector<amrex::EBFArrayBoxFactory const *> > eb_farray_box_factory;
+    amrex::Vector<
+        amrex::EBFArrayBoxFactory const *
+    > factories;
+    for (int lev = 0; lev <= finest_level; ++lev) {
+        factories.push_back(&WarpX::fieldEBFactory(lev));
+    }
+    eb_farray_box_factory = factories;
+#else
+    std::optional<amrex::Vector<amrex::FArrayBoxFactory const *> > eb_farray_box_factory;
+#endif
+
+    ablastr::fields::computePhi(
+        rho,
+        phi,
+        beta,
+        required_precision,
+        absolute_tolerance,
+        max_iters,
+        verbosity,
+        this->geom,
+        this->dmap,
+        this->grids,
+        this->m_poisson_boundary_handler,
+        WarpX::do_single_precision_comms,
+        this->ref_ratio,
+        post_phi_calculation,
+        gett_new(0),
+        eb_farray_box_factory
+    );
 
 }
 
@@ -468,26 +358,26 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
    \param[in] idim The dimension for which the Dirichlet boundary condition is set
 */
 void
-WarpX::setPhiBC( amrex::Vector<std::unique_ptr<amrex::MultiFab>>& phi ) const
+WarpX::setPhiBC ( amrex::Vector<std::unique_ptr<amrex::MultiFab>>& phi ) const
 {
     // check if any dimension has non-periodic boundary conditions
-    if (!field_boundary_handler.has_non_periodic) return;
+    if (!m_poisson_boundary_handler.has_non_periodic) return;
 
     // get the boundary potentials at the current time
     amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_lo;
     amrex::Array<amrex::Real,AMREX_SPACEDIM> phi_bc_values_hi;
-    phi_bc_values_lo[WARPX_ZINDEX] = field_boundary_handler.potential_zlo(gett_new(0));
-    phi_bc_values_hi[WARPX_ZINDEX] = field_boundary_handler.potential_zhi(gett_new(0));
+    phi_bc_values_lo[WARPX_ZINDEX] = m_poisson_boundary_handler.potential_zlo(gett_new(0));
+    phi_bc_values_hi[WARPX_ZINDEX] = m_poisson_boundary_handler.potential_zhi(gett_new(0));
 #ifndef WARPX_DIM_1D_Z
-    phi_bc_values_lo[0] = field_boundary_handler.potential_xlo(gett_new(0));
-    phi_bc_values_hi[0] = field_boundary_handler.potential_xhi(gett_new(0));
+    phi_bc_values_lo[0] = m_poisson_boundary_handler.potential_xlo(gett_new(0));
+    phi_bc_values_hi[0] = m_poisson_boundary_handler.potential_xhi(gett_new(0));
 #endif
 #if defined(WARPX_DIM_3D)
-    phi_bc_values_lo[1] = field_boundary_handler.potential_ylo(gett_new(0));
-    phi_bc_values_hi[1] = field_boundary_handler.potential_yhi(gett_new(0));
+    phi_bc_values_lo[1] = m_poisson_boundary_handler.potential_ylo(gett_new(0));
+    phi_bc_values_hi[1] = m_poisson_boundary_handler.potential_yhi(gett_new(0));
 #endif
 
-    auto dirichlet_flag = field_boundary_handler.dirichlet_flag;
+    auto dirichlet_flag = m_poisson_boundary_handler.dirichlet_flag;
 
     // loop over all mesh refinement levels and set the boundary values
     for (int lev=0; lev <= max_level; lev++) {
@@ -769,7 +659,7 @@ WarpX::computeB (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3> >
     }
 }
 
-void ElectrostaticSolver::BoundaryHandler::definePhiBCs ( )
+void ElectrostaticSolver::PoissonBoundaryHandler::definePhiBCs ( )
 {
     int dim_start = 0;
 #ifdef WARPX_DIM_RZ
@@ -835,7 +725,7 @@ void ElectrostaticSolver::BoundaryHandler::definePhiBCs ( )
     bcs_set = true;
 }
 
-void ElectrostaticSolver::BoundaryHandler::buildParsers ()
+void ElectrostaticSolver::PoissonBoundaryHandler::buildParsers ()
 {
     potential_xlo_parser = makeParser(potential_xlo_str, {"t"});
     potential_xhi_parser = makeParser(potential_xhi_str, {"t"});

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -80,7 +80,7 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
             WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
             if (species.initialize_self_fields ||
                 (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
-                AddSpaceChargeField(species); // this
+                AddSpaceChargeField(species);
             }
         }
 
@@ -174,7 +174,6 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     bool const reset = true;
     bool const do_rz_volume_scaling = true;
     pc.DepositCharge(rho, local, reset, do_rz_volume_scaling);
-    // ImpactX: add MPI comms to make deposition non-local
 
     // Get the particle beta vector
     bool const local_average = false; // Average across all MPI ranks
@@ -184,11 +183,11 @@ WarpX::AddSpaceChargeField (WarpXParticleContainer& pc)
     // Compute the potential phi, by solving the Poisson equation
     computePhi( rho, phi, beta, pc.self_fields_required_precision,
                 pc.self_fields_absolute_tolerance, pc.self_fields_max_iters,
-                pc.self_fields_verbosity ); // this
+                pc.self_fields_verbosity );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
-    computeE( Efield_fp, phi, beta ); // modify for ImpactX to be nodal
-    computeB( Bfield_fp, phi, beta ); // modify for ImpactX to be nodal
+    computeE( Efield_fp, phi, beta );
+    computeB( Bfield_fp, phi, beta );
 
 }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -675,7 +675,11 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
         // Exchange guard cells
         if (local == false) {
-            ablastr::utils::communication::SumBoundary(*rho[lev], WarpX::do_single_precision_comms, m_gdb->Geom(lev).periodicity());
+            ablastr::utils::communication::SumBoundary(
+                *rho[lev],
+                WarpX::do_single_precision_comms,
+                m_gdb->Geom(lev).periodicity()
+            );
         }
     }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -43,7 +43,7 @@
 #include <AMReX_Array.H>
 #include <AMReX_Config.H>
 #ifdef AMREX_USE_EB
-#   include "AMReX_EBFabFactory.H"
+#   include <AMReX_EBFabFactory.H>
 #endif
 #include <AMReX_GpuContainers.H>
 #include <AMReX_IntVect.H>
@@ -760,7 +760,7 @@ public:
      */
     const amrex::IntVect get_numprocs() const {return numprocs;}
 
-    ElectrostaticSolver::BoundaryHandler field_boundary_handler;
+    ElectrostaticSolver::PoissonBoundaryHandler m_poisson_boundary_handler;
     void ComputeSpaceChargeField (bool const reset_fields);
     void AddBoundaryField ();
     void AddSpaceChargeField (WarpXParticleContainer& pc);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -681,14 +681,14 @@ WarpX::ReadParameters ()
         }
         // Parse the input file for domain boundary potentials
         ParmParse pp_boundary("boundary");
-        pp_boundary.query("potential_lo_x", field_boundary_handler.potential_xlo_str);
-        pp_boundary.query("potential_hi_x", field_boundary_handler.potential_xhi_str);
-        pp_boundary.query("potential_lo_y", field_boundary_handler.potential_ylo_str);
-        pp_boundary.query("potential_hi_y", field_boundary_handler.potential_yhi_str);
-        pp_boundary.query("potential_lo_z", field_boundary_handler.potential_zlo_str);
-        pp_boundary.query("potential_hi_z", field_boundary_handler.potential_zhi_str);
-        pp_warpx.query("eb_potential(x,y,z,t)", field_boundary_handler.potential_eb_str);
-        field_boundary_handler.buildParsers();
+        pp_boundary.query("potential_lo_x", m_poisson_boundary_handler.potential_xlo_str);
+        pp_boundary.query("potential_hi_x", m_poisson_boundary_handler.potential_xhi_str);
+        pp_boundary.query("potential_lo_y", m_poisson_boundary_handler.potential_ylo_str);
+        pp_boundary.query("potential_hi_y", m_poisson_boundary_handler.potential_yhi_str);
+        pp_boundary.query("potential_lo_z", m_poisson_boundary_handler.potential_zlo_str);
+        pp_boundary.query("potential_hi_z", m_poisson_boundary_handler.potential_zhi_str);
+        pp_warpx.query("eb_potential(x,y,z,t)", m_poisson_boundary_handler.potential_eb_str);
+        m_poisson_boundary_handler.buildParsers();
 
         queryWithParser(pp_warpx, "const_dt", const_dt);
 

--- a/Source/ablastr/CMakeLists.txt
+++ b/Source/ablastr/CMakeLists.txt
@@ -1,3 +1,4 @@
+#add_subdirectory(fields)
 #add_subdirectory(particles)
 #add_subdirectory(profiler)
 add_subdirectory(utils)

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -1,0 +1,290 @@
+/* Copyright 2019-2022 Axel Huebl, Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef ABLASTR_POISSON_SOLVER_H
+#define ABLASTR_POISSON_SOLVER_H
+
+#include "Utils/WarpXConst.H"
+
+#include <ablastr/utils/Communication.H>
+#include <ablastr/warn_manager/WarnManager.H>
+
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+#include <AMReX_MLLinOp.H>
+#include <AMReX_Vector.H>
+#include <AMReX_Array.H>
+#include <AMReX_MLNodeTensorLaplacian.H>
+#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
+#   include <AMReX_MLEBNodeFDLaplacian.H>
+#endif
+#ifdef AMREX_USE_EB
+#   include <AMReX_EBFabFactory.H>
+#endif
+#include <AMReX_Parser.H>
+#include <AMReX_REAL.H>
+#include <AMReX_MFInterp_C.H>
+
+#include <AMReX_Array.H>
+#include <AMReX_Array4.H>
+#include <AMReX_BLassert.H>
+#include <AMReX_Box.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_Config.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_FArrayBox.H>
+#include <AMReX_FabArray.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_GpuControl.H>
+#include <AMReX_GpuLaunch.H>
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_IndexType.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_LO_BCTYPES.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_MLMG.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+#include <AMReX_SPACE.H>
+#include <AMReX_Vector.H>
+#include <AMReX_MFInterp_C.H>
+
+#include <array>
+#include <optional>
+
+
+namespace ablastr::fields {
+
+/** Compute the potential `phi` by solving the Poisson equation
+ *
+ * Uses `rho` as a source, assuming that the source moves at a
+ * constant speed \f$\vec{\beta}\f$. This uses the AMReX solver.
+ *
+ * More specifically, this solves the equation
+ * \f[
+ *   \vec{\nabla}^2 r \phi - (\vec{\beta}\cdot\vec{\nabla})^2 r \phi = -\frac{r \rho}{\epsilon_0}
+ * \f]
+ *
+ * \tparam T_BoundaryHandler handler for boundary conditions, for example @see ElectrostaticSolver::PoissonBoundaryHandler
+ * \tparam T_PostPhiCalculationFunctor a calculation per level directly after phi was calculated
+ * \tparam T_FArrayBoxFactory usually nothing or an amrex::EBFArrayBoxFactory (EB ONLY)
+ * \param[in] rho The charge density a given species
+ * \param[out] phi The potential to be computed by this function
+ * \param[in] beta Represents the velocity of the source of `phi`
+ * \param[in] required_precision The relative convergence threshold for the MLMG solver
+ * \param[in] absolute_tolerance The absolute convergence threshold for the MLMG solver
+ * \param[in] max_iters The maximum number of iterations allowed for the MLMG solver
+ * \param[in] verbosity The verbosity setting for the MLMG solver
+ * \param[in] geom the geometry per level (e.g., from AmrMesh)
+ * \param[in] dmap the distribution mapping per level (e.g., from AmrMesh)
+ * \param[in] grids the grids per level (e.g., from AmrMesh)
+ * \param[in] boundary_handler a handler for boundary conditions, for example @see ElectrostaticSolver::PoissonBoundaryHandler
+ * \param[in] do_single_precision_comms perform communications in single precision
+ * \param[in] rel_ref_ratio mesh refinement ratio between levels (default: 1)
+ * \param[in] post_phi_calculation perform a calculation per level directly after phi was calculated; required for embedded boundaries (default: none)
+ * \param[in] current_time the current time; required for embedded boundaries (default: none)
+ * \param[in] eb_farray_box_factory a factory for field data, @see amrex::EBFArrayBoxFactory; required for embedded boundaries (default: none)
+ */
+template<
+    typename T_BoundaryHandler,
+    typename T_PostPhiCalculationFunctor,
+    typename T_FArrayBoxFactory = void
+>
+void
+computePhi (amrex::Vector<std::unique_ptr<amrex::MultiFab> > const & rho,
+            amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
+            std::array<amrex::Real, 3> const beta,
+            amrex::Real const required_precision,
+            amrex::Real absolute_tolerance,
+            int const max_iters,
+            int const verbosity,
+            amrex::Vector<amrex::Geometry> const geom,
+            amrex::Vector<amrex::DistributionMapping> const dmap,
+            amrex::Vector<amrex::BoxArray> const grids,
+            T_BoundaryHandler const boundary_handler,
+            bool const do_single_precision_comms = false,
+            std::optional<amrex::Vector<amrex::IntVect> > rel_ref_ratio = std::nullopt,
+            std::optional<T_PostPhiCalculationFunctor> post_phi_calculation = std::nullopt,
+            [[maybe_unused]] std::optional<amrex::Real const> current_time = std::nullopt, // only used for EB
+            [[maybe_unused]] std::optional<amrex::Vector<T_FArrayBoxFactory const *> > eb_farray_box_factory = std::nullopt // only used for EB
+)
+{
+    using namespace amrex::literals;
+
+    if (!rel_ref_ratio.has_value()) {
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(rho.size() == 1u,
+                                           "rel_ref_ratio must be set if mesh-refinement is used");
+        rel_ref_ratio = amrex::Vector<amrex::IntVect>{{amrex::IntVect(AMREX_D_DECL(1, 1, 1))}};
+    }
+
+    int const finest_level = rho.size() - 1u;
+
+    // scale rho appropriately; also determine if rho is zero everywhere
+    amrex::Real max_norm_b = 0.0;
+    for (int lev=0; lev<=finest_level; lev++) {
+        rho[lev]->mult(-1._rt/PhysConst::ep0);
+        max_norm_b = amrex::max(max_norm_b, rho[lev]->norm0());
+    }
+    amrex::ParallelDescriptor::ReduceRealMax(max_norm_b);
+
+    bool always_use_bnorm = (max_norm_b > 0);
+    if (!always_use_bnorm) {
+        if (absolute_tolerance == 0.0) absolute_tolerance = amrex::Real(1e-6);
+        ablastr::warn_manager::WMRecordWarning(
+                "ElectrostaticSolver",
+                "Max norm of rho is 0",
+                ablastr::warn_manager::WarnPriority::low
+        );
+    }
+
+    amrex::LPInfo info;
+    for (int lev=0; lev<=finest_level; lev++) {
+        // Set the value of beta
+        amrex::Array<amrex::Real,AMREX_SPACEDIM> beta_solver =
+#if defined(WARPX_DIM_1D_Z)
+                {{ beta[2] }};  // beta_x and beta_z
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                {{ beta[0], beta[2] }};  // beta_x and beta_z
+#else
+                {{ beta[0], beta[1], beta[2] }};
+#endif
+
+#if !(defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ))
+        // Determine whether to use semi-coarsening
+        amrex::Array<amrex::Real,AMREX_SPACEDIM> dx_scaled
+                {AMREX_D_DECL(geom[lev].CellSize(0)/std::sqrt(1._rt-beta_solver[0]*beta_solver[0]),
+                              geom[lev].CellSize(1)/std::sqrt(1._rt-beta_solver[1]*beta_solver[1]),
+                              geom[lev].CellSize(2)/std::sqrt(1._rt-beta_solver[2]*beta_solver[2]))};
+        int max_semicoarsening_level = 0;
+        int semicoarsening_direction = -1;
+        int min_dir = std::distance(dx_scaled.begin(),
+                                    std::min_element(dx_scaled.begin(),dx_scaled.end()));
+        int max_dir = std::distance(dx_scaled.begin(),
+                                    std::max_element(dx_scaled.begin(),dx_scaled.end()));
+        if (dx_scaled[max_dir] > dx_scaled[min_dir]) {
+            semicoarsening_direction = max_dir;
+            max_semicoarsening_level = static_cast<int>
+            (std::log2(dx_scaled[max_dir]/dx_scaled[min_dir]));
+        }
+        if (max_semicoarsening_level > 0) {
+            info.setSemicoarsening(true);
+            info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+            info.setSemicoarseningDirection(semicoarsening_direction);
+        }
+#endif
+
+#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
+        // In the presence of EB or RZ: the solver assumes that the beam is
+        // propagating along  one of the axes of the grid, i.e. that only *one*
+        // of the components of `beta` is non-negligible.
+        amrex::MLEBNodeFDLaplacian linop( {geom[lev]}, {grids[lev]}, {dmap[lev]}, info
+#if defined(AMREX_USE_EB)
+            , {eb_farray_box_factory.value()[lev]}
+#endif
+        );
+
+        // Note: this assumes that the beam is propagating along
+        // one of the axes of the grid, i.e. that only *one* of the
+        // components of `beta` is non-negligible. // we use this
+#if defined(WARPX_DIM_RZ)
+        linop.setSigma({0._rt, 1._rt-beta_solver[1]*beta_solver[1]});
+#else
+        linop.setSigma({AMREX_D_DECL(
+            1._rt-beta_solver[0]*beta_solver[0],
+            1._rt-beta_solver[1]*beta_solver[1],
+            1._rt-beta_solver[2]*beta_solver[2])});
+#endif
+
+#if defined(AMREX_USE_EB)
+        // if the EB potential only depends on time, the potential can be passed
+        // as a float instead of a callable
+        if (boundary_handler.phi_EB_only_t) {
+            linop.setEBDirichlet(boundary_handler.potential_eb_t(current_time.value()));
+        }
+        else
+            linop.setEBDirichlet(boundary_handler.getPhiEB(current_time.value()));
+#endif
+#else
+        // In the absence of EB and RZ: use a more generic solver
+        // that can handle beams propagating in any direction
+        amrex::MLNodeTensorLaplacian linop( {geom[lev]}, {grids[lev]},
+                                     {dmap[lev]}, info );
+        linop.setBeta( beta_solver ); // for the non-axis-aligned solver
+#endif
+
+        // Solve the Poisson equation
+        linop.setDomainBC( boundary_handler.lobc, boundary_handler.hibc );
+#ifdef WARPX_DIM_RZ
+        linop.setRZ(true);
+#endif
+        amrex::MLMG mlmg(linop); // actual solver defined here
+        mlmg.setVerbose(verbosity);
+        mlmg.setMaxIter(max_iters);
+        mlmg.setAlwaysUseBNorm(always_use_bnorm);
+
+        // Solve Poisson equation at lev
+        mlmg.solve( {phi[lev].get()}, {rho[lev].get()},
+                    required_precision, absolute_tolerance );
+
+        // needed for solving the levels by levels:
+        // - coarser level is initial guess for finer level
+        // - coarser level provides boundary values for finer level patch
+        // Interpolation from phi[lev] to phi[lev+1]
+        // (This provides both the boundary conditions and initial guess for phi[lev+1])
+        if (lev < finest_level) {
+
+            // Allocate phi_cp for lev+1
+            amrex::BoxArray ba = phi[lev+1]->boxArray();
+            const amrex::IntVect& refratio = rel_ref_ratio.value()[lev];
+            ba.coarsen(refratio);
+            const int ncomp = linop.getNComp();
+            amrex::MultiFab phi_cp(ba, phi[lev+1]->DistributionMap(), ncomp, 1);
+
+            // Copy from phi[lev] to phi_cp (in parallel)
+            const amrex::IntVect& ng = amrex::IntVect::TheUnitVector();
+            const amrex::Periodicity& crse_period = geom[lev].periodicity();
+            // TODO: move WarpXCommUtil.cpp over to ABLASTR
+            ablastr::utils::communication::ParallelCopy(
+                phi_cp,
+                *phi[lev],
+                0,
+                0,
+                1,
+                ng,
+                ng,
+                do_single_precision_comms,
+                crse_period
+            );
+
+            // Local interpolation from phi_cp to phi[lev+1]
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(*phi[lev+1],amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                amrex::Array4<amrex::Real> const& phi_fp_arr = phi[lev+1]->array(mfi);
+                amrex::Array4<amrex::Real> const& phi_cp_arr = phi_cp.array(mfi);
+
+                amrex::Box const& b = mfi.tilebox(phi[lev+1]->ixType().toIntVect());
+                amrex::ParallelFor( b,
+                                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    amrex::mf_nodebilin_interp(i, j, k, 0, phi_fp_arr, 0, phi_cp_arr, 0, refratio);
+                });
+            }
+
+        }
+
+        // Run additional operations, such as calculation of the E field for embedded boundaries
+        if (post_phi_calculation.has_value())
+            post_phi_calculation.value()(mlmg, lev);
+
+    } // loop over lev(els)
+}
+
+} // namespace ablastr::fields
+
+#endif // ABLASTR_POISSON_SOLVER_H


### PR DESCRIPTION
Expose the computation of the electro-static potential for relativistic beams via ABLASTR for ImpactX.

- [x] depends on merging #3024 first
- [x] depends on merging #3026 first
- [x] depends on merging #3167 first