### PR TITLE
Docs: New OLCF Machine

### DIFF
--- a/Docs/source/install/hpc.rst
+++ b/Docs/source/install/hpc.rst
@@ -29,6 +29,7 @@ HPC Systems
    hpc/summit
    hpc/spock
    hpc/crusher
+   hpc/frontier
    hpc/juwels
    hpc/lassen
    hpc/quartz

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -33,6 +33,8 @@ Use the following commands to download the WarpX source code and switch to the c
    git clone https://github.com/ECP-WarpX/picsar.git $HOME/src/picsar
    git clone -b 0.14.5 https://github.com/openPMD/openPMD-api.git $HOME/src/openPMD-api
 
+To enable HDF5, work-around the broken ``HDF5_VERSION`` variable (empty) in the Cray PE by commenting out the following lines in ``$HOME/src/openPMD-api/CMakeLists.txt``:
+https://github.com/openPMD/openPMD-api/blob/0.14.5/CMakeLists.txt#L216-L220
 
 We use the following modules and environments on the system (``$HOME/frontier_warpx.profile``).
 

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -1,0 +1,104 @@
+.. _building-frontier:
+
+Frontier (OLCF)
+===============
+
+The `Frontier cluster (see: Crusher) <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html>`_ is located at OLCF.
+Each node contains 4 AMD MI250X GPUs, each with 2 Graphics Compute Dies (GCDs) for a total of 8 GCDs per node.
+You can think of the 8 GCDs as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E).
+
+If you are new to this system, please see the following resources:
+
+* `Crusher user guide <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html>`_
+* Batch system: `Slurm <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#running-jobs>`_
+* `Production directories <https://docs.olcf.ornl.gov/data/storage_overview.html>`_:
+
+  * ``$PROJWORK/$proj/``: shared with all members of a project (recommended)
+  * ``$MEMBERWORK/$proj/``: single user (usually smaller quota)
+  * ``$WORLDWORK/$proj/``: shared with all users
+  * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
+    That means you cannot run in your ``$HOME``.
+
+
+Installation
+------------
+
+Use the following commands to download the WarpX source code and switch to the correct branch:
+
+.. code-block:: bash
+
+   git clone https://github.com/ECP-WarpX/WarpX.git $HOME/src/warpx
+
+We use the following modules and environments on the system (``$HOME/frontier_warpx.profile``).
+
+.. literalinclude:: ../../../../Tools/machines/frontier-olcf/frontier_warpx.profile.example
+   :language: bash
+   :caption: You can copy this file from ``Tools/machines/frontier-olcf/frontier_warpx.profile.example``.
+
+We recommend to store the above lines in a file, such as ``$HOME/frontier_warpx.profile``, and load it into your shell after a login:
+
+.. code-block:: bash
+
+   source $HOME/frontier_warpx.profile
+
+
+Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+
+.. code-block:: bash
+
+   cd $HOME/src/warpx
+   rm -rf build
+
+   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=HIP
+   cmake --build build -j 10
+
+The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
+
+
+.. _running-cpp-frontier:
+
+Running
+-------
+
+.. _running-cpp-frontier-MI100-GPUs:
+
+MI250X GPUs (2x64 GB)
+^^^^^^^^^^^^^^^^^^^^^
+
+After requesting an interactive node with the ``getNode`` alias above, run a simulation like this, here using 8 MPI ranks and a single node:
+
+.. code-block:: bash
+
+   runNode ./warpx inputs
+
+Or in non-interactive runs:
+
+.. literalinclude:: ../../../../Tools/machines/frontier-olcf/submit.sh
+   :language: bash
+   :caption: You can copy this file from ``Tools/machines/frontier-olcf/submit.sh``.
+
+
+.. _post-processing-frontier:
+
+Post-Processing
+---------------
+
+For post-processing, most users use Python via OLCFs's `Jupyter service <https://jupyter.olcf.ornl.gov>`__ (`Docs <https://docs.olcf.ornl.gov/services_and_applications/jupyter/index.html>`__).
+
+Please follow the same guidance as for :ref:`OLCF Summit post-processing <post-processing-summit>`.
+
+.. _known-frontier-issues:
+
+Known System Issues
+-------------------
+
+.. warning::
+
+   May 16th, 2022 (OLCFHELP-6888):
+   There is a caching bug in Libfrabric that causes WarpX simulations to occasionally hang on Crusher on more than 1 node.
+
+   As a work-around, please export the following environment variable in your job scripts unti the issue is fixed:
+
+   .. code-block:: bash
+
+      export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -23,11 +23,16 @@ If you are new to this system, please see the following resources:
 Installation
 ------------
 
