### PR TITLE
Extract function for two-particle fusion reaction

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -65,7 +65,6 @@ namespace {
     {
         // General notations in this function:
         //     x_sq denotes the square of x
-        //     x_star denotes the value of x in the proton+boron center of mass frame
         //     x_Bestar denotes the value of x in the Beryllium rest frame
 
         using namespace amrex::literals;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -8,6 +8,7 @@
 #ifndef PROTON_BORON_FUSION_INITIALIZE_MOMENTUM_H
 #define PROTON_BORON_FUSION_INITIALIZE_MOMENTUM_H
 
+#include "TwoProductFusionUtil.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/ParticleUtils.H"
 #include "Utils/WarpXConst.H"
@@ -83,102 +84,28 @@ namespace {
         // precision anyways.
         constexpr double m_alpha = PhysConst::m_p * 3.97369_prt;
         constexpr double m_beryllium = PhysConst::m_p * 7.94748_prt;
-        constexpr double ma_sq = m_alpha*m_alpha;
         constexpr double mBe_sq = m_beryllium*m_beryllium;
         constexpr amrex::ParticleReal c_sq = PhysConst::c * PhysConst::c;
-        constexpr amrex::ParticleReal inv_csq = 1._prt / ( c_sq );
-        // Rest energy of proton+boron
-        const amrex::ParticleReal E_rest_pb = (m1 + m2)*c_sq;
-        // Rest energy of alpha+beryllium
-        constexpr amrex::ParticleReal E_rest_abe = (m_alpha + m_beryllium)*c_sq;
 
-        // Normalized momentum of colliding particles (proton and boron)
-        const amrex::ParticleReal u1x = soa_1.m_rdata[PIdx::ux][idx_1];
-        const amrex::ParticleReal u1y = soa_1.m_rdata[PIdx::uy][idx_1];
-        const amrex::ParticleReal u1z = soa_1.m_rdata[PIdx::uz][idx_1];
-        const amrex::ParticleReal u2x = soa_2.m_rdata[PIdx::ux][idx_2];
-        const amrex::ParticleReal u2y = soa_2.m_rdata[PIdx::uy][idx_2];
-        const amrex::ParticleReal u2z = soa_2.m_rdata[PIdx::uz][idx_2];
+        // Compute the resulting momenta of the alpha and beryllium particles
+        // produced in the fusion reaction
+        amrex::ParticleReal ux_alpha1 = 0.0, uy_alpha1 = 0.0, uz_alpha1 = 0.0;
+        amrex::ParticleReal ux_Be = 0.0, uy_Be = 0.0, uz_Be = 0.0;
+        TwoProductFusionComputeProductMomenta (
+            soa_1.m_rdata[PIdx::ux][idx_1],
+            soa_1.m_rdata[PIdx::uy][idx_1],
+            soa_1.m_rdata[PIdx::uz][idx_1], m1,
+            soa_2.m_rdata[PIdx::ux][idx_2],
+            soa_2.m_rdata[PIdx::uy][idx_2],
+            soa_2.m_rdata[PIdx::uz][idx_2], m2,
+            ux_alpha1, uy_alpha1, uz_alpha1, m_alpha,
+            ux_Be, uy_Be, uz_Be, m_beryllium,
+            E_fusion, engine);
 
-        // Compute Lorentz factor gamma in the lab frame
-        const amrex::ParticleReal g1 = std::sqrt( 1._prt + (u1x*u1x+u1y*u1y+u1z*u1z)*inv_csq );
-        const amrex::ParticleReal g2 = std::sqrt( 1._prt + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_csq );
-
-        // Compute momenta
-        const amrex::ParticleReal p1x = u1x * m1;
-        const amrex::ParticleReal p1y = u1y * m1;
-        const amrex::ParticleReal p1z = u1z * m1;
-        const amrex::ParticleReal p2x = u2x * m2;
-        const amrex::ParticleReal p2y = u2y * m2;
-        const amrex::ParticleReal p2z = u2z * m2;
-        // Square norm of the total (sum between the two particles) momenta in the lab frame
-        auto constexpr pow2 = [](double const x) { return x*x; };
-        const amrex::ParticleReal p_total_sq =  pow2(p1x+p2x) +
-                                                pow2(p1y+p2y) +
-                                                pow2(p1z+p2z);
-
-        // Total energy of proton+boron in the lab frame
-        const amrex::ParticleReal E_lab = (m1 * g1 + m2 * g2) * c_sq;
-        // Total energy squared of proton+boron in the center of mass frame, calculated using the
-        // Lorentz invariance of the four-momentum norm
-        const amrex::ParticleReal E_star_sq = E_lab*E_lab - c_sq*p_total_sq;
-        // Total energy squared of beryllium+alpha in the center of mass frame
-        // In principle, the term - E_rest_pb + E_rest_abe + E_fusion is not needed and equal to
-        // zero (i.e. the energy liberated during fusion is equal to the mass difference). However,
-        // due to possible inconsistencies in how the mass is defined in the code (e.g. currently,
-        // the mass of hydrogen is the mass of the proton, not including the electron, while the
-        // mass of the other elements is the atomic mass, that includes the electrons mass), it is
-        // probably more robust to subtract the rest masses and to add the fusion energy to the
-        // total kinetic energy.
-        const amrex::ParticleReal E_star_f_sq = pow2(std::sqrt(E_star_sq)
-                                                         - E_rest_pb + E_rest_abe + E_fusion);
-
-        // Square of the norm of the momentum of Beryllium or alpha in the center of mass frame
-        // Formula obtained by inverting E^2 = p^2*c^2 + m^2*c^4 in the COM frame for each particle
-        auto constexpr pow3 = [](double const x) { return x*x*x; };
-        const amrex::ParticleReal p_star_f_sq =
-            E_star_f_sq*0.25_prt*inv_csq - (ma_sq + mBe_sq)*c_sq*0.5_prt +
-            pow3(c_sq)*0.25_prt * pow2(ma_sq - mBe_sq) / E_star_f_sq;
-
-        // Compute momentum of first alpha in the center of mass frame, assuming isotropic
-        // distribution
-        amrex::ParticleReal px_star, py_star, pz_star;
-        ParticleUtils::RandomizeVelocity(px_star, py_star, pz_star, std::sqrt(p_star_f_sq),
-                                         engine);
-
-        // Next step is to convert momentum of first alpha to lab frame
-        amrex::ParticleReal px_alpha1, py_alpha1, pz_alpha1;
-        // Preliminary calculation: compute center of mass velocity vc
-        const amrex::ParticleReal mass_g = m1 * g1 + m2 * g2;
-        const amrex::ParticleReal vcx    = (p1x+p2x) / mass_g;
-        const amrex::ParticleReal vcy    = (p1y+p2y) / mass_g;
-        const amrex::ParticleReal vcz    = (p1z+p2z) / mass_g;
-        const amrex::ParticleReal vc_sq   = vcx*vcx + vcy*vcy + vcz*vcz;
-
-        // Convert momentum of first alpha to lab frame, using equation (13) of F. Perez et al.,
-        // Phys.Plasmas.19.083104 (2012)
-        if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
-        {
-            const amrex::ParticleReal gc = 1._prt / std::sqrt( 1._prt - vc_sq*inv_csq );
-            const amrex::ParticleReal g_star = std::sqrt(1._prt + p_star_f_sq / (ma_sq*c_sq));
-            const amrex::ParticleReal vcDps = vcx*px_star + vcy*py_star + vcz*pz_star;
-            const amrex::ParticleReal factor0 = (gc-1._prt)/vc_sq;
-            const amrex::ParticleReal factor = factor0*vcDps + m_alpha*g_star*gc;
-            px_alpha1 = px_star + vcx * factor;
-            py_alpha1 = py_star + vcy * factor;
-            pz_alpha1 = pz_star + vcz * factor;
-        }
-        else // If center of mass velocity is zero, we are already in the lab frame
-        {
-            px_alpha1 = px_star;
-            py_alpha1 = py_star;
-            pz_alpha1 = pz_star;
-        }
-
-        // Compute momentum of beryllium in lab frame, using total momentum conservation
-        const amrex::ParticleReal px_Be = p1x + p2x - px_alpha1;
-        const amrex::ParticleReal py_Be = p1y + p2y - py_alpha1;
-        const amrex::ParticleReal pz_Be = p1z + p2z - pz_alpha1;
+        // Compute momentum of beryllium in lab frame
+        const amrex::ParticleReal px_Be = m_beryllium * ux_Be;
+        const amrex::ParticleReal py_Be = m_beryllium * uy_Be;
+        const amrex::ParticleReal pz_Be = m_beryllium * uz_Be;
 
         // Compute momentum norm of second and third alphas in Beryllium rest frame
         // Factor 0.5 is here because each alpha only gets half of the decay energy
@@ -227,12 +154,12 @@ namespace {
         // Fill alpha species momentum data with the computed momentum (note that we actually
         // create 6 alphas, 3 at the position of the proton and 3 at the position of the boron, so
         // each computed momentum is used twice)
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start] = px_alpha1/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start] = py_alpha1/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start] = pz_alpha1/m_alpha;
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 1] = px_alpha1/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 1] = py_alpha1/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 1] = pz_alpha1/m_alpha;
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start] = ux_alpha1;
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start] = uy_alpha1;
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start] = uz_alpha1;
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 1] = ux_alpha1;
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 1] = uy_alpha1;
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 1] = uz_alpha1;
         soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 2] = px_alpha2/m_alpha;
         soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 2] = py_alpha2/m_alpha;
         soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 2] = pz_alpha2/m_alpha;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
