### PR TITLE
Fill Guard Cells of Fields and Currents Independently

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -133,6 +133,8 @@ public:
          int do_moving_window, int pml_has_particles, int do_pml_in_domain,
          const bool do_multi_J,
          const bool do_pml_dive_cleaning, const bool do_pml_divb_cleaning,
+         const amrex::IntVect& fill_guards_fields,
+         const amrex::IntVect& fill_guards_current,
          int max_guard_EB, amrex::Real v_sigma_sb,
          const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
          const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
@@ -208,6 +210,9 @@ private:
     bool m_dive_cleaning;
     bool m_divb_cleaning;
 
+    const amrex::IntVect m_fill_guards_fields;
+    const amrex::IntVect m_fill_guards_current;
+
     const amrex::Geometry* m_geom;
     const amrex::Geometry* m_cgeom;
 
@@ -280,7 +285,8 @@ void PushPMLPSATDSinglePatch( const int lev,
     std::array<std::unique_ptr<amrex::MultiFab>,3>& pml_E,
     std::array<std::unique_ptr<amrex::MultiFab>,3>& pml_B,
     std::unique_ptr<amrex::MultiFab>& pml_F,
-    std::unique_ptr<amrex::MultiFab>& pml_G);
+    std::unique_ptr<amrex::MultiFab>& pml_G,
+    const amrex::IntVect& fill_guards);
 #endif
 
 #endif

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -550,10 +550,14 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
           int do_moving_window, int /*pml_has_particles*/, int do_pml_in_domain,
           const bool do_multi_J,
           const bool do_pml_dive_cleaning, const bool do_pml_divb_cleaning,
+          const amrex::IntVect& fill_guards_fields,
+          const amrex::IntVect& fill_guards_current,
           int max_guard_EB, const amrex::Real v_sigma_sb,
           const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
     : m_dive_cleaning(do_pml_dive_cleaning),
       m_divb_cleaning(do_pml_divb_cleaning),
+      m_fill_guards_fields(fill_guards_fields),
+      m_fill_guards_current(fill_guards_current),
       m_geom(geom),
       m_cgeom(cgeom)
 {
@@ -742,7 +746,6 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             "PML: PSATD solver selected but not built.");
 #else
         // Flags passed to the spectral solver constructor
-        const amrex::IntVect fill_guards = amrex::IntVect(0);
         const bool in_pml = true;
         const bool periodic_single_box = false;
         const bool update_with_rho = false;
@@ -754,7 +757,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         amrex::Vector<amrex::Real> const v_comoving_zero = {0., 0., 0.};
         realspace_ba.enclosedCells().grow(nge); // cell-centered + guard cells
         spectral_solver_fp = std::make_unique<SpectralSolver>(lev, realspace_ba, dm,
-            nox_fft, noy_fft, noz_fft, do_nodal, fill_guards, v_galilean_zero,
+            nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero,
             v_comoving_zero, dx, dt, in_pml, periodic_single_box, update_with_rho,
             fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif
@@ -862,7 +865,6 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
                 "PML: PSATD solver selected but not built.");
 #else
             // Flags passed to the spectral solver constructor
-            const amrex::IntVect fill_guards = amrex::IntVect(0);
             const bool in_pml = true;
             const bool periodic_single_box = false;
             const bool update_with_rho = false;
@@ -874,7 +876,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
             amrex::Vector<amrex::Real> const v_comoving_zero = {0., 0., 0.};
             realspace_cba.enclosedCells().grow(nge); // cell-centered + guard cells
             spectral_solver_cp = std::make_unique<SpectralSolver>(lev, realspace_cba, cdm,
-                nox_fft, noy_fft, noz_fft, do_nodal, fill_guards, v_galilean_zero,
+                nox_fft, noy_fft, noz_fft, do_nodal, v_galilean_zero,
                 v_comoving_zero, cdx, dt, in_pml, periodic_single_box, update_with_rho,
                 fft_do_time_averaging, do_multi_J, m_dive_cleaning, m_divb_cleaning);
 #endif
