### PR TITLE
Synchronize all nodal points in sub-cycling loop

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -788,6 +788,12 @@ WarpX::OneStep_sub1 (Real curtime)
     }
     if ( safe_guard_cells )
         FillBoundaryB(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolver);
+
+    // Synchronize all nodal points at the end of the timestep
+    NodalSync(Efield_fp, Efield_cp);
+    NodalSync(Bfield_fp, Bfield_cp);
+    if (WarpX::do_dive_cleaning) NodalSync(F_fp, F_cp);
+    if (do_pml) NodalSyncPML();
 }
 
 void


### PR DESCRIPTION
This should avoid instabilities that happen at the boundary of domains.