### PR TITLE
Updated 1D CI tests with particles because of update of yt

### DIFF
--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -70,12 +70,13 @@ for fn in fn_list:
     # load file
     ds  = yt.load( fn )
     ad  = ds.all_data()
-    px  = ad['particle_momentum_x'].to_ndarray()
+    pxe  = ad['electron', 'particle_momentum_x'].to_ndarray()
+    pxi  = ad['ion', 'particle_momentum_x'].to_ndarray()
     # get time index j
     j = int(fn[-5:])
     # compute error
-    vxe = numpy.mean(px[ 0:ne])/me/c
-    vxi = numpy.mean(px[ne:np])/mi/c
+    vxe = numpy.mean(pxe)/me/c
+    vxi = numpy.mean(pxi)/mi/c
     vxd = vxe - vxi
     fit = a*math.exp(b*j)
     error = error + abs(fit-vxd)

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_1d.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_1d.json
@@ -2,9 +2,9 @@
   "electrons": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
-    "particle_position_x": 0.0,
-    "particle_weight": 0.0
+    "particle_momentum_z": 1.183644630083563e-22,
+    "particle_position_x": 2.560000000000000e-03,
+    "particle_weight": 8.000000000000000e+19
   },
   "lev=0": {
     "Bx": 0.0,
@@ -20,8 +20,8 @@
   "positrons": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
-    "particle_position_x": 0.0,
-    "particle_weight": 0.0
+    "particle_momentum_z": 1.183644630083563e-22,
+    "particle_position_x": 2.560000000000001e-03,
+    "particle_weight": 8.000000000000000e+19
   }
 }

--- a/Regression/Checksum/benchmarks_json/LaserAcceleration_1d.json
+++ b/Regression/Checksum/benchmarks_json/LaserAcceleration_1d.json
@@ -1,12 +1,12 @@
 {
   "electrons": {
     "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
-    "particle_orig_z": 0.0,
-    "particle_position_x": 0.0,
-    "particle_regionofinterest": 0.0,
-    "particle_weight": 0.0
+    "particle_momentum_y": 1.2426858089556802e-20,
+    "particle_momentum_z": 1.4187765007430268e-21,
+    "particle_orig_z": 0.022432812500000038,
+    "particle_position_x": 0.02243266637270741,
+    "particle_regionofinterest": 40.0,
+    "particle_weight": 5.20625e+18
   },
   "lev=0": {
     "Bx": 178016.7504669478,

--- a/Regression/Checksum/benchmarks_json/Python_LaserAcceleration_1d.json
+++ b/Regression/Checksum/benchmarks_json/Python_LaserAcceleration_1d.json
@@ -1,10 +1,10 @@
 {
   "electrons": {
     "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
-    "particle_position_x": 0.0,
-    "particle_weight": 0.0
+    "particle_momentum_y": 1.2426858089556802e-20,
+    "particle_momentum_z": 1.4187765007430268e-21,
+    "particle_position_x": 0.02243266637270741,
+    "particle_weight": 5.20625e+18
   },
   "lev=0": {
     "Bx": 178016.7504669478,

--- a/Regression/Checksum/benchmarks_json/Python_PlasmaAcceleration1d.json
+++ b/Regression/Checksum/benchmarks_json/Python_PlasmaAcceleration1d.json
@@ -12,7 +12,7 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 0.0,
-    "particle_weight": 0.0
+    "particle_position_x": 3.9920000000000724,
+    "particle_weight": 4.0000000000000456e+18
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ setup(
     #    ]
     #},
     extras_require={
-        'all': ['openPMD-api~=0.14.2', 'openPMD-viewer~=1.1', 'yt>=4.0.1', 'matplotlib'],
+        'all': ['openPMD-api~=0.14.2', 'openPMD-viewer~=1.1', 'yt>=4.1.0', 'matplotlib'],
     },
     # cmdclass={'test': PyTest},
     # platforms='any',


### PR DESCRIPTION
This resets the benchmark data for several 1D tests. Previously, yt could not read in the particles from 1D plot data files so the benchmarks for the particle data was all zeros. A fix was made to yt (PR #4112) that allowed it to read in the particle data. With that fix, the checksum evaluation now reads in the particles and generates nonzero values, causing the benchmarks to fail. This PR updates the benchmark values to use the correct nonzero values.

This PR also updates the required version of yt to 4.1.0 (which includes the above mentioned PR).