### PR TITLE
Change Default for `psatd.current_correction`

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1718,8 +1718,9 @@ Numerics and algorithms
     Therefore, all the approximations that are usually made when using local FFTs with guard cells
     (for problems with multiple boxes) become exact in the case of the periodic, single-box FFT without guard cells.
 
-* ``psatd.current_correction`` (`0` or `1`; default: `0`)
+* ``psatd.current_correction`` (`0` or `1`; default: `1`, with the exceptions mentioned below)
     If true, a current correction scheme in Fourier space is applied in order to guarantee charge conservation.
+    The default value is ``psatd.current_correction=1``, unless a charge-conserving current deposition scheme is used (by setting ``algo.current_deposition=esirkepov`` or ``algo.current_deposition=vay``) or unless the ``div(E)`` cleaning scheme is used (by setting ``warpx.do_dive_cleaning=1``).
 
     If ``psatd.v_galilean`` is zero, the spectral solver used is the standard PSATD scheme described in (`Vay et al, JCP 243, 2013 <https://doi.org/10.1016/j.jcp.2013.03.010>`_) and the current correction reads
 
@@ -1737,10 +1738,7 @@ Numerics and algorithms
 
     where :math:`\theta=\exp(i\,\boldsymbol{k}\cdot\boldsymbol{v}_G\,\Delta{t}/2)`.
 
