### PR TITLE
Use ablastr::utils::communication::FillBoundary instead of amrex::FillBoundary in PML_RZ

### DIFF
--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -14,6 +14,8 @@
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
 
+#include <ablastr/utils/Communication.H>
+
 #include <AMReX.H>
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
@@ -148,7 +150,7 @@ PML_RZ::FillBoundaryE (PatchType patch_type)
     {
         const amrex::Periodicity& period = m_geom->periodicity();
         Vector<amrex::MultiFab*> mf{pml_E_fp[0].get(),pml_E_fp[1].get()};
-        amrex::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
 }
 
@@ -165,7 +167,7 @@ PML_RZ::FillBoundaryB (PatchType patch_type)
     {
         const amrex::Periodicity& period = m_geom->periodicity();
         Vector<amrex::MultiFab*> mf{pml_B_fp[0].get(),pml_B_fp[1].get()};
-        amrex::FillBoundary(mf, period);
+        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
     }
 }
 


### PR DESCRIPTION
This is a small fix to make PML_RZ consistent with the rest of the code.