### PR TITLE
Fix Docs for `psatd.update_with_rho`

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1759,8 +1759,6 @@ Numerics and algorithms
     If false, instead, the update equation for the electric field is expressed in terms of the current density :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}` only.
     If charge is expected to be conserved (by setting, for example, ``psatd.current_correction=1``), then the two formulations are expected to be equivalent.
 
-    This option is currently implemented only for the standard PSATD and Galilean PSATD schemes, while it is not yet available for the averaged Galilean PSATD scheme (activated by the input parameter ``psatd.do_time_averaging``).
-
     If ``psatd.v_galilean`` is zero, the spectral solver used is the standard PSATD scheme described in (`Vay et al, JCP 243, 2013 <https://doi.org/10.1016/j.jcp.2013.03.010>`_):
 
     1. if ``psatd.update_with_rho=0``, the update equation for the electric field reads
@@ -1822,6 +1820,8 @@ Numerics and algorithms
     The coefficients :math:`C`, :math:`S`, :math:`\theta`, :math:`\nu`, :math:`\chi_1`, :math:`\chi_2`, and :math:`\chi_3` are defined in (`Lehe et al, PRE 94, 2016 <https://doi.org/10.1103/PhysRevE.94.053305>`_).
 
     The default value for ``psatd.update_with_rho`` is ``1`` if ``psatd.v_galilean`` is non-zero and ``0`` otherwise.
+    The option ``psatd.update_with_rho=0`` is not implemented with the following algorithms:
+    comoving PSATD (``psatd.v_comoving``), time averaging (``psatd.do_time_averaging=1``), div(E) cleaning (``warpx.do_dive_cleaning=1``), and multi-J (``warpx.do_multi_J=1``).
 
     Note that the update with and without rho is also supported in RZ geometry.
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1271,7 +1271,7 @@ WarpX::ReadParameters ()
         );
 
 #   ifdef WARPX_DIM_RZ
-        update_with_rho = true;  // Must be true for RZ PSATD
+        update_with_rho = true;
 #   else
         if (m_v_galilean[0] == 0. && m_v_galilean[1] == 0. && m_v_galilean[2] == 0. &&
             m_v_comoving[0] == 0. && m_v_comoving[1] == 0. && m_v_comoving[2] == 0.) {


### PR DESCRIPTION
Fix #3324. As reported by @hklion, the documentation for `psatd.update_with_rho` was partially wrong.

Now we state that `psatd.update_with_rho=0` is not implemented with the following algorithms:
- comoving PSATD
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/WarpX.cpp#L1293-L1296
- time averaging
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.cpp#L106-L109
- div(E) cleaning
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/WarpX.cpp#L1288-L1291
- multi-J deposition
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/WarpX.cpp#L1305-L1307

I also removed the inline comment "Must be true for RZ PSATD" here
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/WarpX.cpp#L1273-L1275
because both options (with/without rho) are implement in the RZ PSATD solver, see for example here:
https://github.com/ECP-WarpX/WarpX/blob/642f6c0f4ea5a524e6f73f2123aebbdef70c94fd/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp#L191-L199
