### PR TITLE
Optimizations for BP5 engine of ADIOS2: Use span-based API and avoid flushing before closing an Iteration

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -732,7 +732,6 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
     }
 
     // open files from all processors, in case some will not contribute below
-    // @todo move to SetStep
     m_Series->flush();
 
     // dump individual particles
@@ -815,15 +814,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
             offset += numParticleOnTile64;
         }
     }
-    /*
-     * Deliberately not flushing here.
-     * The ADIOS2 BP5 engine can read data directly from user-specified pointers
-     * if there happens no adios2::Engine::PerformPuts() (invoked by Series::flush())
-     * before adios2::Engine::EndStep() (invoked by Iteration::close()).
-     * So, in order to avoid unneeded data copies, don't flush anymore until
-     * closing this iteration.
-     */
-    // m_Series->flush();
+    m_Series->flush();
 }
 
 void
@@ -1423,15 +1414,8 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
 #ifdef AMREX_USE_GPU
         amrex::Gpu::streamSynchronize();
 #endif
-        /*
-         * Deliberately not flushing here.
-         * The ADIOS2 BP5 engine can read data directly from user-specified pointers
-         * if there happens no adios2::Engine::PerformPuts() (invoked by Series::flush())
-         * before adios2::Engine::EndStep() (invoked by Iteration::close()).
-         * So, in order to avoid unneeded data copies, don't flush anymore until
-         * closing this iteration.
-         */
-        // m_Series->flush();
+        // Flush data to disk after looping over all components
+        m_Series->flush();
     } // levels loop (i)
 }
 #endif // WARPX_USE_OPENPMD

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -732,6 +732,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
     }
 
     // open files from all processors, in case some will not contribute below
+    // @todo move to SetStep
     m_Series->flush();
 
     // dump individual particles
@@ -814,7 +815,15 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
             offset += numParticleOnTile64;
         }
     }
-    m_Series->flush();
+    /*
+     * Deliberately not flushing here.
+     * The ADIOS2 BP5 engine can read data directly from user-specified pointers
+     * if there happens no adios2::Engine::PerformPuts() (invoked by Series::flush())
+     * before adios2::Engine::EndStep() (invoked by Iteration::close()).
+     * So, in order to avoid unneeded data copies, don't flush anymore until
+     * closing this iteration.
+     */
+    // m_Series->flush();
 }
 
 void
@@ -1414,8 +1423,15 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
 #ifdef AMREX_USE_GPU
         amrex::Gpu::streamSynchronize();
 #endif
-        // Flush data to disk after looping over all components
-        m_Series->flush();
+        /*
+         * Deliberately not flushing here.
+         * The ADIOS2 BP5 engine can read data directly from user-specified pointers
+         * if there happens no adios2::Engine::PerformPuts() (invoked by Series::flush())
+         * before adios2::Engine::EndStep() (invoked by Iteration::close()).
+         * So, in order to avoid unneeded data copies, don't flush anymore until
+         * closing this iteration.
+         */
+        // m_Series->flush();
     } // levels loop (i)
 }
 #endif // WARPX_USE_OPENPMD

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -756,14 +756,10 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
                 auto const positionComponents = detail::getParticlePositionComponentLabels();
 #if defined(WARPX_DIM_RZ)
                 {
-                   std::shared_ptr<amrex::ParticleReal> z(
-                           new amrex::ParticleReal[numParticleOnTile],
-                           [](amrex::ParticleReal const *p) { delete[] p; }
-                   );
+                   auto z = currSpecies["position"]["z"].storeChunk<amrex::ParticleReal>({offset}, {numParticleOnTile64});
+                   auto zBuffer = z.currentBuffer();
                    for (auto i = 0; i < numParticleOnTile; i++)
-                       z.get()[i] = aos[i].pos(1);  // {0: "r", 1: "z"}
-                   std::string const positionComponent = "z";
-                   currSpecies["position"]["z"].storeChunk(z, {offset}, {numParticleOnTile64});
+                       zBuffer[i] = aos[i].pos(1);  // {0: "r", 1: "z"}
                 }
 
                 //   reconstruct x and y from polar coordinates r, theta
