### PR TITLE
Use blaspp::gemm on GPU for Hankel transform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ if(WarpX_PSATD)
         # BLAS++ forgets to declare cuBLAS and cuRAND dependencies
         if(WarpX_COMPUTE STREQUAL CUDA)
             find_package(CUDAToolkit REQUIRED)
-            target_link_libraries(ablastr PUBLIC CUDA::cudart CUDA::curand CUDA::cublas)
+            target_link_libraries(ablastr PUBLIC CUDA::cudart CUDA::cublas)
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ if(WarpX_PSATD)
         target_link_libraries(ablastr PUBLIC blaspp)
         target_link_libraries(ablastr PUBLIC lapackpp)
 
-        # BLAS++ forgets to declare cuBLAS and cuRAND dependencies
+        # BLAS++ forgets to declare cuBLAS and cudaRT dependencies
         if(WarpX_COMPUTE STREQUAL CUDA)
             find_package(CUDAToolkit REQUIRED)
             target_link_libraries(ablastr PUBLIC CUDA::cudart CUDA::cublas)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,12 @@ if(WarpX_PSATD)
     if(WarpX_DIMS STREQUAL RZ)
         target_link_libraries(ablastr PUBLIC blaspp)
         target_link_libraries(ablastr PUBLIC lapackpp)
+
+        # BLAS++ forgets to declare cuBLAS and cuRAND dependencies
+        if(WarpX_COMPUTE STREQUAL CUDA)
+            find_package(CUDAToolkit REQUIRED)
+            target_link_libraries(ablastr PUBLIC CUDA::cudart CUDA::curand CUDA::cublas)
+        endif()
     endif()
 endif()
 

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -66,13 +66,13 @@ And since Perlmutter does not yet provide a module for them, install ADIOS2, BLA
    # BLAS++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/blaspp.git src/blaspp
    rm -rf src/blaspp-pm-build
-   CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=ON -Dgpu_backend=cuda -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/blaspp-master
+   CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/blaspp-master
    cmake --build src/blaspp-pm-build --target install --parallel 16
 
    # LAPACK++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/lapackpp.git src/lapackpp
    rm -rf src/lapackpp-pm-build
-   CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-pm-build -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DLAPACK_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/lapackpp-master
+   CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-pm-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/lapackpp-master
    cmake --build src/lapackpp-pm-build --target install --parallel 16
 
 Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -66,7 +66,7 @@ And since Perlmutter does not yet provide a module for them, install ADIOS2, BLA
    # BLAS++ (for PSATD+RZ)
    git clone https://bitbucket.org/icl/blaspp.git src/blaspp
    rm -rf src/blaspp-pm-build
-   CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=ON -Dgpu_backend=CUDA -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/blaspp-master
+   CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=ON -Dgpu_backend=cuda -Duse_cmake_find_blas=ON -DBLAS_LIBRARIES=${CRAY_LIBSCI_PREFIX_DIR}/lib/libsci_gnu.a -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/blaspp-master
    cmake --build src/blaspp-pm-build --target install --parallel 16
 
    # LAPACK++ (for PSATD+RZ)

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -45,6 +45,22 @@ We recommend to store the above lines in a file, such as ``$HOME/summit_warpx.pr
 
    source $HOME/summit_warpx.profile
 
+For PSATD+RZ simulations, you will need to build BLAS++ and LAPACK++:
+
+.. code-block:: bash
+
+  # BLAS++ (for PSATD+RZ)
+  git clone https://bitbucket.org/icl/blaspp.git src/blaspp
+  rm -rf src/blaspp-summit-build
+  cmake -S src/blaspp -B src/blaspp-summit-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/summit/blaspp-master
+  cmake --build src/blaspp-summit-build --target install --parallel 10
+
+  # LAPACK++ (for PSATD+RZ)
+  git clone https://bitbucket.org/icl/lapackpp.git src/lapackpp
+  rm -rf src/lapackpp-summit-build
+  cmake -S src/lapackpp -B src/lapackpp-summit-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/summit/lapackpp-master
+  cmake --build src/lapackpp-summit-build --target install --parallel 10
+
 Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):
 
 .. code-block:: bash

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
@@ -9,7 +9,9 @@
 
 #include <AMReX_FArrayBox.H>
 
