### PR TITLE
Fold Python tests into their corresponding base configurations, to better exploit ccache

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -31,8 +31,6 @@ jobs:
         WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
       cartesian3d:
         WARPX_CI_REGULAR_CARTESIAN_3D: 'TRUE'
-      python:
-        WARPX_CI_PYTHON_MAIN: 'TRUE'
       single_precision:
         WARPX_CI_SINGLE_PRECISION: 'TRUE'
       rz_or_nompi:
@@ -100,7 +98,7 @@ jobs:
           -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
         python3 -m pip install --upgrade openpmd-api
       fi
-      if [[ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" || "${WARPX_CI_PYTHON_MAIN:-FALSE}" == "TRUE" ]]; then
+      if [[ "${WARPX_CI_RZ_OR_NOMPI:-FALSE}" == "TRUE" ]]; then
         cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/blaspp.git \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
           -DCMAKE_CXX_STANDARD=17                       \

--- a/.github/workflows/source/test_ci_matrix.sh
+++ b/.github/workflows/source/test_ci_matrix.sh
@@ -19,8 +19,6 @@ WARPX_CI_REGULAR_CARTESIAN_2D=TRUE python prepare_file_ci.py
 grep "\[" ci-tests.ini >>  ci_matrix_elements.txt
 WARPX_CI_REGULAR_CARTESIAN_3D=TRUE python prepare_file_ci.py
 grep "\[" ci-tests.ini >>  ci_matrix_elements.txt
-WARPX_CI_PYTHON_MAIN=TRUE       python prepare_file_ci.py
-grep "\[" ci-tests.ini >> ci_matrix_elements.txt
 WARPX_CI_SINGLE_PRECISION=TRUE  python prepare_file_ci.py
 grep "\[" ci-tests.ini >> ci_matrix_elements.txt
 WARPX_CI_RZ_OR_NOMPI=TRUE      python prepare_file_ci.py

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1044,8 +1044,8 @@ inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
 runtime_params =
 customRunCmd = python3 PICMI_inputs_1d.py
 dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1782,8 +1782,8 @@ inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasm
 runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
 dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3055,8 +3055,8 @@ inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.p
 runtime_params =
 customRunCmd = python3 PICMI_inputs_1d.py --test
 dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -64,7 +64,7 @@ branch = 3ca867b8cce86b9892b45ff78df8630500dc3bb4
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx
 branch = development
-cmakeSetupOpts = -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON
+cmakeSetupOpts = -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON -DWarpX_LIB=ON
 
 # individual problems follow
 
@@ -876,7 +876,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir_rz_multimode_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -896,7 +896,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_runtime_component_analyze.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 1
 restartFileNum = 5
@@ -916,7 +916,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_restart_eb.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 1
 restartFileNum = 30
@@ -1007,7 +1007,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1045,7 +1045,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_1d.py
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1118,7 +1118,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1174,7 +1174,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir_rt.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1687,7 +1687,7 @@ customRunCmd = python3 PICMI_inputs_gaussian_beam.py
 runtime_params =
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1707,7 +1707,7 @@ customRunCmd = python3 PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 runtime_params =
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1743,7 +1743,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1763,7 +1763,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration_mr.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1783,7 +1783,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1922,7 +1922,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_rz.py
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -1942,7 +1942,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_langmuir2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2097,7 +2097,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2596,7 +2596,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2872,7 +2872,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2943,7 +2943,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -2999,7 +2999,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_3d.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3037,7 +3037,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3056,7 +3056,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_1d.py --test
 dim = 1
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3111,7 +3111,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_scrape.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3131,7 +3131,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_reflection.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3149,7 +3149,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3167,7 +3167,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py --unique
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3185,7 +3185,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_prev_pos_2d.py
 dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3312,7 +3312,7 @@ runtime_params =
 customRunCmd = python3 PICMI_inputs_2d.py
 dim = 2
 addToCompileString = USE_PSATD=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1
@@ -3331,7 +3331,7 @@ runtime_params =
 customRunCmd = python PICMI_inputs_EB_API.py
 dim = 3
 addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_LIB=ON -DWarpX_APP=OFF
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
 target = pip_install
 restartTest = 0
 useMPI = 1

--- a/Regression/prepare_file_ci.py
+++ b/Regression/prepare_file_ci.py
@@ -20,7 +20,6 @@ ci_regular_cartesian_1d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_1D') == 'TR
 ci_regular_cartesian_2d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_2D') == 'TRUE'
 ci_regular_cartesian_3d = os.environ.get('WARPX_CI_REGULAR_CARTESIAN_3D') == 'TRUE'
 ci_psatd = os.environ.get('WARPX_CI_PSATD', 'TRUE') == 'TRUE'
-ci_python_main = os.environ.get('WARPX_CI_PYTHON_MAIN') == 'TRUE'
 ci_single_precision = os.environ.get('WARPX_CI_SINGLE_PRECISION') == 'TRUE'
 ci_rz_or_nompi = os.environ.get('WARPX_CI_RZ_OR_NOMPI') == 'TRUE'
 ci_qed = os.environ.get('WARPX_CI_QED') == 'TRUE'
@@ -117,7 +116,6 @@ def select_tests(blocks, match_string_list, do_test):
 if ci_regular_cartesian_1d:
     test_blocks = select_tests(test_blocks, ['dim = 1'], True)
     test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
@@ -126,7 +124,6 @@ if ci_regular_cartesian_1d:
 if ci_regular_cartesian_2d:
     test_blocks = select_tests(test_blocks, ['dim = 2'], True)
     test_blocks = select_tests(test_blocks, ['USE_RZ=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
@@ -134,21 +131,15 @@ if ci_regular_cartesian_2d:
 
 if ci_regular_cartesian_3d:
     test_blocks = select_tests(test_blocks, ['dim = 3'], True)
-    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], False)
     test_blocks = select_tests(test_blocks, ['useMPI = 0'], False)
     test_blocks = select_tests(test_blocks, ['QED=TRUE'], False)
-    test_blocks = select_tests(test_blocks, ['USE_EB=TRUE'], False)
-
-if ci_python_main:
-    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], True)
     test_blocks = select_tests(test_blocks, ['USE_EB=TRUE'], False)
 
 if ci_single_precision:
     test_blocks = select_tests(test_blocks, ['PRECISION=FLOAT', 'USE_SINGLE_PRECISION_PARTICLES=TRUE'], True)
 
 if ci_rz_or_nompi:
