### PR TITLE
Enable Particle RZ BackTransformed Diagnostics

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -143,6 +143,9 @@ struct LorentzTransformParticles
         dst.m_aos[i_dst].pos(0) = xp;
         dst.m_aos[i_dst].pos(1) = yp;
         dst.m_aos[i_dst].pos(2) = zp;
+#elif defined (WARPX_DIM_RZ)
+        dst.m_aos[i_dst].pos(0) = std::sqrt(xp*xp + yp*yp);
+        dst.m_aos[i_dst].pos(1) = zp;
 #elif defined (WARPX_DIM_XZ)
         dst.m_aos[i_dst].pos(0) = xp;
         dst.m_aos[i_dst].pos(1) = zp;

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -146,6 +146,7 @@ struct LorentzTransformParticles
 #elif defined (WARPX_DIM_RZ)
         dst.m_aos[i_dst].pos(0) = std::sqrt(xp*xp + yp*yp);
         dst.m_aos[i_dst].pos(1) = zp;
+        dst.m_rdata[PIdx::theta][i_dst] = std::atan2(yp, xp);
 #elif defined (WARPX_DIM_XZ)
         dst.m_aos[i_dst].pos(0) = xp;
         dst.m_aos[i_dst].pos(1) = zp;

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -27,7 +27,7 @@ MultiDiagnostics::MultiDiagnostics ()
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
 #ifdef WARPX_DIM_RZ
             ablastr::warn_manager::WMRecordWarning("MultiDiagnostics", "BackTransformed diagnostics for fields is not yet fully implemented in RZ. Field output might be incorrect.");
-#endif            
+#endif
         } else if ( diags_types[i] == DiagTypes::BoundaryScraping ){
             alldiags[i] = std::make_unique<BoundaryScrapingDiagnostics>(i, diags_names[i]);
         } else {

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -4,7 +4,7 @@
 #include "Diagnostics/FullDiagnostics.H"
 #include "Diagnostics/BoundaryScrapingDiagnostics.H"
 #include "Utils/TextMsg.H"
-
+#include <ablastr/warn_manager/WarnManager.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX.H>
 #include <AMReX_REAL.H>
@@ -25,6 +25,9 @@ MultiDiagnostics::MultiDiagnostics ()
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
+#ifdef WARPX_DIM_RZ
+            ablastr::warn_manager::WMRecordWarning("MultiDiagnostics", "BackTransformed diagnostics for fields is not yet fully implemented in RZ. Field output might be incorrect.");
+#endif            
         } else if ( diags_types[i] == DiagTypes::BoundaryScraping ){
             alldiags[i] = std::make_unique<BoundaryScrapingDiagnostics>(i, diags_names[i]);
         } else {

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -24,11 +24,7 @@ MultiDiagnostics::MultiDiagnostics ()
         if ( diags_types[i] == DiagTypes::Full ){
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
-#ifdef WARPX_DIM_RZ
-            amrex::Abort(Utils::TextMsg::Err("BackTransformed diagnostics is currently not supported for RZ"));
-#else
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
-#endif
         } else if ( diags_types[i] == DiagTypes::BoundaryScraping ){
             alldiags[i] = std::make_unique<BoundaryScrapingDiagnostics>(i, diags_names[i]);
         } else {


### PR DESCRIPTION
Athough we still need to work on the RZ BTD for the **fields**, the code for the **particles** is essentially working. 
This PR enables this functionality, in particular by enabling registering the Lorentz transform of the position, which was previously missing.

This is partly addressing #2467.