### PR TITLE
[WIP] BTD openPMD: Finalize w/o Particles

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -719,8 +719,10 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
         doParticleSetup = is_first_flush_with_particles || is_last_flush_and_never_particles;
 
     // this setup stage also implicitly calls "makeEmpty" if needed (i.e., is_last_flush_and_never_particles)
-    //   for BTD, we call this multiple times as we may resize in subsequent dumps if number of particles in the buffer > 0
-    if (doParticleSetup || is_resizing_flush) {
+    //   - for BTD, we call this multiple times as we may resize in subsequent dumps if number of particles in the buffer > 0
+    //   - for BTD, we also call this in the last flush to a step, in case that step adds no new particles
+    //     - this is needed so we can call SetConstParticleRecordsEDPIC below
+    if (doParticleSetup || is_resizing_flush || is_last_flush_to_step) {
         SetupPos(currSpecies, NewParticleVectorSize, isBTD);
         SetupRealProperties(pc, currSpecies, write_real_comp, real_comp_names, write_int_comp, int_comp_names,
                             NewParticleVectorSize, isBTD);


### PR DESCRIPTION
Handle the corner-case that we finalize a labframe simulation without having particles in that last dump.

Otherwise `SetConstParticleRecordsEDPIC` will cause a
```
A Record can not be written without any contained RecordComponents: id
```

Once we configure the record component attributes.

## Notes to Reviewer

- [ ] We investigate a crash from an inputs file in RZ for particles, so this might be not what we want to do. In our inputs file, we have a weird situation that there are no writes ever to the lab station for particles, but suddenly it shows up as if it had written 50k particles. For the same case in 3D, we see that there actually is a pc passed with 50k particles at some point, which is missing in RZ.

Thus, this patch here **might better not be merged** if we find the root cause of this.

I suspect this is caused by the bookkeeping logic in `BTDiagnostics::Flush`` with regards to passed particle containers for actual writes and book keeping in `UpdateTotalParticlesFlushed` for `m_totalParticles_flushed_already`.