### PR TITLE
[mini] Fix unused import warnings in python analysis scripts

### DIFF
--- a/Examples/Tests/ion_stopping/analysis_ion_stopping.py
+++ b/Examples/Tests/ion_stopping/analysis_ion_stopping.py
@@ -16,7 +16,7 @@ import re
 import sys
 
 import numpy as np
-from scipy.constants import c, e, epsilon_0, k, m_e, m_p
+from scipy.constants import e, epsilon_0, k, m_e, m_p
 import yt
 
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')

--- a/Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
+++ b/Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
@@ -16,8 +16,7 @@ import sys
 
 import numpy as np
 import openpmd_api as io
-from scipy.constants import c, e
-from scipy.constants import m_e, m_p
+from scipy.constants import c, e, m_e, m_p
 import yt
 
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')

--- a/Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
+++ b/Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
@@ -17,9 +17,7 @@ import sys
 import numpy as np
 import openpmd_api as io
 from scipy.constants import c, e
-from scipy.constants import epsilon_0 as eps0
 from scipy.constants import m_e, m_p
-from scipy.constants import mu_0 as mu0
 import yt
 
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')


### PR DESCRIPTION
These warnings were issued by the lgtm automated check in #3298 