### PR TITLE
ABLASTR: Move Communication Utilities

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1188,7 +1188,9 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
     if (do_pml_in_domain){
         // Valid cells of the PML and of the regular grid overlap
         // Copy from valid cells of the PML to valid cells of the regular grid
-        ablastr::utils::communication::ParallelCopy(reg, totpmlmf, 0, 0, 1, IntVect(0), IntVect(0), period);
+        ablastr::utils::communication::ParallelCopy(reg, totpmlmf, 0, 0, 1, IntVect(0), IntVect(0),
+                                                    WarpX::do_single_precision_comms,
+                                                    period);
     } else {
         // Valid cells of the PML only overlap with guard cells of regular grid
         // (and outermost valid cell of the regular grid, for nodal direction)
@@ -1196,7 +1198,9 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         // but avoid updating the outermost valid cell
         if (ngr.max() > 0) {
             MultiFab::Copy(tmpregmf, reg, 0, 0, 1, ngr);
-            ablastr::utils::communication::ParallelCopy(tmpregmf, totpmlmf, 0, 0, 1, IntVect(0), ngr, period);
+            ablastr::utils::communication::ParallelCopy(tmpregmf, totpmlmf, 0, 0, 1, IntVect(0), ngr,
+                                   WarpX::do_single_precision_comms,
+                                                        period);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -1229,9 +1233,12 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         // Where valid cells of tmpregmf overlap with PML valid cells,
         // copy the PML (this is order to avoid overwriting PML valid cells,
         // in the next `ParallelCopy`)
-        ablastr::utils::communication::ParallelCopy(tmpregmf, pml,0, 0, ncp, IntVect(0), IntVect(0), period);
+        ablastr::utils::communication::ParallelCopy(tmpregmf, pml, 0, 0, ncp, IntVect(0), IntVect(0),
+                                                    WarpX::do_single_precision_comms,
+                                                    period);
     }
-    ablastr::utils::communication::ParallelCopy(pml, tmpregmf, 0, 0, ncp, IntVect(0), ngp, period);
+    ablastr::utils::communication::ParallelCopy(pml, tmpregmf, 0, 0, ncp, IntVect(0), ngp,
+                                                WarpX::do_single_precision_comms, period);
 }
 
 
@@ -1241,7 +1248,8 @@ PML::CopyToPML (MultiFab& pml, MultiFab& reg, const Geometry& geom)
   const IntVect& ngp = pml.nGrowVect();
   const auto& period = geom.periodicity();
 
-    ablastr::utils::communication::ParallelCopy(pml, reg, 0, 0, 1, IntVect(0), ngp, period);
+    ablastr::utils::communication::ParallelCopy(pml, reg, 0, 0, 1, IntVect(0), ngp,
+                                                WarpX::do_single_precision_comms, period);
 }
 
 void
@@ -1267,13 +1275,13 @@ PML::FillBoundaryE (PatchType patch_type)
     {
         const auto& period = m_geom->periodicity();
         Vector<MultiFab*> mf{pml_E_fp[0].get(),pml_E_fp[1].get(),pml_E_fp[2].get()};
-        ablastr::utils::communication::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse && pml_E_cp[0] && pml_E_cp[0]->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
         Vector<MultiFab*> mf{pml_E_cp[0].get(),pml_E_cp[1].get(),pml_E_cp[2].get()};
-        ablastr::utils::communication::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
 }
 
@@ -1291,13 +1299,13 @@ PML::FillBoundaryB (PatchType patch_type)
     {
         const auto& period = m_geom->periodicity();
         Vector<MultiFab*> mf{pml_B_fp[0].get(),pml_B_fp[1].get(),pml_B_fp[2].get()};
-        ablastr::utils::communication::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse && pml_B_cp[0])
     {
         const auto& period = m_cgeom->periodicity();
         Vector<MultiFab*> mf{pml_B_cp[0].get(),pml_B_cp[1].get(),pml_B_cp[2].get()};
-        ablastr::utils::communication::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
 }
 
@@ -1314,12 +1322,12 @@ PML::FillBoundaryF (PatchType patch_type)
     if (patch_type == PatchType::fine && pml_F_fp && pml_F_fp->nGrowVect().max() > 0)
     {
         const auto& period = m_geom->periodicity();
-        ablastr::utils::communication::FillBoundary(*pml_F_fp, period);
+        ablastr::utils::communication::FillBoundary(*pml_F_fp, WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse && pml_F_cp && pml_F_cp->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
-        ablastr::utils::communication::FillBoundary(*pml_F_cp, period);
+        ablastr::utils::communication::FillBoundary(*pml_F_cp, WarpX::do_single_precision_comms, period);
     }
 }
 
@@ -1336,12 +1344,12 @@ PML::FillBoundaryG (PatchType patch_type)
     if (patch_type == PatchType::fine && pml_G_fp && pml_G_fp->nGrowVect().max() > 0)
     {
         const auto& period = m_geom->periodicity();
-        ablastr::utils::communication::FillBoundary(*pml_G_fp, period);
+        ablastr::utils::communication::FillBoundary(*pml_G_fp, WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse && pml_G_cp && pml_G_cp->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
-        ablastr::utils::communication::FillBoundary(*pml_G_cp, period);
+        ablastr::utils::communication::FillBoundary(*pml_G_cp, WarpX::do_single_precision_comms, period);
     }
 }
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -19,7 +19,8 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
-#include "Parallelization/WarpXCommUtil.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX.H>
 #include <AMReX_Algorithm.H>
@@ -1187,7 +1188,7 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
     if (do_pml_in_domain){
         // Valid cells of the PML and of the regular grid overlap
         // Copy from valid cells of the PML to valid cells of the regular grid
-        WarpXCommUtil::ParallelCopy(reg, totpmlmf, 0, 0, 1, IntVect(0), IntVect(0), period);
+        ablastr::utils::communication::ParallelCopy(reg, totpmlmf, 0, 0, 1, IntVect(0), IntVect(0), period);
     } else {
         // Valid cells of the PML only overlap with guard cells of regular grid
         // (and outermost valid cell of the regular grid, for nodal direction)
@@ -1195,7 +1196,7 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         // but avoid updating the outermost valid cell
         if (ngr.max() > 0) {
             MultiFab::Copy(tmpregmf, reg, 0, 0, 1, ngr);
-            WarpXCommUtil::ParallelCopy(tmpregmf, totpmlmf, 0, 0, 1, IntVect(0), ngr, period);
+            ablastr::utils::communication::ParallelCopy(tmpregmf, totpmlmf, 0, 0, 1, IntVect(0), ngr, period);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -1228,9 +1229,9 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         // Where valid cells of tmpregmf overlap with PML valid cells,
         // copy the PML (this is order to avoid overwriting PML valid cells,
         // in the next `ParallelCopy`)
-        WarpXCommUtil::ParallelCopy(tmpregmf, pml,0, 0, ncp, IntVect(0), IntVect(0), period);
+        ablastr::utils::communication::ParallelCopy(tmpregmf, pml,0, 0, ncp, IntVect(0), IntVect(0), period);
     }
-    WarpXCommUtil::ParallelCopy(pml, tmpregmf, 0, 0, ncp, IntVect(0), ngp, period);
+    ablastr::utils::communication::ParallelCopy(pml, tmpregmf, 0, 0, ncp, IntVect(0), ngp, period);
 }
 
 
@@ -1240,7 +1241,7 @@ PML::CopyToPML (MultiFab& pml, MultiFab& reg, const Geometry& geom)
   const IntVect& ngp = pml.nGrowVect();
   const auto& period = geom.periodicity();
 
-  WarpXCommUtil::ParallelCopy(pml, reg, 0, 0, 1, IntVect(0), ngp, period);
+    ablastr::utils::communication::ParallelCopy(pml, reg, 0, 0, 1, IntVect(0), ngp, period);
 }
 
 void
@@ -1266,13 +1267,13 @@ PML::FillBoundaryE (PatchType patch_type)
     {
         const auto& period = m_geom->periodicity();
         Vector<MultiFab*> mf{pml_E_fp[0].get(),pml_E_fp[1].get(),pml_E_fp[2].get()};
-        WarpXCommUtil::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, period);
     }
     else if (patch_type == PatchType::coarse && pml_E_cp[0] && pml_E_cp[0]->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
         Vector<MultiFab*> mf{pml_E_cp[0].get(),pml_E_cp[1].get(),pml_E_cp[2].get()};
-        WarpXCommUtil::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, period);
     }
 }
 
@@ -1290,13 +1291,13 @@ PML::FillBoundaryB (PatchType patch_type)
     {
         const auto& period = m_geom->periodicity();
         Vector<MultiFab*> mf{pml_B_fp[0].get(),pml_B_fp[1].get(),pml_B_fp[2].get()};
-        WarpXCommUtil::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, period);
     }
     else if (patch_type == PatchType::coarse && pml_B_cp[0])
     {
         const auto& period = m_cgeom->periodicity();
         Vector<MultiFab*> mf{pml_B_cp[0].get(),pml_B_cp[1].get(),pml_B_cp[2].get()};
-        WarpXCommUtil::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, period);
     }
 }
 
@@ -1313,12 +1314,12 @@ PML::FillBoundaryF (PatchType patch_type)
     if (patch_type == PatchType::fine && pml_F_fp && pml_F_fp->nGrowVect().max() > 0)
     {
         const auto& period = m_geom->periodicity();
-        WarpXCommUtil::FillBoundary(*pml_F_fp, period);
+        ablastr::utils::communication::FillBoundary(*pml_F_fp, period);
     }
     else if (patch_type == PatchType::coarse && pml_F_cp && pml_F_cp->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
-        WarpXCommUtil::FillBoundary(*pml_F_cp, period);
+        ablastr::utils::communication::FillBoundary(*pml_F_cp, period);
     }
 }
 
