### PR TITLE
OLCF Jupyter: Mamba is Pre-Installed

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -344,10 +344,7 @@ When starting up a post-processing session, run this in your first cells:
    # work-around for OLCFHELP-4242
    !jupyter serverextension enable --py --sys-prefix dask_labextension
 
-   # next Jupyter cell: install a faster & better conda package manager
-   !conda install -c conda-forge -y mamba
-
-   # next cell: the software you want
+   # next Jupyter cell: the software you want
    !mamba install --quiet -c conda-forge -y openpmd-api openpmd-viewer ipympl ipywidgets fast-histogram yt
 
    # restart notebook


### PR DESCRIPTION
Mamba is now pre-installed on OLCF Jupyter base images! :)
This speeds up our setup to ~<1min (from ~10min).