@@ -1406,9 +1408,9 @@ void
 PML::PushPSATD (const int lev) {
 
     // Update the fields on the fine and coarse patch
-    PushPMLPSATDSinglePatch(lev, *spectral_solver_fp, pml_E_fp, pml_B_fp, pml_F_fp, pml_G_fp);
+    PushPMLPSATDSinglePatch(lev, *spectral_solver_fp, pml_E_fp, pml_B_fp, pml_F_fp, pml_G_fp, m_fill_guards_fields);
     if (spectral_solver_cp) {
-        PushPMLPSATDSinglePatch(lev, *spectral_solver_cp, pml_E_cp, pml_B_cp, pml_F_cp, pml_G_cp);
+        PushPMLPSATDSinglePatch(lev, *spectral_solver_cp, pml_E_cp, pml_B_cp, pml_F_cp, pml_G_cp, m_fill_guards_fields);
     }
 }
 
@@ -1419,7 +1421,8 @@ PushPMLPSATDSinglePatch (
     std::array<std::unique_ptr<amrex::MultiFab>,3>& pml_E,
     std::array<std::unique_ptr<amrex::MultiFab>,3>& pml_B,
     std::unique_ptr<amrex::MultiFab>& pml_F,
-    std::unique_ptr<amrex::MultiFab>& pml_G)
+    std::unique_ptr<amrex::MultiFab>& pml_G,
+    const amrex::IntVect& fill_guards)
 {
     const SpectralFieldIndex& Idx = solver.m_spectral_index;
 
@@ -1463,39 +1466,39 @@ PushPMLPSATDSinglePatch (
     solver.pushSpectralFields();
 
     // Perform backward Fourier transforms
-    solver.BackwardTransform(lev, *pml_E[0], Idx.Exy, PMLComp::xy);
-    solver.BackwardTransform(lev, *pml_E[0], Idx.Exz, PMLComp::xz);
-    solver.BackwardTransform(lev, *pml_E[1], Idx.Eyx, PMLComp::yx);
-    solver.BackwardTransform(lev, *pml_E[1], Idx.Eyz, PMLComp::yz);
-    solver.BackwardTransform(lev, *pml_E[2], Idx.Ezx, PMLComp::zx);
-    solver.BackwardTransform(lev, *pml_E[2], Idx.Ezy, PMLComp::zy);
-    solver.BackwardTransform(lev, *pml_B[0], Idx.Bxy, PMLComp::xy);
-    solver.BackwardTransform(lev, *pml_B[0], Idx.Bxz, PMLComp::xz);
-    solver.BackwardTransform(lev, *pml_B[1], Idx.Byx, PMLComp::yx);
-    solver.BackwardTransform(lev, *pml_B[1], Idx.Byz, PMLComp::yz);
-    solver.BackwardTransform(lev, *pml_B[2], Idx.Bzx, PMLComp::zx);
-    solver.BackwardTransform(lev, *pml_B[2], Idx.Bzy, PMLComp::zy);
+    solver.BackwardTransform(lev, *pml_E[0], Idx.Exy, fill_guards, PMLComp::xy);
+    solver.BackwardTransform(lev, *pml_E[0], Idx.Exz, fill_guards, PMLComp::xz);
+    solver.BackwardTransform(lev, *pml_E[1], Idx.Eyx, fill_guards, PMLComp::yx);
+    solver.BackwardTransform(lev, *pml_E[1], Idx.Eyz, fill_guards, PMLComp::yz);
+    solver.BackwardTransform(lev, *pml_E[2], Idx.Ezx, fill_guards, PMLComp::zx);
+    solver.BackwardTransform(lev, *pml_E[2], Idx.Ezy, fill_guards, PMLComp::zy);
+    solver.BackwardTransform(lev, *pml_B[0], Idx.Bxy, fill_guards, PMLComp::xy);
+    solver.BackwardTransform(lev, *pml_B[0], Idx.Bxz, fill_guards, PMLComp::xz);
+    solver.BackwardTransform(lev, *pml_B[1], Idx.Byx, fill_guards, PMLComp::yx);
+    solver.BackwardTransform(lev, *pml_B[1], Idx.Byz, fill_guards, PMLComp::yz);
+    solver.BackwardTransform(lev, *pml_B[2], Idx.Bzx, fill_guards, PMLComp::zx);
+    solver.BackwardTransform(lev, *pml_B[2], Idx.Bzy, fill_guards, PMLComp::zy);
 
     // WarpX::do_pml_dive_cleaning = true
     if (pml_F)
     {
-        solver.BackwardTransform(lev, *pml_E[0], Idx.Exx, PMLComp::xx);
-        solver.BackwardTransform(lev, *pml_E[1], Idx.Eyy, PMLComp::yy);
-        solver.BackwardTransform(lev, *pml_E[2], Idx.Ezz, PMLComp::zz);
-        solver.BackwardTransform(lev, *pml_F, Idx.Fx, PMLComp::x);
-        solver.BackwardTransform(lev, *pml_F, Idx.Fy, PMLComp::y);
-        solver.BackwardTransform(lev, *pml_F, Idx.Fz, PMLComp::z);
+        solver.BackwardTransform(lev, *pml_E[0], Idx.Exx, fill_guards, PMLComp::xx);
+        solver.BackwardTransform(lev, *pml_E[1], Idx.Eyy, fill_guards, PMLComp::yy);
+        solver.BackwardTransform(lev, *pml_E[2], Idx.Ezz, fill_guards, PMLComp::zz);
+        solver.BackwardTransform(lev, *pml_F, Idx.Fx, fill_guards, PMLComp::x);
+        solver.BackwardTransform(lev, *pml_F, Idx.Fy, fill_guards, PMLComp::y);
+        solver.BackwardTransform(lev, *pml_F, Idx.Fz, fill_guards, PMLComp::z);
     }
 
     // WarpX::do_pml_divb_cleaning = true
     if (pml_G)
     {
-        solver.BackwardTransform(lev, *pml_B[0], Idx.Bxx, PMLComp::xx);
-        solver.BackwardTransform(lev, *pml_B[1], Idx.Byy, PMLComp::yy);
-        solver.BackwardTransform(lev, *pml_B[2], Idx.Bzz, PMLComp::zz);
-        solver.BackwardTransform(lev, *pml_G, Idx.Gx, PMLComp::x);
-        solver.BackwardTransform(lev, *pml_G, Idx.Gy, PMLComp::y);
-        solver.BackwardTransform(lev, *pml_G, Idx.Gz, PMLComp::z);
+        solver.BackwardTransform(lev, *pml_B[0], Idx.Bxx, fill_guards, PMLComp::xx);
+        solver.BackwardTransform(lev, *pml_B[1], Idx.Byy, fill_guards, PMLComp::yy);
+        solver.BackwardTransform(lev, *pml_B[2], Idx.Bzz, fill_guards, PMLComp::zz);
+        solver.BackwardTransform(lev, *pml_G, Idx.Gx, fill_guards, PMLComp::x);
+        solver.BackwardTransform(lev, *pml_G, Idx.Gy, fill_guards, PMLComp::y);
+        solver.BackwardTransform(lev, *pml_G, Idx.Gz, fill_guards, PMLComp::z);
     }
 }
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -38,7 +38,6 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * \param[in] norder_y order of the spectral solver along y
          * \param[in] norder_z order of the spectral solver along z
          * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
-         * \param[in] fill_guards Update the guard cells (in addition to the valid cells) when pushing the fields in time
          * \param[in] v_galilean Galilean velocity (three-dimensional array)
          * \param[in] dt time step of the simulation
          * \param[in] update_with_rho whether the update equation for E uses rho or not
@@ -54,7 +53,6 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
             const int norder_y,
             const int norder_z,
             const bool nodal,
-            const amrex::IntVect& fill_guards,
             const amrex::Vector<amrex::Real>& v_galilean,
             const amrex::Real dt,
             const bool update_with_rho,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp
@@ -35,7 +35,6 @@ PsatdAlgorithm::PsatdAlgorithm(
     const int norder_y,
     const int norder_z,
     const bool nodal,
-    const amrex::IntVect& fill_guards,
     const amrex::Vector<amrex::Real>& v_galilean,
     const amrex::Real dt,
     const bool update_with_rho,
@@ -43,7 +42,7 @@ PsatdAlgorithm::PsatdAlgorithm(
     const bool dive_cleaning,
     const bool divb_cleaning)
     // Initializer list
-    : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal, fill_guards),
+    : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal),
     m_spectral_index(spectral_index),
     // Initialize the centered finite-order modified k vectors:
     // these are computed always with the assumption of centered grids

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.H
@@ -33,7 +33,6 @@ class PsatdAlgorithmComoving : public SpectralBaseAlgorithm
                                 const int norder_y,
                                 const int norder_z,
                                 const bool nodal,
