### PR TITLE
Python: 3.7+

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -24,6 +24,10 @@ jobs:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.x'
     - name: install dependencies
       run: |
         .github/workflows/dependencies/nvcc11.sh

--- a/Docs/source/dataanalysis/plot_parallel.rst
+++ b/Docs/source/dataanalysis/plot_parallel.rst
@@ -12,8 +12,7 @@ Most of its dependencies are standard Python packages, that come with a default
 Anaconda installation or can be installed with ``pip`` or ``conda``:
 `os, matplotlib, sys, argparse, matplotlib, scipy`.
 
-Additional dependencies are ``yt >= 3.5`` ( or ``yt >= 3.6`` if you are using
-rigid injection, see section :doc:`yt` on how to install ``yt``), and ``mpi4py``.
+Additional dependencies are ``yt >= 4.0.1`` and ``mpi4py``.
 
 Run serial
 ----------

--- a/Docs/source/developers/gnumake/python.rst
+++ b/Docs/source/developers/gnumake/python.rst
@@ -3,7 +3,7 @@
 Installing WarpX as a Python package
 ====================================
 
-A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Pythone version 3.6 or newer.
+A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Pythone version 3.7 or newer.
 
 For a full Python installation of WarpX
 ---------------------------------------

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -27,7 +27,7 @@ Optional dependencies include:
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
-- `Python 3.6+ <https://www.python.org>`__
+- `Python 3.7+ <https://www.python.org>`__
 
   - `mpi4py <https://mpi4py.readthedocs.io>`__
   - `numpy <https://numpy.org>`__

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -4,7 +4,7 @@ Python (PICMI)
 ==============
 
 WarpX uses the `PICMI standard <https://github.com/picmi-standard/picmi>`__ for its Python input files.
-Python version 3.6 or newer is required.
+Python version 3.7 or newer is required.
 
 Example input files can be found in :ref:`the examples section <usage-examples>`.
 The examples support running in both modes by commenting and uncommenting the appropriate lines.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -60,6 +60,6 @@ setup(name = 'pywarpx',
       description = """Wrapper of WarpX""",
       package_data = package_data,
       install_requires = ['numpy', 'picmistandard==0.0.19', 'periodictable'],
-      python_requires = '>=3.6',
+      python_requires = '>=3.7',
       zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -297,7 +297,7 @@ setup(
     cmdclass=cmdclass,
     # scripts=['warpx_1d', 'warpx_2d', 'warpx_3d', 'warpx_rz'],
     zip_safe=False,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -307,7 +307,7 @@ setup(
     #    ]
     #},
     extras_require={
-        'all': ['openPMD-api~=0.14.2', 'openPMD-viewer~=1.1', 'yt~=3.6,>=4.0.1', 'matplotlib'],
+        'all': ['openPMD-api~=0.14.2', 'openPMD-viewer~=1.1', 'yt>=4.0.1', 'matplotlib'],
     },
     # cmdclass={'test': PyTest},
     # platforms='any',
@@ -321,7 +321,6 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Python 3.6 is now end-of-life. Bump support to 3.7+.

Also updated docs & requirements to use yt 4.0.1+ only (as we don't test older releases anymore).