### PR TITLE
[WIP] Add user-defined particle attributes to some diagnostics parsers

### DIFF
--- a/Docs/source/developers/gnumake.rst
+++ b/Docs/source/developers/gnumake.rst
@@ -66,6 +66,7 @@ options are:
     * ``MPI_THREAD_MULTIPLE=TRUE`` or ``FALSE``: Whether to initialize MPI with thread multiple support. Required to use asynchronous IO with more than ``amrex.async_out_nfiles`` (by default, 64) MPI tasks.
       Please see :ref:`data formats <dataanalysis-formats>` for more information.
     * ``PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE``: Switch from default double precision to single precision (experimental).
+    * ``EXTRA_PARSER_ARGS=0`` or other positive integer: Maximum number of user-defined particle attributes to use in some diagnostics parser functions
 
 For a description of these different options, see the `corresponding page <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html>`__ in the AMReX documentation.
 

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -100,6 +100,7 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_QED``                 **ON**/OFF                                   QED support (requires PICSAR)
 ``WarpX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation support (requires PICSAR and Boost)
 ``WarpX_SENSEI``              ON/**OFF**                                   SENSEI in situ visualization
+``WarpX_EXTRA_PARSER_ARGS``   **0** (positive integer)                     Maximum number of user-defined particle attributes to use in some parser functions
 ============================= ============================================ =========================================================
 
 WarpX can be configured in further detail with options from AMReX, which are documented in the AMReX manual:
@@ -271,6 +272,7 @@ Environment Variable          Default & Values                             Descr
 ``WARPX_PSATD``               ON/**OFF**                                   Spectral solver
 ``WARPX_QED``                 **ON**/OFF                                   PICSAR QED (requires PICSAR)
 ``WARPX_QED_TABLE_GEN``       ON/**OFF**                                   QED table generation (requires PICSAR and Boost)
+``WARPX_EXTRA_PARSER_ARGS``   **0** (positive integer)                     Maximum number of user-defined particle attributes to use in some parser functions
 ``BUILD_PARALLEL``            ``2``                                        Number of threads to use for parallel builds
 ``BUILD_SHARED_LIBS``         ON/**OFF**                                   Build shared libraries for dependencies
 ``HDF5_USE_STATIC_LIBRARIES`` ON/**OFF**                                   Prefer static libraries for HDF5 dependency (openPMD)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2044,12 +2044,24 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
    where :math:`w_i` is the particle weight, :math:`f()` is the parser function, and :math:`(x_i,y_i,z_i)` are particle positions in units of a meter. The sums are over all particles of type ``<species>`` in a cell (ignoring the particle shape factor) that satisfy ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
    When ``<diag_name>.particle_fields.<field_name>.do_average`` is `0`, the division by the sum over particle weights is not done.
+   The function and filter may include user-defined particle attributes if they are listed in ``<diag_name>.particle_fields.field_name.extra_attributes``.
+   The argument list in the parameter name will stay the same if additional attributes are used.
    In 1D or 2D, the particle coordinates will follow the WarpX convention. :math:`(u_{x,i},u_{y,i},u_{z,i})` are components of the particle four-velocity. :math:`u = \gamma v/c`, :math:`\gamma` is the Lorentz factor, :math:`v` is the particle velocity, and :math:`c` is the speed of light.
+
+
+* ``<diag_name>.particle_fields.<field_name>.extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+    Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)``.
+    Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
 
 * ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)`` (parser `string`, optional)
     Parser function returning a boolean for whether to include a particle in the diagnostic.
     If not specified, all particles will be included (see above).
-    The function arguments are the same as above.
+    The function arguments are the same as above, and user-defined particle attributes may be included if they are listed in ``<diag_name>.particle_fields.<field_name>.filter_extra_attributes``.
+    The argument list in the parameter name will stay the same if additional attributes are used.
+
+* ``<diag_name>.particle_fields.<field_name>.filter_extra_attributes`` (list `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+    Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
+    Either real or integer attributes may be used in the parser, but the code will pick the real attribute if a real and an integer attribute share a name.
 
 * ``<diag_name>.plot_raw_fields`` (`0` or `1`) optional (default `0`)
     By default, the fields written in the plot files are averaged on the cell centers.
@@ -2113,9 +2125,15 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     :math:`\gamma v/c`, where
     :math:`\gamma` is the Lorentz factor,
     :math:`v/c` is the particle velocity normalized by the speed of light.
+    Real or integer user-defined particle attributes can also be used as arguments if listed in ``<diag_name>.<species_name>.plot_filter_function_extra_attributes``.
+    The argument list in the parameter name will stay the same if additional attributes are used.
     E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
     positions `x` greater than `0`, and those having velocity `uz` less than 10,
     will be dumped.
+
+* ``<diag_name>.<species_name>.plot_filter_function_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
+    Names of user-defined particle attributes that may appear in ``<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)``.
+    Either real or integer attributes may be used in the parser, but the code will pick the real attribute if a real and an integer attribute share a name.
 
 * ``amrex.async_out`` (`0` or `1`) optional (default `0`)
     Whether to use asynchronous IO when writing plotfiles. This only has an effect
@@ -2534,6 +2552,8 @@ Reduced Diagnostics
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
+            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.histogram_extra_attributes``.
+            The argument list in the parameter name will stay the same if additional attributes are used.
             E.g.
             ``x`` produces the position (density) distribution in `x`.
             ``ux`` produces the velocity distribution in `x`,
@@ -2543,6 +2563,10 @@ Reduced Diagnostics
             :math:`\sum\limits_{i=1}^N` is the sum over :math:`N` particles
             in that bin,
             :math:`w_i` denotes the weight of the ith particle.
+
+        * ``<reduced_diags_name>.histogram_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+            Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)``.
+            Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
 
         * ``<reduced_diags_name>.bin_number`` (`int` > 0)
             This is the number of bins used for the histogram.
@@ -2583,9 +2607,15 @@ Reduced Diagnostics
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
+            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.filter_extra_attributes`` (see below).
+            The argument list in the parameter name will stay the same if additional attributes are used.
             E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
             positions `x` greater than `0`, and those having velocity `uz` less than 10,
             will be taken into account when calculating the histogram.
+
+        * ``<reduced_diags_name>.filter_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
+             Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)``.
+             Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
 
         The output columns are
         values of the 1st bin, the 2nd bin, ..., the nth bin.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2044,22 +2044,22 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
    where :math:`w_i` is the particle weight, :math:`f()` is the parser function, and :math:`(x_i,y_i,z_i)` are particle positions in units of a meter. The sums are over all particles of type ``<species>`` in a cell (ignoring the particle shape factor) that satisfy ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
    When ``<diag_name>.particle_fields.<field_name>.do_average`` is `0`, the division by the sum over particle weights is not done.
-   The function and filter may include user-defined particle attributes if they are listed in ``<diag_name>.particle_fields.field_name.extra_attributes``.
+   The function and filter may include user-defined particle attributes if they are listed in ``<diag_name>.particle_fields.field_name.extra_args``.
    The argument list in the parameter name will stay the same if additional attributes are used.
    In 1D or 2D, the particle coordinates will follow the WarpX convention. :math:`(u_{x,i},u_{y,i},u_{z,i})` are components of the particle four-velocity. :math:`u = \gamma v/c`, :math:`\gamma` is the Lorentz factor, :math:`v` is the particle velocity, and :math:`c` is the speed of light.
 
 
-* ``<diag_name>.particle_fields.<field_name>.extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+* ``<diag_name>.particle_fields.<field_name>.extra_args`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
     Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)``.
     Either real or integer attributes may be used in the parser, though integers will be cast to reals first.
 
 * ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)`` (parser `string`, optional)
     Parser function returning a boolean for whether to include a particle in the diagnostic.
     If not specified, all particles will be included (see above).
-    The function arguments are the same as above, and user-defined particle attributes may be included if they are listed in ``<diag_name>.particle_fields.<field_name>.filter_extra_attributes``.
+    The function arguments are the same as above, and user-defined particle attributes may be included if they are listed in ``<diag_name>.particle_fields.<field_name>.filter_extra_args``.
     The argument list in the parameter name will stay the same if additional attributes are used.
 
-* ``<diag_name>.particle_fields.<field_name>.filter_extra_attributes`` (list `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+* ``<diag_name>.particle_fields.<field_name>.filter_extra_args`` (list `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
     Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
     Either real or integer attributes may be used in the parser.
 
@@ -2125,13 +2125,13 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     :math:`\gamma v/c`, where
     :math:`\gamma` is the Lorentz factor,
     :math:`v/c` is the particle velocity normalized by the speed of light.
-    Real or integer user-defined particle attributes can also be used as arguments if listed in ``<diag_name>.<species_name>.plot_filter_extra_attributes``.
+    Real or integer user-defined particle attributes can also be used as arguments if listed in ``<diag_name>.<species_name>.plot_filter_function_extra_args``.
     The argument list in the parameter name will stay the same if additional attributes are used.
     E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
     positions `x` greater than `0`, and those having velocity `uz` less than 10,
     will be dumped.
 
-* ``<diag_name>.<species_name>.plot_filter_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
+* ``<diag_name>.<species_name>.plot_filter_function_extra_args`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
     Names of user-defined particle attributes that may appear in ``<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)``.
     Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 
@@ -2552,7 +2552,7 @@ Reduced Diagnostics
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.histogram_extra_attributes``.
+            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.histogram_function_extra_args``.
             The argument list in the parameter name will stay the same if additional attributes are used.
             E.g.
             ``x`` produces the position (density) distribution in `x`.
@@ -2564,7 +2564,7 @@ Reduced Diagnostics
             in that bin,
             :math:`w_i` denotes the weight of the ith particle.
 
-        * ``<reduced_diags_name>.histogram_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
+        * ``<reduced_diags_name>.histogram_function_extra_args`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
             Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)``.
             Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 
@@ -2607,13 +2607,13 @@ Reduced Diagnostics
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.filter_extra_attributes`` (see below).
+            Real or integer user-defined particle attributes may also be used if they are listed in ``<reduced_diags_name>.filter_function_extra_args`` (see below).
             The argument list in the parameter name will stay the same if additional attributes are used.
             E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
             positions `x` greater than `0`, and those having velocity `uz` less than 10,
             will be taken into account when calculating the histogram.
 
-        * ``<reduced_diags_name>.filter_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
+        * ``<reduced_diags_name>.filter_function_extra_args`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
              Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)``.
              Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2051,7 +2051,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.particle_fields.<field_name>.extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
     Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)``.
-    Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
+    Either real or integer attributes may be used in the parser, though integers will be cast to reals first.
 
 * ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)`` (parser `string`, optional)
     Parser function returning a boolean for whether to include a particle in the diagnostic.
@@ -2061,7 +2061,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.particle_fields.<field_name>.filter_extra_attributes`` (list `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
     Names of user-defined particle attributes that may appear in the parser string ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
-    Either real or integer attributes may be used in the parser, but the code will pick the real attribute if a real and an integer attribute share a name.
+    Either real or integer attributes may be used in the parser.
 
 * ``<diag_name>.plot_raw_fields`` (`0` or `1`) optional (default `0`)
     By default, the fields written in the plot files are averaged on the cell centers.
@@ -2133,7 +2133,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.<species_name>.plot_filter_function_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
     Names of user-defined particle attributes that may appear in ``<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)``.
-    Either real or integer attributes may be used in the parser, but the code will pick the real attribute if a real and an integer attribute share a name.
+    Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 
 * ``amrex.async_out`` (`0` or `1`) optional (default `0`)
     Whether to use asynchronous IO when writing plotfiles. This only has an effect
@@ -2566,7 +2566,7 @@ Reduced Diagnostics
 
         * ``<reduced_diags_name>.histogram_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``, optional)
             Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)``.
-            Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
+            Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 
         * ``<reduced_diags_name>.bin_number`` (`int` > 0)
             This is the number of bins used for the histogram.
@@ -2615,7 +2615,7 @@ Reduced Diagnostics
 
         * ``<reduced_diags_name>.filter_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
              Names of user-defined particle attributes that may appear in the parser string ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)``.
-             Either real or integer attributes may be used in the parser, but the code will use the real attribute if a real and an integer attribute share a name.
+             Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 
         The output columns are
         values of the 1st bin, the 2nd bin, ..., the nth bin.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2125,13 +2125,13 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     :math:`\gamma v/c`, where
     :math:`\gamma` is the Lorentz factor,
     :math:`v/c` is the particle velocity normalized by the speed of light.
-    Real or integer user-defined particle attributes can also be used as arguments if listed in ``<diag_name>.<species_name>.plot_filter_function_extra_attributes``.
+    Real or integer user-defined particle attributes can also be used as arguments if listed in ``<diag_name>.<species_name>.plot_filter_extra_attributes``.
     The argument list in the parameter name will stay the same if additional attributes are used.
     E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
     positions `x` greater than `0`, and those having velocity `uz` less than 10,
     will be dumped.
 
-* ``<diag_name>.<species_name>.plot_filter_function_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
+* ``<diag_name>.<species_name>.plot_filter_extra_attributes`` (list of `strings`, length ``<= WarpX_EXTRA_PARSER_ARGS``) optional
     Names of user-defined particle attributes that may appear in ``<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)``.
     Either real or integer attributes may be used in the parser, though integers will be cast to reals.
 

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
@@ -49,14 +49,16 @@ private:
     int const m_ispec; /**< index of species to average over */
     bool const m_do_average; /**< Whether to calculate the average of the data */
     bool const m_do_filter; /**< whether to apply #m_filter_fn */
