### PR TITLE
Move shared functionality between `picmi.UniformDistribution` and `picmi.AnalyticDistribution` into a parent class

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -384,7 +384,7 @@ class DensityDistributionBase(object):
             species.__setattr__(f'momentum_function_u{sdir}(x,y,z)', f'({expression})/{constants.c}')
 
 
-class UniformDistribution(DensityDistributionBase, picmistandard.PICMI_UniformDistribution):
+class UniformDistribution(picmistandard.PICMI_UniformDistribution, DensityDistributionBase):
     def initialize_inputs(self, species_number, layout, species, density_scale):
 
         self.set_mangle_dict()
@@ -397,7 +397,7 @@ class UniformDistribution(DensityDistributionBase, picmistandard.PICMI_UniformDi
             species.density *= density_scale
 
 
-class AnalyticDistribution(DensityDistributionBase, picmistandard.PICMI_AnalyticDistribution):
+class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution, DensityDistributionBase):
     def initialize_inputs(self, species_number, layout, species, density_scale):
 
         self.set_mangle_dict()

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -342,11 +342,19 @@ class UniformDistribution(picmistandard.PICMI_UniformDistribution):
         species.zmin = self.lower_bound[2]
         species.zmax = self.upper_bound[2]
 
-        # --- Only constant density is supported at this time
-        species.profile = "constant"
-        species.density = self.density
-        if density_scale is not None:
-            species.density *= density_scale
+        # --- Check if the density is a simple number
+        if isinstance(self.density, float):
+            species.profile = "constant"
+            species.density = self.density
+            if density_scale is not None:
+                species.density *= density_scale
+        else:
+            species.profile = "parse_density_function"
+            if density_scale is not None:
+                raise AttributeError(
+                    "Cannot use `density_scale` with a parsable density function."
+                )
+            species.__setattr__('density_function(x,y,z)', self.density)
 
         # --- Note that WarpX takes gamma*beta as input
         if np.any(np.not_equal(self.rms_velocity, 0.)):

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -322,12 +322,13 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
 
 
 class DensityDistributionBase(object):
-    """This is a base class for several predefined density distributions, meant
-    to capture universal initialization logic."""
-    def init(self, kw):
-        self.mangle_dict = None
+    """This is a base class for several predefined density distributions. It
+    captures universal initialization logic."""
 
     def set_mangle_dict(self):
+        if not hasattr(self, 'mangle_dict'):
+            self.mangle_dict = None
+
         if hasattr(self, "user_defined_kw") and self.mangle_dict is None:
             # Only do this once so that the same variables can be used multiple
             # times

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -321,9 +321,10 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
             species.uz = self.centroid_velocity[2]/constants.c
 
 
-class UniformDistribution(picmistandard.PICMI_UniformDistribution):
-    def initialize_inputs(self, species_number, layout, species, density_scale):
-
+class DensityDistributionBase(object):
+    """This is a base class for several predefined density distributions, meant
+    to capture universal initialization logic."""
+    def set_species_attributes(self, species, layout):
         if isinstance(layout, GriddedLayout):
             # --- Note that the grid attribute of GriddedLayout is ignored
             species.injection_style = "nuniformpercell"
@@ -341,78 +342,14 @@ class UniformDistribution(picmistandard.PICMI_UniformDistribution):
         species.ymax = self.upper_bound[1]
         species.zmin = self.lower_bound[2]
         species.zmax = self.upper_bound[2]
-
-        # --- Check if the density is a simple number
-        if isinstance(self.density, float):
-            species.profile = "constant"
-            species.density = self.density
-            if density_scale is not None:
-                species.density *= density_scale
-        else:
-            species.profile = "parse_density_function"
-            if density_scale is not None:
-                raise AttributeError(
-                    "Cannot use `density_scale` with a parsable density function."
-                )
-            species.__setattr__('density_function(x,y,z)', self.density)
-
-        # --- Note that WarpX takes gamma*beta as input
-        if np.any(np.not_equal(self.rms_velocity, 0.)):
-            species.momentum_distribution_type = "gaussian"
-            species.ux_m = self.directed_velocity[0]/constants.c
-            species.uy_m = self.directed_velocity[1]/constants.c
-            species.uz_m = self.directed_velocity[2]/constants.c
-            species.ux_th = self.rms_velocity[0]/constants.c
-            species.uy_th = self.rms_velocity[1]/constants.c
-            species.uz_th = self.rms_velocity[2]/constants.c
-        else:
-            species.momentum_distribution_type = "constant"
-            species.ux = self.directed_velocity[0]/constants.c
-            species.uy = self.directed_velocity[1]/constants.c
-            species.uz = self.directed_velocity[2]/constants.c
 
         if self.fill_in:
             species.do_continuous_injection = 1
 
