### PR TITLE
Fix openPMD RZ with load-balancing

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -281,11 +281,7 @@ Diagnostics::InitData ()
         // the corresponding functor is also initialized for all the levels
         for (int lev = 0; lev < nmax_lev; ++lev) {
             // allocate and initialize m_all_field_functors depending on diag type
-            if (dims == "RZ" and m_format == "openpmd") {
-                InitializeFieldFunctorsRZopenPMD(lev);
-            } else {
-                InitializeFieldFunctors(lev);
-            }
+            InitializeFieldFunctors(lev);
         }
         // loop over the levels selected for output
         // This includes all the levels for full diagnostics

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -274,9 +274,6 @@ Diagnostics::InitData ()
     // initialize member variables and arrays specific to each derived class
     // (FullDiagnostics, BTDiagnostics, etc.)
     DerivedInitData();
-    amrex::ParmParse pp_geometry("geometry");
-    std::string dims;
-    pp_geometry.get("dims", dims);
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         // loop over all levels
         // This includes full diagnostics and BTD as well as cell-center functors for BTD.

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -563,6 +563,14 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
 void
 FullDiagnostics::InitializeFieldFunctors (int lev)
 {
+#ifdef WARPX_DIM_RZ
+    // For RZ, with openPMD, we need a special initialization instead
+    if (m_format == "openpmd") {
+        InitializeFieldFunctorsRZopenPMD(lev);
+        return; // We skip the rest of this function
+    }
+#endif
+
     auto & warpx = WarpX::GetInstance();
 
     // Clear any pre-existing vector to release stored data.


### PR DESCRIPTION
When running with load-balancing, the regridding function calls [`MultiDiagnostics::InitializeFieldFunctors`](https://github.com/ECP-WarpX/WarpX/blob/development/Source/Diagnostics/MultiDiagnostics.cpp#L46) which in turn calls `Diagnostics::InitializeFieldFunctors` but fails to call the specialized version (`InitializeFieldFunctorsRZopenPMD`) in the case of RZ openPMD.

Therefore, the new code calls `InitializeFieldFunctorsRZopenPMD` directly **inside** `InitializeFieldFunctors`.