### PR TITLE
Avoid division by 0 in plasma lenses

### DIFF
--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -151,10 +151,7 @@ struct GetExternalEBField
             // This assumes that vzp > 0.
             amrex::ParticleReal const zl_bounded = std::min(std::max(zl, lens_start), lens_end);
             amrex::ParticleReal const zr_bounded = std::min(std::max(zr, lens_start), lens_end);
-            amrex::ParticleReal frac=1.;
-            if (zr != zl) {
-              frac = (zr_bounded - zl_bounded)/(zr - zl);
-            }
+            amrex::ParticleReal const frac = ((zr - zl) == 0._rt ? 1._rt : (zr_bounded - zl_bounded)/(zr - zl));
 
             // Note that "+=" is used since the fields may have been set above
             // if a different E or Btype was specified.

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -151,7 +151,10 @@ struct GetExternalEBField
             // This assumes that vzp > 0.
             amrex::ParticleReal const zl_bounded = std::min(std::max(zl, lens_start), lens_end);
             amrex::ParticleReal const zr_bounded = std::min(std::max(zr, lens_start), lens_end);
-            amrex::ParticleReal const frac = (zr_bounded - zl_bounded)/(zr - zl);
+            amrex::ParticleReal frac=1.;
+            if (zr != zl) {
+              frac = (zr_bounded - zl_bounded)/(zr - zl);
+            }
 
             // Note that "+=" is used since the fields may have been set above
             // if a different E or Btype was specified.


### PR DESCRIPTION
The code that calculates the residence correction for the plasma lens can result in a division by 0 if the particle is at rest (i.e. `zr = zl`). 

This PR avoids this issue by adding a corresponding if condition. However, there are probably also other ways to avoid this. @dpgrote Feel free to suggest alternatives.