### PR TITLE
Enable openPMD diagnostics with only particles (no fields)

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1992,7 +1992,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
-    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Note that ``phi`` will only be written out when do_electrostatic==labframe. Also, note that for ``<diag_name>.diag_type = BackTransformed``, the only scalar field currently supported is ``rho``.
+    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``divE`` ``divB`` and ``rho_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species. Use ``<diag_name>.fields_to_plot = none`` in order to disable field output (only available with the openPMD output format). Note that ``phi`` will only be written out when do_electrostatic==labframe. Also, note that for ``<diag_name>.diag_type = BackTransformed``, the only scalar field currently supported is ``rho``.
     Possible vector field components in Cartesian geometry: ``Ex`` ``Ey`` ``Ez`` ``Bx`` ``By`` ``Bz`` ``jx`` ``jy`` ``jz``.
     Possible vector field components in RZ geometry: ``Er`` ``Et`` ``Ez`` ``Br`` ``Bt`` ``Bz`` ``jr`` ``jt`` ``jz``.
     Default is ``<diag_name>.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz``,

--- a/Examples/Tests/scraping/inputs_rz
+++ b/Examples/Tests/scraping/inputs_rz
@@ -50,7 +50,7 @@ diag1.fields_to_plot = Ex
 
 diag2.intervals = 1
 diag2.diag_type = Full
-diag2.fields_to_plot = Er
+diag2.fields_to_plot = none
 diag2.format = openpmd
 
 diag3.diag_type = BoundaryScraping

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -69,6 +69,11 @@ Diagnostics::BaseReadParameters ()
             m_varnames_fields = {"Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"};
         }
     }
+    if (m_varnames_fields[0] == "none") {
+        m_varnames_fields = {};
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_format == "openpmd",
+           "`fields_to_plot = none` only works in combination with `format = openpmd`");
+    }
 
     // Sanity check if user requests to plot phi
     if (WarpXUtilStr::is_in(m_varnames_fields, "phi")){


### PR DESCRIPTION
This PR allows the user to only output particles (no fields), by setting:
```
<diag_name>.fields_to_plot = none
```
in the input script.

This currently only works with the openPMD format since, by construction, plotfiles require at least one field to be output.