### PR TITLE
Add properties for neutron, hydrogen isotopes, helium isotopes

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -573,7 +573,12 @@ Particle initialization
 
 * ``<species_name>.species_type`` (`string`) optional (default `unspecified`)
     Type of physical species.
-    Currently, the accepted species are ``"electron"``, ``"positron"``, ``"photon"``, ``"hydrogen"`` (or equivalently ``"proton"``), ``"helium"`` (or equivalently ``"alpha"``), ``"boron"``, ``"carbon"``, ``"oxygen"``, ``"nitrogen"``, ``"argon"``, ``"copper"`` and ``"xenon"``.
+    Currently, the accepted species are ``"electron"``, ``"positron"``, ``"photon"``,
+    ``"neutron"``, ``"hydrogen"`` (or equivalently ``"proton"``), ``"deuterium"``
+    (or equivalently ``"hydrogen2"``), ``"tritium"`` (or equivalently ``"hydrogen3"``),
+    ``"helium"`` (or equivalently ``"alpha"``), ``"helium3"``, ``"helium4"``,
+    ``"boron"``, ``"boron10"``, ``"boron11"``, ``"carbon"``, ``"oxygen"``,
+    ``"nitrogen"``, ``"argon"``, ``"copper"`` and ``"xenon"``.
     Either this or both ``mass`` and ``charge`` have to be specified.
 
 * ``<species_name>.charge`` (`float`) optional (default `NaN`)

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -18,7 +18,7 @@
 #include <string>
 
 enum struct PhysicalSpecies{unspecified=0, electron, positron, photon, neutron,
-    hydrogen, deuterium, tritium, helium, helium3, helium4, boron, boron10,
+    hydrogen, hydrogen2, hydrogen3, helium, helium3, helium4, boron, boron10,
     boron11, carbon, nitrogen, oxygen, argon, copper, xenon};
 
 namespace species
@@ -34,22 +34,20 @@ namespace species
             return PhysicalSpecies::positron;
         if( species=="photon" )
             return PhysicalSpecies::photon;
-        if( species=="photon" )
-            return PhysicalSpecies::photon;
-        if( species=="hydrogen" )
+        if( species=="neutron" )
+            return PhysicalSpecies::neutron;
+        if( (species=="hydrogen") || (species=="proton") )
             return PhysicalSpecies::hydrogen;
-        if( species=="proton" )
-            return PhysicalSpecies::hydrogen;
-        if( species=="deuterium" )
-            return PhysicalSpecies::deuterium;
-        if( species=="tritium" )
-            return PhysicalSpecies::tritium;
+        if( (species=="hydrogen2") || (species=="deuterium") )
+            return PhysicalSpecies::hydrogen2;
+        if (species=="hydrogen3") || (species=="tritium") )
+            return PhysicalSpecies::hydrogen3;
         if( species=="helium" )
             return PhysicalSpecies::helium;
         if( species=="helium3" )
             return PhysicalSpecies::helium3;
         if( species=="helium4" )
-            return PhysicalSpecies::helium3;
+            return PhysicalSpecies::helium4;
         if( species=="alpha" )
             return PhysicalSpecies::helium;
         if( species=="boron" )
@@ -90,9 +88,9 @@ namespace species
             return 0.;
         case PhysicalSpecies::hydrogen:
             return PhysConst::q_e;
-        case PhysicalSpecies::deuterium:
+        case PhysicalSpecies::hydrogen2:
             return PhysConst::q_e;
-        case PhysicalSpecies::tritium:
+        case PhysicalSpecies::hydrogen3:
             return PhysConst::q_e;
         case PhysicalSpecies::helium:
             return PhysConst::q_e * amrex::Real(2.0);
@@ -140,12 +138,10 @@ namespace species
             return PhysConst::m_p * amrex::Real(1.0013784193052508);
         case PhysicalSpecies::hydrogen:
             return PhysConst::m_p;
-        case PhysicalSpecies::hydrogen:
-            return PhysConst::m_p;
-        case PhysicalSpecies::deuterium:
-            return PhysConst::m_p * amrex::Real(1.9990075013626882);
-        case PhysicalSpecies::tritium:
-            return PhysConst::m_p * amrex::Real(2.9937170341239963);
+        case PhysicalSpecies::hydrogen2:
+            return PhysConst::m_p * amrex::Real(1.99901);
+        case PhysicalSpecies::hydrogen3:
+            return PhysConst::m_p * amrex::Real(2.99372);
         case PhysicalSpecies::helium:
             return PhysConst::m_p * amrex::Real(3.97369);
         case PhysicalSpecies::helium3:
@@ -190,12 +186,16 @@ namespace species
             return "photon";
         case PhysicalSpecies::hydrogen:
             return "hydrogen";
-        case PhysicalSpecies::deuterium:
-            return "deuterium";
-        case PhysicalSpecies::tritium:
-            return "tritium";
+        case PhysicalSpecies::hydrogen2:
+            return "hydrogen2";
+        case PhysicalSpecies::hydrogen3:
+            return "hydrogen3";
         case PhysicalSpecies::helium:
             return "helium";
+        case PhysicalSpecies::helium:
+            return "helium3";
+        case PhysicalSpecies::helium:
+            return "helium4";
         case PhysicalSpecies::boron:
             return "boron";
         case PhysicalSpecies::boron10:

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -40,7 +40,7 @@ namespace species
             return PhysicalSpecies::hydrogen;
         if( (species=="hydrogen2") || (species=="deuterium") )
             return PhysicalSpecies::hydrogen2;
