### PR TITLE
openPMD Engines: Allow Params w/o Type

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -181,34 +181,44 @@ namespace detail
                 op_block += R"END(,
           "parameters": {
 )END";
-            op_block += op_parameters + "}";
+            op_block += op_parameters +
+                        "\n          }";
         }
             op_block += R"END(
         }
       ]
     })END";
-        if (!engine_type.empty())
-            op_block += ",";
-
+            if (!engine_type.empty() || !en_parameters.empty())
+                op_block += ",";
         }  // end operator string block
 
         // add the engine string block
-        if (!engine_type.empty()) {
+        if (!engine_type.empty() || !en_parameters.empty())
+        {
             en_block = R"END(
-    "engine": {
-      "type": ")END";
-            en_block += engine_type + "\"";
+    "engine": {)END";
 
+            // non-default engine type
+            if (!engine_type.empty()) {
+                en_block += R"END(
+      "type": ")END";
+                en_block += engine_type + "\"";
+
+                if(!en_parameters.empty())
+                    en_block += ",";
+            }
+
+            // non-default engine parameters
             if (!en_parameters.empty()) {
-                en_block += R"END(,
+                en_block += R"END(
       "parameters": {
 )END";
-            en_block += en_parameters + "}";
+                en_block += en_parameters +
+                            "\n      }";
             }
 
             en_block += R"END(
     })END";
-
         }  // end engine string block
 
         options = top_block + op_block + en_block + end_block;


### PR DESCRIPTION
The current implementation only accepted parameters for ADIOS2 engines if the engine type was also specified. That is not necessary, the default (bp4) will usually be taken and thus the documentation did not work.

This fixes it, keeping the engine type optional in the inputs.

```
<diag_name>.adios2_engine.type = bp4  # now optional, as documented

<diag_name>.adios2_engine.parameters.NumAggregators = 2048
<diag_name>.adios2_engine.parameters.BurstBufferPath="/mnt/bb/username"
```

Follow-up to @kshitij-v-mehta's #2872 :)

cc @guj I think you saw that in recent tests with burst buffers as well (engine params were ignored)?
cc @franzpoeschel just fyi