### PR TITLE
Remove some magic numbers

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
@@ -10,6 +10,7 @@
 
 #include "ReducedDiags.H"
 
+#include <map>
 #include <string>
 
 /**
@@ -36,6 +37,16 @@ public:
      */
     void ComputeDiags(int step) override final;
 
+private:
+    /// auxiliary structure to store headers and indices of the reduced diagnostics
+    struct aux_header_index
+    {
+        std::string header;
+        int idx;
+    };
+
+    /// map to store header texts and indices of the reduced diagnostics
+    std::map<std::string, aux_header_index> m_headers_indices;
 };
 
 #endif

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -82,16 +82,41 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
         // get WarpXParticleContainer class object
         auto & myspc = mypc.GetParticleContainer(i_s);
 
-        if (myspc.DoQED())
-        {
-            // resize data array for QED species
-            const int num_quantities = 18;
-            m_data.resize(num_quantities,0.0);
-        } else
-        {
-            // resize data array for regular species
-            const int num_quantities = 16;
-            m_data.resize(num_quantities,0.0);
+        auto all_diag_names = std::vector<std::string> {};
+        auto add_diag = [&,c=0] (
+            const std::string& name, const std::string& header) mutable {
+            m_headers_indices[name] = aux_header_index{header, c++};
+            all_diag_names.push_back(name);
+        };
+
+        add_diag("xmin", "xmin(m)");
+        add_diag("xmax", "xmax(m)");
+        add_diag("ymin", "ymin(m)");
+        add_diag("ymax", "ymax(m)");
+        add_diag("zmin", "zmin(m)");
+        add_diag("zmax", "zmax(m)");
+        add_diag("pxmin", "pxmin(kg*m/s)");
+        add_diag("pxmax", "pxmax(kg*m/s)");
+        add_diag("pymin", "pymin(kg*m/s)");
+        add_diag("pymax", "pymax(kg*m/s)");
+        add_diag("pzmin", "pzmin(kg*m/s)");
+        add_diag("pzmax", "pzmax(kg*m/s)");
+        add_diag("gmin", "gmin()");
+        add_diag("gmax", "gmax()");
+
+#if (defined WARPX_DIM_3D)
+        add_diag("wmin", "wmin()");
+        add_diag("wmax", "wmax()");
+#elif (defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ))
+        add_diag("wmin", "wmin(1/m)");
+        add_diag("wmax", "wmax(1/m)");
+#else
+        add_diag("wmin", "wmin(1/m^2)");
+        add_diag("wmax", "wmax(1/m^2)");
+#endif
+        if (myspc.DoQED()){
+            add_diag("chimin", "chimin()");
+            add_diag("chimax", "chimax()");
         }
 
         if (ParallelDescriptor::IOProcessor())
@@ -103,55 +128,14 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
                 ofs.open(m_path + m_rd_name + "." + m_extension,
                     std::ofstream::out | std::ofstream::app);
                 // write header row
-                int c = 0;
+                int off = 0;
                 ofs << "#";
-                ofs << "[" << c++ << "]step()";
+                ofs << "[" << off++ << "]step()";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]time(s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]xmin(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]xmax(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]ymin(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]ymax(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]zmin(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]zmax(m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pxmin(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pxmax(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pymin(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pymax(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pzmin(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]pzmax(kg*m/s)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]gmin()";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]gmax()";
-                ofs << m_sep;
-#if (defined WARPX_DIM_3D)
-                ofs << "[" << c++ << "]wmin()";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]wmax()";
-#else
-                ofs << "[" << c++ << "]wmin(1/m)";
-                ofs << m_sep;
-                ofs << "[" << c++ << "]wmax(1/m)";
-#endif
-                if (myspc.DoQED())
-                {
-                    ofs << m_sep;
-                    ofs << "[" << c++ << "]chimin()";
-                    ofs << m_sep;
-                    ofs << "[" << c++ << "]chimax()";
+                ofs << "[" << off++ << "]time(s)";
+                for (const auto& name : all_diag_names){
+                    const auto& el = m_headers_indices[name];
+                    ofs << m_sep << "[" << el.idx + off << "]" << el.header;
                 }
                 ofs << std::endl;
                 // close file
@@ -487,35 +471,32 @@ void ParticleExtrema::ComputeDiags (int step)
             ParallelDescriptor::ReduceRealMax(chimax_f);
         }
 #endif
-        constexpr auto
-            idx_xmin   = 0  , idx_xmax   = 1   , idx_ymin   = 2 , idx_ymax   = 3,
-            idx_zmin   = 4  , idx_zmax   = 5   , idx_uxminm = 6 , idx_uxmaxm = 7,
-            idx_uyminm = 8  , idx_uymaxm = 9   , idx_uzminm = 10, idx_uzmaxm = 11,
-            idx_gmin   = 12 , idx_gmax   = 13  , idx_wmin   = 14, idx_wmax   = 15;
-        [[maybe_unused]] constexpr auto
-            idx_chimin_f = 16, idx_chimax_f = 17;
 
-        m_data[idx_xmin]  = xmin;
-        m_data[idx_xmax]  = xmax;
-        m_data[idx_ymin]  = ymin;
-        m_data[idx_ymax]  = ymax;
-        m_data[idx_zmin]  = zmin;
-        m_data[idx_zmax]  = zmax;
-        m_data[idx_uxminm]  = uxmin*m;
-        m_data[idx_uxmaxm]  = uxmax*m;
-        m_data[idx_uyminm]  = uymin*m;
-        m_data[idx_uymaxm]  = uymax*m;
-        m_data[idx_uzminm] = uzmin*m;
-        m_data[idx_uzmaxm] = uzmax*m;
-        m_data[idx_gmin] = gmin;
-        m_data[idx_gmax] = gmax;
-        m_data[idx_wmin] = wmin;
-        m_data[idx_wmax] = wmax;
+        const auto get_idx = [&](const std::string& name){
+            return m_headers_indices.at(name).idx;
+        };
+
+        m_data[get_idx("xmin")]  = xmin;
+        m_data[get_idx("xmax")]  = xmax;
+        m_data[get_idx("ymin")]  = ymin;
+        m_data[get_idx("ymax")]  = ymax;
+        m_data[get_idx("zmin")]  = zmin;
+        m_data[get_idx("zmax")]  = zmax;
+        m_data[get_idx("pxmin")]  = uxmin*m;
+        m_data[get_idx("pxmax")]  = uxmax*m;
+        m_data[get_idx("pymin")]  = uymin*m;
+        m_data[get_idx("pymax")]  = uymax*m;
+        m_data[get_idx("pzmin")] = uzmin*m;
+        m_data[get_idx("pzmax")] = uzmax*m;
+        m_data[get_idx("gmin")] = gmin;
+        m_data[get_idx("gmax")] = gmax;
+        m_data[get_idx("wmin")] = wmin;
+        m_data[get_idx("wmax")] = wmax;
 #if (defined WARPX_QED)
         if (myspc.DoQED())
         {
-            m_data[idx_chimin_f] = chimin_f;
-            m_data[idx_chimax_f] = chimax_f;
+            m_data[get_idx("chimin")] = chimin_f;
+            m_data[get_idx("chimax")] = chimax_f;
         }
 #endif
     }

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -119,6 +119,8 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
             add_diag("chimax", "chimax()");
         }
 
+        m_data.resize(all_diag_names.size());
+
         if (ParallelDescriptor::IOProcessor())
         {
             if ( m_IsNotRestart )
@@ -408,7 +410,6 @@ void ParticleExtrema::ComputeDiags (int step)
                     // declare external fields
                     const int offset = 0;
                     const auto getExternalEB = GetExternalEBField(pti, offset);
-
                     // define variables in preparation for field gathering
                     amrex::Box box = pti.tilebox();
                     box.grow(ngEB);

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -487,27 +487,35 @@ void ParticleExtrema::ComputeDiags (int step)
             ParallelDescriptor::ReduceRealMax(chimax_f);
         }
 #endif
-        m_data[0]  = xmin;
-        m_data[1]  = xmax;
-        m_data[2]  = ymin;
-        m_data[3]  = ymax;
-        m_data[4]  = zmin;
-        m_data[5]  = zmax;
-        m_data[6]  = uxmin*m;
-        m_data[7]  = uxmax*m;
-        m_data[8]  = uymin*m;
-        m_data[9]  = uymax*m;
-        m_data[10] = uzmin*m;
-        m_data[11] = uzmax*m;
-        m_data[12] = gmin;
-        m_data[13] = gmax;
-        m_data[14] = wmin;
-        m_data[15] = wmax;
+        constexpr auto
+            idx_xmin   = 0  , idx_xmax   = 1   , idx_ymin   = 2 , idx_ymax   = 3,
+            idx_zmin   = 4  , idx_zmax   = 5   , idx_uxminm = 6 , idx_uxmaxm = 7,
+            idx_uyminm = 8  , idx_uymaxm = 9   , idx_uzminm = 10, idx_uzmaxm = 11,
+            idx_gmin   = 12 , idx_gmax   = 13  , idx_wmin   = 14, idx_wmax   = 15;
+        [[maybe_unused]] constexpr auto
+            idx_chimin_f = 16, idx_chimax_f = 17;
+
+        m_data[idx_xmin]  = xmin;
+        m_data[idx_xmax]  = xmax;
+        m_data[idx_ymin]  = ymin;
+        m_data[idx_ymax]  = ymax;
+        m_data[idx_zmin]  = zmin;
+        m_data[idx_zmax]  = zmax;
+        m_data[idx_uxminm]  = uxmin*m;
+        m_data[idx_uxmaxm]  = uxmax*m;
+        m_data[idx_uyminm]  = uymin*m;
+        m_data[idx_uymaxm]  = uymax*m;
+        m_data[idx_uzminm] = uzmin*m;
+        m_data[idx_uzmaxm] = uzmax*m;
+        m_data[idx_gmin] = gmin;
+        m_data[idx_gmax] = gmax;
+        m_data[idx_wmin] = wmin;
+        m_data[idx_wmax] = wmax;
 #if (defined WARPX_QED)
         if (myspc.DoQED())
         {
-            m_data[16] = chimin_f;
-            m_data[17] = chimax_f;
+            m_data[idx_chimin_f] = chimin_f;
+            m_data[idx_chimax_f] = chimax_f;
         }
 #endif
     }

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -30,6 +30,15 @@
 
 using namespace amrex;
 
