### PR TITLE
Doc: Update Perlmutter Python/HDF5

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -13,7 +13,7 @@ module load cudatoolkit
 module load boost/1.78.0-gnu
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.0.7
+module load cray-hdf5-parallel/1.12.1.1
 export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/adios2-2.7.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/blaspp-master:$CMAKE_PREFIX_PATH
@@ -25,7 +25,7 @@ export LD_LIBRARY_PATH=$HOME/sw/perlmutter/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$HOME/sw/perlmutter/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.4.2
+module load cray-python/3.9.7.1
 
 if [ -d "$HOME/sw/perlmutter/venvs/warpx" ]
 then

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -49,8 +49,8 @@ export CRAY_ACCEL_TARGET=nvidia80
 export AMREX_CUDA_ARCH=8.0
 
 # compiler environment hints
-export CC=$(which gcc)
-export CXX=$(which g++)
-export FC=$(which gfortran)
+export CC=cc
+export CXX=CC
+export FC=ftn
 export CUDACXX=$(which nvcc)
-export CUDAHOSTCXX=$(which g++)
+export CUDAHOSTCXX=CC


### PR DESCRIPTION
Update Perlmutter modules after the last days' updates rolled out.

cc @tanweihou

### To Do 

- [x] figure out HDF5 issue (not found anymore, missing `HDF5_LIBRARIES`: 
  - NERSC issue `INC0184303`
  - https://gitlab.kitware.com/cmake/cmake/-/issues/22368#note_1181441
- [x] test