### PR TITLE
BTD fields with RZ + openPMD - single mode only

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -76,6 +76,8 @@ private:
     void InitializeFieldFunctors (int lev) override;
 
     void InitializeFieldFunctorsRZopenPMD (int lev) override;
+    /** Whether to dump the RZ modes */
+    bool m_dump_rz_modes = false;
     void AddRZModesToOutputNames (const std::string& field, const int ncomp, bool cellcenter_data);
     /** This function allocates and initializes particle buffers for all the snapshots.
      * This is currently an empty function:
@@ -370,6 +372,7 @@ private:
     void ClearParticleBuffer(int i_buffer);
     /** Redistributes particles to the buffer box array in the lab-frame */
     void RedistributeParticleBuffer (const int i_buffer);
+    void UpdateVarnamesForRZopenPMD();
 
 };
 #endif // WARPX_BTDIAGNOSTICS_H_

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -74,10 +74,24 @@ private:
      *                is initialized.
      */
     void InitializeFieldFunctors (int lev) override;
-
+    /** Initialize functors that store pointers to the fields in RZ requested by the user.
+     *  Additionally, the cell-center functors that stores pointers to all fields,
+     *  namely, Er, Et, Ez, Br, Bt, Bz, jr, jt, jz, and rho is also initialized.
+     * \param[in] lev level on which the vector of unique_ptrs to field functors
+     *                is initialized.
+     */
     void InitializeFieldFunctorsRZopenPMD (int lev) override;
-    /** Whether to dump the RZ modes */
-    bool m_dump_rz_modes = false;
+    /** Populating m_varnames with real and imaginary parts of each RZ mode.
+     *  Modes are numbered from 0 to (nmodes-1) and mode 0 is purely real.
+     *  Both m_cellcenter_varnames (storing cell-centered data) and
+     *  m_varnames (storing back-transformed field data) are modified to include RZ modes to include
+     *  field_modeid_real/imag. For example, for Er with two modes, the varnames are
+     *  Er_0_real, Er_1_real, Er_1_imag
+     * \param[in] field field-name
+     * \param[in] ncomp number of rz components (if 2 modes, the ncomp is 2*nmodes-1)
+     * \param[in] cellcenter_data if true, m_cellcenter_varnames are updated
+                                  if false, m_varnames is updated
+     */
     void AddRZModesToOutputNames (const std::string& field, const int ncomp, bool cellcenter_data);
     /** This function allocates and initializes particle buffers for all the snapshots.
      * This is currently an empty function:

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -74,6 +74,9 @@ private:
      *                is initialized.
      */
     void InitializeFieldFunctors (int lev) override;
+
+    void InitializeFieldFunctorsRZopenPMD (int lev) override;
+    void AddRZModesToOutputNames (const std::string& field, const int ncomp, bool cellcenter_data);
     /** This function allocates and initializes particle buffers for all the snapshots.
      * This is currently an empty function:
      * The particle containers required for this must be added to populate this function.
@@ -313,9 +316,20 @@ private:
      *  All the fields are stored regardless of the specific fields to plot selected
      *  by the user.
      */
+#ifdef WARPX_DIM_RZ
+    amrex::Vector< std::string > m_cellcenter_varnames = {"Er", "Et", "Ez",
+                                                          "Br", "Bt", "Bz",
+                                                          "jr", "jt", "jz", "rho"};
+    amrex::Vector< std::string > m_cellcenter_varnames_fields = {"Er", "Et", "Ez",
+                                                                 "Br", "Bt", "Bz",
+                                                                 "jr", "jt", "jz",
+                                                                 "rho"};
+#else
     amrex::Vector< std::string > m_cellcenter_varnames = {"Ex", "Ey", "Ez",
                                                           "Bx", "By", "Bz",
                                                           "jx", "jy", "jz", "rho"};