+#ifdef AMREX_USE_GPU
 #include <blas.hh>
+#endif
 
 #include <memory>
 
@@ -50,7 +52,9 @@ class HankelTransform
         RealVector m_invM;
         RealVector m_M;
 
-    std::unique_ptr<blas::Queue> m_queue;
+#ifdef AMREX_USE_GPU
+        std::unique_ptr<blas::Queue> m_queue;
+#endif
 };
 
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
@@ -8,9 +8,11 @@
 #define WARPX_HANKEL_TRANSFORM_H_
 
 #include <AMReX_FArrayBox.H>
+#include <AMReX_REAL.H>
+#include <AMReX_GpuContainers.H>
 
 #ifdef AMREX_USE_GPU
-#include <blas.hh>
+#   include <blas.hh>
 #endif
 
 #include <memory>

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
@@ -9,6 +9,10 @@
 
 #include <AMReX_FArrayBox.H>
 
+#include <blas.hh>
+
+#include <memory>
+
 /* \brief This defines the class that performs the Hankel transform.
  * Original authors: Remi Lehe, Manuel Kirchen
  *
@@ -45,6 +49,8 @@ class HankelTransform
 
         RealVector m_invM;
         RealVector m_M;
+
+	std::unique_ptr<blas::Queue> m_queue;
 };
 
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
@@ -50,7 +50,7 @@ class HankelTransform
         RealVector m_invM;
         RealVector m_M;
 
-	std::unique_ptr<blas::Queue> m_queue;
+    std::unique_ptr<blas::Queue> m_queue;
 };
 
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -33,6 +33,8 @@ HankelTransform::HankelTransform (int const hankel_order,
 
 #ifdef AMREX_USE_GPU
     // BLAS setup
+    //   SYCL note: we need to double check AMReX device ID conventions and
+    //   BLAS++ device ID conventions are the same
     int const device_id = amrex::Gpu::Device::deviceId();
     m_queue = std::make_unique<blas::Queue>( device_id, 0 );
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -245,7 +245,7 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                m_nr, nz, m_nk, 1._rt,
                m_invM.dataPtr(), m_nr,
                G.dataPtr(G_icomp), m_nk, 0._rt,
-               F.dataPtr(F_icomp)+ngr, nrF
+               F.dataPtr(F_icomp)+ngr, nrF,
 #ifdef AMREX_USE_GPU
               *m_queue
 #endif

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -31,8 +31,8 @@ HankelTransform::HankelTransform (int const hankel_order,
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(hankel_order-1 <= azimuthal_mode && azimuthal_mode <= hankel_order+1,
                                      "azimuthal_mode must be either hankel_order-1, hankel_order or hankel_order+1");
 
-    // BLAS setup
 #ifdef AMREX_USE_GPU
+    // BLAS setup
     int const device_id = amrex::Gpu::Device::deviceId();
     m_queue = std::make_unique<blas::Queue>( device_id, 0 );
 #endif
@@ -217,7 +217,7 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
                F.dataPtr(F_icomp)+ngr, nrF, 0._rt,
                G.dataPtr(G_icomp), m_nk,
 #ifdef AMREX_USE_GPU
-               *m_queue
+               *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
 }
@@ -245,9 +245,9 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                m_nr, nz, m_nk, 1._rt,
                m_invM.dataPtr(), m_nr,
                G.dataPtr(G_icomp), m_nk, 0._rt,
-               F.dataPtr(F_icomp)+ngr, nrF,
+               F.dataPtr(F_icomp)+ngr, nrF
 #ifdef AMREX_USE_GPU
-              *m_queue
+               , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -210,6 +210,10 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
     AMREX_ALWAYS_ASSERT(ngr >= 0);
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
 
+    // We perform stream synchronization since `gemm` may be running
+    // on a different stream.
+    amrex::Gpu::synchronize();
+
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nk, nz, m_nr, 1._rt,
@@ -220,6 +224,11 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
                , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
+
+    // We perform stream synchronization since `gemm` may be running
+    // on a different stream.
+    amrex::Gpu::synchronize();
+
 }
 
 void
@@ -240,6 +249,10 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
     AMREX_ALWAYS_ASSERT(ngr >= 0);
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
 
+    // We perform stream synchronization since `gemm` may be running
+    // on a different stream.
+    amrex::Gpu::synchronize();
+
     // Note that m_invM is flagged to be transposed since it has dimensions (m_nk, m_nr)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nr, nz, m_nk, 1._rt,
@@ -250,4 +263,8 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
+
+    // We perform stream synchronization since `gemm` may be running
+    // on a different stream.
+    amrex::Gpu::synchronize();
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -212,7 +212,7 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
 
     // We perform stream synchronization since `gemm` may be running
     // on a different stream.
-    amrex::Gpu::synchronize();
+    amrex::Gpu::streamSynchronize();
 
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
@@ -227,7 +227,7 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
 
     // We perform stream synchronization since `gemm` may be running
     // on a different stream.
-    amrex::Gpu::synchronize();
+    amrex::Gpu::streamSynchronize();
 
 }
 
@@ -251,7 +251,7 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
 
     // We perform stream synchronization since `gemm` may be running
     // on a different stream.
-    amrex::Gpu::synchronize();
+    amrex::Gpu::streamSynchronize();
 
     // Note that m_invM is flagged to be transposed since it has dimensions (m_nk, m_nr)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
@@ -266,5 +266,5 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
 
     // We perform stream synchronization since `gemm` may be running
     // on a different stream.
-    amrex::Gpu::synchronize();
+    amrex::Gpu::streamSynchronize();
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -200,11 +200,14 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
 
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
     amrex::Gpu::synchronize();
+    int const device_id = amrex::Gpu::Device::deviceId();
+    blas::Queue queue( device_id, 0 );
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nk, nz, m_nr, 1._rt,
                m_M.dataPtr(), m_nk,
                F.dataPtr(F_icomp)+ngr, nrF, 0._rt,
-               G.dataPtr(G_icomp), m_nk);
+               G.dataPtr(G_icomp), m_nk,
+               queue);
     amrex::Gpu::synchronize();
 }
 

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -215,9 +215,9 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
                m_nk, nz, m_nr, 1._rt,
                m_M.dataPtr(), m_nk,
                F.dataPtr(F_icomp)+ngr, nrF, 0._rt,
-               G.dataPtr(G_icomp), m_nk,
+               G.dataPtr(G_icomp), m_nk
 #ifdef AMREX_USE_GPU
-               *m_queue // Calls the GPU version of blas::gemm
+               , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -197,7 +197,7 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
                                          amrex::FArrayBox      & G, int const G_icomp)
 {
     WARPX_PROFILE("HankelTransform::HankelInverseTransform");
- 
+
     amrex::Box const& F_box = F.box();
     amrex::Box const& G_box = G.box();
 
@@ -225,7 +225,7 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                                          amrex::FArrayBox      & F, int const F_icomp)
 {
     WARPX_PROFILE("HankelTransform::HankelInverseTransform");
- 
+
     amrex::Box const& G_box = G.box();
     amrex::Box const& F_box = F.box();
 

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -199,13 +199,13 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
 
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
-    Gpu::synchronize();
+    amrex::Gpu::synchronize();
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nk, nz, m_nr, 1._rt,
                m_M.dataPtr(), m_nk,
                F.dataPtr(F_icomp)+ngr, nrF, 0._rt,
                G.dataPtr(G_icomp), m_nk);
-    Gpu::synchronize();
+    amrex::Gpu::synchronize();
 }
 
 void

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -196,7 +196,7 @@ void
 HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_icomp,
                                          amrex::FArrayBox      & G, int const G_icomp)
 {
-    WARPX_PROFILE("HankelTransform::HankelInverseTransform");
+    WARPX_PROFILE("HankelTransform::HankelForwardTransform");
 
     amrex::Box const& F_box = F.box();
     amrex::Box const& G_box = G.box();

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -199,12 +199,13 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
 
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
+    Gpu::synchronize();
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nk, nz, m_nr, 1._rt,
                m_M.dataPtr(), m_nk,
                F.dataPtr(F_icomp)+ngr, nrF, 0._rt,
                G.dataPtr(G_icomp), m_nk);
-
+    Gpu::synchronize();
 }
 
 void

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -13,8 +13,11 @@ module load cuda/11.3.1
 # optional: faster re-builds
 module load ccache
 
-# optional: for PSATD support (CPU only)
-#module load fftw/3.3.9
+# optional: for RZ+PSATD support
+export CMAKE_PREFIX_PATH=$HOME/sw/summit/blaspp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$HOME/sw/summit/lapackpp-master:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$HOME/sw/summit/blaspp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/sw/summit/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
 module load boost/1.76.0

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -1,4 +1,3 @@
-
 # please set your project account
 #export proj=<yourProject>
 

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -1,3 +1,4 @@
+
 # please set your project account
 #export proj=<yourProject>
 
@@ -13,8 +14,8 @@ module load cuda/11.3.1
 module load ccache
 
 # optional: for PSATD in RZ geometry support
-module load blaspp/2021.04.01-cpu
-module load lapackpp/2021.04.00-cpu
+module load blaspp/2021.04.01
+module load lapackpp/2021.04.00
 
 # optional: for PSATD support (CPU only)
 #module load fftw/3.3.9

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -12,7 +12,7 @@ module load cuda/11.3.1
 # optional: faster re-builds
 module load ccache
 
-# optional: for RZ+PSATD support
+# optional: for PSATD in RZ geometry support
 export CMAKE_PREFIX_PATH=$HOME/sw/summit/blaspp-master:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$HOME/sw/summit/lapackpp-master:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$HOME/sw/summit/blaspp-master/lib64:$LD_LIBRARY_PATH

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -13,10 +13,6 @@ module load cuda/11.3.1
 # optional: faster re-builds
 module load ccache
 
-# optional: for PSATD in RZ geometry support
-module load blaspp/2021.04.01
-module load lapackpp/2021.04.00
-
 # optional: for PSATD support (CPU only)
 #module load fftw/3.3.9
 


### PR DESCRIPTION
This PR calls `blaspp::gemm` on GPU (which, under the hood, calls `cuBLAS` or `rocBLAS`, i.e. a highly-optimized implementation of the matrix multiplication), instead of the current hand-written matrix multiplication.

Here is the test input script that we used in benchmarks (which uses a box with 512 cells in the radial direction, so that the Hankel transform dominates the compute time): 
[inputs.txt](https://github.com/ECP-WarpX/WarpX/files/9560069/inputs.txt)

Using the default stream:
- [x] Test on Crusher
        - Time per PIC iteration in `development`: **0.03606965 s**
        - Time per PIC iteration with this PR:  **0.007180295 s** (5x faster)
- [x] Test on Summit
        - Time per PIC iteration in `development`: **0.025 s**
        - Time per PIC iteration with this PR:  **0.0094 s** (2.7x faster)
- [x] Test on Perlmutter
        - Time per PIC iteration in `development`: **0.019 s**
        - Time per PIC iteration with this PR:  **0.006 s** (3.2x faster)

Follow-up PR: using the AMReX streams in `blas::Queue`.

(We excluded the first iteration from the timing, because we noticed that the first call to rocBLAS/cuBLAS takes a significant amount of time).