### PR TITLE
Bug fix for BTD - particle BA, and geom, same as field buffer

### DIFF
--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -69,6 +69,7 @@ btd_pltfile.dt_snapshots_lab = 1.8679589331096515e-13
 btd_pltfile.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
 btd_pltfile.format = plotfile
 btd_pltfile.buffer_size = 32
+btd_pltfile.write_species = 0
 
 # old BTD diagnostics
 warpx.do_back_transformed_diagnostics = 1

--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -58,7 +58,7 @@ btd_openpmd.do_back_transformed_fields = 1
 btd_openpmd.num_snapshots_lab = 2
 btd_openpmd.dt_snapshots_lab = 1.8679589331096515e-13
 btd_openpmd.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
-btd_openpmd.format = plotfile
+btd_openpmd.format = openpmd
 btd_openpmd.openpmd_backend = h5
 btd_openpmd.buffer_size = 32
 

--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -49,7 +49,7 @@ beam.zinject_plane = 20.e-6
 beam.rigid_advance = true
 
 # Diagnostics
-diagnostics.diags_names = diag1 btd_openpmd btd_pltfile
+diagnostics.diags_names = diag1 btd_pltfile
 diag1.intervals = 10000
 diag1.diag_type = Full
 
@@ -58,7 +58,7 @@ btd_openpmd.do_back_transformed_fields = 1
 btd_openpmd.num_snapshots_lab = 2
 btd_openpmd.dt_snapshots_lab = 1.8679589331096515e-13
 btd_openpmd.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
-btd_openpmd.format = openpmd
+btd_openpmd.format = plotfile
 btd_openpmd.openpmd_backend = h5
 btd_openpmd.buffer_size = 32
 
@@ -69,7 +69,7 @@ btd_pltfile.dt_snapshots_lab = 1.8679589331096515e-13
 btd_pltfile.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
 btd_pltfile.format = plotfile
 btd_pltfile.buffer_size = 32
-btd_pltfile.write_species = 0
+btd_pltfile.write_species = 1
 
 # old BTD diagnostics
 warpx.do_back_transformed_diagnostics = 1

--- a/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
+++ b/Examples/Modules/RigidInjection/inputs_2d_BoostedFrame
@@ -49,7 +49,7 @@ beam.zinject_plane = 20.e-6
 beam.rigid_advance = true
 
 # Diagnostics
-diagnostics.diags_names = diag1 btd_pltfile
+diagnostics.diags_names = diag1 btd_pltfile btd_openpmd
 diag1.intervals = 10000
 diag1.diag_type = Full
 

--- a/Examples/Modules/boosted_diags/inputs_3d_slice
+++ b/Examples/Modules/boosted_diags/inputs_3d_slice
@@ -10,7 +10,7 @@ my_constants.ymin = -128.e-6
 my_constants.zmin = -40.e-6
 my_constants.xmax = +128.e-6
 my_constants.ymax = +128.e-6
-my_constants.zmax = 0.96e-6
+my_constants.zmax = 0.e-6
 
 geometry.dims = 3
 geometry.prob_lo     = xmin ymin zmin
@@ -133,6 +133,7 @@ btd_pltfile.dz_snapshots_lab = 0.001
 btd_pltfile.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
 btd_pltfile.format = plotfile
 btd_pltfile.buffer_size = 32
+btd_pltfile.write_species = 0
 
 # old BTD diagnostics
 warpx.do_back_transformed_diagnostics = 1

--- a/Examples/Modules/boosted_diags/inputs_3d_slice
+++ b/Examples/Modules/boosted_diags/inputs_3d_slice
@@ -133,7 +133,7 @@ btd_pltfile.dz_snapshots_lab = 0.001
 btd_pltfile.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
 btd_pltfile.format = plotfile
 btd_pltfile.buffer_size = 32
-btd_pltfile.write_species = 0
+btd_pltfile.write_species = 1
 
 # old BTD diagnostics
 warpx.do_back_transformed_diagnostics = 1

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -149,9 +149,6 @@ private:
 
     /** Vector of lab-frame time corresponding to each snapshot */
     amrex::Vector<amrex::Real> m_t_lab;
-    /** Vector of lab-frame physical domain corresponding to the boosted-frame simulation
-     *  domain at lab-frame time corresponding to each snapshot*/
-    amrex::Vector<amrex::RealBox> m_prob_domain_lab;
     /** Vector of user-defined physical region for diagnostics in lab-frame
      *  for each back-transformed snapshot */
     amrex::Vector<amrex::RealBox> m_snapshot_domain_lab;

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -207,6 +207,7 @@ private:
     /** Vector of counters tracking number of times the buffer of multifab is
      *  flushed out and emptied before being refilled again for each snapshot */
     amrex::Vector<int> m_buffer_flush_counter;