-                                const amrex::IntVect& fill_guards,
                                 const amrex::Vector<amrex::Real>& v_comoving,
                                 const amrex::Real dt,
                                 const bool update_with_rho);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
@@ -26,12 +26,11 @@ PsatdAlgorithmComoving::PsatdAlgorithmComoving (const SpectralKSpace& spectral_k
                                                 const SpectralFieldIndex& spectral_index,
                                                 const int norder_x, const int norder_y,
                                                 const int norder_z, const bool nodal,
-                                                const amrex::IntVect& fill_guards,
                                                 const amrex::Vector<amrex::Real>& v_comoving,
                                                 const amrex::Real dt,
                                                 const bool update_with_rho)
      // Members initialization
-     : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal, fill_guards),
+     : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal),
        m_spectral_index(spectral_index),
        // Initialize the infinite-order k vectors (the argument n_order = -1 selects
        // the infinite order option, the argument nodal = false is then irrelevant)

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
@@ -41,7 +41,6 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
          * \param[in] norder_y order of the spectral solver along y
          * \param[in] norder_z order of the spectral solver along z
          * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
-         * \param[in] fill_guards Update the guard cells (in addition to the valid cells) when pushing the fields in time
          * \param[in] dt time step of the simulation
          * \param[in] time_averaging whether to use time averaging for large time steps
          * \param[in] dive_cleaning Update F as part of the field update, so that errors in divE=rho propagate away at the speed of light
