### PR TITLE
Docs: Dependencies w/ Ascent & SENSEI

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -25,6 +25,8 @@ Optional dependencies include:
 - `openPMD-api 0.14.2+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
+- `Ascent 0.8.0+ <https://ascent.readthedocs.io>`__: for in situ 3D visualization
+- `SENSEI 4.0.0+ <https://sensei-insitu.org>`__: for in situ analysis and visualization
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
 - `Python 3.7+ <https://www.python.org>`__


### PR DESCRIPTION
Add Ascent and SENSEI minimal versions to our dependency doc page.