### PR TITLE
Write Inputs to `warpx_used_inputs`

### DIFF
--- a/Docs/source/usage/how_to_run.rst
+++ b/Docs/source/usage/how_to_run.rst
@@ -92,3 +92,15 @@ On an :ref:`HPC system <install-hpc>`, you would instead submit the :ref:`job sc
    .. code-block:: bash
 
       mpirun -np 4 ./warpx <input_file> max_step=10 warpx.numprocs=1 2 2
+
+5. Outputs
+----------
+
+By default, WarpX will write a status update to the terminal (``stdout``).
+On :ref:`HPC systems <install-hpc>`, we usually store a copy of this in a file called ``outputs.txt``.
+
+We also store by default an exact copy of all explicitly and implicitly used inputs parameters in a file called ``warpx_used_inputs``.
+This is important for reproducibility, since as we wrote in the previous paragraph, the options in the input file can be extended and overwritten from the command line.
+
+:ref:`Further configured diagnostics <running-cpp-parameters-diagnostics>` are explained in the next sections.
+By default, they are written to a subdirectory in ``diags/`` and can use various :ref:`output formats <dataanalysis-formats>`.

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -62,12 +62,11 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
-#include <sstream>
 
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 
@@ -347,6 +346,17 @@ WarpX::PrintMainPICparameters ()
 }
 
 void
+WarpX::WriteUsedInputsFile (std::string const & filename) const
+{
+    amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
+
+    std::ofstream jobInfoFile;
+    jobInfoFile.open(filename.c_str(), std::ios::out);
+    ParmParse::dumpTable(jobInfoFile, true);
+    jobInfoFile.close();
+}
+
+void
 WarpX::InitData ()
 {
     WARPX_PROFILE("WarpX::InitData()");
@@ -400,6 +410,7 @@ WarpX::InitData ()
     CheckGuardCells();
 
     PrintMainPICparameters();
+    WriteUsedInputsFile();
 
     if (restart_chkfile.empty())
     {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -497,6 +497,9 @@ public:
     /** Print main PIC parameters to stdout */
     void PrintMainPICparameters ();
 
+    /** Write a file that record all inputs: inputs file + command line options */
+    void WriteUsedInputsFile (std::string const & filename = "warpx_used_inputs") const;
+
     /** Print dt and dx,dy,dz */
     void PrintDtDxDyDz ();
 


### PR DESCRIPTION
Write a general file `warpx_used_inputs` that contains all inputs of a simulation.

This is needed, since we add & overwrite the inputs parameters in the inputs file with command-line options regularly. Writing the actually used inputs increases reproducibility of such workflows, especially in unsupervised scripted runs/optimizations.

- [x] tested
- [x] doc as subsection of run https://warpx.readthedocs.io/en/latest/usage/how_to_run.html#run