### PR TITLE
Add Python callback call when a checkpointing signal is received

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -264,6 +264,7 @@ _beforestep = CallbackFunctions('beforestep')
 _afterstep = CallbackFunctions('afterstep')
 _afterdiagnostics = CallbackFunctions('afterdiagnostics')
 _afterrestart = CallbackFunctions('afterrestart',lcallonce=1)
+_oncheckpointsignal = CallbackFunctions('oncheckpointsignal')
 _particleinjection = CallbackFunctions('particleinjection')
 _appliedfields = CallbackFunctions('appliedfields')
 
@@ -505,6 +506,20 @@ def isinstalledafterrestart(f):
     "Checks if the function is called immediately after a restart"
     raise Exception('restart call back not implemented yet')
     return _afterrestart.isinstalledfuncinlist(f)
+
+# ----------------------------------------------------------------------------
+def oncheckpointsignal(f):
+    installoncheckpointsignal(f)
+    return f
+def installoncheckpointsignal(f):
+    "Adds a function to the list of functions called on checkpoint signal"
+    _oncheckpointsignal.installfuncinlist(f)
+def uninstalloncheckpointsignal(f):
+    "Removes the function from the list of functions called on checkpoint signal"
+    _oncheckpointsignal.uninstallfuncinlist(f)
+def isinstalledoncheckpointsignal(f):
+    "Checks if the function is called on checkpoint signal"
+    return _oncheckpointsignal.isinstalledfuncinlist(f)
 
 # ----------------------------------------------------------------------------
 def callfromparticleinjection(f):

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -979,5 +979,6 @@ WarpX::HandleSignals()
 
     if (SignalHandling::TestAndResetActionRequestFlag(SignalHandling::SIGNAL_REQUESTS_CHECKPOINT)) {
         multi_diags->FilterComputePackFlushLastTimestep( istep[0] );
+        ExecutePythonCallback("oncheckpointsignal");
     }
 }

--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -22,7 +22,7 @@
  * afterinit, beforecollisions, aftercollisions, beforeEsolve, poissonsolver,
  * afterEsolve, beforedeposition, afterdeposition, particlescraper,
  * particleloader, beforestep, afterstep, afterdiagnostics, afterrestart,
- * particleinjection and appliedfields.
+ * oncheckpointsignal, particleinjection and appliedfields.
 */
 extern std::map< std::string, WARPX_CALLBACK_PY_FUNC_0 > warpx_callback_py_map;
 


### PR DESCRIPTION
We have some Python specific diagnostics that we checkpoint (timeseries of injected and scraped charges) whenever WarpX checkpoints are created. This callback allows us to trigger writing those diagnostics if the user sends a checkpointing signal to the WarpX process. 
This functionality is particularly useful to us while running simulations on AWS where SPOT instances can be arbitrarily reclaimed by AWS - we can now benefit maximally from the lower cost SPOT instances.