### PR TITLE
[WIP] Multi-J PSATD: Add Option Rho Quadratic in Time

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H
@@ -57,7 +57,8 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
             const amrex::Real dt,
             const bool time_averaging,
             const bool dive_cleaning,
-            const bool divb_cleaning);
+            const bool divb_cleaning,
+            const int rho_in_time);
 
         /**
          * \brief Updates the E and B fields in spectral space, according to the multi-J PSATD equations
@@ -118,6 +119,7 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
         // These real and complex coefficients are always allocated
         SpectralRealCoefficients C_coef, S_ck_coef;
         SpectralRealCoefficients X1_coef, X2_coef, X3_coef, X5_coef, X6_coef;
+        SpectralRealCoefficients Y1_coef, Y2_coef, Y3_coef;
 
         SpectralFieldIndex m_spectral_index;
 
@@ -126,6 +128,7 @@ class PsatdAlgorithmJLinearInTime : public SpectralBaseAlgorithm
         bool m_time_averaging;
         bool m_dive_cleaning;
         bool m_divb_cleaning;
+        int m_rho_in_time;
 };
 #endif // WARPX_USE_PSATD
 #endif // WARPX_PSATD_ALGORITHM_J_LINEAR_IN_TIME_H_

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -55,7 +55,7 @@ SpectralSolver::SpectralSolver(
             k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
             dt, dive_cleaning, divb_cleaning);
     }
-    else // PSATD equations in the regulard grids
+    else // PSATD equations in the regular grids
     {
         // Comoving PSATD algorithm
         if (v_comoving[0] != 0. || v_comoving[1] != 0. || v_comoving[2] != 0.)
@@ -77,7 +77,7 @@ SpectralSolver::SpectralSolver(
             {
                 algorithm = std::make_unique<PsatdAlgorithmJLinearInTime>(
                     k_space, dm, m_spectral_index, norder_x, norder_y, norder_z, nodal,
-                    dt, fft_do_time_averaging, dive_cleaning, divb_cleaning);
+                    dt, fft_do_time_averaging, dive_cleaning, divb_cleaning, rho_in_time);
             }
         }
     }

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -545,6 +545,21 @@ WarpX::PSATDPushSpectralFields ()
     }
 }
 
+void WarpX::PSATDMoveRhoNewToRhoMid ()
+{
+    const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
+
+    for (int lev=0; lev<=finest_level; ++lev)
+    {
+        spectral_solver_fp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
+
+        if (spectral_solver_cp[lev])
+        {
+            spectral_solver_cp[lev]->CopySpectralDataComp(Idx.rho_new, Idx.rho_mid);
+        }
+    }
+}
+
 void
 WarpX::PSATDMoveRhoNewToRhoOld ()
 {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1565,6 +1565,11 @@ private:
         const int icomp, const int dcomp, const bool apply_kspace_filter=true);
 
     /**
+     * \brief Copy rho_new to rho_mid in spectral space
+     */
+    void PSATDMoveRhoNewToRhoMid ();
+
+    /**
      * \brief Copy rho_new to rho_old in spectral space
      */
     void PSATDMoveRhoNewToRhoOld ();


### PR DESCRIPTION
Implement some of the changes originally introduced in #2730, namely rho quadratic in time for the multi-J PSATD algorithm.

To-do:
- [ ] Test
- [ ] Implement equations with div(E) cleaning<sup>1</sup>
- [ ] Implement equations with time averaging<sup>1</sup>
- [ ] Add assert/warning for options not supported<sup>2</sup>
- [ ] Add/Upgrade CI tests to cover new options

<sup>1</sup> Maybe in separate PRs, if the correctness of the corresponding results is not fully assessed and understood.
<sup>2</sup> E.g., standard PSATD with rho quadratic must be run as multi-J PSATD with rho quadratic and one deposition.