### PR TITLE
Fix Wrong Abort Message for PSATD w/ Time Averaging

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -104,7 +104,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     }
     if (time_averaging && !update_with_rho)
     {
-        amrex::Abort("PSATD: warpx.time_averaging = 1 implemented only with psatd.update_with_rho = 1");
+        amrex::Abort("PSATD: psatd.do_time_averaging = 1 implemented only with psatd.update_with_rho = 1");
     }
 }
 


### PR DESCRIPTION
The abort message was referring to `warpx.time_averaging`, which is not an available input parameter. The correct input parameter to refer to is `psatd.do_time_averaging`.