### PR TITLE
Fix value of particle container m_do_back_transformed_particles when …

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -107,9 +107,11 @@ void BTDiagnostics::DerivedInitData ()
     // Turn on do_back_transformed_particles in the particle containers so that
     // the tmp_particle_data is allocated and the data of the corresponding species is
     // copied and stored in tmp_particle_data before particles are pushed.
-    for (auto const& species : m_output_species_names){
+    if (m_do_back_transformed_particles) {
         mpc.SetDoBackTransformedParticles(m_do_back_transformed_particles);
-        mpc.SetDoBackTransformedParticles(species, m_do_back_transformed_particles);
+        for (auto const& species : m_output_species_names){
+            mpc.SetDoBackTransformedParticles(species, m_do_back_transformed_particles);
+        }
     }
     m_particles_buffer.resize(m_num_buffers);
     m_totalParticles_flushed_already.resize(m_num_buffers);


### PR DESCRIPTION
…there are multiple BT diagnostics

The value of the member variable `m_do_back_transformed_particles` in the particle containers is directly set from that of the same variable in the `BTDiagnostic` class. However, I think that in principle there can be multiple BT diagnostics but there will only be one e.g. `MultiParticleContainer`.
Looking at the code, it looks like the value of `m_do_back_transformed_particles` in the particle containers will be that of the last BT diagnostic that is initialized. This is potentially incorrect (for instance if the last BTdiagnostic has particles turned off but the one before has particles turned on), and I would think that the correct way would be to set `m_do_back_transformed_particles` to `true` in the particle containers if it is true for at least one of the BT diags. Am I correct?