### PR TITLE
Docs: Lassen Disable MPI-I/O file lock

### DIFF
--- a/Tools/machines/lassen-llnl/lassen.bsub
+++ b/Tools/machines/lassen-llnl/lassen.bsub
@@ -40,6 +40,13 @@ cat > romio-hints << EOL
    cb_nodes ${NUM_HOSTS}
 EOL
 
+# OpenMPI file locks are slow and not needed
+# https://github.com/open-mpi/ompi/issues/10053
+export OMPI_MCA_sharedfp=^lockedfile,individual
+
+# HDF5: disable slow locks (promise not to open half-written files)
+export HDF5_USE_FILE_LOCKING=FALSE
+
 # OpenMP: 1 thread per MPI rank
 export OMP_NUM_THREADS=1
 


### PR DESCRIPTION
Saw lockfiles being present while parallel HDF5 writes are active. Will now workaround a OpenMPI bug that uses file locking on Lassen (OLCF).
  https://github.com/open-mpi/ompi/issues/10053

Parallel HDF5 performance is still not going up much... We prepared a support email.

Follow-up to #3264 