-    /** Parser function to be averaged by the functor. Arguments: x, y, z, ux, uy, uz */
+    /** Number of arguments in parser functions. Default arguments: x, y, z, ux, uy, uz */
+    static constexpr int m_nvars_parser = 6;
+    /** Parser function to be averaged by the functor.*/
     std::unique_ptr<amrex::Parser> m_map_fn_parser;
-    /** Parser function to filter particles before pass to map. Arguments: x, y, z, ux, uy, uz */
+    /** Parser function to filter particles before pass to map. */
     std::unique_ptr<amrex::Parser> m_filter_fn_parser;
     /** Compiled #m_map_fn_parser */
-    amrex::ParserExecutor<6> m_map_fn;
+    amrex::ParserExecutor<m_nvars_parser> m_map_fn;
     /** Compiled #m_filter_fn_parser */
-    amrex::ParserExecutor<6> m_filter_fn;
+    amrex::ParserExecutor<m_nvars_parser> m_filter_fn;
 };
 
 #endif // WARPX_PARTICLEREDUCTIONFUNCTOR_H_

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -61,10 +61,15 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
                 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
                 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
             {
+                // Data container to pass to parsers. Order: x, y, z, ux, uy, uz, (optional: user-defined particle attributes)
+                amrex::GpuArray<amrex::ParticleReal, m_nvars_parser> parser_data;
                 // Get position in WarpX convention to use in parser. Will be different from
                 // p.pos() for 1D and 2D simulations.
                 amrex::ParticleReal xw = 0._rt, yw = 0._rt, zw = 0._rt;
                 get_particle_position(p, xw, yw, zw);
+                parser_data[0] = xw;
+                parser_data[1] = yw;
+                parser_data[2] = zw;
 
                 // Get position in AMReX convention to calculate corresponding index.
                 // Ideally this will be replaced with the AMReX NGP interpolator
@@ -86,12 +91,12 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
 #endif
 
                 // Fix dimensions since parser assumes u = gamma * v / c
-                amrex::ParticleReal ux = p.rdata(PIdx::ux) / PhysConst::c;
-                amrex::ParticleReal uy = p.rdata(PIdx::uy) / PhysConst::c;
-                amrex::ParticleReal uz = p.rdata(PIdx::uz) / PhysConst::c;
+                parser_data[3] = p.rdata(PIdx::ux) / PhysConst::c;
+                parser_data[4] = p.rdata(PIdx::uy) / PhysConst::c;
+                parser_data[5] = p.rdata(PIdx::uz) / PhysConst::c;
                 amrex::Real value;
-                if ((do_filter) && (!filter_fn(xw, yw, zw, ux, uy, uz))) value = 0._rt;
-                else value = map_fn(xw, yw, zw, ux, uy, uz);
+                if ((do_filter) && (!filter_fn(parser_data))) value = 0._rt;
+                else value = map_fn(parser_data);
                 amrex::Gpu::Atomic::AddNoRet(&out_array(ii, jj, kk, 0), (amrex::Real)(p.rdata(PIdx::w) * value));
             });
     if (m_do_average) {

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -29,12 +29,12 @@ ParticleReductionFunctor::ParticleReductionFunctor (const amrex::MultiFab* mf_sr
     // Allocate and compile a parser based on the input string fn_str
     m_map_fn_parser = std::make_unique<amrex::Parser>(makeParser(
                 fn_str, {"x", "y", "z", "ux", "uy", "uz"}));
-    m_map_fn = m_map_fn_parser->compile<6>();
+    m_map_fn = m_map_fn_parser->compile<m_nvars_parser>();
     // Do the same for filter function, if it exists
     if (m_do_filter) {
         m_filter_fn_parser = std::make_unique<amrex::Parser>(makeParser(
                filter_str, {"x", "y", "z", "ux", "uy", "uz"}));
-        m_filter_fn = m_filter_fn_parser->compile<6>();
+        m_filter_fn = m_filter_fn_parser->compile<m_nvars_parser>();
     }
 }
 

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -13,6 +13,7 @@
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
 
+#include <AMReX_Array.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_Parser.H>
 #include <AMReX_Random.H>
@@ -114,8 +115,16 @@ struct ParserFilter
     bool operator () (const SuperParticleType& p, const amrex::RandomEngine&) const noexcept
     {
         if ( !m_is_active ) return 1;
+        // Container to store parser args. Order: t, x, y, z, ux, uy, ux, (optional: user-defined particle attributes)
+        amrex::GpuArray<amrex::Real, ParticleDiag::m_nvars> parser_data;
+        parser_data[0] = m_t;
+        // Compute and pack position
         amrex::ParticleReal x, y, z;
         get_particle_position(p, x, y, z);
+        parser_data[1] = x;
+        parser_data[2] = y;
+        parser_data[3] = z;
+        // Compute and pack momenta
         amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
         amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
         amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
@@ -126,7 +135,11 @@ struct ParserFilter
             uz /= m_mass;
         }
         // ux, uy, uz are now in beta*gamma
-        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz)) return 1;
+        parser_data[4] = ux;
+        parser_data[5] = uy;
+        parser_data[6] = uz;
+
+        if ( m_function_partparser(parser_data) ) return 1;
         else return 0;
     }
 private:

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -7,6 +7,7 @@
 #ifndef FILTERFUNCTORS_H
 #define FILTERFUNCTORS_H
 
