### PR TITLE
Implement output of scraped particles at domain boundaries

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -957,7 +957,7 @@ Particle initialization
     the above mentioned function.
 
     .. note::
-        When accessing the data via Python, the scraped particle buffer relies on the user 
+        When accessing the data via Python, the scraped particle buffer relies on the user
         to clear the buffer after processing the data. The
         buffer will grow unbounded as particles are scraped and therefore could
         lead to memory issues if not periodically cleared. To clear the buffer

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2246,10 +2246,11 @@ Back-Transformed Diagnostics (legacy output)
 Boundary Scraping Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``BoundaryScrapingDiagnostics`` are used to collect the particles that are absorbed at the embedded boundary, throughout the simulation.
+``BoundaryScrapingDiagnostics`` are used to collect the particles that are absorbed at the boundaries, throughout the simulation.
 (Note that this diagnostics does not save any field ; it only saves particles.)
 Currently, the only supported output format is openPMD, so the user needs to set ``<diag>.format=openpmd``. In addition, the user needs
-to set ``<species>.save_particles_at_eb=1`` for each of the species that are to be saved in this diagnostic.
+to set ``<species>.save_particles_at_xlo/ylo/zlo``, ``<species>.save_particles_at_xhi/yhi/zhi``, ``<species>.save_particles_at_eb``
+to ``1`` for the species and boundaries that are to be recorded on file.
 
 In addition to their usual attributes, the saved particles have an additional integer attribute ``timestamp``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary.

--- a/Examples/Tests/embedded_circle/inputs_2d
+++ b/Examples/Tests/embedded_circle/inputs_2d
@@ -37,8 +37,8 @@ electrons.density = 10.2e16
 electrons.profile = constant
 electrons.momentum_distribution_type = maxwell_boltzmann
 electrons.theta = (kb*30000/(m_e*clight^2))
-electrons.save_particles_at_zlo = 1
-electrons.save_particles_at_zhi = 1
+electrons.save_particles_at_xlo = 1
+electrons.save_particles_at_xhi = 1
 electrons.save_particles_at_eb = 1
 
 ar_ions.species_type = argon
@@ -55,8 +55,8 @@ ar_ions.uz_m = 0.0
 ar_ions.ux_th = 2.6285641070031447e-06
 ar_ions.uy_th = 2.6285641070031447e-06
 ar_ions.uz_th = 2.6285641070031447e-06
-ar_ions.save_particles_at_zlo = 1
-ar_ions.save_particles_at_zhi = 1
+ar_ions.save_particles_at_xlo = 1
+ar_ions.save_particles_at_xhi = 1
 ar_ions.save_particles_at_eb = 1
 
 collisions.collision_names = coll_electrons coll_ar_ions
@@ -80,8 +80,12 @@ coll_ar_ions.back_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/i
 coll_ar_ions.elastic_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/ion_scattering.dat
 coll_ar_ions.charge_exchange_cross_section = ../../../../warpx-data/MCC_cross_sections/Ar/charge_exchange.dat
 
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 diag3
 diag1.diag_type = Full
 diag1.format = plotfile
 diag1.intervals = 1
 diag1.fields_to_plot = phi rho_electrons rho_ar_ions
+
+diag3.diag_type = BoundaryScraping
+diag3.format = openpmd
+diag3.intervals = 5

--- a/Examples/Tests/scraping/analysis_rz.py
+++ b/Examples/Tests/scraping/analysis_rz.py
@@ -47,7 +47,7 @@ assert(error==tolerance)
 # remaining particles and scraped particles is equal to the
 # original number of particles
 ts_full = OpenPMDTimeSeries('./diags/diag2/')
-ts_scraping = OpenPMDTimeSeries('./diags/diag3/')
+ts_scraping = OpenPMDTimeSeries('./diags/diag3/particles_at_eb')
 
 def n_remaining_particles( iteration ):
     w, = ts_full.get_particle(['w'], iteration=iteration)

--- a/Examples/Tests/scraping/inputs_rz
+++ b/Examples/Tests/scraping/inputs_rz
@@ -40,10 +40,6 @@ electron.momentum_function_ux(x,y,z) = "if(x*x+y*y>0.0, -1.0*x/sqrt(x*x+y*y), 0.
 electron.momentum_function_uy(x,y,z) = "if(x*x+y*y>0.0, -1.0*y/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uz(x,y,z) = "0"
 electron.do_not_deposit = 1
