### PR TITLE
[WIP] abort if RZ + Yee (FDTD) + momentum-conserving

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -979,7 +979,7 @@ WarpX::ReadParameters ()
 
 #ifdef WARPX_DIM_RZ
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            maxwell_solver_id == MaxwellSolverAlgo::Yee, 
+            maxwell_solver_id == MaxwellSolverAlgo::Yee,
             "RZ + FDTD + momentum-conserving is known to be problematic.  Please use energy-conserving field gathering.");
 #endif
         }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -972,9 +972,16 @@ WarpX::ReadParameters ()
             "Vay deposition not implemented with mesh refinement");
 
         field_gathering_algo = GetAlgorithmInteger(pp_algo, "field_gathering");
+
         if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
             // Use same shape factors in all directions, for gathering
             galerkin_interpolation = false;
+
+#ifdef WARPX_DIM_RZ
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            maxwell_solver_id == MaxwellSolverAlgo::Yee, 
+            "RZ + FDTD + momentum-conserving is known to be problematic.  Please use energy-conserving field gathering.");
+#endif
         }
 
         em_solver_medium = GetAlgorithmInteger(pp_algo, "em_solver_medium");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -978,9 +978,9 @@ WarpX::ReadParameters ()
             galerkin_interpolation = false;
 
 #ifdef WARPX_DIM_RZ
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            maxwell_solver_id != MaxwellSolverAlgo::Yee,
-            "RZ + FDTD + momentum-conserving is known to be problematic.  Please use energy-conserving field gathering.");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                maxwell_solver_id != MaxwellSolverAlgo::Yee,
+                "RZ + FDTD + momentum-conserving is known to be problematic.  Please use energy-conserving field gathering.");
 #endif
         }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -979,7 +979,7 @@ WarpX::ReadParameters ()
 
 #ifdef WARPX_DIM_RZ
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            maxwell_solver_id == MaxwellSolverAlgo::Yee,
+            maxwell_solver_id != MaxwellSolverAlgo::Yee,
             "RZ + FDTD + momentum-conserving is known to be problematic.  Please use energy-conserving field gathering.");
 #endif
         }


### PR DESCRIPTION
This aborts with a warning message if a user attempts an RZ simulation with the Yee solver and momentum-conserving field gathering.  These options were seen to be problematic in issue #3182.