### PR TITLE
Use the same types for different pinned-memory particle containers

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1036,7 +1036,7 @@ BTDiagnostics::InitializeParticleBuffer ()
         for (int isp = 0; isp < m_particles_buffer[i].size(); ++isp) {
             m_totalParticles_flushed_already[i][isp] = 0;
             m_totalParticles_in_buffer[i][isp] = 0;
-            m_particles_buffer[i][isp] = std::make_unique<PinnedMemoryParticleContainer>(&WarpX::GetInstance());
+            m_particles_buffer[i][isp] = std::make_unique<PinnedMemoryParticleContainer>(WarpX::GetInstance().GetParGDB());
             const int idx = mpc.getSpeciesID(m_output_species_names[isp]);
             m_output_species[i].push_back(ParticleDiag(m_diag_name,
                                                        m_output_species_names[isp],

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -194,7 +194,7 @@ BackTransformParticleFunctor final : public ComputeParticleDiagFunctor
 public:
     BackTransformParticleFunctor(WarpXParticleContainer *pc_src, std::string species_name, int num_buffers);
     /** Computes the Lorentz transform of source particles to obtain lab-frame data in pc_dst*/
-    void operator () (ParticleContainer& pc_dst, int &TotalParticleCounter, int i_buffer) const override;
+    void operator () (PinnedMemoryParticleContainer& pc_dst, int &TotalParticleCounter, int i_buffer) const override;
     void InitData() override;
     /** \brief Prepare data required to back-transform particle attribtutes for lab-frame snapshot, i_buffer
      *

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
@@ -75,7 +75,7 @@ BackTransformParticleFunctor::BackTransformParticleFunctor (
 
 
 void
-BackTransformParticleFunctor::operator () (ParticleContainer& pc_dst, int &totalParticleCounter, int i_buffer) const
+BackTransformParticleFunctor::operator () (PinnedMemoryParticleContainer& pc_dst, int &totalParticleCounter, int i_buffer) const
 {
     if (m_perform_backtransform[i_buffer] == 0) return;
     auto &warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
@@ -8,6 +8,7 @@
 #define WARPX_COMPUTEPARTICLEDIAGFUNCTOR_H_
 
 #include "Particles/WarpXParticleContainer.H"
+#include "Particles/PinnedMemoryParticleContainer.H"
 #include <AMReX.H>
 #include <AMReX_AmrParticles.H>
 
@@ -18,7 +19,6 @@ class
 ComputeParticleDiagFunctor
 {
 public:
-    using ParticleContainer = typename amrex::AmrParticleContainer<0, 0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
 
     ComputeParticleDiagFunctor( ) {}
     /** Virtual Destructor to handle clean destruction of derived classes */
@@ -52,7 +52,7 @@ public:
      *  \param[out] pc_dst  output particle container where the result is stored.
      *  \param[in] i_buffer snapshot index for which the particle buffer is processed
      */
-    virtual void operator () (ParticleContainer& pc_dst, int &totalParticlesInBuffer, int i_buffer = 0) const = 0;
+    virtual void operator () (PinnedMemoryParticleContainer& pc_dst, int &totalParticlesInBuffer, int i_buffer = 0) const = 0;
     virtual void InitData () {}
 };
 

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -9,6 +9,7 @@
 
 #include "Particles/MultiParticleContainer_fwd.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Particles/PinnedMemoryParticleContainer.H"
 
 #include <vector>
 
@@ -18,8 +19,6 @@
 class ParticleBoundaryBuffer
 {
 public:
-    using BufferType = typename WarpXParticleContainer::ContainerLike<amrex::PinnedArenaAllocator>;
-
     ParticleBoundaryBuffer ();
 
     int numSpecies() const { return getSpeciesNames().size(); }
@@ -45,7 +44,7 @@ public:
 
     int getNumParticlesInContainer(const std::string species_name, int boundary);
 
-    BufferType& getParticleBuffer(const std::string species_name, int boundary);
+    PinnedMemoryParticleContainer& getParticleBuffer(const std::string species_name, int boundary);
 
     static constexpr int numBoundaries () {
         return AMREX_SPACEDIM*2
@@ -57,7 +56,7 @@ public:
 
 private:
     // over boundary, then number of species
-    std::vector<std::vector<BufferType> > m_particle_containers;
+    std::vector<std::vector<PinnedMemoryParticleContainer> > m_particle_containers;
 
     // over boundary, then number of species
     std::vector<std::vector<int> > m_do_boundary_buffer;

--- a/Source/Particles/PinnedMemoryParticleContainer.H
+++ b/Source/Particles/PinnedMemoryParticleContainer.H
@@ -9,6 +9,6 @@
 
 #include <AMReX_ParIter.H>
 
-using PinnedMemoryParticleContainer = typename amrex::AmrParticleContainer<0,0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>;
+using PinnedMemoryParticleContainer = WarpXParticleContainer::ContainerLike<amrex::PinnedArenaAllocator>;
 
 #endif


### PR DESCRIPTION
We use different pinned memory containers throughout the code. 

This PR attempts to clean up the code by unifying these different types and use `PinnedMemoryParticleContainer` everywhere.

Note that the actual type of `PinnedMemoryParticleContainer` was switched from `amrex::AmrParticleContainer<0,0, PIdx::nattribs, 0, amrex::PinnedArenaAllocator>` to ` WarpXParticleContainer::ContainerLike<amrex::PinnedArenaAllocator>`. This should however not affect WarpX since these two types are very similar.