@@ -1335,12 +1336,12 @@ PML::FillBoundaryG (PatchType patch_type)
     if (patch_type == PatchType::fine && pml_G_fp && pml_G_fp->nGrowVect().max() > 0)
     {
         const auto& period = m_geom->periodicity();
-        WarpXCommUtil::FillBoundary(*pml_G_fp, period);
+        ablastr::utils::communication::FillBoundary(*pml_G_fp, period);
     }
     else if (patch_type == PatchType::coarse && pml_G_cp && pml_G_cp->nGrowVect().max() > 0)
     {
         const auto& period = m_cgeom->periodicity();
-        WarpXCommUtil::FillBoundary(*pml_G_cp, period);
+        ablastr::utils::communication::FillBoundary(*pml_G_cp, period);
     }
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -13,13 +13,14 @@
 #include "ComputeDiagFunctors/RhoFunctor.H"
 #include "Diagnostics/Diagnostics.H"
 #include "Diagnostics/FlushFormats/FlushFormat.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "ComputeDiagFunctors/BackTransformParticleFunctor.H"
 #include "Utils/CoarsenIO.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX.H>
 #include <AMReX_Algorithm.H>
@@ -511,7 +512,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
         AMREX_ALWAYS_ASSERT( icomp_dst == m_cellcenter_varnames.size() );
         // fill boundary call is required to average_down (flatten) data to
         // the coarsest level.
-        WarpXCommUtil::FillBoundary(*m_cell_centered_data[lev], warpx.Geom(lev).periodicity());
+        ablastr::utils::communication::FillBoundary(*m_cell_centered_data[lev], warpx.Geom(lev).periodicity());
     }
     // Flattening out MF over levels
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -512,7 +512,8 @@ BTDiagnostics::PrepareFieldDataForOutput ()
         AMREX_ALWAYS_ASSERT( icomp_dst == m_cellcenter_varnames.size() );
         // fill boundary call is required to average_down (flatten) data to
         // the coarsest level.
-        ablastr::utils::communication::FillBoundary(*m_cell_centered_data[lev], warpx.Geom(lev).periodicity());
+        ablastr::utils::communication::FillBoundary(*m_cell_centered_data[lev], WarpX::do_single_precision_comms,
+                                                    warpx.Geom(lev).periodicity());
     }
     // Flattening out MF over levels
 

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -792,7 +792,9 @@ void BackTransformedDiagnostic::Flush (const Geometry& /*geom*/)
                 tmp.setVal(0.0);
 
                 ablastr::utils::communication::ParallelCopy(tmp, *lf_diags->m_data_buffer_, 0, 0, ncomp,
-                                            IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
+                                                            IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                            IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                            WarpX::do_single_precision_comms);
 
 #ifdef WARPX_USE_HDF5
                 for (int comp = 0; comp < ncomp; ++comp) {
@@ -948,7 +950,9 @@ writeLabFrameData (const MultiFab* cell_centered_data,
              // tmp_slice_ptr which has the dmap of the
              // data_buffer that stores the back-transformed data.
             ablastr::utils::communication::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, ncomp,
-                                         IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
+                                                        IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                        IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                        WarpX::do_single_precision_comms);
              lf_diags->AddDataToBuffer(*tmp_slice_ptr, i_lab,
                                                map_actual_fields_to_dump);
              tmp_slice_ptr = nullptr;

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -7,12 +7,13 @@
  */
 #include "BackTransformedDiagnostic.H"
 
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/TextMsg.H"
 #include "WarpX.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX_Array4.H>
 #include <AMReX_BLassert.H>
@@ -790,7 +791,7 @@ void BackTransformedDiagnostic::Flush (const Geometry& /*geom*/)
                 MultiFab tmp(buff_ba, buff_dm, ncomp, 0);
                 tmp.setVal(0.0);
 
-                WarpXCommUtil::ParallelCopy(tmp, *lf_diags->m_data_buffer_, 0, 0, ncomp,
+                ablastr::utils::communication::ParallelCopy(tmp, *lf_diags->m_data_buffer_, 0, 0, ncomp,
                                             IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
 
 #ifdef WARPX_USE_HDF5
@@ -946,7 +947,7 @@ writeLabFrameData (const MultiFab* cell_centered_data,
              // which has the dmap of the domain to
              // tmp_slice_ptr which has the dmap of the
              // data_buffer that stores the back-transformed data.
-             WarpXCommUtil::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, ncomp,
+            ablastr::utils::communication::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, ncomp,
                                          IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
              lf_diags->AddDataToBuffer(*tmp_slice_ptr, i_lab,
                                                map_actual_fields_to_dump);

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -7,9 +7,10 @@
 #include "BackTransformFunctor.H"
 
 #include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX_Array4.H>
 #include <AMReX_BoxArray.H>
@@ -87,7 +88,7 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         // Parallel copy the lab-frame data from "slice" MultiFab with
         // ncomp=10 and boosted-frame dmap to "tmp_slice_ptr" MultiFab with
         // ncomp=10 and dmap of the destination Multifab, which will store the final data
-        WarpXCommUtil::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, slice->nComp(),
+        ablastr::utils::communication::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, slice->nComp(),
                                     IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
         // Now we will cherry pick only the user-defined fields from
         // tmp_slice_ptr to dst_mf

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -89,7 +89,9 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         // ncomp=10 and boosted-frame dmap to "tmp_slice_ptr" MultiFab with
         // ncomp=10 and dmap of the destination Multifab, which will store the final data
         ablastr::utils::communication::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, slice->nComp(),
-                                    IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, 0, 0)));
+                                                    IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                    IntVect(AMREX_D_DECL(0, 0, 0)),
+                                                    WarpX::do_single_precision_comms);
         // Now we will cherry pick only the user-defined fields from
         // tmp_slice_ptr to dst_mf
         const int k_lab = m_k_index_zlab[i_buffer];

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -12,13 +12,13 @@
 #include "FlushFormats/FlushFormatPlotfile.H"
 #include "FlushFormats/FlushFormatSensei.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
 #include "WarpX.H"
 
+#include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -442,7 +442,7 @@ Diagnostics::ComputeAndPack ()
 
             // needed for contour plots of rho, i.e. ascent/sensei
             if (m_format == "sensei" || m_format == "ascent") {
-                WarpXCommUtil::FillBoundary(m_mf_output[i_buffer][lev], warpx.Geom(lev).periodicity());
+                ablastr::utils::communication::FillBoundary(m_mf_output[i_buffer][lev], warpx.Geom(lev).periodicity());
             }
         }
         // Call Particle functor

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -442,7 +442,8 @@ Diagnostics::ComputeAndPack ()
 
             // needed for contour plots of rho, i.e. ascent/sensei
             if (m_format == "sensei" || m_format == "ascent") {
-                ablastr::utils::communication::FillBoundary(m_mf_output[i_buffer][lev], warpx.Geom(lev).periodicity());
+                ablastr::utils::communication::FillBoundary(m_mf_output[i_buffer][lev], WarpX::do_single_precision_comms,
+                                                            warpx.Geom(lev).periodicity());
             }
         }
         // Call Particle functor

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -9,8 +9,8 @@
 
 #include "WarpX.H"
 #include "Utils/TextMsg.H"
-#include "Parallelization/WarpXCommUtil.H"
 
+#include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -148,7 +148,7 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
     // Copy data from domain to slice that has same cell size as that of //
     // the domain mf. src and dst have the same number of ghost cells    //
     amrex::IntVect nghost_vect(AMREX_D_DECL(nghost, nghost, nghost));
