### PR TITLE
Initialize multi-physics module (ionization, QED) when restarting a simulation from a checkpoint

### DIFF
--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -93,6 +93,8 @@ public:
 
     void InitData ();
 
+    void InitMultiPhysicsModules ();
+
     ///
     /// This evolves all the particles by one PIC time step, including current deposition, the
     /// field solve, and pushing the particles, for all the species in the MultiParticleContainer.

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -397,6 +397,29 @@ MultiParticleContainer::AllocData ()
 void
 MultiParticleContainer::InitData ()
 {
+    InitMultiPhysicsModules();
+
+    for (auto& pc : allcontainers) {
+        pc->InitData();
+    }
+    pc_tmp->InitData();
+
+}
+
+void
+MultiParticleContainer::PostRestart ()
+{
+    InitMultiPhysicsModules();
+
+    for (auto& pc : allcontainers) {
+        pc->PostRestart();
+    }
+    pc_tmp->PostRestart();
+}
+
+void
+MultiParticleContainer::InitMultiPhysicsModules ()
+{
     // Init ionization module here instead of in the MultiParticleContainer
     // constructor because dt is required to compute ionization rate pre-factors
     for (auto& pc : allcontainers) {
@@ -410,21 +433,6 @@ MultiParticleContainer::InitData ()
     CheckQEDProductSpecies();
     InitQED();
 #endif
-
-    for (auto& pc : allcontainers) {
-        pc->InitData();
-    }
-    pc_tmp->InitData();
-
-}
-
-void
-MultiParticleContainer::PostRestart ()
-{
-    for (auto& pc : allcontainers) {
-        pc->PostRestart();
-    }
-    pc_tmp->PostRestart();
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -397,21 +397,34 @@ MultiParticleContainer::AllocData ()
 void
 MultiParticleContainer::InitData ()
 {
+    // Init ionization module here instead of in the MultiParticleContainer
+    // constructor because dt is required to compute ionization rate pre-factors
     for (auto& pc : allcontainers) {
-        pc->InitData();
+        pc->InitIonizationModule();
     }
-    pc_tmp->InitData();
     // For each species, get the ID of its product species.
     // This is used for ionization and pair creation processes.
     mapSpeciesProduct();
-
     CheckIonizationProductSpecies();
-
 #ifdef WARPX_QED
     CheckQEDProductSpecies();
     InitQED();
 #endif
 
+    for (auto& pc : allcontainers) {
+        pc->InitData();
+    }
+    pc_tmp->InitData();
+
+}
+
+void
+MultiParticleContainer::PostRestart ()
+{
+    for (auto& pc : allcontainers) {
+        pc->PostRestart();
+    }
+    pc_tmp->PostRestart();
 }
 
 void
@@ -654,15 +667,6 @@ MultiParticleContainer::SetParticleDistributionMap (int lev, DistributionMapping
     for (auto& pc : allcontainers) {
         pc->SetParticleDistributionMap(lev,new_dm);
     }
-}
-
-void
-MultiParticleContainer::PostRestart ()
-{
-    for (auto& pc : allcontainers) {
-        pc->PostRestart();
-    }
-    pc_tmp->PostRestart();
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -64,7 +64,7 @@ public:
 
     virtual void WriteHeader (std::ostream& os) const override;
 
-    void InitIonizationModule ();
+    virtual void InitIonizationModule () override;
 
     /**
      * \brief Evolve is the central function PhysicalParticleContainer that

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -385,9 +385,6 @@ PhysicalParticleContainer::BackwardCompatibility ()
 
 void PhysicalParticleContainer::InitData ()
 {
-    // Init ionization module here instead of in the PhysicalParticleContainer
-    // constructor because dt is required
-    if (do_field_ionization) {InitIonizationModule();}
     AddParticles(0); // Note - add on level 0
     Redistribute();  // We then redistribute
 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -130,7 +130,7 @@ public:
 
     virtual void InitData () = 0;
 
-    virtual void InitIonizationModule () {};
+    virtual void InitIonizationModule () {}
 
     /**
      * Evolve is the central WarpXParticleContainer function that advances

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -130,6 +130,8 @@ public:
 
     virtual void InitData () = 0;
 
+    virtual void InitIonizationModule () {};
+
     /**
      * Evolve is the central WarpXParticleContainer function that advances
      * particles for a time dt (typically one timestep). It is a pure virtual


### PR DESCRIPTION
In the current version of WarpX, the initialization of the multi-physics module (ionization, QED) is done in the function `MultiParticleContainer::InitData`. This function is only called when starting a simulation from scratch, not when restarting a simulation from a checkpoint (when restarting a simulation, the code calls `MultiParticleContainer::PostRestart` instead of `MultiParticleContainer::InitData`).

In this PR, the initialization of the multi-physics module is isolated into a dedicated function (`InitMultiPhysicsModules`) which is now called both in `InitData` and `PostRestart`.