+namespace
+{
+    template <typename T>
+    constexpr T perp_tolerance = T(1.0e-14);
+
+    template<>
+    constexpr float perp_tolerance<float> = 1.0e-7f;
+}
+
 void
 WarpXLaserProfiles::GaussianLaserProfile::init (
     const amrex::ParmParse& ppl,
@@ -63,18 +72,10 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
         std::inner_product(
             m_common_params.nvec.begin(),
             m_common_params.nvec.end(),
-            m_params.stc_direction.begin(), 0.0);
+            m_params.stc_direction.begin(), Real(0.0));
 
-    const auto msg = "stc_direction is not perpendicular to the laser plane vector";
-    if constexpr (std::is_same<amrex::Real,double>()){
-        constexpr auto tol_double = 1.0e14_rt;
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol_double, msg);
-    }
-    else{
-        constexpr auto tol_float = 1.0e-7_rt;
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol_float, msg);
-    }
-
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < ::perp_tolerance<Real>,
+        "stc_direction is not perpendicular to the laser plane vector");
 
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -65,10 +65,16 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
             m_common_params.nvec.end(),
             m_params.stc_direction.begin(), 0.0);
 
-    constexpr auto tol = static_cast<amrex::Real>(
-        std::is_same<amrex::Real,double>() ? 1.0e-14 : 1.0e-7);
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol,
-        "stc_direction is not perpendicular to the laser plane vector");
+    const auto msg = "stc_direction is not perpendicular to the laser plane vector";
+    if constexpr (std::is_same<amrex::Real,double>()){
+        constexpr auto tol_double = 1.0e14_rt;
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol_double, msg);
+    }
+    else{
+        constexpr auto tol_float = 1.0e-7_rt;
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol_float, msg);
+    }
+
 
     // Get angle between p_X and stc_direction
     // in 2d, stcs are in the simulation plane

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <numeric>
+#include <type_traits>
 #include <vector>
 
 using namespace amrex;
