### PR TITLE
Fix: Install ABLASTR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ configure_file(
 # Installs ####################################################################
 #
 # headers, libraries and executables
-set(WarpX_INSTALL_TARGET_NAMES)
+set(WarpX_INSTALL_TARGET_NAMES ablastr)
 if(WarpX_APP)
     list(APPEND WarpX_INSTALL_TARGET_NAMES app)
 endif()


### PR DESCRIPTION
Since ABLASTR is a proper library now, we need to install it as well.
Otherwise, (non-default) shared builds will fail to find `libablastr.so` at runtime.

Follow-up to #2968
Affected releases: `22.04` and `22.05`