### PR TITLE
Update 2D nuclear fusion test input file

### DIFF
--- a/Examples/Modules/nuclear_fusion/inputs_2d
+++ b/Examples/Modules/nuclear_fusion/inputs_2d
@@ -32,7 +32,7 @@ algo.particle_shape = 1
 particles.species_names = proton1 boron1 alpha1 proton2 boron2 alpha2 proton3 boron3 alpha3
                           proton4 boron4 alpha4 proton5 boron5 alpha5
 
-my_constants.m_b11 =  10.9298*m_p # Boron 11 mass
+my_constants.m_b11 =  11.00930536*m_u # Boron 11 mass
 my_constants.m_reduced = m_p*m_b11/(m_p+m_b11)
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
@@ -63,7 +63,7 @@ boron1.momentum_function_uz(x,y,z) = -sqrt(2*m_reduced*Energy_step*(floor(z)**2)
 boron1.do_not_push = 1
 boron1.do_not_deposit = 1
 
-alpha1.species_type = alpha
+alpha1.species_type = helium
 alpha1.do_not_push = 1
 alpha1.do_not_deposit = 1
 
@@ -94,7 +94,7 @@ boron2.momentum_distribution_type = "constant"
 boron2.do_not_push = 1
 boron2.do_not_deposit = 1
 
-alpha2.species_type = alpha
+alpha2.species_type = helium
 alpha2.do_not_push = 1
 alpha2.do_not_deposit = 1
 
@@ -120,7 +120,7 @@ boron3.theta = temperature/(m_b11*clight**2)
 boron3.do_not_push = 1
 boron3.do_not_deposit = 1
 
-alpha3.species_type = alpha
+alpha3.species_type = helium
 alpha3.do_not_push = 1
 alpha3.do_not_deposit = 1
 
@@ -145,7 +145,7 @@ boron4.momentum_distribution_type = "constant"
 boron4.do_not_push = 1
 boron4.do_not_deposit = 1
 
-alpha4.species_type = alpha
+alpha4.species_type = helium
 alpha4.do_not_push = 1
 alpha4.do_not_deposit = 1
 
@@ -168,7 +168,7 @@ boron5.momentum_distribution_type = "constant"
 boron5.do_not_push = 1
 boron5.do_not_deposit = 1
 
-alpha5.species_type = alpha
+alpha5.species_type = helium
 alpha5.do_not_push = 1
 alpha5.do_not_deposit = 1
 

--- a/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_2D.json
+++ b/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_2D.json
@@ -1,52 +1,52 @@
 {
   "alpha1": {
-    "particle_cpu": 61116.0,
-    "particle_id": 1374948741264.0,
-    "particle_momentum_x": 4.688186295441445e-15,
-    "particle_momentum_y": 4.7208784582798594e-15,
-    "particle_momentum_z": 4.7027632008939775e-15,
-    "particle_position_x": 462511.1275563426,
-    "particle_position_y": 978224.9637545305,
-    "particle_weight": 2.965237716665655e-28
+    "particle_cpu": 61206.0,
+    "particle_id": 1369246086324.0,
+    "particle_momentum_x": 4.714227948839551e-15,
+    "particle_momentum_y": 4.676078701959904e-15,
+    "particle_momentum_z": 4.676142266462326e-15,
+    "particle_position_x": 463834.9497057527,
+    "particle_position_y": 977592.6452214213,
+    "particle_weight": 2.940000093807323e-28
   },
   "alpha2": {
-    "particle_cpu": 54822.0,
-    "particle_id": 1218578759043.0,
-    "particle_momentum_x": 4.157834044969911e-15,
-    "particle_momentum_y": 4.10466425159846e-15,
-    "particle_momentum_z": 4.1936423888353025e-15,
-    "particle_position_x": 411510.6935411271,
-    "particle_position_y": 872044.4445281675,
-    "particle_weight": 2.965764768724028e+18
+    "particle_cpu": 54468.0,
+    "particle_id": 1214972952561.0,
+    "particle_momentum_x": 4.081538674143691e-15,
+    "particle_momentum_y": 4.122349693618236e-15,
+    "particle_momentum_z": 4.201699189448955e-15,
+    "particle_position_x": 410664.0477768091,
+    "particle_position_y": 868193.1483606595,
+    "particle_weight": 2.959852107088932e+18
   },
   "alpha3": {
-    "particle_cpu": 6450.0,
-    "particle_id": 158818703625.0,
-    "particle_momentum_x": 5.052515917170244e-16,
-    "particle_momentum_y": 4.950394146977726e-16,
-    "particle_momentum_z": 4.896418624715863e-16,
-    "particle_position_x": 54341.27656876971,
-    "particle_position_y": 104940.19225774865,
-    "particle_weight": 1.5087701480905637e+27
+    "particle_cpu": 6528.0,
+    "particle_id": 154374474171.0,
+    "particle_momentum_x": 4.934249084589244e-16,
+    "particle_momentum_y": 4.791039564460439e-16,
+    "particle_momentum_z": 4.698462130524534e-16,
+    "particle_position_x": 52309.63968324501,
+    "particle_position_y": 104322.0547863817,
+    "particle_weight": 1.491736282762796e+27
   },
   "alpha4": {
     "particle_cpu": 307200.0,
-    "particle_id": 7432143974400.0,
-    "particle_momentum_x": 2.335145239158059e-14,
-    "particle_momentum_y": 2.348323075031563e-14,
-    "particle_momentum_z": 2.3477654672120372e-14,
-    "particle_position_x": 2458256.1229268126,
-    "particle_position_y": 4915207.19087103,
+    "particle_id": 7431790080000.0,
+    "particle_momentum_x": 2.342240913445794e-14,
+    "particle_momentum_y": 2.34177318709557e-14,
+    "particle_momentum_z": 2.353174771675334e-14,
+    "particle_position_x": 2457367.458278153,
+    "particle_position_y": 4915112.044373058,
     "particle_weight": 384.0000000000002
   },
   "alpha5": {
     "particle_cpu": 307200.0,
-    "particle_id": 7620887654400.0,
-    "particle_momentum_x": 2.3402087717265325e-14,
-    "particle_momentum_y": 2.3415304986163325e-14,
-    "particle_momentum_z": 2.3501245625975474e-14,
-    "particle_position_x": 2457680.608473036,
-    "particle_position_y": 4915446.400371841,
+    "particle_id": 7620533760000.0,
+    "particle_momentum_x": 2.330088308142745e-14,
+    "particle_momentum_y": 2.344976927616691e-14,
+    "particle_momentum_z": 2.361827647381584e-14,
+    "particle_position_x": 2457556.857163842,
+    "particle_position_y": 4914659.635379327,
     "particle_weight": 3.839999999999998e-19
   },
   "boron1": {
@@ -54,7 +54,7 @@
     "particle_id": 78643205120000.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.524243076150406e-13,
+    "particle_momentum_z": 2.524242836246531e-13,
     "particle_position_x": 40958301.591654316,
     "particle_position_y": 81921136.14476715,
     "particle_weight": 128.00000000000261
@@ -72,12 +72,12 @@
   "boron3": {
     "particle_cpu": 512000.0,
     "particle_id": 11639194112000.0,
-    "particle_momentum_x": 9.274252125064723e-15,
-    "particle_momentum_y": 9.27253250840722e-15,
-    "particle_momentum_z": 9.276115198445575e-15,
-    "particle_position_x": 4095810.08236732,
-    "particle_position_y": 8192326.250658387,
-    "particle_weight": 6.399497076617303e+30
+    "particle_momentum_x": 9.277692671587846e-15,
+    "particle_momentum_y": 9.268409636965691e-15,
+    "particle_momentum_z": 9.279446607709548e-15,
+    "particle_position_x": 4096178.166422465,
+    "particle_position_y": 8192499.706038672,
+    "particle_weight": 6.399502754572407e+30
   },
   "boron5": {
     "particle_cpu": 51200.0,
@@ -85,19 +85,19 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 409516.8988702324,
-    "particle_position_y": 819323.2418191985,
+    "particle_position_x": 409547.3312927569,
+    "particle_position_y": 819118.5558814355,
     "particle_weight": 127.99999999999999
   },
   "lev=0": {
-    "rho": 0.000000000000000e+00
+    "rho": 0.0
   },
   "proton1": {
     "particle_cpu": 5120000.0,
     "particle_id": 26214405120000.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.524243076150406e-13,
+    "particle_momentum_z": 2.524242836246531e-13,
     "particle_position_x": 40960140.72983792,
     "particle_position_y": 81919772.69310114,
     "particle_weight": 128.00000000000261
@@ -113,14 +113,14 @@
     "particle_weight": 1.2885512789516445e+28
   },
   "proton3": {
-    "particle_cpu": 307170.0,
-    "particle_id": 6731210814406.0,
-    "particle_momentum_x": 1.6817613332220226e-15,
-    "particle_momentum_y": 1.6822707864863416e-15,
-    "particle_momentum_z": 1.6798193398170112e-15,
-    "particle_position_x": 2457375.867254385,
-    "particle_position_y": 4914855.8979505645,
-    "particle_weight": 1.2794970766173041e+30
+    "particle_cpu": 307162.0,
+    "particle_id": 6731056725872.0,
+    "particle_momentum_x": 1.684214433067055e-15,
+    "particle_momentum_y": 1.682290595962152e-15,
+    "particle_momentum_z": 1.679806121802876e-15,
+    "particle_position_x": 2457258.407562205,
+    "particle_position_y": 4914234.891662369,
+    "particle_weight": 1.279502754572413e+30
   },
   "proton4": {
     "particle_cpu": 51200.0,
@@ -128,8 +128,8 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 1.7581275870306353e-15,
-    "particle_position_x": 409842.79569749814,
-    "particle_position_y": 819245.2000431926,
+    "particle_position_x": 409630.8789482905,
+    "particle_position_y": 819198.7077771134,
     "particle_weight": 1.2800000000000004e+37
   },
   "proton5": {
@@ -138,8 +138,8 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 1.7581275870306353e-15,
-    "particle_position_x": 409709.9706207799,
-    "particle_position_y": 819158.891638082,
+    "particle_position_x": 409638.2877618571,
+    "particle_position_y": 819101.3225783394,
     "particle_weight": 1.2800000000000004e+37
   }
 }


### PR DESCRIPTION
Looks like separately merging #3090 and #2540 has broken CI.

The input file of the 2D proton-boron fusion test needs to be updated. (and possibly we will need to update some benchmarks as well, we'll see)