@@ -55,7 +54,6 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
             const int norder_y,
             const int norder_z,
             const bool nodal,
-            const amrex::IntVect& fill_guards,
             const amrex::Real dt,
             const bool time_averaging,
             const bool dive_cleaning,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.cpp
@@ -35,13 +35,12 @@ PsatdAlgorithmJLinearInTime::PsatdAlgorithmJLinearInTime(
     const int norder_y,
     const int norder_z,
     const bool nodal,
-    const amrex::IntVect& fill_guards,
     const amrex::Real dt,
     const bool time_averaging,
     const bool dive_cleaning,
     const bool divb_cleaning)
     // Initializer list
-    : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal, fill_guards),
+    : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal),
     m_spectral_index(spectral_index),
     m_dt(dt),
     m_time_averaging(time_averaging),

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.H
@@ -32,7 +32,6 @@ class PsatdAlgorithmPml : public SpectralBaseAlgorithm
                           const SpectralFieldIndex& spectral_index,
                           const int norder_x, const int norder_y,
                           const int norder_z, const bool nodal,
-                          const amrex::IntVect& fill_guards,
                           const amrex::Real dt,
                           const bool dive_cleaning,
                           const bool divb_cleaning);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPml.cpp
@@ -35,10 +35,10 @@ PsatdAlgorithmPml::PsatdAlgorithmPml(const SpectralKSpace& spectral_kspace,
                                      const SpectralFieldIndex& spectral_index,
                                      const int norder_x, const int norder_y,
                                      const int norder_z, const bool nodal,
-                                     const amrex::IntVect& fill_guards, const Real dt,
+                                     const Real dt,
                                      const bool dive_cleaning, const bool divb_cleaning)
      // Initialize members of base class
-     : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal, fill_guards),
+     : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, nodal),
        m_spectral_index(spectral_index),
        m_dt(dt),
        m_dive_cleaning(dive_cleaning),

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
@@ -71,8 +71,6 @@ class SpectralBaseAlgorithm
 
     protected: // Meant to be used in the subclasses
 
-        amrex::IntVect m_fill_guards;
-
         using SpectralRealCoefficients = \
             amrex::FabArray< amrex::BaseFab <amrex::Real> >;
         using SpectralComplexCoefficients = \
@@ -85,8 +83,7 @@ class SpectralBaseAlgorithm
                               const amrex::DistributionMapping& dm,
                               const SpectralFieldIndex& spectral_index,
                               const int norder_x, const int norder_y,
-                              const int norder_z, const bool nodal,
-                              const amrex::IntVect& fill_guards);
+                              const int norder_z, const bool nodal);
 
         SpectralFieldIndex m_spectral_index;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.cpp
@@ -31,9 +31,7 @@ SpectralBaseAlgorithm::SpectralBaseAlgorithm(const SpectralKSpace& spectral_kspa
     const amrex::DistributionMapping& dm,
     const SpectralFieldIndex& spectral_index,
     const int norder_x, const int norder_y,
-    const int norder_z, const bool nodal,
-    const amrex::IntVect& fill_guards):
-        m_fill_guards(fill_guards),
+    const int norder_z, const bool nodal):
         m_spectral_index(spectral_index),
     // Compute and assign the modified k vectors
         modified_kx_vec(spectral_kspace.getModifiedKComponent(dm,0,norder_x,nodal)),
