### PR TITLE
Improve memory footprint for ParticleInitialize

### DIFF
--- a/Examples/Tests/nci_fdtd_stability/inputs_2d
+++ b/Examples/Tests/nci_fdtd_stability/inputs_2d
@@ -48,10 +48,10 @@ electrons.ux_th  = 1.e-5
 electrons.uy_th  = 1.e-5
 electrons.uz_th  = 1.e-5
 electrons.uz_m  = 1000.  # Mean momentum along z (unitless)
-electrons.xmin = -10.e-6
-electrons.xmax = +10.e-6
-electrons.ymin = -10.e-6
-electrons.ymax = +10.e-6
+electrons.xmin = -10.e-6 - 1e-7
+electrons.xmax = +10.e-6 + 1e-7
+electrons.ymin = -10.e-6 - 1e-7
+electrons.ymax = +10.e-6 + 1e-7
 
 ions.charge = q_e
 ions.mass = m_p
@@ -61,10 +61,10 @@ ions.profile = constant
 ions.density = 1.e29  # number of electrons per m^3
 ions.momentum_distribution_type = "constant"
 ions.uz  = 1000.  # Momentum along z (unitless)
-ions.xmin = -10.e-6
-ions.xmax = +10.e-6
-ions.ymin = -10.e-6
-ions.ymax = +10.e-6
+ions.xmin = -10.e-6 - 1e-7
+ions.xmax = +10.e-6 + 1e-7
+ions.ymin = -10.e-6 - 1e-7
+ions.ymax = +10.e-6 + 1e-7
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nci_fdtd_stability/inputs_2d
+++ b/Examples/Tests/nci_fdtd_stability/inputs_2d
@@ -48,10 +48,10 @@ electrons.ux_th  = 1.e-5
 electrons.uy_th  = 1.e-5
 electrons.uz_th  = 1.e-5
 electrons.uz_m  = 1000.  # Mean momentum along z (unitless)
-electrons.xmin = -10.e-6 - 1e-7
-electrons.xmax = +10.e-6 + 1e-7
-electrons.ymin = -10.e-6 - 1e-7
-electrons.ymax = +10.e-6 + 1e-7
+electrons.xmin = -10.e-6 - 1e-7 # adding buffer of fraction of cell-size
+electrons.xmax = +10.e-6 + 1e-7 # adding buffer of fraction of cell-size
+electrons.ymin = -10.e-6 - 1e-7 # adding buffer of fraction of cell-size
+electrons.ymax = +10.e-6 + 1e-7 # adding buffer of fraction of cell-size
 
 ions.charge = q_e
 ions.mass = m_p
@@ -61,10 +61,10 @@ ions.profile = constant
 ions.density = 1.e29  # number of electrons per m^3
 ions.momentum_distribution_type = "constant"
 ions.uz  = 1000.  # Momentum along z (unitless)
-ions.xmin = -10.e-6 - 1e-7
-ions.xmax = +10.e-6 + 1e-7
-ions.ymin = -10.e-6 - 1e-7
-ions.ymax = +10.e-6 + 1e-7
+ions.xmin = -10.e-6 - 1e-7 # adding buffer of fraction of cell-size
+ions.xmax = +10.e-6 + 1e-7 # adding buffer of fraction of cell-size
+ions.ymin = -10.e-6 - 1e-7 # adding buffer of fraction of cell-size
+ions.ymax = +10.e-6 + 1e-7 # adding buffer of fraction of cell-size
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/resampling/inputs_leveling_thinning
+++ b/Examples/Tests/resampling/inputs_leveling_thinning
@@ -1,5 +1,5 @@
 max_step = 8
-amr.n_cell = 32 32
+amr.n_cell = 16 16
 amr.blocking_factor = 8
 amr.max_grid_size = 8
 geometry.dims = 2
@@ -40,10 +40,10 @@ resampled_part1.resampling_trigger_max_avg_ppc = 395
 resampled_part2.species_type = electron
 resampled_part2.injection_style = NRandomPerCell
 resampled_part2.num_particles_per_cell = 100000
-resampled_part2.zmin = 0.01
-resampled_part2.zmax = 0.99
-resampled_part2.xmin = 0.01
-resampled_part2.xmax = 0.99
+resampled_part2.zmin = 0.001
+resampled_part2.zmax = 0.999
+resampled_part2.xmin = 0.001
+resampled_part2.xmax = 0.999
 resampled_part2.profile = parse_density_function
 # Trick to get a Gaussian weight distribution is to do a Box-Muller transform using the position
 # within the cell as the two random variables. Here, we have a distribution with standard deviation

