### PR TITLE
[WIP] New Function to Allocate MultiFabs w/ Initial Value

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -657,45 +657,58 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     const int ncompe = (m_dive_cleaning) ? 3 : 2;
     const int ncompb = (m_divb_cleaning) ? 3 : 2;
 
-    pml_E_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect() ), dm, ncompe, nge );
-    pml_E_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect() ), dm, ncompe, nge );
-    pml_E_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, ncompe, nge );
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_E_fp[0],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect()),
+        dm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_fp[x]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_E_fp[1],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect()),
+        dm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_fp[y]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_E_fp[2],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect()),
+        dm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_fp[z]"));
 
-    pml_B_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,0).ixType().toIntVect() ), dm, ncompb, ngb );
-    pml_B_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,1).ixType().toIntVect() ), dm, ncompb, ngb );
-    pml_B_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getBfield_fp(0,2).ixType().toIntVect() ), dm, ncompb, ngb );
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_B_fp[0],
+        amrex::convert(ba, WarpX::GetInstance().getBfield_fp(0,0).ixType().toIntVect()),
+        dm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_fp[x]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_B_fp[1],
+        amrex::convert(ba, WarpX::GetInstance().getBfield_fp(0,1).ixType().toIntVect()),
+        dm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_fp[y]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_B_fp[2],
+        amrex::convert(ba, WarpX::GetInstance().getBfield_fp(0,2).ixType().toIntVect()),
+        dm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_fp[z]"));
 
-    pml_E_fp[0]->setVal(0.0);
-    pml_E_fp[1]->setVal(0.0);
-    pml_E_fp[2]->setVal(0.0);
-    pml_B_fp[0]->setVal(0.0);
-    pml_B_fp[1]->setVal(0.0);
-    pml_B_fp[2]->setVal(0.0);
-
-    pml_j_fp[0] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,0).ixType().toIntVect() ), dm, 1, ngb );
-    pml_j_fp[1] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,1).ixType().toIntVect() ), dm, 1, ngb );
-    pml_j_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getcurrent_fp(0,2).ixType().toIntVect() ), dm, 1, ngb );
-
-    pml_j_fp[0]->setVal(0.0);
-    pml_j_fp[1]->setVal(0.0);
-    pml_j_fp[2]->setVal(0.0);
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_j_fp[0],
+        amrex::convert(ba, WarpX::GetInstance().getcurrent_fp(0,0).ixType().toIntVect()),
+        dm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_fp[x]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_j_fp[1],
+        amrex::convert(ba, WarpX::GetInstance().getcurrent_fp(0,1).ixType().toIntVect()),
+        dm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_fp[y]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_j_fp[2],
+        amrex::convert(ba, WarpX::GetInstance().getcurrent_fp(0,2).ixType().toIntVect()),
+        dm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_fp[z]"));
 
 #ifdef AMREX_USE_EB
-    pml_edge_lengths[0] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect() ), dm, WarpX::ncomps, max_guard_EB );
-    pml_edge_lengths[1] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect() ), dm, WarpX::ncomps, max_guard_EB );
-    pml_edge_lengths[2] = std::make_unique<MultiFab>(amrex::convert( ba,
-        WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, WarpX::ncomps, max_guard_EB );
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_edge_lengths[0],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,0).ixType().toIntVect()),
+        dm, WarpX::ncomps, amrex::IntVect(max_guard_EB), 0.0_rt, amrex::MFInfo().SetTag("pml_edge_lengths[x]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_edge_lengths[1],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,1).ixType().toIntVect()),
+        dm, WarpX::ncomps, amrex::IntVect(max_guard_EB), 0.0_rt, amrex::MFInfo().SetTag("pml_edge_lengths[y]"));
+    WarpX::GetInstance().AllocInitMultiFab(
+        pml_edge_lengths[2],
+        amrex::convert(ba, WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect()),
+        dm, WarpX::ncomps, amrex::IntVect(max_guard_EB), 0.0_rt, amrex::MFInfo().SetTag("pml_edge_lengths[z]"));
 
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
         WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
