### PR TITLE
[WIP] Add runtime option to print out data on the memory usage for each species each time step.

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -282,7 +282,7 @@ Setting up the field mesh
     both the minimum required storage and the actual size allocated in vectors.
     Note that this requires doing extra MPI reductions so it will likely slow
     down program execution, particularly at scale.
-    
+
 * ``particles.deposit_on_main_grid`` (`list of strings`)
     When using mesh refinement: the particle species whose name are included
     in the list will deposit their charge/current directly on the main grid

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -277,6 +277,12 @@ Setting up the field mesh
     Perform MPI communications for field guard regions in single precision.
     Only meaningful for ``WarpX_PRECISION=DOUBLE``.
 
+* ``warpx.print_species_mem_usage`` (`bool`; `false` by default)
+    Print out data on the memory usage by particles across MPI ranks. Includes
+    both the minimum required storage and the actual size allocated in vectors.
+    Note that this requires doing extra MPI reductions so it will likely slow
+    down program execution, particularly at scale.
+    
 * ``particles.deposit_on_main_grid`` (`list of strings`)
     When using mesh refinement: the particle species whose name are included
     in the list will deposit their charge/current directly on the main grid

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -303,6 +303,8 @@ WarpX::Evolve (int numsteps)
             }
         }
 
+        if (print_species_mem_usage) { mypc->PrintMemoryUsage(); }
+
         if (sort_intervals.contains(step+1)) {
             if (verbose) {
                 amrex::Print() << Utils::TextMsg::Info("re-sorting particles");

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -295,6 +295,8 @@ public:
 
     void ScrapeParticles (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
 
+    void PrintMemoryUsage () const;
+    
     std::string m_B_ext_particle_s = "none";
     std::string m_E_ext_particle_s = "none";
     // External fields added to particle fields.

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -296,7 +296,7 @@ public:
     void ScrapeParticles (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
 
     void PrintMemoryUsage () const;
-    
+
     std::string m_B_ext_particle_s = "none";
     std::string m_E_ext_particle_s = "none";
     // External fields added to particle fields.

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -419,6 +419,46 @@ MultiParticleContainer::PostRestart ()
 }
 
 void
+MultiParticleContainer::PrintMemoryUsage () const
+{
+    Long mn = 0;
+    Long mx = 0;
+    Long cnt = 0;
+
+    Long mn_cap = 0;
+    Long mx_cap = 0;
+    Long cnt_cap = 0;
+
+    for (int i=0; i < static_cast<int>(species_names.size()); i++)
+    {
+        const auto& pc = allcontainers[i];
+        amrex::Print() << "Memory usage data for species " << species_names[i] << ": \n";
+        amrex::Print() << "Required to store particles: \n";
+        pc->ByteSpread(mn, mx, cnt);
+        amrex::Print() << "Actual vector capacity: \n";
+        pc->PrintCapacity(mn_cap, mx_cap, cnt_cap);
+        amrex::Print() << "\n";
+    }
+
+    amrex::Print() << "Total bytes across all species required to store particles: \n";
+    amrex::Print() << "[Min: "
+                   << mn
+                   << ", Max: "
+                   << mx
+                   << ", Total: "
+                   << cnt
+                   << "]\n";
+    amrex::Print() << "Actual vector capacity (bytes): \n";
+    amrex::Print() << "[Min: "
+                   << mn_cap
+                   << ", Max: "
+                   << mx_cap
+                   << ", Total: "
+                   << cnt_cap
+                   << "]\n";
+}
+
+void
 MultiParticleContainer::InitMultiPhysicsModules ()
 {
     // Init ionization module here instead of in the MultiParticleContainer

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -205,7 +205,7 @@ public:
 
     //! print out diagnostic information about the memory usage for each species
     static bool print_species_mem_usage;
-    
+
     //! Whether to fill guard cells when computing inverse FFTs of fields
     static amrex::IntVect m_fill_guards_fields;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -203,6 +203,9 @@ public:
     //! perform field communications in single precision
     static bool do_single_precision_comms;
 
+    //! print out diagnostic information about the memory usage for each species
+    static bool print_species_mem_usage;
+    
     //! Whether to fill guard cells when computing inverse FFTs of fields
     static amrex::IntVect m_fill_guards_fields;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -127,6 +127,7 @@ bool WarpX::do_divb_cleaning = false;
 int WarpX::em_solver_medium;
 int WarpX::macroscopic_solver_algo;
 bool WarpX::do_single_precision_comms = false;
+bool WarpX::print_species_mem_usage = false;
 amrex::Vector<int> WarpX::field_boundary_lo(AMREX_SPACEDIM,0);
 amrex::Vector<int> WarpX::field_boundary_hi(AMREX_SPACEDIM,0);
 amrex::Vector<ParticleBoundaryType> WarpX::particle_boundary_lo(AMREX_SPACEDIM,ParticleBoundaryType::Absorbing);
@@ -758,6 +759,7 @@ WarpX::ReadParameters ()
                 ablastr::warn_manager::WarnPriority::low);
         }
 #endif
+        pp_warpx.query("print_species_mem_usage", print_species_mem_usage);
 
         pp_warpx.query("serialize_initial_conditions", serialize_initial_conditions);
         pp_warpx.query("refine_plasma", refine_plasma);


### PR DESCRIPTION
Requires AMReX PR 2949: https://github.com/AMReX-Codes/amrex/pull/2949
- [x] #3412
- [ ] write this in a table/file for easier processing

Sample output:

```
STEP 20 starts ...
Memory usage data for species electrons_h:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 311874496 (4873039), Max: 312337728 (4880277), Total: 1248577984 (19509031)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 340157312, Max: 340157312, Total: 1360629248]

Memory usage data for species electrons_c:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 874304320 (13661005), Max: 875307328 (13676677), Total: 3498921280 (54670645)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 1148030976, Max: 1148030976, Total: 4592123904]

Memory usage data for species electrons_n:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 252427200 (3944175), Max: 252742336 (3949099), Total: 1010237952 (15784968)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 340157312, Max: 340157312, Total: 1360629248]

Memory usage data for species hydrogen:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 432537600 (4915200), Max: 432537600 (4915200), Total: 1730150400 (19660800)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 467716304, Max: 467716304, Total: 1870865216]

Memory usage data for species carbon:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 226099200 (2457600), Max: 226099200 (2457600), Total: 904396800 (9830400)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 324186776, Max: 324186776, Total: 1296747104]

Memory usage data for species nitrogen:
Required to store particles:
ParticleContainer spread across MPI nodes - bytes (num particles): [Min: 55771136 (606208), Max: 55771136 (606208), Total: 223084544 (2424832)]
Actual vector capacity:
ParticleContainer spread across MPI nodes - bytes: [Min: 64036884, Max: 64036884, Total: 256147536]

Total bytes across all species required to store particles:
[Min: 2153013952, Max: 2154795328, Total: 8615368960]
Actual vector capacity (bytes):
[Min: 2684285564, Max: 2684285564, Total: 10737142256]
```