-        if (species=="hydrogen3") || (species=="tritium") )
+        if( (species=="hydrogen3") || (species=="tritium") )
             return PhysicalSpecies::hydrogen3;
         if( (species=="helium") || (species=="alpha") )
             return PhysicalSpecies::helium;

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -42,14 +42,12 @@ namespace species
             return PhysicalSpecies::hydrogen2;
         if (species=="hydrogen3") || (species=="tritium") )
             return PhysicalSpecies::hydrogen3;
-        if( species=="helium" )
+        if( (species=="helium") || (species=="alpha") )
             return PhysicalSpecies::helium;
         if( species=="helium3" )
             return PhysicalSpecies::helium3;
         if( species=="helium4" )
             return PhysicalSpecies::helium4;
-        if( species=="alpha" )
-            return PhysicalSpecies::helium;
         if( species=="boron" )
             return PhysicalSpecies::boron;
         if( species=="boron10" )

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -192,9 +192,9 @@ namespace species
             return "hydrogen3";
         case PhysicalSpecies::helium:
             return "helium";
-        case PhysicalSpecies::helium:
+        case PhysicalSpecies::helium3:
             return "helium3";
-        case PhysicalSpecies::helium:
+        case PhysicalSpecies::helium4:
             return "helium4";
         case PhysicalSpecies::boron:
             return "boron";

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -17,8 +17,9 @@
 #include <map>
 #include <string>
 
-enum struct PhysicalSpecies{unspecified=0, electron, positron, photon, hydrogen, helium, boron,
-                            boron10, boron11, carbon, nitrogen, oxygen, argon, copper, xenon};
+enum struct PhysicalSpecies{unspecified=0, electron, positron, photon, neutron,
+    hydrogen, deuterium, tritium, helium, helium3, helium4, boron, boron10,
+    boron11, carbon, nitrogen, oxygen, argon, copper, xenon};
 
 namespace species
 {
@@ -33,12 +34,22 @@ namespace species
             return PhysicalSpecies::positron;
         if( species=="photon" )
             return PhysicalSpecies::photon;
+        if( species=="photon" )
+            return PhysicalSpecies::photon;
         if( species=="hydrogen" )
             return PhysicalSpecies::hydrogen;
         if( species=="proton" )
             return PhysicalSpecies::hydrogen;
+        if( species=="deuterium" )
+            return PhysicalSpecies::deuterium;
+        if( species=="tritium" )
+            return PhysicalSpecies::tritium;
         if( species=="helium" )
             return PhysicalSpecies::helium;
+        if( species=="helium3" )
+            return PhysicalSpecies::helium3;
+        if( species=="helium4" )
+            return PhysicalSpecies::helium3;
         if( species=="alpha" )
             return PhysicalSpecies::helium;
         if( species=="boron" )
@@ -75,9 +86,19 @@ namespace species
             return PhysConst::q_e;
         case PhysicalSpecies::photon:
             return 0.;
+        case PhysicalSpecies::neutron:
+            return 0.;
         case PhysicalSpecies::hydrogen:
             return PhysConst::q_e;
+        case PhysicalSpecies::deuterium:
+            return PhysConst::q_e;
+        case PhysicalSpecies::tritium:
+            return PhysConst::q_e;
         case PhysicalSpecies::helium:
+            return PhysConst::q_e * amrex::Real(2.0);
+        case PhysicalSpecies::helium3:
+            return PhysConst::q_e * amrex::Real(2.0);
+        case PhysicalSpecies::helium4:
             return PhysConst::q_e * amrex::Real(2.0);
         case PhysicalSpecies::boron:
             return PhysConst::q_e * amrex::Real(5.0);
@@ -115,10 +136,22 @@ namespace species
             return PhysConst::m_e;
         case PhysicalSpecies::photon:
             return 0.;
+        case PhysicalSpecies::neutron:
+            return PhysConst::m_p * amrex::Real(1.0013784193052508);
         case PhysicalSpecies::hydrogen:
             return PhysConst::m_p;
+        case PhysicalSpecies::hydrogen:
+            return PhysConst::m_p;
+        case PhysicalSpecies::deuterium:
+            return PhysConst::m_p * amrex::Real(1.9990075013626882);
+        case PhysicalSpecies::tritium:
+            return PhysConst::m_p * amrex::Real(2.9937170341239963);
         case PhysicalSpecies::helium:
             return PhysConst::m_p * amrex::Real(3.97369);
+        case PhysicalSpecies::helium3:
+            return PhysConst::m_p * amrex::Real(2.99369);
+        case PhysicalSpecies::helium4:
+            return PhysConst::m_p * amrex::Real(3.97314);
         case PhysicalSpecies::boron:
             return PhysConst::m_p * amrex::Real(10.7319);
         case PhysicalSpecies::boron10:
@@ -157,6 +190,10 @@ namespace species
             return "photon";
         case PhysicalSpecies::hydrogen:
             return "hydrogen";
+        case PhysicalSpecies::deuterium:
+            return "deuterium";
+        case PhysicalSpecies::tritium:
+            return "tritium";
         case PhysicalSpecies::helium:
             return "helium";
         case PhysicalSpecies::boron:


### PR DESCRIPTION
This adds the values of the mass and charge for the following species:
- neutron
- deuterium
- tritium
- helium3
- helium4

The mass data is taken from:
- [this NIST page](https://physics.nist.gov/cgi-bin/cuu/Value?mn) for the neutron
- [this NIST page](https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=H) for the isotopes of hydrogen
- [this NIST page](https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=He) for the isotopes of helium

In the cases of the isotopes, I subtracted the mass of the electron, and converted to the units of proton mass, using:
```
M = (M_nist * m_u - m_e) / m_p
```
where `m_u` is the atomic mass unit, `m_e` is the electron mass, `m_p` is the proton mass.