@@ -714,8 +727,9 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     if (m_dive_cleaning)
     {
         const amrex::IntVect& F_nodal_flag = amrex::IntVect::TheNodeVector();
-        pml_F_fp = std::make_unique<MultiFab>(amrex::convert(ba, F_nodal_flag), dm, 3, ngf);
-        pml_F_fp->setVal(0.0);
+        WarpX::GetInstance().AllocInitMultiFab(
+            pml_F_fp,amrex::convert(ba, F_nodal_flag), dm, 3, ngf, 0.0_rt,
+            amrex::MFInfo().SetTag("pml_F_fp"));
     }
 
     if (m_divb_cleaning)
@@ -723,8 +737,9 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         // TODO Shall we define a separate guard cells parameter ngG?
         const amrex::IntVect& G_nodal_flag = (do_nodal) ? amrex::IntVect::TheNodeVector()
                                                         : amrex::IntVect::TheCellVector();
-        pml_G_fp = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, 3, ngf);
-        pml_G_fp->setVal(0.0);
+        WarpX::GetInstance().AllocInitMultiFab(
+            pml_G_fp, amrex::convert(ba, G_nodal_flag), dm, 3, ngf, 0.0_rt,
+            amrex::MFInfo().SetTag("pml_G_fp"));
     }
 
     Box single_domain_box = is_single_box_domain ? domain0 : Box();
@@ -803,32 +818,32 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             cdm.define(cba);
         }
 
-        pml_E_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,0).ixType().toIntVect() ), cdm, ncompe, nge );
-        pml_E_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,1).ixType().toIntVect() ), cdm, ncompe, nge );
-        pml_E_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getEfield_cp(1,2).ixType().toIntVect() ), cdm, ncompe, nge );
+        WarpX::GetInstance().AllocInitMultiFab(pml_E_cp[0],
+            amrex::convert(cba, WarpX::GetInstance().getEfield_cp(1,0).ixType().toIntVect()),
+            cdm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_cp[x]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_E_cp[1],
+            amrex::convert(cba, WarpX::GetInstance().getEfield_cp(1,1).ixType().toIntVect()),
+            cdm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_cp[y]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_E_cp[2],
+            amrex::convert(cba, WarpX::GetInstance().getEfield_cp(1,2).ixType().toIntVect()),
+            cdm, ncompe, nge, 0.0_rt, amrex::MFInfo().SetTag("pml_E_cp[z]"));
 
-        pml_B_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,0).ixType().toIntVect() ), cdm, ncompb, ngb );
-        pml_B_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,1).ixType().toIntVect() ), cdm, ncompb, ngb );
-        pml_B_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getBfield_cp(1,2).ixType().toIntVect() ), cdm, ncompb, ngb );
-
-        pml_E_cp[0]->setVal(0.0);
-        pml_E_cp[1]->setVal(0.0);
-        pml_E_cp[2]->setVal(0.0);
-        pml_B_cp[0]->setVal(0.0);
-        pml_B_cp[1]->setVal(0.0);
-        pml_B_cp[2]->setVal(0.0);
+        WarpX::GetInstance().AllocInitMultiFab(pml_B_cp[0],
+            amrex::convert(cba, WarpX::GetInstance().getBfield_cp(1,0).ixType().toIntVect()),
+            cdm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_cp[x]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_B_cp[1],
+            amrex::convert(cba, WarpX::GetInstance().getBfield_cp(1,1).ixType().toIntVect()),
+            cdm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_cp[y]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_B_cp[2],
+            amrex::convert(cba, WarpX::GetInstance().getBfield_cp(1,2).ixType().toIntVect()),
+            cdm, ncompb, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_B_cp[z]"));
 
         if (m_dive_cleaning)
         {
             const amrex::IntVect& F_nodal_flag = amrex::IntVect::TheNodeVector();
-            pml_F_cp = std::make_unique<MultiFab>(amrex::convert(cba, F_nodal_flag), cdm, 3, ngf);
-            pml_F_cp->setVal(0.0);
+            WarpX::GetInstance().AllocInitMultiFab(
+                pml_F_cp, amrex::convert(cba, F_nodal_flag), cdm, 3, ngf, 0.0_rt,
+                amrex::MFInfo().SetTag("pml_F_cp"));
         }
 
         if (m_divb_cleaning)
@@ -836,20 +851,20 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             // TODO Shall we define a separate guard cells parameter ngG?
             const amrex::IntVect& G_nodal_flag = (do_nodal) ? amrex::IntVect::TheNodeVector()
                                                             : amrex::IntVect::TheCellVector();
-            pml_G_cp = std::make_unique<MultiFab>(amrex::convert(cba, G_nodal_flag), cdm, 3, ngf);
-            pml_G_cp->setVal(0.0);
+            WarpX::GetInstance().AllocInitMultiFab(
+                pml_G_cp, amrex::convert(cba, G_nodal_flag), cdm, 3, ngf, 0.0_rt,
+                amrex::MFInfo().SetTag("pml_G_cp"));
         }
 
