### PR TITLE
Implement emulated MR mode

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -879,14 +879,23 @@ WarpX::PushParticlesandDepose (int lev, amrex::Real cur_time, DtType a_dt_type, 
         current_z = current_fp[lev][2].get();
     }
 
+//    mypc->Evolve(lev,
+//                 *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
+//                 *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2],
+//                 *current_x, *current_y, *current_z,
+//                 current_buf[lev][0].get(), current_buf[lev][1].get(), current_buf[lev][2].get(),
+//                 rho_fp[lev].get(), charge_buf[lev].get(),
+//                 Efield_cax[lev][0].get(), Efield_cax[lev][1].get(), Efield_cax[lev][2].get(),
+//                 Bfield_cax[lev][0].get(), Bfield_cax[lev][1].get(), Bfield_cax[lev][2].get(),
+//                 cur_time, dt[lev], a_dt_type, skip_deposition);
     mypc->Evolve(lev,
                  *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
                  *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2],
                  *current_x, *current_y, *current_z,
                  current_buf[lev][0].get(), current_buf[lev][1].get(), current_buf[lev][2].get(),
                  rho_fp[lev].get(), charge_buf[lev].get(),
-                 Efield_cax[lev][0].get(), Efield_cax[lev][1].get(), Efield_cax[lev][2].get(),
-                 Bfield_cax[lev][0].get(), Bfield_cax[lev][1].get(), Bfield_cax[lev][2].get(),
+                 Efield_cp[lev][0].get(), Efield_cp[lev][1].get(), Efield_cp[lev][2].get(),
+                 Bfield_cp[lev][0].get(), Bfield_cp[lev][1].get(), Bfield_cp[lev][2].get(),
                  cur_time, dt[lev], a_dt_type, skip_deposition);
 #ifdef WARPX_DIM_RZ
     if (! skip_deposition) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -888,15 +888,17 @@ WarpX::PushParticlesandDepose (int lev, amrex::Real cur_time, DtType a_dt_type, 
 //                 Efield_cax[lev][0].get(), Efield_cax[lev][1].get(), Efield_cax[lev][2].get(),
 //                 Bfield_cax[lev][0].get(), Bfield_cax[lev][1].get(), Bfield_cax[lev][2].get(),
 //                 cur_time, dt[lev], a_dt_type, skip_deposition);
+
     mypc->Evolve(lev,
-                 *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
-                 *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2],
+                 *Efield_fp[lev][0],*Efield_fp[lev][1],*Efield_fp[lev][2],
+                 *Bfield_fp[lev][0],*Bfield_fp[lev][1],*Bfield_fp[lev][2],
                  *current_x, *current_y, *current_z,
                  current_buf[lev][0].get(), current_buf[lev][1].get(), current_buf[lev][2].get(),
                  rho_fp[lev].get(), charge_buf[lev].get(),
                  Efield_cp[lev][0].get(), Efield_cp[lev][1].get(), Efield_cp[lev][2].get(),
                  Bfield_cp[lev][0].get(), Bfield_cp[lev][1].get(), Bfield_cp[lev][2].get(),
                  cur_time, dt[lev], a_dt_type, skip_deposition);
