### PR TITLE
`SyncCurrent`: Pass References To Current MultiFabs

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -398,14 +398,17 @@ WarpX::OneStep_nosub (Real cur_time)
 
     ExecutePythonCallback("afterdeposition");
 
-    // Synchronize J and rho.
+    // Synchronize J and rho: filter, exchange boundary, interpolate across levels.
     // With Vay current deposition, the current deposited at this point is not yet
     // the actual current J. This is computed later in WarpX::PushPSATD, by calling
     // WarpX::PSATDVayDeposition. The function SyncCurrent is called after that,
     // instead of here, so that we synchronize the correct current.
+    // With current centering, the nodal current is deposited in 'current_fp_nodal':
+    // SyncCurrent stores the result of its centering into 'current_fp' and then
+    // performs both filtering, if used, and exchange of guard cells.
     if (WarpX::current_deposition_algo != CurrentDepositionAlgo::Vay)
     {
-        SyncCurrent();
+        SyncCurrent(current_fp, current_cp);
     }
     SyncRho();
 
@@ -533,8 +536,12 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
     //    (dt[0] denotes the time step on mesh refinement level 0)
     auto& current = (WarpX::do_current_centering) ? current_fp_nodal : current_fp;
     mypc->DepositCurrent(current, dt[0], -dt[0]);
-    // Filter, exchange boundary, and interpolate across levels
-    SyncCurrent();
+    // Synchronize J: filter, exchange boundary, and interpolate across levels.
+    // With current centering, the nodal current is deposited in 'current',
+    // namely 'current_fp_nodal': SyncCurrent stores the result of its centering
+    // into 'current_fp' and then performs both filtering, if used, and exchange
+    // of guard cells.
+    SyncCurrent(current_fp, current_cp);
     // Forward FFT of J
     PSATDForwardTransformJ(current_fp, current_cp);
 
@@ -557,8 +564,12 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         // Deposit new J at relative time t_depose with time step dt
         // (dt[0] denotes the time step on mesh refinement level 0)
         mypc->DepositCurrent(current, dt[0], t_depose);
-        // Filter, exchange boundary, and interpolate across levels
-        SyncCurrent();
+        // Synchronize J: filter, exchange boundary, and interpolate across levels.
+        // With current centering, the nodal current is deposited in 'current',
+        // namely 'current_fp_nodal': SyncCurrent stores the result of its centering
+        // into 'current_fp' and then performs both filtering, if used, and exchange
+        // of guard cells.
+        SyncCurrent(current_fp, current_cp);
         // Forward FFT of J
         PSATDForwardTransformJ(current_fp, current_cp);
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -635,7 +635,7 @@ WarpX::PushPSATD ()
         PSATDVayDeposition();
         PSATDBackwardTransformJ(current_fp, current_cp);
         PSATDSubtractCurrentPartialSumsAvg();
-        SyncCurrent();
+        SyncCurrent(current_fp, current_cp);
         PSATDForwardTransformJ(current_fp, current_cp);
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -855,12 +855,11 @@ WarpX::FillBoundaryAux (int lev, IntVect ng)
 }
 
 void
-WarpX::SyncCurrent ()
+WarpX::SyncCurrent (
+    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
+    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp)
 {
     WARPX_PROFILE("WarpX::SyncCurrent()");
-
-    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp = current_fp;
-    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp = current_cp;
 
     // If warpx.do_current_centering = 1, center currents from nodal grid to staggered grid
     if (WarpX::do_current_centering)

--- a/Source/Python/WarpXWrappers.H
+++ b/Source/Python/WarpXWrappers.H
@@ -130,7 +130,9 @@ extern "C" {
   void warpx_FillBoundaryE ();
   void warpx_FillBoundaryB ();
   void warpx_SyncRho ();
-  void warpx_SyncCurrent ();
+  void warpx_SyncCurrent (
+      const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
+      const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp);
   void warpx_UpdateAuxilaryData ();
   void warpx_PushParticlesandDepose (amrex::Real cur_time);
 

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -660,9 +660,11 @@ namespace
         WarpX& warpx = WarpX::GetInstance();
         warpx.SyncRho();
     }
-    void warpx_SyncCurrent () {
+    void warpx_SyncCurrent (
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp) {
         WarpX& warpx = WarpX::GetInstance();
-        warpx.SyncCurrent();
+        warpx.SyncCurrent(J_fp, J_cp);
     }
     void warpx_UpdateAuxilaryData () {
         WarpX& warpx = WarpX::GetInstance();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -643,9 +643,21 @@ public:
     void FillBoundaryG   (int lev, amrex::IntVect ng, const bool nodal_sync = false);
     void FillBoundaryAux (int lev, amrex::IntVect ng);
 
+    /**
+     * \brief Apply filter and sum guard cells across MR levels.
+     * If current centering is used, center the current from a nodal grid
+     * to a staggered grid. For each MR level beyond level 0, interpolate
+     * the fine-patch current onto the coarse-patch current at the same level.
+     * Then, for each MR level, including level 0, apply filter and sum guard
+     * cells across levels.
+     *
+     * \param[in,out] J_fp reference to fine-patch current \c MultiFab (all MR levels)
+     * \param[in,out] J_cp reference to coarse-patch current \c MultiFab (all MR levels)
+     */
     void SyncCurrent (
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp);
+
     void SyncRho ();
 
     amrex::Vector<int> getnsubsteps () const {return nsubsteps;}

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -643,7 +643,9 @@ public:
     void FillBoundaryG   (int lev, amrex::IntVect ng, const bool nodal_sync = false);
     void FillBoundaryAux (int lev, amrex::IntVect ng);
 
-    void SyncCurrent ();
+    void SyncCurrent (
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp);
     void SyncRho ();
 
     amrex::Vector<int> getnsubsteps () const {return nsubsteps;}


### PR DESCRIPTION
This is a follow-up PR to #2965. The flexibility of passing to `SyncCurrent` any current MultiFabs as input arguments is needed in a variety of other PRs related to the development and debugging of Vay's current deposition scheme. I also added more detailed comments to explain what happens with current centering, when the hybrid scheme is used.