### PR TITLE
Fix miscellaneous issues found with clang tidy

### DIFF
--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -4,20 +4,15 @@
 #include "Evolve/WarpXDtType.H"
 #include "WarpX_PEC.H"
 
-#include <AMReX_REAL.H>
-#include <AMReX_Vector.H>
-#include <AMReX_Print.H>
-#include <array>
-#include <memory>
-
 #include <AMReX.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_IntVect.H>
-#include <AMReX_Print.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
+#include <AMReX_Print.H>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 using namespace amrex::literals;
 using namespace amrex;

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -32,7 +32,7 @@ class Diagnostics
 public:
     Diagnostics (int i, std::string name);
     /** Virtual Destructor to handle clean destruction of derived classes */
-    virtual ~Diagnostics () ;
+    virtual ~Diagnostics () = default;
     /** Pack (stack) all fields in the cell-centered output MultiFab m_mf_output.
      *
      * Fields are computed (e.g., cell-centered or back-transformed)

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -32,7 +32,7 @@ class Diagnostics
 public:
     Diagnostics (int i, std::string name);
     /** Virtual Destructor to handle clean destruction of derived classes */
-    virtual ~Diagnostics () = default;
+    virtual ~Diagnostics ();
     /** Pack (stack) all fields in the cell-centered output MultiFab m_mf_output.
      *
      * Fields are computed (e.g., cell-centered or back-transformed)

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -39,9 +39,7 @@ Diagnostics::Diagnostics (int i, std::string name)
 {
 }
 
-Diagnostics::~Diagnostics ()
-{
-}
+Diagnostics::~Diagnostics () = default;
 
 bool
 Diagnostics::BaseReadParameters ()

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -39,8 +39,6 @@ Diagnostics::Diagnostics (int i, std::string name)
 {
 }
 
-Diagnostics::~Diagnostics () = default;
-
 bool
 Diagnostics::BaseReadParameters ()
 {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -39,6 +39,9 @@ Diagnostics::Diagnostics (int i, std::string name)
 {
 }
 
+Diagnostics::~Diagnostics ()
+{}
+
 bool
 Diagnostics::BaseReadParameters ()
 {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -39,8 +39,7 @@ Diagnostics::Diagnostics (int i, std::string name)
 {
 }
 
-Diagnostics::~Diagnostics ()
-{}
+Diagnostics::~Diagnostics () = default;
 
 bool
 Diagnostics::BaseReadParameters ()

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -179,7 +179,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
 
     // get the string lengths on IO proc
     ParallelDescriptor::Gather(&length, 1,                     // send
-                               &m_data_string_recvcount[0], 1, // receive
+                               m_data_string_recvcount.data(), 1, // receive
                                ParallelDescriptor::IOProcessorNumber());
 
     // determine total length of collected strings for root, and set displacements;
@@ -205,7 +205,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
     // collect the hostnames; m_data_string_recvbuf will provide mapping from rank-->hostname
     ParallelDescriptor::Gatherv(&hostname[0],              /* hostname ID */
                                 length,                    /* length of hostname */
-                                &m_data_string_recvbuf[0], /* write data into string buffer */
+                                m_data_string_recvbuf.data(), /* write data into string buffer */
                                 m_data_string_recvcount,   /* how many messages to receive */
                                 m_data_string_disp,        /* starting position in recv buffer to place received msg */
                                 ParallelDescriptor::IOProcessorNumber());

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -23,7 +23,6 @@
 #include <AMReX_GpuDevice.H>
 #include <AMReX_GpuElixir.H>
 #include <AMReX_GpuLaunch.H>
-#include <AMReX_GpuLaunch.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_IndexType.H>
 #include <AMReX_LayoutData.H>

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -41,7 +41,7 @@ class PlasmaInjector
 
 public:
 
-    PlasmaInjector ();
+    PlasmaInjector () = default;
 
     PlasmaInjector (int ispecies, const std::string& name);
 

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -51,7 +51,7 @@ namespace {
     }
 }
 
-PlasmaInjector::PlasmaInjector () {}
+PlasmaInjector::PlasmaInjector () = default;
 
 PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     : species_id(ispecies), species_name(name)

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -51,8 +51,6 @@ namespace {
     }
 }
 