--- a/Examples/Tests/resampling/inputs_leveling_thinning
+++ b/Examples/Tests/resampling/inputs_leveling_thinning
@@ -40,10 +40,10 @@ resampled_part1.resampling_trigger_max_avg_ppc = 395
 resampled_part2.species_type = electron
 resampled_part2.injection_style = NRandomPerCell
 resampled_part2.num_particles_per_cell = 100000
-resampled_part2.zmin = 0.
-resampled_part2.zmax = 1.
-resampled_part2.xmin = 0.
-resampled_part2.xmax = 1.
+resampled_part2.zmin = 0.01
+resampled_part2.zmax = 0.99
+resampled_part2.xmin = 0.01
+resampled_part2.xmax = 0.99
 resampled_part2.profile = parse_density_function
 # Trick to get a Gaussian weight distribution is to do a Box-Muller transform using the position
 # within the cell as the two random variables. Here, we have a distribution with standard deviation

--- a/Examples/Tests/resampling/inputs_leveling_thinning
+++ b/Examples/Tests/resampling/inputs_leveling_thinning
@@ -1,5 +1,5 @@
 max_step = 8
-amr.n_cell = 16 16
+amr.n_cell = 32 32
 amr.blocking_factor = 8
 amr.max_grid_size = 8
 geometry.dims = 2

--- a/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
+++ b/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
@@ -1,33 +1,33 @@
 {
   "electrons": {
-    "particle_momentum_x": 3.7558265697785297e-19,
+    "particle_momentum_x": 3.924978793639722e-19,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.6241045337016777e-18,
-    "particle_position_x": 0.008080139452222582,
-    "particle_position_y": 0.030470786164249836,
-    "particle_weight": 2.6527193922723818e+17
+    "particle_momentum_z": 1.6531781161630182e-18,
+    "particle_position_x": 0.008174406825176781,
+    "particle_position_y": 0.030854054377836164,
+    "particle_weight": 2.6494574815747686e+17
   },
   "hydrogen": {
-    "particle_momentum_x": 2.230242228305449e-18,
-    "particle_momentum_z": 1.087276856218956e-18,
-    "particle_orig_x": 0.008248212890625,
-    "particle_orig_z": 0.0368645947265625,
-    "particle_position_x": 0.008247833494376897,
-    "particle_position_y": 0.03686279813152423,
-    "particle_weight": 2.6934893377423152e+17
+    "particle_momentum_x": 2.2282828780834146e-18,
+    "particle_momentum_z": 1.0851862321717955e-18,
+    "particle_orig_x": 0.008197167968750002,
+    "particle_orig_z": 0.036522314453125,
+    "particle_position_x": 0.008196791928459133,
+    "particle_position_y": 0.03652051811944703,
+    "particle_weight": 2.7152730477070458e+17
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 11411806.976599155,
+    "By": 11404616.733041402,
     "Bz": 0.0,
-    "Ex": 2035695789467976.2,
+    "Ex": 2032977227921656.0,
     "Ey": 0.0,
-    "Ez": 323118235034526.9,
-    "jx": 1.656704421803856e+19,
+    "Ez": 317987205247174.75,
+    "jx": 1.6377970880819999e+19,
     "jy": 0.0,
-    "jz": 8.846078579875918e+18,
-    "rho": 61752907894.83176,
-    "rho_electrons": 17451375232572.703,
-    "rho_hydrogen": 17441818436520.373
+    "jz": 8.817456212655565e+18,
+    "rho": 60944064977.941765,
+    "rho_electrons": 17448235212566.305,
+    "rho_hydrogen": 17441805684524.002
   }
 }

--- a/Regression/Checksum/benchmarks_json/leveling_thinning.json
+++ b/Regression/Checksum/benchmarks_json/leveling_thinning.json
@@ -14,16 +14,16 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 485368.303735276,
-    "particle_position_y": 484224.66261508386,
-    "particle_weight": 255.7814999999979
+    "particle_position_x": 485879.18021793937,
+    "particle_position_y": 484466.34922379535,
+    "particle_weight": 256.2546999999979
   },
   "resampled_part2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 38419.04911639948,
