### PR TITLE
Use forward declaration for WarpXFaceInfoBox

### DIFF
--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -7,6 +7,8 @@
 
 #include "WarpX.H"
 
+#include "WarpXFaceInfoBox.H"
+
 #include "Utils/TextMsg.H"
 
 #include <AMReX_Scan.H>

--- a/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
+++ b/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
@@ -8,6 +8,8 @@
 #ifndef WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXFACEINFOBOX_H
 #define WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXFACEINFOBOX_H
 
+#include "WarpXFaceInfoBox_fwd.H"
+
 #include <AMReX_Gpu.H>
 #include <AMReX_BaseFab.H>
 

--- a/Source/EmbeddedBoundary/WarpXFaceInfoBox_fwd.H
+++ b/Source/EmbeddedBoundary/WarpXFaceInfoBox_fwd.H
@@ -1,0 +1,13 @@
+/* Copyright 2022 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXFACEINFOBOX_FWD_H
+#define WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXFACEINFOBOX_FWD_H
+
+struct FaceInfoBox;
+
+#endif //WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXFACEINFOBOX_FWD_H

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -6,6 +6,7 @@
  */
 #include "FiniteDifferenceSolver.H"
 
+#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
 #ifndef WARPX_DIM_RZ
 #   include "FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
 #   include "FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -8,7 +8,7 @@
 #ifndef WARPX_FINITE_DIFFERENCE_SOLVER_H_
 #define WARPX_FINITE_DIFFERENCE_SOLVER_H_
 
-#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
+#include "EmbeddedBoundary/WarpXFaceInfoBox_fwd.H"
 #include "FiniteDifferenceSolver_fwd.H"
 
 #include "BoundaryConditions/PML_fwd.H"

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -10,6 +10,7 @@
 
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
+#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Particles/WarpXParticleContainer.H"

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -16,12 +16,14 @@
 #include "Diagnostics/BackTransformedDiagnostic_fwd.H"
 #include "Diagnostics/MultiDiagnostics_fwd.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags_fwd.H"
-#include "Evolve/WarpXDtType.H"
-#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
-#include "FieldSolver/ElectrostaticSolver.H"
+#include "EmbeddedBoundary/WarpXFaceInfoBox_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H"
+#include "Filter/NCIGodfreyFilter_fwd.H"
 #include "Particles/ParticleBoundaryBuffer_fwd.H"
+#include "Particles/MultiParticleContainer_fwd.H"
+#include "Particles/WarpXParticleContainer_fwd.H"
+#include "Utils/WarnManager_fwd.H"
 #ifdef WARPX_USE_PSATD
 #   ifdef WARPX_DIM_RZ
 #       include "FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H"
@@ -30,13 +32,11 @@
 #       include "FieldSolver/SpectralSolver/SpectralSolver_fwd.H"
 #   endif
 #endif
+#include "Evolve/WarpXDtType.H"
+#include "FieldSolver/ElectrostaticSolver.H"
 #include "Filter/BilinearFilter.H"
-#include "Filter/NCIGodfreyFilter_fwd.H"
 #include "Parallelization/GuardCellManager.H"
-#include "Particles/MultiParticleContainer_fwd.H"
-#include "Particles/WarpXParticleContainer_fwd.H"
 #include "Utils/IntervalsParser.H"
-#include "Utils/WarnManager_fwd.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <AMReX.H>

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -15,6 +15,7 @@
 #include "Diagnostics/BackTransformedDiagnostic.H"
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
+#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #ifdef WARPX_USE_PSATD


### PR DESCRIPTION
This PR adds a forward declaration for WarpXFaceInfoBox, which is then used in the WarpX.H file

### Background

- https://warpx.readthedocs.io/en/latest/developers/faq.html#what-are-include-fwd-h-and-include-fwd-h-files
- https://en.wikipedia.org/wiki/Forward_declaration
- https://warpx.readthedocs.io/en/latest/developers/repo_organization.html#developers-cpp-includes-fwd