### PR TITLE
Docs: Fix Missing "s" in <diags>.adios2_engine.parameters

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1951,7 +1951,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
     .. code-block:: text
 
-        <diag_name>.adios2_engine.parameter.NumAggregators = 2048
+        <diag_name>.adios2_engine.parameters.NumAggregators = 2048
         <diag_name>.adios2_engine.parameters.BurstBufferPath="/mnt/bb/username"
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)


### PR DESCRIPTION
Fix a typo in the `<digs>.adios2_engine.parameters.NumAggregators` example.

Follow-up to #2872