### PR TITLE
Stricter Tolerance for 3D Langmuir Tests

### DIFF
--- a/Examples/Tests/Langmuir/analysis_langmuir_multi.py
+++ b/Examples/Tests/Langmuir/analysis_langmuir_multi.py
@@ -142,7 +142,7 @@ ax2.set_title(r'$E_z$ (theory)')
 fig.tight_layout()
 fig.savefig('Langmuir_multi_analysis.png', dpi = 200)
 
-tolerance_rel = 0.15
+tolerance_rel = 5e-2
 
 print("error_rel    : " + str(error_rel))
 print("tolerance_rel: " + str(tolerance_rel))


### PR DESCRIPTION
While looking into some benchmark resets for #3092, I noticed that we can probably decrease the relative tolerance used to compare the simulation results with the theoretical predictions for the 3D Langmuir tests. I think we can set the relative tolerance to `5e-2`, instead of the previous `15e-2`, thus making the analysis slightly more stringent for these 3D basic tests.