### PR TITLE
BTD: Improve Z-Slice Message

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <cstdio>
 #include <memory>
+#include <string>
 #include <vector>
 
 using namespace amrex::literals;
@@ -579,7 +580,14 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         m_current_z_lab[i_buffer] >= m_buffer_domain_lab[i_buffer].lo(m_moving_window_dir) and
                         m_current_z_lab[i_buffer] <= m_buffer_domain_lab[i_buffer].hi(m_moving_window_dir),
-                        "z-slice in lab-frame is outside the buffer domain physical extent. ");
+                        "z-slice in lab-frame (" +
+                        std::to_string(m_current_z_lab[i_buffer]) +
+                        ") is outside the buffer domain physical extent (" +
+                        std::to_string(m_buffer_domain_lab[i_buffer].lo(m_moving_window_dir)) +
+                        " to " +
+                        std::to_string(m_buffer_domain_lab[i_buffer].hi(m_moving_window_dir)) +
+                        ")."
+                    );
                 }
                 m_all_field_functors[lev][i]->PrepareFunctorData (
                                              i_buffer, ZSliceInDomain,


### PR DESCRIPTION
Add values that are checked to the msg, e.g., I see:
```
z-slice in lab-frame (0.049998) is outside the buffer domain
physical extent (0.049998 to 0.050000).
```