@@ -63,7 +64,9 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
             m_common_params.nvec.begin(),
             m_common_params.nvec.end(),
             m_params.stc_direction.begin(), 0.0);
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < 1.0e-14,
+
+    constexpr auto tol = std::is_same<amrex::Real,double>() ? 1.0e-14_rt : 1.0e-7_rt;
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol,
         "stc_direction is not perpendicular to the laser plane vector");
 
     // Get angle between p_X and stc_direction

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -29,15 +29,6 @@
 
 using namespace amrex;
 
-namespace
-{
-    template <typename T>
-    constexpr T perp_tolerance = T(1.0e-14);
-
-    template<>
-    constexpr float perp_tolerance<float> = 1.0e-7f;
-}
-
 void
 WarpXLaserProfiles::GaussianLaserProfile::init (
     const amrex::ParmParse& ppl,
@@ -71,9 +62,9 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
         std::inner_product(
             m_common_params.nvec.begin(),
             m_common_params.nvec.end(),
-            m_params.stc_direction.begin(), Real(0.0));
+            m_params.stc_direction.begin(), 0.0);
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < ::perp_tolerance<Real>,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < 1.0e-14,
         "stc_direction is not perpendicular to the laser plane vector");
 
     // Get angle between p_X and stc_direction

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -25,7 +25,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <numeric>
-#include <type_traits>
 #include <vector>
 
 using namespace amrex;

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -65,7 +65,8 @@ WarpXLaserProfiles::GaussianLaserProfile::init (
             m_common_params.nvec.end(),
             m_params.stc_direction.begin(), 0.0);
 
