### PR TITLE
Modify naming of species in CI fusion test

### DIFF
--- a/Examples/Modules/nuclear_fusion/analysis_deuterium_tritium_fusion.py
+++ b/Examples/Modules/nuclear_fusion/analysis_deuterium_tritium_fusion.py
@@ -50,12 +50,12 @@ default_tol = 1.e-12 # Default relative tolerance
 
 ## Define reactants and products
 reactant_species = ['deuterium', 'tritium']
-product_species = ['helium', 'neutron']
+product_species = ['helium4', 'neutron']
 
 mass = {
     'deuterium': 2.01410177812*scc.m_u,
     'tritium': 3.0160492779*scc.m_u,
-    'helium': 4.00260325413*scc.m_u,
+    'helium4': 4.00260325413*scc.m_u,
     'neutron': 1.0013784193052508*scc.m_p
 }
 m_reduced = np.product([mass[s] for s in reactant_species])/np.sum([mass[s] for s in reactant_species])
@@ -390,11 +390,11 @@ def main():
         data = {}
 
         for species_name in reactant_species:
-            add_species_to_dict(ad_start, data, species_name+str(i), species_name, "start")
-            add_species_to_dict(ad_end, data, species_name+str(i), species_name, "end")
+            add_species_to_dict(ad_start, data, species_name+'_'+str(i), species_name, "start")
+            add_species_to_dict(ad_end, data, species_name+'_'+str(i), species_name, "end")
 
         for species_name in product_species:
-            add_species_to_dict(ad_end, data, species_name+str(i), species_name, "end")
+            add_species_to_dict(ad_end, data, species_name+'_'+str(i), species_name, "end")
 
         # General checks that are performed for all tests
         generic_check(data)

--- a/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
+++ b/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
@@ -98,7 +98,7 @@ deuterium_2.momentum_distribution_type = "constant"
 deuterium_2.do_not_push = 1
 deuterium_2.do_not_deposit = 1
 
-helium4_2.species_type = helium4_4
+helium4_2.species_type = helium4
 helium4_2.do_not_push = 1
 helium4_2.do_not_deposit = 1
 

--- a/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
+++ b/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
@@ -29,7 +29,7 @@ algo.particle_shape = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.species_names = deuterium1 tritium1 helium1 neutron1 deuterium2 tritium2 helium2 neutron2
+particles.species_names = deuterium_1 deuterium_1 helium4_1 neutron_1 deuterium_2 deuterium_2 helium4_2 neutron_2
 
 my_constants.m_deuterium = 2.01410177812*m_u
 my_constants.m_tritium = 3.0160492779*m_u
@@ -37,87 +37,87 @@ my_constants.m_reduced = m_deuterium*m_tritium/(m_deuterium+m_tritium)
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
 
-deuterium1.species_type = deuterium
-deuterium1.injection_style = "NRandomPerCell"
-deuterium1.num_particles_per_cell = 10000
-deuterium1.profile = constant
-deuterium1.density = 1.
-deuterium1.momentum_distribution_type = "parse_momentum_function"
-deuterium1.momentum_function_ux(x,y,z) = 0.
-deuterium1.momentum_function_uy(x,y,z) = 0.
+deuterium_1.species_type = deuterium
+deuterium_1.injection_style = "NRandomPerCell"
+deuterium_1.num_particles_per_cell = 10000
+deuterium_1.profile = constant
+deuterium_1.density = 1.
+deuterium_1.momentum_distribution_type = "parse_momentum_function"
+deuterium_1.momentum_function_ux(x,y,z) = 0.
+deuterium_1.momentum_function_uy(x,y,z) = 0.
 ## Thanks to the floor, all particles in the same cell have the exact same momentum
-deuterium1.momentum_function_uz(x,y,z) = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight)
-deuterium1.do_not_push = 1
-deuterium1.do_not_deposit = 1
+deuterium_1.momentum_function_uz(x,y,z) = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight)
+deuterium_1.do_not_push = 1
+deuterium_1.do_not_deposit = 1
 
