### PR TITLE
Add STL files support in pywarpx

### DIFF
--- a/Python/pywarpx/EB.py
+++ b/Python/pywarpx/EB.py
@@ -1,0 +1,9 @@
+# Copyright 2021 Roelof Groenewald
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+from .Bucket import Bucket
+
+eb = Bucket('eb2')

--- a/Python/pywarpx/EB.py
+++ b/Python/pywarpx/EB.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Roelof Groenewald
+# Copyright 2022 Lorenzo Giacomel
 #
 # This file is part of WarpX.
 #

--- a/Python/pywarpx/EB2.py
+++ b/Python/pywarpx/EB2.py
@@ -6,4 +6,4 @@
 
 from .Bucket import Bucket
 
-eb = Bucket('eb2')
+eb2 = Bucket('eb2')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -1,5 +1,5 @@
-# Copyright 2016-2020 Andrew Myers, David Grote, Maxence Thevenet
-# Remi Lehe
+# Copyright 2016-2022 Andrew Myers, David Grote, Maxence Thevenet
+# Remi Lehe, Lorenzo Giacomel
 #
 # This file is part of WarpX.
 #

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -13,6 +13,7 @@ from .Bucket import Bucket
 from .Collisions import collisions, collisions_list
 from .Constants import my_constants
 from .Diagnostics import diagnostics
+from .EB import eb
 from .Geometry import geometry
 from .Interpolation import interpolation
 from .Langmuirwave import langmuirwave
@@ -38,6 +39,7 @@ class WarpX(Bucket):
         argv += langmuirwave.attrlist()
         argv += interpolation.attrlist()
         argv += psatd.attrlist()
+        argv += eb.attrlist()
 
         # --- Search through species_names and add any predefined particle objects in the list.
         particles_list_names = [p.instancename for p in particles_list]

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -13,7 +13,7 @@ from .Bucket import Bucket
 from .Collisions import collisions, collisions_list
 from .Constants import my_constants
 from .Diagnostics import diagnostics
-from .EB import eb
+from .EB2 import eb2
 from .Geometry import geometry
 from .Interpolation import interpolation
 from .Langmuirwave import langmuirwave
@@ -39,7 +39,7 @@ class WarpX(Bucket):
         argv += langmuirwave.attrlist()
         argv += interpolation.attrlist()
         argv += psatd.attrlist()
-        argv += eb.attrlist()
+        argv += eb2.attrlist()
 
         # --- Search through species_names and add any predefined particle objects in the list.
         particles_list_names = [p.instancename for p in particles_list]

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -10,7 +10,7 @@ from .Boundary import boundary
 from .Collisions import collisions
 from .Constants import my_constants
 from .Diagnostics import diagnostics
-from .EB import eb
+from .EB2 import eb2
 from .Geometry import geometry
 from .Interpolation import interpolation
 from .Langmuirwave import langmuirwave

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -10,6 +10,7 @@ from .Boundary import boundary
 from .Collisions import collisions
 from .Constants import my_constants
 from .Diagnostics import diagnostics
+from .EB import eb
 from .Geometry import geometry
 from .Interpolation import interpolation
 from .Langmuirwave import langmuirwave

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Andrew Myers, David Grote, Lorenzo Giacomel
+# Copyright 2016-2022 Andrew Myers, David Grote, Lorenzo Giacomel
 #
 # This file is part of WarpX.
 #

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Andrew Myers, David Grote
+# Copyright 2016-2019 Andrew Myers, David Grote, Lorenzo Giacomel
 #
 # This file is part of WarpX.
 #

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -921,15 +921,15 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
     an implicit function or as an STL file (ASCII or binary). In the latter case the
     geometry specified in the STL file can be scaled, translated and inverted.
     - implicit_function: Analytic expression describing the embedded boundary
