### PR TITLE
Fix for 1D CUDA builds

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -354,6 +354,10 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
         (m_params.t_coords.back()-m_params.t_coords.front())/(m_params.nt-1) +
         m_params.t_coords.front();
 
+#if (defined WARPX_DIM_1D_Z)
+    amrex::Abort(Utils::TextMsg::Err(
+        "WarpXLaserProfiles::FromTXYEFileLaserProfile Not implemented for 1D"));
+#endif
     // Loop through the macroparticle to calculate the proper amplitude
     amrex::ParallelFor(
     np,
@@ -430,8 +434,6 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(
         // TODO: implement WARPX_DIM_1D_Z
         amrex::ignore_unused(x_0, x_1, tmp_e_max, p_E_data, tmp_idx_first_time,
                              t_left, t_right, Xp, Yp, t, idx_x_left);
-        amrex::Abort(Utils::TextMsg::Err(
-            "WarpXLaserProfiles::FromTXYEFileLaserProfile Not implemented for the current geometry"));
 #endif
         }
     );
@@ -464,6 +466,11 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_nonuniform
     const int idx_t_right = idx_t_left+1;
     const auto t_left = m_params.t_coords[idx_t_left];
     const auto t_right = m_params.t_coords[idx_t_right];
+
+#if (defined WARPX_DIM_1D_Z)
+    amrex::Abort(Utils::TextMsg::Err(
+        "WarpXLaserProfiles::FromTXYEFileLaserProfile Not implemented for 1D"));
+#endif
 
     // Loop through the macroparticle to calculate the proper amplitude
     amrex::ParallelFor(
@@ -533,8 +540,6 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_nonuniform
         // TODO: implement WARPX_DIM_1D_Z
         amrex::ignore_unused(idx_x_left, idx_t_left, idx_t_right, tmp_e_max,
                              p_E_data, tmp_idx_first_time, t_left, t_right, t);
-        amrex::Abort(Utils::TextMsg::Err(
-            "WarpXLaserProfiles::FromTXYEFileLaserProfile Not implemented for the current geometry"));
 #endif
         }
     );


### PR DESCRIPTION
I am currently seeing 1D CUDA builds fail with messages like:
```
  [ 85%] Building CUDA object CMakeFiles/WarpX.dir/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp.o

  /merunset/WarpX/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp(432): error: calling a __host__ function("amrex::Abort(const    ::std::__cxx11::basic_string<char,     ::std::char_traits<char> , ::std::allocator<char> >  &)") from a __device__ function("WarpXLaserProfiles::FromTXYEFileLaserProfile::internal_fill_amplitude_uniform(int, int, const double *, const double *, double, double *) const::[lambda(int) (instance 1)]::operator () const") is not allowed

  /merunset/WarpX/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp(432): error: identifier "amrex::Abort" is undefined in device code
```
This build issue is fixed by the current PR.