### PR TITLE
Do not query redundant `do_back_transformed_particles`

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -99,7 +99,7 @@ void BTDiagnostics::DerivedInitData ()
     if (m_output_species_names.size() == 0 and write_species == 1)
         m_output_species_names = mpc.GetSpeciesNames();
 
-    if (m_output_species_names.size() > 0) {
+    if (m_output_species_names.size() > 0 and write_species == 1) {
         m_do_back_transformed_particles = true;
     } else {
         m_do_back_transformed_particles = false;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -149,8 +149,6 @@ BTDiagnostics::ReadParameters ()
     m_file_prefix = "diags/" + m_diag_name;
     pp_diag_name.query("file_prefix", m_file_prefix);
     pp_diag_name.query("do_back_transformed_fields", m_do_back_transformed_fields);
-    pp_diag_name.query("do_back_transformed_particles", m_do_back_transformed_particles);
-    AMREX_ALWAYS_ASSERT(m_do_back_transformed_fields or m_do_back_transformed_particles);
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_back_transformed_fields, " fields must be turned on for the new back-transformed diagnostics");
     if (m_do_back_transformed_fields == false) m_varnames.clear();
 


### PR DESCRIPTION
This input parameter (which is not in the doc) is redundant with the `write_species` input parameter and is in fact never used since it is overwritten there:

https://github.com/ECP-WarpX/WarpX/blob/95e92ff51599b685af4d09f867af4c49a42f2a72/Source/Diagnostics/BTDiagnostics.cpp#L102-L105

I've also slightly modified line 102 above so that `m_do_back_transformed_particles` is false when `write_species` is false. I think this could happen if a user specifies a list of species to plot for this diag as well as `diag.write_species = 0`. In that case `m_do_back_transformed_particles` would be set to true in the particle containers (which I guess causes some memory allocation), which I think should not be the case because the diagnostic member variable `m_output_species_names` would be cleared soon after:

https://github.com/ECP-WarpX/WarpX/blob/95e92ff51599b685af4d09f867af4c49a42f2a72/Source/Diagnostics/Diagnostics.cpp#L313-L322