### PR TITLE
Use maps to store physical properties in Source/Particles/SpeciesPhysicalProperties

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
@@ -5,9 +5,12 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "BackTransformParticleFunctor.H"
+
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/WarpXConst.H"
 #include "WarpX.H"
+
 #include <AMReX.H>
 #include <AMReX_Print.H>
 #include <AMReX_BaseFwd.H>

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -125,7 +125,10 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     std::string physical_species_s;
     bool species_is_specified = pp_species_name.query("species_type", physical_species_s);
     if (species_is_specified){
-        physical_species = species::from_string( physical_species_s );
+        const auto physical_species_from_string = species::from_string( physical_species_s );
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(physical_species_from_string,
+            physical_species_s + " does not exist!");
+        physical_species = physical_species_from_string.value();
         charge = species::get_charge( physical_species );
         mass = species::get_mass( physical_species );
     }

--- a/Source/Particles/CMakeLists.txt
+++ b/Source/Particles/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(WarpX
     WarpXParticleContainer.cpp
     LaserParticleContainer.cpp
     ParticleBoundaryBuffer.cpp
+    SpeciesPhysicalProperties.cpp
 )
 
 #add_subdirectory(Algorithms)

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -12,6 +12,7 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpXAlgorithmSelection.H"
+#include "Utils/WarpXConst.H"
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"
 #endif

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -4,6 +4,7 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 
 #include "Particles/WarpXParticleContainer_fwd.H"
+#include "Utils/WarpXConst.H"
 
 #include <AMReX.H>
 #include <AMReX_Array.H>

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -6,6 +6,7 @@ CEXE_sources += PhotonParticleContainer.cpp
 CEXE_sources += LaserParticleContainer.cpp
 CEXE_sources += ParticleBoundaryBuffer.cpp
 CEXE_sources += ParticleBoundaries.cpp
+CEXE_sources += SpeciesPhysicalProperties.cpp
 
 include $(WARPX_HOME)/Source/Particles/Algorithms/Make.package
 include $(WARPX_HOME)/Source/Particles/Pusher/Make.package

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -8,13 +8,9 @@
 #ifndef WARPX_SPECIESPHYSICALPROPERTIES_H_
 #define WARPX_SPECIESPHYSICALPROPERTIES_H_
 
-#include "Utils/WarpXConst.H"
-
-#include <AMReX_AmrCore.H>
 #include <AMReX_REAL.H>
 
