### PR TITLE
Perlmutter: Boost Software Module (QED)

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -9,6 +9,9 @@ module load cudatoolkit
 # optional: just an additional text editor
 # module load nano  # TODO: request from support
 
+# optional: for QED support with detailed tables
+module load boost/1.78.0-gnu
+
 # optional: for openPMD and PSATD+RZ support
 module load cray-hdf5-parallel/1.12.0.7
 export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/c-blosc-1.21.1:$CMAKE_PREFIX_PATH

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -103,7 +103,7 @@ if(WarpX_QED)
     set(WarpX_picsar_repo "https://github.com/ECP-WarpX/picsar.git"
         CACHE STRING
         "Repository URI to pull and build PICSAR from if(WarpX_picsar_internal)")
-    set(WarpX_picsar_branch "e7ef03b852b889d69cfaf3852ab1aa926d20fcb0"
+    set(WarpX_picsar_branch "a621a5a41fb8f7dbb19e03ec8f75c50f3b26b546"
         CACHE STRING
         "Repository branch for WarpX_picsar_repo if(WarpX_picsar_internal)")
 


### PR DESCRIPTION
Document a compatible Boost module on Perlmutter.
This is needed for detailed table generation for the QED module (`WarpX_QED_TABLE_GEN=ON`).

- [x] Also needs a fix in PICSAR-QED to compile on Perlmutter (CPU only issue): https://github.com/ECP-WarpX/picsar/pull/43