### PR TITLE
Add Headers to Input File Written by PICMI

### DIFF
--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -5,6 +5,7 @@
 #
 # License: BSD-3-Clause-LBNL
 
+import re
 from . import Particles
 from .Algo import algo
 from .Amr import amr
@@ -103,8 +104,7 @@ class WarpX(Bucket):
 
             prefix_old = ''
             for arg in argv:
-                dot_found = (arg.find('.') >= 0)
-                prefix_new = arg[0:arg.find('.')] if dot_found else arg[0:arg.find('=')].rstrip()
+                prefix_new = re.split(' |\.', arg)[0]
                 if prefix_new != prefix_old:
                     ff.write(f'# {prefix_new}\n')
                     prefix_old = prefix_new

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -6,6 +6,7 @@
 # License: BSD-3-Clause-LBNL
 
 import re
+
 from . import Particles
 from .Algo import algo
 from .Amr import amr

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -101,7 +101,13 @@ class WarpX(Bucket):
 
         with open(filename, 'w') as ff:
 
+            prefix_old = ''
             for arg in argv:
+                dot_found = (arg.find('.') >= 0)
+                prefix_new = arg[0:arg.find('.')] if dot_found else arg[0:arg.find('=')].rstrip()
+                if prefix_new != prefix_old:
+                    ff.write(f'# {prefix_new}\n')
+                    prefix_old = prefix_new
                 ff.write(f'{arg}\n')
 
 warpx = WarpX('warpx')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -109,6 +109,8 @@ class WarpX(Bucket):
                 # before each group to make the input file more human readable
                 prefix_new = re.split(' |\.', arg)[0]
                 if prefix_new != prefix_old:
+                    if prefix_old != '':
+                        ff.write('\n')
                     ff.write(f'# {prefix_new}\n')
                     prefix_old = prefix_new
                 ff.write(f'{arg}\n')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -105,6 +105,8 @@ class WarpX(Bucket):
 
             prefix_old = ''
             for arg in argv:
+                # This prints the name of the input group (prefix) as a header
+                # before each group to make the input file more human readable
                 prefix_new = re.split(' |\.', arg)[0]
                 if prefix_new != prefix_old:
                     ff.write(f'# {prefix_new}\n')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -113,6 +113,7 @@ class WarpX(Bucket):
                         ff.write('\n')
                     ff.write(f'# {prefix_new}\n')
                     prefix_old = prefix_new
+
                 ff.write(f'{arg}\n')
 
 warpx = WarpX('warpx')


### PR DESCRIPTION
This adds headers such as `# algo` on the top of the block of input parameters that start with `algo.` in the input file written by PICMI with the method `write_input_file`.

I see this PR as a follow-up of #2732, whose purpose was to make such input files more human readable. In my opinion, the new headers make the input file even more human readable. Though maybe it's only because of the color scheme of my editor and/or it's only subjective anyways, not sure.

If you think this does not improve the readability, feel free to close the PR.

Here's a comparison of an example of input file without and with headers:

![inputs_PICMI_old](https://user-images.githubusercontent.com/59625522/167227622-c0869081-251e-4f1f-b037-40e6cf381b1a.png)

![inputs_PICMI_new](https://user-images.githubusercontent.com/59625522/167517262-c59a4ede-27dc-43e2-869f-b6f28ea32a9c.png)

