### PR TITLE
[WIP] Esirkepov: Avoid Dynamic Loops & Indices

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -540,8 +540,8 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             // which can be at a different grid location.
             // Keep these double to avoid bug in single precision
 #if !defined(WARPX_DIM_1D_Z)
-            double sx_new[depos_order + 3] = {0.};
-            double sx_old[depos_order + 3] = {0.};
+            double sx_new[depos_order + 2] = {0.};
+            double sx_old[depos_order + 2] = {0.};
 #endif
 #if defined(WARPX_DIM_3D)
             // Keep these double to avoid bug in single precision
@@ -556,11 +556,24 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             // Compute shape factors for position as they are now and at old positions
             // [ijk]_new: leftmost grid point that the particle touches
             Compute_shape_factor< depos_order > compute_shape_factor;
+            Compute_shape_factor_uni< depos_order > compute_shape_factor_uni;
             Compute_shifted_shape_factor< depos_order > compute_shifted_shape_factor;
 
 #if !defined(WARPX_DIM_1D_Z)
-            const int i_new = compute_shape_factor(sx_new+1, x_new);
-            const int i_old = compute_shifted_shape_factor(sx_old, x_old, i_new);
+            constexpr double half_cell_even_order = (depos_order+1)%2 * 0.5;
+            constexpr int half_cell_left_offset = depos_order/2;
+            // index of the cell the particle belongs to
+            const int i_new = static_cast<int>(x_new + half_cell_even_order);
+            const int i_old = static_cast<int>(x_old + half_cell_even_order);
+
+            const int i_min = std::min(i_new, i_old);  // just used if left/right moving
+            const int i_shift_new = (i_new-i_min);  // 0 or 1
+            const int i_shift_old = (i_old-i_min);  // 0 or 1
+            compute_shape_factor_uni(i_new, sx_new+i_shift_new, x_new);
+            compute_shape_factor_uni(i_old, sx_old+i_shift_old, x_old);
+
+            // index of the leftmost cell where particle deposits
+            const int i_leftmost = i_min - half_cell_left_offset;
 #endif
 #if defined(WARPX_DIM_3D)
             const int j_new = compute_shape_factor(sy_new+1, y_new);
@@ -569,11 +582,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             const int k_new = compute_shape_factor(sz_new+1, z_new);
             const int k_old = compute_shifted_shape_factor(sz_old, z_old, k_new);
 
-            // computes min/max positions of current contributions
+            // computes max positions of current contributions
 #if !defined(WARPX_DIM_1D_Z)
-            int dil = 1, diu = 1;
-            if (i_old < i_new) dil = 0;
-            if (i_old > i_new) diu = 0;
+            int diu = (i_old != i_new) ? 1 : 0;
 #endif
 #if defined(WARPX_DIM_3D)
             int djl = 1, dju = 1;
@@ -594,12 +605,11 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     if (j > depos_order+2-dju) continue;
                     amrex::Real sdxi = 0._rt;
                     for (int i=0; i<=depos_order+1; i++) {
-                        if (i < dil) continue;
-                        if (i > depos_order+1-diu) continue;
+                        if (i > depos_order-diu) continue;
                         sdxi += wqx*(sx_old[i] - sx_new[i])*(
                             one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
                            +one_sixth*(sy_new[j]*sz_old[k] + sy_old[j]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
+                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_leftmost+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
                     }
                 }
             }
