### PR TITLE
Change particle filter parser to check it as a boolean instead of comparing to 0.5

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2045,7 +2045,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     The value provided should be an integer greater than or equal to 0.
 
 * ``<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)`` (`string`) optional
-    Users can provide an expression returning a boolean for whether a particle is dumped (the exact test is whether the return value is `> 0.5`).
+    Users can provide an expression returning a boolean for whether a particle is dumped.
     `t` represents the physical time in seconds during the simulation.
     `x, y, z` represent particle positions in the unit of meter.
     `ux, uy, uz` represent particle velocities in the unit of
@@ -2491,8 +2491,7 @@ Reduced Diagnostics
 
         * ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)`` (`string`) optional
             Users can provide an expression returning a boolean for whether a particle is taken
-            into account when calculating the histogram (the exact test is whether the return
-            value is `> 0.5`).
+            into account when calculating the histogram.
             `t` represents the physical time in seconds during the simulation.
             `x, y, z` represent particle positions in the unit of meter.
             `ux, uy, uz` represent particle velocities in the unit of

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -93,7 +93,7 @@ struct ParserFilter
 {
     /** constructor
      * \param a_is_active whether the test is active
-     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a value > 0.5 for selected particle
+     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a boolean for selected particle
      * \param a_mass mass of the particle species
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -125,7 +125,7 @@ struct ParserFilter
             uz /= m_mass;
         }
         // ux, uy, uz are now in beta*gamma
-        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
+        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) ) return 1;
         else return 0;
     }
 private:


### PR DESCRIPTION
In discussing #3001, @EZoni pointed out that comparing the diagnostics particle filter functions to 0.5 isn't intuitive, especially because they are described as booleans. I also realized that there was a mismatch between the documentation and the implementation in the particle histograms. We think it would make more sense to check the filter functions as booleans, rather than by comparing to 0.5. For boolean expressions, this will be equivalent. This PR is also to check that this change wouldn't break any tests.

* The filter function in the particle histogram was already checking `if (filter(...))` rather than `if (filter(...) > 0.5)`, so I've updated the documentation to match.
* The `ParserFilter` in `Particles/Filter/FilterFunctors.H` is used to filter the particles written out in `FullDiagnostics` for both plotfiles and OpenPMD. It's currently checking `if (filter(...) > 0.5)` so I've changed it to `if (filter(...))` and updated the documentation.