@@ -773,47 +769,39 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
                 WARPX_ALWAYS_ASSERT_WITH_MESSAGE(int(soa.GetRealData(PIdx::theta).size()) == numParticleOnTile,
                                                  "openPMD: theta and tile size do not match");
                 {
-                    std::shared_ptr< amrex::ParticleReal > x(
-                            new amrex::ParticleReal[numParticleOnTile],
-                            [](amrex::ParticleReal const *p){ delete[] p; }
-                    );
-                    std::shared_ptr< amrex::ParticleReal > y(
-                            new amrex::ParticleReal[numParticleOnTile],
-                            [](amrex::ParticleReal const *p){ delete[] p; }
-                    );
+                    auto x = currSpecies["position"]["x"].storeChunk<amrex::ParticleReal>({offset}, {numParticleOnTile64});
+                    auto y = currSpecies["position"]["y"].storeChunk<amrex::ParticleReal>({offset}, {numParticleOnTile64});
+                    auto xBuffer = x.currentBuffer();
+                    auto yBuffer = y.currentBuffer();
                     for (auto i=0; i<numParticleOnTile; i++) {
                         auto const r = aos[i].pos(0);  // {0: "r", 1: "z"}
-                        x.get()[i] = r * std::cos(theta[i]);
-                        y.get()[i] = r * std::sin(theta[i]);
+                        xBuffer[i] = r * std::cos(theta[i]);
+                        yBuffer[i] = r * std::sin(theta[i]);
                     }
-                    currSpecies["position"]["x"].storeChunk(x, {offset}, {numParticleOnTile64});
-                    currSpecies["position"]["y"].storeChunk(y, {offset}, {numParticleOnTile64});
                 }
 #else
                 for (auto currDim = 0; currDim < AMREX_SPACEDIM; currDim++) {
-                    std::shared_ptr<amrex::ParticleReal> curr(
-                            new amrex::ParticleReal[numParticleOnTile],
-                            [](amrex::ParticleReal const *p) { delete[] p; }
-                    );
-                    for (auto i = 0; i < numParticleOnTile; i++) {
-                        curr.get()[i] = aos[i].pos(currDim);
-                    }
+                    // std::shared_ptr<amrex::ParticleReal> curr(
+                    //         new amrex::ParticleReal[numParticleOnTile],
+                    //         [](amrex::ParticleReal const *p) { delete[] p; }
+                    // );
                     std::string const positionComponent = positionComponents[currDim];
-                    currSpecies["position"][positionComponent].storeChunk(curr, {offset},
+                    auto curr = currSpecies["position"][positionComponent].storeChunk<amrex::ParticleReal>({offset},
                                                                           {numParticleOnTile64});
+                    auto currBuffer = curr.currentBuffer();
+                    for (auto i = 0; i < numParticleOnTile; i++) {
+                        currBuffer[i] = aos[i].pos(currDim);
+                    }
                 }
 #endif
 
                 // save particle ID after converting it to a globally unique ID
-                std::shared_ptr<uint64_t> ids(
-                        new uint64_t[numParticleOnTile],
-                        [](uint64_t const *p) { delete[] p; }
-                );
-                for (auto i = 0; i < numParticleOnTile; i++) {
-                    ids.get()[i] = ablastr::particles::localIDtoGlobal(aos[i].id(), aos[i].cpu());
-                }
                 auto const scalar = openPMD::RecordComponent::SCALAR;
-                currSpecies["id"][scalar].storeChunk(ids, {offset}, {numParticleOnTile64});
+                auto ids = currSpecies["id"][scalar].storeChunk<uint64_t>({offset}, {numParticleOnTile64});
+                auto idsBuffer = ids.currentBuffer();
+                for (auto i = 0; i < numParticleOnTile; i++) {
+                    idsBuffer[i] = ablastr::particles::localIDtoGlobal(aos[i].id(), aos[i].cpu());
+                }
 
             }
             //  save "extra" particle properties in AoS and SoA