@@ -607,8 +617,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 if (k < dkl) continue;
                 if (k > depos_order+2-dku) continue;
                 for (int i=0; i<=depos_order+2; i++) {
-                    if (i < dil) continue;
-                    if (i > depos_order+2-diu) continue;
+                    if (i > depos_order+1-diu) continue;
                     amrex::Real sdyj = 0._rt;
                     for (int j=0; j<=depos_order+1; j++) {
                         if (j < djl) continue;
@@ -616,16 +625,15 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                         sdyj += wqy*(sy_old[j] - sy_new[j])*(
                             one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                            +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
+                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_leftmost+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
                     }
                 }
             }
             for (int j=0; j<=depos_order+2; j++) {
                 if (j < djl) continue;
                 if (j > depos_order+2-dju) continue;
-                for (int i=0; i<=depos_order+2; i++) {
-                    if (i < dil) continue;
-                    if (i > depos_order+2) continue;
+                for (int i=0; i<=depos_order+1; i++) {
+                    if (i > depos_order+1-diu) continue;
                     amrex::Real sdzk = 0._rt;
                     for (int k=0; k<=depos_order+1; k++) {
                         if (k < dkl) continue;
@@ -633,7 +641,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                         sdzk += wqz*(sz_old[k] - sz_new[k])*(
                             one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])
                            +one_sixth*(sx_new[i]*sy_old[j] + sx_old[i]*sy_new[j]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
+                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_leftmost+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
                     }
                 }
             }
@@ -645,17 +653,16 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 if (k > depos_order+2-dku) continue;
                 amrex::Real sdxi = 0._rt;
                 for (int i=0; i<=depos_order+1; i++) {
-                    if (i < dil) continue;
                     if (i > depos_order+1-diu) continue;
                     sdxi += wqx*(sx_old[i] - sx_new[i])*0.5_rt*(sz_new[k] + sz_old[k]);
-                    amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdxi);
+                    amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 0), sdxi);
 #if defined(WARPX_DIM_RZ)
                     Complex xy_mid = xy_mid0; // Throughout the following loop, xy_mid takes the value e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         const Complex djr_cmplx = 2._rt *sdxi*xy_mid;
-                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djr_cmplx.real());
-                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djr_cmplx.imag());
+                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode-1), djr_cmplx.real());
+                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode), djr_cmplx.imag());
                         xy_mid = xy_mid*xy_mid0;
                     }
 #endif
@@ -665,12 +672,11 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 if (k < dkl) continue;
                 if (k > depos_order+2-dku) continue;
                 for (int i=0; i<=depos_order+2; i++) {
-                    if (i < dil) continue;
                     if (i > depos_order+2-diu) continue;
                     Real const sdyj = wq*vy*invvol*(
                         one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                        +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
-                    amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdyj);
+                    amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 0), sdyj);
 #if defined(WARPX_DIM_RZ)
                     Complex xy_new = xy_new0;
                     Complex xy_mid = xy_mid0;
@@ -679,11 +685,11 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         // The minus sign comes from the different convention with respect to Davidson et al.
-                        const Complex djt_cmplx = -2._rt * I*(i_new-1 + i + xmin*dxi)*wq*invdtdx/(amrex::Real)imode
+                        const Complex djt_cmplx = -2._rt * I*(i_leftmost + i + xmin*dxi)*wq*invdtdx/(amrex::Real)imode
                                                   *(Complex(sx_new[i]*sz_new[k], 0._rt)*(xy_new - xy_mid)
                                                   + Complex(sx_old[i]*sz_old[k], 0._rt)*(xy_mid - xy_old));
-                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djt_cmplx.real());
-                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djt_cmplx.imag());
+                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode-1), djt_cmplx.real());
+                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode), djt_cmplx.imag());
                         xy_new = xy_new*xy_new0;
                         xy_mid = xy_mid*xy_mid0;
                         xy_old = xy_old*xy_old0;
@@ -692,21 +698,20 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 }
             }
             for (int i=0; i<=depos_order+2; i++) {
-                if (i < dil) continue;
                 if (i > depos_order+2-diu) continue;
                 Real sdzk = 0._rt;
                 for (int k=0; k<=depos_order+1; k++) {
                     if (k < dkl) continue;
                     if (k > depos_order+1-dku) continue;
                     sdzk += wqz*(sz_old[k] - sz_new[k])*0.5_rt*(sx_new[i] + sx_old[i]);
-                    amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdzk);
+                    amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 0), sdzk);
 #if defined(WARPX_DIM_RZ)
                     Complex xy_mid = xy_mid0; // Throughout the following loop, xy_mid takes the value e^{i m theta}
                     for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
                         // The factor 2 comes from the normalization of the modes
                         const Complex djz_cmplx = 2._rt * sdzk * xy_mid;
