### PR TITLE
Avoid unnecessary construction of CopyParticleAttribs

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2594,11 +2594,14 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr() + offset;
     ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr() + offset;
 
-    auto copyAttribs = CopyParticleAttribs(pti, tmp_particle_data, offset);
     int do_copy = ( (WarpX::do_back_transformed_diagnostics
                      && do_back_transformed_diagnostics
                      && a_dt_type!=DtType::SecondHalf)
                   || (m_do_back_transformed_particles && (a_dt_type!=DtType::SecondHalf)) );
+    CopyParticleAttribs copyAttribs;
+    if (do_copy) {
+        copyAttribs = CopyParticleAttribs(pti, tmp_particle_data, offset);
+    }
 
     int* AMREX_RESTRICT ion_lev = nullptr;
     if (do_field_ionization) {

--- a/Source/Particles/Pusher/CopyParticleAttribs.H
+++ b/Source/Particles/Pusher/CopyParticleAttribs.H
@@ -36,6 +36,8 @@ struct CopyParticleAttribs
     amrex::ParticleReal* AMREX_RESTRICT uypold = nullptr;
     amrex::ParticleReal* AMREX_RESTRICT uzpold = nullptr;
 
+    CopyParticleAttribs () = default;
+
     /** \brief Construct a new functor
      *
      * \param a_pti iterator to the tile containing the macroparticles


### PR DESCRIPTION
If it's not used there is no reason to construct a CopyParticleAttribs
object.  In fact, it could result in a runtime `std::out_of_range` error in
`std::map::at()` because `tmp_particle_data` is used in the
CopyParticleAttribs constructor, but in `PhysicalParticleContainer::Evolve`,
`tmp_particle_data` is properly prepared only when doing back transformed
diagnostics.