### PR TITLE
Fixes to Physics_applications/capacitive_discharge/PICMI*

### DIFF
--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -60,7 +60,7 @@ class PoissonSolver1D(picmi.ElectrostaticSolver):
 
         super(PoissonSolver1D, self).initialize_inputs()
 
-        self.nz = self.grid.nx
+        self.nz = self.grid.number_of_cells[0]
         self.dz = (self.grid.xmax - self.grid.xmin) / self.nz
 
         self.nxguardphi = 1

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -91,8 +91,8 @@ class PoissonSolverPseudo1D(picmi.ElectrostaticSolver):
 
         super(PoissonSolverPseudo1D, self).initialize_inputs()
 
-        self.nx = self.grid.nx
-        self.nz = self.grid.ny
+        self.nx = self.grid.number_of_cells[0]
+        self.nz = self.grid.number_of_cells[1]
         self.dx = (self.grid.xmax - self.grid.xmin) / self.nx
         self.dz = (self.grid.ymax - self.grid.ymin) / self.nz
 


### PR DESCRIPTION
A change was made in PICMI so that for the grid objects, the separate names for the number of cells in each dimension (i.e. nx, ny, nz) are no longer saved as attributes, and the implementations need to use the vector `number_of_cells` instead. This PR fixes several PICMI input files that were using the separate names.

This PR is needed in preparation for PR #3329 which increments the PICMI version which includes the change above.