-    constexpr auto tol = std::is_same<amrex::Real,double>() ? 1.0e-14_rt : 1.0e-7_rt;
+    constexpr auto tol = static_cast<amrex::Real>(
+        std::is_same<amrex::Real,double>() ? 1.0e-14 : 1.0e-7);
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(dp2) < tol,
         "stc_direction is not perpendicular to the laser plane vector");
 

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -69,10 +69,21 @@ WarpXLaserProfiles::HarrisLaserProfile::fill_amplitude (
 
     // time envelope is given by the Harris function
     Real time_envelope = 0.;
+
+    constexpr auto norm = 1._rt/32._rt;
+    constexpr auto c_0 = 10._rt;
+    constexpr auto c_1 = -15._rt;
+    constexpr auto c_2 = 6._rt;
+    constexpr auto c_3 = -1._rt;
+    constexpr auto a_1 = 1._rt;
+    constexpr auto a_2 = 2._rt;
+    constexpr auto a_3 = 3._rt;
+
     if (t < m_params.duration)
-        time_envelope = 1._rt/32._rt * (10._rt - 15._rt*std::cos(arg_env) +
-                                  6._rt*std::cos(2._rt*arg_env) -
-                                  std::cos(3._rt*arg_env));
+        time_envelope =  norm * (c_0 +
+                                 c_1*std::cos(a_1*arg_env) +
+                                 c_2*std::cos(a_2*arg_env) +
+                                 c_3*std::cos(a_3*arg_env));
 
     // Copy member variables to tmp copies for GPU runs.
     const auto tmp_e_max = m_common_params.e_max;

--- a/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
+++ b/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
@@ -59,8 +59,9 @@ BackgroundStopping::BackgroundStopping (std::string const collision_name)
                  "For background stopping, the background temperature must be specified.");
     }
 
