### PR TITLE
[WIP] Handled expanded particle ID range in Python 

### DIFF
--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -19,7 +19,7 @@ from .PSATD import psatd
 from .Particles import electrons, newspecies, particles, positrons, protons
 from .WarpX import warpx
 from ._libwarpx import libwarpx
-from .amrex_particle_id_utils import get_id, get_cpu
+from .amrex_particle_id_utils import get_cpu, get_id
 
 # This is a circulor import and must happen after the import of libwarpx
 from . import picmi # isort:skip

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -19,6 +19,7 @@ from .PSATD import psatd
 from .Particles import electrons, newspecies, particles, positrons, protons
 from .WarpX import warpx
 from ._libwarpx import libwarpx
+from .amrex_particle_id_utils import get_id, get_cpu
 
 # This is a circulor import and must happen after the import of libwarpx
 from . import picmi # isort:skip

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -143,13 +143,13 @@ class LibWarpX():
         # our particle data type, depends on _ParticleReal_size
         _p_struct = (
             [(d, self._numpy_particlereal_dtype) for d in 'xyz'[:self.dim]]
-            + [('id', 'i4'), ('cpu', 'i4')]
+            + [('idcpu', 'u8')]
         )
         self._p_dtype = np.dtype(_p_struct, align=True)
 
         _numpy_to_ctypes = {}
         _numpy_to_ctypes[self._numpy_particlereal_dtype] = c_particlereal
-        _numpy_to_ctypes['i4'] = ctypes.c_int
+        _numpy_to_ctypes['u8'] = ctypes.c_uint64
 
         class Particle(ctypes.Structure):
             _fields_ = [(v[0], _numpy_to_ctypes[v[1]]) for v in _p_struct]
@@ -727,7 +727,7 @@ class LibWarpX():
         '''
         This returns a list of numpy arrays containing the particle struct data
         on each tile for this process. The particle data is represented as a structured
-        numpy array and contains the particle 'x', 'y', 'z', 'id', and 'cpu'.
+        numpy array and contains the particle 'x', 'y', 'z', and 'idcpu'.
 
         The data for the numpy arrays are not copied, but share the underlying
         memory buffer with WarpX. The numpy arrays are fully writeable.
@@ -882,22 +882,24 @@ class LibWarpX():
     def get_particle_id(self, species_name, level=0):
         '''
 
-        Return a list of numpy arrays containing the particle 'id'
-        positions on each tile.
+        Return a list of numpy arrays containing the particle id
+        numbers on each tile.
 
         '''
+        from .amrex_particle_id_utils import get_id
         structs = self.get_particle_structs(species_name, level)
-        return [struct['id'] for struct in structs]
+        return [get_id(struct['idcpu']) for struct in structs]
 
     def get_particle_cpu(self, species_name, level=0):
         '''
 
-        Return a list of numpy arrays containing the particle 'cpu'
-        positions on each tile.
+        Return a list of numpy arrays containing the particle cpu
+        numbers on each tile.
 
         '''
+        from .amrex_particle_id_utils import get_cpu
         structs = self.get_particle_structs(species_name, level)
-        return [struct['cpu'] for struct in structs]
+        return [get_cpu(struct['idcpu']) for struct in structs]
 
     def get_particle_weight(self, species_name, level=0):
         '''
@@ -1048,7 +1050,7 @@ class LibWarpX():
         This returns a list of numpy arrays containing the particle struct data
         for a species that has been scraped by a specific simulation boundary. The
         particle data is represented as a structured numpy array and contains the
-        particle 'x', 'y', 'z', 'id', and 'cpu'.
+        particle 'x', 'y', 'z', and 'idcpu'.
 
         The data for the numpy arrays are not copied, but share the underlying
         memory buffer with WarpX. The numpy arrays are fully writeable.

