### PR TITLE
Docs: Spack Desktop Environment

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -41,44 +41,82 @@ Install
 
 Pick *one* of the installation methods below to install all dependencies for WarpX development in a consistent manner.
 
+Conda (Linux/macOS/Windows)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With MPI (only Linux/macOS):
+
+.. code-block:: bash
+
+   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp "openpmd-api=*=mpi_mpich*" python numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba ninja mpich pip virtualenv
+   source activate warpx-dev
+
+Without MPI:
+
+.. code-block:: bash
+
+   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp openpmd-api python numpy pandas scipy yt fftw pkg-config matplotlib mamba ninja pip virtualenv
+   source activate warpx-dev
+
+   # compile WarpX with -DWarpX_MPI=OFF
+
+For legacy ``GNUmake`` builds, after each ``source activate warpx-dev``, you also need to set:
+
+.. code-block:: bash
+
+   export FFTW_HOME=${CONDA_PREFIX}
+   export BLASPP_HOME=${CONDA_PREFIX}
+   export LAPACKPP_HOME=${CONDA_PREFIX}
+
+.. note::
+
+   A general option to deactivate that conda self-activates its base environment.
+   This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
+
+   .. code-block:: bash
+
+      conda config --set auto_activate_base false
+
+
 Spack (macOS/Linux)
 ^^^^^^^^^^^^^^^^^^^
 
+First, download a `Spack desktop development environment <https://github.com/ECP-WarpX/WarpX/blob/development/Tools/machines/desktop>`__ of your choice.
+For most desktop development, pick the OpenMP environment for CPUs unless you have a supported GPU.
+
+* **Ubuntu** Linux:
+
+  * OpenMP: ``system=ubuntu; compute=openmp`` (CPUs)
+  * CUDA: ``system=ubuntu; compute=cuda`` (Nvidia GPUs)
+  * ROCm: ``system=ubuntu; compute=rocm`` (AMD GPUs)
+  * SYCL: *todo* (Intel GPUs)
+* **macOS**: first, prepare with ``brew install gpg2; brew install gcc``
+
+  * OpenMP: ``system=macos; compute=openmp``
+
 .. code-block:: bash
 
-   spack env create warpx-dev
-   spack env activate warpx-dev
+   # download environment file
+   curl -sLo https://raw.githubusercontent.com/ECP-WarpX/WarpX/development/Tools/machines/desktop/spack-${system}-${compute}.sh
 
-   spack add adios2        # for openPMD
-   spack add blaspp        # for PSATD in RZ
-   spack add ccache
-   spack add cmake
-   spack add fftw          # for PSATD
-   spack add hdf5          # for openPMD
-   spack add lapackpp      # for PSATD in RZ
-   spack add mpi
-   spack add openpmd-api   # for openPMD
-   spack add pkgconfig     # for fftw
+   # create new development environment
+   spack env create warpx-${compute}-dev spack-${system}-${compute}.yaml
+   spack env activate warpx-${compute}-dev
 
-   # OpenMP support on macOS
-   [[ $OSTYPE == 'darwin'* ]] && spack add llvm-openmp
-
-   # optional:
-   # spack add python
-   # spack add py-pip
-   # spack add cuda
-
+   # installation
    spack install
+   python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy virtualenv yt
 
-In new terminal sessions, re-activate the environment with ``spack env activate warpx-dev`` again.
-
-If you also want to run runtime tests and added Python (``spack add python`` and ``spack add py-pip``) above, install also these additional Python packages in the active Spack environment:
+In new terminal sessions, re-activate the environment with
 
 .. code-block:: bash
 
-   python3 -m pip install matplotlib yt scipy pandas numpy openpmd-api virtualenv
+   spack env activate warpx-openmp-dev
 
