### PR TITLE
Docs: New Perlmutter Default Env, Microarch

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -47,6 +47,10 @@ export CRAY_ACCEL_TARGET=nvidia80
 # optimize CUDA compilation for A100
 export AMREX_CUDA_ARCH=8.0
 
+# optimize CPU microarchitecture for AMD EPYC 3rd Gen (Milan/Zen3)
+export CXXFLAGS="-march=znver3"
+export CFLAGS="-march=znver3"
+
 # compiler environment hints
 export CC=cc
 export CXX=CC

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -49,8 +49,9 @@ export CRAY_ACCEL_TARGET=nvidia80
 export AMREX_CUDA_ARCH=8.0
 
 # optimize CPU microarchitecture for AMD EPYC 3rd Gen (Milan/Zen3)
-export CXXFLAGS="-march=znver3"
-export CFLAGS="-march=znver3"
+# note: the cc/CC/ftn wrappers below add those
+#export CXXFLAGS="-march=znver3"
+#export CFLAGS="-march=znver3"
 
 # compiler environment hints
 export CC=cc

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -3,7 +3,6 @@
 
 # required dependencies
 module load cmake/3.22.0
-module swap PrgEnv-nvidia PrgEnv-gnu
 module load cudatoolkit
 
 # optional: just an additional text editor

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -3,6 +3,7 @@
 
 # required dependencies
 module load cmake/3.22.0
+module load PrgEnv-gnu
 module load cudatoolkit
 
 # optional: just an additional text editor


### PR DESCRIPTION
The default environment on Perlmutter is now the one we already used, `PrgEnv-gnu`. Thus, we don't need to switch anymore.

Build CPU microarch: Tuned for Zen3, which is used on Login and Compute nodes alike: https://docs.nersc.gov/systems/perlmutter/system_details/ - already done since #3079