### PR TITLE
MultiParticleContainer: Prevent Bugs in Some `setVal` Calls

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -503,9 +503,9 @@ MultiParticleContainer::DepositCurrent (
     // Reset the J arrays
     for (int lev = 0; lev < J.size(); ++lev)
     {
-        J[lev][0]->setVal(0.0, J[lev][0]->nGrowVect());
-        J[lev][1]->setVal(0.0, J[lev][1]->nGrowVect());
-        J[lev][2]->setVal(0.0, J[lev][2]->nGrowVect());
+        J[lev][0]->setVal(0.0_rt);
+        J[lev][1]->setVal(0.0_rt);
+        J[lev][2]->setVal(0.0_rt);
     }
 
     // Call the deposition kernel for each species
@@ -530,7 +530,7 @@ MultiParticleContainer::DepositCharge (
     // Reset the rho array
     for (int lev = 0; lev < rho.size(); ++lev)
     {
-        rho[lev]->setVal(0.0, 0, WarpX::ncomps, rho[lev]->nGrowVect());
+        rho[lev]->setVal(0.0_rt);
     }
 
     // Push the particles in time, if needed


### PR DESCRIPTION
Having calls such as `rho[lev]->setVal(0.0, 0, WarpX::ncomps, rho[lev]->nGrowVect());` is potentially buggy if `rho[lev]->nComp()` is different than `WarpX::ncomps`, which is possible (depending on the algorithms used):
https://github.com/ECP-WarpX/WarpX/blob/af5b5764f8a1657a3da901447a3ddf0c358c0b7c/Source/WarpX.cpp#L1872-L1877

It seems to me that it is more robust to call `setVal` with its default arguments (number of components and ghost cells), which should set the given value for all components of the MultiFab and in all of the allocated ghost cells. I do this here for both `MultiParticleContainer::DepositCharge` and `MultiParticleContainer::DepositCurrent`, for consistency.