### PR TITLE
Fix LB FullDiagnostics: Redistribute MultiFabs

### DIFF
--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -9,6 +9,7 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Particles/PinnedMemoryParticleContainer.H"
 
+#include <AMReX_DistributionMapping.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
@@ -62,6 +63,12 @@ public:
     virtual void Flush (int i_buffer) = 0;
     /** Initialize pointers to main fields and allocate output multifab m_mf_output. */
     void InitData ();
+    /** Redistribute parallel data structures during load balance
+     *
+     * \param[in] lev level to remake
+     * @param[in] dm new distribution mapping
+     */
+    void RemakeLevel (int const lev, amrex::DistributionMapping const & dm);
     /** Initialize functors that store pointers to the fields requested by the user.
      *
      * Derived classes MUST implement this function, and it must allocate m_all_field_functors

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -12,6 +12,7 @@
 #include "FlushFormats/FlushFormatPlotfile.H"
 #include "FlushFormats/FlushFormatSensei.H"
 #include "Particles/MultiParticleContainer.H"
+#include "Parallelization/WarpXRegrid.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -345,6 +346,27 @@ Diagnostics::InitData ()
     }
 }
 
+void
+Diagnostics::RemakeLevel (int const lev, amrex::DistributionMapping const & dm) {
+    bool const redistribute = false; // TODO: review me. Anything special for BTD here?
+
+    // note: m_num_buffers is one for FullDiags and >=1 for BTD
+    for (int i = 0; i < m_num_buffers; ++i) {
+        RemakeMultiFab(m_mf_output[i][lev], dm, redistribute);
+    }
+    //m_geom_output // TODO likely needs to be re-done after MultiFab::RemakeLevel ?
+
+    // some collection of PinnedMemoryParticleContainer for BTD?
+    // looks like BTDiagnostics::RedistributeParticleBuffer takes care of this
+    //m_particles_buffer
+
+    // a collection of ParticleDiag that holds a pointer to a m_pinned_pc
+    //m_output_species // TODO?
+
+    // also needed, seems to be done separately already (TODO: unify me)
+    //m_all_field_functors
+    //m_all_particle_functors
+}
 
 void
 Diagnostics::InitBaseData ()

--- a/Source/Diagnostics/MultiDiagnostics.H
+++ b/Source/Diagnostics/MultiDiagnostics.H
@@ -5,6 +5,7 @@
 
 #include "MultiDiagnostics_fwd.H"
 
+#include <AMReX_DistributionMapping.H>
 #include <AMReX_Vector.H>
 
 #include <memory>
@@ -30,14 +31,21 @@ public:
     /** \brief Called only at the last iteration. Loop over each diag and if m_dump_last_timestep
      *         is true, compute diags and flush with force_flush=true. */
     void FilterComputePackFlushLastTimestep (int step);
+    /** Redistribute parallel data structures during load balance
+     *
+     * \param[in] lev level to remake
+     * \param[in] dm new distribution mapping
+     */
+    void RemakeLevel (int const lev, amrex::DistributionMapping const & dm);
+    /** Start a new iteration, i.e., dump has not been done yet. */
+    void NewIteration ();
+private:
     /** \brief Loop over diags in all diags and call their InitializeFieldFunctors.
                Called when a new partitioning is generated at level, lev.
       * \param[in] lev level at this the field functors are initialized.
       */
     void InitializeFieldFunctors (int lev);
-    /** Start a new iteration, i.e., dump has not been done yet. */
-    void NewIteration ();
-private:
+
     /** Vector of pointers to all diagnostics */
     amrex::Vector<std::unique_ptr<Diagnostics> > alldiags;
     int ndiags = 0; /**< number of different diagnostics */

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -46,6 +46,17 @@ MultiDiagnostics::InitData ()
 }
 
 void
+MultiDiagnostics::RemakeLevel ( int const lev, amrex::DistributionMapping const & dm )
+{
+    for( auto& diag : alldiags ) {
+        diag->RemakeLevel( lev, dm );
+    }
+
+    // Re-initialize diagnostic functors that stores pointers to the user-requested fields at level, lev.
+    InitializeFieldFunctors(lev);
+}
+
+void
 MultiDiagnostics::InitializeFieldFunctors ( int lev )
 {
     for( auto& diag : alldiags ){

--- a/Source/Parallelization/WarpXRegrid.H
+++ b/Source/Parallelization/WarpXRegrid.H
@@ -1,0 +1,41 @@
+/* Copyright 2022 Andrew Myers, Axel Huebl, Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_PARALLELIZATION_REGRID_H
+#define WARPX_PARALLELIZATION_REGRID_H
+
+#include <AMReX.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+
+/** ...
+ *
+ * @tparam T_MultiFabType ..
+ * @param mf ..
+ * @param dm ..
+ * @param redistribute ..
+ */
+template< typename T_MultiFabType >
+void
+RemakeMultiFab (
+    T_MultiFabType & mf,
+    amrex::DistributionMapping const& dm,
+    const bool redistribute)
+{
+    const amrex::IntVect& ng = mf.nGrowVect();
+    auto pmf = T_MultiFabType(mf.boxArray(), dm, mf.nComp(), ng);
+    if (redistribute) pmf.Redistribute(mf, 0, 0, mf.nComp(), ng);
+    mf = std::move(pmf);
+}
+
+#endif // WARPX_PARALLELIZATION_REGRID_H


### PR DESCRIPTION
Discovered by @WeiqunZhang on Friday: The full diagnostics hold a persistent collection of `MultiFab`s for I/O, which are not redistributed on load balance (dynamic) mesh refinement, e.g., patch removal.

As far as we assessed so far, this is currently only a performance issue at scale.

cc @WeiqunZhang for review
cc @atmyers for particle related questions
cc @RevathiJambunathan for BTD related questions - clarified offline
cc @MaxThevenet @RTSandberg for prior updates / FYI