### PR TITLE
Add workaround for Libfabric bug on Crusher to job script.

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -86,3 +86,19 @@ Post-Processing
 For post-processing, most users use Python via OLCFs's `Jupyter service <https://jupyter.olcf.ornl.gov>`__ (`Docs <https://docs.olcf.ornl.gov/services_and_applications/jupyter/index.html>`__).
 
 Please follow the same guidance as for :ref:`OLCF Summit post-processing <post-processing-summit>`.
+
+.. _known-crusher-issues:
+
+Known System Issues
+-------------------
+
+.. warning::
+
+   May 16th, 2022 (OLCFHELP-6888):
+   There is a caching bug in Libfrabric that causes WarpX simulations to occasionally hang on Crusher on more than 1 node.
+
+   As a work-around, please export the following environment variable in your job scripts unti the issue is fixed:
+
+   .. code-block:: bash
+
+      export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching

--- a/Tools/machines/crusher-olcf/submit.sh
+++ b/Tools/machines/crusher-olcf/submit.sh
@@ -19,5 +19,10 @@
 # (GCDs) for a total of 8 GCDs per node. The programmer can think of the 8 GCDs
 # as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E).
 
+# note (5-16-22)
+# this environment setting is currently needed on Crusher to work-around a
+# known issue with Libfabric
+export FI_MR_CACHE_MAX_COUNT=0
+
 export OMP_NUM_THREADS=8
 srun ./warpx inputs > output.txt


### PR DESCRIPTION
This allows us to run on multiple nodes on Crusher while they work on a proper fix.