### PR TITLE
Fix few "magic constants" & undefined variables found with clang-tidy

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -43,6 +43,11 @@
 
 using namespace amrex::literals;
 
+namespace
+{
+    const int permission_flag_rwxrxrx = 0755;
+}
+
 BTDiagnostics::BTDiagnostics (int i, std::string name)
     : Diagnostics(i, name)
 {

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -844,16 +844,16 @@ void BTDiagnostics::MergeBuffersForPlotfile (int i_snapshot)
         // Create directory only when the first buffer is flushed out.
         if (m_buffer_flush_counter[i_snapshot] == 0 ) {
             // Create Level_0 directory to store all Cell_D and Cell_H files
-            if (!amrex::UtilCreateDirectory(snapshot_Level0_path, 0755) )
+            if (!amrex::UtilCreateDirectory(snapshot_Level0_path, permission_flag_rwxrxrx) )
                 amrex::CreateDirectoryFailed(snapshot_Level0_path);
             // Create directory for each species selected for diagnostic
             for (int i = 0; i < m_particles_buffer[i_snapshot].size(); ++i) {
                 std::string snapshot_species_path = snapshot_path + "/" + m_output_species_names[i];
-                if ( !amrex::UtilCreateDirectory(snapshot_species_path, 0755))
+                if ( !amrex::UtilCreateDirectory(snapshot_species_path, permission_flag_rwxrxrx))
                     amrex::CreateDirectoryFailed(snapshot_species_path);
                 // Create Level_0 directory for particles to store Particle_H and DATA files
                 std::string species_Level0_path = snapshot_species_path + "/Level_0";
-                if ( !amrex::UtilCreateDirectory(species_Level0_path, 0755))
+                if ( !amrex::UtilCreateDirectory(species_Level0_path, permission_flag_rwxrxrx))
                     amrex::CreateDirectoryFailed(species_Level0_path);
             }
             std::string buffer_WarpXHeader_path = recent_Buffer_filepath + "/WarpXHeader";

--- a/Source/Diagnostics/BackTransformedDiagnostic.cpp
+++ b/Source/Diagnostics/BackTransformedDiagnostic.cpp
@@ -52,6 +52,11 @@
 
 using namespace amrex;
 
+namespace
+{
+    const int permission_flag_rwxrxrx = 0755;
+}
+
 #ifdef WARPX_USE_HDF5
 
 /*
@@ -532,7 +537,7 @@ LorentzTransformZ (MultiFab& data, Real gamma_boost, Real beta_boost)
             {
                 // Transform the transverse E and B fields. Note that ez and bz are not
                 // changed by the tranform.
-                Real e_lab, b_lab, j_lab, r_lab;
+                Real e_lab = 0.0_rt, b_lab = 0.0_rt, j_lab = 0.0_rt, r_lab = 0.0_rt;
                 e_lab = gamma_boost * (arr(i, j, k, 0) +
                                        beta_boost*clight*arr(i, j, k, 4));
                 b_lab = gamma_boost * (arr(i, j, k, 4) +
@@ -550,13 +555,16 @@ LorentzTransformZ (MultiFab& data, Real gamma_boost, Real beta_boost)
                 arr(i, j, k, 3) = b_lab;
 
                 // Transform the charge and current density. Only the z component of j is affected.
-                j_lab = gamma_boost*(arr(i, j, k, 8) +
-                                     beta_boost*clight*arr(i, j, k, 9));
-                r_lab = gamma_boost*(arr(i, j, k, 9) +
-                                     beta_boost*arr(i, j, k, 8)/clight);
+                const int j_comp_index = 8;
+                const int r_comp_index = 9;
 
-                arr(i, j, k, 8) = j_lab;
-                arr(i, j, k, 9) = r_lab;
+                j_lab = gamma_boost*(arr(i, j, k, j_comp_index) +
+                                     beta_boost*clight*arr(i, j, k, j_comp_index));
+                r_lab = gamma_boost*(arr(i, j, k, r_comp_index) +
+                                     beta_boost*arr(i, j, k, r_comp_index)/clight);
+
+                arr(i, j, k, j_comp_index) = j_lab;
+                arr(i, j, k, r_comp_index) = r_lab;
             }
         );
     }
@@ -615,7 +623,7 @@ BackTransformedDiagnostic (Real zmin_lab, Real zmax_lab, Real v_window_lab,
     // Query fields to dump
     std::vector<std::string> user_fields_to_dump;
     ParmParse pp_warpx("warpx");
-    bool do_user_fields;
+    bool do_user_fields = false;
     do_user_fields = pp_warpx.queryarr("back_transformed_diag_fields", user_fields_to_dump);
     if (queryWithParser(pp_warpx, "buffer_size", m_num_buffer_)) {
         if (m_max_box_size_ < m_num_buffer_) m_max_box_size_ = m_num_buffer_;
@@ -1138,7 +1146,7 @@ writeMetaData ()
 
     if (ParallelDescriptor::IOProcessor()) {
         const std::string fullpath = WarpX::lab_data_directory + "/snapshots";
-        if (!UtilCreateDirectory(fullpath, 0755))
+        if (!UtilCreateDirectory(fullpath, permission_flag_rwxrxrx))
             CreateDirectoryFailed(fullpath);
 
         VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
@@ -1160,7 +1168,7 @@ writeMetaData ()
 
         if (m_N_slice_snapshots_ > 0) {
            const std::string fullpath_slice = WarpX::lab_data_directory + "/slices";
-           if (!UtilCreateDirectory(fullpath_slice, 0755))
+           if (!UtilCreateDirectory(fullpath_slice, permission_flag_rwxrxrx))
                CreateDirectoryFailed(fullpath_slice);
 
            VisMF::IO_Buffer io_buffer_slice(VisMF::IO_Buffer_Size);
@@ -1285,13 +1293,13 @@ createLabFrameDirectories() {
 #else
     if (ParallelDescriptor::IOProcessor()) {
 
-        if (!UtilCreateDirectory(m_file_name, 0755))
+        if (!UtilCreateDirectory(m_file_name, permission_flag_rwxrxrx))
             CreateDirectoryFailed(m_file_name);
 
         const int nlevels = 1;
         for(int i = 0; i < nlevels; ++i) {
             const std::string &fullpath = LevelFullPath(i, m_file_name);
-            if (!UtilCreateDirectory(fullpath, 0755))
+            if (!UtilCreateDirectory(fullpath, permission_flag_rwxrxrx))
                 CreateDirectoryFailed(fullpath);
         }
 
@@ -1305,7 +1313,7 @@ createLabFrameDirectories() {
             const std::string& species_name =
                 species_names[mypc.mapSpeciesBackTransformedDiagnostics(i)];
             const std::string fullpath = m_file_name + "/" + species_name;
-            if (!UtilCreateDirectory(fullpath, 0755))
+            if (!UtilCreateDirectory(fullpath, permission_flag_rwxrxrx))
                 CreateDirectoryFailed(fullpath);
         }
     }

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -44,7 +44,8 @@ ReducedDiags::ReducedDiags (std::string rd_name)
     if (ParallelDescriptor::IOProcessor())
     {
         // create folder
-        if (!UtilCreateDirectory(m_path, 0755))
+        const int permission_flag_rwxrxrx = 0755;
+        if (!UtilCreateDirectory(m_path, permission_flag_rwxrxrx))
         { CreateDirectoryFailed(m_path); }
 
         // replace / create output file

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -83,7 +83,8 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
 
     const RealBox& real_box = dom_geom[0].ProbDomain();
     RealBox slice_cc_nd_box;
-    int slice_grid_size = 32;
+    const int default_grid_size = 32;
+    int slice_grid_size = default_grid_size;
 
     bool interpolate = false;
     bool coarsen = false;
@@ -304,6 +305,8 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
                warnMsg.str(), ablastr::warn_manager::WarnPriority::low);
         }
 
+         const auto very_small_number = 1E-10;
+
         // Factor to ensure index values computation depending on index type //
         double fac = ( 1.0 - SliceType[idim] )*dom_geom[0].CellSize(idim)*0.5;
         // if dimension is reduced to one cell length //
@@ -319,11 +322,11 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
                 slice_lo[idim] = static_cast<int>(
                                  floor( ( (slice_cc_nd_box.lo(idim)
                                  - (real_box.lo(idim) + fac ) )
-                                 / dom_geom[0].CellSize(idim)) + fac * 1E-10) );
+                                 / dom_geom[0].CellSize(idim)) + fac * very_small_number) );
                 slice_lo2[idim] = static_cast<int>(
                                  ceil( ( (slice_cc_nd_box.lo(idim)
                                  - (real_box.lo(idim) + fac) )
-                                 / dom_geom[0].CellSize(idim)) - fac * 1E-10 ) );
+                                 / dom_geom[0].CellSize(idim)) - fac * very_small_number) );
             }
             else {
                 slice_lo[idim] = static_cast<int>(
@@ -353,9 +356,9 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
         else
         {
             // moving realbox.lo and reabox.hi to nearest coarsenable grid point //
-            auto index_lo = static_cast<int>(floor(((slice_realbox.lo(idim) +  1E-10
+            auto index_lo = static_cast<int>(floor(((slice_realbox.lo(idim) +  very_small_number
                             - (real_box.lo(idim))) / dom_geom[0].CellSize(idim))) );
-            auto index_hi = static_cast<int>(ceil(((slice_realbox.hi(idim)  - 1E-10
+            auto index_hi = static_cast<int>(ceil(((slice_realbox.hi(idim)  - very_small_number
                             - (real_box.lo(idim))) / dom_geom[0].CellSize(idim))) );
 
             bool modify_cr = true;
@@ -378,8 +381,9 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
 
                 // If modified index.hi is > baselinebox.hi, move the point  //
                 // to the previous coarsenable point                         //
+                const auto small_number = 0.01;
                 if ( (hi_new * dom_geom[0].CellSize(idim))
-                      > real_box.hi(idim) - real_box.lo(idim) + dom_geom[0].CellSize(idim)*0.01 )
+                      > real_box.hi(idim) - real_box.lo(idim) + dom_geom[0].CellSize(idim)*small_number)
                 {
                    hi_new = index_hi - mod_hi;
                 }


### PR DESCRIPTION
This PR fixes few "magic constants" & undefined variables found using the `clang-tidy` tool