-electron.save_particles_at_xlo = 1
-electron.save_particles_at_xhi = 1
-electron.save_particles_at_zlo = 1
-electron.save_particles_at_zhi = 1
 electron.save_particles_at_eb = 1
 
 diagnostics.diags_names = diag1 diag2 diag3

--- a/Examples/Tests/scraping/inputs_rz
+++ b/Examples/Tests/scraping/inputs_rz
@@ -40,6 +40,10 @@ electron.momentum_function_ux(x,y,z) = "if(x*x+y*y>0.0, -1.0*x/sqrt(x*x+y*y), 0.
 electron.momentum_function_uy(x,y,z) = "if(x*x+y*y>0.0, -1.0*y/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uz(x,y,z) = "0"
 electron.do_not_deposit = 1
+electron.save_particles_at_xlo = 1
+electron.save_particles_at_xhi = 1
+electron.save_particles_at_zlo = 1
+electron.save_particles_at_zhi = 1
 electron.save_particles_at_eb = 1
 
 diagnostics.diags_names = diag1 diag2 diag3

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2785,8 +2785,8 @@ buildDir = .
 inputFile = Examples/Tests/embedded_circle/inputs_2d
 runtime_params = warpx.abort_on_warning_threshold = high
 dim = 2
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+addToCompileString = USE_EB=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -725,6 +725,7 @@ BTDiagnostics::Flush (int i_buffer)
     }
     SetSnapshotFullStatus(i_buffer);
     bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 ) ? true : false;
+    bool const use_pinned_pc = true;
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];
 
@@ -777,7 +778,7 @@ BTDiagnostics::Flush (int i_buffer)
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         labtime, m_output_species[i_buffer], nlev_output, file_name, m_file_min_digits,
         m_plot_raw_fields, m_plot_raw_fields_guards,
-        isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush,
+        use_pinned_pc, isBTD, i_buffer, m_geom_snapshot[i_buffer][0], isLastBTDFlush,
         m_totalParticles_flushed_already[i_buffer]);
 
     for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -8,6 +8,7 @@
 #define WARPX_BOUNDARYSCRAPINGDIAGNOSTICS_H_
 
 #include "Diagnostics.H"
+#include "Utils/IntervalsParser.H"
 
 #include <string>
 
@@ -28,6 +29,10 @@ public:
 private:
     /** Read relevant parameters for BoundaryScraping */
     void ReadParameters ();
+
+    /** Determines timesteps at which the particles are written out */
+    IntervalsParser m_intervals;
+
     /** \brief Flush data to file. */
     void Flush (int i_buffer) override;
     /** \brief Return whether to dump data to file at this time step.

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -34,8 +34,7 @@ private:
      * (i.e. whether to call Flush)
      *
      * \param[in] step current time step
-     * \param[in] i_buffer used only for BackTransformedDiagnostics.
-     * For BoundaryScrapingDiagnostics, this is always 0
+     * \param[in] i_buffer index of the boundary buffer used (e.g. upper/lower boundary, EB boundary)
      * \param[in] force_flush if true, return true for any step
      */
     bool DoDump (int step, int i_buffer, bool force_flush=false) override;

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -116,11 +116,13 @@ BoundaryScrapingDiagnostics::InitializeParticleBuffer ()
         }
     }
     // Initialize total number of particles flushed
-    m_totalParticles_flushed_already.resize(1);
-    int const n_species = m_output_species_names.size();
-    m_totalParticles_flushed_already[0].resize(n_species);
-    for (int i_species=0; i_species<n_species; i_species++) {
-        m_totalParticles_flushed_already[0][i_species] = 0;
+    m_totalParticles_flushed_already.resize(m_num_buffers);
+    for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
+        int const n_species = m_output_species_names.size();
+        m_totalParticles_flushed_already[i_buffer].resize(n_species);
+        for (int i_species=0; i_species<n_species; i_species++) {
+            m_totalParticles_flushed_already[i_buffer][i_species] = 0;
+        }
     }
 }
 