-                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode-1), djz_cmplx.real());
-                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 2*imode), djz_cmplx.imag());
+                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode-1), djz_cmplx.real());
+                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_leftmost+i, lo.y+k_new-1+k, 0, 2*imode), djz_cmplx.imag());
                         xy_mid = xy_mid*xy_mid0;
                     }
 #endif

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -586,10 +586,16 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int j=djl; j<=depos_order+2-dju; j++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
+                for (int j=0; j<=depos_order+2; j++) {
+                    if (j < djl) continue;
+                    if (j > depos_order+2-dju) continue;
                     amrex::Real sdxi = 0._rt;
-                    for (int i=dil; i<=depos_order+1-diu; i++) {
+                    for (int i=0; i<=depos_order+1; i++) {
+                        if (i < dil) continue;
+                        if (i > depos_order+1-diu) continue;
                         sdxi += wqx*(sx_old[i] - sx_new[i])*(
                             one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
                            +one_sixth*(sy_new[j]*sz_old[k] + sy_old[j]*sz_new[k]));
@@ -597,10 +603,16 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     }
                 }
             }
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int i=dil; i<=depos_order+2-diu; i++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
+                for (int i=0; i<=depos_order+2; i++) {
+                    if (i < dil) continue;
+                    if (i > depos_order+2-diu) continue;
                     amrex::Real sdyj = 0._rt;
-                    for (int j=djl; j<=depos_order+1-dju; j++) {
+                    for (int j=0; j<=depos_order+1; j++) {
+                        if (j < djl) continue;
+                        if (j > depos_order+1-dju) continue;
                         sdyj += wqy*(sy_old[j] - sy_new[j])*(
                             one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                            +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
@@ -608,10 +620,16 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     }
                 }
             }
-            for (int j=djl; j<=depos_order+2-dju; j++) {
-                for (int i=dil; i<=depos_order+2-diu; i++) {
+            for (int j=0; j<=depos_order+2; j++) {
+                if (j < djl) continue;
+                if (j > depos_order+2-dju) continue;
+                for (int i=0; i<=depos_order+2; i++) {
+                    if (i < dil) continue;
+                    if (i > depos_order+2) continue;
                     amrex::Real sdzk = 0._rt;
-                    for (int k=dkl; k<=depos_order+1-dku; k++) {
+                    for (int k=0; k<=depos_order+1; k++) {
+                        if (k < dkl) continue;
+                        if (k > depos_order+1-dku) continue;
                         sdzk += wqz*(sz_old[k] - sz_new[k])*(
                             one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])
                            +one_sixth*(sx_new[i]*sy_old[j] + sx_old[i]*sy_new[j]));
@@ -622,9 +640,13 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
 
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
                 amrex::Real sdxi = 0._rt;
-                for (int i=dil; i<=depos_order+1-diu; i++) {
+                for (int i=0; i<=depos_order+1; i++) {
+                    if (i < dil) continue;
+                    if (i > depos_order+1-diu) continue;
                     sdxi += wqx*(sx_old[i] - sx_new[i])*0.5_rt*(sz_new[k] + sz_old[k]);
                     amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdxi);
 #if defined(WARPX_DIM_RZ)
@@ -639,8 +661,12 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 #endif
                 }
             }
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int i=dil; i<=depos_order+2-diu; i++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
+                for (int i=0; i<=depos_order+2; i++) {
+                    if (i < dil) continue;
+                    if (i > depos_order+2-diu) continue;
                     Real const sdyj = wq*vy*invvol*(
                         one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                        +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
@@ -665,9 +691,13 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 #endif
                 }
             }
-            for (int i=dil; i<=depos_order+2-diu; i++) {
+            for (int i=0; i<=depos_order+2; i++) {
+                if (i < dil) continue;
+                if (i > depos_order+2-diu) continue;
                 Real sdzk = 0._rt;
-                for (int k=dkl; k<=depos_order+1-dku; k++) {
+                for (int k=0; k<=depos_order+1; k++) {
+                    if (k < dkl) continue;
+                    if (k > depos_order+1-dku) continue;
                     sdzk += wqz*(sz_old[k] - sz_new[k])*0.5_rt*(sx_new[i] + sx_old[i]);
                     amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+k_new-1+k, 0, 0), sdzk);
 #if defined(WARPX_DIM_RZ)
@@ -684,17 +714,23 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             }
 #elif defined(WARPX_DIM_1D_Z)
 
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
                 amrex::Real sdxi = 0._rt;
                 sdxi += wq*vx*invvol*0.5_rt*(sz_old[k] + sz_new[k]);
                 amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+k_new-1+k, 0, 0, 0), sdxi);
             }
-            for (int k=dkl; k<=depos_order+2-dku; k++) {
+            for (int k=0; k<=depos_order+2; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+2-dku) continue;
                 amrex::Real sdyj = 0._rt;
                 sdyj += wq*vy*invvol*0.5_rt*(sz_old[k] + sz_new[k]);
                 amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+k_new-1+k, 0, 0, 0), sdyj);
             }
