### PR TITLE
CMake: Move Install Defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,6 @@ set_ccache()
 # temporary build directories
 set_default_build_dirs()
 
-# install directories
-set_default_install_dirs()
-
 
 # Options and Variants ########################################################
 #
@@ -364,6 +361,9 @@ configure_file(
 
 # Installs ####################################################################
 #
+# default installation directories
+set_default_install_dirs()
+
 # headers, libraries and executables
 set(WarpX_INSTALL_TARGET_NAMES ablastr)
 if(WarpX_APP)


### PR DESCRIPTION
Moving setting defaults for install dirs to the install section.
This improves logic when using WarpX as subproject, e.g., in ABLASTR.