### PR TITLE
Fix bug in automatic_text_wrap

### DIFF
--- a/Source/ablastr/utils/TextMsg.cpp
+++ b/Source/ablastr/utils/TextMsg.cpp
@@ -107,7 +107,8 @@ ablastr::utils::automatic_text_wrap (
                 }
                 else{
                     wrapped_text_lines.push_back(ss_line_out.str());
-                    ss_line_out = std::stringstream{word};
+                    ss_line_out.str("");
+                    ss_line_out << word;
                     counter = wlen;
                 }
             }


### PR DESCRIPTION
Recently @EZoni spotted a bug in the `automatic_text_wrap` function (used to format warning messages). In some cases a word was lost in the formatted message. This PR should fix the bug.