### PR TITLE
CI: Fix Small Issue w/ Langmuir Plots

### DIFF
--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -118,20 +118,22 @@ for field in ['Ex', 'Ey', 'Ez']:
 
 # Plot the last field from the loop (Ez at iteration 40)
 fig, (ax1, ax2) = plt.subplots(1, 2, dpi = 100)
-vmin = min(E_sim.min(), E_th.min())
-vmax = max(E_sim.max(), E_th.max())
-# First plot
+# First plot (slice at y=0)
+E_plot = E_sim[:,Ncell[1]//2+1,:]
+vmin = E_plot.min()
+vmax = E_plot.max()
 cax1 = make_axes_locatable(ax1).append_axes('right', size = '5%', pad = '5%')
-# Plot slice at y=0
-im1 = ax1.imshow(E_sim[:,Ncell[1]//2+1,:], origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
+im1 = ax1.imshow(E_plot, origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
 cb1 = fig.colorbar(im1, cax = cax1)
 ax1.set_xlabel(r'$z$')
 ax1.set_ylabel(r'$x$')
 ax1.set_title(r'$E_z$ (sim)')
-# Second plot
+# Second plot (slice at y=0)
+E_plot = E_th[:,Ncell[1]//2+1,:]
+vmin = E_plot.min()
+vmax = E_plot.max()
 cax2 = make_axes_locatable(ax2).append_axes('right', size = '5%', pad = '5%')
-# Plot slice at y=0
-im2 = ax2.imshow(E_th[:,Ncell[1]//2+1,:], origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
+im2 = ax2.imshow(E_plot, origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
 cb2 = fig.colorbar(im2, cax = cax2)
 ax2.set_xlabel(r'$z$')
 ax2.set_ylabel(r'$x$')

--- a/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi_2d.py
@@ -92,9 +92,9 @@ for field in ['Ex', 'Ez']:
 
 # Plot the last field from the loop (Ez at iteration 40)
 fig, (ax1, ax2) = plt.subplots(1, 2, dpi = 100)
-vmin = min(E_sim.min(), E_th.min())
-vmax = max(E_sim.max(), E_th.max())
 # First plot
+vmin = E_sim.min()
+vmax = E_sim.max()
 cax1 = make_axes_locatable(ax1).append_axes('right', size = '5%', pad = '5%')
 im1 = ax1.imshow(E_sim, origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
 cb1 = fig.colorbar(im1, cax = cax1)
@@ -102,6 +102,8 @@ ax1.set_xlabel(r'$z$')
 ax1.set_ylabel(r'$x$')
 ax1.set_title(r'$E_z$ (sim)')
 # Second plot
+vmin = E_th.min()
+vmax = E_th.max()
 cax2 = make_axes_locatable(ax2).append_axes('right', size = '5%', pad = '5%')
 im2 = ax2.imshow(E_th, origin = 'lower', extent = edge, vmin = vmin, vmax = vmax)
 cb2 = fig.colorbar(im2, cax = cax2)


### PR DESCRIPTION
This was introduced by mistake in #2960 and #2999. If one is debugging a PR that by chance produces the wrong electric field `E_sim`, for example with very high min/max values because of some instability, then using the same (global) min/max values for the colorbars of both the plot of `E_sim` and the plot of `E_th` would result in the wrong plot for `E_th` (whose wrong colorbar would make the plot not look like it should according to the theoretical formulas). This makes sure that the colorbar of the theory plot is separate and not affected by potential bugs in the simulation plot, making debugging easier.