### PR TITLE
Fix unnecessary float to double promotions

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -267,13 +267,13 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
     amrex::IntVect hi(1);
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
         // lo index with same cell-size as simulation at level, lev.
-        const int lo_index = static_cast<int>( floor(
+        const int lo_index = static_cast<int>( std::floor(
                 ( diag_dom.lo(idim) - warpx.Geom(lev).ProbLo(idim) ) /
                   warpx.Geom(lev).CellSize(idim) ) );
         // Taking max of (0,lo_index) because lo_index must always be >=0
         lo[idim] = std::max( 0, lo_index );
         // hi index with same cell-size as simulation at level, lev.
-        const int hi_index =  static_cast<int>( ceil(
+        const int hi_index =  static_cast<int>( std::ceil(
                 ( diag_dom.hi(idim) - warpx.Geom(lev).ProbLo(idim) ) /
                   warpx.Geom(lev).CellSize(idim) ) );
         // Taking max of (0,hi_index) because hi_index must always be >=0
@@ -339,14 +339,14 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
     amrex::IntVect ref_ratio = amrex::IntVect(1);
     if (lev > 0 ) ref_ratio = WarpX::RefRatio(lev-1);
     // Number of lab-frame cells in z-direction at level, lev
-    const int num_zcells_lab = static_cast<int>( floor (
+    const int num_zcells_lab = static_cast<int>( std::floor (
                                    ( zmax_buffer_lab - zmin_buffer_lab)
                                    / dz_lab(warpx.getdt(lev), ref_ratio[m_moving_window_dir])                               ) );
     // Take the max of 0 and num_zcells_lab
     int Nz_lab = std::max( 0, num_zcells_lab );
 #if (AMREX_SPACEDIM >= 2)
     // Number of lab-frame cells in x-direction at level, lev
-    const int num_xcells_lab = static_cast<int>( floor (
+    const int num_xcells_lab = static_cast<int>( std::floor (
                                   ( diag_dom.hi(0) - diag_dom.lo(0) )
                                   / warpx.Geom(lev).CellSize(0)
                               ) );
@@ -355,7 +355,7 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev)
 #endif
 #if defined(WARPX_DIM_3D)
     // Number of lab-frame cells in the y-direction at level, lev
-    const int num_ycells_lab = static_cast<int>( floor (
+    const int num_ycells_lab = static_cast<int>( std::floor (
                                    ( diag_dom.hi(1) - diag_dom.lo(1) )
                                    / warpx.Geom(lev).CellSize(1)
                                ) );
@@ -653,7 +653,7 @@ BTDiagnostics::DefineSnapshotGeometry (const int i_buffer, const int lev)
         // for the ith snapshot
         // estimating the maximum number of buffer multifabs needed to obtain the
         // full lab-frame snapshot
-        m_max_buffer_multifabs[i_buffer] = static_cast<int>( ceil (
+        m_max_buffer_multifabs[i_buffer] = static_cast<int>( std::ceil (
             amrex::Real(m_snapshot_ncells_lab[i_buffer][m_moving_window_dir]) /
             amrex::Real(m_buffer_size) ) );
         // number of cells in z is modified since each buffer multifab always

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -812,7 +812,7 @@ void BackTransformedDiagnostic::Flush (const Geometry& /*geom*/)
                 // Loop over species to be dumped to BFD
                 for (int j = 0; j < mypc.nSpeciesBackTransformedDiagnostics(); ++j) {
                     // Get species name
-                    std::string species_name =
+                    const std::string& species_name =
                         species_names[mypc.mapSpeciesBackTransformedDiagnostics(j)];
 #ifdef WARPX_USE_HDF5
                     // Dump species data
@@ -999,7 +999,7 @@ writeLabFrameData (const MultiFab* cell_centered_data,
                 // Loop over species to be dumped to BFD
                 for (int j = 0; j < mypc.nSpeciesBackTransformedDiagnostics(); ++j) {
                     // Get species name
-                    const std::string species_name = species_names[
+                    const std::string& species_name = species_names[
                                       mypc.mapSpeciesBackTransformedDiagnostics(j)];
 #ifdef WARPX_USE_HDF5
                     // Write data to disk (HDF5)
@@ -1203,7 +1203,7 @@ LabFrameSnapShot (Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
    m_diag_domain_lab_ = diag_domain_lab;
    m_buff_box_ = diag_box;
    m_ncomp_to_dump_ = ncomp_to_dump;
-   m_mesh_field_names_ = mesh_field_names;
+   m_mesh_field_names_ = std::move(mesh_field_names);
    m_file_num = file_num_in;
    m_current_z_lab = 0.0;
    m_current_z_boost = 0.0;
@@ -1297,7 +1297,7 @@ createLabFrameDirectories() {
         // Loop over species to be dumped to BFD
         for(int i = 0; i < mypc.nSpeciesBackTransformedDiagnostics(); ++i) {
             // Get species name
-            std::string species_name =
+            const std::string& species_name =
                 species_names[mypc.mapSpeciesBackTransformedDiagnostics(i)];
             const std::string fullpath = m_file_name + "/" + species_name;
             if (!UtilCreateDirectory(fullpath, 0755))
@@ -1377,7 +1377,7 @@ LabFrameSlice(Real t_lab_in, Real t_boost, Real inv_gamma_boost_in,
     m_diag_domain_lab_ = diag_domain_lab;
     m_buff_box_ = diag_box;
     m_ncomp_to_dump_ = ncomp_to_dump;
-    m_mesh_field_names_ = mesh_field_names;
+    m_mesh_field_names_ = std::move(mesh_field_names);
     m_file_num = file_num_in;
     m_current_z_lab = 0.0;
     m_current_z_boost = 0.0;

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -35,7 +35,7 @@
 using namespace amrex::literals;
 
 Diagnostics::Diagnostics (int i, std::string name)
-    : m_diag_name(name), m_diag_index(i)
+    : m_diag_name(std::move(name)), m_diag_index(i)
 {
 }
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -469,10 +469,10 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
          // To ensure that the diagnostic lo and hi are within the domain defined at level, lev.
         diag_dom.setLo(idim, std::max(m_lo[idim],warpx.Geom(lev).ProbLo(idim)) );
         diag_dom.setHi(idim, std::min(m_hi[idim],warpx.Geom(lev).ProbHi(idim)) );
-        if ( fabs(warpx.Geom(lev).ProbLo(idim) - diag_dom.lo(idim))
+        if ( std::fabs(warpx.Geom(lev).ProbLo(idim) - diag_dom.lo(idim))
                                >  warpx.Geom(lev).CellSize(idim) )
              use_warpxba = false;
-        if ( fabs(warpx.Geom(lev).ProbHi(idim) - diag_dom.hi(idim))
+        if ( std::fabs(warpx.Geom(lev).ProbHi(idim) - diag_dom.hi(idim))
                                > warpx.Geom(lev).CellSize(idim) )
              use_warpxba = false;
 
@@ -493,11 +493,11 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
         amrex::IntVect hi(1);
         for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
             // lo index with same cell-size as simulation at level, lev.
-            lo[idim] = std::max( static_cast<int>( floor (
+            lo[idim] = std::max( static_cast<int>( std::floor (
                           ( diag_dom.lo(idim) - warpx.Geom(lev).ProbLo(idim)) /
                             warpx.Geom(lev).CellSize(idim)) ), 0 );
             // hi index with same cell-size as simulation at level, lev.
-            hi[idim] = std::max( static_cast<int> ( ceil (
+            hi[idim] = std::max( static_cast<int> ( std::ceil (
                           ( diag_dom.hi(idim) - warpx.Geom(lev).ProbLo(idim)) /
                             warpx.Geom(lev).CellSize(idim) ) ), 0) - 1 ;
             // if hi<=lo, then hi = lo + 1, to ensure one cell in that dimension

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -326,11 +326,11 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
             }
             else {
                 slice_lo[idim] = static_cast<int>(
-                                  round( (slice_cc_nd_box.lo(idim)
+                                  std::round( (slice_cc_nd_box.lo(idim)
                                   - (real_box.lo(idim) ) )
                                   / dom_geom[0].CellSize(idim)) );
                 slice_lo2[idim] = static_cast<int>(
-                                  ceil((slice_cc_nd_box.lo(idim)
+                                  std::ceil((slice_cc_nd_box.lo(idim)
                                   - (real_box.lo(idim) ) )
                                   / dom_geom[0].CellSize(idim) ) );
             }

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -262,7 +262,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::find_left_right_time_indices(amrex
         const auto t_min = m_params.t_coords.front();
         const auto t_max = m_params.t_coords.back();
         const auto temp_idx_t_right = static_cast<int>(
-            ceil( (m_params.nt-1)*(t-t_min)/(t_max-t_min)));
+            std::ceil( (m_params.nt-1)*(t-t_min)/(t_max-t_min)));
         idx_t_right = max(min(temp_idx_t_right, m_params.nt-1),1);
     }
     else{
@@ -370,7 +370,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
 #endif
         //Find indices and coordinates along x
         const int temp_idx_x_right = static_cast<int>(
-            ceil((tmp_nx-1)*(Xp[i]- tmp_x_min)/(tmp_x_max-tmp_x_min)));
+            std::ceil((tmp_nx-1)*(Xp[i]- tmp_x_min)/(tmp_x_max-tmp_x_min)));
         const int idx_x_right =
             max(min(temp_idx_x_right,tmp_nx-1),static_cast<int>(1));
         const int idx_x_left = idx_x_right - 1;
@@ -382,7 +382,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
 #if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
         //Find indices and coordinates along y
         const int temp_idx_y_right = static_cast<int>(
-            ceil((tmp_ny-1)*(Yp[i]- tmp_y_min)/(tmp_y_max-tmp_y_min)));
+            std::ceil((tmp_ny-1)*(Yp[i]- tmp_y_min)/(tmp_y_max-tmp_y_min)));
         const int idx_y_right =
             max(min(temp_idx_y_right,tmp_ny-1),static_cast<int>(1));
         const int idx_y_left = idx_y_right - 1;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -121,9 +121,9 @@ public:
      * @param[in] priority priority of the warning message ("medium" by default)
      */
     void RecordWarning(
-        std::string topic,
-        std::string text,
-        WarnPriority priority = WarnPriority::medium);
+        const std::string& topic,
+        const std::string& text,
+        const WarnPriority& priority = WarnPriority::medium);
 
     /**
      * \brief This function prints all the warning messages collected on the present MPI rank

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -438,9 +438,9 @@ WarpX::~WarpX ()
 
 void
 WarpX::RecordWarning(
-        std::string topic,
-        std::string text,
-        WarnPriority priority)
+        const std::string& topic,
+        const std::string& text,
+        const WarnPriority& priority)
 {
     WARPX_PROFILE("WarpX::RecordWarning");
 


### PR DESCRIPTION
This PR fixes few (most likely) unwanted float to double promotions. I've found these issues using `clang-tidy`