-tritium1.species_type = tritium
-tritium1.injection_style = "NRandomPerCell"
-tritium1.num_particles_per_cell = 10000
-tritium1.profile = constant
-tritium1.density = 1.
-tritium1.momentum_distribution_type = "parse_momentum_function"
-tritium1.momentum_function_ux(x,y,z) = 0.
-tritium1.momentum_function_uy(x,y,z) = 0.
+deuterium_1.species_type = tritium
+deuterium_1.injection_style = "NRandomPerCell"
+deuterium_1.num_particles_per_cell = 10000
+deuterium_1.profile = constant
+deuterium_1.density = 1.
+deuterium_1.momentum_distribution_type = "parse_momentum_function"
+deuterium_1.momentum_function_ux(x,y,z) = 0.
+deuterium_1.momentum_function_uy(x,y,z) = 0.
 ## Thanks to the floor, all particles in the same cell have the exact same momentum
-tritium1.momentum_function_uz(x,y,z) = -sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight)
-tritium1.do_not_push = 1
-tritium1.do_not_deposit = 1
+deuterium_1.momentum_function_uz(x,y,z) = -sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight)
+deuterium_1.do_not_push = 1
+deuterium_1.do_not_deposit = 1
 
-helium1.species_type = helium4
-helium1.do_not_push = 1
-helium1.do_not_deposit = 1
+helium4_1.species_type = helium4
+helium4_1.do_not_push = 1
+helium4_1.do_not_deposit = 1
 
-neutron1.species_type = neutron
-neutron1.do_not_push = 1
-neutron1.do_not_deposit = 1
+neutron_1.species_type = neutron
+neutron_1.do_not_push = 1
+neutron_1.do_not_deposit = 1
 
 my_constants.background_dens = 1.e26
 my_constants.beam_dens = 1.e20
 
-deuterium2.species_type = deuterium
-deuterium2.injection_style = "NRandomPerCell"
-deuterium2.num_particles_per_cell = 1000
-deuterium2.profile = "parse_density_function"
+deuterium_2.species_type = deuterium
+deuterium_2.injection_style = "NRandomPerCell"
+deuterium_2.num_particles_per_cell = 1000
+deuterium_2.profile = "parse_density_function"
 ## A tenth of the macroparticles in each cell is made of immobile high-density background deuteriums.
 ## The other nine tenths are made of fast low-density beam deuteriums.
-deuterium2.density_function(x,y,z) = if(y - floor(y) < 0.1, 10.*background_dens, 10./9.*beam_dens)
-deuterium2.momentum_distribution_type = "parse_momentum_function"
-deuterium2.momentum_function_ux(x,y,z) = 0.
-deuterium2.momentum_function_uy(x,y,z) = 0.
-deuterium2.momentum_function_uz(x,y,z) = "if(y - floor(y) < 0.1,
+deuterium_2.density_function(x,y,z) = if(y - floor(y) < 0.1, 10.*background_dens, 10./9.*beam_dens)
+deuterium_2.momentum_distribution_type = "parse_momentum_function"
+deuterium_2.momentum_function_ux(x,y,z) = 0.
+deuterium_2.momentum_function_uy(x,y,z) = 0.
+deuterium_2.momentum_function_uz(x,y,z) = "if(y - floor(y) < 0.1,
                                           0., sqrt(2*m_deuterium*Energy_step*(floor(z)**2))/(m_deuterium*clight))"
-deuterium2.do_not_push = 1
-deuterium2.do_not_deposit = 1
+deuterium_2.do_not_push = 1
+deuterium_2.do_not_deposit = 1
 