-        pml_j_cp[0] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,0).ixType().toIntVect() ), cdm, 1, ngb );
-        pml_j_cp[1] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,1).ixType().toIntVect() ), cdm, 1, ngb );
-        pml_j_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
-            WarpX::GetInstance().getcurrent_cp(1,2).ixType().toIntVect() ), cdm, 1, ngb );
-
-        pml_j_cp[0]->setVal(0.0);
-        pml_j_cp[1]->setVal(0.0);
-        pml_j_cp[2]->setVal(0.0);
+        WarpX::GetInstance().AllocInitMultiFab(pml_j_cp[0],
+            amrex::convert(cba, WarpX::GetInstance().getcurrent_cp(1,0).ixType().toIntVect()),
+            cdm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_cp[x]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_j_cp[1],
+            amrex::convert(cba, WarpX::GetInstance().getcurrent_cp(1,1).ixType().toIntVect()),
+            cdm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_cp[y]"));
+        WarpX::GetInstance().AllocInitMultiFab(pml_j_cp[2],
+            amrex::convert(cba, WarpX::GetInstance().getcurrent_cp(1,2).ixType().toIntVect()),
+            cdm, 1, ngb, 0.0_rt, amrex::MFInfo().SetTag("pml_j_cp[z]"));
 
         single_domain_box = is_single_box_domain ? cdomain : Box();
         sigba_cp = std::make_unique<MultiSigmaBox>(cba, cdm, grid_cba_reduced, cgeom->CellSize(),

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -711,25 +711,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     pp_psatd.query("do_time_averaging", fft_do_time_averaging );
 
     for (int i = 0; i < 3; ++i) {
-        current_fp[lev][i]->setVal(0.0);
-        if (lev > 0)
-           current_cp[lev][i]->setVal(0.0);
-
-        // Initialize aux MultiFabs on level 0
-        if (lev == 0) {
-            Bfield_aux[lev][i]->setVal(0.0);
-            Efield_aux[lev][i]->setVal(0.0);
-        }
-
-        if (WarpX::do_current_centering)
-        {
-            current_fp_nodal[lev][i]->setVal(0.0);
-        }
-
-        if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
-        {
-            current_fp_vay[lev][i]->setVal(0.0);
-        }
 
         if (B_ext_grid_s == "constant" || B_ext_grid_s == "default") {
            Bfield_fp[lev][i]->setVal(B_external_grid[i]);
@@ -898,30 +879,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
            }
 #endif
        }
-    }
-
-    if (F_fp[lev]) {
-        F_fp[lev]->setVal(0.0);
-    }
-
-    if (G_fp[lev]) {
-        G_fp[lev]->setVal(0.0);
-    }
-
-    if (rho_fp[lev]) {
-        rho_fp[lev]->setVal(0.0);
-    }
-
-    if (F_cp[lev]) {
-        F_cp[lev]->setVal(0.0);
-    }
-
-    if (G_cp[lev]) {
-        G_cp[lev]->setVal(0.0);
-    }
-
-    if (rho_cp[lev]) {
-        rho_cp[lev]->setVal(0.0);
     }
 
     if (costs[lev]) {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1095,7 +1095,7 @@ private:
         const int ncomp,
         const amrex::IntVect& ngrow,
         const amrex::Real value,
-        const amrex::MFInfo& tag);
+        const amrex::MFInfo& tag=amrex::MFInfo().SetTag(""));
 
 #ifdef WARPX_USE_PSATD
 #   ifdef WARPX_DIM_RZ

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1087,6 +1087,16 @@ private:
                         const amrex::IntVect& ngEB, const amrex::IntVect& ngJ,
                         const amrex::IntVect& ngRho, const amrex::IntVect& ngF,
                         const amrex::IntVect& ngG, const bool aux_is_nodal);
