### PR TITLE
Nuclear fusion: remove underflow warning in single precision

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -86,13 +86,13 @@ namespace {
         // Rest energy of alpha+beryllium
         constexpr amrex::ParticleReal E_rest_abe = (m_alpha + m_beryllium)*c_sq;
 
-        // These constexprs underflow in single precision because we use SI units and sometimes the
-        // code won't compile. Nuclear fusion module does not currently work with single precision
-        // anyways so these #ifdef are just here to make sure that the code always compiles with
-        // single precision.
+        // These constexprs underflow in single precision because we use SI units, which can cause
+        // compilation to fail or generate a warning. Nuclear fusion module does not currently work
+        // with single precision anyways so this #ifdef is here to make sure that compilation
+        // always succeeds with single precision.
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-        const amrex::ParticleReal ma_sq = m_alpha*m_alpha;
-        const amrex::ParticleReal mBe_sq = m_beryllium*m_beryllium;
+        constexpr amrex::ParticleReal ma_sq = std::numeric_limits<amrex::ParticleReal>::min();
+        constexpr amrex::ParticleReal mBe_sq = std::numeric_limits<amrex::ParticleReal>::min();
 #else
         constexpr amrex::ParticleReal ma_sq = m_alpha*m_alpha;
         constexpr amrex::ParticleReal mBe_sq = m_beryllium*m_beryllium;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -77,20 +77,20 @@ namespace {
         // cf. JEFF-3.3 radioactive decay data library (2017)
         constexpr amrex::ParticleReal E_decay = 0.0918984_prt*mev_to_joule;
 
-        constexpr amrex::ParticleReal m_alpha = PhysConst::m_p * 3.97369_prt;
-        constexpr amrex::ParticleReal m_beryllium = PhysConst::m_p * 7.94748_prt;
+        // The constexprs ma_sq and mBe_sq underflow in single precision because we use SI units,
+        // which can cause compilation to fail or generate a warning, so we're explicitly setting
+        // them as double. Note that nuclear fusion module does not currently work with single
+        // precision anyways.
+        constexpr double m_alpha = PhysConst::m_p * 3.97369_prt;
+        constexpr double m_beryllium = PhysConst::m_p * 7.94748_prt;
+        constexpr double ma_sq = m_alpha*m_alpha;
+        constexpr double mBe_sq = m_beryllium*m_beryllium;
         constexpr amrex::ParticleReal c_sq = PhysConst::c * PhysConst::c;
         constexpr amrex::ParticleReal inv_csq = 1._prt / ( c_sq );
         // Rest energy of proton+boron
         const amrex::ParticleReal E_rest_pb = (m1 + m2)*c_sq;
         // Rest energy of alpha+beryllium
         constexpr amrex::ParticleReal E_rest_abe = (m_alpha + m_beryllium)*c_sq;
-
-        // These constexprs underflow in single precision because we use SI units, which can cause
-        // compilation to fail or generate a warning, so we're explicitly setting them as double.
-        // Note that nuclear fusion module does not currently work with single precision anyways.
-        constexpr double ma_sq = m_alpha*m_alpha;
-        constexpr double mBe_sq = m_beryllium*m_beryllium;
 
         // Normalized momentum of colliding particles (proton and boron)
         const amrex::ParticleReal u1x = soa_1.m_rdata[PIdx::ux][idx_1];

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -87,16 +87,10 @@ namespace {
         constexpr amrex::ParticleReal E_rest_abe = (m_alpha + m_beryllium)*c_sq;
 
         // These constexprs underflow in single precision because we use SI units, which can cause
-        // compilation to fail or generate a warning. Nuclear fusion module does not currently work
-        // with single precision anyways so this #ifdef is here to make sure that compilation
-        // always succeeds with single precision.
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-        constexpr amrex::ParticleReal ma_sq = std::numeric_limits<amrex::ParticleReal>::min();
-        constexpr amrex::ParticleReal mBe_sq = std::numeric_limits<amrex::ParticleReal>::min();
-#else
-        constexpr amrex::ParticleReal ma_sq = m_alpha*m_alpha;
-        constexpr amrex::ParticleReal mBe_sq = m_beryllium*m_beryllium;
-#endif
+        // compilation to fail or generate a warning, so we're explicitly setting them as double.
+        // Note that nuclear fusion module does not currently work with single precision anyways.
+        constexpr double ma_sq = m_alpha*m_alpha;
+        constexpr double mBe_sq = m_beryllium*m_beryllium;
 
         // Normalized momentum of colliding particles (proton and boron)
         const amrex::ParticleReal u1x = soa_1.m_rdata[PIdx::ux][idx_1];


### PR DESCRIPTION
Close #2616, #3041 

These values underflow in single precision which can cause a warning during compilation, so I just set them to `std::numeric_limits<amrex::ParticleReal>::min()` (nuclear fusion currently does not support single precision anyways).