-tritium2.species_type = tritium
-tritium2.injection_style = "NRandomPerCell"
-tritium2.num_particles_per_cell = 100
-tritium2.profile = constant
-tritium2.density = background_dens
-tritium2.momentum_distribution_type = "constant"
-tritium2.do_not_push = 1
-tritium2.do_not_deposit = 1
+deuterium_2.species_type = tritium
+deuterium_2.injection_style = "NRandomPerCell"
+deuterium_2.num_particles_per_cell = 100
+deuterium_2.profile = constant
+deuterium_2.density = background_dens
+deuterium_2.momentum_distribution_type = "constant"
+deuterium_2.do_not_push = 1
+deuterium_2.do_not_deposit = 1
 
-helium2.species_type = helium4
-helium2.do_not_push = 1
-helium2.do_not_deposit = 1
+helium4_2.species_type = helium4_4
+helium4_2.do_not_push = 1
+helium4_2.do_not_deposit = 1
 
-neutron2.species_type = neutron
-neutron2.do_not_push = 1
-neutron2.do_not_deposit = 1
+neutron_2.species_type = neutron
+neutron_2.do_not_push = 1
+neutron_2.do_not_deposit = 1
 
 #################################
 ############ COLLISION ##########
 #################################
 collisions.collision_names = DTF1 DTF2
 
-DTF1.species = deuterium1 tritium1
-DTF1.product_species = helium1 neutron1
+DTF1.species = deuterium_1 deuterium_1
+DTF1.product_species = helium4_1 neutron_1
 DTF1.type = nuclearfusion
 DTF1.fusion_multiplier = 1.e50
 
-DTF2.species = deuterium2 tritium2
-DTF2.product_species = helium2 neutron2
+DTF2.species = deuterium_2 deuterium_2
+DTF2.product_species = helium4_2 neutron_2
 DTF2.type = nuclearfusion
 DTF2.fusion_multiplier = 1.e15
 DTF2.fusion_probability_target_value = 0.02

--- a/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
+++ b/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_3d
@@ -29,7 +29,7 @@ algo.particle_shape = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.species_names = deuterium_1 deuterium_1 helium4_1 neutron_1 deuterium_2 deuterium_2 helium4_2 neutron_2
+particles.species_names = deuterium_1 tritium_1 helium4_1 neutron_1 deuterium_2 tritium_2 helium4_2 neutron_2
 
 my_constants.m_deuterium = 2.01410177812*m_u
 my_constants.m_tritium = 3.0160492779*m_u
@@ -50,18 +50,18 @@ deuterium_1.momentum_function_uz(x,y,z) = sqrt(2*m_reduced*Energy_step*(floor(z)
 deuterium_1.do_not_push = 1
 deuterium_1.do_not_deposit = 1
 
-deuterium_1.species_type = tritium
-deuterium_1.injection_style = "NRandomPerCell"
-deuterium_1.num_particles_per_cell = 10000
-deuterium_1.profile = constant
-deuterium_1.density = 1.
-deuterium_1.momentum_distribution_type = "parse_momentum_function"
-deuterium_1.momentum_function_ux(x,y,z) = 0.
-deuterium_1.momentum_function_uy(x,y,z) = 0.
+tritium_1.species_type = tritium
+tritium_1.injection_style = "NRandomPerCell"
+tritium_1.num_particles_per_cell = 10000
+tritium_1.profile = constant
+tritium_1.density = 1.
+tritium_1.momentum_distribution_type = "parse_momentum_function"
+tritium_1.momentum_function_ux(x,y,z) = 0.
+tritium_1.momentum_function_uy(x,y,z) = 0.
 ## Thanks to the floor, all particles in the same cell have the exact same momentum
-deuterium_1.momentum_function_uz(x,y,z) = -sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight)
-deuterium_1.do_not_push = 1
-deuterium_1.do_not_deposit = 1
+tritium_1.momentum_function_uz(x,y,z) = -sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight)
+tritium_1.do_not_push = 1
+tritium_1.do_not_deposit = 1
 
 helium4_1.species_type = helium4
 helium4_1.do_not_push = 1
@@ -89,14 +89,14 @@ deuterium_2.momentum_function_uz(x,y,z) = "if(y - floor(y) < 0.1,
 deuterium_2.do_not_push = 1
 deuterium_2.do_not_deposit = 1
 