--- a/Python/pywarpx/amrex_particle_id_utils.cpp
+++ b/Python/pywarpx/amrex_particle_id_utils.cpp
@@ -1,0 +1,113 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "numpy/ndarraytypes.h"
+#include "numpy/ufuncobject.h"
+#include "numpy/npy_3kcompat.h"
+#include <math.h>
+
+static PyMethodDef GetIDMethods[] = {
+    {NULL, NULL, 0, NULL}
+};
+
+static long uint64_t_to_long_id (uint64_t idcpu) {
+    long r = 0;
+
+    uint64_t sign = idcpu >> 63;  // extract leftmost sign bit
+    uint64_t val  = ((idcpu >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
+
+    long lval = static_cast<long>(val);  // bc we take -
+    r = (sign) ? lval : -lval;
+    return r;
+}
+
+static long uint64_t_to_long_cpu (uint64_t idcpu) {
+    return idcpu & 0x00FFFFFF;
+}
+
+/* The loop definition must precede the PyMODINIT_FUNC. */
+
+static void get_id (char **args, const npy_intp *dimensions,
+                    const npy_intp *steps, void *data)
+{
+    npy_intp i;
+    npy_intp n = dimensions[0];
+    char *in = args[0], *out = args[1];
+    npy_intp in_step = steps[0], out_step = steps[1];
+
+    for (i = 0; i < n; i++) {
+        *((long *)out) = uint64_t_to_long_id( *((uint64_t *)in));
+        in += in_step;
+        out += out_step;
+    }
+}
+
+/* The loop definition must precede the PyMODINIT_FUNC. */
+
+static void get_cpu (char **args, const npy_intp *dimensions,
+                    const npy_intp *steps, void *data)
+{
+    npy_intp i;
+    npy_intp n = dimensions[0];
+    char *in = args[0], *out = args[1];
+    npy_intp in_step = steps[0], out_step = steps[1];
+
+    for (i = 0; i < n; i++) {
+        *((long *)out) = uint64_t_to_long_cpu( *((uint64_t *)in));
+        in += in_step;
+        out += out_step;
+    }
+}
+
+/* This a pointer to the above function */
+PyUFuncGenericFunction id_funcs[1] = {&get_id};
+
+/* This a pointer to the above function */
+PyUFuncGenericFunction cpu_funcs[1] = {&get_cpu};
+
+/* These are the input and return dtypes of the get_id functions.*/
+static char id_types[2] = {NPY_UINT64, NPY_LONG};
+
+/* These are the input and return dtypes of the get_cpu function*/
+static char cpu_types[2] = {NPY_UINT64, NPY_INT};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "amrex_particle_id_utils",
+    NULL,
+    -1,
+    GetIDMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit_amrex_particle_id_utils (void)
+{
+    PyObject *m, *get_id, *get_cpu, *d;
+    m = PyModule_Create(&moduledef);
+    if (!m) {
+        return NULL;
+    }
+
+    import_array();
+    import_umath();
+
+    get_id = PyUFunc_FromFuncAndData(id_funcs, NULL, id_types, 1, 1, 1,
+                                     PyUFunc_None, "get_id",
+                                     "get_id_docstring", 0);
+
+    get_cpu = PyUFunc_FromFuncAndData(cpu_funcs, NULL, cpu_types, 1, 1, 1,
+                                      PyUFunc_None, "get_cpu",
+                                      "get_cpu_docstring", 0);
+
+    d = PyModule_GetDict(m);
+
+    PyDict_SetItemString(d, "get_id", get_id);
+    PyDict_SetItemString(d, "get_cpu", get_cpu);
+
+    Py_DECREF(get_id);
+    Py_DECREF(get_cpu);
+
+    return m;
+}

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 from setuptools import setup
+from setuptools import Extension
 
 argparser = argparse.ArgumentParser(add_help=False)
 argparser.add_argument('--with-libwarpx', type=str, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the GNU makefile build system.')
@@ -53,6 +54,8 @@ elif args.with_lib_dir or PYWARPX_LIB_DIR:
 else:
     package_data = {}
 
+import numpy as np
+
 setup(name = 'pywarpx',
       version = '22.10',
       packages = ['pywarpx'],
@@ -61,5 +64,12 @@ setup(name = 'pywarpx',
       package_data = package_data,
       install_requires = ['numpy', 'picmistandard==0.0.20', 'periodictable'],
       python_requires = '>=3.7',
+      ext_modules=[
+          Extension(
+              'pywarpx/amrex_particle_id_utils',
+              sources=['pywarpx/amrex_particle_id_utils.cpp'],
+              include_dirs=[np.get_include()]
+          ),
+      ],
       zip_safe=False
 )

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -16,8 +16,7 @@ import argparse
 import os
 import sys
 
-from setuptools import setup
-from setuptools import Extension
+from setuptools import Extension, setup
 
 argparser = argparse.ArgumentParser(add_help=False)
 argparser.add_argument('--with-libwarpx', type=str, default=None, help='Install libwarpx with the given value as DIM. This option is only used by the GNU makefile build system.')


### PR DESCRIPTION
Convert to long and int, respectively, when getting the particle id and cpu numbers through the Python interface. This is handled by a couple of numpy ufuncs that can convert from the bit-packed representation to the id and cpu.