### PR TITLE
Fix compilation of RZ version on GPU

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -197,9 +197,6 @@ public:
             }
 
 #if (defined WARPX_DIM_RZ)
-            /* This momentum rotation is analogous to the one in ElasticCollisionPerez.H. */
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(WarpX::n_rz_azimuthal_modes==1,
-              "RZ mode `warpx.n_rz_azimuthal_modes` must be 1 when using the binary nuclear fusion module.");
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif


### PR DESCRIPTION
The recent PR https://github.com/ECP-WarpX/WarpX/pull/3255 broke compilation for the RZ code on GPU. (It seems that this was not tested in CI.)

This is due to a check which we already do anyways here:
https://github.com/ECP-WarpX/WarpX/blob/development/Source/Particles/Collision/CollisionHandler.cpp#L35

Therefore, I removed the duplicated check here, in order to fix the compilation on GPU