### PR TITLE
Fix perlmutter script.

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -15,7 +15,7 @@
 ##SBATCH -q early_science
 #SBATCH -C gpu
 #SBATCH -c 32
-#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-gpu=1
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=single:1
 #SBATCH -o WarpX.o%j

--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -14,7 +14,7 @@
 #SBATCH -q regular
 #SBATCH -C gpu
 #SBATCH -c 32
-#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-gpu=1
 #SBATCH --gpus-per-node=4
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j


### PR DESCRIPTION
Fixing the bug reported in Comment #3356.

#SBATCH --ntasks-per-node=4
#SBATCH --gpus-per-node=4

--ntasks-per-node=4, in combination with --gpus-per-node=4, is to loose to describe what we want and allows SLURM to decide how to distribute those tasks across Gpus, which seems to lead to the classic "Multiple GPUs" warning and potential impact on simulations.

--ntasks-per-gpu=1 is the better choice. This forces the desired distribution and removes the warnings.

Confirmed against AMReX's HeatEquation & with NERSC's affinity script to confirm each ranks sees a unique GPU: https://docs.nersc.gov/jobs/affinity/#gpus