### PR TITLE
ABLASTR: Move Used Inputs Helper

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -29,6 +29,7 @@
 #include "Utils/WarpXUtil.H"
 
 #include <ablastr/utils/Communication.H>
+#include <ablastr/utils/UsedInputsFile.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -64,7 +65,6 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -350,14 +350,7 @@ WarpX::PrintMainPICparameters ()
 void
 WarpX::WriteUsedInputsFile (std::string const & filename) const
 {
-    amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
-
-    if (ParallelDescriptor::IOProcessor()) {
-        std::ofstream jobInfoFile;
-        jobInfoFile.open(filename.c_str(), std::ios::out);
-        ParmParse::dumpTable(jobInfoFile, true);
-        jobInfoFile.close();
-    }
+    ablastr::utils::write_used_inputs_file(filename);
 }
 
 void

--- a/Source/ablastr/utils/CMakeLists.txt
+++ b/Source/ablastr/utils/CMakeLists.txt
@@ -1,8 +1,9 @@
 target_sources(ablastr
   PRIVATE
     Communication.cpp
-    TextMsg.cpp
     SignalHandling.cpp
+    TextMsg.cpp
+    UsedInputsFile.cpp
 )
 
 add_subdirectory(msg_logger)

--- a/Source/ablastr/utils/Make.package
+++ b/Source/ablastr/utils/Make.package
@@ -1,6 +1,7 @@
-CEXE_sources += TextMsg.cpp
-CEXE_sources += SignalHandling.cpp
 CEXE_sources += Communication.cpp
+CEXE_sources += SignalHandling.cpp
+CEXE_sources += TextMsg.cpp
+CEXE_sources += UsedInputsFile.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/utils
 

--- a/Source/ablastr/utils/UsedInputsFile.H
+++ b/Source/ablastr/utils/UsedInputsFile.H
@@ -1,0 +1,27 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef ABLASTR_USED_INPUTS_FILE_H
+#define ABLASTR_USED_INPUTS_FILE_H
+
+#include <string>
+
+
+namespace ablastr::utils
+{
+    /** Write a file that record all inputs: inputs file + command line options
+     *
+     * This uses the same syntax as amrex::ParmParse inputs files.
+     * Only the AMReX IOProcessor writes.
+     *
+     * @param filename the name of the text file to write
+     */
+    void
+    write_used_inputs_file (std::string const & filename);
+}
+
+#endif // ABLASTR_USED_INPUTS_FILE_H

--- a/Source/ablastr/utils/UsedInputsFile.cpp
+++ b/Source/ablastr/utils/UsedInputsFile.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2022 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "UsedInputsFile.H"
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+
+#include <fstream>
+#include <ios>
+#include <string>
+
+
+void
+ablastr::utils::write_used_inputs_file (std::string const & filename)
+{
+    amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
+
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        std::ofstream jobInfoFile;
+        jobInfoFile.open(filename.c_str(), std::ios::out);
+        amrex::ParmParse::dumpTable(jobInfoFile, true);
+        jobInfoFile.close();
+    }
+}


### PR DESCRIPTION
Move the helper to write a file for used inputs to ABLASTR.

Follow-up to  #3132 #3234