-    "particle_position_y": 38054.448891953645,
-    "particle_weight": 2.836692166357862
+    "particle_position_x": 38089.14806219578,
+    "particle_position_y": 37818.512934148945,
+    "particle_weight": 2.8175309517949136
   }
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -993,14 +993,33 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 // update pcount by checking which particles have non-zero density
                 int flag_pcount = 0;
                 for (int ip = 0; ip < num_ppc*r; ++ip) {
-                    amrex::Real dens1 = inj_rho->getDensity(lo.x, lo.y, lo.z);
-                    amrex::Real dens2 = inj_rho->getDensity(lo.x, lo.y, hi.z);
-                    amrex::Real dens3 = inj_rho->getDensity(lo.x, hi.y, lo.z);
-                    amrex::Real dens4 = inj_rho->getDensity(hi.x, lo.y, lo.z);
-                    amrex::Real dens5 = inj_rho->getDensity(lo.x, hi.y, hi.z);
-                    amrex::Real dens6 = inj_rho->getDensity(hi.x, lo.y, hi.z);
-                    amrex::Real dens7 = inj_rho->getDensity(hi.x, hi.y, lo.z);
-                    amrex::Real dens8 = inj_rho->getDensity(hi.x, hi.y, hi.z);
+                    amrex::Real dens1 = 0;
+                    amrex::Real dens2 = 0;
+                    amrex::Real dens3 = 0;
+                    amrex::Real dens4 = 0;
+                    amrex::Real dens5 = 0;
+                    amrex::Real dens6 = 0;
+                    amrex::Real dens7 = 0;
+                    amrex::Real dens8 = 0;
+                    // To ensure density parser does not encounter erroneous
+                    // arithmetic operation, such as log(0) or sqrt(-1)
+                    // check if cell-corner is within injection bounds
+                    if (inj_pos->insideBounds(lo.x, lo.y, lo.z))
+                        dens1 = inj_rho->getDensity(lo.x, lo.y, lo.z);
+                    if (inj_pos->insideBounds(lo.x, lo.y, hi.z))
+                        dens2 = inj_rho->getDensity(lo.x, lo.y, hi.z);
+                    if (inj_pos->insideBounds(lo.x, hi.y, lo.z))
+                        dens3 = inj_rho->getDensity(lo.x, hi.y, lo.z);
+                    if (inj_pos->insideBounds(hi.x, lo.y, lo.z))
+                        dens4 = inj_rho->getDensity(hi.x, lo.y, lo.z);
+                    if (inj_pos->insideBounds(lo.x, hi.y, hi.z))
+                        dens5 = inj_rho->getDensity(lo.x, hi.y, hi.z);
+                    if (inj_pos->insideBounds(hi.x, lo.y, hi.z))
+                        dens6 = inj_rho->getDensity(hi.x, lo.y, hi.z);
+                    if (inj_pos->insideBounds(hi.x, hi.y, lo.z))
+                        dens7 = inj_rho->getDensity(hi.x, hi.y, lo.z);
+                    if (inj_pos->insideBounds(hi.x, hi.y, hi.z))
+                        dens8 = inj_rho->getDensity(hi.x, hi.y, hi.z);
                     if (  dens1 > 0 || dens2 > 0 || dens3 > 0 || dens4 > 0
                        || dens5 > 0 || dens6 > 0 || dens7 > 0 || dens8 > 0) {
                         flag_pcount = 1;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1019,8 +1019,6 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
             amrex::ignore_unused(j,k);
 #endif
         });
-        // Need synchronize since we have tmp xlim, ylim, zlim arrays
-        amrex::Gpu::synchronize();
 
         // Max number of new particles. All of them are created,
         // and invalid ones are then discarded

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1000,7 +1000,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                     for (const auto& x : xlim)
                         for (const auto& y : ylim)
                             for (const auto& z : zlim)
-                                if (inj_pos->insideBounds(x,y,z) and (inj_rho->getDensity(x,y,z) > 0) )
+                                if (inj_pos->insideBounds(x,y,z) and (inj_rho->getDensity(x,y,z) > 0) ) {
                                     return 1;
                                 } else {
                                     return 0;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1000,10 +1000,11 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                     for (const auto& x : xlim)
                         for (const auto& y : ylim)
                             for (const auto& z : zlim)
-                                if (inj_pos->insideBounds(x,y,z)) {
-                                    if (inj_rho->getDensity(x,y,z) > 0) return 1;
+                                if (inj_pos->insideBounds(x,y,z) and (inj_rho->getDensity(x,y,z) > 0) )
+                                    return 1;
+                                } else {
+                                    return 0;
                                 }
-                    return 0;
                 };
                 const int flag_pcount = checker();
                 if (flag_pcount == 1) {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1002,9 +1002,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                             for (const auto& z : zlim)
                                 if (inj_pos->insideBounds(x,y,z) and (inj_rho->getDensity(x,y,z) > 0) ) {
                                     return 1;
-                                } else {
-                                    return 0;
                                 }
+                                return 0;
                 };
                 const int flag_pcount = checker();
                 if (flag_pcount == 1) {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -989,7 +989,17 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 } else {
                     r = 1;
                 }
