### PR TITLE
Remove unused enum from PhysicalParticleContainer

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -46,13 +46,6 @@ class PhysicalParticleContainer
 {
 public:
 
-    enum PhysicalParticleType{
-        electron,
-        positron,
-        photon,
-        other
-    };
-
     PhysicalParticleContainer (amrex::AmrCore* amr_core,
                                int ispecies,
                                const std::string& name);


### PR DESCRIPTION
This PR removes an unused enum.