### PR TITLE
openPMD-api: 0.14.5

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -81,7 +81,7 @@ if(WarpX_OPENPMD)
     set(WarpX_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(WarpX_openpmd_internal)")
-    set(WarpX_openpmd_branch "0.14.3"
+    set(WarpX_openpmd_branch "0.14.5"
         CACHE STRING
         "Repository branch for WarpX_openpmd_repo if(WarpX_openpmd_internal)")
 


### PR DESCRIPTION
Automatically pull the lastet openPMD-api release, 0.14.5.

Updating from 0.14.3 to 0.14.5 fixes a couple of small read and backend bugs.
- Changelog: https://github.com/openPMD/openPMD-api/blob/0.14.5/CHANGELOG.rst#0145

For reading fields, we especially want this feature from 0.14.4 @Yin-YinjianZhao :)
- https://github.com/openPMD/openPMD-api/pull/1137