### PR TITLE
Fix: Write Used Inputs Once

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -352,10 +352,12 @@ WarpX::WriteUsedInputsFile (std::string const & filename) const
 {
     amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
 
-    std::ofstream jobInfoFile;
-    jobInfoFile.open(filename.c_str(), std::ios::out);
-    ParmParse::dumpTable(jobInfoFile, true);
-    jobInfoFile.close();
+    if (ParallelDescriptor::IOProcessor()) {
+        std::ofstream jobInfoFile;
+        jobInfoFile.open(filename.c_str(), std::ios::out);
+        ParmParse::dumpTable(jobInfoFile, true);
+        jobInfoFile.close();
+    }
 }
 
 void


### PR DESCRIPTION
Follow-up to #3132:
Ooopsi, nearly killed a PFS again :D
Only the IO processor should write this and not every rank on the planet.

- [x] tested

First spotted by @atmyers :sparkles: 