### PR TITLE
Cleanup how fields_to_plot = none is handled

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -106,7 +106,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd amrex && git checkout --detach cbdc6580ee3d78cccdd37172e4ba077ee181f483 && cd -
+        cd amrex && git checkout --detach a633d2bff1db1a3335efd077a34b6a8dcfb4e793 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-11-nvcc:

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = cbdc6580ee3d78cccdd37172e4ba077ee181f483
+branch = a633d2bff1db1a3335efd077a34b6a8dcfb4e793
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = cbdc6580ee3d78cccdd37172e4ba077ee181f483
+branch = a633d2bff1db1a3335efd077a34b6a8dcfb4e793
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -71,17 +71,15 @@ FlushFormatPlotfile::WriteToFile (
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::Version_v1);
     if (plot_raw_fields) rfs.emplace_back("raw_fields");
-    if (varnames.size() > 0) {
-        amrex::WriteMultiLevelPlotfile(filename, nlev,
-                                       amrex::GetVecOfConstPtrs(mf),
-                                       varnames, geom,
-                                       static_cast<Real>(time), iteration, warpx.refRatio(),
-                                       "HyperCLaw-V1.1",
-                                       "Level_",
-                                       "Cell",
-                                       rfs
-                                       );
-    }
+    amrex::WriteMultiLevelPlotfile(filename, nlev,
+                                   amrex::GetVecOfConstPtrs(mf),
+                                   varnames, geom,
+                                   static_cast<Real>(time), iteration, warpx.refRatio(),
+                                   "HyperCLaw-V1.1",
+                                   "Level_",
+                                   "Cell",
+                                   rfs
+                                   );
 
     WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards);
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -540,12 +540,8 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
     if (use_warpxba == false) dmap = amrex::DistributionMapping{ba};
     // Allocate output MultiFab for diagnostics. The data will be stored at cell-centers.
     int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
-    // The zero is hard-coded since the number of output buffers = 1 for FullDiagnostics
     int const ncomp = static_cast<int>(m_varnames.size());
-    if (ncomp > 0) {
-        m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
-    }
-
+    m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
 
     if (lev == 0) {
         // The extent of the domain covered by the diag multifab, m_mf_output

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -241,7 +241,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "cbdc6580ee3d78cccdd37172e4ba077ee181f483"
+set(WarpX_amrex_branch "a633d2bff1db1a3335efd077a34b6a8dcfb4e793"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -71,7 +71,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach cbdc6580ee3d78cccdd37172e4ba077ee181f483 && cd -
+cd amrex && git checkout --detach a633d2bff1db1a3335efd077a34b6a8dcfb4e793 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 


### PR DESCRIPTION
There has been a change in AMReX that allows MultiFabs to be created with ncomp = 0. (AMReX PR #2873) This allows the handling the `fields_to_plot = none` to be cleaned up, removing the `if` checks around the allocation and call to `WriteToFile`.

This also fixes another issue that arose in PR #2419, that the plot files were not readable by Yt (because the Header file was not written out). With this PR, that is also fixed.

Once the version of AMReX that WarpX depends on is updated, I remove the WIP and this can be merged.