+    amrex::Vector<int> m_buffer_k_index_hi;
     /** Multi-level cell-centered multifab with all field-data components, namely,
      *  Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho.
      *  This cell-centered data extending over the entire domain
@@ -276,7 +277,7 @@ private:
                when buffer counter is equal to m_buffer_size
      */
     bool buffer_full (int i_buffer) {
-        return ( m_buffer_counter[i_buffer] == m_buffer_size );
+        return (k_index_zlab(i_buffer,0) == m_buffer_box[i_buffer].smallEnd(m_moving_window_dir));
     }
 
     /** whether field buffer is empty.

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1130,7 +1130,6 @@ BTDiagnostics::PrepareParticleDataForOutput()
                             amrex::BoxArray buffer_ba( particle_buffer_box );
                             buffer_ba.maxSize(m_max_box_size);
                             amrex::DistributionMapping buffer_dmap(buffer_ba);
-//                            m_particles_buffer[i_buffer][i]->SetParGDB(m_geom_snapshot[i_buffer][lev], buffer_dmap, buffer_ba);
                             m_particles_buffer[i_buffer][i]->SetParticleBoxArray(lev, buffer_ba);
                             m_particles_buffer[i_buffer][i]->SetParticleDistributionMap(lev, buffer_dmap);
                             m_particles_buffer[i_buffer][i]->SetParticleGeometry(lev, m_geom_snapshot[i_buffer][lev]);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -683,7 +683,6 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
 
         // Modifying the physical coordinates of the lab-frame snapshot to be
         // consistent with the above modified domain-indices in m_snapshot_box.
-        amrex::IntVect ref_ratio = amrex::IntVect(1);
         if (lev == 0) {
             // The extent of the physical domain covered by the ith snapshot
             // Default non-periodic geometry for diags

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -546,10 +546,10 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                    {
                        amrex::Print() << " current zlab " << m_current_z_lab[i_buffer] << " lo : " << m_buffer_domain_lab[i_buffer].lo(m_moving_window_dir) << " hi " << m_buffer_domain_lab[i_buffer].hi(m_moving_window_dir) << "\n";
                    }
-                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                        m_current_z_lab[i_buffer] >= m_buffer_domain_lab[i_buffer].lo(m_moving_window_dir) and
-                        m_current_z_lab[i_buffer] <= m_buffer_domain_lab[i_buffer].hi(m_moving_window_dir),
-                        "z-slice in lab-frame is outside the buffer domain physical extent. ");
+                    //WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    //    m_current_z_lab[i_buffer] >= m_buffer_domain_lab[i_buffer].lo(m_moving_window_dir) and
+                    //    m_current_z_lab[i_buffer] <= m_buffer_domain_lab[i_buffer].hi(m_moving_window_dir),
+                    //    "z-slice in lab-frame is outside the buffer domain physical extent. ");
                 }
                 m_all_field_functors[lev][i]->PrepareFunctorData (
                                              i_buffer, ZSliceInDomain,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -142,10 +142,6 @@ BTDiagnostics::ReadParameters ()
         m_crse_ratio == amrex::IntVect(1),
         "Only support for coarsening ratio of 1 in all directions is included for BTD\n"
         );
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        warpx.Geom(0).ProbHi(WARPX_ZINDEX) == 0._rt,
-        " The geometry.prob_hi of the boosted-frame domain in the moving window direction must be ==0.\n"
-        );
 
     // Read list of back-transform diag parameters requested by the user //
     amrex::ParmParse pp_diag_name(m_diag_name);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -673,7 +673,6 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
 {
     if ( m_do_back_transformed_fields ) {
         auto & warpx = WarpX::GetInstance();
-        const int k_lab = k_index_zlab(i_buffer, lev);
         // Setting hi k-index for the first buffer
         m_buffer_k_index_hi[i_buffer] = m_snapshot_box[i_buffer].bigEnd(m_moving_window_dir);
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -774,7 +774,7 @@ BTDiagnostics::Flush (int i_buffer)
         isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush,
         m_totalParticles_flushed_already[i_buffer]);
 
- 
+
     for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
         // Buffer particle container reset to include geometry, dmap, Boxarray, and refratio
         // so that particles from finest level can also be selected and transformed

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -305,9 +305,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         auto tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
         if (isBTD) {
             PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
-            tmp.SetParticleGeometry(0,pinned_pc->Geom(0));
-            tmp.SetParticleBoxArray(0,pinned_pc->ParticleBoxArray(0));
-            tmp.SetParticleDistributionMap(0, pinned_pc->ParticleDistributionMap(0));
+            tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
         }
 
         Vector<std::string> real_names;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -626,9 +626,6 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
                      * parser_filter(p, engine) * geometry_filter(p, engine);
           }, true);
       } else if (isBTD) {
-          tmp.SetParticleGeometry(0,pinned_pc->Geom(0));
-          tmp.SetParticleBoxArray(0,pinned_pc->ParticleBoxArray(0));
-          tmp.SetParticleDistributionMap(0, pinned_pc->ParticleDistributionMap(0));
           tmp.copyParticles(*pinned_pc, true);
       }
 


### PR DESCRIPTION
This PR ensures that the BoxArray and geometry object used for particle buffer is same as that for the field buffer. 
This PR solves part of the problem with Issue #2746 i.e., particles are redistributed correctly to the box array for a single-level simulation. 
Here is the plotfile result - I have slightly modified the input file from the Issue to ensure its single level and could be tested with plotfiles, and changed prob-hi in z-direction to be ==0
 (Work is in progress to test single-level OpenPMD output -- this should ideally just work.)

![Screenshot from 2022-04-20 16-25-44](https://user-images.githubusercontent.com/41089244/164344036-a564df66-fe02-4d5d-aa1d-b8d500015763.png)
input file : 
[inputs.3d.txt](https://github.com/ECP-WarpX/WarpX/files/8526196/inputs.3d.txt)

However, the code still crashes for the same input file and test with mesh-refinement. 
I am discussing this offline with @atmyers to understand how to ensure particle container for BTD does not use finestLevel from the simulation, but from the diagnostics.
**Update : This is fixed after @atmyers merged a PR to amrex https://github.com/AMReX-Codes/amrex/pull/2732** 
**The code now works without and with mesh refinement**


Also, the Prob hi in the ZINDEX direction must be 0.0 for cases with and without mesh-refienement. 
Added an ASSERT in the code to crash with error message. 
Discussing this offline with @RemiLehe and @atmyers to see how to incorporate an offset for Lo,Hi in the lab-frame.
**Update : This is fixed as well.** 


