### PR TITLE
order-independent rho_<species> in RZ + openPMD

### DIFF
--- a/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
+++ b/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import openpmd_api as io
+import numpy as np
 
 series = io.Series("LaserAccelerationRZ_opmd_plt/openpmd_%T.h5", io.Access.read_only)
 
@@ -8,7 +9,7 @@ assert len(series.iterations) == 3, 'improper number of iterations stored'
 
 ii = series.iterations[20]
 
-assert len(ii.meshes) == 7, 'improper number of meshes'
+assert len(ii.meshes) == 8, 'improper number of meshes'
 
 # select j_t
 jt = ii.meshes['j']['t']
@@ -22,3 +23,26 @@ assert Nz == 512, 'Wrong number of z points stored or possible incorrect orderin
 
 assert ii.meshes['part_per_grid'][io.Mesh_Record_Component.SCALAR].shape == [512,64], 'problem with part_per_grid'
 assert ii.meshes['rho_electrons'][io.Mesh_Record_Component.SCALAR].shape == [3, 512, 64], 'problem with rho_electrons'
+
+
+### test that openpmd+RZ
+### 1. creates rho per species correctly
+### 2. orders these appropriately
+rhoe_mesh = ii.meshes['rho_electrons']
+rhob_mesh = ii.meshes['rho_beam']
+dz, dr = rhoe_mesh.grid_spacing
+zmin, rmin = rhoe_mesh.grid_global_offset
+
+rhoe = rhoe_mesh[io.Mesh_Record_Component.SCALAR][:]
+rhob = rhob_mesh[io.Mesh_Record_Component.SCALAR][:]
+series.flush()
+_, nz, _ = rhoe.shape
+
+zlist = zmin + dz * np.arange(nz)
+rhoe0 = rhoe[0] # 0 mode
+rhob0 = rhob[0] # 0 mode
+
+electron_meanz = np.sum(np.dot(zlist, rhoe0))/ np.sum(rhoe0)
+beam_meanz = np.sum(np.dot(zlist, rhob0))/ np.sum(rhob0)
+
+assert ((electron_meanz > 0) and (beam_meanz < 0)), 'problem with openPMD+RZ.  Maybe openPMD+RZ mixed up the order of rho_<species> diagnostics?'

--- a/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
+++ b/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
@@ -36,8 +36,7 @@ zmin, rmin = rhoe_mesh.grid_global_offset
 rhoe = rhoe_mesh[io.Mesh_Record_Component.SCALAR][:]
 rhob = rhob_mesh[io.Mesh_Record_Component.SCALAR][:]
 series.flush()
-_, nz, _ = rhoe.shape
-
+nm, nz, nr = rhoe.shape
 zlist = zmin + dz * np.arange(nz)
 rhoe0 = rhoe[0] # 0 mode
 rhob0 = rhob[0] # 0 mode

--- a/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
+++ b/Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import openpmd_api as io
 import numpy as np
+import openpmd_api as io
 
 series = io.Series("LaserAccelerationRZ_opmd_plt/openpmd_%T.h5", io.Access.read_only)
 

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1938,7 +1938,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [LaserAccelerationRZ_opmd]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs_rz
-runtime_params = diag1.format=openpmd diag1.openpmd_backend=h5 max_step=20 diag1.fields_to_plot=Er Bt Bz jr jt jz rho part_per_cell part_per_grid rho_electrons
+runtime_params = diag1.format=openpmd diag1.openpmd_backend=h5 max_step=20 diag1.fields_to_plot=Er Bt Bz jr jt jz rho part_per_cell part_per_grid rho_beam rho_electrons
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_OPENPMD=ON

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -262,7 +262,7 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, m_rho_per_species_index[i],
                                                         false, ncomp);
             if (update_varnames) {
-                AddRZModesToOutputNames(std::string("rho_") + m_all_species_names[i], ncomp);
+                AddRZModesToOutputNames(std::string("rho_") + m_all_species_names[m_rho_per_species_index[i]], ncomp);
             }
             i++;
         } else if ( m_varnames_fields[comp] == "F" ){


### PR DESCRIPTION
This fixes some order dependency in the rho per species diagnostic when using RZ + openPMD.  

In [this input deck](https://github.com/ECP-WarpX/WarpX/files/9411099/inputs.txt), three species (e1, e2, e3) are spatially ordered and ordered in the declaration:

``particles.species_names = e1 e2 e3``
``e1.zmin =  10.e-6``
``e1.zmax =  20.e-6``
``e2.zmin =  40.e-6``
``e2.zmax =  50.e-6``
``e3.zmin =  60.e-6``
``e3.zmax =  70.e-6``
but the diagnostic order is mixed up:
``diag1.fields_to_plot = rho_e2 rho_e3 rho_e1``

Previously, their density plot had the species mixed up
<img width="444" alt="Screen Shot 2022-08-23 at 4 29 53 PM" src="https://user-images.githubusercontent.com/10621396/186284334-e713982a-f0fb-47a8-8e0f-43ac2a26ba02.png">
but with this fix the densities are read correctly, regardless of the differing order between species and diagnostic declarations:
<img width="456" alt="Screen Shot 2022-08-23 at 4 37 34 PM" src="https://user-images.githubusercontent.com/10621396/186284503-037eac57-b5af-4ac8-bf42-f4f2b23f6039.png">