-    This option is currently implemented only for the standard PSATD and Galilean PSATD schemes, while it is not yet available for the averaged Galilean PSATD scheme (activated by the input parameter ``psatd.do_time_averaging``).
-
-    This option guarantees charge conservation only when used in combination with ``psatd.periodic_single_box_fft=1``, namely for periodic single-box simulations with global FFTs without guard cells.
-    The implementation for domain decomposition with local FFTs over guard cells is planned but not yet completed.
+    This option is currently implemented only for the standard PSATD, Galilean PSATD, and averaged Galilean PSATD schemes, while it is not yet available for the multi-J algorithm.
 
 * ``psatd.update_with_rho`` (`0` or `1`)
     If true, the update equation for the electric field is expressed in terms of both the current density and the charge density, namely :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}`, :math:`\widehat\rho^{n}`, and :math:`\widehat\rho^{n+1}`.

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -104,7 +104,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
 [pml_x_psatd]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -137,7 +137,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [pml_psatd_rz]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -528,7 +528,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct warpx.cfl = 0.5773502691896258
+runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -623,7 +623,7 @@ analysisOutputImage = Langmuir_multi_2d_MR.png
 [Langmuir_multi_2d_MR_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz
+runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -642,7 +642,7 @@ analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
 [Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -661,7 +661,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd_momentum_conserving]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
+runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -756,7 +756,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
+runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -832,7 +832,7 @@ analysisRoutine = Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
 [Langmuir_multi_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -1228,7 +1228,7 @@ analysisRoutine = Examples/Tests/restart/analysis_restart.py
 [restart_psatd]
 buildDir = .
 inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -1247,7 +1247,7 @@ analysisRoutine = Examples/Tests/restart/analysis_restart.py
 [restart_psatd_time_avg]
 buildDir = .
 inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1 psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2270,7 +2270,7 @@ analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags_s
 [galilean_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_2d
-runtime_params = warpx.do_nodal=1 algo.current_deposition=direct
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2306,7 +2306,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [galilean_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_2d_hybrid
-runtime_params =
+runtime_params = psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2324,7 +2324,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [comoving_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/comoving/inputs_2d_hybrid
-runtime_params =
+runtime_params = psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2342,7 +2342,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [galilean_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2378,7 +2378,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [galilean_3d_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_3d
-runtime_params = warpx.do_nodal=1 algo.current_deposition=direct
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2414,7 +2414,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_3d.py
 [averaged_galilean_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
-runtime_params =
+runtime_params = psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2432,7 +2432,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [averaged_galilean_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
-runtime_params = amr.max_grid_size_x = 128  amr.max_grid_size_y = 64  warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noz = 8
+runtime_params = amr.max_grid_size_x = 128  amr.max_grid_size_y = 64  warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2450,7 +2450,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [averaged_galilean_3d_psatd]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
-runtime_params =
+runtime_params = psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2468,7 +2468,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_3d.py
 [averaged_galilean_3d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
-runtime_params = warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noy = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noy = 8  interpolation.current_centering_noz = 8
+runtime_params = warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noy = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noy = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -104,7 +104,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_ckc.py
 [pml_x_psatd]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -121,7 +121,7 @@ analysisRoutine = Examples/Tests/PML/analysis_pml_psatd.py
 [pml_psatd_dive_divb_cleaning]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_3d
-runtime_params = warpx.do_similar_dm_pml = 0
+runtime_params = warpx.do_similar_dm_pml=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -137,7 +137,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [pml_psatd_rz]
 buildDir = .
 inputFile = Examples/Tests/PML/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -414,7 +414,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd_div_cleaning]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F
+runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -528,7 +528,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_3d_multi_rt
-runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.do_nodal=1 algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -623,7 +623,7 @@ analysisOutputImage = Langmuir_multi_2d_MR.png
 [Langmuir_multi_2d_MR_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz psatd.current_correction=0
+runtime_params = algo.maxwell_solver = psatd  warpx.use_filter = 1  amr.max_level = 1  amr.ref_ratio = 4  warpx.fine_tag_lo = -10.e-6 -10.e-6  warpx.fine_tag_hi = 10.e-6 10.e-6  diag1.electrons.variables = w ux uy uz  diag1.positrons.variables = w ux uy uz psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -642,7 +642,7 @@ analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
 [Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -661,7 +661,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd_momentum_conserving]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -756,7 +756,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_2d_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rt
-runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd warpx.do_nodal=1 algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -832,7 +832,7 @@ analysisRoutine = Examples/Tests/FluxInjection/analysis_flux_injection_rz.py
 [Langmuir_multi_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/Langmuir/inputs_2d_multi_rz_rt
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -1228,7 +1228,7 @@ analysisRoutine = Examples/Tests/restart/analysis_restart.py
 [restart_psatd]
 buildDir = .
 inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -1247,7 +1247,7 @@ analysisRoutine = Examples/Tests/restart/analysis_restart.py
 [restart_psatd_time_avg]
 buildDir = .
 inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1 psatd.current_correction=0
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2270,7 +2270,7 @@ analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags_s
 [galilean_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_2d
-runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2306,7 +2306,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [galilean_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_2d_hybrid
-runtime_params = psatd.current_correction=0
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2324,7 +2324,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [comoving_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/comoving/inputs_2d_hybrid
-runtime_params = psatd.current_correction=0
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2342,7 +2342,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [galilean_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2378,7 +2378,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [galilean_3d_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_3d
-runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0
+runtime_params = warpx.do_nodal=1 algo.current_deposition=direct psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2414,7 +2414,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_3d.py
 [averaged_galilean_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
-runtime_params = psatd.current_correction=0
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2432,7 +2432,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [averaged_galilean_2d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_2d
-runtime_params = amr.max_grid_size_x = 128  amr.max_grid_size_y = 64  warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0
+runtime_params = amr.max_grid_size_x = 128  amr.max_grid_size_y = 64  warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2450,7 +2450,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_2d.py
 [averaged_galilean_3d_psatd]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
-runtime_params = psatd.current_correction=0
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2468,7 +2468,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_3d.py
 [averaged_galilean_3d_psatd_hybrid]
 buildDir = .
 inputFile = Examples/Tests/averaged_galilean/inputs_avg_3d
-runtime_params = warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noy = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noy = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0
+runtime_params = warpx.do_nodal = 0  algo.field_gathering = momentum-conserving  interpolation.field_centering_nox = 8  interpolation.field_centering_noy = 8  interpolation.field_centering_noz = 8  warpx.do_current_centering = 1  interpolation.current_centering_nox = 8  interpolation.current_centering_noy = 8  interpolation.current_centering_noz = 8 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -2486,7 +2486,7 @@ analysisRoutine = Examples/Tests/galilean/analysis_3d.py
 [multi_J_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/multi_J/inputs_2d
-runtime_params =
+runtime_params = warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2504,7 +2504,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [multi_J_2d_psatd_pml]
 buildDir = .
 inputFile = Examples/Tests/multi_J/inputs_2d_pml
-runtime_params =
+runtime_params = warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2522,7 +2522,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [multi_J_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/multi_J/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -582,6 +582,12 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
             PSATDForwardTransformRho(rho_fp, rho_cp, 0, 1);
         }
 
+        if (WarpX::current_correction)
+        {
+            amrex::Abort(Utils::TextMsg::Err(
+                "Current correction not implemented for multi-J algorithm."));
+        }
+
         // Advance E,B,F,G fields in time and update the average fields
         PSATDPushSpectralFields();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -243,9 +243,9 @@ public:
     //! and #current_centering_noz
     static bool do_current_centering;
 
-    //! If true, a correction is applied to the current in Fourier space, so that the continuity
-    //! equation is satisfied
-    bool current_correction = false;
+    //! If true, a correction is applied to the current in Fourier space,
+    //  to satisfy the continuity equation and charge conservation
+    bool current_correction;
 
     //! If true, the PSATD update equation for E contains both J and rho
     //! (default is false for standard PSATD and true for Galilean PSATD)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1307,11 +1307,6 @@ WarpX::ReadParameters ()
             "Vay current deposition not implemented for Galilean algorithms"
         );
 
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (!current_correction) || v_galilean_is_zero || (!fft_do_time_averaging),
-            "Current correction not implemented for averaged Galilean algorithm"
-        );
-
 #   ifdef WARPX_DIM_RZ
         update_with_rho = true;  // Must be true for RZ PSATD
 #   else

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1222,6 +1222,21 @@ WarpX::ReadParameters ()
         }
 
         pp_psatd.query("current_correction", current_correction);
+
+        if (current_correction == false &&
+            current_deposition_algo != CurrentDepositionAlgo::Esirkepov &&
+            current_deposition_algo != CurrentDepositionAlgo::Vay)
+        {
+            RecordWarning(
+                "Algorithms",
+                "The chosen current deposition algorithm does not guarantee"
+                " charge conservation, and no additional current correction"
+                " algorithm is activated in order to compensate for that."
+                " Lack of charge conservation may negatively affect the"
+                " results of the simulation.",
+                WarnPriority::low);
+        }
+
         pp_psatd.query("do_time_averaging", fft_do_time_averaging);
 
         if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1221,6 +1221,10 @@ WarpX::ReadParameters ()
             current_correction = false;
         }
 
+        // TODO Remove this default when current correction will
+        // be implemented for the multi-J algorithm as well.
+        if (do_multi_J) current_correction = false;
+
         pp_psatd.query("current_correction", current_correction);
 
         if (current_correction == false &&

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1204,22 +1204,25 @@ WarpX::ReadParameters ()
             queryWithParser(pp_psatd, "noz", noz_fft);
         }
 
-
         if (!fft_periodic_single_box) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nox_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(noy_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(noz_fft > 0, "PSATD order must be finite unless psatd.periodic_single_box_fft is used");
         }
 
+        // Current correction activated by default, unless a charge-conserving
+        // current deposition (Esirkepov, Vay) or the div(E) cleaning scheme
+        // are used
+        current_correction = true;
+        if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov ||
+            WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay ||
+            WarpX::do_dive_cleaning)
+        {
+            current_correction = false;
+        }
+
         pp_psatd.query("current_correction", current_correction);
         pp_psatd.query("do_time_averaging", fft_do_time_averaging);
-
-        if (WarpX::current_correction == true)
-        {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                fft_periodic_single_box == true,
-                "Option psatd.current_correction=1 must be used with psatd.periodic_single_box_fft=1.");
-        }
 
         if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
         {


### PR DESCRIPTION
Change default for `psatd.current_correction`: always active, unless either a charge-conserving current deposition scheme (Esirkepov, Vay) or the div(E) scheme are used. 

Also, due to the new default, we do not require anymore that the current correction be used only in combination with the periodic single box option.

To-do:
- [x] Fix CI tests (will deactivate current correction to keep CI status as it was before this change)
- [x] Add warnings (if charge conservation is not guaranteed by either of the available methods)

P.S. An example of a realistic test case where charge conservation plays a significant role is given in #2462.