### PR TITLE
remove extraneous WARPX_DIM_RZ

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -129,7 +129,7 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
     // and the amplitude of the laser
 #if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
     prefactor = prefactor / diffract_factor;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+#elif defined(WARPX_DIM_XZ)
     prefactor = prefactor / amrex::sqrt(diffract_factor);
 #endif
 


### PR DESCRIPTION
In the Gaussian Laser initialization, `WARPX_DIM_RZ` appeared in an`#if` condition and the immediately following `#elif` condition.  The second `WARPX_DIM_RZ`, in the `#elif`,  is vacuous and has been removed