### PR TITLE
[WIP]Fix fields_to_plot = none

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -71,17 +71,15 @@ FlushFormatPlotfile::WriteToFile (
     VisMF::Header::Version current_version = VisMF::GetHeaderVersion();
     VisMF::SetHeaderVersion(amrex::VisMF::Header::Version_v1);
     if (plot_raw_fields) rfs.emplace_back("raw_fields");
-    if (varnames.size() > 0) {
-        amrex::WriteMultiLevelPlotfile(filename, nlev,
-                                       amrex::GetVecOfConstPtrs(mf),
-                                       varnames, geom,
-                                       static_cast<Real>(time), iteration, warpx.refRatio(),
-                                       "HyperCLaw-V1.1",
-                                       "Level_",
-                                       "Cell",
-                                       rfs
-                                       );
-    }
+    amrex::WriteMultiLevelPlotfile(filename, nlev,
+                                   amrex::GetVecOfConstPtrs(mf),
+                                   varnames, geom,
+                                   static_cast<Real>(time), iteration, warpx.refRatio(),
+                                   "HyperCLaw-V1.1",
+                                   "Level_",
+                                   "Cell",
+                                   rfs
+                                   );
 
     WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards);
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -540,12 +540,18 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev ) {
     if (use_warpxba == false) dmap = amrex::DistributionMapping{ba};
     // Allocate output MultiFab for diagnostics. The data will be stored at cell-centers.
     int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
-    // The zero is hard-coded since the number of output buffers = 1 for FullDiagnostics
-    int const ncomp = static_cast<int>(m_varnames.size());
-    if (ncomp > 0) {
-        m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
-    }
 
+    int const ncomp = static_cast<int>(m_varnames.size());
+    // Even if ncomp is zero, the MultiFab needs to be setup with the appropriate ba and dmap for
+    // the particles to be handled properly.
+    // So, if ncomp is zero, set ncomp_temp = 1 since MultiFab cannot be allocated with ncomp == 0.
+    int const ncomp_temp = (ncomp == 0 ? 1 : ncomp);
+    m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp_temp, ngrow);
+    if (ncomp == 0) {
+        // Now, hack the MultiFab setting the number of components to zero (since that number
+        // must be consistent with the size of m_varnames).
+        m_mf_output[i_buffer][lev].n_comp = 0;
+    }
 
     if (lev == 0) {
         // The extent of the domain covered by the diag multifab, m_mf_output


### PR DESCRIPTION
With the previous change to allow `fields_to_plot = none`, PR #2419, the resulting plot files could not be read in by Yt since there was no `Header` file, which is required by Yt. This change fixes that with a bit of a hack.

The previous problem was that the MultiFab holding the data to be written out was being allocated but with the number of components zero. This fails, causing a seg fault deep inside of AMReX. The hack is to create the MultiFab with ncomp = 1, but then hack it setting its attribute n_comp = 0. This works locally, and hopefully will pass the CI tests.

With this change, the Header file is written out and the plot file can be read with Yt.