-    - stl_file: STL file containing the embedded boundary geometry
-    - stl_scale: factor by which the STL geometry is scaled
-    - stl_center: vector by which the STL geometry is translated
+    - stl_file: STL file path (string), file contains the embedded boundary geometry
+    - stl_scale: factor by which the STL geometry is scaled (pure number)
+    - stl_center: vector by which the STL geometry is translated (in meters)
     - stl_reverse_normal: if True inverts the orientation of the STL geometry
     - potential: Analytic expression defining the potential. Can only be specified
                  when the solver is electrostatic. Optional, defaults to 0.
      Parameters used in the expressions should be given as additional keyword arguments.
     """
-    def __init__(self, implicit_function=None, stl_file=None, stl_scale=None, stl_center=None, stl_reverse_normal=None,
+    def __init__(self, implicit_function=None, stl_file=None, stl_scale=None, stl_center=None, stl_reverse_normal=False,
                  potential=None, **kw):
 
         assert stl_file is None or implicit_function is None, Exception('Only one between implicit_function and '
@@ -939,9 +939,9 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         self.stl_file = stl_file
 
         if stl_file is None:
-            assert stl_scale is None, Exception('EB can be scaled only when using an stl file')
-            assert stl_center is None, Exception('EB can be translated only when using an stl file')
-            assert stl_reverse_normal is None, Exception('EB can be reversed only when using an stl file')
+            assert stl_scale is None, Exception('EB can only be scaled only when using an stl file')
+            assert stl_center is None, Exception('EB can only be translated only when using an stl file')
+            assert stl_reverse_normal is False, Exception('EB can only be reversed only when using an stl file')
 
         self.stl_scale = stl_scale
         self.stl_center = stl_center

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -917,8 +917,14 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
     """
     Custom class to handle set up of embedded boundaries specific to WarpX.
     If embedded boundary initialization is added to picmistandard this can be
-    changed to inherit that functionality.
+    changed to inherit that functionality. The geometry can be specified either as
+    an implicit function or as an STL file (ASCII or binary). In the latter case the
+    geometry specified in the STL file can be scaled, translated and inverted.
     - implicit_function: Analytic expression describing the embedded boundary
+    - stl_file: STL file containing the embedded boundary geometry
+    - stl_scale: factor by which the STL geometry is scaled
+    - stl_center: vector by which the STL geometry is translated
+    - stl_reverse_normal: if True inverts the orientation of the STL geometry
     - potential: Analytic expression defining the potential. Can only be specified
                  when the solver is electrostatic. Optional, defaults to 0.
      Parameters used in the expressions should be given as additional keyword arguments.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -965,11 +965,11 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
             pywarpx.warpx.eb_implicit_function = expression
 
         if self.stl_file is not None:
-            pywarpx.eb.geom_type = "stl"
-            pywarpx.eb.stl_file = self.stl_file
-            pywarpx.eb.stl_scale = self.stl_scale
-            pywarpx.eb.stl_center = self.stl_center
-            pywarpx.eb.stl_reverse_normal = self.stl_reverse_normal
+            pywarpx.eb2.geom_type = "stl"
+            pywarpx.eb2.stl_file = self.stl_file
+            pywarpx.eb2.stl_scale = self.stl_scale
+            pywarpx.eb2.stl_center = self.stl_center
+            pywarpx.eb2.stl_reverse_normal = self.stl_reverse_normal
 
         if self.potential is not None:
             assert isinstance(solver, ElectrostaticSolver), Exception('The potential is only supported with the ElectrostaticSolver')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -925,6 +925,10 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
     """
     def __init__(self, implicit_function=None, stl_file=None, stl_scale=None, stl_center=None, stl_reverse_normal=None,
                  potential=None, **kw):
+
+        assert stl_file is None or implicit_function is None, Exception('Only one between implicit_function and '
+                                                                            'stl_file can be specified')
+
         self.implicit_function = implicit_function
         self.stl_file = stl_file
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1,5 +1,5 @@
 # Copyright 2018-2020 Andrew Myers, David Grote, Ligia Diana Amorim
-# Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+# Maxence Thevenet, Remi Lehe, Revathi Jambunathan, Lorenzo Giacomel
 #
 #
 # This file is part of WarpX.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Andrew Myers, David Grote, Ligia Diana Amorim
+# Copyright 2018-2022 Andrew Myers, David Grote, Ligia Diana Amorim
 # Maxence Thevenet, Remi Lehe, Revathi Jambunathan, Lorenzo Giacomel
 #
 #


### PR DESCRIPTION
With this PR we add to the Python interface the possibility to specify the embedded boundary as an STL file.

AMReX reads the inputs related to STL files from the `eb2` parser, so we add a new corresponding bucket to pywarpx to handle these inputs.

In a follow up PR it would probably make sense to move also the implicit function input to this bucket and to the eb2 parser.