-                pcounts[index] = num_ppc*r;
+//                pcounts[index] = num_ppc*r;
+                // update pcount by checking which particles have non-zero density
+                int total_pcount = 0;
+                for (int i = 0; i < num_ppc*r; ++i) {
+                    const XDim3 r =
+                        inj_pos->getPositionUnitBox(i, lrrfac);
+                    auto pos = getCellCoords(overlap_corner, dx, r, iv);
+                    dens = inj_rho->getDensity(xp, yp, zp);
+                    if (dens > density_min) total_pcount++;
+                }
+                pcounts[index] = total_pcount;
             }
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
             amrex::ignore_unused(k);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -989,17 +989,30 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 } else {
                     r = 1;
                 }
-//                pcounts[index] = num_ppc*r;
+                pcounts[index] = num_ppc*r;
                 // update pcount by checking which particles have non-zero density
-                int total_pcount = 0;
-                for (int i = 0; i < num_ppc*r; ++i) {
-                    const XDim3 r =
-                        inj_pos->getPositionUnitBox(i, lrrfac);
-                    auto pos = getCellCoords(overlap_corner, dx, r, iv);
-                    dens = inj_rho->getDensity(xp, yp, zp);
-                    if (dens > density_min) total_pcount++;
+                int flag_pcount = 0;
+                for (int ip = 0; ip < num_ppc*r; ++ip) {
+                    const XDim3 r_loc =
+                        inj_pos->getPositionUnitBox(ip, lrrfac, amrex::RandomEngine{});
+                    amrex::Real dens1 = inj_rho->getDensity(lo.x, lo.y, lo.z);
+                    amrex::Real dens2 = inj_rho->getDensity(lo.x, lo.y, hi.z);
+                    amrex::Real dens3 = inj_rho->getDensity(lo.x, hi.y, lo.z);
+                    amrex::Real dens4 = inj_rho->getDensity(hi.x, lo.y, lo.z);
+                    amrex::Real dens5 = inj_rho->getDensity(lo.x, hi.y, hi.z);
+                    amrex::Real dens6 = inj_rho->getDensity(hi.x, lo.y, hi.z);
+                    amrex::Real dens7 = inj_rho->getDensity(hi.x, hi.y, lo.z);
+                    amrex::Real dens8 = inj_rho->getDensity(hi.x, hi.y, hi.z);
+                    if (  dens1 > 0 || dens2 > 0 || dens3 > 0 || dens4 > 0
+                       || dens5 > 0 || dens6 > 0 || dens7 > 0 || dens8 > 0) {
+                        flag_pcount = 1;
+                    }
                 }
-                pcounts[index] = total_pcount;
+                if (flag_pcount == 1) {
+                    pcounts[index] = num_ppc*r;
+                } else {
+                    pcounts[index] = 0;
+                }
             }
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
             amrex::ignore_unused(k);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1003,7 +1003,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                                 if (inj_pos->insideBounds(x,y,z) and (inj_rho->getDensity(x,y,z) > 0) ) {
                                     return 1;
                                 }