@@ -932,16 +920,13 @@ WarpXOpenPMDPlot::SaveRealProperty (ParticleIter& pti,
           auto currRecord = currSpecies[record_name];
           auto currRecordComp = currRecord[component_name];
 
-          std::shared_ptr< amrex::ParticleReal > d(
-              new amrex::ParticleReal[numParticleOnTile],
-              [](amrex::ParticleReal const *p){ delete[] p; }
-          );
-
-          for( auto kk=0; kk<numParticleOnTile; kk++ )
-               d.get()[kk] = aos[kk].rdata(idx);
-
-          currRecordComp.storeChunk(d,
+          auto d = currRecordComp.storeChunk<amrex::ParticleReal>(
                {offset}, {numParticleOnTile64});
+
+          auto dBuffer = d.currentBuffer();
+          for( auto kk=0; kk<numParticleOnTile; kk++ )
+               dBuffer[kk] = aos[kk].rdata(idx);
+
       }
     }
   }


### PR DESCRIPTION
Unlike previous engines in ADIOS2, BP5 can avoid copying data to internal buffers if one uses an optimized workflow. The following sequence of operations should be avoided:
```cpp
engine.Put(dataPtr, …, adios2::Mode::Deferred);
// …
engine.PerformPuts(); // this provokes a copy to internal buffers
// …
engine.EndStep();
```

This PR uses two optimizations to avoid that workflow:

1. Use the Span API of openPMD/ADIOS2. Instead of creating buffers inside WarpX, this asks the IO backend to create a buffer for us to write into it. The problem of data copies is avoided entirely since the data is created at the right place already.
    This optimization benefits all ADIOS2 engines that support the Span API (e.g. BP4), openPMD-api automatically switches to a fallback otherwise.
2. In other places, the data already exists in WarpX in the right format as static data, or needs to be downloaded into pinned memory which is not supported by the Span API. The "normal" storeChunk/Put API must be used, so the above workflow should be avoided. Do this by deleting instances of `Series::flush()` between `RecordComponent::storeChunk()` and `Iteration::endStep()`.

Notes:

* For creating a memory profile and seeing if this PR makes a difference: https://github.com/KDE/heaptrack
* Optimization (2) is hard to maintain. There is nothing that stops someone to put a `Series::flush()` somewhere in these routines at a later point, this way destroying the optimization again.
    Suggestion: Add something like `Series::promiseNoFlushesUntilEndstep()` to the openPMD-api that throws an error if a flush does indeed happen.
* Another idea we had was to add a `unique_ptr` overload to `RecordComponent::storeChunk()`. This way, the backend knows that it is the unique owner of the data and can autonomously decide to delay showing the data to ADIOS2 until directly before EndStep. This is semantically only applicable to the pinned memory instance here in WarpX, the other places are static data, not unique data.

Question to Axel: The following shared_ptr does correctly handle destroying the pinned memory again, right? There is no custom destructor given, so I'm wondering.
```cpp
#ifdef AMREX_USE_GPU
                if (fab.arena()->isManaged() || fab.arena()->isDevice()) {
                    amrex::BaseFab<amrex::Real> foo(local_box, 1, amrex::The_Pinned_Arena());
                    std::shared_ptr<amrex::Real> data_pinned(foo.release());
                    amrex::Gpu::dtoh_memcpy_async(data_pinned.get(), fab.dataPtr(icomp), local_box.numPts()*sizeof(amrex::Real));
                    // intentionally delayed until before we .flush(): amrex::Gpu::streamSynchronize();
                    mesh_comp.storeChunk(data_pinned, chunk_offset, chunk_size);
                } else
#endif
```

Close #3133