### PR TITLE
Poisson Solver: Fix Bug w/ Semi-coarsening and EB

### DIFF
--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -152,7 +152,7 @@ computePhi (amrex::Vector<std::unique_ptr<amrex::MultiFab> > const & rho,
                 {{ beta[0], beta[1], beta[2] }};
 #endif
 
-#if !(defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ))
+#if !(defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ))
         // Determine whether to use semi-coarsening
         amrex::Array<amrex::Real,AMREX_SPACEDIM> dx_scaled
                 {AMREX_D_DECL(geom[lev].CellSize(0)/std::sqrt(1._rt-beta_solver[0]*beta_solver[0]),


### PR DESCRIPTION
Implement @WeiqunZhang's suggestion in https://github.com/ECP-WarpX/WarpX/issues/3233#issuecomment-1182587487 to fix #3233.

@RemiLehe 
The test reported in the issue seems now to run without segmentation fault.
Not sure about the correctness of the results, you can probably check that better.