### PR TITLE
Use GetWithParser for particles_per_cell

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -240,7 +240,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     // so that inj_pos->getPositionUnitBox calls
     // InjectorPosition[Random or Regular].getPositionUnitBox.
     else if (injection_style == "nrandompercell") {
-        queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell);
+        getWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell);
 #if WARPX_DIM_RZ
         if (WarpX::n_rz_azimuthal_modes > 1) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -258,7 +258,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         parseMomentum(pp_species_name);
     } else if (injection_style == "nfluxpercell") {
         surface_flux = true;
-        queryWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell_real);
+        getWithParser(pp_species_name, "num_particles_per_cell", num_particles_per_cell_real);
 #ifdef WARPX_DIM_RZ
         if (WarpX::n_rz_azimuthal_modes > 1) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(


### PR DESCRIPTION
When switching between `NUniformPerCell` to `NRandomPerCell`
I forgot to use `<species>.num_particles_per_cell` in the input file and was using the previous input line 
'<species>.num_particles_cell_per_dim' 
The simulation would just hang. 
I think it would be necessary to actually crash here.