-    m_background_density_func = m_background_density_parser.compile<4>();
-    m_background_temperature_func = m_background_temperature_parser.compile<4>();
+    constexpr auto num_parser_args = 4;
+    m_background_density_func = m_background_density_parser.compile<num_parser_args>();
+    m_background_temperature_func = m_background_temperature_parser.compile<num_parser_args>();
 
     if (m_background_type == BackgroundStoppingType::ELECTRONS) {
         m_background_mass = PhysConst::m_e;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -159,10 +159,14 @@ void BreitWheelerEngine::compute_lookup_tables (
 
 void BreitWheelerEngine::init_builtin_dndt_table()
 {
+    constexpr auto default_chi_phot_min = 0.02_prt;
+    constexpr auto default_chi_phot_max = 200.0_prt;
+    constexpr auto default_chi_phot_how_many = 64;
+
     BW_dndt_table_params dndt_params;
-    dndt_params.chi_phot_min = 0.02_prt;
-    dndt_params.chi_phot_max = 200.0_prt;
-    dndt_params.chi_phot_how_many = 64;
+    dndt_params.chi_phot_min = default_chi_phot_min;
+    dndt_params.chi_phot_max = default_chi_phot_max;
+    dndt_params.chi_phot_how_many = default_chi_phot_how_many;
 
     const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{
         -1.34808e+02_prt, -1.16674e+02_prt, -1.01006e+02_prt, -8.74694e+01_prt,
@@ -189,11 +193,16 @@ void BreitWheelerEngine::init_builtin_dndt_table()
 
 void BreitWheelerEngine::init_builtin_pair_prod_table()
 {
+    constexpr auto default_chi_phot_min = 0.02_prt;
+    constexpr auto default_chi_phot_max = 200.0_prt;
+    constexpr auto default_chi_phot_how_many = 64;
+    constexpr auto default_frac_how_many = 64;
+
     BW_pair_prod_table_params pair_prod_params;
-    pair_prod_params.chi_phot_min = 0.02_prt;
-    pair_prod_params.chi_phot_max = 200.0_prt;
-    pair_prod_params.chi_phot_how_many = 64;
-    pair_prod_params.frac_how_many = 64;
+    pair_prod_params.chi_phot_min = default_chi_phot_min;
+    pair_prod_params.chi_phot_max = default_chi_phot_max;
+    pair_prod_params.chi_phot_how_many = default_chi_phot_how_many;
+    pair_prod_params.frac_how_many = default_frac_how_many;
 
     const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{
         0.00000e+00_prt, 0.00000e+00_prt, 0.00000e+00_prt, 0.00000e+00_prt,

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
@@ -158,10 +158,14 @@ void QuantumSynchrotronEngine::compute_lookup_tables (
 
 void QuantumSynchrotronEngine::init_builtin_dndt_table()
 {
+    constexpr auto default_chi_part_min = 1.0e-3_prt;
+    constexpr auto default_chi_part_max = 200.0_prt;
+    constexpr auto default_chi_part_how_many = 64;
+
     QS_dndt_table_params dndt_params;
-    dndt_params.chi_part_min = 1.0e-3_prt;
-    dndt_params.chi_part_max = 200.0_prt;
-    dndt_params.chi_part_how_many = 64;
+    dndt_params.chi_part_min = default_chi_part_min;
+    dndt_params.chi_part_max = default_chi_part_max;
+    dndt_params.chi_part_how_many = default_chi_part_how_many;
 
 
     const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{
@@ -190,12 +194,18 @@ void QuantumSynchrotronEngine::init_builtin_dndt_table()
 
 void QuantumSynchrotronEngine::init_builtin_phot_em_table()
 {
+    constexpr auto default_chi_part_min = 1.0e-3_prt;
+    constexpr auto default_chi_part_max = 200.0_prt;
+    constexpr auto default_frac_min = 1.0e-12_prt;
+    constexpr auto default_chi_part_how_many = 64;
+    constexpr auto default_frac_how_many = 64;
+
     QS_phot_em_table_params phot_em_params;
-    phot_em_params.chi_part_min = 1.0e-3_prt;
-    phot_em_params.chi_part_max = 200.0_prt;
-    phot_em_params.frac_min = 1.0e-12_prt;
-    phot_em_params.chi_part_how_many = 64;
-    phot_em_params.frac_how_many = 64;
+    phot_em_params.chi_part_min = default_chi_part_min;
+    phot_em_params.chi_part_max = default_chi_part_max;
+    phot_em_params.frac_min = default_frac_min;
+    phot_em_params.chi_part_how_many = default_chi_part_how_many;
+    phot_em_params.frac_how_many = default_frac_how_many;
 
 
 const auto vals = amrex::Gpu::DeviceVector<amrex::ParticleReal>{

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -53,17 +53,19 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, int a_offset)
     if (mypc.m_E_ext_particle_s == "parse_e_ext_particle_function")
     {
         m_Etype = ExternalFieldInitType::Parser;
-        m_Exfield_partparser = mypc.m_Ex_particle_parser->compile<4>();
-        m_Eyfield_partparser = mypc.m_Ey_particle_parser->compile<4>();
-        m_Ezfield_partparser = mypc.m_Ez_particle_parser->compile<4>();
+        constexpr auto num_arguments = 4; //x,y,z,t
+        m_Exfield_partparser = mypc.m_Ex_particle_parser->compile<num_arguments>();
+        m_Eyfield_partparser = mypc.m_Ey_particle_parser->compile<num_arguments>();
+        m_Ezfield_partparser = mypc.m_Ez_particle_parser->compile<num_arguments>();
     }
 
     if (mypc.m_B_ext_particle_s == "parse_b_ext_particle_function")
     {
         m_Btype = ExternalFieldInitType::Parser;
-        m_Bxfield_partparser = mypc.m_Bx_particle_parser->compile<4>();
-        m_Byfield_partparser = mypc.m_By_particle_parser->compile<4>();
-        m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<4>();
+        constexpr auto num_arguments = 4; //x,y,z,t
+        m_Bxfield_partparser = mypc.m_Bx_particle_parser->compile<num_arguments>();
+        m_Byfield_partparser = mypc.m_By_particle_parser->compile<num_arguments>();
+        m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<num_arguments>();
     }
 
     if (mypc.m_E_ext_particle_s == "repeated_plasma_lens" ||

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -73,24 +73,41 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
         m_do_boundary_buffer[i].resize(numSpecies(), 0);
     }
 
+#if defined(WARPX_DIM_1D_Z)
+    constexpr auto idx_zlo = 0;
+    constexpr auto idx_zhi = 1;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+    constexpr auto idx_xlo = 0;
+    constexpr auto idx_xhi = 1;
+    constexpr auto idx_zlo = 2;
+    constexpr auto idx_zhi = 3;
+#else
+    constexpr auto idx_xlo = 0;
+    constexpr auto idx_xhi = 1;
+    constexpr auto idx_ylo = 2;
+    constexpr auto idx_yhi = 3;
+    constexpr auto idx_zlo = 4;
+    constexpr auto idx_zhi = 5;
+#endif
+
     for (int ispecies = 0; ispecies < numSpecies(); ++ispecies)
     {
         amrex::ParmParse pp_species(getSpeciesNames()[ispecies]);
 #if defined(WARPX_DIM_1D_Z)
-        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[0][ispecies]);
-        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[1][ispecies]);
+        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[idx_zlo][ispecies]);
+        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[idx_zhi][ispecies]);
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        pp_species.query("save_particles_at_xlo", m_do_boundary_buffer[0][ispecies]);
-        pp_species.query("save_particles_at_xhi", m_do_boundary_buffer[1][ispecies]);
-        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[2][ispecies]);
-        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[3][ispecies]);
+        pp_species.query("save_particles_at_xlo", m_do_boundary_buffer[idx_xlo][ispecies]);
+        pp_species.query("save_particles_at_xhi", m_do_boundary_buffer[idx_xhi][ispecies]);
+        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[idx_zlo][ispecies]);
+        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[idx_zhi][ispecies]);
 #else
-        pp_species.query("save_particles_at_xlo", m_do_boundary_buffer[0][ispecies]);
-        pp_species.query("save_particles_at_xhi", m_do_boundary_buffer[1][ispecies]);
-        pp_species.query("save_particles_at_ylo", m_do_boundary_buffer[2][ispecies]);
-        pp_species.query("save_particles_at_yhi", m_do_boundary_buffer[3][ispecies]);
-        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[4][ispecies]);
-        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[5][ispecies]);
+        pp_species.query("save_particles_at_xlo", m_do_boundary_buffer[idx_xlo][ispecies]);
+        pp_species.query("save_particles_at_xhi", m_do_boundary_buffer[idx_xhi][ispecies]);
+        pp_species.query("save_particles_at_ylo", m_do_boundary_buffer[idx_ylo][ispecies]);
+        pp_species.query("save_particles_at_yhi", m_do_boundary_buffer[idx_yhi][ispecies]);
+        pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[idx_zlo][ispecies]);
+        pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[idx_zhi][ispecies]);
 #endif
 #ifdef AMREX_USE_EB
         pp_species.query("save_particles_at_eb", m_do_boundary_buffer[AMREX_SPACEDIM*2][ispecies]);