-            for (int k=dkl; k<=depos_order+1-dku; k++) {
+            for (int k=0; k<=depos_order+1; k++) {
+                if (k < dkl) continue;
+                if (k > depos_order+1-dku) continue;
                 amrex::Real sdzk = 0._rt;
                 sdzk += wqz*(sz_old[k] - sz_new[k]);
                 amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+k_new-1+k, 0, 0, 0), sdzk);

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -94,20 +94,27 @@ struct Compute_shifted_shape_factor
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
-            //const int i_shift = i - i_new;
+            const int i_shift = i - i_new;
             //sx[1+i_shift] = T(1.0) - xint;
             //sx[2+i_shift] = xint;
             sx[1] = T(1.0) - xint;
             sx[2] = xint;
 
             AMREX_ASSERT_WITH_MESSAGE(
-                i - i_new == 0 || i - i_new == -1,
+                (i_shift == 0) || (i_shift == -1) || (i_shift == 1),
                 "Compute_shifted_shape_factor: shift out of range");
 
-            const bool shift = i != i_new;
-            sx[0] = shift ? sx[1] : T(0.0);
-            sx[1] = shift ? sx[2] : sx[1];
-            sx[2] = shift ? T(0.0) : sx[2];
+            const bool downshift = i_shift == -1;
+            sx[0] = downshift ? sx[1] : T(0.0);
+            sx[1] = downshift ? sx[2] : sx[1];
+            sx[2] = downshift ? sx[3] : sx[2];
+            sx[3] = downshift ? T(0.0) : sx[3];
+
+            const bool upshift = i_shift == 1;
+            sx[3] = upshift ? sx[2] : T(0.0);
+            sx[2] = upshift ? sx[1] : sx[2];
+            sx[1] = upshift ? sx[0] : sx[1];
+            sx[0] = upshift ? T(0.0) : sx[0];
 
             return i;
         }
@@ -118,24 +125,32 @@ struct Compute_shifted_shape_factor
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
-            //const int i_shift = i - (i_new + 1);
+            const int i_shift = i - (i_new + 1);
             //sx[1+i_shift] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
             //sx[2+i_shift] = T(0.75) - xint*xint;
             //sx[3+i_shift] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
 
             AMREX_ASSERT_WITH_MESSAGE(
-                i - (i_new + 1) == 0 || i - (i_new + 1) == -1,
+                (i_shift == 0) || (i_shift == -1) || (i_shift == 1),
                 "Compute_shifted_shape_factor: shift out of range");
 
-            const bool shift = i != (i_new + 1);
             sx[1] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
             sx[2] = T(0.75) - xint*xint;
             sx[3] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
 
