### PR TITLE
Add 1d support to `_libwarpx.py` functions `get_particle_X`

### DIFF
--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -77,18 +77,6 @@ class PoissonSolver1D(picmi.ElectrostaticSolver):
         system."""
         self.nsolve = self.nz + 1
 
-        # Set up the tridiagonal computation matrix in order to solve A*phi =
-        # rho for phi.
-        self.A_ldiag = np.ones(self.nsolve-1) / self.dz**2
-        self.A_mdiag = -2.*np.ones(self.nsolve) / self.dz**2
-        self.A_udiag = np.ones(self.nsolve-1) / self.dz**2
-
-        self.A_mdiag[0] = 1.
-        self.A_udiag[0] = 0.0
-
-        self.A_mdiag[-1] = 1.
-        self.A_ldiag[-1] = 0.0
-
         # Set up the computation matrix in order to solve A*phi = rho
         A = np.zeros((self.nsolve, self.nsolve))
         idx = np.arange(self.nsolve)
@@ -357,6 +345,19 @@ class CapacitiveDischargeExample(object):
 
         if self.sim.extension.getMyProc() == 0:
             np.save(f'ion_density_case_{self.n+1}.npy', self.ion_density_array)
+
+        # query the particle z-coordinates if this is run during CI testing
+        # to cover that functionality
+        if self.test:
+            nparts = self.sim.extension.get_particle_count(
+                'he_ions', local=True
+            )
+            z_coords = np.concatenate(
+                self.sim.extension.get_particle_z('he_ions')
+            )
+            assert len(z_coords) == nparts
+            assert np.all(z_coords >= 0.0) and np.all(z_coords <= self.gap)
+
 
 ##########################
 # parse input parameters

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -831,6 +831,8 @@ class LibWarpX():
             return [struct['x'] for struct in structs]
         elif self.geometry_dim == 'rz':
             return [struct['x']*np.cos(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
+        elif self.geometry_dim == '1d':
+            raise Exception('get_particle_x: There is no x coordinate with 1D Cartesian')
 
     def get_particle_y(self, species_name, level=0):
         '''
@@ -840,10 +842,12 @@ class LibWarpX():
 
         '''
         structs = self.get_particle_structs(species_name, level)
-        if self.geometry_dim == '3d' or self.geometry_dim == '2d':
+        if self.geometry_dim == '3d':
             return [struct['y'] for struct in structs]
         elif self.geometry_dim == 'rz':
             return [struct['x']*np.sin(theta) for struct, theta in zip(structs, self.get_particle_theta(species_name))]
+        elif self.geometry_dim == '1d' or self.geometry_dim == '2d':
+            raise Exception('get_particle_y: There is no y coordinate with 1D or 2D Cartesian')
 
     def get_particle_r(self, species_name, level=0):
         '''
@@ -857,8 +861,8 @@ class LibWarpX():
             return [struct['x'] for struct in structs]
         elif self.geometry_dim == '3d':
             return [np.sqrt(struct['x']**2 + struct['y']**2) for struct in structs]
-        elif self.geometry_dim == '2d':
-            raise Exception('get_particle_r: There is no r coordinate with 2D Cartesian')
+        elif self.geometry_dim == '2d' or self.geometry_dim == '1d':
+            raise Exception('get_particle_r: There is no r coordinate with 1D or 2D Cartesian')
 
     def get_particle_z(self, species_name, level=0):
         '''
@@ -872,6 +876,8 @@ class LibWarpX():
             return [struct['z'] for struct in structs]
         elif self.geometry_dim == 'rz' or self.geometry_dim == '2d':
             return [struct['y'] for struct in structs]
+        elif self.geometry_dim == '1d':
+            return [struct['x'] for struct in structs]
 
     def get_particle_id(self, species_name, level=0):
         '''
@@ -946,8 +952,8 @@ class LibWarpX():
         elif self.geometry_dim == '3d':
             structs = self.get_particle_structs(species_name, level)
             return [np.arctan2(struct['y'], struct['x']) for struct in structs]
-        elif self.geometry_dim == '2d':
-            raise Exception('get_particle_r: There is no theta coordinate with 2D Cartesian')
+        elif self.geometry_dim == '2d' or self.geometry_dim == '1d':
+            raise Exception('get_particle_theta: There is no theta coordinate with 1D or 2D Cartesian')
 
     def get_particle_comp_index(self, species_name, pid_name):
         '''


### PR DESCRIPTION
The handy libwarpx functions to get particle coordinates do not yet support 1d simulations. This PR adds that support.
One thing that might need some discussion is how to treat dimensions not included in the coordinate system chosen. For example, if `get_particle_y()` is called in 2d the previous implementation was to return the same coordinate as when calling `get_particle_z()`. But if `get_particle_r()` was called in a 2d Cartesian simulation an exception was raised saying r is not defined in 2d Cartesian.