### PR TITLE
CMake: AMReX_PIC (`-fPIC`) for ABLASTR

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -88,7 +88,7 @@ macro(find_amrex)
         endif()
 
         # shared libs, i.e. for Python bindings, need relocatable code
-        if(WarpX_LIB)
+        if(WarpX_LIB OR ABLASTR_POSITION_INDEPENDENT_CODE)
             set(AMReX_PIC ON CACHE INTERNAL "")
         endif()
 


### PR DESCRIPTION
Superbuilds: Make sure that AMReX is also build with position independent code if the corresponding ABLASTR option is set.

Follow-up to #3081 needed for ImpactX (where we set `WarpX_LIB` and `_APP` to `OFF`).