### PR TITLE
CI: GH Action Key Update

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,7 +1,6 @@
 name: 🐧 CUDA
 
 on: [push, pull_request]
-# test
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda
@@ -38,8 +37,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-nvcc-
+          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}
+          ccache-cuda-nvcc
     - name: install openPMD-api
       run: |
         export CEI_SUDO="sudo"
@@ -98,8 +97,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-gnumake-
+          ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}
+          ccache-cuda-gnumake
     - name: build WarpX
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -135,8 +134,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-nvhpc-
+          ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}
+          ccache-cuda-nvhpc
     - name: Build & Install
       run: |
         source /etc/profile.d/modules.sh

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,6 +1,7 @@
 name: 🐧 CUDA
 
 on: [push, pull_request]
+# test
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -29,8 +29,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-
-          ccache-hip-3dsp-
+          ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}
+          ccache-hip-3dsp
     - name: build WarpX
       shell: bash
       run: |
@@ -84,8 +84,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-
-          ccache-hip-2ddp-
+          ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}
+          ccache-hip-2ddp
     - name: build WarpX
       shell: bash
       run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -31,8 +31,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-icc-
+          ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}
+          ccache-intel-icc
     - name: build WarpX
       run: |
         set +eu
@@ -86,8 +86,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-icpx-
+          ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}
+          ccache-intel-icpx
     - name: build WarpX
       shell: bash
       run: |
@@ -144,8 +144,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-dpcc-
+          ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}
+          ccache-intel-dpcc
     - name: build WarpX
       shell: bash
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,8 +43,8 @@ jobs:
         path: /Users/runner/Library/Caches/ccache
         key: ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-
-          ccache-macos-appleclang-
+          ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}
+          ccache-macos-appleclang
     - name: build WarpX
       run: |
         cmake -S . -B build_dp         \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,8 +28,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-cxxminimal-
+          ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}
+          ccache-openmp-cxxminimal
     - name: build WarpX
       run: |
         cmake -S . -B build_3D         \
@@ -72,8 +72,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-gccablastr-
+          ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}
+          ccache-openmp-gccablastr
     - name: build WarpX
       run: |
         cmake -S . -B build            \
@@ -108,8 +108,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-openmp-pyfull-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-openmp-pyfull-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-pyfull-
+          ccache-openmp-pyfull-${{ hashFiles('.github/workflows/ubuntu.yml') }}
+          ccache-openmp-pyfull
     - name: build WarpX
       run: |
         python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,8 +23,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
-          ccache-windows-winmsvc-
+          ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}
+          ccache-windows-winmsvc
     - name: Build & Install
       run: |
         cmake -S . -B build               `
@@ -63,8 +63,8 @@ jobs:
           ~/.cache/ccache
         key: ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
         restore-keys: |
-          ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}-
-          ccache-windows-winclang-
+          ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}
+          ccache-windows-winclang
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build & Install
       shell: cmd


### PR DESCRIPTION
It looks like GH Actions slightly changed the syntax for cache keys.
This fixes the resulting breakage.

- [x] spot if there is an issue (e.g. https://github.com/kngott/WarpX/actions/runs/2929984658/workflow#L100)
![Screenshot from 2022-08-26 11-07-43](https://user-images.githubusercontent.com/1353258/186965841-55f79e4c-7197-4c13-9e3d-c06ef4eba7f0.png)

- [ ] fix the issue