### PR TITLE
Apply shift in BTD for zmax different than 0

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -233,8 +233,9 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
 {
     auto & warpx = WarpX::GetInstance();
     // Lab-frame time for the i^th snapshot
-    m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab;
-
+    amrex::Real zmax_0 = warpx.Geom(lev).ProbHi(m_moving_window_dir);
+    m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab
+        + m_gamma_boost*m_beta_boost*zmax_0/PhysConst::c;
 
     // Compute lab-frame co-ordinates that correspond to the simulation domain
     // at level, lev, and time, m_t_lab[i_buffer] for each ith buffer.

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -233,9 +233,8 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
 {
     auto & warpx = WarpX::GetInstance();
     // Lab-frame time for the i^th snapshot
-    amrex::Real zmax_0 = warpx.Geom(lev).ProbHi(m_moving_window_dir);
-    m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab
-        + m_gamma_boost*m_beta_boost*zmax_0/PhysConst::c;
+    m_t_lab.at(i_buffer) = i_buffer * m_dt_snapshots_lab;
+
 
     // Compute lab-frame co-ordinates that correspond to the simulation domain
     // at level, lev, and time, m_t_lab[i_buffer] for each ith buffer.


### PR DESCRIPTION
In the BTD, the lab snapshot are done for `t_lab = 0, dt_snapshot, 2*dt_snapshot, 3*dt_snapshot, ...`

However, when `zmax > 0`, we cannot fully reconstruct the data for `t_lab=0`. This because, in this case, the Lorentz transform implies that we need data from **negative** `t_boost`, i.e. from before the beginning of the simulation.

In this PR, the lab snapshot are instead requested for `t_lab = t0, t0+dt_snapshot, t0+2*dt_snapshot, t0+3*dt_snapshot, ...`, where the offset `t0` is set so as to ensure that the Lorentz transform never requires data from negative time.