-deuterium_2.species_type = tritium
-deuterium_2.injection_style = "NRandomPerCell"
-deuterium_2.num_particles_per_cell = 100
-deuterium_2.profile = constant
-deuterium_2.density = background_dens
-deuterium_2.momentum_distribution_type = "constant"
-deuterium_2.do_not_push = 1
-deuterium_2.do_not_deposit = 1
+tritium_2.species_type = tritium
+tritium_2.injection_style = "NRandomPerCell"
+tritium_2.num_particles_per_cell = 100
+tritium_2.profile = constant
+tritium_2.density = background_dens
+tritium_2.momentum_distribution_type = "constant"
+tritium_2.do_not_push = 1
+tritium_2.do_not_deposit = 1
 
 helium4_2.species_type = helium4
 helium4_2.do_not_push = 1
@@ -111,12 +111,12 @@ neutron_2.do_not_deposit = 1
 #################################
 collisions.collision_names = DTF1 DTF2
 
-DTF1.species = deuterium_1 deuterium_1
+DTF1.species = deuterium_1 tritium_1
 DTF1.product_species = helium4_1 neutron_1
 DTF1.type = nuclearfusion
 DTF1.fusion_multiplier = 1.e50
 
-DTF2.species = deuterium_2 deuterium_2
+DTF2.species = deuterium_2 tritium_2
 DTF2.product_species = helium4_2 neutron_2
 DTF2.type = nuclearfusion
 DTF2.fusion_multiplier = 1.e15

--- a/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_rz
+++ b/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_rz
@@ -98,7 +98,7 @@ tritium_2.momentum_distribution_type = "constant"
 tritium_2.do_not_push = 1
 tritium_2.do_not_deposit = 1
 
-helium4_2.species_type = helium4_4
+helium4_2.species_type = helium4
 helium4_2.do_not_push = 1
 helium4_2.do_not_deposit = 1
 

--- a/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_rz
+++ b/Examples/Modules/nuclear_fusion/inputs_deuterium_tritium_rz
@@ -29,7 +29,7 @@ algo.particle_shape = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.species_names = deuterium1 tritium1 helium1 neutron1 deuterium2 tritium2 helium2 neutron2
+particles.species_names = deuterium_1 tritium_1 helium4_1 neutron_1 deuterium_2 tritium_2 helium4_2 neutron_2
 
 my_constants.m_deuterium = 2.01410177812*m_u
 my_constants.m_tritium = 3.0160492779*m_u
@@ -37,87 +37,87 @@ my_constants.m_reduced = m_deuterium*m_tritium/(m_deuterium+m_tritium)
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
 
-deuterium1.species_type = deuterium
-deuterium1.injection_style = "NRandomPerCell"
-deuterium1.num_particles_per_cell = 80000
-deuterium1.profile = constant
-deuterium1.density = 1.
-deuterium1.momentum_distribution_type = parse_momentum_function
+deuterium_1.species_type = deuterium
+deuterium_1.injection_style = "NRandomPerCell"
+deuterium_1.num_particles_per_cell = 80000
+deuterium_1.profile = constant
+deuterium_1.density = 1.
+deuterium_1.momentum_distribution_type = parse_momentum_function
 ## Thanks to the floor, all particles in the same cell have the exact same momentum
-deuterium1.momentum_function_ux(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight); if(x*x+y*y>0.0, -u*y/sqrt(x*x+y*y), 0.0)" # azimuthal velocity
-deuterium1.momentum_function_uy(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight); if(x*x+y*y>0.0, u*x/sqrt(x*x+y*y), 0.0)" # azimuthal velocity
-deuterium1.momentum_function_uz(x,y,z) = "0"
-deuterium1.do_not_push = 1
-deuterium1.do_not_deposit = 1
+deuterium_1.momentum_function_ux(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight); if(x*x+y*y>0.0, -u*y/sqrt(x*x+y*y), 0.0)" # azimuthal velocity
+deuterium_1.momentum_function_uy(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_deuterium*clight); if(x*x+y*y>0.0, u*x/sqrt(x*x+y*y), 0.0)" # azimuthal velocity
+deuterium_1.momentum_function_uz(x,y,z) = "0"
+deuterium_1.do_not_push = 1
+deuterium_1.do_not_deposit = 1
 
