### PR TITLE
`isort`: AMReX, WarpX, etc. as First Party

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,3 +35,4 @@ indent_size = unset
 [*.py]
 # isort config
 force_sort_within_sections = true
+known_first_party = amrex,impactx,picmistandard,pywarpx,warpx

--- a/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
+++ b/Examples/Modules/embedded_boundary_python_API/PICMI_inputs_EB_API.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
+
 from pywarpx import fields, picmi
 
 max_steps = 1

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -8,9 +8,10 @@ import argparse
 import sys
 
 import numpy as np
-from pywarpx import callbacks, fields, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
+
+from pywarpx import callbacks, fields, picmi
 
 constants = picmi.constants
 

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -6,9 +6,10 @@
 # --- used for the field solve step.
 
 import numpy as np
-from pywarpx import callbacks, fields, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
+
+from pywarpx import callbacks, fields, picmi
 
 constants = picmi.constants
 

--- a/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
+++ b/Examples/Tests/Langmuir/PICMI_inputs_langmuir_rz_multimode_analyze.py
@@ -9,6 +9,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pywarpx import fields, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_2d.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 
 import numpy as np
+
 from pywarpx import callbacks, picmi
 
 # Create the parser and add the argument

--- a/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/ParticleDataPython/PICMI_inputs_prev_pos_2d.py
@@ -3,6 +3,7 @@
 # --- Input file to test the saving of old particle positions
 
 import numpy as np
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/PythonWrappers/PICMI_inputs_2d.py
+++ b/Examples/Tests/PythonWrappers/PICMI_inputs_2d.py
@@ -3,6 +3,7 @@
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 import numpy as np
+
 from pywarpx import picmi
 
 # Number of time steps

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -6,6 +6,7 @@
 # --- if the correct amount of processors are initialized in AMReX.
 
 from mpi4py import MPI
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -7,6 +7,7 @@
 import sys
 
 import numpy as np
+
 from pywarpx import callbacks, picmi
 
 ##########################

--- a/Python/pywarpx/WarpInterface.py
+++ b/Python/pywarpx/WarpInterface.py
@@ -14,8 +14,9 @@
 # The class WarpX_EM3D inherits from Warp's EM3D class. It primarily provides
 # access to the field plotting routines.
 
-from pywarpx import PGroup
 import warp
+
+from pywarpx import PGroup
 
 from . import fields
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -13,6 +13,7 @@ import re
 
 import numpy as np
 import periodictable
+
 import picmistandard
 import pywarpx
 


### PR DESCRIPTION
Mark the `amrex` and `pywarpx`, `picmistandard`, ... imports as first party, so that they do not change if run locally or remotely pre/post install.

- https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html
- https://github.com/PyCQA/isort/issues/448#issuecomment-456595042