-If you want to run the ``./run_test.sh`` :ref:`test script <developers-testing>`, which uses our legacy GNUmake build system, you need to set the following environment hints after ``spack env activate warpx-dev`` for dependent software:
+again.
+Replace ``openmp`` with the equivalent you chose.
+
+For legacy ``GNUmake`` builds, after each ``source activate warpx-openmp-dev``, you also need to set:
 
 .. code-block:: bash
 
@@ -118,34 +156,6 @@ If you also want to compile with PSATD in RZ, you need to manually install BLAS+
        -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
    cmake-easyinstall --prefix=/usr/local git+https://bitbucket.org/icl/lapackpp.git \
        -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-
-
-Conda (Linux/macOS/Windows)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Without MPI:
-
-.. code-block:: bash
-
-   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp openpmd-api python numpy pandas scipy yt fftw pkg-config matplotlib mamba ninja pip virtualenv
-   source activate warpx-dev
-
-   # compile WarpX with -DWarpX_MPI=OFF
-
-With MPI (only Linux/macOS):
-
-.. code-block:: bash
-
-   conda create -n warpx-dev -c conda-forge blaspp ccache cmake compilers git lapackpp "openpmd-api=*=mpi_openmpi*" python numpy pandas scipy yt "fftw=*=mpi_openmpi*" pkg-config matplotlib mamba ninja openmpi pip virtualenv
-   source activate warpx-dev
-
-For legacy ``GNUmake`` builds, after each ``source activate warpx-dev``, you also need to set:
-
-.. code-block:: bash
-
-   export FFTW_HOME=${CONDA_PREFIX}
-   export BLASPP_HOME=${CONDA_PREFIX}
-   export LAPACKPP_HOME=${CONDA_PREFIX}
 
 
 Apt (Debian/Ubuntu)

--- a/Tools/machines/desktop/spack-macos-openmp.yaml
+++ b/Tools/machines/desktop/spack-macos-openmp.yaml
@@ -1,0 +1,120 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html
+#
+# Inside the directory of this file
+#   spack env create warpx-openmp-dev spack-macos-openmp.yaml
+#   spack env activate warpx-openmp-dev
+#   spack install  # only needed the first time
+#
+spack:
+  specs:
+  - adios2 ~fortran
+  - ascent +adios2 +python ~fortran
+  - blaspp
+  - boost
+  - ccache
+  - cmake
+  - conduit ~fortran
+  - fftw
+  - hdf5 ~fortran
+  - lapackpp
+  - mpi
+  - llvm-openmp
+  - pkgconfig
+  - python
+  - py-cython
+  - py-h5py
+  - py-libensemble +nlopt
+  - py-mpi4py
+  - py-numpy
+  - py-pip
+  - py-setuptools
+  - py-wheel
+  - sensei +ascent ~catalyst +python
+# not yet ready for macOS prime time
+#   https://github.com/spack/spack/issues/32283
+#   https://github.com/spack/spack/pull/32285
+#   https://github.com/spack/spack/pull/32284
+#  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+# skipped to save time: 3D post-processing
+#  - paraview +adios2 +python3 +qt
+# skipped to save time, because they are faster installed via pip afterwards
+# python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy yt
+#  - py-jupyter
+#  - py-matplotlib +animation +fonts +latex +movies backend=macosx
+#  - openpmd-api +python
+#  - py-openpmd-viewer +numba +jupyter
+#  - py-pandas
+#  - py-pyqt5
+#  - py-scipy
+#  - py-yt
+
+  packages:
+    all:
+      variants: +mpi ~fortran
+      # BLAS/LAPACK: the default (accelerate) pulls veclibfort@0.4.2 for
+      #              py-numpy, which fails to build on M1
+      # MPI: the default (openmpi) triggers annoying firewall warnings when
+      #      running executables
+      providers:
+        blas: [openblas]
+        lapack: [openblas]
+        mpi: [mpich]
+    # default blocks at HDF5 1.8, resulting in unmergable solution
+    conduit:
+      variants: ~hdf5_compat ~fortran
+    # otherwise concretization error between ccache and all other variants
+    zstd:
+      variants: +programs
+
+  compilers:
+  # macOS
+  # preparation: you first need to install xcode (app store) and gcc (homebrew) and gpg2 (homebrew)
+  - compiler:
+      spec: apple-clang@13.1.6
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: /opt/homebrew/bin/gfortran
+        fc: /opt/homebrew/bin/gfortran
+      flags: {}
+      operating_system: monterey
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: apple-clang@13.1.6
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: /opt/homebrew/bin/gfortran
+        fc: /opt/homebrew/bin/gfortran
+      flags: {}
+      operating_system: monterey
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  # binary caches
+  mirrors:
+    E4S: https://cache.e4s.io
+    LLNL: https://mirror.spack.io
+# needs boto3
+#    E4Smac: s3://spack-binaries/develop/e4s-mac
+
+  # do not try to reuse existing packages, which can confuse the concretizer
+  concretizer:
+    reuse: false
+    unify: true
+
+  # limit the build parallelism (default: call virtual cores)
+#  config:
+#    build_jobs: 6

