### PR TITLE
Perlmutter: Work-Around CUDA-Aware MPI & Slurm

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -16,6 +16,7 @@
 #SBATCH -C gpu
 #SBATCH -c 32
 #SBATCH --ntasks-per-node=4
+#SBATCH --gpus-per-node=4
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j
 

--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -16,8 +16,6 @@
 #SBATCH -C gpu
 #SBATCH -c 32
 #SBATCH --ntasks-per-node=4
-#SBATCH --gpus-per-task=1
-#SBATCH --gpu-bind=single:1
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j
 
@@ -41,6 +39,9 @@
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
+
+# expose one GPU per MPI rank
+export CUDA_VISIBLE_DEVICES=$SLURM_LOCALID
 
 EXE=./warpx
 #EXE=../WarpX/build/bin/warpx.3d.MPI.CUDA.DP.OPMD.QED


### PR DESCRIPTION
There are known HPE bugs with cgroups on Perlmutter that can blow up simulations (segfault) with CUDA-aware MPI.

We avoid the respective Slurm options now and just manually control the exposed GPUs per MPI rank.