+
 #ifdef WARPX_DIM_RZ
     if (! skip_deposition) {
         // This is called after all particles have deposited their current and charge.

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -271,10 +271,10 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 void
 WarpX::UpdateAuxilaryDataSameType ()
 {
-    //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0 
+    //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0
     if (lev == 0)
     {
-       
+
         // B field
         const IntVect& refinement_ratio = refRatio(lev-1);
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -276,7 +276,8 @@ WarpX::UpdateAuxilaryDataSameType ()
     {
 
         // B field
-        const IntVect& refinement_ratio = refRatio(lev-1);
+        const IntVect& refinement_ratio = refRatio(lev);
+        //const IntVect& refinement_ratio = refRatio(lev-1);
 
         std::array<const MultiFab*,3> fine_B { Bfield_fp[lev][0].get(),
                                              Bfield_fp[lev][1].get(),

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -271,13 +271,17 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 void
 WarpX::UpdateAuxilaryDataSameType ()
 {
+
     //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0
     for (int lev = 0; lev <= 0; ++lev)
     {
 
+        const IntVect& refinement_ratio{2,2,2};
+
         // B field
-        const IntVect& refinement_ratio = refRatio(lev);
-        //const IntVect& refinement_ratio = refRatio(lev-1);
+        Bfield_cp[lev][0]->setVal(0.0);
+        Bfield_cp[lev][1]->setVal(0.0);
+        Bfield_cp[lev][2]->setVal(0.0);
 
         std::array<const MultiFab*,3> fine_B { Bfield_fp[lev][0].get(),
                                              Bfield_fp[lev][1].get(),
@@ -291,6 +295,9 @@ WarpX::UpdateAuxilaryDataSameType ()
         CoarsenMR::Coarsen( *crse_B[2], *fine_B[2], refinement_ratio );
 
         // E field
+        Efield_cp[lev][0]->setVal(0.0);
+        Efield_cp[lev][1]->setVal(0.0);
+        Efield_cp[lev][2]->setVal(0.0);
 
         std::array<const MultiFab*,3> fine_E { Efield_fp[lev][0].get(),
                                              Efield_fp[lev][1].get(),
@@ -304,6 +311,7 @@ WarpX::UpdateAuxilaryDataSameType ()
         CoarsenMR::Coarsen( *crse_E[2], *fine_E[2], refinement_ratio );
 
     }
+
 
     for (int lev = 1; lev <= finest_level; ++lev)
     {

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -272,36 +272,35 @@ void
 WarpX::UpdateAuxilaryDataSameType ()
 {
     //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0 
-    if (lev == 0)
+    for (int lev = 0; lev <= 0; ++lev)
     {
        
         // B field
         const IntVect& refinement_ratio = refRatio(lev-1);
 
-        std::array<const MultiFab*,3> fine { Bfield_fp[lev][0].get(),
+        std::array<const MultiFab*,3> fine_B { Bfield_fp[lev][0].get(),
                                              Bfield_fp[lev][1].get(),
                                              Bfield_fp[lev][2].get() };
-        std::array<      MultiFab*,3> crse { Bfield_cp[lev][0].get(),
+        std::array<      MultiFab*,3> crse_B { Bfield_cp[lev][0].get(),
                                              Bfield_cp[lev][1].get(),
                                              Bfield_cp[lev][2].get() };
 
-        CoarsenMR::Coarsen( *crse[0], *fine[0], refinement_ratio );
-        CoarsenMR::Coarsen( *crse[1], *fine[1], refinement_ratio );
-        CoarsenMR::Coarsen( *crse[2], *fine[2], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_B[0], *fine_B[0], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_B[1], *fine_B[1], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_B[2], *fine_B[2], refinement_ratio );
 
         // E field
-        const IntVect& refinement_ratio = refRatio(lev-1);
 
-        std::array<const MultiFab*,3> fine { Efield_fp[lev][0].get(),
+        std::array<const MultiFab*,3> fine_E { Efield_fp[lev][0].get(),
                                              Efield_fp[lev][1].get(),
                                              Efield_fp[lev][2].get() };
-        std::array<      MultiFab*,3> crse { Efield_cp[lev][0].get(),
+        std::array<      MultiFab*,3> crse_E { Efield_cp[lev][0].get(),
                                              Efield_cp[lev][1].get(),
                                              Efield_cp[lev][2].get() };
 
-        CoarsenMR::Coarsen( *crse[0], *fine[0], refinement_ratio );
-        CoarsenMR::Coarsen( *crse[1], *fine[1], refinement_ratio );
-        CoarsenMR::Coarsen( *crse[2], *fine[2], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_E[0], *fine_E[0], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_E[1], *fine_E[1], refinement_ratio );
+        CoarsenMR::Coarsen( *crse_E[2], *fine_E[2], refinement_ratio );
 
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -271,7 +271,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 void
 WarpX::UpdateAuxilaryDataSameType ()
 {
-    //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0 
+    //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0
     for (int lev = 0; lev <= 0; ++lev)
     {
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -271,6 +271,40 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 void
 WarpX::UpdateAuxilaryDataSameType ()
 {
+    //Emulate MR : coarsen the _fp from level 0 to get the _cp from level 0 
+    if (lev == 0)
+    {
+       
+        // B field
+        const IntVect& refinement_ratio = refRatio(lev-1);
+
+        std::array<const MultiFab*,3> fine { Bfield_fp[lev][0].get(),
+                                             Bfield_fp[lev][1].get(),
+                                             Bfield_fp[lev][2].get() };
+        std::array<      MultiFab*,3> crse { Bfield_cp[lev][0].get(),
+                                             Bfield_cp[lev][1].get(),
+                                             Bfield_cp[lev][2].get() };
+
+        CoarsenMR::Coarsen( *crse[0], *fine[0], refinement_ratio );
+        CoarsenMR::Coarsen( *crse[1], *fine[1], refinement_ratio );
+        CoarsenMR::Coarsen( *crse[2], *fine[2], refinement_ratio );
+
+        // E field
+        const IntVect& refinement_ratio = refRatio(lev-1);
+
+        std::array<const MultiFab*,3> fine { Efield_fp[lev][0].get(),
+                                             Efield_fp[lev][1].get(),
+                                             Efield_fp[lev][2].get() };
+        std::array<      MultiFab*,3> crse { Efield_cp[lev][0].get(),
+                                             Efield_cp[lev][1].get(),
+                                             Efield_cp[lev][2].get() };
+
+        CoarsenMR::Coarsen( *crse[0], *fine[0], refinement_ratio );
+        CoarsenMR::Coarsen( *crse[1], *fine[1], refinement_ratio );
+        CoarsenMR::Coarsen( *crse[2], *fine[2], refinement_ratio );
+
+    }
+
     for (int lev = 1; lev <= finest_level; ++lev)
     {
         const amrex::Periodicity& crse_period = Geom(lev-1).periodicity();

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -95,6 +95,8 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     constexpr int NODE = amrex::IndexType::NODE;
     constexpr int CELL = amrex::IndexType::CELL;
 
+//    std::cout << "(dx,dy,dz) = (" << dx[0] << ", " << dx[1] << ", " << dx[2] << ")" << std::endl;
+//    std::cout << "(xmin,ymin,zmin) = (" << xmin << ", " << ymin << ", " << zmin << ")" << std::endl;
     // --- Compute shape factors
 
     Compute_shape_factor< depos_order > const compute_shape_factor;
@@ -361,6 +363,10 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     for (int iz=0; iz<=depos_order; iz++){
         for (int iy=0; iy<=depos_order; iy++){
             for (int ix=0; ix<= depos_order - galerkin_interpolation; ix++){
+                if((lo.x+j_ex+ix == -3) && (lo.y+k_ex+iy == -3) && (lo.z+l_ex+iz == 107)) {
+                  std::cout << "(xp,yp,zp) = (" << xp << ", " << yp << ", " << zp << ") " << "(lo.x,lo.y,lo.z) = (" << lo.x << ", " << lo.y << ", "<< lo.z <<") " <<"(j_ex,k_ex,l_ex) = (" << j_ex << ", " << k_ex << ", "<< l_ex <<") " << "(ix,iy,iz) = (" << ix << ", "<< iy << ", "<< iz <<")"<< std::endl;
+
+                }
                 Exp += sx_ex[ix]*sy_ex[iy]*sz_ex[iz]*
                     ex_arr(lo.x+j_ex+ix, lo.y+k_ex+iy, lo.z+l_ex+iz);
             }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1782,6 +1782,7 @@ PhysicalParticleContainer::Evolve (int lev,
             }
 
             const long np_current = (cjx) ? nfine_current : np;
+            std::cout << " np_current = " << nfine_current << ", np = " << np << std::endl;
 
             if (rho && ! skip_deposition) {
                 // Deposit charge before particle push, in component 0 of MultiFab rho.
@@ -1795,13 +1796,14 @@ PhysicalParticleContainer::Evolve (int lev,
                               np_current, thread_num, lev, lev);
                 if (has_buffer){
                     DepositCharge(pti, wp, ion_lev, crho, 0, np_current,
-                                  np-np_current, thread_num, lev, lev-1);
+                                  np-np_current, thread_num, lev, lev);
                 }
             }
 
             if (! do_not_push)
             {
                 const long np_gather = (cEx) ? nfine_gather : np;
+                //const long np_gather = nfine_gather;
 
                 int e_is_nodal = Ex.is_nodal() and Ey.is_nodal() and Ez.is_nodal();
 
@@ -1816,7 +1818,7 @@ PhysicalParticleContainer::Evolve (int lev,
 
                 if (np_gather < np)
                 {
-                    const IntVect& ref_ratio = WarpX::RefRatio(lev-1);
+                    const IntVect& ref_ratio = WarpX::RefRatio(lev);
                     const Box& cbox = amrex::coarsen(box,ref_ratio);
 
                     // Data on the grid
@@ -1843,11 +1845,12 @@ PhysicalParticleContainer::Evolve (int lev,
 
                     // Field gather and push for particles in gather buffers
                     e_is_nodal = cEx->is_nodal() and cEy->is_nodal() and cEz->is_nodal();
+                std::cout << " Here nfine_gather = " << nfine_gather << ", np = " << np << std::endl;
                     PushPX(pti, cexfab, ceyfab, cezfab,
                            cbxfab, cbyfab, cbzfab,
                            cEx->nGrowVect(), e_is_nodal,
                            nfine_gather, np-nfine_gather,
-                           lev, lev-1, dt, ScaleFields(false), a_dt_type);
+                           lev, lev, dt, ScaleFields(false), a_dt_type);
                 }
 
                 WARPX_PROFILE_VAR_STOP(blp_fg);
@@ -1864,18 +1867,22 @@ PhysicalParticleContainer::Evolve (int lev,
                     } else {
                         ion_lev = nullptr;
                     }
+                std::cout << "1 Here np_current = " << np_current << ", np = " << np << std::endl;
                     // Deposit inside domains
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                    0, np_current, thread_num,
                                    lev, lev, dt, relative_time);
+                std::cout << "2 Here np_current = " << np_current << ", np = " << np << std::endl;
 
                     if (has_buffer)
                     {
+                std::cout << "3 Here np_current = " << np_current << ", np = " << np << std::endl;
                         // Deposit in buffers
                         DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                        np_current, np-np_current, thread_num,
-                                       lev, lev-1, dt, relative_time);
+                                       lev, lev, dt, relative_time);
                     }
+                std::cout << "4 Here np_current = " << np_current << ", np = " << np << std::endl;
                 } // end of "if do_electrostatic == ElectrostaticSolverAlgo::None"
             } // end of "if do_not_push"
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1782,7 +1782,6 @@ PhysicalParticleContainer::Evolve (int lev,
             }
 
             const long np_current = (cjx) ? nfine_current : np;
-            std::cout << " np_current = " << nfine_current << ", np = " << np << std::endl;
 
             if (rho && ! skip_deposition) {
                 // Deposit charge before particle push, in component 0 of MultiFab rho.
@@ -1796,14 +1795,17 @@ PhysicalParticleContainer::Evolve (int lev,
                               np_current, thread_num, lev, lev);
                 if (has_buffer){
                     DepositCharge(pti, wp, ion_lev, crho, 0, np_current,
-                                  np-np_current, thread_num, lev, lev);
+                                  np-np_current, thread_num, lev, lev-1);
                 }
             }
 
             if (! do_not_push)
             {
                 const long np_gather = (cEx) ? nfine_gather : np;
-                //const long np_gather = nfine_gather;
+                //std::cout << "np_gather = " << np_gather << std::endl;
+                //std::cout << "nfine_gather = " << nfine_gather << std::endl;
+                //std::cout << "np_current = " << np_current << std::endl;
+                //std::cout << "np = " << np << std::endl;
 
                 int e_is_nodal = Ex.is_nodal() and Ey.is_nodal() and Ez.is_nodal();
 
@@ -1818,7 +1820,8 @@ PhysicalParticleContainer::Evolve (int lev,
 
                 if (np_gather < np)
                 {
-                    const IntVect& ref_ratio = WarpX::RefRatio(lev);
+                    const IntVect& ref_ratio{2,2,2};
+                    //const IntVect& ref_ratio = WarpX::RefRatio(lev);
                     const Box& cbox = amrex::coarsen(box,ref_ratio);
 
                     // Data on the grid
@@ -1829,6 +1832,7 @@ PhysicalParticleContainer::Evolve (int lev,
                     FArrayBox const* cbyfab = &(*cBy)[pti];
                     FArrayBox const* cbzfab = &(*cBz)[pti];
 
+                    //std::cout << "cexType = " << cexfab->box().ixType() << std::endl;
                     if (WarpX::use_fdtd_nci_corr)
                     {
                         // Filter arrays (*cEx)[pti], store the result in
@@ -1845,12 +1849,11 @@ PhysicalParticleContainer::Evolve (int lev,
 
                     // Field gather and push for particles in gather buffers
                     e_is_nodal = cEx->is_nodal() and cEy->is_nodal() and cEz->is_nodal();
-                std::cout << " Here nfine_gather = " << nfine_gather << ", np = " << np << std::endl;
                     PushPX(pti, cexfab, ceyfab, cezfab,
                            cbxfab, cbyfab, cbzfab,
                            cEx->nGrowVect(), e_is_nodal,
                            nfine_gather, np-nfine_gather,
-                           lev, lev, dt, ScaleFields(false), a_dt_type);
+                           lev, lev-1, dt, ScaleFields(false), a_dt_type);
                 }
 
                 WARPX_PROFILE_VAR_STOP(blp_fg);
@@ -1867,22 +1870,18 @@ PhysicalParticleContainer::Evolve (int lev,
                     } else {
                         ion_lev = nullptr;
                     }
-                std::cout << "1 Here np_current = " << np_current << ", np = " << np << std::endl;
                     // Deposit inside domains
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                    0, np_current, thread_num,
                                    lev, lev, dt, relative_time);
-                std::cout << "2 Here np_current = " << np_current << ", np = " << np << std::endl;
 
                     if (has_buffer)
                     {
-                std::cout << "3 Here np_current = " << np_current << ", np = " << np << std::endl;
                         // Deposit in buffers
                         DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, cjx, cjy, cjz,
                                        np_current, np-np_current, thread_num,
-                                       lev, lev, dt, relative_time);
+                                       lev, lev-1, dt, relative_time);
                     }
-                std::cout << "4 Here np_current = " << np_current << ", np = " << np << std::endl;
                 } // end of "if do_electrostatic == ElectrostaticSolverAlgo::None"
             } // end of "if do_not_push"
 
@@ -2556,17 +2555,25 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     // Get cell size on gather_lev
     const std::array<Real,3>& dx = WarpX::CellSize(std::max(gather_lev,0));
 
+ //   std::cout << "lev = " << lev << ", gather_lev = " << gather_lev << std::endl;
     // Get box from which field is gathered.
     // If not gathering from the finest level, the box is coarsened.
     Box box;
     if (lev == gather_lev) {
         box = pti.tilebox();
     } else {
-        const IntVect& ref_ratio = WarpX::RefRatio(gather_lev);
-        box = amrex::coarsen(pti.tilebox(),ref_ratio);
+        if (gather_lev < 0) {
+            const IntVect& ref_ratio{2,2,2};
+            //const IntVect& ref_ratio = WarpX::RefRatio(gather_lev+1);
+            box = amrex::coarsen(pti.tilebox(),ref_ratio);
+        } else {
+            const IntVect& ref_ratio = WarpX::RefRatio(gather_lev);
+            box = amrex::coarsen(pti.tilebox(),ref_ratio);
+        } 
     }
 
     // Add guard cells to the box.
+    //std::cout << "ngEB = " << ngEB << std::endl;
     box.grow(ngEB);
 
     const auto getPosition = GetParticlePosition(pti, offset);
@@ -2575,16 +2582,27 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     const auto getExternalEB = GetExternalEBField(pti, offset);
 
     // Lower corner of tile box physical domain (take into account Galilean shift)
-    const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, gather_lev, 0._rt);
+    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, gather_lev, 0._rt);
+    const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner((pti.tilebox().grow(2*ngEB)), lev, 0._rt);
+    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(pti.tilebox(), lev, 0._rt);
+    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, lev, 0._rt);
 
     const Dim3 lo = lbound(box);
+    //const Dim3 lo = lbound(pti.tilebox());
 
     bool galerkin_interpolation = WarpX::galerkin_interpolation;
     int nox = WarpX::nox;
     int n_rz_azimuthal_modes = WarpX::n_rz_azimuthal_modes;
 
-    amrex::GpuArray<amrex::Real, 3> dx_arr = {dx[0], dx[1], dx[2]};
+    //amrex::GpuArray<amrex::Real, 3> dx_arr = {dx[0], dx[1], dx[2]};
+    amrex::GpuArray<amrex::Real, 3> dx_arr;
+    if (gather_lev < 0) {
+       dx_arr = {2.0*dx[0], 2.0*dx[1], 2.0*dx[2]};
+    } else {
+       dx_arr = {dx[0], dx[1], dx[2]};
+    }
     amrex::GpuArray<amrex::Real, 3> xyzmin_arr = {xyzmin[0], xyzmin[1], xyzmin[2]};
+//    std::cout << "gather_lev = " << gather_lev << ", dx_arr[0] = " << 2.0*dx[0] << std::endl;
 
     amrex::Array4<const amrex::Real> const& ex_arr = exfab->array();
     amrex::Array4<const amrex::Real> const& ey_arr = eyfab->array();
@@ -2659,10 +2677,21 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
     const auto t_do_not_gather = do_not_gather;
 
+////    const Geometry& geom = Geom(0); //delete this line
+//    std::cout << "Here box = " << box << std::endl;        
+//    std::cout << "Here lo = " << lbound(box) << std::endl;        
+////    std::cout << "geom = " << geom << std::endl;        
+//    std::cout << "Here box = " << box << std::endl;        
+//    std::cout << "(xmin,ymin,zmin) = (" << xyzmin_arr[0] << ", " << xyzmin_arr[1] << ", " << xyzmin_arr[2] << ")" << std::endl;
+//    std::cout << "(dx,dy,dz) = (" << dx_arr[0] << ", " << dx_arr[1] << ", " << dx_arr[2] << ")" << std::endl;
+//    std::cout << "galerkin_interpolation = " << galerkin_interpolation << std::endl;
+
     amrex::ParallelFor( np_to_push, [=] AMREX_GPU_DEVICE (long ip)
     {
         amrex::ParticleReal xp, yp, zp;
         getPosition(ip, xp, yp, zp);
+
+        //std::cout << "gather_lev = " << gather_lev << ". (xp,yp,zp) = (" << xp << ", " << yp << ", " << zp << ")" << std::endl; 
 
         if (save_previous_position) {
 #if (AMREX_SPACEDIM >= 2)
@@ -2689,6 +2718,9 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
 
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+
+//        std::cout << "gather_lev = " << gather_lev << ".(Exp,Eyp,Ezp) = (" << Exp << ", " << Eyp << ", " << Ezp << ")" << std::endl; 
+//        std::cout << "gather_lev = " << gather_lev << ".(Bxp,Byp,Bzp) = (" << Bxp << ", " << Byp << ", " << Bzp << ")" << std::endl; 
 
         doParticlePush(getPosition, setPosition, copyAttribs, ip,
                        ux[ip], uy[ip], uz[ip],

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2582,10 +2582,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     const auto getExternalEB = GetExternalEBField(pti, offset);
 
     // Lower corner of tile box physical domain (take into account Galilean shift)
-    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, gather_lev, 0._rt);
-    const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner((pti.tilebox().grow(2*ngEB)), lev, 0._rt);
-    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(pti.tilebox(), lev, 0._rt);
-    //const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner(box, lev, 0._rt);
+    const std::array<amrex::Real, 3>& xyzmin = WarpX::LowerCorner((gather_lev < 0) ? (pti.tilebox().grow(2*ngEB)) : box, lev, 0._rt);
 
     const Dim3 lo = lbound(box);
     //const Dim3 lo = lbound(pti.tilebox());

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2569,7 +2569,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         } else {
             const IntVect& ref_ratio = WarpX::RefRatio(gather_lev);
             box = amrex::coarsen(pti.tilebox(),ref_ratio);
-        } 
+        }
     }
 
     // Add guard cells to the box.
@@ -2678,10 +2678,10 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     const auto t_do_not_gather = do_not_gather;
 
 ////    const Geometry& geom = Geom(0); //delete this line
-//    std::cout << "Here box = " << box << std::endl;        
-//    std::cout << "Here lo = " << lbound(box) << std::endl;        
-////    std::cout << "geom = " << geom << std::endl;        
-//    std::cout << "Here box = " << box << std::endl;        
+//    std::cout << "Here box = " << box << std::endl;
+//    std::cout << "Here lo = " << lbound(box) << std::endl;
+////    std::cout << "geom = " << geom << std::endl;
+//    std::cout << "Here box = " << box << std::endl;
 //    std::cout << "(xmin,ymin,zmin) = (" << xyzmin_arr[0] << ", " << xyzmin_arr[1] << ", " << xyzmin_arr[2] << ")" << std::endl;
 //    std::cout << "(dx,dy,dz) = (" << dx_arr[0] << ", " << dx_arr[1] << ", " << dx_arr[2] << ")" << std::endl;
 //    std::cout << "galerkin_interpolation = " << galerkin_interpolation << std::endl;
@@ -2691,7 +2691,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         amrex::ParticleReal xp, yp, zp;
         getPosition(ip, xp, yp, zp);
 
-        //std::cout << "gather_lev = " << gather_lev << ". (xp,yp,zp) = (" << xp << ", " << yp << ", " << zp << ")" << std::endl; 
+        //std::cout << "gather_lev = " << gather_lev << ". (xp,yp,zp) = (" << xp << ", " << yp << ", " << zp << ")" << std::endl;
 
         if (save_previous_position) {
 #if (AMREX_SPACEDIM >= 2)
@@ -2719,8 +2719,8 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
 
-//        std::cout << "gather_lev = " << gather_lev << ".(Exp,Eyp,Ezp) = (" << Exp << ", " << Eyp << ", " << Ezp << ")" << std::endl; 
-//        std::cout << "gather_lev = " << gather_lev << ".(Bxp,Byp,Bzp) = (" << Bxp << ", " << Byp << ", " << Bzp << ")" << std::endl; 
+//        std::cout << "gather_lev = " << gather_lev << ".(Exp,Eyp,Ezp) = (" << Exp << ", " << Eyp << ", " << Ezp << ")" << std::endl;
+//        std::cout << "gather_lev = " << gather_lev << ".(Bxp,Byp,Bzp) = (" << Bxp << ", " << Byp << ", " << Bzp << ")" << std::endl;
 
         doParticlePush(getPosition, setPosition, copyAttribs, ip,
                        ux[ip], uy[ip], uz[ip],

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -66,10 +66,15 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
 
     // First, partition particles into the larger buffer
 
+//    std::cout << "WarpX::n_field_gather_buffer = " << WarpX::n_field_gather_buffer << std::endl;
+//    std::cout << "WarpX::n_current_deposition_buffer = " << WarpX::n_current_deposition_buffer << std::endl;
+//    std::cout << "gather_mask = " << gather_masks << std::endl;
+//    std::cout << "current_mask = " << current_masks << std::endl;
     // - Select the larger buffer
     iMultiFab const* bmasks =
         (WarpX::n_field_gather_buffer >= WarpX::n_current_deposition_buffer) ?
         gather_masks : current_masks;
+//    std::cout << "bmasks = " << bmasks << std::endl;
     // - For each particle, find whether it is in the larger buffer,
     //   by looking up the mask. Store the answer in `inexflag`.
     amrex::ParallelFor( np, fillBufferFlag(pti, bmasks, inexflag, Geom(lev)) );
@@ -120,6 +125,9 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
         }
     }
 
+    std::cout << "np = " << np << std::endl;
+    std::cout << "nfine_gather = " << nfine_gather << std::endl;
+    std::cout << "nfine_current = " << nfine_current << std::endl;
     // only deposit / gather to coarsest grid
     if (m_deposit_on_main_grid && lev > 0) {
         nfine_current = 0;

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -125,9 +125,6 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
         }
     }
 
-    std::cout << "np = " << np << std::endl;
-    std::cout << "nfine_gather = " << nfine_gather << std::endl;
-    std::cout << "nfine_current = " << nfine_current << std::endl;
     // only deposit / gather to coarsest grid
     if (m_deposit_on_main_grid && lev > 0) {
         nfine_current = 0;

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -119,6 +119,7 @@ class fillBufferFlag
             // Find the value of the buffer flag in this cell and
             // store it at the corresponding particle position in the array `inexflag`
             m_inexflag_ptr[i] = m_buffer_mask(iv);
+            //if(m_buffer_mask(iv) == 1 ) std::cout << "iv = " << iv << ", m_inexflag_ptr[" << i << "] = " << m_inexflag_ptr[i] << std::endl;
         }
 
     private:

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1092,7 +1092,7 @@ private:
     std::unique_ptr<amrex::MultiFab> GetCellCenteredData();
 
     void BuildBufferMasks ();
-    void BuildBufferMasksInBox ( const amrex::Box tbx, amrex::IArrayBox &buffer_mask,
+    void BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &buffer_mask,
                                  const amrex::IArrayBox &guard_mask, const int ng );
     const amrex::iMultiFab* getCurrentBufferMasks (int lev) const {
         return current_buffer_masks[lev].get();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2632,7 +2632,7 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
 
                 if (x > fine_tag_lo[0] && x < fine_tag_hi[0]){
                    if (y > fine_tag_lo[1] && y < fine_tag_hi[1]){
-                      if (z > fine_tag_lo[2] && z < fine_tag_hi[2]){ 
+                      if (z > fine_tag_lo[2] && z < fine_tag_hi[2]){
                          setnull = true;
                       }
                    }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2033,8 +2033,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     //
     // The coarse patch
     //
-    if (lev > 0)
-    {
+
         BoxArray cba = ba;
         cba.coarsen(refRatio(lev-1));
         std::array<Real,3> cdx = CellSize(lev-1);
@@ -2129,7 +2128,6 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             m_fdtd_solver_cp[lev] = std::make_unique<FiniteDifferenceSolver>(maxwell_solver_id, cdx,
                                                                              do_nodal);
         }
-    }
 
     //
     // Copy of the coarse aux

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2134,6 +2134,8 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     //gather buffer for lev = 0 : emulated MR
     gather_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1 );
+    current_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1);
+    current_buffer_masks[lev]->setVal(1);
 
     //
     // Copy of the coarse aux
@@ -2517,7 +2519,7 @@ WarpX::BuildBufferMasks ()
 {
     for (int lev = 0; lev <= maxLevel(); ++lev)
     {
-        for (int ipass = 0; ipass < 2; ++ipass)
+        for (int ipass = 1; ipass < 2; ++ipass)
         {
             int ngbuffer = (ipass == 0) ? n_current_deposition_buffer : n_field_gather_buffer;
             iMultiFab* bmasks = (ipass == 0) ? current_buffer_masks[lev].get() : gather_buffer_masks[lev].get();
@@ -2592,8 +2594,8 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
 
         if (x > fine_tag_lo[0] && x < fine_tag_hi[0]) setnull = true;
 
-        if ( setnull ) msk(i,j,k) = 0;
-        else           msk(i,j,k) = 1;
+        if ( setnull ) msk(i,j,k) = 1;
+        else           msk(i,j,k) = 0;
     }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     int k = lo.z;
@@ -2613,8 +2615,8 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
                }
             }
 
-            if ( setnull ) msk(i,j,k) = 0;
-            else           msk(i,j,k) = 1;
+            if ( setnull ) msk(i,j,k) = 1;
+            else           msk(i,j,k) = 0;
         }
     }
 #elif defined(WARPX_DIM_3D)
@@ -2638,10 +2640,11 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
                    }
                  }
 
-                if ( setnull ) msk(i,j,k) = 0;
-                else           msk(i,j,k) = 1;
+                if ( setnull ) msk(i,j,k) = 1;
+                else           msk(i,j,k) = 0;
 
-                //if(msk(i,j,k) == 0)std::cout << " 3D mask : (x,y,z) = ("<< x << ", "<< y << ", "<< z <<". msk (" << i << ", " << j << ", "<< k << ") = " << msk(i,j,k) << std::endl;
+                //std::cout << " 3D mask : (x,y,z) = ("<< x << ", "<< y << ", "<< z <<". msk (" << i << ", " << j << ", "<< k << ") = " << msk(i,j,k) << std::endl;
+                //if(msk(i,j,k) == 1)std::cout << " 3D mask : (x,y,z) = ("<< x << ", "<< y << ", "<< z <<". msk (" << i << ", " << j << ", "<< k << ") = " << msk(i,j,k) << std::endl;
             }
         }
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2043,7 +2043,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         for(int i = 0; i < 3; i++) cdx[i] = 2.0*cdx[i];
 
         std::cout << "cba = " << crba << std::endl;
-        
+
         std::cout << "ba = " << ba << std::endl;
 
         // Create the MultiFabs for B

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2034,59 +2034,65 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // The coarse patch
     //
 
-        BoxArray cba = ba;
-    //    cba.coarsen(refRatio(lev-1));
-    //    std::array<Real,3> cdx = CellSize(lev-1);
+        BoxArray crba = ba;
 
-        cba.coarsen(refRatio(lev));
+        const IntVect& crse_ratio{2,2,2};
+        crba.coarsen(crse_ratio);
+
         std::array<Real,3> cdx = CellSize(lev);
+        for(int i = 0; i < 3; i++) cdx[i] = 2.0*cdx[i];
+
+        std::cout << "cba = " << crba << std::endl;
+        
+        std::cout << "ba = " << ba << std::endl;
 
         // Create the MultiFabs for B
-        Bfield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[x]"));
-        Bfield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[y]"));
-        Bfield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[z]"));
+        Bfield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(crba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[x]"));
+        Bfield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(crba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[y]"));
+        Bfield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(crba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[z]"));
 
         // Create the MultiFabs for E
-        Efield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[x]"));
-        Efield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[y]"));
-        Efield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[z]"));
+        Efield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(crba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[x]"));
+        std::cout << "amrex::convert(crba,Ex_nodal_flag) = " << amrex::convert(crba,Ex_nodal_flag) << std::endl;
+        Efield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(crba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[y]"));
+        Efield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(crba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[z]"));
 
         // Create the MultiFabs for B_avg
-        Bfield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[x]"));
-        Bfield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[y]"));
-        Bfield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[z]"));
+        Bfield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(crba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[x]"));
+        Bfield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(crba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[y]"));
+        Bfield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(crba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[z]"));
 
         // Create the MultiFabs for E_avg
-        Efield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[x]"));
-        Efield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[y]"));
-        Efield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[z]"));
+        Efield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(crba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[x]"));
+        Efield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(crba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[y]"));
+        Efield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(crba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[z]"));
 
         // Create the MultiFabs for the current
-        current_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_cp[x]"));
-        current_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_cp[y]"));
-        current_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_cp[z]"));
+        current_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(crba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_cp[x]"));
+        current_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(crba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_cp[y]"));
+        current_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(crba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_cp[z]"));
 
         if (deposit_charge) {
             // For the multi-J algorithm we can allocate only one rho component (no distinction between old and new)
             const int rho_ncomps = (WarpX::do_multi_J) ? ncomps : 2*ncomps;
-            rho_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_cp"));
+            rho_cp[lev] = std::make_unique<MultiFab>(amrex::convert(crba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_cp"));
         }
 
         if (do_dive_cleaning)
         {
-            F_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,IntVect::TheUnitVector()),dm,ncomps, ngF.max(),tag("F_cp"));
+            F_cp[lev] = std::make_unique<MultiFab>(amrex::convert(crba,IntVect::TheUnitVector()),dm,ncomps, ngF.max(),tag("F_cp"));
         }
 
         if (do_divb_cleaning)
         {
             if (do_nodal)
             {
-                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba, IntVect::TheUnitVector()),
+                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(crba, IntVect::TheUnitVector()),
                                                        dm, ncomps, ngG.max(), tag("G_cp"));
             }
             else // do_nodal = 0
             {
-                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba, IntVect::TheZeroVector()),
+                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(crba, IntVect::TheZeroVector()),
                                                        dm, ncomps, ngG.max(), tag("G_cp"));
             }
         }
@@ -2100,7 +2106,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 #else
 
             // Get the cell-centered box, with guard cells
-            BoxArray c_realspace_ba = cba;// Copy box
+            BoxArray c_realspace_ba = crba;// Copy box
             c_realspace_ba.enclosedCells(); // Make it cell-centered
             // Define spectral solver
 #ifdef WARPX_DIM_RZ
@@ -2132,10 +2138,24 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                                                                              do_nodal);
         }
 
-    //gather buffer for lev = 0 : emulated MR
-    gather_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1 );
-    current_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1);
-    current_buffer_masks[lev]->setVal(1);
+//      gather buffer and current buffer masks for lev = 0 : emulated MR
+
+    if (n_field_gather_buffer > 0 ) {
+       gather_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1 );
+    }
+
+    if (n_current_deposition_buffer > 0) {
+        current_buf[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_buf[x]"));
+        current_buf[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_buf[y]"));
+        current_buf[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_buf[z]"));
+        if (rho_cp[lev]) {
+            charge_buf[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,2*ncomps,ngRho,tag("charge_buf"));
+        }
+        current_buffer_masks[lev] = std::make_unique<iMultiFab>(ba, dm, ncomps, 1);
+        current_buffer_masks[lev]->setVal(1);
+     }
+        // Current buffer masks have 1 ghost cell, because of the fact
+        // that particles may move by more than one cell when using subcycling.
 
     //
     // Copy of the coarse aux
@@ -2523,10 +2543,8 @@ WarpX::BuildBufferMasks ()
         {
             int ngbuffer = (ipass == 0) ? n_current_deposition_buffer : n_field_gather_buffer;
             iMultiFab* bmasks = (ipass == 0) ? current_buffer_masks[lev].get() : gather_buffer_masks[lev].get();
-//            std::cout << "ngbuffer = " << ngbuffer << ", and bmasks = " << bmasks <<std::endl;
-//            std::cout << "n_current_deposition_buffer = " << n_current_deposition_buffer << ", and n_field_gather_buffer = " << n_field_gather_buffer <<std::endl;
-//            std::cout << "current_buffer_masks[lev].get() = " << current_buffer_masks[lev].get() << ", gather_buffer_masks[lev].get() " << gather_buffer_masks[lev].get() <<std::endl;
-//            std::cout << "current_buffer_masks[lev+1].get() = " << current_buffer_masks[lev+1].get() << ", gather_buffer_masks[lev+1].get() " << gather_buffer_masks[lev+1].get() <<std::endl;
+
+            std::cout << "ngbuffer = " << ngbuffer << std::endl;
             if (bmasks)
             {
                 const IntVect ngtmp = ngbuffer + bmasks->nGrowVect();
@@ -2572,14 +2590,12 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
     fine_tag_hi = RealVect{f_hi};
 
     const auto problo = Geom(lev).ProbLoArray();
-    const auto probhi = Geom(lev).ProbHiArray();
     const auto dx = Geom(lev).CellSizeArray();
 
     bool setnull;
     const amrex::Dim3 lo = amrex::lbound( tbx );
     const amrex::Dim3 hi = amrex::ubound( tbx );
     Array4<int> msk = buffer_mask.array();
-    Array4<int const> gmsk = guard_mask.array();
 
 #if defined(WARPX_DIM_1D_Z)
     int k = lo.z;
@@ -2650,6 +2666,12 @@ WarpX::BuildBufferMasksInBox ( int lev, const amrex::Box tbx, amrex::IArrayBox &
     }
 #endif
 
+//    bool setnull;
+//    const amrex::Dim3 lo = amrex::lbound( tbx );
+//    const amrex::Dim3 hi = amrex::ubound( tbx );
+//    Array4<int> msk = buffer_mask.array();
+//    Array4<int const> gmsk = guard_mask.array();
+//
 //#if defined(WARPX_DIM_1D_Z)
 //    int k = lo.z;
 //    int j = lo.y;


### PR DESCRIPTION
This PR implements the emulated MR mode described in the issue: https://github.com/ECP-WarpX/WarpX/issues/3103

The idea would be to use only one level (`max_level=0`), but allocate the coarse patch for the `level 0` (i.e. the `_cp` arrays) and use the gather buffers to tell particles to gather from the `_cp` array if they are not inside `fine_tag_lo/hi`.

Steps:

- Allocate `_cp` array for level 0

-  At each timestep, before the gather operation: `coarsen` the `_fp` from `level 0` to get the `_cp` from level 0. (This could be done inside the function `UpdateAuxilaryDataSameType`: by adding an if condition `if (lev == 0)`, and filling `Bfield_cp` and `Efield_cp` with the coarsen data of the `_fp` arrays, by using the function `CoarsenMR::Coarsen`.)

-  We need to make sure that `gather_buffer_masks` is allocated for level 0. We would modify the function `BuildBufferMasksInBox` so as to fill the `gather_buffe`r with 0 or 1 according to the user input `fine_tag_lo/hi` and the position of each cell

-  The gather code should automatically use the above-mentioned buffers, so that it needs not be modified in principle. We should be careful that a few if condition are not disabling the code, e.g. https://github.com/ECP-WarpX/WarpX/blob/development/Source/Particles/PhysicalParticleContainer.cpp#L1696

We need to be careful that the current buffer (as opposed to the gather buffer) are defined in such a way that they will not interfere with the above operations.