### PR TITLE
Fix particle flux injection, when the number of macroparticle per timestep is low.

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1595,7 +1595,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 }
 #endif
 
-                Real weight = dens * scale_fac * dt * num_ppc_real / pcounts[index];
+                Real weight = dens * scale_fac * dt;
 #ifdef WARPX_DIM_RZ
                 // The particle weight is proportional to the user-specified
                 // flux (denoted as `dens` here) and the emission surface within


### PR DESCRIPTION
**Description edited by @RemiLehe**

When using particle flux injection, the user specifies how many macroparticles should be emitted, per timestep and per cell. The number of macroparticles emitted at each timestep is then stochastic (see [this line](https://github.com/ECP-WarpX/WarpX/blob/development/Source/Particles/PhysicalParticleContainer.cpp#L1383)) so that, on average, the number of particles emitted per timestep matches the value specified by the user.

In the current version of WarpX, the weight of the macroparticles is adjusted (see [this line](https://github.com/ECP-WarpX/WarpX/blob/development/Source/Particles/PhysicalParticleContainer.cpp#L1598)) so that the flux of **physical** particles matches **exactly** the value specified by the user **at each timestep**, instead of fluctuating due to the stochasticity of the number of macroparticles.

However, this is incorrect when the average number of macroparticles per timestep required by the user is much lower than 1 (i.e. `num_ppc_real < 1`). In this case, some timesteps will results in **no** macroparticles being emitted, and in this case the weight cannot be adjusted properly. The overall result is that the average number of **physical** particles emitted does not match the value requested by the user.

Instead, this PR removes the adjustment of the weight. As a result, the number of physical particles emitted at each timestep will fluctuate (proportionally to the number of macroparticles emitted at each timestep), but will match the required value on average.