### PR TITLE
Properly check that `save_particles_at_eb=1` when using `BoundaryScraping` diagnostic

### DIFF
--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -102,7 +102,7 @@ BoundaryScrapingDiagnostics::InitializeParticleBuffer ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         particle_saving_activated.size() == 0u,
         error_string);
-    
+
     // Initialize one ParticleDiag per species requested
     ParticleBoundaryBuffer& particle_buffer = warpx.GetParticleBoundaryBuffer();
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {


### PR DESCRIPTION
The code for `BoundaryScraping` contains some code that checks that the flag `save_particles_at_eb` has been activated. However, this code relies on the variable `m_output_species` being properly initialized, which is not the case in the current version of WarpX.

I moved this check to the function `InitializeParticleBuffer`, just after `m_output_species` is initialized.

This fixes #3248.  