@@ -159,7 +161,7 @@ BoundaryScrapingDiagnostics::Flush (int i_buffer)
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         0., m_output_species[i_buffer], nlev_output, m_file_prefix,
-        m_file_min_digits, false, false, isBTD, 0, geom,
-        isLastBTD, m_totalParticles_flushed_already[0]);
+        m_file_min_digits, false, false, isBTD, i_buffer, geom,
+        isLastBTD, m_totalParticles_flushed_already[i_buffer]);
 
 }

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -120,7 +120,7 @@ BoundaryScrapingDiagnostics::InitializeParticleBuffer ()
     int const n_species = m_output_species_names.size();
     m_totalParticles_flushed_already[0].resize(n_species);
     for (int i_species=0; i_species<n_species; i_species++) {
-        m_totalParticles_flushed_already[i_buffer][i_species] = 0;
+        m_totalParticles_flushed_already[0][i_species] = 0;
     }
 }
 

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -159,7 +159,7 @@ BoundaryScrapingDiagnostics::Flush (int i_buffer)
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         0., m_output_species[i_buffer], nlev_output, m_file_prefix,
-        m_file_min_digits, false, false, isBTD, i_buffer, geom,
+        m_file_min_digits, false, false, isBTD, 0, geom,
         isLastBTD, m_totalParticles_flushed_already[0]);
 
 }

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -48,28 +48,6 @@ BoundaryScrapingDiagnostics::ReadParameters ()
     amrex::Abort("You need to compile WarpX with openPMD support, in order to use BoundaryScrapingDiagnostic: -DWarpX_OPENPMD=ON");
 #endif
 
-    // TODO add check for `save_particle_at_xlo`, etc.
-    // Check that saving at EB has been activated for each requested species
-    std::set<std::string> particle_saving_activated;
-    for (auto const& species_name : m_output_species_names){
-        amrex::ParmParse pp(species_name);
-        bool save_particles_at_eb;
-        pp.query("save_particles_at_eb", save_particles_at_eb);
-        if (save_particles_at_eb == false) particle_saving_activated.insert(species_name);
-    }
-    std::string error_string = "You need to set "
-        "you need to set:\n";
-    for (auto const& species_name : particle_saving_activated){
-        error_string
-            .append("  ")
-            .append(species_name)
-            .append("save_particles_at_eb=1\n");
-    }
-    error_string.append("in order to use for the BoundaryScrapingDiagnostic.");
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        particle_saving_activated.size() == 0u,
-        error_string);
-
     // Check that the output format is openPMD
     error_string = std::string("You need to set `")
         .append(m_diag_name)

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -49,7 +49,7 @@ BoundaryScrapingDiagnostics::ReadParameters ()
 #endif
 
     // Check that the output format is openPMD
-    error_string = std::string("You need to set `")
+    std::string error_string = std::string("You need to set `")
         .append(m_diag_name)
         .append(".format=openpmd` for the BoundaryScrapingDiagnostic.");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -13,6 +13,7 @@
 #include "WarpX.H"
 
 #include <AMReX.H>
+#include <AMReX_ParmParse.H>
 
 #include <set>
 #include <string>
@@ -55,6 +56,13 @@ BoundaryScrapingDiagnostics::ReadParameters ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_format == "openpmd",
         error_string);
+
+    // Check for the optional intervals parameter
+    amrex::ParmParse pp_diag_name(m_diag_name);
+    std::vector<std::string> intervals_string_vec = {"0"};
+    pp_diag_name.queryarr("intervals", intervals_string_vec);
+    m_intervals = IntervalsParser(intervals_string_vec);
+
 }
 
 void
@@ -111,12 +119,12 @@ BoundaryScrapingDiagnostics::DoComputeAndPack (int /*step*/, bool /*force_flush*
 }
 
 bool
-BoundaryScrapingDiagnostics::DoDump (int /*step*/, int /*i_buffer*/, bool force_flush)
+BoundaryScrapingDiagnostics::DoDump (int step, int /*i_buffer*/, bool force_flush)
 {
     if (force_flush) {
         return true;
     } else {
-        return false;
+        return (m_intervals.contains(step+1));
     }
 }
 