-
-class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution):
-    def init(self, kw):
-        self.mangle_dict = None
-
-    def initialize_inputs(self, species_number, layout, species, density_scale):
-
-        if isinstance(layout, GriddedLayout):
-            # --- Note that the grid attribute of GriddedLayout is ignored
-            species.injection_style = "nuniformpercell"
-            species.num_particles_per_cell_each_dim = layout.n_macroparticle_per_cell
-        elif isinstance(layout, PseudoRandomLayout):
-            assert (layout.n_macroparticles_per_cell is not None), Exception('WarpX only supports n_macroparticles_per_cell for the PseudoRandomLayout with UniformDistribution')
-            species.injection_style = "nrandompercell"
-            species.num_particles_per_cell = layout.n_macroparticles_per_cell
-        else:
-            raise Exception('WarpX does not support the specified layout for UniformDistribution')
-
-        species.xmin = self.lower_bound[0]
-        species.xmax = self.upper_bound[0]
-        species.ymin = self.lower_bound[1]
-        species.ymax = self.upper_bound[1]
-        species.zmin = self.lower_bound[2]
-        species.zmax = self.upper_bound[2]
-
-        if self.mangle_dict is None:
-            # Only do this once so that the same variables are used in this distribution
-            # is used multiple times
-            self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
-        expression = pywarpx.my_constants.mangle_expression(self.density_expression, self.mangle_dict)
-
-        species.profile = "parse_density_function"
-        if density_scale is None:
-            species.__setattr__('density_function(x,y,z)', expression)
-        else:
-            species.__setattr__('density_function(x,y,z)', "{}*({})".format(density_scale, expression))
-
         # --- Note that WarpX takes gamma*beta as input
-        if np.any(np.not_equal(self.momentum_expressions, None)):
+        if (hasattr(self, "momentum_expressions")
+            and np.any(np.not_equal(self.momentum_expressions, None))
+        ):
             species.momentum_distribution_type = 'parse_momentum_function'
             self.setup_parse_momentum_functions(species)
         elif np.any(np.not_equal(self.rms_velocity, 0.)):
@@ -429,9 +366,6 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution):
             species.uy = self.directed_velocity[1]/constants.c
             species.uz = self.directed_velocity[2]/constants.c
 
-        if self.fill_in:
-            species.do_continuous_injection = 1
-
     def setup_parse_momentum_functions(self, species):
         for sdir, idir in zip(['x', 'y', 'z'], [0, 1, 2]):
             if self.momentum_expressions[idir] is not None:
@@ -439,6 +373,40 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution):
             else:
                 expression = f'{self.directed_velocity[idir]}'
             species.__setattr__(f'momentum_function_u{sdir}(x,y,z)', f'({expression})/{constants.c}')
+
+
+class UniformDistribution(DensityDistributionBase, picmistandard.PICMI_UniformDistribution):
+    def initialize_inputs(self, species_number, layout, species, density_scale):
+
+        self.set_species_attributes(species, layout)
+
+        # --- Only constant density is supported by this class
+        species.profile = "constant"
+        species.density = self.density
+        if density_scale is not None:
+            species.density *= density_scale
+
+
+class AnalyticDistribution(DensityDistributionBase, picmistandard.PICMI_AnalyticDistribution):
+    def init(self, kw):
+        self.mangle_dict = None
+
+    def initialize_inputs(self, species_number, layout, species, density_scale):
+
+        self.set_species_attributes(species, layout)
+
+        if self.mangle_dict is None:
+            # Only do this once so that the same variables are used in this distribution
+            # is used multiple times
+            self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
+        expression = pywarpx.my_constants.mangle_expression(self.density_expression, self.mangle_dict)
+
+        species.profile = "parse_density_function"
+        if density_scale is None:
+            species.__setattr__('density_function(x,y,z)', expression)
+        else:
+            species.__setattr__('density_function(x,y,z)', "{}*({})".format(density_scale, expression))
+
 
 class ParticleListDistribution(picmistandard.PICMI_ParticleListDistribution):
     def init(self, kw):


### PR DESCRIPTION
Just a quick PR to allow a density function to be used in Python initialized simulations.