### PR TITLE
Fix Breaking Pip 22.1 Logic

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,6 +37,7 @@ jobs:
         cmake --build build --config Debug --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade cmake
         $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
         python3 -m pip install . -vv --no-build-isolation
 
@@ -81,6 +82,7 @@ jobs:
         cmake --build build --config Release --parallel 2
 
         python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade cmake
         set "PYWARPX_LIB_DIR=%cd%\build\lib\"
         python3 -m pip install . -vv --no-build-isolation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,7 @@ if(WarpX_LIB)
         ${CMAKE_COMMAND} -E rm -f ${WarpX_BINARY_DIR}/pywarpx*whl
         COMMAND
             ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                python3 -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${WarpX_SOURCE_DIR}
+                python3 -m pip wheel -v --no-build-isolation ${WarpX_SOURCE_DIR}
         WORKING_DIRECTORY
             ${WarpX_BINARY_DIR}
         DEPENDS

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -199,6 +199,7 @@ PICMI Python Bindings
    .. code-block:: bash
 
       python3 -m pip install -U pip setuptools wheel
+      python3 -m pip install -U cmake
 
 For PICMI Python bindings, configure WarpX to produce a library and call our ``pip_install`` *CMake target*:
 

--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -137,6 +137,7 @@ Now, ensure Python tooling is up-to-date:
 .. code-block:: bash
 
    python3 -m pip install -U pip setuptools wheel
+   python3 -m pip install -U cmake
 
 Then we compile WarpX as in the previous section (with or without CUDA) adding ``-DWarpX_LIB=ON`` and then we install it into our Python:
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -62,6 +62,7 @@ rm -rf py-venv
 python3 -m venv py-venv
 source py-venv/bin/activate
 python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade cmake
 # setuptools/mp4py work-around, see
 #   https://github.com/mpi4py/mpi4py/pull/159
 #   https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274


### PR DESCRIPTION
## No Build Isolation & Build Dependencies

Pip's `--no-build-isolation` says we have to have build-deps pre-installed. But Pip does offer no option to install those from `pyproject.toml` :cry:
https://github.com/pypa/pip/issues/9794

We want isolated builds, because they
- have a deterministic, relative path that we can cache with ccache (can probably also be done by setting `export TMPDIR`)
- can use external modules for our build dependencies, e.g., if pypi.org ships no `cmake` for a host arch (looking at you, PPC64le, until recently)

## Dropped in-tree-build

Pip now made `in-tree-build` the default.
```
option --use-feature: invalid choice: 'in-tree-build' (choose from '2020-resolver', 'fast-deps')
```

Great, if they would silently ignore the old option during the transition :cry: 

Of course, there is no way to force a minimal version of pip:
https://github.com/pypa/pip/issues/4145#issuecomment-266245512
> I can't see why a project would need to require a given version of pip.

:cry: 
https://github.com/pypa/pip/issues/11118