-    WarpXCommUtil::ParallelCopy(*smf, mf, 0, 0, ncomp,nghost_vect,nghost_vect);
+    ablastr::utils::communication::ParallelCopy(*smf, mf, 0, 0, ncomp,nghost_vect,nghost_vect);
 
     // inteprolate if required on refined slice //
     if (interpolate == 1 ) {

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -148,7 +148,7 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
     // Copy data from domain to slice that has same cell size as that of //
     // the domain mf. src and dst have the same number of ghost cells    //
     amrex::IntVect nghost_vect(AMREX_D_DECL(nghost, nghost, nghost));
-    ablastr::utils::communication::ParallelCopy(*smf, mf, 0, 0, ncomp,nghost_vect,nghost_vect);
+    ablastr::utils::communication::ParallelCopy(*smf, mf, 0, 0, ncomp, nghost_vect, nghost_vect, WarpX::do_single_precision_comms);
 
     // inteprolate if required on refined slice //
     if (interpolate == 1 ) {

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -13,11 +13,12 @@
 #endif
 #include "FieldIO.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/CoarsenIO.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
+
+#include <ablastr/utils/Communication.H>
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
@@ -381,7 +382,7 @@ WarpX::GetCellCenteredData() {
         const std::unique_ptr<MultiFab>& charge_density = mypc->GetChargeDensity(lev);
         AverageAndPackScalarField( *cc[lev], *charge_density, dmap[lev], dcomp, ng );
 
-        WarpXCommUtil::FillBoundary(*cc[lev], geom[lev].periodicity());
+        ablastr::utils::communication::FillBoundary(*cc[lev], geom[lev].periodicity());
     }
 
     for (int lev = finest_level; lev > 0; --lev)

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -382,7 +382,7 @@ WarpX::GetCellCenteredData() {
         const std::unique_ptr<MultiFab>& charge_density = mypc->GetChargeDensity(lev);
         AverageAndPackScalarField( *cc[lev], *charge_density, dmap[lev], dcomp, ng );
 
-        ablastr::utils::communication::FillBoundary(*cc[lev], geom[lev].periodicity());
+        ablastr::utils::communication::FillBoundary(*cc[lev], WarpX::do_single_precision_comms, geom[lev].periodicity());
     }
 
     for (int lev = finest_level; lev > 0; --lev)

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -395,7 +395,9 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
             // Copy from phi[lev] to phi_cp (in parallel)
             const amrex::IntVect& ng = IntVect::TheUnitVector();
             const amrex::Periodicity& crse_period = Geom(lev).periodicity();
-            ablastr::utils::communication::ParallelCopy(phi_cp, *phi[lev], 0, 0, 1, ng, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(phi_cp, *phi[lev], 0, 0, 1, ng, ng,
+                                                        WarpX::do_single_precision_comms,
+                                                        crse_period);
 
             // Local interpolation from phi_cp to phi[lev+1]
 #ifdef AMREX_USE_OMP

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -16,8 +16,8 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXProfilerWrapper.H"
-#include "Parallelization/WarpXCommUtil.H"
 
+#include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX_Array.H>
@@ -395,7 +395,7 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
             // Copy from phi[lev] to phi_cp (in parallel)
             const amrex::IntVect& ng = IntVect::TheUnitVector();
             const amrex::Periodicity& crse_period = Geom(lev).periodicity();
-            WarpXCommUtil::ParallelCopy(phi_cp, *phi[lev], 0, 0, 1, ng, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(phi_cp, *phi[lev], 0, 0, 1, ng, ng, crse_period);
 
             // Local interpolation from phi_cp to phi[lev+1]
 #ifdef AMREX_USE_OMP

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -21,7 +21,6 @@
 #include "Filter/BilinearFilter.H"
 #include "Filter/NCIGodfreyFilter.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/MPIInitHelpers.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -29,6 +28,7 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXUtil.H"
 
+#include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>

--- a/Source/Parallelization/CMakeLists.txt
+++ b/Source/Parallelization/CMakeLists.txt
@@ -3,5 +3,4 @@ target_sources(WarpX
     GuardCellManager.cpp
     WarpXComm.cpp
     WarpXRegrid.cpp
-    WarpXCommUtil.cpp
 )

--- a/Source/Parallelization/Make.package
+++ b/Source/Parallelization/Make.package
@@ -1,6 +1,5 @@
 CEXE_sources += WarpXComm.cpp
 CEXE_sources += WarpXRegrid.cpp
 CEXE_sources += GuardCellManager.cpp
-CEXE_sources += WarpXCommUtil.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parallelization

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -19,8 +19,9 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpXComm_K.H"
-#include "WarpXCommUtil.H"
 #include "WarpXSumGuardCells.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX.H>
 #include <AMReX_Array.H>
@@ -177,7 +178,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
                 // Copy Bfield_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
                 // Bfield_aux and filling up to ng (=nGrow) guard cells in Btmp
-                WarpXCommUtil::ParallelCopy(*Btmp[i], *Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
+                ablastr::utils::communication::ParallelCopy(*Btmp[i], *Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -234,7 +235,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
                 // Copy Efield_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
                 // Efield_aux and filling up to ng (=nGrow) guard cells in Etmp
-                WarpXCommUtil::ParallelCopy(*Etmp[i], *Efield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
+                ablastr::utils::communication::ParallelCopy(*Etmp[i], *Efield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -291,9 +292,9 @@ WarpX::UpdateAuxilaryDataSameType ()
             // Copy Bfield_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
             // cells from Bfield_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
 
-            WarpXCommUtil::ParallelCopy(dBx, *Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
-            WarpXCommUtil::ParallelCopy(dBy, *Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
-            WarpXCommUtil::ParallelCopy(dBz, *Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dBx, *Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dBy, *Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dBz, *Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
 
             if (Bfield_cax[lev][0])
             {
@@ -355,9 +356,9 @@ WarpX::UpdateAuxilaryDataSameType ()
             const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
             // Copy Efield_aux to the dE MultiFabs, using up to ng_src (=ng_FieldGather) guard
             // cells from Efield_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
-            WarpXCommUtil::ParallelCopy(dEx, *Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
-            WarpXCommUtil::ParallelCopy(dEy, *Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
-            WarpXCommUtil::ParallelCopy(dEz, *Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dEx, *Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dEy, *Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dEz, *Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
 
             if (Efield_cax[lev][0])
             {
@@ -563,7 +564,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        WarpXCommUtil::FillBoundary(*mf[i], nghost, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, period, nodal_sync);
     }
 }
 
@@ -620,7 +621,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        WarpXCommUtil::FillBoundary(*mf[i], nghost, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, period, nodal_sync);
     }
 }
 
@@ -644,14 +645,14 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Efield_avg_fp[lev][0].get(),Efield_avg_fp[lev][1].get(),Efield_avg_fp[lev][2].get()};
-            WarpXCommUtil::FillBoundary(mf, period);
+            ablastr::utils::communication::FillBoundary(mf, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
-            WarpXCommUtil::FillBoundary(*Efield_avg_fp[lev][0], ng, period);
-            WarpXCommUtil::FillBoundary(*Efield_avg_fp[lev][1], ng, period);
-            WarpXCommUtil::FillBoundary(*Efield_avg_fp[lev][2], ng, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -664,15 +665,15 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Efield_avg_cp[lev][0].get(),Efield_avg_cp[lev][1].get(),Efield_avg_cp[lev][2].get()};
-            WarpXCommUtil::FillBoundary(mf, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, cperiod);
 
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
-            WarpXCommUtil::FillBoundary(*Efield_avg_cp[lev][0], ng, cperiod);
-            WarpXCommUtil::FillBoundary(*Efield_avg_cp[lev][1], ng, cperiod);
-            WarpXCommUtil::FillBoundary(*Efield_avg_cp[lev][2], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, cperiod);
         }
     }
 }
@@ -697,14 +698,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Bfield_avg_fp[lev][0].get(),Bfield_avg_fp[lev][1].get(),Bfield_avg_fp[lev][2].get()};
-            WarpXCommUtil::FillBoundary(mf, period);
+            ablastr::utils::communication::FillBoundary(mf, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
-            WarpXCommUtil::FillBoundary(*Bfield_avg_fp[lev][0], ng, period);
-            WarpXCommUtil::FillBoundary(*Bfield_avg_fp[lev][1], ng, period);
-            WarpXCommUtil::FillBoundary(*Bfield_avg_fp[lev][2], ng, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -717,14 +718,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Bfield_avg_cp[lev][0].get(),Bfield_avg_cp[lev][1].get(),Bfield_avg_cp[lev][2].get()};
-            WarpXCommUtil::FillBoundary(mf, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, cperiod);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
-            WarpXCommUtil::FillBoundary(*Bfield_avg_cp[lev][0], ng, cperiod);
-            WarpXCommUtil::FillBoundary(*Bfield_avg_cp[lev][1], ng, cperiod);
-            WarpXCommUtil::FillBoundary(*Bfield_avg_cp[lev][2], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, cperiod);
         }
     }
 }
@@ -751,7 +752,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, const bool noda
         {
             const amrex::Periodicity& period = Geom(lev).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? F_fp[lev]->nGrowVect() : ng;
-            WarpXCommUtil::FillBoundary(*F_fp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*F_fp[lev], nghost, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -766,7 +767,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, const bool noda
         {
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? F_cp[lev]->nGrowVect() : ng;
-            WarpXCommUtil::FillBoundary(*F_cp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*F_cp[lev], nghost, period, nodal_sync);
         }
     }
 }
@@ -795,7 +796,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, const bool
         {
             const amrex::Periodicity& period = Geom(lev).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? G_fp[lev]->nGrowVect() : ng;
-            WarpXCommUtil::FillBoundary(*G_fp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_fp[lev], nghost, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -810,7 +811,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, const bool
         {
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? G_cp[lev]->nGrowVect() : ng;
-            WarpXCommUtil::FillBoundary(*G_cp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_cp[lev], nghost, period, nodal_sync);
         }
     }
 }
@@ -828,12 +829,12 @@ void
 WarpX::FillBoundaryAux (int lev, IntVect ng)
 {
     const amrex::Periodicity& period = Geom(lev).periodicity();
-    WarpXCommUtil::FillBoundary(*Efield_aux[lev][0], ng, period);
-    WarpXCommUtil::FillBoundary(*Efield_aux[lev][1], ng, period);
-    WarpXCommUtil::FillBoundary(*Efield_aux[lev][2], ng, period);
-    WarpXCommUtil::FillBoundary(*Bfield_aux[lev][0], ng, period);
-    WarpXCommUtil::FillBoundary(*Bfield_aux[lev][1], ng, period);
-    WarpXCommUtil::FillBoundary(*Bfield_aux[lev][2], ng, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, period);
 }
 
 void
@@ -1034,7 +1035,7 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                 bilinear_filter.ApplyStencil(jfb, *current_buf[lev+1][idim], lev+1);
 
                 MultiFab::Add(jfb, jfc, 0, 0, current_buf[lev+1][idim]->nComp(), ng);
-                WarpXCommUtil::ParallelAdd(mf, jfb, 0, 0, current_buf[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
+                ablastr::utils::communication::ParallelAdd(mf, jfb, 0, 0, current_buf[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
 
                 WarpXSumGuardCells(*J_cp[lev+1][idim], jfc, period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
@@ -1048,7 +1049,7 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                             J_cp[lev+1][idim]->DistributionMap(), J_cp[lev+1][idim]->nComp(), ng);
                 bilinear_filter.ApplyStencil(jf, *J_cp[lev+1][idim], lev+1);
 
-                WarpXCommUtil::ParallelAdd(mf, jf, 0, 0, J_cp[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
+                ablastr::utils::communication::ParallelAdd(mf, jf, 0, 0, J_cp[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
                 WarpXSumGuardCells(*J_cp[lev+1][idim], jf, period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
             else if (current_buf[lev+1][idim]) // but no filter
@@ -1057,7 +1058,7 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                 MultiFab::Add(*current_buf[lev+1][idim],
                                *J_cp [lev+1][idim], 0, 0, current_buf[lev+1][idim]->nComp(),
                                J_cp[lev+1][idim]->nGrowVect());
-                WarpXCommUtil::ParallelAdd(mf, *current_buf[lev+1][idim], 0, 0, current_buf[lev+1][idim]->nComp(),
+                ablastr::utils::communication::ParallelAdd(mf, *current_buf[lev+1][idim], 0, 0, current_buf[lev+1][idim]->nComp(),
                                            current_buf[lev+1][idim]->nGrowVect(), IntVect::TheZeroVector(),
                                            period);
                 WarpXSumGuardCells(*(J_cp[lev+1][idim]), period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
@@ -1065,7 +1066,7 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
             else // no filter, no buffer
             {
                 ng_depos_J.min(ng);
-                WarpXCommUtil::ParallelAdd(mf, *J_cp[lev+1][idim], 0, 0, J_cp[lev+1][idim]->nComp(),
+                ablastr::utils::communication::ParallelAdd(mf, *J_cp[lev+1][idim], 0, 0, J_cp[lev+1][idim]->nComp(),
                                            J_cp[lev+1][idim]->nGrowVect(), IntVect::TheZeroVector(),
                                            period);
                 WarpXSumGuardCells(*(J_cp[lev+1][idim]), period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
@@ -1170,7 +1171,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
 
             MultiFab::Add(rhofb, rhofc, 0, 0, ncomp, ng);
 
-            WarpXCommUtil::ParallelAdd(mf, rhofb, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
+            ablastr::utils::communication::ParallelAdd(mf, rhofb, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
             WarpXSumGuardCells( *charge_cp[lev+1], rhofc, period, ng_depos_rho, icomp, ncomp );
         }
         else if (use_filter) // but no buffer
@@ -1181,7 +1182,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             MultiFab rf(charge_cp[lev+1]->boxArray(), charge_cp[lev+1]->DistributionMap(), ncomp, ng);
             bilinear_filter.ApplyStencil(rf, *charge_cp[lev+1], lev+1, icomp, 0, ncomp);
 
-            WarpXCommUtil::ParallelAdd(mf, rf, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
+            ablastr::utils::communication::ParallelAdd(mf, rf, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
             WarpXSumGuardCells( *charge_cp[lev+1], rf, period, ng_depos_rho, icomp, ncomp );
         }
         else if (charge_buf[lev+1]) // but no filter
@@ -1191,7 +1192,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
                           *charge_cp[lev+1], icomp, icomp, ncomp,
                            charge_cp[lev+1]->nGrowVect());
 
-            WarpXCommUtil::ParallelAdd(mf, *charge_buf[lev+1], icomp, 0,
+            ablastr::utils::communication::ParallelAdd(mf, *charge_buf[lev+1], icomp, 0,
                                        ncomp,
                                        charge_buf[lev+1]->nGrowVect(), IntVect::TheZeroVector(),
                                        period);
@@ -1200,7 +1201,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
         else // no filter, no buffer
         {
             ng_depos_rho.min(ng);
-            WarpXCommUtil::ParallelAdd(mf, *charge_cp[lev+1], icomp, 0, ncomp,
+            ablastr::utils::communication::ParallelAdd(mf, *charge_cp[lev+1], icomp, 0, ncomp,
                                        charge_cp[lev+1]->nGrowVect(), IntVect::TheZeroVector(),
                                        period);
             WarpXSumGuardCells(*(charge_cp[lev+1]), period, ng_depos_rho, icomp, ncomp);
@@ -1220,16 +1221,16 @@ void WarpX::NodalSyncJ (
     if (patch_type == PatchType::fine)
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        WarpXCommUtil::OverrideSync(*J_fp[lev][0], period);
-        WarpXCommUtil::OverrideSync(*J_fp[lev][1], period);
-        WarpXCommUtil::OverrideSync(*J_fp[lev][2], period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][0], period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][1], period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][2], period);
     }
     else if (patch_type == PatchType::coarse)
     {
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
-        WarpXCommUtil::OverrideSync(*J_cp[lev][0], cperiod);
-        WarpXCommUtil::OverrideSync(*J_cp[lev][1], cperiod);
-        WarpXCommUtil::OverrideSync(*J_cp[lev][2], cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][0], cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][1], cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][2], cperiod);
     }
 }
 
@@ -1247,13 +1248,13 @@ void WarpX::NodalSyncRho (
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
         MultiFab rhof(*charge_fp[lev], amrex::make_alias, icomp, ncomp);
-        WarpXCommUtil::OverrideSync(rhof, period);
+        ablastr::utils::communication::OverrideSync(rhof, period);
     }
     else if (patch_type == PatchType::coarse && charge_cp[lev])
     {
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         MultiFab rhoc(*charge_cp[lev], amrex::make_alias, icomp, ncomp);
-        WarpXCommUtil::OverrideSync(rhoc, cperiod);
+        ablastr::utils::communication::OverrideSync(rhoc, cperiod);
     }
 }
 
@@ -1283,17 +1284,17 @@ void WarpX::NodalSyncPML (int lev, PatchType patch_type)
 
         // Always synchronize nodal points
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        WarpXCommUtil::OverrideSync(*pml_E[0], period);
-        WarpXCommUtil::OverrideSync(*pml_E[1], period);
-        WarpXCommUtil::OverrideSync(*pml_E[2], period);
-        WarpXCommUtil::OverrideSync(*pml_B[0], period);
-        WarpXCommUtil::OverrideSync(*pml_B[1], period);
-        WarpXCommUtil::OverrideSync(*pml_B[2], period);
+        ablastr::utils::communication::OverrideSync(*pml_E[0], period);
+        ablastr::utils::communication::OverrideSync(*pml_E[1], period);
+        ablastr::utils::communication::OverrideSync(*pml_E[2], period);
+        ablastr::utils::communication::OverrideSync(*pml_B[0], period);
+        ablastr::utils::communication::OverrideSync(*pml_B[1], period);
+        ablastr::utils::communication::OverrideSync(*pml_B[2], period);
         if (pml_F) {
-            WarpXCommUtil::OverrideSync(*pml_F, period);
+            ablastr::utils::communication::OverrideSync(*pml_F, period);
         }
         if (pml_G) {
-            WarpXCommUtil::OverrideSync(*pml_G, period);
+            ablastr::utils::communication::OverrideSync(*pml_G, period);
         }
     }
 
@@ -1324,16 +1325,16 @@ void WarpX::NodalSync (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>
     for (int lev = 0; lev <= WarpX::finest_level; lev++)
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        WarpXCommUtil::OverrideSync(*mf_fp[lev][0], period);
-        WarpXCommUtil::OverrideSync(*mf_fp[lev][1], period);
-        WarpXCommUtil::OverrideSync(*mf_fp[lev][2], period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][0], period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][1], period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][2], period);
 
         if (lev > 0)
         {
             const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
-            WarpXCommUtil::OverrideSync(*mf_cp[lev][0], cperiod);
-            WarpXCommUtil::OverrideSync(*mf_cp[lev][1], cperiod);
-            WarpXCommUtil::OverrideSync(*mf_cp[lev][2], cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][0], cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][1], cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][2], cperiod);
         }
     }
 }

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -178,7 +178,8 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
                 // Copy Bfield_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
                 // Bfield_aux and filling up to ng (=nGrow) guard cells in Btmp
-                ablastr::utils::communication::ParallelCopy(*Btmp[i], *Bfield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
+                ablastr::utils::communication::ParallelCopy(*Btmp[i], *Bfield_aux[lev - 1][i], 0, 0, 1,
+                                                            ng_src, ng, WarpX::do_single_precision_comms, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -235,7 +236,8 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
                 // Copy Efield_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
                 // Efield_aux and filling up to ng (=nGrow) guard cells in Etmp
-                ablastr::utils::communication::ParallelCopy(*Etmp[i], *Efield_aux[lev-1][i], 0, 0, 1, ng_src, ng, cperiod);
+                ablastr::utils::communication::ParallelCopy(*Etmp[i], *Efield_aux[lev - 1][i], 0, 0, 1,
+                                                            ng_src, ng, WarpX::do_single_precision_comms, cperiod);
             }
 
 #ifdef AMREX_USE_OMP
@@ -292,9 +294,15 @@ WarpX::UpdateAuxilaryDataSameType ()
             // Copy Bfield_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
             // cells from Bfield_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
 
-            ablastr::utils::communication::ParallelCopy(dBx, *Bfield_aux[lev-1][0], 0, 0, Bfield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
-            ablastr::utils::communication::ParallelCopy(dBy, *Bfield_aux[lev-1][1], 0, 0, Bfield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
-            ablastr::utils::communication::ParallelCopy(dBz, *Bfield_aux[lev-1][2], 0, 0, Bfield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dBx, *Bfield_aux[lev - 1][0], 0, 0,
+                                                        Bfield_aux[lev - 1][0]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                        crse_period);
+            ablastr::utils::communication::ParallelCopy(dBy, *Bfield_aux[lev - 1][1], 0, 0,
+                                                        Bfield_aux[lev - 1][1]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                        crse_period);
+            ablastr::utils::communication::ParallelCopy(dBz, *Bfield_aux[lev - 1][2], 0, 0,
+                                                        Bfield_aux[lev - 1][2]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                        crse_period);
 
             if (Bfield_cax[lev][0])
             {
@@ -356,9 +364,18 @@ WarpX::UpdateAuxilaryDataSameType ()
             const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
             // Copy Efield_aux to the dE MultiFabs, using up to ng_src (=ng_FieldGather) guard
             // cells from Efield_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
-            ablastr::utils::communication::ParallelCopy(dEx, *Efield_aux[lev-1][0], 0, 0, Efield_aux[lev-1][0]->nComp(), ng_src, ng, crse_period);
-            ablastr::utils::communication::ParallelCopy(dEy, *Efield_aux[lev-1][1], 0, 0, Efield_aux[lev-1][1]->nComp(), ng_src, ng, crse_period);
-            ablastr::utils::communication::ParallelCopy(dEz, *Efield_aux[lev-1][2], 0, 0, Efield_aux[lev-1][2]->nComp(), ng_src, ng, crse_period);
+            ablastr::utils::communication::ParallelCopy(dEx, *Efield_aux[lev - 1][0], 0, 0,
+                                                        Efield_aux[lev - 1][0]->nComp(), ng_src, ng,
+                                                        WarpX::do_single_precision_comms,
+                                                        crse_period);
+            ablastr::utils::communication::ParallelCopy(dEy, *Efield_aux[lev - 1][1], 0, 0,
+                                                        Efield_aux[lev - 1][1]->nComp(), ng_src, ng,
+                                                        WarpX::do_single_precision_comms,
+                                                        crse_period);
+            ablastr::utils::communication::ParallelCopy(dEz, *Efield_aux[lev - 1][2], 0, 0,
+                                                        Efield_aux[lev - 1][2]->nComp(), ng_src, ng,
+                                                        WarpX::do_single_precision_comms,
+                                                        crse_period);
 
             if (Efield_cax[lev][0])
             {
@@ -564,7 +581,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        ablastr::utils::communication::FillBoundary(*mf[i], nghost, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
     }
 }
 
@@ -621,7 +638,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        ablastr::utils::communication::FillBoundary(*mf[i], nghost, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
     }
 }
 
@@ -645,14 +662,14 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Efield_avg_fp[lev][0].get(),Efield_avg_fp[lev][1].get(),Efield_avg_fp[lev][2].get()};
-            ablastr::utils::communication::FillBoundary(mf, period);
+            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -665,15 +682,15 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Efield_avg_cp[lev][0].get(),Efield_avg_cp[lev][1].get(),Efield_avg_cp[lev][2].get()};
-            ablastr::utils::communication::FillBoundary(mf, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
 
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Efield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
         }
     }
 }
@@ -698,14 +715,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ) {
             Vector<MultiFab*> mf{Bfield_avg_fp[lev][0].get(),Bfield_avg_fp[lev][1].get(),Bfield_avg_fp[lev][2].get()};
-            ablastr::utils::communication::FillBoundary(mf, period);
+            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_fp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -718,14 +735,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ){
             Vector<MultiFab*> mf{Bfield_avg_cp[lev][0].get(),Bfield_avg_cp[lev][1].get(),Bfield_avg_cp[lev][2].get()};
-            ablastr::utils::communication::FillBoundary(mf, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng <= Bfield_avg_cp[lev][0]->nGrowVect(),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
         }
     }
 }
@@ -752,7 +769,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, const bool noda
         {
             const amrex::Periodicity& period = Geom(lev).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? F_fp[lev]->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*F_fp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*F_fp[lev], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -767,7 +784,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, const bool noda
         {
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? F_cp[lev]->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*F_cp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*F_cp[lev], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
         }
     }
 }
@@ -796,7 +813,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, const bool
         {
             const amrex::Periodicity& period = Geom(lev).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? G_fp[lev]->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*G_fp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_fp[lev], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -811,7 +828,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, const bool
         {
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             const amrex::IntVect& nghost = (safe_guard_cells) ? G_cp[lev]->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*G_cp[lev], nghost, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_cp[lev], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
         }
     }
 }
@@ -829,12 +846,12 @@ void
 WarpX::FillBoundaryAux (int lev, IntVect ng)
 {
     const amrex::Periodicity& period = Geom(lev).periodicity();
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
 }
 
 void
@@ -1035,7 +1052,8 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                 bilinear_filter.ApplyStencil(jfb, *current_buf[lev+1][idim], lev+1);
 
                 MultiFab::Add(jfb, jfc, 0, 0, current_buf[lev+1][idim]->nComp(), ng);
-                ablastr::utils::communication::ParallelAdd(mf, jfb, 0, 0, current_buf[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
+                ablastr::utils::communication::ParallelAdd(mf, jfb, 0, 0, current_buf[lev + 1][idim]->nComp(),
+                                                           ng, IntVect::TheZeroVector(), WarpX::do_single_precision_comms, period);
 
                 WarpXSumGuardCells(*J_cp[lev+1][idim], jfc, period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
@@ -1049,7 +1067,8 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                             J_cp[lev+1][idim]->DistributionMap(), J_cp[lev+1][idim]->nComp(), ng);
                 bilinear_filter.ApplyStencil(jf, *J_cp[lev+1][idim], lev+1);
 
-                ablastr::utils::communication::ParallelAdd(mf, jf, 0, 0, J_cp[lev+1][idim]->nComp(), ng, IntVect::TheZeroVector(), period);
+                ablastr::utils::communication::ParallelAdd(mf, jf, 0, 0, J_cp[lev + 1][idim]->nComp(), ng,
+                                                           IntVect::TheZeroVector(), WarpX::do_single_precision_comms, period);
                 WarpXSumGuardCells(*J_cp[lev+1][idim], jf, period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
             else if (current_buf[lev+1][idim]) // but no filter
@@ -1058,17 +1077,21 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
                 MultiFab::Add(*current_buf[lev+1][idim],
                                *J_cp [lev+1][idim], 0, 0, current_buf[lev+1][idim]->nComp(),
                                J_cp[lev+1][idim]->nGrowVect());
-                ablastr::utils::communication::ParallelAdd(mf, *current_buf[lev+1][idim], 0, 0, current_buf[lev+1][idim]->nComp(),
-                                           current_buf[lev+1][idim]->nGrowVect(), IntVect::TheZeroVector(),
-                                           period);
+                ablastr::utils::communication::ParallelAdd(mf, *current_buf[lev + 1][idim], 0, 0,
+                                                           current_buf[lev + 1][idim]->nComp(),
+                                                           current_buf[lev + 1][idim]->nGrowVect(),
+                                                           IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                           period);
                 WarpXSumGuardCells(*(J_cp[lev+1][idim]), period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
             else // no filter, no buffer
             {
                 ng_depos_J.min(ng);
-                ablastr::utils::communication::ParallelAdd(mf, *J_cp[lev+1][idim], 0, 0, J_cp[lev+1][idim]->nComp(),
-                                           J_cp[lev+1][idim]->nGrowVect(), IntVect::TheZeroVector(),
-                                           period);
+                ablastr::utils::communication::ParallelAdd(mf, *J_cp[lev + 1][idim], 0, 0,
+                                                           J_cp[lev + 1][idim]->nComp(),
+                                                           J_cp[lev + 1][idim]->nGrowVect(),
+                                                           IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                           period);
                 WarpXSumGuardCells(*(J_cp[lev+1][idim]), period, ng_depos_J, 0, J_cp[lev+1][idim]->nComp());
             }
             MultiFab::Add(*J_fp[lev][idim], mf, 0, 0, J_fp[lev+1][idim]->nComp(), 0);
@@ -1171,7 +1194,8 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
 
             MultiFab::Add(rhofb, rhofc, 0, 0, ncomp, ng);
 
-            ablastr::utils::communication::ParallelAdd(mf, rhofb, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
+            ablastr::utils::communication::ParallelAdd(mf, rhofb, 0, 0, ncomp, ng, IntVect::TheZeroVector(),
+                                                       WarpX::do_single_precision_comms, period);
             WarpXSumGuardCells( *charge_cp[lev+1], rhofc, period, ng_depos_rho, icomp, ncomp );
         }
         else if (use_filter) // but no buffer
@@ -1182,7 +1206,8 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             MultiFab rf(charge_cp[lev+1]->boxArray(), charge_cp[lev+1]->DistributionMap(), ncomp, ng);
             bilinear_filter.ApplyStencil(rf, *charge_cp[lev+1], lev+1, icomp, 0, ncomp);
 
-            ablastr::utils::communication::ParallelAdd(mf, rf, 0, 0, ncomp, ng, IntVect::TheZeroVector(), period);
+            ablastr::utils::communication::ParallelAdd(mf, rf, 0, 0, ncomp, ng, IntVect::TheZeroVector(),
+                                                       WarpX::do_single_precision_comms, period);
             WarpXSumGuardCells( *charge_cp[lev+1], rf, period, ng_depos_rho, icomp, ncomp );
         }
         else if (charge_buf[lev+1]) // but no filter
@@ -1192,18 +1217,20 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
                           *charge_cp[lev+1], icomp, icomp, ncomp,
                            charge_cp[lev+1]->nGrowVect());
 
-            ablastr::utils::communication::ParallelAdd(mf, *charge_buf[lev+1], icomp, 0,
-                                       ncomp,
-                                       charge_buf[lev+1]->nGrowVect(), IntVect::TheZeroVector(),
-                                       period);
+            ablastr::utils::communication::ParallelAdd(mf, *charge_buf[lev + 1], icomp, 0,
+                                                       ncomp,
+                                                       charge_buf[lev + 1]->nGrowVect(),
+                                                       IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                       period);
             WarpXSumGuardCells(*(charge_cp[lev+1]), period, ng_depos_rho, icomp, ncomp);
         }
         else // no filter, no buffer
         {
             ng_depos_rho.min(ng);
-            ablastr::utils::communication::ParallelAdd(mf, *charge_cp[lev+1], icomp, 0, ncomp,
-                                       charge_cp[lev+1]->nGrowVect(), IntVect::TheZeroVector(),
-                                       period);
+            ablastr::utils::communication::ParallelAdd(mf, *charge_cp[lev + 1], icomp, 0, ncomp,
+                                                       charge_cp[lev + 1]->nGrowVect(),
+                                                       IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                       period);
             WarpXSumGuardCells(*(charge_cp[lev+1]), period, ng_depos_rho, icomp, ncomp);
         }
         MultiFab::Add(*charge_fp[lev], mf, 0, icomp, ncomp, 0);
@@ -1221,16 +1248,16 @@ void WarpX::NodalSyncJ (
     if (patch_type == PatchType::fine)
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        ablastr::utils::communication::OverrideSync(*J_fp[lev][0], period);
-        ablastr::utils::communication::OverrideSync(*J_fp[lev][1], period);
-        ablastr::utils::communication::OverrideSync(*J_fp[lev][2], period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][0], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][1], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*J_fp[lev][2], WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse)
     {
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
-        ablastr::utils::communication::OverrideSync(*J_cp[lev][0], cperiod);
-        ablastr::utils::communication::OverrideSync(*J_cp[lev][1], cperiod);
-        ablastr::utils::communication::OverrideSync(*J_cp[lev][2], cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][0], WarpX::do_single_precision_comms, cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][1], WarpX::do_single_precision_comms, cperiod);
+        ablastr::utils::communication::OverrideSync(*J_cp[lev][2], WarpX::do_single_precision_comms, cperiod);
     }
 }
 
