### PR TITLE
Add species name to 2 error messages

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -156,7 +156,8 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         charge_is_specified ||
         species_is_specified ||
         (injection_style == "external_file"),
-        "Need to specify at least one of species_type or charge"
+        "Need to specify at least one of species_type or charge for species '" +
+        species_name + "'."
     );
 
     if ( mass_is_specified && species_is_specified ){
@@ -170,7 +171,8 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         mass_is_specified ||
         species_is_specified ||
         (injection_style == "external_file"),
-        "Need to specify at least one of species_type or mass"
+        "Need to specify at least one of species_type or mass for species '" +
+        species_name + "'."
     );
 
     num_particles_per_cell_each_dim.assign(3, 0);


### PR DESCRIPTION
This PR makes two error messages more readable by adding the name of the species that has some issues.