--- a/Tools/machines/desktop/spack-ubuntu-cuda.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-cuda.yaml
@@ -1,0 +1,101 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html
+#
+# Inside the directory of this file
+#   spack env create warpx-cuda-dev spack-ubuntu-cuda.yaml
+#   spack env activate warpx-cuda-dev
+#   spack install  # only needed the first time
+#
+spack:
+  specs:
+  - adios2
+  - blaspp
+  - boost
+  - ccache
+  - cmake
+  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+  - cuda
+  - fftw
+  - hdf5
+  - lapackpp
+  - mpi
+  - pkgconfig
+  - python
+  - py-cython
+  - py-h5py
+  - py-libensemble +nlopt
+  - py-mpi4py
+  - py-numpy
+  - py-pip
+  - py-setuptools
+  - py-wheel
+# skipped to save time: 3D post-processing
+#  - paraview +adios2 +python3 +qt
+# skipped to save time, because they are faster installed via pip afterwards
+# python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy yt
+#  - py-jupyter
+#  - py-matplotlib +animation +fonts +latex +movies
+#  - openpmd-api +python
+#  - py-openpmd-viewer +numba +jupyter
+#  - py-pandas
+#  - py-pyqt5
+#  - py-scipy
+#  - py-yt
+
+  packages:
+    all:
+      # note: add +cuda cuda_arch=70
+      #       or respective CUDA capability instead of 70 to variants below
+      variants: +mpi ~fortran +cuda cuda_arch=70
+    # default blocks at HDF5 1.8, resulting in unmergable solution
+    conduit:
+      variants: ~hdf5_compat
+
+  compilers:
+  # Ubuntu
+  - compiler:
+      spec: gcc@11.2.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu22.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.4.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  # binary caches
+  mirrors:
+    E4S: https://cache.e4s.io
+    LLNL: https://mirror.spack.io
+
+  # do not try to reuse existing packages, which can confuse the concretizer
+  concretizer:
+    reuse: false
+    unify: true
+
+  # limit the build parallelism (default: call virtual cores)
+#  config:
+#    build_jobs: 6