-#include <limits>
-#include <map>
+#include <optional>
 #include <string>
 
 enum struct PhysicalSpecies{unspecified=0, electron, positron, photon, hydrogen, helium, boron,
@@ -22,166 +18,37 @@ enum struct PhysicalSpecies{unspecified=0, electron, positron, photon, hydrogen,
 
 namespace species
 {
-    AMREX_FORCE_INLINE
-    PhysicalSpecies from_string(std::string species)
-    {
-        if( species=="unspecified" )
-            return PhysicalSpecies::unspecified;
-        if( species=="electron" )
-            return PhysicalSpecies::electron;
-        if( species=="positron" )
-            return PhysicalSpecies::positron;
-        if( species=="photon" )
-            return PhysicalSpecies::photon;
-        if( species=="hydrogen" )
-            return PhysicalSpecies::hydrogen;
-        if( species=="proton" )
-            return PhysicalSpecies::hydrogen;
-        if( species=="helium" )
-            return PhysicalSpecies::helium;
-        if( species=="alpha" )
-            return PhysicalSpecies::helium;
-        if( species=="boron" )
-            return PhysicalSpecies::boron;
-        if( species=="boron10" )
-            return PhysicalSpecies::boron10;
-        if( species=="boron11" )
-            return PhysicalSpecies::boron11;
-        if( species=="carbon" )
-            return PhysicalSpecies::carbon;
-        if( species=="nitrogen" )
-            return PhysicalSpecies::nitrogen;
-        if( species=="oxygen" )
-            return PhysicalSpecies::oxygen;
-        if( species=="argon" )
-            return PhysicalSpecies::argon;
-        if( species=="copper" )
-            return PhysicalSpecies::copper;
-        if( species=="xenon" )
-            return PhysicalSpecies::xenon;
-        amrex::Abort("unknown PhysicalSpecies");
-        return PhysicalSpecies::unspecified;
-    }
+    /**
+     * \brief Returns the PhysicalSpecies associated to a given name
+     *
+     * \param[in] species_name the name of a species
+     * \return the PhysicalSpecies corresponding to species_name (if it exists)
+     */
+    std::optional<PhysicalSpecies> from_string (const std::string& species_name);
 
-    AMREX_FORCE_INLINE
-    amrex::Real get_charge (PhysicalSpecies ps)
-    {
-        switch(ps) {
-        case PhysicalSpecies::unspecified:
-            return std::numeric_limits<amrex::Real>::quiet_NaN();
-        case PhysicalSpecies::electron:
-            return -PhysConst::q_e;
-        case PhysicalSpecies::positron:
-            return PhysConst::q_e;
-        case PhysicalSpecies::photon:
-            return 0.;
-        case PhysicalSpecies::hydrogen:
-            return PhysConst::q_e;
-        case PhysicalSpecies::helium:
-            return PhysConst::q_e * amrex::Real(2.0);
-        case PhysicalSpecies::boron:
-            return PhysConst::q_e * amrex::Real(5.0);
-        case PhysicalSpecies::boron10:
-            return PhysConst::q_e * amrex::Real(5.0);
-        case PhysicalSpecies::boron11:
-            return PhysConst::q_e * amrex::Real(5.0);
-        case PhysicalSpecies::carbon:
-            return PhysConst::q_e * amrex::Real(6.0);
-        case PhysicalSpecies::nitrogen:
-            return PhysConst::q_e * amrex::Real(7.0);
-        case PhysicalSpecies::oxygen:
-            return PhysConst::q_e * amrex::Real(8.0);
-        case PhysicalSpecies::argon:
-            return PhysConst::q_e * amrex::Real(18.0);
-        case PhysicalSpecies::copper:
-            return PhysConst::q_e * amrex::Real(29.0);
-        case PhysicalSpecies::xenon:
-            return PhysConst::q_e * amrex::Real(54.0);
-        default:
-            amrex::Abort("unknown PhysicalSpecies");
-            return 0.;
-        }
-    }
+    /**
+     * \brief Returns the charge associated to a PhysicalSpecies
+     *
+     * \param[in] ps the PhysicalSpecies
+     * \return the charge associated to the PhysicalSpecies
+     */
+    amrex::Real get_charge (const PhysicalSpecies& ps);
 
-    AMREX_FORCE_INLINE
-    amrex::Real get_mass (PhysicalSpecies ps)
-    {
-        switch(ps) {
-        case PhysicalSpecies::unspecified:
-            return std::numeric_limits<amrex::Real>::quiet_NaN();
-        case PhysicalSpecies::electron:
-            return PhysConst::m_e;
-        case PhysicalSpecies::positron:
-            return PhysConst::m_e;
-        case PhysicalSpecies::photon:
-            return 0.;
-        case PhysicalSpecies::hydrogen:
-            return PhysConst::m_p;
-        case PhysicalSpecies::helium:
-            return PhysConst::m_p * amrex::Real(3.97369);
-        case PhysicalSpecies::boron:
-            return PhysConst::m_p * amrex::Real(10.7319);
-        case PhysicalSpecies::boron10:
-            return PhysConst::m_p * amrex::Real(9.94060);
-        case PhysicalSpecies::boron11:
-            return PhysConst::m_p * amrex::Real(10.9298);
-        case PhysicalSpecies::carbon:
-            return PhysConst::m_e * amrex::Real(22032.0);
-        case PhysicalSpecies::nitrogen:
-            return PhysConst::m_e * amrex::Real(25716.9);
-        case PhysicalSpecies::oxygen:
-            return PhysConst::m_p * amrex::Real(15.8834);
-        case PhysicalSpecies::argon:
-            return PhysConst::m_p * amrex::Real(39.9480);
-        case PhysicalSpecies::copper:
-            return PhysConst::m_p * amrex::Real(63.0864);
-        case PhysicalSpecies::xenon:
-            return PhysConst::m_p * amrex::Real(131.293);
-        default:
-            amrex::Abort("unknown PhysicalSpecies");
-            return 0.;
-        }
-    }
+    /**
+     * \brief Returns the mass associated to a PhysicalSpecies
+     *
+     * \param[in] ps the PhysicalSpecies
+     * \return the mass associated to the PhysicalSpecies
+     */
+    amrex::Real get_mass (const PhysicalSpecies& ps);
 
-    AMREX_FORCE_INLINE
-    std::string get_name (PhysicalSpecies ps)
-    {
-        switch(ps) {
-        case PhysicalSpecies::unspecified:
-            return "unspecified";
-        case PhysicalSpecies::electron:
-            return "electron";
-        case PhysicalSpecies::positron:
-            return "positron";
-        case PhysicalSpecies::photon:
-            return "photon";
-        case PhysicalSpecies::hydrogen:
-            return "hydrogen";
-        case PhysicalSpecies::helium:
-            return "helium";
-        case PhysicalSpecies::boron:
-            return "boron";
-        case PhysicalSpecies::boron10:
-            return "boron10";
-        case PhysicalSpecies::boron11:
-            return "boron11";
-        case PhysicalSpecies::carbon:
-            return "carbon";
-        case PhysicalSpecies::nitrogen:
-            return "nitrogen";
-        case PhysicalSpecies::oxygen:
-            return "oxygen";
-        case PhysicalSpecies::argon:
-            return "argon";
-        case PhysicalSpecies::copper:
-            return "copper";
-        case PhysicalSpecies::xenon:
-            return "xenon";
-        default:
-            amrex::Abort("unknown PhysicalSpecies");
-            return "";
-        }
-    }
+    /**
+     * \brief Returns the name associated to a PhysicalSpecies
+     *
+     * \param[in] ps the PhysicalSpecies
+     * \return the name associated to the PhysicalSpecies
+     */
+    std::string get_name (const PhysicalSpecies& ps);
 }
 
 #endif // WARPX_SPECIESPHYSICALPROPERTIES_H_

--- a/Source/Particles/SpeciesPhysicalProperties.cpp
+++ b/Source/Particles/SpeciesPhysicalProperties.cpp
@@ -1,0 +1,124 @@
+/* Copyright 2021 Luca Fedeli Maxence Thevenet
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "SpeciesPhysicalProperties.H"
+
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_AmrCore.H>
+
+#include <limits>
+#include <map>
+#include <string>
+
+using namespace species;
+
+namespace {
+    struct Properties
+    {
+        amrex::Real mass;
+        amrex::Real charge;
+    };
+
+    const auto string_to_species = std::map<std::string, PhysicalSpecies>{
+        {"unspecified", PhysicalSpecies::unspecified},
+        {"electron"   , PhysicalSpecies::electron},
+        {"positron"   , PhysicalSpecies::positron},
+        {"photon"     , PhysicalSpecies::photon},
+        {"hydrogen"   , PhysicalSpecies::hydrogen},
+        {"proton"     , PhysicalSpecies::hydrogen},
+        {"helium"     , PhysicalSpecies::helium},
+        {"alpha"      , PhysicalSpecies::helium},
+        {"boron"      , PhysicalSpecies::boron},
+        {"boron10"    , PhysicalSpecies::boron10},
+        {"boron11"    , PhysicalSpecies::boron11},
+        {"carbon"     , PhysicalSpecies::carbon},
+        {"nitrogen"   , PhysicalSpecies::nitrogen},
+        {"oxygen"     , PhysicalSpecies::oxygen},
+        {"argon"      , PhysicalSpecies::argon},
+        {"copper"     , PhysicalSpecies::copper},
+        {"xenon"      , PhysicalSpecies::xenon}
+    };
+
+    const auto species_to_string = std::map<PhysicalSpecies, std::string>{
+        {PhysicalSpecies::unspecified, "unspecified"},
+        {hysicalSpecies::electron    , "electron"},
+        {PhysicalSpecies::positron   , "positron"},
+        {PhysicalSpecies::photon     , "photon"},
+        {PhysicalSpecies::hydrogen   , "hydrogen"},
+        {PhysicalSpecies::helium     , "helium"},
+        {PhysicalSpecies::boron      , "boron"},
+        {PhysicalSpecies::boron10    , "boron10"},
+        {PhysicalSpecies::boron11    , "boron11"},
+        {PhysicalSpecies::carbon     , "carbon"},
+        {PhysicalSpecies::nitrogen   , "nitrogen"},
+        {PhysicalSpecies::oxygen     , "oxygen"},
+        {PhysicalSpecies::argon      , "argon"},
+        {PhysicalSpecies::copper     , "copper"},
+        {PhysicalSpecies::xenon      , "xenon"}
+    };
+
+    constexpr auto quiet_NaN = std::numeric_limits<amrex::Real>::quiet_NaN();
+
+    const
+    std::map<PhysicalSpecies,Properties> species_to_properties
+    {
+        {PhysicalSpecies::unspecified,
+            Properties{quiet_NaN, quiet_NaN}},
+        {PhysicalSpecies::electron,
+            Properties{PhysConst::m_e, -PhysConst::q_e}},
+        {PhysicalSpecies::positron,
+            Properties{PhysConst::m_e, PhysConst::q_e}},
+        {PhysicalSpecies::photon ,
+            Properties{amrex::Real(0.0), PhysConst::q_e}},
+        {PhysicalSpecies::hydrogen,
+            Properties{PhysConst::m_p, PhysConst::q_e}},
+        {PhysicalSpecies::helium,
+            Properties{PhysConst::m_p * amrex::Real(3.97369), PhysConst::q_e * amrex::Real(2.0)}},
+        {PhysicalSpecies::boron,
+            Properties{PhysConst::m_p * amrex::Real(10.7319), PhysConst::q_e * amrex::Real(5.0)}},
+        {PhysicalSpecies::boron10,
+            Properties{PhysConst::m_p * amrex::Real(9.94060), PhysConst::q_e * amrex::Real(5.0)}},
+        {PhysicalSpecies::boron11,
+            Properties{PhysConst::m_p * amrex::Real(10.9298), PhysConst::q_e * amrex::Real(5.0)}},
+        {PhysicalSpecies::carbon,
+            Properties{PhysConst::m_e * amrex::Real(22032.0), PhysConst::q_e * amrex::Real(6.0)}},
+        {PhysicalSpecies::nitrogen,
+            Properties{PhysConst::m_e * amrex::Real(25716.9), PhysConst::q_e * amrex::Real(7.0)}},
+        {PhysicalSpecies::oxygen,
+            Properties{PhysConst::m_p * amrex::Real(15.8834), PhysConst::q_e * amrex::Real(8.0)}},
+        {PhysicalSpecies::argon,
+            Properties{PhysConst::m_p * amrex::Real(39.9480), PhysConst::q_e * amrex::Real(18.0)}},
+        {PhysicalSpecies::copper,
+            Properties{PhysConst::m_p * amrex::Real(63.0864), PhysConst::q_e * amrex::Real(29.0)}},
+        {PhysicalSpecies::xenon,
+            Properties{hysConst::m_p * amrex::Real(131.293), PhysConst::q_e * amrex::Real(54.0)}}
+    };
+}
+
+namespace species
+{
+    std::optional<PhysicalSpecies> from_string(std::string species)
+    {
+        const auto phys_spec = string_to_species.find(species);
+        return (phys_spec != species.end())?
+            phys_spec : std::nullopt;
+    }
+
+    amrex::Real get_charge (PhysicalSpecies ps)
+    {
+        return species_to_properties.at(ps).charge;
+    }
+
+    amrex::Real get_mass (PhysicalSpecies ps)
+    {
+        return species_to_properties.at(ps).mass;
+    }
+
+    std::string get_name (PhysicalSpecies ps)
+    {
+        return species_to_string.at(ps);
+    }


### PR DESCRIPTION
This PR uses maps to store physical properties in `SpeciesPhysicalProperties` , making it easier to expand the list of supported materials in the future.