@@ -124,22 +132,34 @@ void
 BoundaryScrapingDiagnostics::Flush (int i_buffer)
 {
     auto & warpx = WarpX::GetInstance();
+    ParticleBoundaryBuffer& particle_buffer = warpx.GetParticleBoundaryBuffer();
 
-    // This is not a backtransform diagnostics, but we still set the flag `isBTD`
-    // This enables:
-    //   - writing the data that was accumulated in a PinnedMemoryParticleContainer
-    //   - writing repeatedly to the same file
-    bool const isBTD = true;
-    // For now, because this function is currently only called at the very end
-    // of the simulation for BoundaryScrapingDiagnostics, we always set `isLastBTD`.
-    // This tells WarpX to write all the metadata (and not purely the particle data)
-    bool const isLastBTD = true;
+    int n_particles = 0;
+    for (auto const& species_name : m_output_species_names) {
+        n_particles += particle_buffer.getNumParticlesInContainer(species_name, i_buffer);
+    }
+
+    // If the saving of the particles was not set up for any of the species for this boundary
+    // or if no particles have been lost, then don't write anything out.
+    if (n_particles == 0) return;
+
+    // This is not a backtransform diagnostics
+    bool const isBTD = false;
+    bool const isLastBTD = false;
+    // The data being written out is saved in a pinned particle container
+    bool const use_pinned_pc = true;
     const amrex::Geometry& geom = warpx.Geom(0); // For compatibility with `WriteToFile` ; not used
+
+    // The data for each boundary is written out to a separate directory with the boundary name
+    std::string file_prefix = m_file_prefix + "/particles_at_" + particle_buffer.boundaryName(i_buffer);
 
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
-        0., m_output_species[i_buffer], nlev_output, m_file_prefix,
-        m_file_min_digits, false, false, isBTD, i_buffer, geom,
+        warpx.gett_new(0), m_output_species[i_buffer], nlev_output, file_prefix,
+        m_file_min_digits, false, false, use_pinned_pc, isBTD, warpx.getistep(0), geom,
         isLastBTD, m_totalParticles_flushed_already[i_buffer]);
+
+    // Now that the data has been written out, clear out the buffer
+    particle_buffer.clearParticles(i_buffer);
 
 }

--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -20,6 +20,7 @@ public:
         const std::string prefix, const int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -37,6 +37,7 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -18,6 +18,7 @@ FlushFormatAscent::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int /*file_min_digits*/, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    const bool /*use_pinned_pc*/,
     bool /*isBTD*/, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/,
     bool /*isLastBTDFlush*/, const amrex::Vector<int>& /* totalParticlesFlushedAlready*/) const
 {

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -24,6 +24,7 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -35,6 +35,7 @@ FlushFormatCheckpoint::WriteToFile (
         const std::string prefix, int file_min_digits,
         bool /*plot_raw_fields*/,
         bool /*plot_raw_fields_guards*/,
+        const bool /*use_pinned_pc*/,
         bool /*isBTD*/, int /*snapshotID*/,
         const amrex::Geometry& /*full_BTD_snapshot*/,
         bool /*isLastBTDFlush*/, const amrex::Vector<int>& /* totalParticlesFlushedAlready*/) const

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -36,6 +36,7 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -113,6 +113,7 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int output_levels,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    const bool use_pinned_pc,
     bool isBTD, int snapshotID, const amrex::Geometry& full_BTD_snapshot,
     bool isLastBTDFlush, const amrex::Vector<int>& totalParticlesFlushedAlready) const
 {
@@ -137,7 +138,7 @@ FlushFormatOpenPMD::WriteToFile (
         varnames, mf, geom, output_levels, output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
-    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, isBTD, isLastBTDFlush, totalParticlesFlushedAlready);
+    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, use_pinned_pc, isBTD, isLastBTDFlush, totalParticlesFlushedAlready);
 
     // signal that no further updates will be written to this iteration
     m_OpenPMDPlotWriter->CloseStep(isBTD, isLastBTDFlush);

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -31,6 +31,7 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -59,6 +59,7 @@ FlushFormatPlotfile::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    const bool /*use_pinned_pc*/,
     bool isBTD, int /*snapshotID*/, const amrex::Geometry& /*full_BTD_snapshot*/,
     bool /*isLastBTDFlush*/, const amrex::Vector<int>& /* totalParticlesFlushedAlready*/) const
 {

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -55,6 +55,7 @@ public:
         const std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        const bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
         bool isLastBTDFlush = false,

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -55,6 +55,7 @@ FlushFormatSensei::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags,
     int nlev, const std::string prefix, int file_min_digits,
     bool plot_raw_fields, bool plot_raw_fields_guards,
+    const bool use_pinned_pc,
     bool isBTD, int snapshotID,
     const amrex::Geometry& full_BTD_snapshot, bool isLastBTDFlush,
     const amrex::Vector<int>& totalParticlesFlushedAlready) const
