### PR TITLE
Bugfix for "particle coordinates" with plane field probe reduced diagnostic

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -118,7 +118,7 @@ private:
     /**
      * Simple utility function to normalize the components of a "vector"
      */
-    void normalize(amrex::Real &x, amrex::Real &y, amrex::Real &z){
+    void normalize(amrex::Real AMREX_RESTRICT &x, amrex::Real AMREX_RESTRICT &y, amrex::Real AMREX_RESTRICT &z){
         amrex::Real mag = std::sqrt(x*x + y*y + z*z);
         x /= mag;
         y /= mag;

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -118,7 +118,8 @@ private:
     /**
      * Simple utility function to normalize the components of a "vector"
      */
-    void normalize(amrex::Real AMREX_RESTRICT &x, amrex::Real AMREX_RESTRICT &y, amrex::Real AMREX_RESTRICT &z){
+    void normalize(amrex::Real &AMREX_RESTRICT x, amrex::Real &AMREX_RESTRICT y,
+                   amrex::Real &AMREX_RESTRICT z){
         amrex::Real mag = std::sqrt(x*x + y*y + z*z);
         x /= mag;
         y /= mag;

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -114,6 +114,16 @@ private:
     /** Check if the probe is in the simulation domain boundary
      */
     bool ProbeInDomain () const;
+
+    /**
+     * Simple utility function to normalize the components of a "vector"
+     */
+    void normalize(amrex::Real &x, amrex::Real &y, amrex::Real &z){
+        amrex::Real mag = std::sqrt(x*x + y*y + z*z);
+        x /= mag;
+        y /= mag;
+        z /= mag;
+    }
 };
 
 #endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_FIELDPROBE_H_

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -240,31 +240,21 @@ FieldProbe::FieldProbe (std::string rd_name)
 
 void FieldProbe::InitData ()
 {
-    if (m_probe_geometry == DetectorGeometry::Point)
+    // create 1D vector for X, Y, and Z coordinates of "particles"
+    amrex::Vector<amrex::ParticleReal> xpos;
+    amrex::Vector<amrex::ParticleReal> ypos;
+    amrex::Vector<amrex::ParticleReal> zpos;
+
+    // for now, only one MPI rank adds probe "particles"
+    if (ParallelDescriptor::IOProcessor())
     {
-
-        // create 1D vector for X, Y, and Z of particles
-        amrex::Vector<amrex::ParticleReal> xpos;
-        amrex::Vector<amrex::ParticleReal> ypos;
-        amrex::Vector<amrex::ParticleReal> zpos;
-
-        // for now, only one MPI rank adds a probe particle
-        if (ParallelDescriptor::IOProcessor())
+        if (m_probe_geometry == DetectorGeometry::Point)
         {
             xpos.push_back(x_probe);
             ypos.push_back(y_probe);
             zpos.push_back(z_probe);
         }
-
-        // add particles on lev 0 to m_probe
-        m_probe.AddNParticles(0, xpos, ypos, zpos);
-    }
-    else if (m_probe_geometry == DetectorGeometry::Line)
-    {
-        amrex::Vector<amrex::ParticleReal> xpos;
-        amrex::Vector<amrex::ParticleReal> ypos;
-        amrex::Vector<amrex::ParticleReal> zpos;
-        if (ParallelDescriptor::IOProcessor())
+        else if (m_probe_geometry == DetectorGeometry::Line)
         {
             xpos.reserve(m_resolution);
             ypos.reserve(m_resolution);
@@ -282,66 +272,71 @@ void FieldProbe::InitData ()
                 zpos.push_back(z_probe + (DetLineStepSize[2] * step));
             }
         }
-        m_probe.AddNParticles(0, xpos, ypos, zpos);
-    }
-    else if (m_probe_geometry == DetectorGeometry::Plane)
-    {
-        amrex::Vector<amrex::ParticleReal> xpos;
-        amrex::Vector<amrex::ParticleReal> ypos;
-        amrex::Vector<amrex::ParticleReal> zpos;
-        if (ParallelDescriptor::IOProcessor())
+        else if (m_probe_geometry == DetectorGeometry::Plane)
         {
             std::size_t const res2 = std::size_t(m_resolution) * std::size_t(m_resolution);
             xpos.reserve(res2);
             ypos.reserve(res2);
             zpos.reserve(res2);
 
+            // ensure that input vectors are normalized
+            normalize(target_normal_x, target_normal_y, target_normal_z);
+            normalize(target_up_x, target_up_y, target_up_z);
+
             // create vector orthonormal to input vectors
             amrex::Real orthotarget[3]{
                 target_normal_y * target_up_z - target_normal_z * target_up_y,
                 target_normal_z * target_up_x - target_normal_x * target_up_z,
                 target_normal_x * target_up_y - target_normal_y * target_up_x};
+
             // find upper left and lower right bounds of detector
             amrex::Real direction[3]{
                 orthotarget[0] - target_up_x,
                 orthotarget[1] - target_up_y,
                 orthotarget[2] - target_up_z};
-            amrex::Real upperleft[3]{
+            normalize(direction[0], direction[1], direction[2]);
+            amrex::Real uppercorner[3]{
                 x_probe - (direction[0] * detector_radius),
                 y_probe - (direction[1] * detector_radius),
                 z_probe - (direction[2] * detector_radius)};
-            amrex::Real lowerright[3]{
+            amrex::Real lowercorner[3]{
+                uppercorner[0] - (target_up_x * std::sqrt(2) * detector_radius),
+                uppercorner[1] - (target_up_y * std::sqrt(2) * detector_radius),
+                uppercorner[2] - (target_up_z * std::sqrt(2) * detector_radius)};
+            amrex::Real loweropposite[3]{
                 x_probe + (direction[0] * detector_radius),
                 y_probe + (direction[1] * detector_radius),
                 z_probe + (direction[2] * detector_radius)};
+
             // create array containing point-to-point step size
-            amrex::Real DetPlaneStepSize[3]{
-                (lowerright[0] - upperleft[0]) / (m_resolution - 1),
-                (lowerright[1] - upperleft[1]) / (m_resolution - 1),
-                (lowerright[2] - upperleft[2]) / (m_resolution - 1)};
+            amrex::Real SideStepSize[3]{
+                (loweropposite[0] - lowercorner[0]) / (m_resolution - 1),
+                (loweropposite[1] - lowercorner[1]) / (m_resolution - 1),
+                (loweropposite[2] - lowercorner[2]) / (m_resolution - 1)};
+            amrex::Real UpStepSize[3]{
+                (uppercorner[0] - lowercorner[0]) / (m_resolution - 1),
+                (uppercorner[1] - lowercorner[1]) / (m_resolution - 1),
+                (uppercorner[2] - lowercorner[2]) / (m_resolution - 1)};
+
             amrex::Real temp_pos[3]{};
-            // Target point on top of plane (arbitrarily top of plane perpendicular to yz)
-            // For each point along top of plane, fill in YZ's beneath, then push back
-            for ( int step = 0; step < m_resolution; step++)
+            // Starting at the lowercorner point, step sideways and up to form
+            // a grid of equally spaced coordinate points
+            for ( int sidestep = 0; sidestep < m_resolution; sidestep++)
             {
-                temp_pos[0] = upperleft[0] + (DetPlaneStepSize[0] * step);
-                for ( int yzstep = 0; yzstep < m_resolution; yzstep++)
+                for ( int upstep = 0; upstep < m_resolution; upstep++)
                 {
-                    temp_pos[1] = upperleft[1] + (DetPlaneStepSize[1] * yzstep);
-                    temp_pos[2] = upperleft[2] + (DetPlaneStepSize[2] * yzstep);
+                    temp_pos[0] = lowercorner[0] + SideStepSize[0] * sidestep + UpStepSize[0] * upstep;
+                    temp_pos[1] = lowercorner[1] + SideStepSize[1] * sidestep + UpStepSize[1] * upstep;
+                    temp_pos[2] = lowercorner[2] + SideStepSize[2] * sidestep + UpStepSize[2] * upstep;
                     xpos.push_back(temp_pos[0]);
                     ypos.push_back(temp_pos[1]);
                     zpos.push_back(temp_pos[2]);
                 }
             }
         }
-        m_probe.AddNParticles(0, xpos, ypos, zpos);
     }
-    else
-    {
-        amrex::Abort(Utils::TextMsg::Err(
-            "Invalid probe geometry. Valid geometries are Point, Line, and Plane."));
-    }
+    // add particles on lev 0 to m_probe
+    m_probe.AddNParticles(0, xpos, ypos, zpos);
 }
 
 void FieldProbe::LoadBalance ()

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -240,6 +240,8 @@ FieldProbe::FieldProbe (std::string rd_name)
 
 void FieldProbe::InitData ()
 {
+    using namespace amrex::literals;
+
     // create 1D vector for X, Y, and Z coordinates of "particles"
     amrex::Vector<amrex::ParticleReal> xpos;
     amrex::Vector<amrex::ParticleReal> ypos;
@@ -300,9 +302,9 @@ void FieldProbe::InitData ()
                 y_probe - (direction[1] * detector_radius),
                 z_probe - (direction[2] * detector_radius)};
             amrex::Real lowercorner[3]{
-                uppercorner[0] - (target_up_x * std::sqrt(2) * detector_radius),
-                uppercorner[1] - (target_up_y * std::sqrt(2) * detector_radius),
-                uppercorner[2] - (target_up_z * std::sqrt(2) * detector_radius)};
+                uppercorner[0] - (target_up_x * std::sqrt(2_rt) * detector_radius),
+                uppercorner[1] - (target_up_y * std::sqrt(2_rt) * detector_radius),
+                uppercorner[2] - (target_up_z * std::sqrt(2_rt) * detector_radius)};
             amrex::Real loweropposite[3]{
                 x_probe + (direction[0] * detector_radius),
                 y_probe + (direction[1] * detector_radius),


### PR DESCRIPTION
I noticed that the way the coordinates for the "plane" field probe reduced diagnostic is calculated has a bug when the plane normal is along x. 
To illustrate the bug consider the following case: Let the `target_up_normal = (0, 0, 1)`, the `target_normal = (1, 0, 0)` and the probe center be at the origin with radius 1. In this case the `DetPlaneStepSize = [0, -2, -2] / (n-1)`, which results in `temp_pos[1] = temp_pos[2]` at all evaluations of the plane coordinates. 

A recent simulation I ran with the plane normal in x gave exactly this undesired outcome:
```
[0]step() [1]time(s) [2]part_x_lev0-(m) [3]part_y_lev0-(m) [4]part_z_lev0-(m) [5]part_Ex_lev0-(V/m) [6]part_Ey_lev0-(V/m) [7]part_Ez_lev0-(V/m) [8]part_Bx_lev0-(T) [9]part_By_lev0-(T) [10]part_Bz_lev0-(T) [11]part_S_lev0-(W/m^2)
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.12121212121212e-06 -7.12121212121212e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
0 0.00000000000000e+00 0.00000000000000e+00 -7.42424242424242e-06 -7.42424242424242e-06 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00 0.00000000000000e+00
...
```

The changes in this PR aligns the grid-coordinate generation with the up-vector provided as input and therefore should be accurate for arbitrary plane normals.
Also, minor code clean-up.