@@ -1248,13 +1275,13 @@ void WarpX::NodalSyncRho (
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
         MultiFab rhof(*charge_fp[lev], amrex::make_alias, icomp, ncomp);
-        ablastr::utils::communication::OverrideSync(rhof, period);
+        ablastr::utils::communication::OverrideSync(rhof, WarpX::do_single_precision_comms, period);
     }
     else if (patch_type == PatchType::coarse && charge_cp[lev])
     {
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         MultiFab rhoc(*charge_cp[lev], amrex::make_alias, icomp, ncomp);
-        ablastr::utils::communication::OverrideSync(rhoc, cperiod);
+        ablastr::utils::communication::OverrideSync(rhoc, WarpX::do_single_precision_comms, cperiod);
     }
 }
 
@@ -1284,17 +1311,17 @@ void WarpX::NodalSyncPML (int lev, PatchType patch_type)
 
         // Always synchronize nodal points
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        ablastr::utils::communication::OverrideSync(*pml_E[0], period);
-        ablastr::utils::communication::OverrideSync(*pml_E[1], period);
-        ablastr::utils::communication::OverrideSync(*pml_E[2], period);
-        ablastr::utils::communication::OverrideSync(*pml_B[0], period);
-        ablastr::utils::communication::OverrideSync(*pml_B[1], period);
-        ablastr::utils::communication::OverrideSync(*pml_B[2], period);
+        ablastr::utils::communication::OverrideSync(*pml_E[0], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*pml_E[1], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*pml_E[2], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*pml_B[0], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*pml_B[1], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*pml_B[2], WarpX::do_single_precision_comms, period);
         if (pml_F) {
-            ablastr::utils::communication::OverrideSync(*pml_F, period);
+            ablastr::utils::communication::OverrideSync(*pml_F, WarpX::do_single_precision_comms, period);
         }
         if (pml_G) {
-            ablastr::utils::communication::OverrideSync(*pml_G, period);
+            ablastr::utils::communication::OverrideSync(*pml_G, WarpX::do_single_precision_comms, period);
         }
     }
 