@@ -102,20 +119,20 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
     }
 
 #if defined(WARPX_DIM_1D_Z)
-    m_boundary_names[0] = "zlo";
-    m_boundary_names[1] = "zhi";
+    m_boundary_names[idx_zlo] = "zlo";
+    m_boundary_names[idx_zhi] = "zhi";
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-    m_boundary_names[0] = "xlo";
-    m_boundary_names[1] = "xhi";
-    m_boundary_names[2] = "zlo";
-    m_boundary_names[3] = "zhi";
+    m_boundary_names[idx_xlo] = "xlo";
+    m_boundary_names[idx_xhi] = "xhi";
+    m_boundary_names[idx_zlo] = "zlo";
+    m_boundary_names[idx_zhi] = "zhi";
 #else
-    m_boundary_names[0] = "xlo";
-    m_boundary_names[1] = "xhi";
-    m_boundary_names[2] = "ylo";
-    m_boundary_names[3] = "yhi";
-    m_boundary_names[4] = "zlo";
-    m_boundary_names[5] = "zhi";
+    m_boundary_names[idx_xlo] = "xlo";
+    m_boundary_names[idx_xhi] = "xhi";
+    m_boundary_names[idx_ylo] = "ylo";
+    m_boundary_names[idx_yhi] = "yhi";
+    m_boundary_names[idx_zlo] = "zlo";
+    m_boundary_names[idx_zhi] = "zhi";
 #endif
 #ifdef AMREX_USE_EB
     m_boundary_names[AMREX_SPACEDIM*2] =  "eb";


### PR DESCRIPTION
This PR removes almost all "magic numbers" from the following files (issues found with the `readability-magic-numbers` option of the `clang-tidy` tool):
```
BackgroundStopping.cpp
GetExternalFields.cpp
QuantumSyncEngineWrapper.cpp
BreitWheelerEngineWrapper.cpp
ParticleBoundaryBuffer.cpp
LaserProfileGaussian.cpp
LaserProfileHarris.cpp
ParticleExtrema.cpp
```