### PR TITLE
AMReX no-MPI Gather Fixed

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,6 +38,8 @@ jobs:
           -DWarpX_MPI=OFF              \
           -DWarpX_QED=OFF
         cmake --build build_3D -j 2
+        ./build_3D/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_3d
+
         cmake -S . -B build_RZ         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_DIMS=RZ              \
@@ -45,6 +47,7 @@ jobs:
           -DWarpX_MPI=OFF              \
           -DWarpX_QED=OFF
         cmake --build build_RZ -j 2
+        ./build_RZ/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_rz
 
   build_gcc_ablastr:
     name: GCC ABLASTR w/o MPI

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -619,15 +619,10 @@ void FieldProbe::ComputeDiags (int step)
             }
             localsize.resize(1, m_data.size());
 
-#ifdef AMREX_USE_MPI
             // gather size of m_data from each processor
             amrex::ParallelDescriptor::Gather(localsize.data(), 1,
                                               length_vector.data(), 1,
                                               amrex::ParallelDescriptor::IOProcessorNumber());
-#else
-            // work-around for https://github.com/AMReX-Codes/amrex/pull/2793
-            length_vector[0] = localsize[0];
-#endif
 
             // IO processor sums values from length_array to get size of total output array.
             /* displs records the size of each m_data as well as previous displs. This array


### PR DESCRIPTION
With https://github.com/ECP-WarpX/WarpX/pull/3147 merged, we have pulled in AMReX https://github.com/AMReX-Codes/amrex/pull/2793

Thus, we can remove the work-around `Field Probe no-MPI Gather` from https://github.com/ECP-WarpX/WarpX/pull/3134 again.