-PlasmaInjector::PlasmaInjector () = default;
-
 PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     : species_id(ispecies), species_name(name)
 {

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -112,7 +112,7 @@ WarpX::LoadBalance ()
             {
                 pmap.resize(static_cast<std::size_t>(nboxes));
             }
-            ParallelDescriptor::Bcast(&pmap[0], pmap.size(), ParallelDescriptor::IOProcessorNumber());
+            ParallelDescriptor::Bcast(pmap.data(), pmap.size(), ParallelDescriptor::IOProcessorNumber());
 
             if (ParallelDescriptor::MyProc() != ParallelDescriptor::IOProcessorNumber())
             {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -689,37 +689,37 @@ MultiParticleContainer
             // and Fills parts[species number i] with particle data from all grids and
             // tiles in diagnostic_particles. parts contains particles from all
             // AMR levels indistinctly.
-            for (auto it = diagnostic_particles[lev].begin(); it != diagnostic_particles[lev].end(); ++it){
+            for (const auto& dp : diagnostic_particles[lev]){
                 // it->first is the [grid index][tile index] key
                 // it->second is the corresponding
                 // WarpXParticleContainer::DiagnosticParticleData value
                 parts[i].GetRealData(DiagIdx::w).insert(  parts[i].GetRealData(DiagIdx::w  ).end(),
-                                                          it->second.GetRealData(DiagIdx::w  ).begin(),
-                                                          it->second.GetRealData(DiagIdx::w  ).end());
+                                                          dp.second.GetRealData(DiagIdx::w  ).begin(),
+                                                          dp.second.GetRealData(DiagIdx::w  ).end());
 
                 parts[i].GetRealData(DiagIdx::x).insert(  parts[i].GetRealData(DiagIdx::x  ).end(),
-                                                          it->second.GetRealData(DiagIdx::x  ).begin(),
-                                                          it->second.GetRealData(DiagIdx::x  ).end());
+                                                          dp.second.GetRealData(DiagIdx::x  ).begin(),
+                                                          dp.second.GetRealData(DiagIdx::x  ).end());
 
                 parts[i].GetRealData(DiagIdx::y).insert(  parts[i].GetRealData(DiagIdx::y  ).end(),
-                                                          it->second.GetRealData(DiagIdx::y  ).begin(),
-                                                          it->second.GetRealData(DiagIdx::y  ).end());
+                                                          dp.second.GetRealData(DiagIdx::y  ).begin(),
+                                                          dp.second.GetRealData(DiagIdx::y  ).end());
 
                 parts[i].GetRealData(DiagIdx::z).insert(  parts[i].GetRealData(DiagIdx::z  ).end(),
-                                                          it->second.GetRealData(DiagIdx::z  ).begin(),
-                                                          it->second.GetRealData(DiagIdx::z  ).end());
+                                                          dp.second.GetRealData(DiagIdx::z  ).begin(),
+                                                          dp.second.GetRealData(DiagIdx::z  ).end());
 
                 parts[i].GetRealData(DiagIdx::ux).insert(  parts[i].GetRealData(DiagIdx::ux).end(),
-                                                           it->second.GetRealData(DiagIdx::ux).begin(),
-                                                           it->second.GetRealData(DiagIdx::ux).end());
+                                                           dp.second.GetRealData(DiagIdx::ux).begin(),
+                                                           dp.second.GetRealData(DiagIdx::ux).end());
 
                 parts[i].GetRealData(DiagIdx::uy).insert(  parts[i].GetRealData(DiagIdx::uy).end(),
-                                                           it->second.GetRealData(DiagIdx::uy).begin(),
-                                                           it->second.GetRealData(DiagIdx::uy).end());
+                                                           dp.second.GetRealData(DiagIdx::uy).begin(),
+                                                           dp.second.GetRealData(DiagIdx::uy).end());
 
                 parts[i].GetRealData(DiagIdx::uz).insert(  parts[i].GetRealData(DiagIdx::uz).end(),
-                                                           it->second.GetRealData(DiagIdx::uz).begin(),
-                                                           it->second.GetRealData(DiagIdx::uz).end());
+                                                           dp.second.GetRealData(DiagIdx::uz).begin(),
+                                                           dp.second.GetRealData(DiagIdx::uz).end());
             }
         }
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -783,8 +783,8 @@ Real WarpXParticleContainer::sumParticleCharge(bool local) {
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             auto& wp = pti.GetAttribs(PIdx::w);
-            for (unsigned long i = 0; i < wp.size(); i++) {
-                total_charge += wp[i];
+            for (const auto& tt : wp) {
+                total_charge += tt;
             }
         }
     }


### PR DESCRIPTION
This PR fixes few miscellaneous issues found with the clang-tidy tool.
(e.g., duplicated includes, use of `&container[0]` instead of `container[0].data()`...)