-    test_blocks = select_tests(test_blocks, ['PYTHON_MAIN=TRUE'], False)
     block1 = select_tests(test_blocks, ['USE_RZ=TRUE'], True)
     block2 = select_tests(test_blocks, ['useMPI = 0'], True)
     test_blocks = block1 + block2

--- a/Regression/prepare_file_ci.py
+++ b/Regression/prepare_file_ci.py
@@ -84,6 +84,9 @@ if ci_num_make_jobs is not None:
 # Prevent emails from being sent
 text = re.sub( 'sendEmailWhenFail = 1', 'sendEmailWhenFail = 0', text )
 
+# Remove Python test (does not compile)
+text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
+
 # Select the tests to be run
 # --------------------------
 

--- a/Regression/prepare_file_ci.py
+++ b/Regression/prepare_file_ci.py
@@ -84,12 +84,6 @@ if ci_num_make_jobs is not None:
 # Prevent emails from being sent
 text = re.sub( 'sendEmailWhenFail = 1', 'sendEmailWhenFail = 0', text )
 
-# Remove Python test (does not compile)
-text = re.sub( '\[Python_Langmuir\]\n(.+\n)*', '', text)
-
-# Remove Langmuir_x/y/z test (too long; not that useful)
-text = re.sub( '\[Langmuir_[xyz]\]\n(.+\n)*', '', text)
-
 # Select the tests to be run
 # --------------------------
 


### PR DESCRIPTION
Rather than building each of 1D, 2D, 3D, and RZ redundantly in a 'Python' CI job, just run the Python tests in the job of the corresponding configuration that will have already done the work of them.