### PR TITLE
Fix #3389: fix update of particles flushed already in BTD

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1192,7 +1192,7 @@ void
 BTDiagnostics::UpdateTotalParticlesFlushed(int i_buffer)
 {
     for (int isp = 0; isp < m_totalParticles_flushed_already[i_buffer].size(); ++isp) {
-        m_totalParticles_flushed_already[i_buffer][isp] += m_totalParticles_in_buffer[i_buffer][isp];
+        m_totalParticles_flushed_already[i_buffer][isp] += m_particles_buffer[i_buffer][isp]->TotalNumberOfParticles();
     }
 }
 


### PR DESCRIPTION
This PR fixes #3420.

The update of the variable `m_totalParticles_flushed_already` uses `m_totalParticles_in_buffer`. 

However, the number of particles in buffer is updated here: https://github.com/ECP-WarpX/WarpX/blob/development/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp#L152
and does not seem that it gets updated when redistributing (and potentially removing some of) the particles of the buffer here:
[`RedistributeParticleBuffer`](https://github.com/ECP-WarpX/WarpX/blob/development/Source/Diagnostics/BTDiagnostics.cpp)

As a consequence, the number of particles written do disk (which happens after `RedistributeParticleBuffer`) is actually lower than `m_totalParticles_flushed_already`, which leads e.g. to inconsistencies in openPMD.

This PR fixes the issue by using the actual number of macroparticles.

Because of the above issue, I would be inclined to completely remove the variable `m_totalParticles_in_buffer` from the code. The only remaining place where it seems to be used, though, is here:
https://github.com/ECP-WarpX/WarpX/blob/development/Source/Diagnostics/BTDiagnostics.cpp#L1142
@RevathiJambunathan Any opinion on whether this could be done differently, so as to remove `m_totalParticles_in_buffer`.