@@ -62,7 +63,7 @@ FlushFormatSensei::WriteToFile (
     amrex::ignore_unused(
         geom, nlev, prefix, file_min_digits,
         plot_raw_fields, plot_raw_fields_guards,
-        isBTD, snapshotID, full_BTD_snapshot,
+        use_pinned_pc, isBTD, snapshotID, full_BTD_snapshot,
         isLastBTDFlush, totalParticlesFlushedAlready);
 
 #ifndef AMREX_USE_SENSEI_INSITU

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -134,6 +134,7 @@ public:
 
   void WriteOpenPMDParticles (
               const amrex::Vector<ParticleDiag>& particle_diags,
+              const bool use_pinned_pc = false,
               const bool isBTD = false,
               const bool isLastBTDFlush = false,
               const amrex::Vector<int>& totalParticlesFlushedAlready = amrex::Vector<int>());

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -564,6 +564,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     if (! isBTD) {
         tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
     } else {
+        if (!pinned_pc->isDefined()) continue; // Skip to the next particle container
         tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
     }
     // names of amrex::Real and int particle attributes in SoA data

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -552,7 +552,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
 
 void
 WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags,
-                  const bool isBTD, const bool isLastBTDFlush, const amrex::Vector<int>& totalParticlesFlushedAlready)
+                  const bool use_pinned_pc, const bool isBTD, const bool isLastBTDFlush,
+                  const amrex::Vector<int>& totalParticlesFlushedAlready)
 {
   WARPX_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDParticles()");
 
@@ -561,11 +562,11 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
     PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
     PinnedMemoryParticleContainer tmp;
-    if (! isBTD) {
-        tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
-    } else {
+    if (isBTD || use_pinned_pc) {
         if (!pinned_pc->isDefined()) continue; // Skip to the next particle container
         tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
+    } else {
+        tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
     }
     // names of amrex::Real and int particle attributes in SoA data
     amrex::Vector<std::string> real_names;
@@ -617,7 +618,9 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
       GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                            particle_diags[i].m_diag_domain);
 
-      if (! isBTD) {
+      if (isBTD || use_pinned_pc) {
+          tmp.copyParticles(*pinned_pc, true);
+      } else {
           using SrcData = WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType;
           tmp.copyParticles(*pc,
                             [=] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip, const amrex::RandomEngine& engine)
@@ -626,8 +629,6 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
               return random_filter(p, engine) * uniform_filter(p, engine)
                      * parser_filter(p, engine) * geometry_filter(p, engine);
           }, true);
-      } else if (isBTD) {
-          tmp.copyParticles(*pinned_pc, true);
       }
 
     // real_names contains a list of all real particle attributes.

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -39,6 +39,7 @@ public:
 
     void redistribute ();
     void clearParticles ();
+    void clearParticles (int const i);
 
     void printNumParticles () const;
 
@@ -56,12 +57,20 @@ public:
             ;
     }
 
+    bool isDefinedForAnySpecies (int const ibuffer) {return (m_do_any_boundary[ibuffer] != 0);}
+
+    std::string boundaryName (int const ibuffer) {return m_boundary_names[ibuffer];}
+
 private:
     // over boundary, then number of species
     std::vector<std::vector<PinnedMemoryParticleContainer> > m_particle_containers;
 
     // over boundary, then number of species
     std::vector<std::vector<int> > m_do_boundary_buffer;