-tritium1.species_type = tritium
-tritium1.injection_style = "NRandomPerCell"
-tritium1.num_particles_per_cell = 80000
-tritium1.profile = constant
-tritium1.density = 1.
-tritium1.momentum_distribution_type = "parse_momentum_function"
+tritium_1.species_type = tritium
+tritium_1.injection_style = "NRandomPerCell"
+tritium_1.num_particles_per_cell = 80000
+tritium_1.profile = constant
+tritium_1.density = 1.
+tritium_1.momentum_distribution_type = "parse_momentum_function"
 ## Thanks to the floor, all particles in the same cell have the exact same momentum
-tritium1.momentum_function_ux(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight); if(x*x+y*y>0.0, u*y/sqrt(x*x+y*y), 0.0)" # counter-streaming azimuthal velocity
-tritium1.momentum_function_uy(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight); if(x*x+y*y>0.0, -u*x/sqrt(x*x+y*y), 0.0)" # counter-streaming azimuthal velocity
-tritium1.momentum_function_uz(x,y,z) = 0
-tritium1.do_not_push = 1
-tritium1.do_not_deposit = 1
+tritium_1.momentum_function_ux(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight); if(x*x+y*y>0.0, u*y/sqrt(x*x+y*y), 0.0)" # counter-streaming azimuthal velocity
+tritium_1.momentum_function_uy(x,y,z) = "u = sqrt(2*m_reduced*Energy_step*(floor(z)**2))/(m_tritium*clight); if(x*x+y*y>0.0, -u*x/sqrt(x*x+y*y), 0.0)" # counter-streaming azimuthal velocity
+tritium_1.momentum_function_uz(x,y,z) = 0
+tritium_1.do_not_push = 1
+tritium_1.do_not_deposit = 1
 
-helium1.species_type = helium4
-helium1.do_not_push = 1
-helium1.do_not_deposit = 1
+helium4_1.species_type = helium4
+helium4_1.do_not_push = 1
+helium4_1.do_not_deposit = 1
 
-neutron1.species_type = neutron
-neutron1.do_not_push = 1
-neutron1.do_not_deposit = 1
+neutron_1.species_type = neutron
+neutron_1.do_not_push = 1
+neutron_1.do_not_deposit = 1
 
 my_constants.background_dens = 1.e26
 my_constants.beam_dens = 1.e20
 
-deuterium2.species_type = deuterium
-deuterium2.injection_style = "NRandomPerCell"
-deuterium2.num_particles_per_cell = 8000
-deuterium2.profile = "parse_density_function"
+deuterium_2.species_type = deuterium
+deuterium_2.injection_style = "NRandomPerCell"
+deuterium_2.num_particles_per_cell = 8000
+deuterium_2.profile = "parse_density_function"
 ## A tenth of the macroparticles in each cell is made of immobile high-density background deuteriums.
 ## The other nine tenths are made of fast low-density beam deuteriums.
-deuterium2.density_function(x,y,z) = if(y - floor(y) < 0.1, 10.*background_dens, 10./9.*beam_dens)
-deuterium2.momentum_distribution_type = "parse_momentum_function"
-deuterium2.momentum_function_ux(x,y,z) = 0.
-deuterium2.momentum_function_uy(x,y,z) = 0.
-deuterium2.momentum_function_uz(x,y,z) = "if(y - floor(y) < 0.1,
+deuterium_2.density_function(x,y,z) = if(y - floor(y) < 0.1, 10.*background_dens, 10./9.*beam_dens)
+deuterium_2.momentum_distribution_type = "parse_momentum_function"
+deuterium_2.momentum_function_ux(x,y,z) = 0.
+deuterium_2.momentum_function_uy(x,y,z) = 0.
+deuterium_2.momentum_function_uz(x,y,z) = "if(y - floor(y) < 0.1,
                                           0., sqrt(2*m_deuterium*Energy_step*(floor(z)**2))/(m_deuterium*clight))"
