### PR TITLE
abort if BTD selected for RZ, and unsupported field/particle varnames

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2006,6 +2006,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
    Note that these averages do not respect the particle shape factor, and instead use nearest-grid point interpolation.
    Default is none.
    Parser functions for these field names are specified by ``<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)``.
+   Also, note that this option is only available for ``<diag_name>.diag_type = Full``
 
 * ``<diag_name>.particle_fields_species`` (list of `strings`, optional)
          Species for which to calculate ``particle_fields_to_plot``.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1988,7 +1988,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
-    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe.
+    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe. Also, note that for ``<diag_name>.diag_type = BackTransformed``, the only scalar field currently supported is ``rho``.
     Possible vector field components in Cartesian geometry: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz``.
     Possible vector field components in RZ geometry: ``Er`` ``Et`` ``Ez`` ``Br`` ``Bt`` ``Bz`` ``jr`` ``jt`` ``jz``.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``,
@@ -2115,7 +2115,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 BackTransformed Diagnostics (with support for Plotfile/openPMD output)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``BackTransformed`` diag type are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame. This option can be set using ``<diag_name>.diag_type = BackTransformed``. Additional options for this diagnostic include:
+``BackTransformed`` diag type are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame. This option can be set using ``<diag_name>.diag_type = BackTransformed``. Note that this diagnostic is not currently supported for RZ.  Additional options for this diagnostic include:
 
 * ``<diag_name>.num_snapshots_lab`` (`integer`)
     Only used when ``<diag_name>.diag_type`` is ``BackTransformed``.

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -186,7 +186,7 @@ BTDiagnostics::ReadParameters ()
     if (pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames) ) {
         amrex::Abort("particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
     }
-    
+
 
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -170,6 +170,18 @@ BTDiagnostics::ReadParameters ()
         if(m_max_box_size < m_buffer_size) m_max_box_size = m_buffer_size;
     }
 
+
+    amrex::Vector< std::string > BTD_varnames_supported = {"Ex", "Ey", "Ez",
+                                                           "Bx", "By", "Bz",
+                                                           "jx", "jy", "jz", "rho"};
+
+    for (const auto& var : m_varnames) {
+        if ( ! WarpXUtilStr::is_in(BTD_varnames_supported, var) ) {
+            amrex::Abort("Input error: field variable " + var + " in " + m_diag_name +
+                         ".fields_to_plot is not supported for BackTransformed diagnostics. Currently supported field variables for BackTransformed diagnostics include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
+        }
+    }
+
 }
 
 bool

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -176,16 +176,16 @@ BTDiagnostics::ReadParameters ()
                                                            "jx", "jy", "jz", "rho"};
 
     for (const auto& var : m_varnames) {
-        if ( ! WarpXUtilStr::is_in(BTD_varnames_supported, var) ) {
-            amrex::Abort("Input error: field variable " + var + " in " + m_diag_name +
-                         ".fields_to_plot is not supported for BackTransformed diagnostics. Currently supported field variables for BackTransformed diagnostics include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
-        }
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ( ! WarpXUtilStr::is_in(BTD_varnames_supported, var )), "Input error: field variable " + var + " in " + m_diag_name
+        + ".fields_to_plot is not supported for BackTransformed diagnostics. Currently supported field variables for BackTransformed diagnostics include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
+//        if ( ! WarpXUtilStr::is_in(BTD_varnames_supported, var) ) {
+//            amrex::Abort("Input error: field variable " + var + " in " + m_diag_name +
+//                         ".fields_to_plot is not supported for BackTransformed diagnostics. Currently supported field variables for BackTransformed diagnostics include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
+//        }
     }
 
-
-    if (pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames) ) {
-        amrex::Abort("particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
-    }
+    bool particle_fields_to_plot_specified = pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames);
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(particle_fields_to_plot_specified, "particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
     
 
 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -176,12 +176,12 @@ BTDiagnostics::ReadParameters ()
                                                            "jx", "jy", "jz", "rho"};
 
     for (const auto& var : m_varnames) {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ( ! WarpXUtilStr::is_in(BTD_varnames_supported, var )), "Input error: field variable " + var + " in " + m_diag_name
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( (WarpXUtilStr::is_in(BTD_varnames_supported, var )), "Input error: field variable " + var + " in " + m_diag_name
         + ".fields_to_plot is not supported for BackTransformed diagnostics. Currently supported field variables for BackTransformed diagnostics include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
     }
 
     bool particle_fields_to_plot_specified = pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames);
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(particle_fields_to_plot_specified, "particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!particle_fields_to_plot_specified, "particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
 
 
 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -182,7 +182,7 @@ BTDiagnostics::ReadParameters ()
 
     bool particle_fields_to_plot_specified = pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames);
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(particle_fields_to_plot_specified, "particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
-    
+
 
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -182,6 +182,12 @@ BTDiagnostics::ReadParameters ()
         }
     }
 
+
+    if (pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames) ) {
+        amrex::Abort("particle_fields_to_plot is currently not supported for BackTransformed Diagnostics");
+    }
+    
+
 }
 
 bool

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -577,7 +577,9 @@ BackTransformedDiagnostic (Real zmin_lab, Real zmax_lab, Real v_window_lab,
       m_particle_slice_width_lab_(particle_slice_width_lab)
 {
 
-
+#ifdef WARPX_DIM_RZ
+    amrex::Abort("BackTransformed diagnostics is currently not supported with RZ");
+#endif
     WARPX_PROFILE("BackTransformedDiagnostic::BackTransformedDiagnostic");
 
     AMREX_ALWAYS_ASSERT(WarpX::do_back_transformed_fields or

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -10,6 +10,7 @@
 #include "Parallelization/WarpXCommUtil.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
+#include "Utils/TextMsg.H"
 #include "WarpX.H"
 
 #include <AMReX_Array4.H>
@@ -578,7 +579,7 @@ BackTransformedDiagnostic (Real zmin_lab, Real zmax_lab, Real v_window_lab,
 {
 
 #ifdef WARPX_DIM_RZ
-    amrex::Abort("BackTransformed diagnostics is currently not supported with RZ");
+    amrex::Abort(Utils::TextMsg::Err("BackTransformed diagnostics is currently not supported with RZ"));
 #endif
     WARPX_PROFILE("BackTransformedDiagnostic::BackTransformedDiagnostic");
 

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -22,7 +22,11 @@ MultiDiagnostics::MultiDiagnostics ()
         if ( diags_types[i] == DiagTypes::Full ){
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
+#ifdef WARPX_DIM_RZ
+            amrex::Abort("Backtransformed diagnostics is currently not supported for RZ");
+#else
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
+#endif
         } else {
             amrex::Abort("Unknown diagnostic type");
         }

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -2,6 +2,7 @@
 
 #include "Diagnostics/BTDiagnostics.H"
 #include "Diagnostics/FullDiagnostics.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX.H>
@@ -23,7 +24,7 @@ MultiDiagnostics::MultiDiagnostics ()
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
 #ifdef WARPX_DIM_RZ
-            amrex::Abort("Backtransformed diagnostics is currently not supported for RZ");
+            amrex::Abort(Utils::TextMsg::Err("BackTransformed diagnostics is currently not supported for RZ"));
 #else
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
 #endif


### PR DESCRIPTION
Until BTD is added in RZ, we will abort when BackTransformed Diagnsostics is selected for RZ simulations.
Additionally, the code will also abort if unsupported fields for BTD are requested by user.