+
+    // over boundary
+    std::vector<int> m_do_any_boundary;
+    std::vector<std::string> m_boundary_names;
 
     mutable std::vector<std::string> m_species_names;
 };

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -64,6 +64,8 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
 {
     m_particle_containers.resize(numBoundaries());
     m_do_boundary_buffer.resize(numBoundaries());
+    m_do_any_boundary.resize(numBoundaries(), 0);
+    m_boundary_names.resize(numBoundaries());
 
     for (int i = 0; i < numBoundaries(); ++i)
     {
@@ -93,7 +95,32 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
 #ifdef AMREX_USE_EB
         pp_species.query("save_particles_at_eb", m_do_boundary_buffer[AMREX_SPACEDIM*2][ispecies]);
 #endif
+        // Set the flag whether the boundary is active or any species
+        for (int i = 0; i < numBoundaries(); ++i) {
+            if (m_do_boundary_buffer[i][ispecies]) m_do_any_boundary[i] = 1;
+        }
     }
+
+#if defined(WARPX_DIM_1D_Z)
+    m_boundary_names[0] = "zlo";
+    m_boundary_names[1] = "zhi";
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+    m_boundary_names[0] = "xlo";
+    m_boundary_names[1] = "xhi";
+    m_boundary_names[2] = "zlo";
+    m_boundary_names[3] = "zhi";
+#else
+    m_boundary_names[0] = "xlo";
+    m_boundary_names[1] = "xhi";
+    m_boundary_names[2] = "ylo";
+    m_boundary_names[3] = "yhi";
+    m_boundary_names[4] = "zlo";
+    m_boundary_names[5] = "zhi";
+#endif
+#ifdef AMREX_USE_EB
+    m_boundary_names[AMREX_SPACEDIM*2] =  "eb";
+#endif
+
 }
 
 void ParticleBoundaryBuffer::printNumParticles () const {
@@ -143,12 +170,16 @@ void ParticleBoundaryBuffer::redistribute () {
 void ParticleBoundaryBuffer::clearParticles () {
     for (int i = 0; i < numBoundaries(); ++i)
     {
-        auto& buffer = m_particle_containers[i];
-        for (int ispecies = 0; ispecies < numSpecies(); ++ispecies)
-        {
-            auto& species_buffer = buffer[ispecies];
-            if (species_buffer.isDefined()) species_buffer.clearParticles();
-        }
+        clearParticles(i);
+    }
+}
+
+void ParticleBoundaryBuffer::clearParticles (int const i) {
+    auto& buffer = m_particle_containers[i];
+    for (int ispecies = 0; ispecies < numSpecies(); ++ispecies)
+    {
+        auto& species_buffer = buffer[ispecies];
+        if (species_buffer.isDefined()) species_buffer.clearParticles();
     }
 }
 
@@ -233,6 +264,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
     auto& buffer = m_particle_containers[m_particle_containers.size()-1];
     for (int i = 0; i < numSpecies(); ++i)
     {
+        if (!m_do_boundary_buffer[AMREX_SPACEDIM*2][i]) continue;
         const auto& pc = mypc.GetParticleContainer(i);
         if (!buffer[i].isDefined())
         {

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -332,8 +332,5 @@ ParticleBoundaryBuffer::getParticleBufferPointer(const std::string species_name,
     auto& buffer = m_particle_containers[boundary];
     auto index = WarpX::GetInstance().GetPartContainer().getSpeciesID(species_name);
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_boundary_buffer[boundary][index],
-                                     "Attempted to get particle buffer for boundary "
-                                     + std::to_string(boundary) + ", which is not used!");
     return &buffer[index];
 }


### PR DESCRIPTION
This replaces PR #3195. In the process of updating that PR, I managed to corrupt the commit history. The new commits from that branch were cherry picked into this branch, plus my new changes.

With this PR, the particles lost at the domain boundaries can be saved to output files. To separate the data, the data from each boundary is written to a separate subdirectory (as explained in the documentation). I've also added the option of setting an interval so that the data is written out during the simulation instead of only at the end.

A bit of extensive changes were needed since getting this to work since a new option was needed in the `WriteToFile` routines specifying a pinned particle container that was separate from the `isBTD` option.

The avoids writing out empty data sets (if there are no particles lost) since the empty data confuse the openpmd reader.