### PR TITLE
Fix: ABLASTR nvcc Phi Fine/Coarse

### DIFF
--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -59,6 +59,41 @@
 
 namespace ablastr::fields {
 
+namespace details
+{
+    /** Local interpolation from phi_cp to phi[lev+1]
+     *
+     * This is needed to work-around an NVCC limitation in downstream code (ImpactX),
+     * when nesting lambdas. Otherwise this could be written directly into the
+     * ParallelFor.
+     *
+     * @param[out] phi_fp_arr phi on the fine level
+     * @param[in] phi_cp_arr phi on the coarse level
+     * @param[in] refratio refinement ration
+     */
+    struct PoissonInterpCPtoFP
+    {
+        PoissonInterpCPtoFP(
+                amrex::Array4<amrex::Real> const phi_fp_arr,
+                amrex::Array4<amrex::Real const> const phi_cp_arr,
+                amrex::IntVect const refratio)
+        : m_phi_fp_arr(phi_fp_arr), m_phi_cp_arr(phi_cp_arr), m_refratio(refratio)
+        {}
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        void
+        operator() (long i, long j, long k) const noexcept
+        {
+            amrex::mf_nodebilin_interp(i, j, k, 0, m_phi_fp_arr, 0, m_phi_cp_arr,
+                                       0, m_refratio);
+        }
+
+        amrex::Array4<amrex::Real> const m_phi_fp_arr;
+        amrex::Array4<amrex::Real const> const m_phi_cp_arr;
+        amrex::IntVect const m_refratio;
+    };
+}
+
 /** Compute the potential `phi` by solving the Poisson equation
  *
  * Uses `rho` as a source, assuming that the source moves at a
@@ -247,7 +282,7 @@ computePhi (amrex::Vector<amrex::MultiFab*> const & rho,
             // Copy from phi[lev] to phi_cp (in parallel)
             const amrex::IntVect& ng = amrex::IntVect::TheUnitVector();
             const amrex::Periodicity& crse_period = geom[lev].periodicity();
-            // TODO: move WarpXCommUtil.cpp over to ABLASTR
+
             ablastr::utils::communication::ParallelCopy(
                 phi_cp,
                 *phi[lev],
@@ -264,17 +299,14 @@ computePhi (amrex::Vector<amrex::MultiFab*> const & rho,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            for (amrex::MFIter mfi(*phi[lev+1],amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-                amrex::Array4<amrex::Real> const& phi_fp_arr = phi[lev+1]->array(mfi);
-                amrex::Array4<amrex::Real> const& phi_cp_arr = phi_cp.array(mfi);
+            for (amrex::MFIter mfi(*phi[lev + 1], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                amrex::Array4<amrex::Real> const phi_fp_arr = phi[lev + 1]->array(mfi);
+                amrex::Array4<amrex::Real const> const phi_cp_arr = phi_cp.array(mfi);
 
-                amrex::Box const& b = mfi.tilebox(phi[lev+1]->ixType().toIntVect());
-                amrex::ParallelFor( b,
-                                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    amrex::mf_nodebilin_interp(i, j, k, 0, phi_fp_arr, 0, phi_cp_arr, 0, refratio);
-                });
+                details::PoissonInterpCPtoFP const interp(phi_fp_arr, phi_cp_arr, refratio);
+
+                amrex::Box const b = mfi.tilebox(phi[lev + 1]->ixType().toIntVect());
+                amrex::ParallelFor(b, interp);
             }
 
         }


### PR DESCRIPTION
Poisson solver: work around an NVCC compile error downstream in ImpactX. This is likely due to nesting of lambdas.