--- a/Tools/machines/desktop/spack-ubuntu-openmp.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-openmp.yaml
@@ -1,0 +1,98 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html
+#
+# Inside the directory of this file
+#   spack env create warpx-openmp-dev spack-ubuntu-openmp.yaml
+#   spack env activate warpx-openmp-dev
+#   spack install  # only needed the first time
+#
+spack:
+  specs:
+  - adios2
+  - blaspp
+  - boost
+  - ccache
+  - cmake
+  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+  - fftw
+  - hdf5
+  - lapackpp
+  - mpi
+  - pkgconfig
+  - python
+  - py-cython
+  - py-h5py
+  - py-libensemble +nlopt
+  - py-mpi4py
+  - py-numpy
+  - py-pip
+  - py-setuptools
+  - py-wheel
+# skipped to save time: 3D post-processing
+#  - paraview +adios2 +python3 +qt
+# skipped to save time, because they are faster installed via pip afterwards
+# python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy yt
+#  - py-jupyter
+#  - py-matplotlib +animation +fonts +latex +movies
+#  - openpmd-api +python
+#  - py-openpmd-viewer +numba +jupyter
+#  - py-pandas
+#  - py-pyqt5
+#  - py-scipy
+#  - py-yt
+
+  packages:
+    all:
+      variants: +mpi ~fortran
+    # default blocks at HDF5 1.8, resulting in unmergable solution
+    conduit:
+      variants: ~hdf5_compat
+
+  compilers:
+  # Ubuntu
+  - compiler:
+      spec: gcc@11.2.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu22.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.4.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  # binary caches
+  mirrors:
+    E4S: https://cache.e4s.io
+    LLNL: https://mirror.spack.io
+
+  # do not try to reuse existing packages, which can confuse the concretizer
+  concretizer:
+    reuse: false
+    unify: true
+
+  # limit the build parallelism (default: call virtual cores)
+#  config:
+#    build_jobs: 6

--- a/Tools/machines/desktop/spack-ubuntu-rocm.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-rocm.yaml
@@ -1,0 +1,102 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html
+#
+# Inside the directory of this file
+#   spack env create warpx-rocm-dev spack-ubuntu-rocm.yaml
+#   spack env activate warpx-rocm-dev
+#   spack install  # only needed the first time
+#
+spack:
+  specs:
+  - adios2
+  - blaspp
+  - boost
+  - ccache
+  - cmake
+  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+  - hdf5
+  - hip
+  - lapackpp
+  - llvm-amdgpu
+  - mpi
+  - pkgconfig
+  - python
+  - py-cython
+  - py-h5py
+  - py-libensemble +nlopt
+  - py-mpi4py
+  - py-numpy
+  - py-pip
+  - py-setuptools
+  - py-wheel
+  - rocfft
+  - rocprim
+  - rocrand
+# skipped to save time: 3D post-processing
+#  - paraview +adios2 +python3 +qt
+# skipped to save time, because they are faster installed via pip afterwards
+# python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy yt
+#  - py-jupyter
+#  - py-matplotlib +animation +fonts +latex +movies
+#  - openpmd-api +python
+#  - py-openpmd-viewer +numba +jupyter
+#  - py-pandas
+#  - py-pyqt5
+#  - py-scipy
+#  - py-yt
+
+  packages:
+    all:
+      variants: +mpi ~fortran +rocm
+    # default blocks at HDF5 1.8, resulting in unmergable solution
+    conduit:
+      variants: ~hdf5_compat
+
+  compilers:
+  # Ubuntu
+  - compiler:
+      spec: gcc@11.2.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu22.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.4.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  # binary caches
+  mirrors:
+    E4S: https://cache.e4s.io
+    LLNL: https://mirror.spack.io
+
+  # do not try to reuse existing packages, which can confuse the concretizer
+  concretizer:
+    reuse: false
+    unify: true
+
+  # limit the build parallelism (default: call virtual cores)
+#  config:
+#    build_jobs: 6


### PR DESCRIPTION
Add Spack environment files for developer desktop/laptop computers.

- [x] link in the docs
- [ ] test each env
  - [x] Linux: OpenMP w/ Ascent (install + run)
  - [ ] Linux: CUDA w/ Ascent
  - [ ] Linux: ROCm w/ Ascent
  - [x] macOS M1: OpenMP w/ Ascent (install + run)
  - [ ] macOS x86_64: OpenMP w/ Ascent

## Dependencies in Spack
- [x] https://github.com/spack/spack/pull/32285
- [x] https://github.com/spack/spack/pull/32284

## Spack Version

Tested with Spack `v0.13.2-14196-g7fc78b8b0f` (tag search off, essentially post 0.18.1 `develop`)