### PR TITLE
Fix out of bounds array access with Particle Scraping + Continuous Injection

### DIFF
--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -156,7 +156,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
             auto& tile = pti.GetParticleTile();
             auto ptd = tile.getParticleTileData();
             const auto np = tile.numParticles();
-            auto& particles = tile.GetArrayOfStructs();
+            amrex::ArrayOfStructs<0, 0, amrex::DefaultAllocator>& particles = tile.GetArrayOfStructs();
             auto phi = (*distance_to_eb[lev])[pti].array();  // signed distance function
             amrex::ParallelForRNG( np,
             [=] AMREX_GPU_DEVICE (const int ip, amrex::RandomEngine const& engine) noexcept

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -156,10 +156,14 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
             auto& tile = pti.GetParticleTile();
             auto ptd = tile.getParticleTileData();
             const auto np = tile.numParticles();
+            auto& particles = tile.GetArrayOfStructs();
             auto phi = (*distance_to_eb[lev])[pti].array();  // signed distance function
             amrex::ParallelForRNG( np,
             [=] AMREX_GPU_DEVICE (const int ip, amrex::RandomEngine const& engine) noexcept
             {
+                // skip particles that are already flagged for removal
+                if (particles[ip].id() < 0) return;
+
                 amrex::ParticleReal xp, yp, zp;
                 getPosition(ip, xp, yp, zp);
 

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -156,7 +156,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
             auto& tile = pti.GetParticleTile();
             auto ptd = tile.getParticleTileData();
             const auto np = tile.numParticles();
-            amrex::ArrayOfStructs<0, 0, amrex::DefaultAllocator>& particles = tile.GetArrayOfStructs();
+            amrex::Particle<0,0> * const particles = tile.GetArrayOfStructs()().data();
             auto phi = (*distance_to_eb[lev])[pti].array();  // signed distance function
             amrex::ParallelForRNG( np,
             [=] AMREX_GPU_DEVICE (const int ip, amrex::RandomEngine const& engine) noexcept


### PR DESCRIPTION
When we use `AddPlasma` to add new particles, we usually create too many particles and discard the invalid ones by setting their id to `-1`. Since #2282, we also set all particle quantities to `0` in order to make sure that no uninitialized quantities are used between the `AddPlasma` routine and the next call to `Redistribute`. However, errors can still occur with invalid particles if we call a routine that does some form of field gathering before calling `Redistribute` and if the position `(0,0,0)` is not in the current box. I've found that such a segfault can occur if we use continuous injection combined with EB particle scraping (I've observed the issue locally and it's very likely that this was causing the segfault in the macOS CI test of #2336).

This issue can easily be fixed by adding a line like `if (particles[ip].id() < 0) return;` inside the `scrapeParticles` function. A more robust solution could be to call `Redistribute` after every call to the continuous injection routines but that would probably make the code slower.