### PR TITLE
Update background_mcc_dp_psp benchmark

### DIFF
--- a/Regression/Checksum/benchmarks_json/background_mcc_dp_psp.json
+++ b/Regression/Checksum/benchmarks_json/background_mcc_dp_psp.json
@@ -12,7 +12,7 @@
   "he_ions": {
     "particle_cpu": 262803.0,
     "particle_id": 206741084466.0,
-    "particle_momentum_x": 2.8825928770053435e-18,
+    "particle_momentum_x": 2.882592880031919e-18,
     "particle_momentum_y": 2.1960207748059422e-18,
     "particle_momentum_z": 2.1982341415215343e-18,
     "particle_position_x": 17605.83295166959,


### PR DESCRIPTION
This PR fixes the benchmark value [he_ions,particle_momentum_x] in the background_mcc_dp_psp CI test.

This fix is needed because of the use of ParticleReal in the MCC collision code, the change in PR #3262, coupled with the similar change in the pusher, PR #3259, resulted in a change in the benchmark value. Unfortunately, PR #3262 was merged before it had been rebased with development and so did not include PR #3259 and so the change in the benchmark was not detected.

Note that the test case was checked (see here https://warpx.readthedocs.io/en/latest/usage/examples.html#capacitive-discharge) to ensure that the code is still producing valid results.