@@ -65,8 +63,6 @@ SpectralBaseAlgorithm::ComputeSpectralDivE (
     field_data.ForwardTransform(lev, *Efield[0], Idx.Ex, 0 );
     field_data.ForwardTransform(lev, *Efield[1], Idx.Ey, 0 );
     field_data.ForwardTransform(lev, *Efield[2], Idx.Ez, 0 );
-
-    const amrex::IntVect& fill_guards = m_fill_guards;
 
     // Loop over boxes
     for (MFIter mfi(field_data.fields); mfi.isValid(); ++mfi){
@@ -107,5 +103,6 @@ SpectralBaseAlgorithm::ComputeSpectralDivE (
     }
 
     // Backward Fourier transform
-    field_data.BackwardTransform(lev, divE, Idx.divE, 0, fill_guards);
+    const amrex::IntVect& fill_guards = amrex::IntVect(0);
+    field_data.BackwardTransform(lev, divE, Idx.divE, fill_guards, 0);
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -127,7 +127,7 @@ class SpectralFieldData
                                const int i_comp);
 
         void BackwardTransform (const int lev, amrex::MultiFab& mf, const int field_index,
-                                const int i_comp, const amrex::IntVect& fill_guards);
+                                const amrex::IntVect& fill_guards, const int i_comp);
 
         // `fields` stores fields in spectral space, as multicomponent FabArray
         SpectralField fields;

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -310,8 +310,8 @@ void
 SpectralFieldData::BackwardTransform (const int lev,
                                       MultiFab& mf,
                                       const int field_index,
-                                      const int i_comp,
-                                      const amrex::IntVect& fill_guards)
+                                      const amrex::IntVect& fill_guards,
+                                      const int i_comp)
 {
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
     bool do_costs = WarpXUtilLoadBalance::doCosts(cost, mf.boxArray(), mf.DistributionMap());

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -47,7 +47,6 @@ class SpectralSolver
          * \param[in] norder_y spectral order along y
          * \param[in] norder_z spectral order along z
          * \param[in] nodal whether the spectral solver is applied to a nodal or staggered grid
-         * \param[in] fill_guards Update the guard cells (in addition to the valid cells) when pushing the fields in time
          * \param[in] v_galilean three-dimensional vector containing the components of the Galilean
          *                       velocity for the standard or averaged Galilean PSATD solvers
          * \param[in] v_comoving three-dimensional vector containing the components of the comoving
@@ -72,7 +71,6 @@ class SpectralSolver
                         const amrex::DistributionMapping& dm,
                         const int norder_x, const int norder_y,
                         const int norder_z, const bool nodal,
-                        const amrex::IntVect& fill_guards,
                         const amrex::Vector<amrex::Real>& v_galilean,
                         const amrex::Vector<amrex::Real>& v_comoving,
                         const amrex::RealVect dx,
@@ -106,6 +104,7 @@ class SpectralSolver
         void BackwardTransform( const int lev,
                                 amrex::MultiFab& mf,
                                 const int field_index,
+                                const amrex::IntVect& fill_guards,
                                 const int i_comp=0 );
 
         /**

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -24,7 +24,6 @@ SpectralSolver::SpectralSolver(
                 const amrex::DistributionMapping& dm,
                 const int norder_x, const int norder_y,
                 const int norder_z, const bool nodal,
-                const amrex::IntVect& fill_guards,
                 const amrex::Vector<amrex::Real>& v_galilean,
                 const amrex::Vector<amrex::Real>& v_comoving,
                 const amrex::RealVect dx, const amrex::Real dt,
@@ -52,7 +51,7 @@ SpectralSolver::SpectralSolver(
     {
         algorithm = std::make_unique<PsatdAlgorithmPml>(
             k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
-            fill_guards, dt, dive_cleaning, divb_cleaning);
+            dt, dive_cleaning, divb_cleaning);
     }
     else // PSATD equations in the regulard grids
     {
@@ -61,7 +60,7 @@ SpectralSolver::SpectralSolver(
         {
             algorithm = std::make_unique<PsatdAlgorithmComoving>(
                 k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
-                fill_guards, v_comoving, dt, update_with_rho);
+                v_comoving, dt, update_with_rho);
         }
         else // PSATD algorithms: standard, Galilean, averaged Galilean, multi-J
         {
@@ -69,13 +68,13 @@ SpectralSolver::SpectralSolver(
             {
                 algorithm = std::make_unique<PsatdAlgorithmJLinearInTime>(
                     k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
-                    fill_guards, dt, fft_do_time_averaging, dive_cleaning, divb_cleaning);
+                    dt, fft_do_time_averaging, dive_cleaning, divb_cleaning);
             }
             else // standard, Galilean, averaged Galilean
             {
                 algorithm = std::make_unique<PsatdAlgorithm>(
                     k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
-                    fill_guards, v_galilean, dt, update_with_rho, fft_do_time_averaging,
+                    v_galilean, dt, update_with_rho, fft_do_time_averaging,
                     dive_cleaning, divb_cleaning);
             }
         }
@@ -84,8 +83,6 @@ SpectralSolver::SpectralSolver(
     // - Initialize arrays for fields in spectral space + FFT plans
     field_data = SpectralFieldData(lev, realspace_ba, k_space, dm,
                                    m_spectral_index.n_fields, periodic_single_box);
-
-    m_fill_guards = fill_guards;
 }
 
 void
@@ -102,10 +99,11 @@ void
 SpectralSolver::BackwardTransform( const int lev,
                                    amrex::MultiFab& mf,
                                    const int field_index,
+                                   const amrex::IntVect& fill_guards,
                                    const int i_comp )
 {
     WARPX_PROFILE("SpectralSolver::BackwardTransform");
-    field_data.BackwardTransform(lev, mf, field_index, i_comp, m_fill_guards);
+    field_data.BackwardTransform(lev, mf, field_index, fill_guards, i_comp);
 }
 
 void

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -159,22 +159,19 @@ void WarpX::PSATDBackwardTransformEBavg (
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
-    // No need to fill guard cells for averaged fields
-    const amrex::IntVect& fill_guards = amrex::IntVect(0);
-
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         BackwardTransformVect(lev, *spectral_solver_fp[lev], E_avg_fp[lev],
-                              Idx.Ex_avg, Idx.Ey_avg, Idx.Ez_avg, fill_guards);
+                              Idx.Ex_avg, Idx.Ey_avg, Idx.Ez_avg, m_fill_guards_fields);
         BackwardTransformVect(lev, *spectral_solver_fp[lev], B_avg_fp[lev],
-                              Idx.Bx_avg, Idx.By_avg, Idx.Bz_avg, fill_guards);
+                              Idx.Bx_avg, Idx.By_avg, Idx.Bz_avg, m_fill_guards_fields);
 
         if (spectral_solver_cp[lev])
         {
             BackwardTransformVect(lev, *spectral_solver_cp[lev], E_avg_cp[lev],
-                                  Idx.Ex_avg, Idx.Ey_avg, Idx.Ez_avg, fill_guards);
+                                  Idx.Ex_avg, Idx.Ey_avg, Idx.Ez_avg, m_fill_guards_fields);
             BackwardTransformVect(lev, *spectral_solver_cp[lev], B_avg_cp[lev],
-                                  Idx.Bx_avg, Idx.By_avg, Idx.Bz_avg, fill_guards);
+                                  Idx.Bx_avg, Idx.By_avg, Idx.Bz_avg, m_fill_guards_fields);
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -497,12 +497,16 @@ WarpX::InitPML ()
         do_pml_Lo[0][0] = 0; // no PML at r=0, in cylindrical geometry
         pml_rz[0] = std::make_unique<PML_RZ>(0, boxArray(0), DistributionMap(0), &Geom(0), pml_ncell, do_pml_in_domain);
 #else
+        // Note: fill_guards_fields and fill_guards_current are both set to
+        // zero (amrex::IntVect(0)) (what we do with damping BCs does not apply
+        // to the PML, for example in the presence of mesh refinement patches)
         pml[0] = std::make_unique<PML>(0, boxArray(0), DistributionMap(0), &Geom(0), nullptr,
                              pml_ncell, pml_delta, amrex::IntVect::TheZeroVector(),
                              dt[0], nox_fft, noy_fft, noz_fft, do_nodal,
                              do_moving_window, pml_has_particles, do_pml_in_domain,
                              do_multi_J,
                              do_pml_dive_cleaning, do_pml_divb_cleaning,
+                             amrex::IntVect(0), amrex::IntVect(0),
                              guard_cells.ng_FieldSolver.max(),
                              v_particle_pml,
                              do_pml_Lo[0], do_pml_Hi[0]);
@@ -529,12 +533,16 @@ WarpX::InitPML ()
                 do_pml_Lo[lev][0] = 0;
             }
 #endif
+            // Note: fill_guards_fields and fill_guards_current are both set to
+            // zero (amrex::IntVect(0)) (what we do with damping BCs does not apply
+            // to the PML, for example in the presence of mesh refinement patches)
             pml[lev] = std::make_unique<PML>(lev, boxArray(lev), DistributionMap(lev),
                                    &Geom(lev), &Geom(lev-1),
                                    pml_ncell, pml_delta, refRatio(lev-1),
                                    dt[lev], nox_fft, noy_fft, noz_fft, do_nodal,
                                    do_moving_window, pml_has_particles, do_pml_in_domain,
                                    do_multi_J, do_pml_dive_cleaning, do_pml_divb_cleaning,
+                                   amrex::IntVect(0), amrex::IntVect(0),
                                    guard_cells.ng_FieldSolver.max(),
                                    v_particle_pml,
                                    do_pml_Lo[lev], do_pml_Hi[lev]);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -203,8 +203,11 @@ public:
     //! perform field communications in single precision
     static bool do_single_precision_comms;
 
-    //! Whether to fill the guard cells when computing inverse FFTs, based on the boundary conditions
-    static amrex::IntVect fill_guards;
+    //! Whether to fill guard cells when computing inverse FFTs of fields
+    static amrex::IntVect m_fill_guards_fields;
+
+    //! Whether to fill guard cells when computing inverse FFTs of currents
+    static amrex::IntVect m_fill_guards_current;
 
     //! Solve additional Maxwell equation for F in order to control errors in Gauss' law
     //! (useful when using current deposition algorithms that are not charge-conserving)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -106,7 +106,8 @@ Real WarpX::moving_window_v = std::numeric_limits<amrex::Real>::max();
 
 bool WarpX::fft_do_time_averaging = false;
 
-amrex::IntVect WarpX::fill_guards = amrex::IntVect(0);
+amrex::IntVect WarpX::m_fill_guards_fields  = amrex::IntVect(0);
+amrex::IntVect WarpX::m_fill_guards_current = amrex::IntVect(0);
 
 Real WarpX::quantum_xi_c2 = PhysConst::xi_c2;
 Real WarpX::gamma_boost = 1._rt;
@@ -1323,14 +1324,14 @@ WarpX::ReadParameters ()
             if (WarpX::field_boundary_lo[dir] == FieldBoundaryType::Damped ||
                 WarpX::field_boundary_hi[dir] == FieldBoundaryType::Damped)
             {
-                WarpX::fill_guards[dir] = 1;
+                WarpX::m_fill_guards_fields[dir] = 1;
             }
         }
 
         // Fill guard cells with backward FFTs if Vay current deposition is used
         if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
         {
-            WarpX::fill_guards = amrex::IntVect(1);
+            WarpX::m_fill_guards_current = amrex::IntVect(1);
         }
     }
 
@@ -2241,7 +2242,6 @@ void WarpX::AllocLevelSpectralSolver (amrex::Vector<std::unique_ptr<SpectralSolv
                                                 noy_fft,
                                                 noz_fft,
                                                 do_nodal,
-                                                WarpX::fill_guards,
                                                 m_v_galilean,
                                                 m_v_comoving,
                                                 dx_vect,


### PR DESCRIPTION
There are situations where it is necessary to fill the guard cells when inverse FFTs of fields and/or currents are computed. For example, we want to fill the guard cells of fields when damped BCs are applied, or we want to fill the guard cells of currents when current correction or Vay deposition are used.

However, so far we only had one single parameter which would apply to both fields and currents. This is not necessary and we prefer to control what we do with the guard cells of fields and currents independently.

The RZ PSATD solver always fills the guard cells along the z direction, so no additional control is needed there. This is the reason why we have different interfaces for the relevant functions (leading to `#ifdef` branching in the implementation). Let me know if we want to change that and have default values (aka, always false, always ignored) in the RZ case.

Other comments to be discussed were added as single comments below.