### PR TITLE
[WIP] Add regions and BLProf only macros.

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -495,7 +495,7 @@ WarpX::OneStep_nosub (Real cur_time)
         if (safe_guard_cells)
             FillBoundaryB(guard_cells.ng_alloc_EB);
     } // !PSATD
-    WARPX_PROFILE_REGION_START("WarpX::nosub::PushE_B");
+    WARPX_PROFILE_REGION_STOP("WarpX::nosub::PushE_B");
 
     ExecutePythonCallback("afterEsolve");
 }

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -20,5 +20,7 @@
 #define WARPX_PROFILE_VAR_START(vname) ABLASTR_PROFILE_VAR_START(vname, WarpX::do_device_synchronize)
 #define WARPX_PROFILE_VAR_STOP(vname) ABLASTR_PROFILE_VAR_STOP(vname, WarpX::do_device_synchronize)
 #define WARPX_PROFILE_REGION(rname) ABLASTR_PROFILE_REGION(rname, WarpX::do_device_synchronize)
+#define WARPX_PROFILE_REGION_START(rname) ABLASTR_PROFILE_REGION_START(rname, WarpX::do_device_synchronize)
+#define WARPX_PROFILE_REGION_STOP(rname) ABLASTR_PROFILE_REGION_STOP(rname, WarpX::do_device_synchronize)
 
 #endif // WARPX_PROFILERWRAPPER_H_

--- a/Source/ablastr/profiler/ProfilerWrapper.H
+++ b/Source/ablastr/profiler/ProfilerWrapper.H
@@ -52,5 +52,7 @@ namespace profiler {
 #define ABLASTR_PROFILE_VAR_START(vname, sync) ablastr::profiler::device_synchronize(sync); BL_PROFILE_VAR_START(vname)
 #define ABLASTR_PROFILE_VAR_STOP(vname, sync) ablastr::profiler::device_synchronize(sync); BL_PROFILE_VAR_STOP(vname)
 #define ABLASTR_PROFILE_REGION(rname, sync) ablastr::profiler::device_synchronize(sync); BL_PROFILE_REGION(rname); ablastr::profiler::SynchronizeOnDestruct BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){sync}
+#define ABLASTR_PROFILE_REGION_START(rname, sync) ablastr::profiler::device_synchronize(sync); BL_PROFILE_REGION_START(rname); ablastr::profiler::SynchronizeOnDestruct BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){sync}
+#define ABLASTR_PROFILE_REGION_STOP(rname, sync) ablastr::profiler::device_synchronize(sync); BL_PROFILE_REGION_STOP(rname); ablastr::profiler::SynchronizeOnDestruct BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){sync}
 
 #endif // ABLASTR_PROFILERWRAPPER_H_


### PR DESCRIPTION
First draft at adding profiling regions to the code.

Adds the Full Profiler only-macros, so this pass doesn't affect the current output, and took my best guess at reasonable regions for the UniformPlasma and KPP tests. First runs seem to work.

Iteration and discussion of where to put regions, and Full Profiler or TinyProfiler regions are welcome.