+#include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXConst.H"
@@ -93,10 +94,10 @@ struct ParserFilter
 {
     /** constructor
      * \param a_is_active whether the test is active
-     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a boolean for selected particle
+     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, plus EXTRA_PARSER_ARGS user-defined particle attributes and returning a boolean for selected particle
      * \param a_mass mass of the particle species
      */
-    ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
+    ParserFilter(bool a_is_active, amrex::ParserExecutor<ParticleDiag::m_nvars> const& a_filter_parser,
                  amrex::Real a_mass)
         : m_is_active(a_is_active), m_function_partparser(a_filter_parser), m_mass(a_mass)
     {
@@ -132,8 +133,8 @@ private:
     /** Whether this diagnostics is activated. Select all particles if false */
     const bool m_is_active;
 public:
-    /** Parser function with 7 input variables, t,x,y,z,ux,uy,uz */
-    amrex::ParserExecutor<7> const m_function_partparser;
+    /** Parser function with m_nvars_parser input variables. Arguments: t,x,y,z,ux,uy,uz plus user-defined attributes*/
+    amrex::ParserExecutor<ParticleDiag::m_nvars> const m_function_partparser;
     /** Store physical time. */
     amrex::ParticleReal m_t;
     /** Mass of particle species */


### PR DESCRIPTION
This is to sketch out my plan to add user-defined particle attributes to some diagnostics parsers (c.f. #3051). Any feedback on the interface or implementation details would be welcome.

An example of how this would work: say we have the attributes `foo` and `bar`, and want to include them in a histogram function. The input file would have the lines
```
foo_histogram.histogram_function(t,x,y,z,ux,uy,uz) = foo * bar * x
foo_histogram.histogram_function_extra_args = foo bar
```
The extra arguments are in their own list because we can't easily search for `foo_histogram.histogram_function(t,x,y,z,ux,uy,uz,foo,bar)`, and I don't think it makes sense to move all of the args to a list like that.

I plan to add this to all diagnostics parsers that take particle data (i.e all of the ones that are functions of `(x,y,z,ux,uy,uz)`). My current list is below, but please let me know if you think I've missed any:

- `<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)`
- `<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)`
- `<diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)`
- `<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)`
- `<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)`

This will add a cmake compile flag ``WarpX_EXTRA_PARSER_ARGS`` (with appropriate analogs for python and Gnumake) that defaults to 0 and sets the maximum number of user-defined particle attributes to be used in the diagnostics parsers above. All of these parsers will be templated on `N = n_current + n_extra` arguments, where `n_current` is the current number of mandatory arguments (usually 6 or 7).

For each of these parsers, add a `additional_args` parameter, which takes a list of strings with length `<= WarpX_EXTRA_PARSER_ARGS`. These are the names of the user-defined particle attributes that can be used in a given parser, in additional to the usual arguments. The list doesn't have to be the same for each parser, and the attributes can be either real or integer, and integers will be cast to reals when the `ParserExecutor` is called.

The real attribute `"foo"` is accessed from `ParticleTileData::m_runtime_rdata[i_foo]`, where the mapping between `"foo"` and `i_foo` is from `ParticleContainer::getParticleComps()`. So this will require some code surgery to expose `ParticleTileData` and `ParticleContainer` where the `ParserExecutor` is called. I've done this in the reconnection branch, for example [here](https://github.com/ECP-WarpX/WarpX/compare/development...RevathiJambunathan:HarrisSheetinX#diff-4c9a1b4d7c4f78632bd061ea54792a1e3e33e9bdad7d591ee0faf9f5d956571aR100).