-deuterium2.do_not_push = 1
-deuterium2.do_not_deposit = 1
+deuterium_2.do_not_push = 1
+deuterium_2.do_not_deposit = 1
 
-tritium2.species_type = tritium
-tritium2.injection_style = "NRandomPerCell"
-tritium2.num_particles_per_cell = 800
-tritium2.profile = constant
-tritium2.density = background_dens
-tritium2.momentum_distribution_type = "constant"
-tritium2.do_not_push = 1
-tritium2.do_not_deposit = 1
+tritium_2.species_type = tritium
+tritium_2.injection_style = "NRandomPerCell"
+tritium_2.num_particles_per_cell = 800
+tritium_2.profile = constant
+tritium_2.density = background_dens
+tritium_2.momentum_distribution_type = "constant"
+tritium_2.do_not_push = 1
+tritium_2.do_not_deposit = 1
 
-helium2.species_type = helium4
-helium2.do_not_push = 1
-helium2.do_not_deposit = 1
+helium4_2.species_type = helium4_4
+helium4_2.do_not_push = 1
+helium4_2.do_not_deposit = 1
 
-neutron2.species_type = neutron
-neutron2.do_not_push = 1
-neutron2.do_not_deposit = 1
+neutron_2.species_type = neutron
+neutron_2.do_not_push = 1
+neutron_2.do_not_deposit = 1
 
 #################################
 ############ COLLISION ##########
 #################################
 collisions.collision_names = DTF1 DTF2
 
-DTF1.species = deuterium1 tritium1
-DTF1.product_species = helium1 neutron1
+DTF1.species = deuterium_1 tritium_1
+DTF1.product_species = helium4_1 neutron_1
 DTF1.type = nuclearfusion
 DTF1.fusion_multiplier = 1.e50
 
-DTF2.species = deuterium2 tritium2
-DTF2.product_species = helium2 neutron2
+DTF2.species = deuterium_2 tritium_2
+DTF2.product_species = helium4_2 neutron_2
 DTF2.type = nuclearfusion
 DTF2.fusion_multiplier = 1.e15
 DTF2.fusion_probability_target_value = 0.02

