### PR TITLE
Remove Unused Function `getcurrent`

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -362,7 +362,6 @@ public:
     amrex::MultiFab * get_pointer_edge_lengths  (int lev, int direction) const { return m_edge_lengths[lev][direction].get(); }
     amrex::MultiFab * get_pointer_face_areas  (int lev, int direction) const { return m_face_areas[lev][direction].get(); }
 
-    const amrex::MultiFab& getcurrent (int lev, int direction) {return *current_fp[lev][direction];}
     const amrex::MultiFab& getEfield  (int lev, int direction) {return *Efield_aux[lev][direction];}
     const amrex::MultiFab& getBfield  (int lev, int direction) {return *Bfield_aux[lev][direction];}
 


### PR DESCRIPTION
I noticed that this function `getcurrent` is a duplicate of `getcurrent_fp`, defined here
https://github.com/ECP-WarpX/WarpX/blob/b6af289b96ebdbf3d46ae66ee00b3216f560349a/Source/WarpX.H#L376
and it is not used anywhere in the code, hence I think we can remove it.