@@ -1325,16 +1352,16 @@ void WarpX::NodalSync (amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>
     for (int lev = 0; lev <= WarpX::finest_level; lev++)
     {
         const amrex::Periodicity& period = Geom(lev).periodicity();
-        ablastr::utils::communication::OverrideSync(*mf_fp[lev][0], period);
-        ablastr::utils::communication::OverrideSync(*mf_fp[lev][1], period);
-        ablastr::utils::communication::OverrideSync(*mf_fp[lev][2], period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][0], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][1], WarpX::do_single_precision_comms, period);
+        ablastr::utils::communication::OverrideSync(*mf_fp[lev][2], WarpX::do_single_precision_comms, period);
 
         if (lev > 0)
         {
             const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
-            ablastr::utils::communication::OverrideSync(*mf_cp[lev][0], cperiod);
-            ablastr::utils::communication::OverrideSync(*mf_cp[lev][1], cperiod);
-            ablastr::utils::communication::OverrideSync(*mf_cp[lev][2], cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][0], WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][1], WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::OverrideSync(*mf_cp[lev][2], WarpX::do_single_precision_comms, cperiod);
         }
     }
 }

--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -10,6 +10,8 @@
 
 #include "Utils/WarpXAlgorithmSelection.H"
 
+#include <ablastr/utils/Communication.H>
+
 #include <AMReX_MultiFab.H>
 
 /** \brief Sum the values of `mf`, where the different boxes overlap
@@ -36,7 +38,7 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
         n_updated_guards = mf.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();
-    WarpXCommUtil::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, period);
+    ablastr::utils::communication::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, period);
 }
 
 /** \brief Sum the values of `src` where the different boxes overlap
@@ -69,7 +71,7 @@ WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
         n_updated_guards = amrex::IntVect::TheZeroVector();
 
     dst.setVal(0., icomp, ncomp, n_updated_guards);
-//    WarpXCommUtil::ParallelAdd(dst, src, 0, icomp, ncomp, src_ngrow, n_updated_guards, period);
+//    ablastr::utils::communication::ParallelAdd(dst, src, 0, icomp, ncomp, src_ngrow, n_updated_guards, period);
     dst.ParallelAdd(src, 0, icomp, ncomp, src_ngrow, n_updated_guards, period);
 }
 

--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -38,7 +38,7 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
         n_updated_guards = mf.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();
-    ablastr::utils::communication::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, period);
+    ablastr::utils::communication::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, WarpX::do_single_precision_comms, period);
 }
 
 /** \brief Sum the values of `src` where the different boxes overlap

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -10,7 +10,6 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "MultiParticleContainer.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Particles/ElementaryProcess/Ionization.H"
 #ifdef WARPX_QED
 #   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
@@ -41,6 +40,7 @@
 
 #include "WarpX.H"
 
+#include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -554,7 +554,7 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
         }
         if (!local) {
             const Geometry& gm = allcontainers[0]->Geom(lev);
-            WarpXCommUtil::SumBoundary(*rho, gm.periodicity());
+            ablastr::utils::communication::SumBoundary(*rho, gm.periodicity());
         }
         return rho;
     }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -554,7 +554,7 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
         }
         if (!local) {
             const Geometry& gm = allcontainers[0]->Geom(lev);
-            ablastr::utils::communication::SumBoundary(*rho, gm.periodicity());
+            ablastr::utils::communication::SumBoundary(*rho, WarpX::do_single_precision_comms, gm.periodicity());
         }
         return rho;
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -675,7 +675,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
         // Exchange guard cells
         if (local == false) {
-            ablastr::utils::communication::SumBoundary(*rho[lev], m_gdb->Geom(lev).periodicity());
+            ablastr::utils::communication::SumBoundary(*rho[lev], WarpX::do_single_precision_comms, m_gdb->Geom(lev).periodicity());
         }
     }
 
@@ -692,10 +692,12 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
             coarsened_fine_data.setVal(0.0);
 
             CoarsenMR::Coarsen( coarsened_fine_data, *rho[lev+1], m_gdb->refRatio(lev) );
-            ablastr::utils::communication::ParallelAdd(*rho[lev], coarsened_fine_data, 0, 0, rho[lev]->nComp(),
-                                       amrex::IntVect::TheZeroVector(),
-                                       amrex::IntVect::TheZeroVector(),
-                                       m_gdb->Geom(lev).periodicity());
+            ablastr::utils::communication::ParallelAdd(*rho[lev], coarsened_fine_data, 0, 0,
+                                                       rho[lev]->nComp(),
+                                                       amrex::IntVect::TheZeroVector(),
+                                                       amrex::IntVect::TheZeroVector(),
+                                                       WarpX::do_single_precision_comms,
+                                                       m_gdb->Geom(lev).periodicity());
         }
     }
 }
@@ -756,7 +758,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     WarpX::GetInstance().ApplyInverseVolumeScalingToChargeDensity(rho.get(), lev);
 #endif
 
-    if (local == false) { ablastr::utils::communication::SumBoundary(*rho, gm.periodicity()); }
+    if (local == false) { ablastr::utils::communication::SumBoundary(*rho, WarpX::do_single_precision_comms, gm.periodicity()); }
 
     return rho;
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -14,7 +14,6 @@
 #include "Deposition/CurrentDeposition.H"
 #include "Pusher/GetAndSetPosition.H"
 #include "Pusher/UpdatePosition.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "ParticleBoundaries_K.H"
 #include "Utils/CoarsenMR.H"
 #include "Utils/TextMsg.H"
@@ -22,6 +21,8 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX.H>
 #include <AMReX_AmrCore.H>
@@ -674,7 +675,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
         // Exchange guard cells
         if (local == false) {
-            WarpXCommUtil::SumBoundary(*rho[lev], m_gdb->Geom(lev).periodicity());
+            ablastr::utils::communication::SumBoundary(*rho[lev], m_gdb->Geom(lev).periodicity());
         }
     }
 
@@ -691,7 +692,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
             coarsened_fine_data.setVal(0.0);
 
             CoarsenMR::Coarsen( coarsened_fine_data, *rho[lev+1], m_gdb->refRatio(lev) );
-            WarpXCommUtil::ParallelAdd(*rho[lev], coarsened_fine_data, 0, 0, rho[lev]->nComp(),
+            ablastr::utils::communication::ParallelAdd(*rho[lev], coarsened_fine_data, 0, 0, rho[lev]->nComp(),
                                        amrex::IntVect::TheZeroVector(),
                                        amrex::IntVect::TheZeroVector(),
                                        m_gdb->Geom(lev).periodicity());
@@ -755,7 +756,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     WarpX::GetInstance().ApplyInverseVolumeScalingToChargeDensity(rho.get(), lev);
 #endif
 
-    if (local == false) { WarpXCommUtil::SumBoundary(*rho, gm.periodicity()); }
+    if (local == false) { ablastr::utils::communication::SumBoundary(*rho, gm.periodicity()); }
 
     return rho;
 }

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -13,10 +13,11 @@
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Particles/MultiParticleContainer.H"
-#include "Parallelization/WarpXCommUtil.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
+
+#include <ablastr/utils/Communication.H>
 
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
@@ -313,7 +314,7 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
 
     if ( WarpX::safe_guard_cells ) {
         // Fill guard cells.
-        WarpXCommUtil::FillBoundary(tmpmf, geom.periodicity());
+        ablastr::utils::communication::FillBoundary(tmpmf, geom.periodicity());
     } else {
         amrex::IntVect ng_mw = amrex::IntVect::TheUnitVector();
         // Enough guard cells in the MW direction
@@ -321,7 +322,7 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
         // Make sure we don't exceed number of guard cells allocated
         ng_mw = ng_mw.min(ng);
         // Fill guard cells.
-        WarpXCommUtil::FillBoundary(tmpmf, ng_mw, geom.periodicity());
+        ablastr::utils::communication::FillBoundary(tmpmf, ng_mw, geom.periodicity());
     }
 
     // Make a box that covers the region that the window moved into

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -314,7 +314,7 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
 
     if ( WarpX::safe_guard_cells ) {
         // Fill guard cells.
-        ablastr::utils::communication::FillBoundary(tmpmf, geom.periodicity());
+        ablastr::utils::communication::FillBoundary(tmpmf, WarpX::do_single_precision_comms, geom.periodicity());
     } else {
         amrex::IntVect ng_mw = amrex::IntVect::TheUnitVector();
         // Enough guard cells in the MW direction
@@ -322,7 +322,7 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
         // Make sure we don't exceed number of guard cells allocated
         ng_mw = ng_mw.min(ng);
         // Fill guard cells.
-        ablastr::utils::communication::FillBoundary(tmpmf, ng_mw, geom.periodicity());
+        ablastr::utils::communication::FillBoundary(tmpmf, ng_mw, WarpX::do_single_precision_comms, geom.periodicity());
     }
 
     // Make a box that covers the region that the window moved into

--- a/Source/ablastr/utils/CMakeLists.txt
+++ b/Source/ablastr/utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(ablastr
   PRIVATE
+    Communication.cpp
     TextMsg.cpp
     SignalHandling.cpp
 )

--- a/Source/ablastr/utils/Communication.H
+++ b/Source/ablastr/utils/Communication.H
@@ -1,11 +1,11 @@
-/* Copyright 2019 Andrew Myers
+/* Copyright 2019-2022 Andrew Myers
  *
  * This file is part of WarpX.
  *
  * License: BSD-3-Clause-LBNL
  */