-Use the following commands to download the WarpX source code and switch to the correct branch:
+Use the following commands to download the WarpX source code and switch to the correct branch.
+**You have to do this on Summit/OLCF Home/etc. since Frontier cannot connect directly to the internet**:
 
 .. code-block:: bash
 
    git clone https://github.com/ECP-WarpX/WarpX.git $HOME/src/warpx
+   git clone https://github.com/AMReX-Codes/amrex.git $HOME/src/amrex
+   git clone https://github.com/ECP-WarpX/picsar.git $HOME/src/picsar
+   git clone -b 0.14.5 https://github.com/openPMD/openPMD-api.git $HOME/src/openPMD-api
+
 
 We use the following modules and environments on the system (``$HOME/frontier_warpx.profile``).
 
@@ -49,8 +54,12 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=HIP
-   cmake --build build -j 10
+   cmake -S . -B build   \
+     -DWarpX_COMPUTE=HIP \
+     -DWarpX_amrex_src=$HOME/src/amrex \
+     -DWarpX_picsar_src=$HOME/src/picsar \
+     -DWarpX_openpmd_src=$HOME/src/openPMD-api
+   cmake --build build -j 32
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
 

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -33,6 +33,9 @@ module load cray-python/3.9.12.1
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand
 
+# make output group-readable by default
+umask 0027
+
 # an alias to request an interactive batch node for one hour
 #   for paralle execution, start on the batch node: srun <command>
 alias getNode="salloc -A $proj -J warpx -t 01:00:00 -p batch -N 1 --ntasks-per-node=8 --gpus-per-task=1 --gpu-bind=closest"

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -35,10 +35,10 @@ shopt -s direxpand
 
 # an alias to request an interactive batch node for one hour
 #   for paralle execution, start on the batch node: srun <command>
-alias getNode="salloc -A $proj -J warpx -t 01:00:00 -p batch -N 1 -c 8 --ntasks-per-node=8"
+alias getNode="salloc -A $proj -J warpx -t 01:00:00 -p batch -N 1 --ntasks-per-node=8 --gpus-per-task=1 --gpu-bind=closest"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
-alias runNode="srun -A $proj -J warpx -t 00:30:00 -p batch -N 1 -c 8 --ntasks-per-node=8"
+alias runNode="srun -A $proj -J warpx -t 00:30:00 -p batch -N 1 --ntasks-per-node=8 --gpus-per-task=1 --gpu-bind=closest"
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -51,5 +51,5 @@ export CC=$(which cc)
 export CXX=$(which CC)
 export FC=$(which ftn)
 export CFLAGS="-I${ROCM_PATH}/include"
-export CXXFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include -Wno-pass-failed"
 export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -1,10 +1,10 @@
 # please set your project account
-#export proj=<yourProject>
+#export proj=APH114-frontier
 
 # required dependencies
-module load cmake/3.22.1
+module load cmake/3.22.2
 module load craype-accel-amd-gfx90a
-module load rocm/5.0.0
+module load rocm/5.1.0
 module load cray-mpich
 #module load cce/14.0.0  # must be loaded after rocm
 
@@ -16,18 +16,19 @@ module load ninja
 module load nano
 
 # optional: for PSATD in RZ geometry support (not yet available)
+#module load cray-libsci_acc/22.06.1.2
 #module load blaspp
 #module load lapackpp
 
 # optional: for QED lookup table generation support
