### PR TITLE
CI Fix: macOS OMP

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,14 +21,28 @@ jobs:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - uses: actions/checkout@v2
+    - name: Brew Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: |
+          /usr/local
+          /Users/runner/Library/Caches/Homebrew
+        key: brew-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}
+        restore-keys: |
+          brew-macos-appleclang-
     - name: install dependencies
       run: |
+        brew --cache
         set +e
         rm -rf /usr/local/bin/2to3
+        brew unlink gcc
         brew update
         brew install ccache
         brew install fftw
         brew install libomp
+        brew link --force libomp
         brew install ninja
         brew install open-mpi
         brew install pkg-config

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -139,6 +139,8 @@ Brew (macOS/Linux)
    brew install git
    brew install hdf5-mpi    # for openPMD
    brew install libomp
+   brew unlink gcc
+   brew link --force libomp
    brew install pkg-config  # for fftw
    brew install open-mpi
    brew install openblas    # for PSATD in RZ


### PR DESCRIPTION
Fix:
```
$ cmake -S . -B build_dp ...
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
...
CMake Error at /usr/local/Cellar/cmake/3.24.2/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
-- Configuring incomplete, errors occurred!
  Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES)
```

```
libomp 14.0.6 is already installed but outdated (so it will be upgraded).
==> Downloading https://ghcr.io/v2/homebrew/core/libomp/manifests/15.0.2
==> Downloading https://ghcr.io/v2/homebrew/core/libomp/blobs/sha256:a4e0796616d09221e2a486c95f9aa7c12d3c617e594b1d463a8f479bd4fa45c2
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:a4e0796616d09221e2a486c95f9aa7c12d3c617e594b1d463a8f479bd4fa45c2?se=2022-10-13T20%3A50%3A00Z&sig=a68J671xfsvWip4TqYo5%2B2E0U5AswwCQDocHLNc6XXE%3D&sp=r&spr=https&sr=b&sv=2019-12-12
==> Upgrading libomp
  14.0.6 -> 15.0.2

==> Pouring libomp--15.0.2.big_sur.bottle.tar.gz
==> Caveats
libomp is keg-only, which means it was not symlinked into /usr/local,
because it can override GCC headers and result in broken builds.

For compilers to find libomp you may need to set:
  export LDFLAGS="-L/usr/local/opt/libomp/lib"
  export CPPFLAGS="-I/usr/local/opt/libomp/include"

==> Summary
🍺  /usr/local/Cellar/libomp/15.0.2: 7 files, 1.7MB
==> Running `brew cleanup libomp`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /usr/local/Cellar/libomp/14.0.6... (7 files, 1.6MB)
Removing: /Users/runner/Library/Caches/Homebrew/libomp--14.0.6... (548.8KB)
```