-#ifndef WARPX_COMMUTIL_H_
-#define WARPX_COMMUTIL_H_
+#ifndef ABLASTR_UTILS_COMMUNICATION_H_
+#define ABLASTR_UTILS_COMMUNICATION_H_
 
 #include <AMReX_FabArray.H>
 #include <AMReX_Gpu.H>
@@ -16,7 +16,7 @@
 
 #include "WarpX.H"
 
-namespace WarpXCommUtil
+namespace ablastr::utils::communication
 {
 
 using comm_float_type = float;
@@ -92,4 +92,4 @@ void OverrideSync (amrex::MultiFab&          mf,
                    const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
 }
 
-#endif
+#endif // ABLASTR_UTILS_COMMUNICATION_H_

--- a/Source/ablastr/utils/Communication.H
+++ b/Source/ablastr/utils/Communication.H
@@ -35,61 +35,70 @@ mixedCopy (amrex::FabArray<FAB1>& dst, amrex::FabArray<FAB2> const& src, int src
     amrex::Gpu::synchronize();
 }
 
-void ParallelCopy (amrex::MultiFab&            dst,
-                   const amrex::MultiFab&      src,
-                   int                         src_comp,
-                   int                         dst_comp,
-                   int                         num_comp,
-                   const amrex::IntVect&       src_nghost,
-                   const amrex::IntVect&       dst_nghost,
-                   const amrex::Periodicity&   period = amrex::Periodicity::NonPeriodic(),
-                   amrex::FabArrayBase::CpOp   op = amrex::FabArrayBase::COPY);
+void ParallelCopy(amrex::MultiFab &dst,
+                  const amrex::MultiFab &src,
+                  int src_comp,
+                  int dst_comp,
+                  int num_comp,
+                  const amrex::IntVect &src_nghost,
+                  const amrex::IntVect &dst_nghost,
+                  bool do_single_precision_comms,
+                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic(),
+                  amrex::FabArrayBase::CpOp op = amrex::FabArrayBase::COPY);
 
-void ParallelAdd (amrex::MultiFab&            dst,
-                  const amrex::MultiFab&      src,
-                  int                         src_comp,
-                  int                         dst_comp,
-                  int                         num_comp,
-                  const amrex::IntVect&       src_nghost,
-                  const amrex::IntVect&       dst_nghost,
-                  const amrex::Periodicity&   period = amrex::Periodicity::NonPeriodic());
+void ParallelAdd (amrex::MultiFab &dst,
+                  const amrex::MultiFab &src,
+                  int src_comp,
+                  int dst_comp,
+                  int num_comp,
+                  const amrex::IntVect &src_nghost,
+                  const amrex::IntVect &dst_nghost,
+                  bool do_single_precision_comms,
+                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
-void FillBoundary (amrex::MultiFab&          mf,
-                   const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void FillBoundary (amrex::MultiFab &mf,
+                   bool do_single_precision_comms,
+                   const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
-void FillBoundary (amrex::MultiFab&          mf,
-                   amrex::IntVect            ng,
-                   const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic(),
-                   const bool                nodal_sync = false);
+void FillBoundary (amrex::MultiFab &mf,
+                   amrex::IntVect ng,
+                   bool do_single_precision_comms,
+                   const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic(),
+                   const bool nodal_sync = false);
 
-void FillBoundary (amrex::iMultiFab&         mf,
-                   const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void FillBoundary (amrex::iMultiFab &mf,
+                   const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
 void FillBoundary (amrex::iMultiFab&         mf,
                    amrex::IntVect            ng,
                    const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
 
 void
-FillBoundary (amrex::Vector<amrex::MultiFab*> const& mf, const amrex::Periodicity& period);
+FillBoundary(amrex::Vector<amrex::MultiFab *> const &mf, bool do_single_precision_comms,
+             const amrex::Periodicity &period);
 
-void SumBoundary (amrex::MultiFab&          mf,
-                  const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void SumBoundary (amrex::MultiFab &mf,
+                  bool do_single_precision_comms,
+                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
-void SumBoundary (amrex::MultiFab&          mf,
-                  int                       start_comp,
-                  int                       num_comps,
-                  amrex::IntVect            ng,
-                  const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void SumBoundary (amrex::MultiFab &mf,
+                  int start_comp,
+                  int num_comps, amrex::IntVect ng,
+                  bool do_single_precision_comms,
+                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
-void SumBoundary (amrex::MultiFab&          mf,
-                  int                       start_comp,
-                  int                       num_comps,
-                  amrex::IntVect            src_ng,
-                  amrex::IntVect            dst_ng,
-                  const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void
+SumBoundary (amrex::MultiFab &mf,
+             int start_comp,
+             int num_comps,
+             amrex::IntVect src_ng,
+             amrex::IntVect dst_ng,
+             bool do_single_precision_comms,
+             const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 
-void OverrideSync (amrex::MultiFab&          mf,
-                   const amrex::Periodicity& period = amrex::Periodicity::NonPeriodic());
+void OverrideSync (amrex::MultiFab &mf,
+                   bool do_single_precision_comms,
+                   const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
 }
 
 #endif // ABLASTR_UTILS_COMMUNICATION_H_

--- a/Source/ablastr/utils/Communication.cpp
+++ b/Source/ablastr/utils/Communication.cpp
@@ -16,21 +16,16 @@
 namespace ablastr::utils::communication
 {
 
-void ParallelCopy (amrex::MultiFab&            dst,
-                   const amrex::MultiFab&      src,
-                   int                         src_comp,
-                   int                         dst_comp,
-                   int                         num_comp,
-                   const amrex::IntVect&       src_nghost,
-                   const amrex::IntVect&       dst_nghost,
-                   const amrex::Periodicity&   period,
-                   amrex::FabArrayBase::CpOp   op)
+void ParallelCopy(amrex::MultiFab &dst, const amrex::MultiFab &src, int src_comp, int dst_comp, int num_comp,
+                  const amrex::IntVect &src_nghost, const amrex::IntVect &dst_nghost,
+                  bool do_single_precision_comms, const amrex::Periodicity &period,
+                  amrex::FabArrayBase::CpOp op)
 {
     BL_PROFILE("ablastr::utils::communication::ParallelCopy");
 
     using ablastr::utils::communication::comm_float_type;
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > src_tmp(src.boxArray(),
                                                                   src.DistributionMap(),
@@ -56,24 +51,19 @@ void ParallelCopy (amrex::MultiFab&            dst,
     }
 }
 
-void ParallelAdd (amrex::MultiFab&            dst,
-                  const amrex::MultiFab&      src,
-                  int                         src_comp,
-                  int                         dst_comp,
-                  int                         num_comp,
-                  const amrex::IntVect&       src_nghost,
-                  const amrex::IntVect&       dst_nghost,
-                  const amrex::Periodicity&   period)
+void ParallelAdd(amrex::MultiFab &dst, const amrex::MultiFab &src, int src_comp, int dst_comp, int num_comp,
+                 const amrex::IntVect &src_nghost, const amrex::IntVect &dst_nghost,
+                 bool do_single_precision_comms, const amrex::Periodicity &period)
 {
-    ablastr::utils::communication::ParallelCopy(dst, src, src_comp, dst_comp, num_comp, src_nghost, dst_nghost, period,
-                                amrex::FabArrayBase::ADD);
+    ablastr::utils::communication::ParallelCopy(dst, src, src_comp, dst_comp, num_comp, src_nghost, dst_nghost,
+                                                do_single_precision_comms, period, amrex::FabArrayBase::ADD);
 }
 
-void FillBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
+void FillBoundary (amrex::MultiFab &mf, bool do_single_precision_comms, const amrex::Periodicity &period)
 {
     BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                                  mf.DistributionMap(),
@@ -92,14 +82,15 @@ void FillBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
     }
 }
 
-void FillBoundary (amrex::MultiFab&          mf,
-                   amrex::IntVect            ng,
-                   const amrex::Periodicity& period,
-                   const bool                nodal_sync)
+void FillBoundary(amrex::MultiFab &mf,
+                  amrex::IntVect ng,
+                  bool do_single_precision_comms,
+                  const amrex::Periodicity &period,
+                  const bool nodal_sync)
 {
     BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                             mf.DistributionMap(),
@@ -127,7 +118,7 @@ void FillBoundary (amrex::MultiFab&          mf,
     }
 }
 
-void FillBoundary (amrex::iMultiFab& imf, const amrex::Periodicity& period)
+void FillBoundary(amrex::iMultiFab &imf, const amrex::Periodicity &period)
 {
     BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
@@ -143,18 +134,19 @@ void FillBoundary (amrex::iMultiFab&         imf,
 }
 
 void
-FillBoundary (amrex::Vector<amrex::MultiFab*> const& mf, const amrex::Periodicity& period)
+FillBoundary(amrex::Vector<amrex::MultiFab *> const &mf, bool do_single_precision_comms,
+             const amrex::Periodicity &period)
 {
     for (auto x : mf) {
-        ablastr::utils::communication::FillBoundary(*x, period);
+        ablastr::utils::communication::FillBoundary(*x, do_single_precision_comms, period);
     }
 }
 
-void SumBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
+void SumBoundary (amrex::MultiFab &mf, bool do_single_precision_comms, const amrex::Periodicity &period)
 {
     BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                                  mf.DistributionMap(),
@@ -173,15 +165,16 @@ void SumBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
     }
 }
 
-void SumBoundary (amrex::MultiFab&          mf,
-                  int                       start_comp,
-                  int                       num_comps,
-                  amrex::IntVect            ng,
-                  const amrex::Periodicity& period)
+void SumBoundary(amrex::MultiFab &mf,
+                 int start_comp,
+                 int num_comps,
+                 amrex::IntVect ng,
+                 bool do_single_precision_comms,
+                 const amrex::Periodicity &period)
 {
     BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                                  mf.DistributionMap(),
@@ -199,16 +192,18 @@ void SumBoundary (amrex::MultiFab&          mf,
     }
 }
 
-void SumBoundary (amrex::MultiFab&          mf,
-                  int                       start_comp,
-                  int                       num_comps,
-                  amrex::IntVect            src_ng,
-                  amrex::IntVect            dst_ng,
-                  const amrex::Periodicity& period)
+void
+SumBoundary (amrex::MultiFab &mf,
+             int start_comp,
+             int num_comps,
+             amrex::IntVect src_ng,
+             amrex::IntVect dst_ng,
+             bool do_single_precision_comms,
+             const amrex::Periodicity &period)
 {
     BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                                  mf.DistributionMap(),
@@ -226,12 +221,13 @@ void SumBoundary (amrex::MultiFab&          mf,
     }
 }
 
-void OverrideSync (amrex::MultiFab&          mf,
-                   const amrex::Periodicity& period)
+void OverrideSync (amrex::MultiFab &mf,
+                   bool do_single_precision_comms,
+                   const amrex::Periodicity &period)
 {
     if (mf.ixType().cellCentered()) return;
 
-    if (WarpX::do_single_precision_comms)
+    if (do_single_precision_comms)
     {
         amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
                                                                  mf.DistributionMap(),

--- a/Source/ablastr/utils/Communication.cpp
+++ b/Source/ablastr/utils/Communication.cpp
@@ -4,7 +4,7 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include "WarpXCommUtil.H"
+#include "Communication.H"
 
 #include <AMReX.H>
 #include <AMReX_BaseFab.H>
@@ -13,7 +13,8 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
 
-namespace WarpXCommUtil {
+namespace ablastr::utils::communication
+{
 
 void ParallelCopy (amrex::MultiFab&            dst,
                    const amrex::MultiFab&      src,
@@ -25,9 +26,9 @@ void ParallelCopy (amrex::MultiFab&            dst,
                    const amrex::Periodicity&   period,
                    amrex::FabArrayBase::CpOp   op)
 {
-    BL_PROFILE("WarpXCommUtil::ParallelCopy");
+    BL_PROFILE("ablastr::utils::communication::ParallelCopy");
 
-    using WarpXCommUtil::comm_float_type;
+    using ablastr::utils::communication::comm_float_type;
 
     if (WarpX::do_single_precision_comms)
     {
@@ -64,13 +65,13 @@ void ParallelAdd (amrex::MultiFab&            dst,
                   const amrex::IntVect&       dst_nghost,
                   const amrex::Periodicity&   period)
 {
-    WarpXCommUtil::ParallelCopy(dst, src, src_comp, dst_comp, num_comp, src_nghost, dst_nghost, period,
+    ablastr::utils::communication::ParallelCopy(dst, src, src_comp, dst_comp, num_comp, src_nghost, dst_nghost, period,
                                 amrex::FabArrayBase::ADD);
 }
 
 void FillBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::FillBoundary");
+    BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
     if (WarpX::do_single_precision_comms)
     {
@@ -96,7 +97,7 @@ void FillBoundary (amrex::MultiFab&          mf,
                    const amrex::Periodicity& period,
                    const bool                nodal_sync)
 {
-    BL_PROFILE("WarpXCommUtil::FillBoundary");
+    BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
     if (WarpX::do_single_precision_comms)
     {
@@ -128,7 +129,7 @@ void FillBoundary (amrex::MultiFab&          mf,
 
 void FillBoundary (amrex::iMultiFab& imf, const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::FillBoundary");
+    BL_PROFILE("ablastr::utils::communication::FillBoundary");
 
     imf.FillBoundary(period);
 }
@@ -137,7 +138,7 @@ void FillBoundary (amrex::iMultiFab&         imf,
                    amrex::IntVect            ng,
                    const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::FillBoundary");
+    BL_PROFILE("ablastr::utils::communication::FillBoundary");
     imf.FillBoundary(ng, period);
 }
 
@@ -145,13 +146,13 @@ void
 FillBoundary (amrex::Vector<amrex::MultiFab*> const& mf, const amrex::Periodicity& period)
 {
     for (auto x : mf) {
-        WarpXCommUtil::FillBoundary(*x, period);
+        ablastr::utils::communication::FillBoundary(*x, period);
     }
 }
 
 void SumBoundary (amrex::MultiFab& mf, const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::SumBoundary");
+    BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
     if (WarpX::do_single_precision_comms)
     {
@@ -178,7 +179,7 @@ void SumBoundary (amrex::MultiFab&          mf,
                   amrex::IntVect            ng,
                   const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::SumBoundary");
+    BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
     if (WarpX::do_single_precision_comms)
     {
@@ -205,7 +206,7 @@ void SumBoundary (amrex::MultiFab&          mf,
                   amrex::IntVect            dst_ng,
                   const amrex::Periodicity& period)
 {
-    BL_PROFILE("WarpXCommUtil::SumBoundary");
+    BL_PROFILE("ablastr::utils::communication::SumBoundary");
 
     if (WarpX::do_single_precision_comms)
     {
@@ -250,4 +251,4 @@ void OverrideSync (amrex::MultiFab&          mf,
     }
 }
 
-}
+} // namespace ablastr::utils::communication

--- a/Source/ablastr/utils/Make.package
+++ b/Source/ablastr/utils/Make.package
@@ -1,4 +1,6 @@
-CEXE_sources += TextMsg.cpp SignalHandling.cpp
+CEXE_sources += TextMsg.cpp
+CEXE_sources += SignalHandling.cpp
+CEXE_sources += Communication.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/utils
 


### PR DESCRIPTION
Move the `WarpXCommUtils` to ABLASTR.

Also refactor out global variable: `WarpX::do_single_precision_comms`