### PR TITLE
Summit: Prepend Hostname & Mapping

### DIFF
--- a/Tools/machines/summit-olcf/summit_power9.bsub
+++ b/Tools/machines/summit-olcf/summit_power9.bsub
@@ -43,10 +43,13 @@ cat > romio-hints << EOL
    romio_ds_write enable
    cb_buffer_size 16777216
    cb_nodes ${NUM_HOSTS}
-   EOL
+EOL
 
 # OpenMP: 21 threads per MPI rank
 export OMP_NUM_THREADS=21
 
+# store out task host mapping: helps identify broken nodes at scale
+jsrun -n 2 -a 1 -c 21 -r 2 -e prepended hostname > task_host_mapping.txt
+
 # run WarpX
-jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt
+jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs -e prepended <path/to/executable> <input file> > output.txt

--- a/Tools/machines/summit-olcf/summit_v100.bsub
+++ b/Tools/machines/summit-olcf/summit_v100.bsub
@@ -49,5 +49,8 @@ EOL
 # OpenMP: 1 thread per MPI rank
 export OMP_NUM_THREADS=1
 
+# store out task host mapping: helps identify broken nodes at scale
+jsrun  -r 6 -a1 -g 1 -c 7 -e prepended hostname > task_host_mapping.txt
+
 # run WarpX
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs -e prepended --smpiargs="-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
Add an additional `jsrun` command on Summit so that one can easier map the run output to a hostname.
Write a `task_host_mapping.txt` file for each run.

This was recommended to us by support to identify a node that has NSF problems at scale - and failed to load a shared library at startup.

Ref.: https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=SSWRJV_10.1.0/jsm/jsrun.html
```
-e , --stdio_mode individual | collected | prepended You can choose one of the following modes for how stdio handles tasks

    individual: The output of each task is sent to a separate file. The name of the files is based on the value of --stdio_stdout and --stdio_stderr options.
    collected: The output is gathered and presented as either the stdio of the jsrun command or sent to the file names specified by the --stdio_stdout and --stdio_stderr options. This mode is the default option.
    prepended: The output is similar to the collected option, except that each task output is prepended with its corresponding task identifier.
```