-            sx[0] = shift ? sx[1] : T(0.0);
-            sx[1] = shift ? sx[2] : sx[1];
-            sx[2] = shift ? sx[3] : sx[2];
-            sx[3] = shift ? T(0.0) : sx[3];
+            const bool downshift = i_shift == -1;
+            sx[0] = downshift ? sx[1] : T(0.0);
+            sx[1] = downshift ? sx[2] : sx[1];
+            sx[2] = downshift ? sx[3] : sx[2];
+            sx[3] = downshift ? sx[4] : sx[3];
+            sx[4] = downshift ? T(0.0) : sx[4];
+
+            const bool upshift = i_shift == 1;
+            sx[4] = upshift ? sx[3] : T(0.0);
+            sx[3] = upshift ? sx[2] : sx[3];
+            sx[2] = upshift ? sx[1] : sx[2];
+            sx[1] = upshift ? sx[0] : sx[1];
+            sx[0] = upshift ? T(0.0) : sx[0];
 
             // index of the leftmost cell where particle deposits
             return i - 1;
@@ -147,27 +162,36 @@ struct Compute_shifted_shape_factor
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
-            //const int i_shift = i - (i_new + 1);
+            const int i_shift = i - (i_new + 1);
             //sx[1+i_shift] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
             //sx[2+i_shift] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
             //sx[3+i_shift] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
             //sx[4+i_shift] = (T(1.0))/(T(6.0))*xint*xint*xint;
 
             AMREX_ASSERT_WITH_MESSAGE(
-                i - (i_new + 1) == 0 || i - (i_new + 1) == -1,
+                (i_shift == 0) || (i_shift == -1) || (i_shift == 1),
                 "Compute_shifted_shape_factor: shift out of range");
 
-            const bool shift = i != (i_new + 1);
             sx[1] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
             sx[2] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
             sx[3] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
             sx[4] = (T(1.0))/(T(6.0))*xint*xint*xint;
 