@@ -29,17 +29,17 @@ namespace {
      * @param[in] u1y_in normalized momentum of the first colliding macroparticles along y (in m.s^-1)
      * @param[in] u1z_in normalized momentum of the first colliding macroparticles along z (in m.s^-1)
      * @param[in] m1_in mass of the first colliding macroparticles
-     * @param[in] u2x_in normalized momentum of the second colliding macroparticles along x
-     * @param[in] u2y_in normalized momentum of the second colliding macroparticles along y
-     * @param[in] u2z_in normalized momentum of the second colliding macroparticles along z
+     * @param[in] u2x_in normalized momentum of the second colliding macroparticles along x (in m.s^-1)
+     * @param[in] u2y_in normalized momentum of the second colliding macroparticles along y (in m.s^-1)
+     * @param[in] u2z_in normalized momentum of the second colliding macroparticles along z (in m.s^-1)
      * @param[in] m2_in mass of the second colliding macroparticles
      * @param[out] u1x_out normalized momentum of the first product macroparticles along x (in m.s^-1)
      * @param[out] u1y_out normalized momentum of the first product macroparticles along y (in m.s^-1)
      * @param[out] u1z_out normalized momentum of the first product macroparticles along z (in m.s^-1)
      * @param[in] m1_out mass of the first product macroparticles
-     * @param[out] u1x_out normalized momentum of the second product macroparticles along x
-     * @param[out] u1y_out normalized momentum of the second product macroparticles along y
-     * @param[out] u1z_out normalized momentum of the second product macroparticles along z
+     * @param[out] u2x_out normalized momentum of the second product macroparticles along x (in m.s^-1)
+     * @param[out] u2y_out normalized momentum of the second product macroparticles along y (in m.s^-1)
+     * @param[out] u2z_out normalized momentum of the second product macroparticles along z (in m.s^-1)
      * @param[in] m2_out mass of the second product macroparticles
      * @param[in] engine the random engine (used to calculate the angle of emission of the products)
      */

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
@@ -40,9 +40,8 @@ namespace {
      * @param[out] u1x_out normalized momentum of the second product macroparticles along x
      * @param[out] u1y_out normalized momentum of the second product macroparticles along y
      * @param[out] u1z_out normalized momentum of the second product macroparticles along z
-     * @param[in] m2_out mass of the first product macroparticles
-     * @param[in] m2_out mass of the first product macroparticles
-     * @param[in] engine the random engine (used to calculate the angle of emission of the productss)
+     * @param[in] m2_out mass of the second product macroparticles
+     * @param[in] engine the random engine (used to calculate the angle of emission of the products)
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void TwoProductFusionComputeProductMomenta (
@@ -129,7 +128,7 @@ namespace {
         const amrex::ParticleReal vcz    = (p1z_in+p2z_in) / mass_g;
         const amrex::ParticleReal vc_sq   = vcx*vcx + vcy*vcy + vcz*vcz;
 
-        // Convert momentum of first alpha to lab frame, using equation (13) of F. Perez et al.,
+        // Convert momentum of first product to lab frame, using equation (13) of F. Perez et al.,
         // Phys.Plasmas.19.083104 (2012)
         if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
         {

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
@@ -19,17 +19,30 @@
 
 namespace {
     /**
-     * \brief TODO
-     * @param[in] soa_1 struct of array data of the first colliding species
-     * @param[in] soa_2 struct of array data of the second colliding species
-     * or tritium)
-     * @param[out] ...
-     * @param[in] idx_1 index of first colliding macroparticle
-     * @param[in] idx_2 index of second colliding macroparticle
-     * @param[in]...
-     * @param[in] m1 mass of first colliding species
-     * @param[in] m2 mass of second colliding species
-     * @param[in] engine the random engine
+     * \brief Given the momenta of two colliding macroparticles in a fusion reaction,
+     * this function computes the momenta of the two product macroparticles.
+     *
+     * This is done by using the conservation of energy and momentum,
+     * and by assuming isotropic emission of the products in the center-of-mass frame
+     *
+     * @param[in] u1x_in normalized momentum of the first colliding macroparticles along x (in m.s^-1)
+     * @param[in] u1y_in normalized momentum of the first colliding macroparticles along y (in m.s^-1)
+     * @param[in] u1z_in normalized momentum of the first colliding macroparticles along z (in m.s^-1)
+     * @param[in] m1_in mass of the first colliding macroparticles
+     * @param[in] u2x_in normalized momentum of the second colliding macroparticles along x
+     * @param[in] u2y_in normalized momentum of the second colliding macroparticles along y
+     * @param[in] u2z_in normalized momentum of the second colliding macroparticles along z
+     * @param[in] m2_in mass of the second colliding macroparticles
+     * @param[out] u1x_out normalized momentum of the first product macroparticles along x (in m.s^-1)
+     * @param[out] u1y_out normalized momentum of the first product macroparticles along y (in m.s^-1)
+     * @param[out] u1z_out normalized momentum of the first product macroparticles along z (in m.s^-1)
+     * @param[in] m1_out mass of the first product macroparticles
+     * @param[out] u1x_out normalized momentum of the second product macroparticles along x
+     * @param[out] u1y_out normalized momentum of the second product macroparticles along y
+     * @param[out] u1z_out normalized momentum of the second product macroparticles along z
+     * @param[in] m2_out mass of the first product macroparticles
+     * @param[in] m2_out mass of the first product macroparticles
+     * @param[in] engine the random engine (used to calculate the angle of emission of the productss)
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void TwoProductFusionComputeProductMomenta (
@@ -80,7 +93,7 @@ namespace {
                                                 pow2(p1y_in+p2y_in) +
                                                 pow2(p1z_in+p2z_in);
 
-        // Total energy of incident species in the lab frame
+        // Total energy of incident macroparticles in the lab frame
         const amrex::ParticleReal E_lab = (m1_in * g1_in + m2_in * g2_in) * c_sq;
         // Total energy squared of proton+boron in the center of mass frame, calculated using the
         // Lorentz invariance of the four-momentum norm
@@ -141,7 +154,7 @@ namespace {
         const amrex::ParticleReal p2y_out = p1y_in + p2y_in - p1y_out;
         const amrex::ParticleReal p2z_out = p1z_in + p2z_in - p1z_out;
 
-        // Compute the momentum of the product species
+        // Compute the momentum of the product macroparticles
         u1x_out = p1x_out/m1_out;
         u1y_out = p1y_out/m1_out;
         u1z_out = p1z_out/m1_out;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionUtil.H
@@ -1,0 +1,154 @@
+/* Copyright 2022 Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef TWO_PRODUCT_FUSION_UTIL_H
+#define TWO_PRODUCT_FUSION_UTIL_H
+
+#include "Utils/ParticleUtils.H"
+#include "Utils/WarpXConst.H"
+
+#include <AMReX_Random.H>
+#include <AMReX_REAL.H>
+
+#include <cmath>
+#include <limits>
+
+namespace {
+    /**
+     * \brief TODO
+     * @param[in] soa_1 struct of array data of the first colliding species
+     * @param[in] soa_2 struct of array data of the second colliding species
+     * or tritium)
+     * @param[out] ...
+     * @param[in] idx_1 index of first colliding macroparticle
+     * @param[in] idx_2 index of second colliding macroparticle
+     * @param[in]...
+     * @param[in] m1 mass of first colliding species
+     * @param[in] m2 mass of second colliding species
+     * @param[in] engine the random engine
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void TwoProductFusionComputeProductMomenta (
+                            const amrex::ParticleReal& u1x_in,
+                            const amrex::ParticleReal& u1y_in,
+                            const amrex::ParticleReal& u1z_in,
+                            const amrex::ParticleReal& m1_in,
+                            const amrex::ParticleReal& u2x_in,
+                            const amrex::ParticleReal& u2y_in,
+                            const amrex::ParticleReal& u2z_in,
+                            const amrex::ParticleReal& m2_in,
+                            amrex::ParticleReal& u1x_out,
+                            amrex::ParticleReal& u1y_out,
+                            amrex::ParticleReal& u1z_out,
+                            const amrex::ParticleReal& m1_out,
+                            amrex::ParticleReal& u2x_out,
+                            amrex::ParticleReal& u2y_out,
+                            amrex::ParticleReal& u2z_out,
+                            const amrex::ParticleReal& m2_out,
+                            const amrex::ParticleReal& E_fusion,
+                            const amrex::RandomEngine& engine )
+    {
+        using namespace amrex::literals;
+
+        constexpr amrex::ParticleReal c_sq = PhysConst::c * PhysConst::c;
+        constexpr amrex::ParticleReal inv_csq = 1._prt / ( c_sq );
+        // Rest energy of incident particles
+        const amrex::ParticleReal E_rest_in = (m1_in + m2_in)*c_sq;
+        // Rest energy of products
+        const amrex::ParticleReal E_rest_out = (m1_out + m2_out)*c_sq;
+
+        // Compute Lorentz factor gamma in the lab frame
+        const amrex::ParticleReal g1_in = std::sqrt( 1._prt
+            + (u1x_in*u1x_in + u1y_in*u1y_in + u1z_in*u1z_in)*inv_csq );
+        const amrex::ParticleReal g2_in = std::sqrt( 1._prt
+            + (u2x_in*u2x_in + u2y_in*u2y_in + u2z_in*u2z_in)*inv_csq );
+
+        // Compute momenta
+        const amrex::ParticleReal p1x_in = u1x_in * m1_in;
+        const amrex::ParticleReal p1y_in = u1y_in * m1_in;
+        const amrex::ParticleReal p1z_in = u1z_in * m1_in;
+        const amrex::ParticleReal p2x_in = u2x_in * m2_in;
+        const amrex::ParticleReal p2y_in = u2y_in * m2_in;
+        const amrex::ParticleReal p2z_in = u2z_in * m2_in;
+        // Square norm of the total (sum between the two particles) momenta in the lab frame
+        auto constexpr pow2 = [](double const x) { return x*x; };
+        const amrex::ParticleReal p_total_sq =  pow2(p1x_in+p2x_in) +
+                                                pow2(p1y_in+p2y_in) +
+                                                pow2(p1z_in+p2z_in);
+
+        // Total energy of incident species in the lab frame
+        const amrex::ParticleReal E_lab = (m1_in * g1_in + m2_in * g2_in) * c_sq;
+        // Total energy squared of proton+boron in the center of mass frame, calculated using the
+        // Lorentz invariance of the four-momentum norm
+        const amrex::ParticleReal E_star_sq = E_lab*E_lab - c_sq*p_total_sq;
+        // Total energy squared of the products in the center of mass frame
+        // In principle, the term - E_rest_in + E_rest_out + E_fusion is not needed and equal to
+        // zero (i.e. the energy liberated during fusion is equal to the mass difference). However,
+        // due to possible inconsistencies in how the mass is defined in the code, it is
+        // probably more robust to subtract the rest masses and to add the fusion energy to the
+        // total kinetic energy.
+        const amrex::ParticleReal E_star_f_sq = pow2(std::sqrt(E_star_sq)
+                                                         - E_rest_in + E_rest_out + E_fusion);
+
+        // Square of the norm of the momentum of the products in the center of mass frame
+        // Formula obtained by inverting E^2 = p^2*c^2 + m^2*c^4 in the COM frame for each particle
+        auto constexpr pow3 = [](double const x) { return x*x*x; };
+        const amrex::ParticleReal p_star_f_sq =
+            E_star_f_sq*0.25_prt*inv_csq - (m1_out*m1_out + m2_out*m2_out)*c_sq*0.5_prt +
+            pow3(c_sq)*0.25_prt * pow2(m1_out*m1_out - m2_out*m2_out) / E_star_f_sq;
+
+        // Compute momentum of first product in the center of mass frame, assuming isotropic
+        // distribution
+        amrex::ParticleReal px_star, py_star, pz_star;
+        ParticleUtils::RandomizeVelocity(px_star, py_star, pz_star, std::sqrt(p_star_f_sq),
+                                         engine);
+
+        // Next step is to convert momenta to lab frame
+        amrex::ParticleReal p1x_out, p1y_out, p1z_out;
+        // Preliminary calculation: compute center of mass velocity vc
+        const amrex::ParticleReal mass_g = m1_in * g1_in + m2_in * g2_in;
+        const amrex::ParticleReal vcx    = (p1x_in+p2x_in) / mass_g;
+        const amrex::ParticleReal vcy    = (p1y_in+p2y_in) / mass_g;
+        const amrex::ParticleReal vcz    = (p1z_in+p2z_in) / mass_g;
+        const amrex::ParticleReal vc_sq   = vcx*vcx + vcy*vcy + vcz*vcz;
+
+        // Convert momentum of first alpha to lab frame, using equation (13) of F. Perez et al.,
+        // Phys.Plasmas.19.083104 (2012)
+        if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
+        {
+            const amrex::ParticleReal gc = 1._prt / std::sqrt( 1._prt - vc_sq*inv_csq );
+            const amrex::ParticleReal g_star = std::sqrt(1._prt + p_star_f_sq / (m1_out*m1_out*c_sq));
+            const amrex::ParticleReal vcDps = vcx*px_star + vcy*py_star + vcz*pz_star;
+            const amrex::ParticleReal factor0 = (gc-1._prt)/vc_sq;
+            const amrex::ParticleReal factor = factor0*vcDps + m1_out*g_star*gc;
+            p1x_out = px_star + vcx * factor;
+            p1y_out = py_star + vcy * factor;
+            p1z_out = pz_star + vcz * factor;
+        }
+        else // If center of mass velocity is zero, we are already in the lab frame
+        {
+            p1x_out = px_star;
+            p1y_out = py_star;
+            p1z_out = pz_star;
+        }
+
+        // Compute momentum of beryllium in lab frame, using total momentum conservation
+        const amrex::ParticleReal p2x_out = p1x_in + p2x_in - p1x_out;
+        const amrex::ParticleReal p2y_out = p1y_in + p2y_in - p1y_out;
+        const amrex::ParticleReal p2z_out = p1z_in + p2z_in - p1z_out;
+
+        // Compute the momentum of the product species
+        u1x_out = p1x_out/m1_out;
+        u1y_out = p1y_out/m1_out;
+        u1z_out = p1z_out/m1_out;
+        u2x_out = p2x_out/m2_out;
+        u2y_out = p2y_out/m2_out;
+        u2z_out = p2z_out/m2_out;
+    }
+}
+
+#endif // TWO_PRODUCT_FUSION_UTIL_H


### PR DESCRIPTION
This PR refactors the p-B fusion code by extracting a function for the first part of the reaction (p+B -> Be+alpha). 

This part is made a separate function that can calculate the momenta of the products in any two-product reaction (X1 + X2 -> Y1+Y2), based on the conservation of energy and momentum. This will be useful in other fusion reaction (e.g. #3153 )