-                                return 0;
+                    return 0;
                 };
                 const int flag_pcount = checker();
                 if (flag_pcount == 1) {

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -993,8 +993,6 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                 // update pcount by checking which particles have non-zero density
                 int flag_pcount = 0;
                 for (int ip = 0; ip < num_ppc*r; ++ip) {
-                    const XDim3 r_loc =
-                        inj_pos->getPositionUnitBox(ip, lrrfac, amrex::RandomEngine{});
                     amrex::Real dens1 = inj_rho->getDensity(lo.x, lo.y, lo.z);
                     amrex::Real dens2 = inj_rho->getDensity(lo.x, lo.y, hi.z);
                     amrex::Real dens3 = inj_rho->getDensity(lo.x, hi.y, lo.z);


### PR DESCRIPTION
This PR solves the issue #3335  where we run out of memory when initializing particles within a region whose bounding box area is larger than the profile itself.

- [ ] docs: remove outdated recommendation paragraph from https://github.com/ECP-WarpX/WarpX/pull/3323#discussion_r1005011585

To recreate the issue, particles are initialized in a spherical ring as shown below 
![Screenshot from 2022-09-13 09-27-52](https://user-images.githubusercontent.com/41089244/189956539-8c8e83f0-ca88-462f-a31f-3e4720b6f514.png)

On crusher I tried the following : 
1. Run development with the input (attached below) with random initialilization with 512 particles per cell (to exaggerate the error)
This simulation ran out of memory on crusher with the following message
```
amrex::Abort::0::Out of gpu memory. Free: 529225728 Asked: 574015488 !!!
SIGABRT
See Backtrace.0 file for details
MPICH ERROR [Rank 0] [job id 180341.5] [Tue Sep 13 11:58:51 2022] [crusher131] - Abort(6) (rank 0 in comm 496): application called MPI_Abort(comm=0x84000000, 6) - process 0

srun: error: crusher131: task 0: Exited with exit code 6
srun: launch/slurm: _step_signal: Terminating StepId=180341.5
```

2. With this PR, the same input file generates the spherical ring. 

To validate the implementation and ensure same number of particles are injected, I also did uniform particle injection and the total particles injected is the same (2 particles per cell per direction in this case). 
I also did a random number injection case with fewer particles and the difference in total particles were approximately equal with some difference that we can attribute to the randomness.

```
# Description:
#
# This initializes the electrons and positrons within a sphere
#

#################################
####### GENERAL PARAMETERS ######
#################################
max_step = 1
amr.n_cell = 128 128 128
amr.max_grid_size = 32
amr.blocking_factor = 32
amr.max_level = 0
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.dims = 3
geometry.prob_lo     = 0.0 0.0 0.0
geometry.prob_hi     = 8 8 8
boundary.field_lo = pml pml pml
boundary.field_hi = pml pml pml


#################################
############ NUMERICS ###########
#################################
algo.maxwell_solver = yee
warpx.verbose = 1
warpx.do_dive_cleaning = 0
warpx.use_filter = 1
warpx.cfl = .95
warpx.do_pml_in_domain = 1
warpx.pml_has_particles = 1
warpx.do_pml_j_damping = 1

my_constants.xc  = 4.
my_constants.yc  = 4.
my_constants.zc  = 4.
my_constants.dens = 1.e16
algo.particle_shape = 3
my_constants.r0 = 3
my_constants.dR = 0.25
#################################
############ PLASMA #############
#################################
particles.species_names = plasma_e plasma_p

plasma_e.charge = -q_e
plasma_e.mass = m_e
plasma_e.injection_style = "NRandomPerCell"
plasma_e.num_particles_per_cell = 512
#plasma_e.injection_style = "NUniformPerCell"
#plasma_e.num_particles_per_cell_each_dim = 2 2 2
plasma_e.profile = parse_density_function
plasma_e.density_function(x,y,z) = "( ((( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<=(r0 + dR)) * ((( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))>=(r0-dR)) )*dens"
plasma_e.momentum_distribution_type = parse_momentum_function
## Inject stationary pairs
plasma_e.momentum_function_ux(x,y,z) = "0.0"
plasma_e.momentum_function_uy(x,y,z) = "0.0"
## uz is always 0 for the injection methods above
plasma_e.momentum_function_uz(x,y,z) = "0.0"
plasma_e.do_continuous_injection = 0
plasma_e.density_min = 0.1

plasma_p.charge = q_e
plasma_p.mass = m_e
plasma_p.injection_style = "NRandomPerCell"
plasma_p.num_particles_per_cell = 512 
plasma_p.profile = parse_density_function
plasma_p.density_function(x,y,z) = "( ((( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<=(r0 + dR)) * ((( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))>=(r0-dR)) )*dens"
#plasma_p.injection_style = "NUniformPerCell"
#plasma_p.num_particles_per_cell_each_dim = 2 2 2
plasma_p.momentum_distribution_type = parse_momentum_function
## Inject stationary pairs
plasma_p.momentum_function_ux(x,y,z) = "0.0"
plasma_p.momentum_function_uy(x,y,z) = "0.0"
## uz ip always 0 for the injection methods above
plasma_p.momentum_function_uz(x,y,z) = "0.0"
plasma_p.do_continuous_injection = 0
plasma_p.density_min = 0.1

diagnostics.diags_names = plt
plt.diag_type = Full
plt.intervals = 1
plt.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho

warpx.reduced_diags_names = PartNum
PartNum.intervals = 1
PartNum.type = ParticleNumber
```
