### PR TITLE
Improve docstrings for some physical constants

### DIFF
--- a/Source/ablastr/constant.H
+++ b/Source/ablastr/constant.H
@@ -23,7 +23,7 @@ namespace ablastr::constant
         static constexpr amrex::Real pi = 3.14159265358979323846_rt;
 
         //! https://tauday.com/tau-manifesto
-        static constexpr amrex::Real tau = 2.0 * 3.14159265358979323846_rt;
+        static constexpr amrex::Real tau = 2.0_rt * pi;
     } // namespace math
 
     /** Physical constants

--- a/Source/ablastr/constant.H
+++ b/Source/ablastr/constant.H
@@ -57,13 +57,13 @@ namespace ablastr::constant
 
         //! reduced Planck Constant = h / tau [J*s]
         static constexpr auto hbar = 1.054571817e-34_rt;
-        //! mu0/(4*MathConst::pi)*q_e*q_e*c/hbar
+        //! fine-structure constant = mu0/(4*MathConst::pi)*q_e*q_e*c/hbar [dimensionless]
         static constexpr auto alpha = 0.007297352573748943_rt;
-        //! 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c)
+        //! classical electron radius = 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c) [m]
         static constexpr auto r_e = 2.817940326204929e-15_rt;
-        //! (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c)
+        //! xi quantum nonlinearity parameter = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c)
         static constexpr double xi = 1.3050122447005176e-52;
-        //! This should be usable for single precision instead of xi; very close to smallest float32 number possible (1.2e-38)
+        //! xi times c2 = xi*c*c. This should be usable for single precision instead of xi; very close to smallest float32 number possible (1.2e-38)
         static constexpr auto xi_c2 = 1.1728865132395492e-35_rt;
 
         //! Boltzmann constant (exact) [J/K]

--- a/Source/ablastr/constant.H
+++ b/Source/ablastr/constant.H
@@ -61,7 +61,7 @@ namespace ablastr::constant
         static constexpr auto alpha = 0.007297352573748943_rt;
         //! classical electron radius = 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c) [m]
         static constexpr auto r_e = 2.817940326204929e-15_rt;
-        //! xi quantum nonlinearity parameter = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c)
+        //! xi: nonlinearity parameter of Heisenberg-Euler effective theory = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c)
         static constexpr double xi = 1.3050122447005176e-52;
         //! xi times c2 = xi*c*c. This should be usable for single precision instead of xi; very close to smallest float32 number possible (1.2e-38)
         static constexpr auto xi_c2 = 1.1728865132395492e-35_rt;


### PR DESCRIPTION
This is a follow-up of https://github.com/ECP-WarpX/WarpX/pull/3405