### PR TITLE
CI: NVHPC New Apt Repo

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -109,8 +109,8 @@ jobs:
         cd amrex && git checkout --detach 3aafa306ad820bbcc50a4b7c14fe912406427d1d && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
-  build_nvhpc21-9-nvcc:
-    name: NVHPC@21.9 NVCC/NVC++ Release [tests]
+  build_nvhpc21-11-nvcc:
+    name: NVHPC@21.11 NVCC/NVC++ Release [tests]
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     env:
@@ -139,7 +139,7 @@ jobs:
     - name: Build & Install
       run: |
         source /etc/profile.d/modules.sh
-        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9
+        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.11
         which nvcc || echo "nvcc not in PATH!"
         which nvc++ || echo "nvc++ not in PATH!"
         which nvc || echo "nvc not in PATH!"

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Axel Huebl
+# Copyright 2021-2022 The WarpX Community
 #
+# Author: Axel Huebl
 # License: BSD-3-Clause-LBNL
 
 set -eu -o pipefail
@@ -19,17 +20,16 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-wget -q https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-21-9_21.9_amd64.deb \
-        https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-2021_21.9_amd64.deb
-sudo apt-get update
-sudo apt-get install -y ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
-rm -rf ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
+  sudo tee /etc/apt/sources.list.d/nvhpc.list
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends nvhpc-21-11
 
 # things should reside in /opt/nvidia/hpc_sdk now
 
 # activation via:
 #   source /etc/profile.d/modules.sh
-#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9
+#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.11
 
 # cmake-easyinstall
 #


### PR DESCRIPTION
Update the NVHPC install instructions to the latest and greatest.
Fix failing CI (dependency install).

Also upgrade to 21.11 as on Perlmutter.