### PR TITLE
Sphinx Extension: Sphinx-Design

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -17,4 +17,5 @@ picmistandard==0.0.19
 pygments
 recommonmark
 sphinx>=2.0
+sphinx-design
 sphinx_rtd_theme>=0.3.1

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -46,6 +46,7 @@ sys.path.insert(0, os.path.join( os.path.abspath(__file__), '../Python') )
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinx_design',
     'breathe'
  ]
 

--- a/Docs/spack.yaml
+++ b/Docs/spack.yaml
@@ -23,4 +23,5 @@ spack:
   - py-breathe
   - py-recommonmark
   - py-pygments
+  - py-sphinx-design
   - py-sphinx-rtd-theme


### PR DESCRIPTION
Enables the Sphinx extension: https://sphinx-design.readthedocs.io/en/rtd-theme/

For future use (esp. tabs).