+
+    void AllocInitMultiFab (
+        std::unique_ptr<amrex::MultiFab>& mf,
+        const amrex::BoxArray& bs,
+        const amrex::DistributionMapping& dm,
+        const int ncomp,
+        const amrex::IntVect& ngrow,
+        const amrex::Real value,
+        const amrex::MFInfo& tag);
+
 #ifdef WARPX_USE_PSATD
 #   ifdef WARPX_DIM_RZ
     void AllocLevelSpectralSolverRZ (amrex::Vector<std::unique_ptr<SpectralSolverRZ>>& spectral_solver,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1773,45 +1773,42 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     //
     std::array<Real,3> dx = CellSize(lev);
 
-    Bfield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_fp[x]"));
-    Bfield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_fp[y]"));
-    Bfield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_fp[z]"));
+    AllocInitMultiFab(Bfield_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_fp[x]"));
+    AllocInitMultiFab(Bfield_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_fp[y]"));
+    AllocInitMultiFab(Bfield_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_fp[z]"));
 
-    Efield_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_fp[x]"));
-    Efield_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_fp[y]"));
-    Efield_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_fp[z]"));
+    AllocInitMultiFab(Efield_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_fp[x]"));
+    AllocInitMultiFab(Efield_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_fp[y]"));
+    AllocInitMultiFab(Efield_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_fp[z]"));
 
-    current_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_fp[x]"));
-    current_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_fp[y]"));
-    current_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_fp[z]"));
+    AllocInitMultiFab(current_fp[lev][0], amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp[x]"));
+    AllocInitMultiFab(current_fp[lev][1], amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp[y]"));
+    AllocInitMultiFab(current_fp[lev][2], amrex::convert(ba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp[z]"));
 
     if (do_current_centering)
     {
         amrex::BoxArray const& nodal_ba = amrex::convert(ba, amrex::IntVect::TheNodeVector());
-        current_fp_nodal[lev][0] = std::make_unique<MultiFab>(nodal_ba, dm, ncomps, ngJ);
-        current_fp_nodal[lev][1] = std::make_unique<MultiFab>(nodal_ba, dm, ncomps, ngJ);
-        current_fp_nodal[lev][2] = std::make_unique<MultiFab>(nodal_ba, dm, ncomps, ngJ);
+        AllocInitMultiFab(current_fp_nodal[lev][0], nodal_ba, dm, ncomps, ngJ, 0.0_rt, tag("current_fp_nodal[x]"));
+        AllocInitMultiFab(current_fp_nodal[lev][1], nodal_ba, dm, ncomps, ngJ, 0.0_rt, tag("current_fp_nodal[y]"));
+        AllocInitMultiFab(current_fp_nodal[lev][2], nodal_ba, dm, ncomps, ngJ, 0.0_rt, tag("current_fp_nodal[z]"));
     }
 
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
     {
-        current_fp_vay[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, rho_nodal_flag),
-            dm, ncomps, ngJ, tag("current_fp_vay[x]"));
-        current_fp_vay[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, rho_nodal_flag),
-            dm, ncomps, ngJ, tag("current_fp_vay[y]"));
-        current_fp_vay[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, rho_nodal_flag),
-            dm, ncomps, ngJ, tag("current_fp_vay[z]"));
+        AllocInitMultiFab(current_fp_vay[lev][0], amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp_vay[x]"));
+        AllocInitMultiFab(current_fp_vay[lev][1], amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp_vay[y]"));
+        AllocInitMultiFab(current_fp_vay[lev][2], amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_fp_vay[z]"));
     }
 
     if (fft_do_time_averaging)
     {
-        Bfield_avg_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_fp[x]"));
-        Bfield_avg_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_fp[y]"));
-        Bfield_avg_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_fp[z]"));
+        AllocInitMultiFab(Bfield_avg_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_fp[x]"));
+        AllocInitMultiFab(Bfield_avg_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_fp[y]"));
+        AllocInitMultiFab(Bfield_avg_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_fp[z]"));
 
-        Efield_avg_fp[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_fp[x]"));
-        Efield_avg_fp[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_fp[y]"));
-        Efield_avg_fp[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_fp[z]"));
+        AllocInitMultiFab(Efield_avg_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_fp[x]"));
+        AllocInitMultiFab(Efield_avg_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_fp[y]"));
+        AllocInitMultiFab(Efield_avg_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_fp[z]"));
     }
 
 #ifdef AMREX_USE_EB
@@ -1855,12 +1852,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             Venl[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, By_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("Venl[y]"));
             Venl[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Bz_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("Venl[z]"));
 
-            ECTRhofield[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, Bx_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("ECTRhofield[x]"));
-            ECTRhofield[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, By_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("ECTRhofield[y]"));
-            ECTRhofield[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Bz_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("ECTRhofield[z]"));
-            ECTRhofield[lev][0]->setVal(0.);
-            ECTRhofield[lev][1]->setVal(0.);
-            ECTRhofield[lev][2]->setVal(0.);
+            AllocInitMultiFab(ECTRhofield[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, 0.0_rt, tag("ECTRhofield[x]"));
+            AllocInitMultiFab(ECTRhofield[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, 0.0_rt, tag("ECTRhofield[y]"));
+            AllocInitMultiFab(ECTRhofield[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, 0.0_rt, tag("ECTRhofield[z]"));
         }
     }
 #endif
@@ -1873,14 +1867,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     {
         // For the multi-J algorithm we can allocate only one rho component (no distinction between old and new)
         const int rho_ncomps = (WarpX::do_multi_J) ? ncomps : 2*ncomps;
-        rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_fp"));
+        AllocInitMultiFab(rho_fp[lev], amrex::convert(ba, rho_nodal_flag), dm, rho_ncomps, ngRho, 0.0_rt, tag("rho_fp"));
     }
 
     if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
     {
         IntVect ngPhi = IntVect( AMREX_D_DECL(1,1,1) );
-        phi_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,phi_nodal_flag),dm,ncomps,ngPhi,tag("phi_fp"));
-        phi_fp[lev]->setVal(0.);
+        AllocInitMultiFab(phi_fp[lev], amrex::convert(ba, phi_nodal_flag), dm, ncomps, ngPhi, 0.0_rt, tag("phi_fp"));
     }
 
     if (do_subcycling == 1 && lev == 0)
@@ -1892,12 +1885,12 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     if (do_dive_cleaning)
     {
-        F_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, F_nodal_flag), dm, ncomps, ngF, tag("F_fp"));
+        AllocInitMultiFab(F_fp[lev], amrex::convert(ba, F_nodal_flag), dm, ncomps, ngF, 0.0_rt, tag("F_fp"));
     }
 
     if (do_divb_cleaning)
     {
-        G_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, ncomps, ngG, tag("G_fp"));
+        AllocInitMultiFab(G_fp[lev], amrex::convert(ba, G_nodal_flag), dm, ncomps, ngG, 0.0_rt, tag("G_fp"));
     }
 
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
@@ -1966,13 +1959,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         // Create aux multifabs on Nodal Box Array
         BoxArray const nba = amrex::convert(ba,IntVect::TheNodeVector());
 
-        Bfield_aux[lev][0] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Bfield_aux[x]"));
-        Bfield_aux[lev][1] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Bfield_aux[y]"));
-        Bfield_aux[lev][2] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Bfield_aux[z]"));
+        AllocInitMultiFab(Bfield_aux[lev][0], nba, dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[x]"));
+        AllocInitMultiFab(Bfield_aux[lev][1], nba, dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[y]"));
+        AllocInitMultiFab(Bfield_aux[lev][2], nba, dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[z]"));
 
-        Efield_aux[lev][0] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Efield_aux[x]"));
-        Efield_aux[lev][1] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Efield_aux[y]"));
-        Efield_aux[lev][2] = std::make_unique<MultiFab>(nba,dm,ncomps,ngEB,tag("Efield_aux[z]"));
+        AllocInitMultiFab(Efield_aux[lev][0], nba, dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[x]"));
+        AllocInitMultiFab(Efield_aux[lev][1], nba, dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[y]"));
+        AllocInitMultiFab(Efield_aux[lev][2], nba, dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[z]"));
     } else if (lev == 0) {
         if (!WarpX::fft_do_time_averaging) {
             // In this case, the aux grid is simply an alias of the fp grid
@@ -1993,13 +1986,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             Bfield_aux[lev][2] = std::make_unique<MultiFab>(*Bfield_avg_fp[lev][2], amrex::make_alias, 0, ncomps);
         }
     } else {
-        Bfield_aux[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_aux[x]"));
-        Bfield_aux[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_aux[y]"));
-        Bfield_aux[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_aux[z]"));
+        AllocInitMultiFab(Bfield_aux[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[x]"));
+        AllocInitMultiFab(Bfield_aux[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[y]"));
+        AllocInitMultiFab(Bfield_aux[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_aux[z]"));
 
-        Efield_aux[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_aux[x]"));
-        Efield_aux[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_aux[y]"));
-        Efield_aux[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_aux[z]"));
+        AllocInitMultiFab(Efield_aux[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[x]"));
+        AllocInitMultiFab(Efield_aux[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[y]"));
+        AllocInitMultiFab(Efield_aux[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_aux[z]"));
     }
 
     //
@@ -2012,53 +2005,51 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         std::array<Real,3> cdx = CellSize(lev-1);
 
         // Create the MultiFabs for B
-        Bfield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[x]"));
-        Bfield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[y]"));
-        Bfield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_cp[z]"));
+        AllocInitMultiFab(Bfield_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_cp[x]"));
+        AllocInitMultiFab(Bfield_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_cp[y]"));
+        AllocInitMultiFab(Bfield_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_cp[z]"));
 
         // Create the MultiFabs for E
-        Efield_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[x]"));
-        Efield_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[y]"));
-        Efield_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_cp[z]"));
+        AllocInitMultiFab(Efield_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_cp[x]"));
+        AllocInitMultiFab(Efield_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_cp[y]"));
+        AllocInitMultiFab(Efield_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_cp[z]"));
 
         if (fft_do_time_averaging)
         {
-            Bfield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Bx_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[x]"));
-            Bfield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,By_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[y]"));
-            Bfield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Bz_nodal_flag),dm,ncomps,ngEB,tag("Bfield_avg_cp[z]"));
+            AllocInitMultiFab(Bfield_avg_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_cp[x]"));
+            AllocInitMultiFab(Bfield_avg_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_cp[y]"));
+            AllocInitMultiFab(Bfield_avg_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Bfield_avg_cp[z]"));
 
-            Efield_avg_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,Ex_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[x]"));
-            Efield_avg_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,Ey_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[y]"));
-            Efield_avg_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngEB,tag("Efield_avg_cp[z]"));
+            AllocInitMultiFab(Efield_avg_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_cp[x]"));
+            AllocInitMultiFab(Efield_avg_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_cp[y]"));
+            AllocInitMultiFab(Efield_avg_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt, tag("Efield_avg_cp[z]"));
         }
 
         // Create the MultiFabs for the current
-        current_cp[lev][0] = std::make_unique<MultiFab>(amrex::convert(cba,jx_nodal_flag),dm,ncomps,ngJ,tag("current_cp[x]"));
-        current_cp[lev][1] = std::make_unique<MultiFab>(amrex::convert(cba,jy_nodal_flag),dm,ncomps,ngJ,tag("current_cp[y]"));
-        current_cp[lev][2] = std::make_unique<MultiFab>(amrex::convert(cba,jz_nodal_flag),dm,ncomps,ngJ,tag("current_cp[z]"));
+        AllocInitMultiFab(current_cp[lev][0], amrex::convert(cba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_cp[x]"));
+        AllocInitMultiFab(current_cp[lev][1], amrex::convert(cba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_cp[y]"));
+        AllocInitMultiFab(current_cp[lev][2], amrex::convert(cba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt, tag("current_cp[z]"));
 
         if (deposit_charge) {
             // For the multi-J algorithm we can allocate only one rho component (no distinction between old and new)
             const int rho_ncomps = (WarpX::do_multi_J) ? ncomps : 2*ncomps;
-            rho_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_cp"));
+            AllocInitMultiFab(rho_cp[lev], amrex::convert(cba, rho_nodal_flag), dm, rho_ncomps, ngRho, 0.0_rt, tag("rho_cp"));
         }
 
         if (do_dive_cleaning)
         {
-            F_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba,IntVect::TheUnitVector()),dm,ncomps, ngF.max(),tag("F_cp"));
+            AllocInitMultiFab(F_cp[lev], amrex::convert(cba, IntVect::TheUnitVector()), dm, ncomps, ngF, 0.0_rt, tag("F_cp"));
         }
 
         if (do_divb_cleaning)
         {
             if (do_nodal)
             {
-                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba, IntVect::TheUnitVector()),
-                                                       dm, ncomps, ngG.max(), tag("G_cp"));
+                AllocInitMultiFab(G_cp[lev], amrex::convert(cba, IntVect::TheUnitVector()), dm, ncomps, ngG, 0.0_rt, tag("G_cp"));
             }
             else // do_nodal = 0
             {
-                G_cp[lev] = std::make_unique<MultiFab>(amrex::convert(cba, IntVect::TheZeroVector()),
-                                                       dm, ncomps, ngG.max(), tag("G_cp"));
+                AllocInitMultiFab(G_cp[lev], amrex::convert(cba, IntVect::TheZeroVector()), dm, ncomps, ngG, 0.0_rt, tag("G_cp"));
             }
         }
 
@@ -2733,4 +2724,17 @@ WarpX::isAnyBoundaryPML()
         if ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) return true;
     }
     return false;
+}
+
+void WarpX::AllocInitMultiFab (
+    std::unique_ptr<amrex::MultiFab>& mf,
+    const amrex::BoxArray& bs,
+    const amrex::DistributionMapping& dm,
+    const int ncomp,
+    const amrex::IntVect& ngrow,
+    const amrex::Real value,
+    const amrex::MFInfo& tag)
+{
+    mf = std::make_unique<amrex::MultiFab>(bs, dm, ncomp, ngrow, tag);
+    mf->setVal(value);
 }


### PR DESCRIPTION
Could something like this be useful? A small WarpX function, `WarpX::AllocInitMultiFab`, that allows us to allocate a MultiFab and initialize at the same time its values using `setVal`. For development and debugging purposes, I personally find it quite useful to have this function ready to use (shorter, less error-prone with respect to uninitialized data), but please feel free to give feedback and we can easily close the PR if there isn't agreement.