### PR TITLE
Warn the user of possible instabilities if PML and PSATD are used together

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -431,6 +431,8 @@ WarpX::InitData ()
     }
 
     PerformanceHints();
+
+    CheckKnownIssues();
 }
 
 void
@@ -1261,4 +1263,18 @@ void WarpX::InitializeEBGridData (int lev)
 #else
     amrex::ignore_unused(lev);
 #endif
+}
+
+void WarpX::CheckKnownIssues()
+{
+    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD &&
+        (std::any_of(do_pml_Lo[0].begin(),do_pml_Lo[0].end(),[](const auto& ee){return ee;}) ||
+        std::any_of(do_pml_Hi[0].begin(),do_pml_Hi[0].end(),[](const auto& ee){return ee;})) )
+        {
+            ablastr::warn_manager::WMRecordWarning(
+                "PML",
+                "Using PSATD together with PML may lead to instabilities if the plasma touches the PML region. "
+                "It is recommended to leave enough empty space between the plama boundary and the PML region.",
+                ablastr::warn_manager::WarnPriority::low);
+        }
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1068,6 +1068,11 @@ private:
      */
     void CheckGuardCells(amrex::MultiFab const& mf);
 
+    /**
+     * \brief Checks for known numerical issues involving different WarpX modules
+     */
+    void CheckKnownIssues();
+
     /** Check the requested resources and write performance hints */
     void PerformanceHints ();
 


### PR DESCRIPTION
This PR adds a warning if PML and PSATD are used together.
It should mitigate issue https://github.com/ECP-WarpX/WarpX/issues/3425