-            sx[0] = shift ? sx[1] : T(0.0);
-            sx[1] = shift ? sx[2] : sx[1];
-            sx[2] = shift ? sx[3] : sx[2];
-            sx[3] = shift ? sx[4] : sx[3];
-            sx[4] = shift ? T(0.0) : sx[4];
+            const bool downshift = i_shift == -1;
+            sx[0] = downshift ? sx[1] : T(0.0);
+            sx[1] = downshift ? sx[2] : sx[1];
+            sx[2] = downshift ? sx[3] : sx[2];
+            sx[3] = downshift ? sx[4] : sx[3];
+            sx[4] = downshift ? sx[5] : sx[4];
+            sx[5] = downshift ? T(0.0) : sx[5];
+
+            const bool upshift = i_shift == 1;
+            sx[5] = upshift ? sx[4] : T(0.0);
+            sx[4] = upshift ? sx[3] : sx[4];
+            sx[3] = upshift ? sx[2] : sx[3];
+            sx[2] = upshift ? sx[1] : sx[2];
+            sx[1] = upshift ? sx[0] : sx[1];
+            sx[0] = upshift ? T(0.0) : sx[0];
 
             // index of the leftmost cell where particle deposits
             return i - 1;

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -89,30 +89,80 @@ struct Compute_shifted_shape_factor
     {
         if constexpr (depos_order == 1){
             const auto i = static_cast<int>(x_old);
-            const int i_shift = i - i_new;
+            //const int i_shift = i - i_new;
+            const bool shift = i != i_new;
             const T xint = x_old - T(i);
-            sx[1+i_shift] = T(1.0) - xint;
-            sx[2+i_shift] = xint;
+
+            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
+
+            // we avoid dynamic indexing here, to enable vectorization (CPU) and
+            // reduce register/lmem footprint (GPU).
+            // The below is equivalent to this:
+            //sx[1+i_shift] = T(1.0) - xint;
+            //sx[2+i_shift] = xint;
+            sx[1] = T(1.0) - xint;
+            sx[2] = xint;
+
+            sx[0] = shift ? sx[1] : T(0.0);
+            sx[1] = shift ? sx[2] : sx[1];
+            sx[2] = shift ? T(0.0) : sx[2];
+
             return i;
         }
         else if constexpr (depos_order == 2){
             const auto i = static_cast<int>(x_old + T(0.5));
-            const int i_shift = i - (i_new + 1);
+            //const int i_shift = i - (i_new + 1);
+            const bool shift = i != (i_new + 1);
             const T xint = x_old - T(i);
-            sx[1+i_shift] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
-            sx[2+i_shift] = T(0.75) - xint*xint;
-            sx[3+i_shift] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
+
+            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
+
+            // we avoid dynamic indexing here, to enable vectorization (CPU) and
+            // reduce register/lmem footprint (GPU).
+            // The below is equivalent to this:
+            //sx[1+i_shift] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
+            //sx[2+i_shift] = T(0.75) - xint*xint;
+            //sx[3+i_shift] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
+
+            sx[1] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
+            sx[2] = T(0.75) - xint*xint;
+            sx[3] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
+
+            sx[0] = shift ? sx[1] : T(0.0);
+            sx[1] = shift ? sx[2] : sx[1];
+            sx[2] = shift ? sx[3] : sx[2];
+            sx[3] = shift ? T(0.0) : sx[3];
+
             // index of the leftmost cell where particle deposits
             return i - 1;
         }
         else if constexpr (depos_order == 3){
             const auto i = static_cast<int>(x_old);
-            const int i_shift = i - (i_new + 1);
+            //const int i_shift = i - (i_new + 1);
+            const bool shift = i != (i_new + 1);
             const T xint = x_old - i;
-            sx[1+i_shift] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
-            sx[2+i_shift] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
-            sx[3+i_shift] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
-            sx[4+i_shift] = (T(1.0))/(T(6.0))*xint*xint*xint;
+
+            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
+
+            // we avoid dynamic indexing here, to enable vectorization (CPU) and
+            // reduce register/lmem footprint (GPU).
+            // The below is equivalent to this:
+            //sx[1+i_shift] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
+            //sx[2+i_shift] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
+            //sx[3+i_shift] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
+            //sx[4+i_shift] = (T(1.0))/(T(6.0))*xint*xint*xint;
+
+            sx[1] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
+            sx[2] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
+            sx[3] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
+            sx[4] = (T(1.0))/(T(6.0))*xint*xint*xint;
+
+            sx[0] = shift ? sx[1] : T(0.0);
+            sx[1] = shift ? sx[2] : sx[1];
+            sx[2] = shift ? sx[3] : sx[2];
+            sx[3] = shift ? sx[4] : sx[3];
+            sx[4] = shift ? T(0.0) : sx[4];
+
             // index of the leftmost cell where particle deposits
             return i - 1;
         }

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -89,20 +89,22 @@ struct Compute_shifted_shape_factor
     {
         if constexpr (depos_order == 1){
             const auto i = static_cast<int>(x_old);
-            //const int i_shift = i - i_new;
-            const bool shift = i != i_new;
             const T xint = x_old - T(i);
-
-            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
 
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
+            //const int i_shift = i - i_new;
             //sx[1+i_shift] = T(1.0) - xint;
             //sx[2+i_shift] = xint;
             sx[1] = T(1.0) - xint;
             sx[2] = xint;
 
+            AMREX_ASSERT_WITH_MESSAGE(
+                i - i_new == 0 || i - i_new == -1,
+                "Compute_shifted_shape_factor: shift out of range");
+
+            const bool shift = i != i_new;
             sx[0] = shift ? sx[1] : T(0.0);
             sx[1] = shift ? sx[2] : sx[1];
             sx[2] = shift ? T(0.0) : sx[2];
@@ -111,19 +113,21 @@ struct Compute_shifted_shape_factor
         }
         else if constexpr (depos_order == 2){
             const auto i = static_cast<int>(x_old + T(0.5));
-            //const int i_shift = i - (i_new + 1);
-            const bool shift = i != (i_new + 1);
             const T xint = x_old - T(i);
-
-            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
 
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
+            //const int i_shift = i - (i_new + 1);
             //sx[1+i_shift] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
             //sx[2+i_shift] = T(0.75) - xint*xint;
             //sx[3+i_shift] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
 
+            AMREX_ASSERT_WITH_MESSAGE(
+                i - (i_new + 1) == 0 || i - (i_new + 1) == -1,
+                "Compute_shifted_shape_factor: shift out of range");
+
+            const bool shift = i != (i_new + 1);
             sx[1] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
             sx[2] = T(0.75) - xint*xint;
             sx[3] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
@@ -138,20 +142,22 @@ struct Compute_shifted_shape_factor
         }
         else if constexpr (depos_order == 3){
             const auto i = static_cast<int>(x_old);
-            //const int i_shift = i - (i_new + 1);
-            const bool shift = i != (i_new + 1);
             const T xint = x_old - i;
-
-            //amrex::AllPrint() << "i_shift=" << i_shift << "\n";
 
             // we avoid dynamic indexing here, to enable vectorization (CPU) and
             // reduce register/lmem footprint (GPU).
             // The below is equivalent to this:
+            //const int i_shift = i - (i_new + 1);
             //sx[1+i_shift] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
             //sx[2+i_shift] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
             //sx[3+i_shift] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
             //sx[4+i_shift] = (T(1.0))/(T(6.0))*xint*xint*xint;
 
+            AMREX_ASSERT_WITH_MESSAGE(
+                i - (i_new + 1) == 0 || i - (i_new + 1) == -1,
+                "Compute_shifted_shape_factor: shift out of range");
+
+            const bool shift = i != (i_new + 1);
             sx[1] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
             sx[2] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
             sx[3] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -70,6 +70,45 @@ struct Compute_shape_factor
     }
 };
 
+template <int depos_order>
+struct Compute_shape_factor_uni
+{
+    template< typename T >
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator()(
+            int i_min,
+            T* const sx,
+            T xmid) const
+    {
+        if constexpr (depos_order == 0){
+            sx[0] = T(1.0);
+        }
+        else if constexpr (depos_order == 1){
+            const T xint = xmid - T(i_min);
+            sx[0] = T(1.0) - xint;
+            sx[1] = xint;
+        }
+        else if constexpr (depos_order == 2){
+            const T xint = xmid - T(i_min);
+            sx[0] = T(0.5)*(T(0.5) - xint)*(T(0.5) - xint);
+            sx[1] = T(0.75) - xint*xint;
+            sx[2] = T(0.5)*(T(0.5) + xint)*(T(0.5) + xint);
+        }
+        else if constexpr (depos_order == 3){
+            const T xint = xmid - T(i_min);
+            sx[0] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
+            sx[1] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
+            sx[2] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
+            sx[3] = (T(1.0))/(T(6.0))*xint*xint*xint;
+        }
+        else{
+            amrex::Abort("Unknown particle shape selected in Compute_shape_factor");
+            amrex::ignore_unused(i_min, sx, xmid);
+        }
+    }
+};
+
+
 
 
 /**


### PR DESCRIPTION
This is the complete version of #2796.

We want to:
- avoid dynamic ranges in loops and
- avoid any dynamic array access

to reduce needed registers & operations (CPU) and match easier to vectorization patterns of compilers (later, CPU).

This PR updates `Compute_shifted_shape_factor` to reduce registers dramatically. Since we only shift by one cell at most, we can do this in a nicely lined up register move.

This update was developed in exchange with @psychocoderHPC from PIConGPU team, who took part of our approach and shared the register shifting trick in return:
- https://github.com/ComputationalRadiationPhysics/picongpu/pull/4124
- https://github.com/ComputationalRadiationPhysics/picongpu/pull/4170

As a follow-up to this PR, we will take a part from https://github.com/ECP-WarpX/WarpX/pull/3168 to replace the cached array of the most outer loop with a computation on the fly.

### To Do

- [ ] Measure registers & lmlm usage before/after this PR
- [ ] Measure runtime before/after this PR

### Refs

https://developer.nvidia.com/blog/fast-dynamic-indexing-private-arrays-cuda/