+#endif
+
 
     /** Merge the lab-frame buffer multifabs so it can be visualized as
      *  a single plotfile

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1377,7 +1377,6 @@ BTDiagnostics::InitializeParticleBuffer ()
 void
 BTDiagnostics::PrepareParticleDataForOutput()
 {
-    auto& warpx = WarpX::GetInstance();
     for (int lev = 0; lev < nlev_output; ++lev) {
         for (int i = 0; i < m_all_particle_functors.size(); ++i)
         {

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -232,10 +232,16 @@ BTDiagnostics::ReadParameters ()
     if (utils::parser::queryWithParser(pp_diag_name, "buffer_size", m_buffer_size)) {
         if(m_max_box_size < m_buffer_size) m_max_box_size = m_buffer_size;
     }
-
+    amrex::Print() << " varname size : " << m_varnames.size() << "\n";
+#ifdef WARPX_DIM_RZ
+    amrex::Vector< std::string > BTD_varnames_supported = {"Er", "Et", "Ez",
+                                                           "Br", "Bt", "Bz",
+                                                           "jr", "jt", "jz", "rho"};
+#else
     amrex::Vector< std::string > BTD_varnames_supported = {"Ex", "Ey", "Ez",
                                                            "Bx", "By", "Bz",
                                                            "jx", "jy", "jz", "rho"};
+#endif
 
     for (const auto& var : m_varnames) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -243,7 +249,8 @@ BTDiagnostics::ReadParameters ()
             "Input error: field variable " + var + " in " + m_diag_name
             + ".fields_to_plot is not supported for BackTransformed diagnostics."
             + " Currently supported field variables for BackTransformed diagnostics "
-            + "include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho");
+            + "include Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho in Cartesian coordinates and "
+            + "Er, Et, Ez, Br, Bt, Bz, jr, jt, jz, and rho in cylindrical (RZ coordinates)");
     }
 
     bool particle_fields_to_plot_specified = pp_diag_name.queryarr("particle_fields_to_plot", m_pfield_varnames);
@@ -498,6 +505,12 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
                   nvars, m_num_buffers, m_varnames);
     }
 
+    // For RZ, initialize field functors RZ for openpmd
+    // This is a specialized call for intializing cell-center functors
+    // such that, all modes of a field component are stored contiguously
+    // For examply, Er0, Er1_real, Er1_imag, etc
+    InitializeFieldFunctorsRZopenPMD(lev);
+
     // Define all cell-centered functors required to compute cell-centere data
     // Fill vector of cell-center functors for all field-components, namely,
     // Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho are included in the
@@ -526,6 +539,102 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
         }
     }
 
+}
+
+void
+BTDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
+{
+#ifdef WARPX_DIM_RZ
+    auto & warpx = WarpX::GetInstance();
+    int ncomp_multimodefab = warpx.get_pointer_Efield_aux(0,0)->nComp();
+    int ncomp = ncomp_multimodefab;
+    // This function may be called multiple times, for different values of `lev`
+    // but the `varnames` need only be updated once.
+    bool update_cellcenter_varnames = (lev == 0);
+    if (update_cellcenter_varnames) {
+        m_cellcenter_varnames.clear();
+        const int n_rz = ncomp * m_cellcenter_varnames.size();
+        m_cellcenter_varnames.reserve(n_rz);
+    }
+
+    // Reset field functors
+    m_cell_center_functors[lev].clear();
+    m_cell_center_functors[lev].resize(m_cellcenter_varnames_fields.size());
+
+    for (int comp=0, n=m_cell_center_functors.at(lev).size(); comp<n; comp++){
+        if        ( m_cellcenter_varnames_fields[comp] == "Er" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Efield_aux(lev, 0), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Er"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "Et" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Efield_aux(lev, 1), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Et"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "Ez" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Efield_aux(lev, 2), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Ez"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "Br" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 0), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Br"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "Bt" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 1), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Bt"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "Bz" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 2), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("Bz"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "jr" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 0), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("jr"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "jt" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 1), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("jt"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "jz" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 2), lev, m_crse_ratio, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("jz"), ncomp, true);
+            }
+        } else if ( m_cellcenter_varnames_fields[comp] == "rho" ){
+            m_cell_center_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, -1, false, ncomp);
+            if (update_cellcenter_varnames) {
+                AddRZModesToOutputNames(std::string("rho"), ncomp, true);
+            }
+        }
+    }
+
+#endif
+    amrex::ignore_unused(lev);
+}
+
+void
+BTDiagnostics::AddRZModesToOutputNames (const std::string& field, const int ncomp, bool cellcenter_data)
+{
+#ifdef WARPX_DIM_RZ
+    // In cylindrical geometry, real and imag part of each mode are also
+    // dumped to file separately, so they need to be added to m_varnames
+    if (cellcenter_data) {
+        m_cellcenter_varnames.push_back( field + "_0_real" );
+        for (int ic=1 ; ic < (ncomp+1)/2 ; ic += 1) {
+            m_cellcenter_varnames.push_back( field + "_" + std::to_string(ic) + "_real" );
+            m_cellcenter_varnames.push_back( field + "_" + std::to_string(ic) + "_imag" );
+        }
+    }
+#else
+    amrex::ignore_unused(field, ncomp, cellcenter_data);
+#endif
 }
 
 void

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -207,7 +207,6 @@ BTDiagnostics::ReadParameters ()
     pp_diag_name.query("do_back_transformed_fields", m_do_back_transformed_fields);
     pp_diag_name.query("do_back_transformed_particles", m_do_back_transformed_particles);
     AMREX_ALWAYS_ASSERT(m_do_back_transformed_fields or m_do_back_transformed_particles);
-//    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_back_transformed_fields, " fields must be turned on for the new back-transformed diagnostics");
     if (m_do_back_transformed_fields == false) m_varnames.clear();
 
 
@@ -271,6 +270,7 @@ bool
 BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
 {
     // timestep < 0, i.e., at initialization time when step == -1
+    amrex::Print() << " buffer " << i_buffer << " full ? " << buffer_full(i_buffer) << " snapshot full " << m_snapshot_full[i_buffer] << " empty ? " << buffer_empty(i_buffer) << "\n";
     if (step < 0 )
         return false;
     // Do not call dump if the snapshot is already full and the files are closed.
@@ -954,6 +954,7 @@ BTDiagnostics::GetZSliceInDomainFlag (const int i_buffer, const int lev)
 void
 BTDiagnostics::Flush (int i_buffer)
 {
+    amrex::Print() << " in flush buffer " << i_buffer << "\n";
     auto & warpx = WarpX::GetInstance();
     std::string file_name = m_file_prefix;
     if (m_format=="plotfile") {
@@ -1013,6 +1014,7 @@ BTDiagnostics::Flush (int i_buffer)
             }
         }
     }
+    amrex::Print() << " writing data " << i_buffer <<"\n";
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         labtime, m_output_species[i_buffer], nlev_output, file_name, m_file_min_digits,

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -197,8 +197,8 @@ BTDiagnostics::ReadParameters ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_crse_ratio == amrex::IntVect(1),
         "Only support for coarsening ratio of 1 in all directions is included for BTD\n"
-        );
-
+        );    
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::n_rz_azimuthal_modes==1, "Currently only one mode is supported for BTD");
     // Read list of back-transform diag parameters requested by the user //
     amrex::ParmParse pp_diag_name(m_diag_name);
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -569,16 +569,16 @@ BTDiagnostics::UpdateVarnamesForRZopenPMD ()
     if (update_varnames) {
         for (int comp=0, n=m_varnames_fields.size(); comp<n; comp++)
         {
-            if (m_varnames[comp] == "Er")  AddRZModesToOutputNames(std::string("Er"), ncomp, false);
-            if (m_varnames[comp] == "Et")  AddRZModesToOutputNames(std::string("Et"), ncomp, false);
-            if (m_varnames[comp] == "Ez")  AddRZModesToOutputNames(std::string("Ez"), ncomp, false);
-            if (m_varnames[comp] == "Br")  AddRZModesToOutputNames(std::string("Br"), ncomp, false);
-            if (m_varnames[comp] == "Bt")  AddRZModesToOutputNames(std::string("Bt"), ncomp, false);
-            if (m_varnames[comp] == "Bz")  AddRZModesToOutputNames(std::string("Bz"), ncomp, false);
-            if (m_varnames[comp] == "jr")  AddRZModesToOutputNames(std::string("jr"), ncomp, false);
-            if (m_varnames[comp] == "jt")  AddRZModesToOutputNames(std::string("jt"), ncomp, false);
-            if (m_varnames[comp] == "jz")  AddRZModesToOutputNames(std::string("jz"), ncomp, false);
-            if (m_varnames[comp] == "rho") AddRZModesToOutputNames(std::string("rho"),ncomp, false);
+            if (m_varnames_fields[comp] == "Er")  AddRZModesToOutputNames(std::string("Er"), ncomp, false);
+            if (m_varnames_fields[comp] == "Et")  AddRZModesToOutputNames(std::string("Et"), ncomp, false);
+            if (m_varnames_fields[comp] == "Ez")  AddRZModesToOutputNames(std::string("Ez"), ncomp, false);
+            if (m_varnames_fields[comp] == "Br")  AddRZModesToOutputNames(std::string("Br"), ncomp, false);
+            if (m_varnames_fields[comp] == "Bt")  AddRZModesToOutputNames(std::string("Bt"), ncomp, false);
+            if (m_varnames_fields[comp] == "Bz")  AddRZModesToOutputNames(std::string("Bz"), ncomp, false);
+            if (m_varnames_fields[comp] == "jr")  AddRZModesToOutputNames(std::string("jr"), ncomp, false);
+            if (m_varnames_fields[comp] == "jt")  AddRZModesToOutputNames(std::string("jt"), ncomp, false);
+            if (m_varnames_fields[comp] == "jz")  AddRZModesToOutputNames(std::string("jz"), ncomp, false);
+            if (m_varnames_fields[comp] == "rho") AddRZModesToOutputNames(std::string("rho"),ncomp, false);
         }
     }
 
@@ -847,8 +847,6 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
         const int hi_k_lab = m_buffer_k_index_hi[i_buffer];
         m_buffer_box[i_buffer].setSmall( m_moving_window_dir, hi_k_lab - m_buffer_size + 1);
         m_buffer_box[i_buffer].setBig( m_moving_window_dir, hi_k_lab );
-        // Setting hi k-index for the next buffer
-        m_buffer_k_index_hi[i_buffer] = m_buffer_box[i_buffer].smallEnd(m_moving_window_dir) - 1;
         amrex::BoxArray buffer_ba( m_buffer_box[i_buffer] );
         buffer_ba.maxSize(m_max_box_size);
         // Generate a new distribution map for the back-transformed buffer multifab
@@ -1034,6 +1032,8 @@ BTDiagnostics::Flush (int i_buffer)
         ResetTotalParticlesInBuffer(i_buffer);
         ClearParticleBuffer(i_buffer);
     }
+    // Setting hi k-index for the next buffer
+    m_buffer_k_index_hi[i_buffer] = m_buffer_box[i_buffer].smallEnd(m_moving_window_dir) - 1;
 }
 
 void BTDiagnostics::RedistributeParticleBuffer (const int i_buffer)

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -197,7 +197,7 @@ BTDiagnostics::ReadParameters ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         m_crse_ratio == amrex::IntVect(1),
         "Only support for coarsening ratio of 1 in all directions is included for BTD\n"
-        );    
+        );
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::n_rz_azimuthal_modes==1, "Currently only one mode is supported for BTD");
     // Read list of back-transform diag parameters requested by the user //
     amrex::ParmParse pp_diag_name(m_diag_name);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -270,7 +270,7 @@ bool
 BTDiagnostics::DoDump (int step, int i_buffer, bool force_flush)
 {
     // timestep < 0, i.e., at initialization time when step == -1
-    amrex::Print() << " buffer " << i_buffer << " full ? " << buffer_full(i_buffer) << " snapshot full " << m_snapshot_full[i_buffer] << " empty ? " << buffer_empty(i_buffer) << "\n";
+    // amrex::AllPrint() << " buffer " << i_buffer << " full ? " << buffer_full(i_buffer) << " snapshot full " << m_snapshot_full[i_buffer] << " empty ? " << buffer_empty(i_buffer) << "\n";
     if (step < 0 )
         return false;
     // Do not call dump if the snapshot is already full and the files are closed.
@@ -499,7 +499,7 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
     // For RZ, initialize field functors RZ for openpmd
     // This is a specialized call for intializing cell-center functors
     // such that, all modes of a field component are stored contiguously
-    // For examply, Er0, Er1_real, Er1_imag, etc
+    // For example, Er0, Er1_real, Er1_imag, etc
     InitializeFieldFunctorsRZopenPMD(lev);
 #else
 
@@ -525,7 +525,6 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
                   m_cell_centered_data[lev].get(), lev,
                   nvars, m_num_buffers, m_varnames);
     }
-
 
     // Define all cell-centered functors required to compute cell-centere data
     // Fill vector of cell-center functors for all field-components, namely,
@@ -677,15 +676,19 @@ BTDiagnostics::AddRZModesToOutputNames (const std::string& field, const int ncom
 #ifdef WARPX_DIM_RZ
     // In cylindrical geometry, real and imag part of each mode are also
     // dumped to file separately, so they need to be added to m_varnames
+    // we number modes from 0 to (nmodes-1);
+    // mode 0 is purely real, all higher modes are complex
+    int const nmodes = (ncomp+1)/2;
+
     if (cellcenter_data) {
         m_cellcenter_varnames.push_back( field + "_0_real" );
-        for (int ic=1 ; ic < (ncomp+1)/2 ; ic += 1) {
+        for (int ic=1; ic < nmodes; ic++) {
             m_cellcenter_varnames.push_back( field + "_" + std::to_string(ic) + "_real" );
             m_cellcenter_varnames.push_back( field + "_" + std::to_string(ic) + "_imag" );
         }
     } else {
         m_varnames.push_back(field + "_0_real");
-        for (int ic=1 ; ic < (ncomp+1)/2 ; ic += 1) {
+        for (int ic=1; ic < nmodes; ic++) {
             m_varnames.push_back( field + "_" + std::to_string(ic) + "_real" );
             m_varnames.push_back( field + "_" + std::to_string(ic) + "_imag" );
         }
@@ -954,7 +957,7 @@ BTDiagnostics::GetZSliceInDomainFlag (const int i_buffer, const int lev)
 void
 BTDiagnostics::Flush (int i_buffer)
 {
-    amrex::Print() << " in flush buffer " << i_buffer << "\n";
+    // amrex::AllPrint() << " in flush buffer " << i_buffer << "\n";
     auto & warpx = WarpX::GetInstance();
     std::string file_name = m_file_prefix;
     if (m_format=="plotfile") {
@@ -1014,7 +1017,7 @@ BTDiagnostics::Flush (int i_buffer)
             }
         }
     }
-    amrex::Print() << " writing data " << i_buffer <<"\n";
+    // amrex::AllPrint() << " writing data " << i_buffer <<"\n";
     m_flush_format->WriteToFile(
         m_varnames, m_mf_output[i_buffer], m_geom_output[i_buffer], warpx.getistep(),
         labtime, m_output_species[i_buffer], nlev_output, file_name, m_file_min_digits,

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -155,6 +155,20 @@ BackTransformFunctor::InitData ()
     m_k_index_zlab.resize( m_num_buffers );
     m_map_varnames.resize( m_varnames.size() );
 
+#ifdef WARPX_DIM_RZ
+    std::map<std::string, int> m_possible_fields_to_dump = {
+        {"Er", 0},
+        {"Et", 1},
+        {"Ez", 2},
+        {"Br", 3},
+        {"Bt", 4},
+        {"Bz", 5},
+        {"jr", 6},
+        {"jt", 7},
+        {"jz", 8},
+        {"rho", 9}
+    };
+#else
     std::map<std::string, int> m_possible_fields_to_dump = {
         {"Ex", 0},
         {"Ey", 1},
@@ -167,6 +181,7 @@ BackTransformFunctor::InitData ()
         {"jz", 8},
         {"rho", 9}
     };
+#endif
 
     for (int i = 0; i < m_varnames.size(); ++i)
     {


### PR DESCRIPTION
- add a test? ->  #3482

I modified the file in Issue #3389 to ensure only one rz mode. 
[inputs_issue3389.txt](https://github.com/ECP-WarpX/WarpX/files/9863901/inputs_issue3389.txt)
Attached is the modified input file 

You can change` fields_to_plot = none `to use Er, Et, Ez , B, j, rho
This runs fine on summit. I am yet to visualize it