### PR TITLE
[WIP] Turn off managed memory by default

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -23,6 +23,8 @@ namespace {
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
         pp_amrex.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        bool the_arena_is_managed = false; // AMReX' default: true
+        pp_amrex.queryAdd("the_arena_is_managed", the_arena_is_managed);
 
         // Work-around:
         // If warpx.numprocs is used for the domain decomposition, we will not use blocking factor


### PR DESCRIPTION
The default in `amrex` is to have managed memory ON by default.
However, this can affect performance if in the code is inadvertently accessing GPU memory from the CPU. @WeiqunZhang also reported that this can in some cases lower the performance of GPU-aware MPI.

It is probably better to turn managed memory OFF by default.