--- a/Regression/Checksum/benchmarks_json/Deuterium_Tritium_Fusion_3D.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Tritium_Fusion_3D.json
@@ -1,5 +1,5 @@
 {
-  "deuterium1": {
+  "deuterium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 2.8875978729147693e-13,
@@ -8,7 +8,7 @@
     "particle_position_z": 81919021.52308556,
     "particle_weight": 1024.000000000021
   },
-  "deuterium2": {
+  "deuterium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 3.356807324363973e-14,
@@ -17,7 +17,7 @@
     "particle_position_z": 8191737.5566503005,
     "particle_weight": 1.0227810240779905e+29
   },
-  "helium1": {
+  "helium4_1": {
     "particle_momentum_x": 1.7519716491839538e-15,
     "particle_momentum_y": 1.7523289312260283e-15,
     "particle_momentum_z": 1.7480231586369996e-15,
@@ -26,7 +26,7 @@
     "particle_position_z": 325970.4138010667,
     "particle_weight": 4.421535775967805e-28
   },
-  "helium2": {
+  "helium4_2": {
     "particle_momentum_x": 1.5330942227771018e-15,
     "particle_momentum_y": 1.5328473121602395e-15,
     "particle_momentum_z": 1.7635828326228758e-15,
@@ -38,7 +38,7 @@
   "lev=0": {
     "rho": 0.0
   },
-  "neutron1": {
+  "neutron_1": {
     "particle_momentum_x": 1.7519716491839538e-15,
     "particle_momentum_y": 1.7523289312260283e-15,
     "particle_momentum_z": 1.7480231586369996e-15,
@@ -47,7 +47,7 @@
     "particle_position_z": 325970.4138010667,
     "particle_weight": 4.421535775967805e-28
   },
-  "neutron2": {
+  "neutron_2": {
     "particle_momentum_x": 1.5330942227771018e-15,
     "particle_momentum_y": 1.5328473121602395e-15,
     "particle_momentum_z": 1.549297051563983e-15,
@@ -56,7 +56,7 @@
     "particle_position_z": 290143.4673994485,
     "particle_weight": 5.756530048087129e+18
   },
-  "tritium1": {
+  "tritium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 2.8875978729147693e-13,
@@ -65,7 +65,7 @@
     "particle_position_z": 81920546.19181262,
     "particle_weight": 1024.000000000021
   },
-  "tritium2": {
+  "tritium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,

--- a/Regression/Checksum/benchmarks_json/Deuterium_Tritium_Fusion_RZ.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Tritium_Fusion_RZ.json
@@ -1,5 +1,5 @@
 {
-  "deuterium1": {
+  "deuterium_1": {
     "particle_momentum_x": 1.8388106511899905e-13,
     "particle_momentum_y": 1.837868790009435e-13,
     "particle_momentum_z": 0.0,
@@ -8,7 +8,7 @@
     "particle_theta": 32166860.23003994,
     "particle_weight": 3216.984554806547
   },
-  "deuterium2": {
+  "deuterium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 3.336364094249911e-14,
@@ -17,7 +17,7 @@
     "particle_theta": 3216444.348910214,
     "particle_weight": 3.1898417901971444e+29
   },
-  "helium1": {
+  "helium4_1": {
     "particle_momentum_x": 1.858124399143442e-15,
     "particle_momentum_y": 1.876715110797694e-15,
     "particle_momentum_z": 1.7098432207359157e-15,
@@ -26,7 +26,7 @@
     "particle_theta": 120064.13771707338,
     "particle_weight": 1.603083276067953e-27
   },
-  "helium2": {
+  "helium4_2": {
     "particle_momentum_x": 1.5195006688950936e-15,
     "particle_momentum_y": 1.52430083815551e-15,
     "particle_momentum_z": 1.7654865863613367e-15,
@@ -38,7 +38,7 @@
   "lev=0": {
     "rho": 0.0
   },
-  "neutron1": {
+  "neutron_1": {
     "particle_momentum_x": 1.7160671487712845e-15,
     "particle_momentum_y": 1.7154753069055672e-15,
     "particle_momentum_z": 1.7098432207359157e-15,
@@ -47,7 +47,7 @@
     "particle_theta": 120064.13771707338,
     "particle_weight": 1.603083276067953e-27
   },
-  "neutron2": {
+  "neutron_2": {
     "particle_momentum_x": 1.5195006688950936e-15,
     "particle_momentum_y": 1.52430083815551e-15,
     "particle_momentum_z": 1.5463311225724366e-15,
@@ -56,7 +56,7 @@
     "particle_theta": 107912.20520382549,
     "particle_weight": 2.0862696876352987e+19
   },
-  "tritium1": {
+  "tritium_1": {
     "particle_momentum_x": 1.8384658063720362e-13,
     "particle_momentum_y": 1.8381593257898129e-13,
     "particle_momentum_z": 0.0,
@@ -65,7 +65,7 @@
     "particle_theta": 32163925.891884565,
     "particle_weight": 3217.0912552970394
   },
-  "tritium2": {
+  "tritium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,


### PR DESCRIPTION
This slightly modifies the naming of the species in the CI fusion test.
This allows for instance to explicitly name the `helium` species `helium4`. It will useful in order to reuse the same analysis script for other reactions (e.g. D+D, which involves `helium3`).