### PR TITLE
Fix MPI Signal Handling on Perlmutter

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -64,15 +64,6 @@ Overall simulation parameters
     It is mainly intended for debug purposes, and is best used with
     ``warpx.always_warn_immediately=1``.
 
-* ``warpx.break_signals`` (array of `string`, separated by spaces) optional
-    A list of signal names or numbers that the simulation should
-    handle by cleanly terminating at the next timestep
-
-* ``warpx.checkpoint_signals`` (array of `string`, separated by spaces) optional
-    A list of signal names or numbers that the simulation should
-    handle by outputting a checkpoint at the next timestep. A
-    diagnostic of type `checkpoint` must be configured.
-
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined
     using `std::random_device` and `std::clock()`,
@@ -147,6 +138,37 @@ Overall simulation parameters
     This will cause severe performance drops.
     Note that even with this set to ``1`` WarpX will not catch all out-of-memory events yet when operating close to maximum device memory.
     `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`_.
+
+Signal Handling
+^^^^^^^^^^^^^^^
+
+WarpX can handle Unix (Linux/macOS) `process signals <https://en.wikipedia.org/wiki/Signal_(IPC)>`__.
+This can be useful to configure jobs on HPC and cloud systems to shut down cleanly when they are close to reaching their allocated walltime or to steer the simulation behavior interactively.
+
+Allowed signal names are documented in the `C++ standard <https://en.cppreference.com/w/cpp/utility/program/SIG_types>`__ and `POSIX <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html>`__.
+We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal configuration name for ``SIGINT`` is ``INT``.
+
+* ``warpx.break_signals`` (array of `string`, separated by spaces) optional
+    A list of signal names or numbers that the simulation should
+    handle by cleanly terminating at the next timestep
+
+* ``warpx.checkpoint_signals`` (array of `string`, separated by spaces) optional
+    A list of signal names or numbers that the simulation should
+    handle by outputting a checkpoint at the next timestep. A
+    diagnostic of type `checkpoint` must be configured.
+
+.. note::
+
+   Certain signals are only available on specific platforms, please see the links above for details.
+   Typically supported on Linux and macOS are ``HUP``, ``INT``, ``QUIT``, ``ABRT``, ``USR1``, ``USR2``, ``TERM``, ``TSTP``, ``URG``, and ``IO`` among others.
+
+   Signals to think about twice before overwriting in *interactive simulations*:
+   Note that ``INT`` (interupt) is the signal that ``Ctrl+C`` sends on the terminal, which most people use to abort a process; once overwritten you need to abort interactive jobs with, e.g., ``Ctrl+\`` (``QUIT``) or sending the ``KILL`` signal.
+   The ``TSTP`` (terminal stop) command is sent interactively from ``Ctrl+Z`` to temporarily send a process to sleep (until send in the background with commands such as ``bg`` or continued with ``fg``), overwriting it would thus disable that functionality.
+   The signals ``KILL`` and ``STOP`` cannot be used.
+
+   The ``FPE`` signal should not be overwritten in WarpX, as it is `controlled by AMReX <https://amrex-codes.github.io/amrex/docs_html/Debugging.html#breaking-into-debuggers>`__ for :ref:`debug workflows that catch invalid floating-point operations <debugging_warpx>`.
+
 
 .. _running-cpp-parameters-box:
 

--- a/Source/ablastr/utils/SignalHandling.H
+++ b/Source/ablastr/utils/SignalHandling.H
@@ -65,7 +65,7 @@ public:
 
 private:
     //! Is any signal handling action configured in signal_conf_requests ?
-    static bool anySignalConfActive ();
+    static bool m_any_signal_action_active;
 
     //! On process 0, whether a given signal has been received since the last check
     static std::atomic<bool> signal_received_flags[NUM_SIGNALS];
@@ -83,7 +83,7 @@ private:
     static bool signal_actions_requested[SIGNAL_REQUESTS_SIZE];
 
      // Don't allow clients to incorrectly try to construct and use an instance of this type
-    SignalHandling() = delete;
+    SignalHandling () = delete;
 };
 
 } // namespace ablastr::utils

--- a/Source/ablastr/utils/SignalHandling.H
+++ b/Source/ablastr/utils/SignalHandling.H
@@ -64,6 +64,9 @@ public:
     static bool TestAndResetActionRequestFlag (int action_to_test);
 
 private:
+    //! Is any signal handling action configured in signal_conf_requests ?
+    static bool anySignalConfActive ();
+
     //! On process 0, whether a given signal has been received since the last check
     static std::atomic<bool> signal_received_flags[NUM_SIGNALS];
 

--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -110,6 +110,18 @@ SignalHandling::parseSignalNameToNumber(const std::string &str)
     return sig;
 }
 
+bool
+SignalHandling::anySignalConfActive ()
+{
+    bool any_signal_active = false;
+    for (int signal_number = 0; signal_number < NUM_SIGNALS; ++signal_number) {
+        for (int signal_request = 0; signal_request < SIGNAL_REQUESTS_SIZE; ++signal_request) {
+            any_signal_active |= signal_conf_requests[signal_request][signal_number];
+        }
+    }
+    return any_signal_active;
+}
+
 void
 SignalHandling::InitSignalHandling()
 {
@@ -140,6 +152,10 @@ SignalHandling::InitSignalHandling()
 void
 SignalHandling::CheckSignals()
 {
+    // Do not perform MPI communication if no signal action is configured
+    if (!anySignalConfActive())
+        return;
+
     // We assume that signals will definitely be delivered to rank 0,
     // and may be delivered to other ranks as well. For coordination,
     // we process them according to when they're received by rank 0.
@@ -171,6 +187,10 @@ SignalHandling::CheckSignals()
 void
 SignalHandling::WaitSignals()
 {
+    // Do not perform MPI communication if no signal action is configured
+    if (!anySignalConfActive())
+        return;
+
 #if defined(AMREX_USE_MPI)
     BL_MPI_REQUIRE(MPI_Wait(&signal_mpi_ibcast_request, MPI_STATUS_IGNORE));
 #endif

--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -162,8 +162,9 @@ SignalHandling::CheckSignals()
 
 #if defined(AMREX_USE_MPI)
     auto comm = amrex::ParallelDescriptor::Communicator();
+    static_assert(sizeof(bool) == 1, "We communicate bools as 1 byte-sized type in MPI");
     BL_MPI_REQUIRE(MPI_Ibcast(signal_actions_requested, SIGNAL_REQUESTS_SIZE,
-                              MPI_CXX_BOOL, 0, comm,&signal_mpi_ibcast_request));
+                              MPI_BYTE, 0, comm,&signal_mpi_ibcast_request));
 #endif
 }
 


### PR DESCRIPTION
Follow-up to #2896. Not part of release `22.04`.
First seen by @RTSandberg and @Yin-YinjianZhao.

Thx to @kngott and Brandon for rapid NERSC consulting support.

## Fix: `MPI_C(XX)_BOOL`

C99 types were aded in MPI-2.2, while Cray's MPICH fork in version 8.1.13 defines `MPI_CXX_BOOL` to `MPI_DATATYPE_NULL` on Perlmutter.

We could use `MPI_C_BOOL`, which is technically a `_Bool` from [<cstdbool>](https://en.cppreference.com/w/cpp/header/cstdbool) (deprecated: C++17; removed: C++20) - or we simply do a static assert on `sizeof(bool)` and communicate as a `MPI_BYTE` or `MPI_CHAR`.

## Do not Broadcast if no action is registered 

Do no MPI Comms if no action is configured.