### PR TITLE
Remove temporary copy of MultiFab

### DIFF
--- a/Source/ablastr/utils/Communication.cpp
+++ b/Source/ablastr/utils/Communication.cpp
@@ -65,16 +65,7 @@ void FillBoundary (amrex::MultiFab &mf, bool do_single_precision_comms, const am
 
     if (do_single_precision_comms)
     {
-        amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
-                                                                 mf.DistributionMap(),
-                                                                 mf.nComp(),
-                                                                 mf.nGrowVect());
-
-        mixedCopy(mf_tmp, mf, 0, 0, mf.nComp(), mf.nGrowVect());
-
-        mf_tmp.FillBoundary(period);
-
-        mixedCopy(mf, mf_tmp, 0, 0, mf.nComp(), mf.nGrowVect());
+        mf.FillBoundary<comm_float_type>(period);
     }
     else
     {


### PR DESCRIPTION
Checks boxes in #3188.

Use template specification of `amrex::FillBoundary` directly with
`comm_float_type` in case of single-precision communication.

Leave out `FillBoundaryAndSync` for now because it requires AMReX changes.

Should this wait for AMReX changes of the other Comm utils like `FillBoundaryAndSync`, `ParallelCopy`, `SumBoundary` etc.?