-#module load boost/1.78.0-cxx17
+module load boost/1.79.0-cxx17
 
 # optional: for openPMD support
 #module load adios2/2.7.1
-#module load cray-hdf5-parallel/1.12.1.1
+module load cray-hdf5-parallel/1.12.1.1
 
 # optional: for Python bindings or libEnsemble
-#module load cray-python/3.9.4.2
+module load cray-python/3.9.12.1
 
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -6,7 +6,7 @@ module load cmake/3.22.2
 module load craype-accel-amd-gfx90a
 module load rocm/5.1.0
 module load cray-mpich
-#module load cce/14.0.0  # must be loaded after rocm
+module load cce/14.0.1  # must be loaded after rocm
 
 # optional: faster builds
 module load ccache

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -1,0 +1,54 @@
+# please set your project account
+#export proj=<yourProject>
+
+# required dependencies
+module load cmake/3.22.1
+module load craype-accel-amd-gfx90a
+module load rocm/5.0.0
+module load cray-mpich
+#module load cce/14.0.0  # must be loaded after rocm
+
+# optional: faster builds
+module load ccache
+module load ninja
+
+# optional: just an additional text editor
+module load nano
+
+# optional: for PSATD in RZ geometry support (not yet available)
+#module load blaspp
+#module load lapackpp
+
+# optional: for QED lookup table generation support
+#module load boost/1.78.0-cxx17
+
+# optional: for openPMD support
+#module load adios2/2.7.1
+#module load cray-hdf5-parallel/1.12.1.1
+
+# optional: for Python bindings or libEnsemble
+#module load cray-python/3.9.4.2
+
+# fix system defaults: do not escape $ with a \ on tab completion
+shopt -s direxpand
+
+# an alias to request an interactive batch node for one hour
+#   for paralle execution, start on the batch node: srun <command>
+alias getNode="salloc -A $proj -J warpx -t 01:00:00 -p batch -N 1 -c 8 --ntasks-per-node=8"
+# an alias to run a command on a batch node for up to 30min
+#   usage: runNode <command>
+alias runNode="srun -A $proj -J warpx -t 00:30:00 -p batch -N 1 -c 8 --ntasks-per-node=8"
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# optimize CUDA compilation for MI250X
+export AMREX_AMD_ARCH=gfx90a
+
+# compiler environment hints
+export CC=$(which cc)
+export CXX=$(which CC)
+export FC=$(which ftn)
+export CFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"

--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -19,9 +19,9 @@
 # (GCDs) for a total of 8 GCDs per node. The programmer can think of the 8 GCDs
 # as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E).
 
-# note (5-16-22)
+# note (5-16-22 and 7-12-22)
 # this environment setting is currently needed on Frontier to work-around a
-# known issue with Libfabric
+# known issue with Libfabric (both in the May and June PE)
 export FI_MR_CACHE_MAX_COUNT=0
 
 export OMP_NUM_THREADS=8

--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#SBATCH -A <project id>
+#SBATCH -J warpx
+#SBATCH -o %x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 1
+
+# From the documentation:
+# Each Frontier compute node consists of [1x] 64-core AMD EPYC 7A53
+# "Optimized 3rd Gen EPYC" CPU (with 2 hardware threads per physical core) with
+# access to 512 GB of DDR4 memory.
+# Each node also contains [4x] AMD MI250X, each with 2 Graphics Compute Dies
+# (GCDs) for a total of 8 GCDs per node. The programmer can think of the 8 GCDs
+# as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E).
+
+# note (5-16-22)
+# this environment setting is currently needed on Frontier to work-around a
+# known issue with Libfabric
+export FI_MR_CACHE_MAX_COUNT=0
+
+export OMP_NUM_THREADS=8
+srun ./warpx inputs > output.txt


### PR DESCRIPTION
Document usage of that new OLCF machine.

- [x] configure
- [x] compile & link
- [x] run on head node
- [x] run on interactive node
- [x] adjust/add and test HDF5
- [x] document interactive node usage

Follow-up PRs:
- [ ] document and test ADIOS2 usage
- [ ] document and test Ascent usage