### PR TITLE
Allow `None` for Maxwell solver

### DIFF
--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -23,6 +23,7 @@ warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.const_dt = 1.224744871e-07
 
+# Do not evolve the E and B fields
 algo.maxwell_solver = none
 
 # Order of particle shape factors
@@ -44,7 +45,6 @@ electron.ux_th = 0.044237441120300
 electron.uy_th = 0.044237441120300
 electron.uz_th = 0.044237441120300
 electron.ux_m  = 0.044237441120300
-electron.do_not_deposit = 1
 
 ion.charge = q_e
 ion.mass = 4.554691780000000e-30
@@ -56,7 +56,6 @@ ion.momentum_distribution_type = "gaussian"
 ion.ux_th = 0.006256118919701
 ion.uy_th = 0.006256118919701
 ion.uz_th = 0.006256118919701
-ion.do_not_deposit = 1
 
 #################################
 ############ COLLISION ##########

--- a/Examples/Tests/collision/inputs_2d
+++ b/Examples/Tests/collision/inputs_2d
@@ -21,7 +21,9 @@ boundary.field_hi = periodic periodic
 #################################
 warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
-warpx.cfl = 1.0
+warpx.const_dt = 1.224744871e-07
+
+algo.maxwell_solver = none
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -21,7 +21,9 @@ boundary.field_hi = periodic periodic periodic
 #################################
 warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
-warpx.cfl = 1.0
+warpx.const_dt = 1.224744871e-07
+
+algo.maxwell_solver = none
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/collision/inputs_3d
+++ b/Examples/Tests/collision/inputs_3d
@@ -23,6 +23,7 @@ warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.const_dt = 1.224744871e-07
 
+# Do not evolve the E and B fields
 algo.maxwell_solver = none
 
 # Order of particle shape factors
@@ -44,7 +45,6 @@ electron.ux_th = 0.044237441120300
 electron.uy_th = 0.044237441120300
 electron.uz_th = 0.044237441120300
 electron.ux_m  = 0.044237441120300
-electron.do_not_deposit = 1
 
 ion.charge = q_e
 ion.mass = 4.554691780000000e-30
@@ -56,7 +56,6 @@ ion.momentum_distribution_type = "gaussian"
 ion.ux_th = 0.006256118919701
 ion.uy_th = 0.006256118919701
 ion.uz_th = 0.006256118919701
-ion.do_not_deposit = 1
 
 #################################
 ############ COLLISION ##########

--- a/Examples/Tests/collision/inputs_rz
+++ b/Examples/Tests/collision/inputs_rz
@@ -23,6 +23,7 @@ warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
 warpx.const_dt = 1.224744871e-07
 
+# Do not evolve the E and B fields
 algo.maxwell_solver = none
 
 # Order of particle shape factors
@@ -43,7 +44,6 @@ electron.momentum_distribution_type = parse_momentum_function
 electron.momentum_function_ux(x,y,z) = "if(x*x+y*y>0.0, 1.0*x/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uy(x,y,z) = "if(x*x+y*y>0.0, 1.0*y/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uz(x,y,z) = "0"
-electron.do_not_deposit = 1
 electron.do_not_push = 1
 
 #################################

--- a/Examples/Tests/collision/inputs_rz
+++ b/Examples/Tests/collision/inputs_rz
@@ -21,7 +21,9 @@ boundary.field_hi = none periodic
 #################################
 warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
-warpx.cfl = 1.0
+warpx.const_dt = 1.224744871e-07
+
+algo.maxwell_solver = none
 
 # Order of particle shape factors
 algo.particle_shape = 1

--- a/Examples/Tests/scraping/inputs_rz
+++ b/Examples/Tests/scraping/inputs_rz
@@ -24,6 +24,7 @@ boundary.potential_hi_z = 0
 warpx.const_dt = 1.216119097e-11
 warpx.eb_implicit_function = "-(x**2-0.1**2)"
 
+# Do not evolve the E and B fields
 algo.maxwell_solver = none
 algo.field_gathering = momentum-conserving
 algo.particle_shape = 1
@@ -39,7 +40,6 @@ electron.momentum_distribution_type = parse_momentum_function
 electron.momentum_function_ux(x,y,z) = "if(x*x+y*y>0.0, -1.0*x/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uy(x,y,z) = "if(x*x+y*y>0.0, -1.0*y/sqrt(x*x+y*y), 0.0)"
 electron.momentum_function_uz(x,y,z) = "0"
-electron.do_not_deposit = 1
 electron.save_particles_at_eb = 1
 
 diagnostics.diags_names = diag1 diag2 diag3

--- a/Examples/Tests/scraping/inputs_rz
+++ b/Examples/Tests/scraping/inputs_rz
@@ -22,9 +22,9 @@ boundary.potential_lo_z = 0
 boundary.potential_hi_z = 0
 
 warpx.const_dt = 1.216119097e-11
-warpx.do_electrostatic = relativistic
 warpx.eb_implicit_function = "-(x**2-0.1**2)"
 
+algo.maxwell_solver = none
 algo.field_gathering = momentum-conserving
 algo.particle_shape = 1
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -598,7 +598,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     IntVect nge = IntVect(AMREX_D_DECL(2, 2, 2));
     IntVect ngb = IntVect(AMREX_D_DECL(2, 2, 2));
     int ngf_int = 0;
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
     IntVect ngf = IntVect(AMREX_D_DECL(ngf_int, ngf_int, ngf_int));
 
     if (do_moving_window) {
@@ -610,7 +610,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         ngf[WarpX::moving_window_dir] = std::max(ngf[WarpX::moving_window_dir], rr);
     }
 
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Increase the number of guard cells, in order to fit the extent
         // of the stencil for the spectral solver
         int ngFFt_x = do_nodal ? nox_fft : nox_fft/2;
@@ -701,9 +701,9 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     pml_edge_lengths[2] = std::make_unique<MultiFab>(amrex::convert( ba,
         WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, WarpX::ncomps, max_guard_EB );
 
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
-        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
-        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+        WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
+        WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
 
         auto const eb_fact = fieldEBFactory();
 
@@ -736,7 +736,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     sigba_fp = std::make_unique<MultiSigmaBox>(ba, dm, grid_ba_reduced, geom->CellSize(),
                                                IntVect(ncell), IntVect(delta), single_domain_box, v_sigma_sb);
 
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
         amrex::ignore_unused(lev, dt, J_in_time, rho_in_time);
 #   if(AMREX_SPACEDIM!=3)
@@ -765,7 +765,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
 
     if (cgeom)
     {
-        if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) {
+        if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
             nge = IntVect(AMREX_D_DECL(1, 1, 1));
             ngb = IntVect(AMREX_D_DECL(1, 1, 1));
         }
@@ -858,7 +858,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         sigba_cp = std::make_unique<MultiSigmaBox>(cba, cdm, grid_cba_reduced, cgeom->CellSize(),
                                                    cncells, cdelta, single_domain_box, v_sigma_sb);
 
-        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
             amrex::ignore_unused(dt);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -598,7 +598,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     IntVect nge = IntVect(AMREX_D_DECL(2, 2, 2));
     IntVect ngb = IntVect(AMREX_D_DECL(2, 2, 2));
     int ngf_int = 0;
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC) ngf_int = std::max( ngf_int, 1 );
     IntVect ngf = IntVect(AMREX_D_DECL(ngf_int, ngf_int, ngf_int));
 
     if (do_moving_window) {
@@ -610,7 +610,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         ngf[WarpX::moving_window_dir] = std::max(ngf[WarpX::moving_window_dir], rr);
     }
 
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Increase the number of guard cells, in order to fit the extent
         // of the stencil for the spectral solver
         int ngFFt_x = do_nodal ? nox_fft : nox_fft/2;
@@ -701,9 +701,9 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     pml_edge_lengths[2] = std::make_unique<MultiFab>(amrex::convert( ba,
         WarpX::GetInstance().getEfield_fp(0,2).ixType().toIntVect() ), dm, WarpX::ncomps, max_guard_EB );
 
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-        WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
-        WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
+        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
+        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
 
         auto const eb_fact = fieldEBFactory();
 
@@ -736,7 +736,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
     sigba_fp = std::make_unique<MultiSigmaBox>(ba, dm, grid_ba_reduced, geom->CellSize(),
                                                IntVect(ncell), IntVect(delta), single_domain_box, v_sigma_sb);
 
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
         amrex::ignore_unused(lev, dt, J_in_time, rho_in_time);
 #   if(AMREX_SPACEDIM!=3)
@@ -765,7 +765,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
 
     if (cgeom)
     {
-        if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) {
             nge = IntVect(AMREX_D_DECL(1, 1, 1));
             ngb = IntVect(AMREX_D_DECL(1, 1, 1));
         }
@@ -858,7 +858,7 @@ PML::PML (const int lev, const BoxArray& grid_ba, const DistributionMapping& gri
         sigba_cp = std::make_unique<MultiSigmaBox>(cba, cdm, grid_cba_reduced, cgeom->CellSize(),
                                                    cncells, cdelta, single_domain_box, v_sigma_sb);
 
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
 #ifndef WARPX_USE_PSATD
             amrex::ignore_unused(dt);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -34,7 +34,7 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const int /*i_
     amrex::IntVect cell_type = amrex::IntVect::TheNodeVector();
 #ifdef WARPX_DIM_RZ
     // For RZ spectral, all quantities are cell centered.
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
         cell_type = amrex::IntVect::TheCellVector();
 #endif
     const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev), cell_type);

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.cpp
@@ -34,7 +34,7 @@ DivEFunctor::operator()(amrex::MultiFab& mf_dst, const int dcomp, const int /*i_
     amrex::IntVect cell_type = amrex::IntVect::TheNodeVector();
 #ifdef WARPX_DIM_RZ
     // For RZ spectral, all quantities are cell centered.
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         cell_type = amrex::IntVect::TheCellVector();
 #endif
     const amrex::BoxArray& ba = amrex::convert(warpx.boxArray(m_lev), cell_type);

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -56,7 +56,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
 
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     // Apply k-space filtering when using the PSATD solver
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         if (WarpX::use_kspace_filter) {
             auto & solver = warpx.get_spectral_solver_fp(m_lev);

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -56,7 +56,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
 
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     // Apply k-space filtering when using the PSATD solver
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         if (WarpX::use_kspace_filter) {
             auto & solver = warpx.get_spectral_solver_fp(m_lev);

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -75,7 +75,7 @@ Diagnostics::BaseReadParameters ()
     // Sanity check if user requests to plot phi
     if (utils::algorithms::is_in(m_varnames_fields, "phi")){
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            warpx.do_electrostatic==ElectrostaticSolverAlgo::LabFrame,
+            warpx.electrostatic_solver_id==ElectrostaticSolverAlgo::LabFrame,
             "plot phi only works if do_electrostatic = labframe");
     }
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1131,7 +1131,7 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
           }
 
       meshes.setAttribute("fieldSolver", []() {
-          switch (WarpX::maxwell_solver_id) {
+          switch (WarpX::electromagnetic_solver_id) {
               case ElectromagneticSolverAlgo::Yee :
                   return "Yee";
               case ElectromagneticSolverAlgo::CKC :

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1132,11 +1132,11 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
 
       meshes.setAttribute("fieldSolver", []() {
           switch (WarpX::maxwell_solver_id) {
-              case MaxwellSolverAlgo::Yee :
+              case ElectromagneticSolverAlgo::Yee :
                   return "Yee";
-              case MaxwellSolverAlgo::CKC :
+              case ElectromagneticSolverAlgo::CKC :
                   return "CK";
-              case MaxwellSolverAlgo::PSATD :
+              case ElectromagneticSolverAlgo::PSATD :
                   return "PSATD";
               default:
                   return "other";

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -36,8 +36,7 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::None){ }
-    else if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)
 #if defined(WARPX_DIM_1D_Z)
@@ -64,8 +63,10 @@ WarpX::ComputeDt ()
             deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx);
 #endif
         } else {
-            amrex::Abort(Utils::TextMsg::Err(
-                "ComputeDt: Unknown algorithm"));
+            if (maxwell_solver_id != MaxwellSolverAlgo::None){
+                amrex::Abort(Utils::TextMsg::Err(
+                    "ComputeDt: Unknown algorithm"));
+            }
         }
     }
 

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -32,7 +32,15 @@
 void
 WarpX::ComputeDt ()
 {
-    // Determine
+    // Handle cases where the timestep is not limited by the speed of light
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
+        for (int lev=0; lev<=max_level; lev++) {
+            dt[lev] = const_dt;
+        }
+        return;
+    }
+
+    // Determine the appropriate timestep as limited by the speed of light
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
@@ -63,10 +71,7 @@ WarpX::ComputeDt ()
             deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx);
 #endif
         } else {
-            if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None){
-                amrex::Abort(Utils::TextMsg::Err(
-                    "ComputeDt: Unknown algorithm"));
-            }
+            amrex::Abort(Utils::TextMsg::Err("ComputeDt: Unknown algorithm"));
         }
     }
 
@@ -76,12 +81,6 @@ WarpX::ComputeDt ()
     if (do_subcycling) {
         for (int lev = max_level-1; lev >= 0; --lev) {
             dt[lev] = dt[lev+1] * refRatio(lev)[0];
-        }
-    }
-
-    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
-        for (int lev=0; lev<=max_level; lev++) {
-            dt[lev] = const_dt;
         }
     }
 }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -36,7 +36,8 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (maxwell_solver_id == MaxwellSolverAlgo::None){ }
+    else if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)
 #if defined(WARPX_DIM_1D_Z)
@@ -77,7 +78,7 @@ WarpX::ComputeDt ()
         }
     }
 
-    if (do_electrostatic != ElectrostaticSolverAlgo::None) {
+    if (maxwell_solver_id == MaxwellSolverAlgo::None) {
         for (int lev=0; lev<=max_level; lev++) {
             dt[lev] = const_dt;
         }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -36,7 +36,7 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)
 #if defined(WARPX_DIM_1D_Z)
@@ -50,20 +50,20 @@ WarpX::ComputeDt ()
         // Computation of dt for FDTD algorithm
 #ifdef WARPX_DIM_RZ
         // - In RZ geometry
-        if (maxwell_solver_id == MaxwellSolverAlgo::Yee) {
+        if (maxwell_solver_id == ElectromagneticSolverAlgo::Yee) {
             deltat = cfl * CylindricalYeeAlgorithm::ComputeMaxDt(dx,  n_rz_azimuthal_modes);
 #else
         // - In Cartesian geometry
         if (do_nodal) {
             deltat = cfl * CartesianNodalAlgorithm::ComputeMaxDt(dx);
-        } else if (maxwell_solver_id == MaxwellSolverAlgo::Yee
-                    || maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::Yee
+                    || maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
             deltat = cfl * CartesianYeeAlgorithm::ComputeMaxDt(dx);
-        } else if (maxwell_solver_id == MaxwellSolverAlgo::CKC) {
+        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) {
             deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx);
 #endif
         } else {
-            if (maxwell_solver_id != MaxwellSolverAlgo::None){
+            if (maxwell_solver_id != ElectromagneticSolverAlgo::None){
                 amrex::Abort(Utils::TextMsg::Err(
                     "ComputeDt: Unknown algorithm"));
             }
@@ -79,7 +79,7 @@ WarpX::ComputeDt ()
         }
     }
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::None) {
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::None) {
         for (int lev=0; lev<=max_level; lev++) {
             dt[lev] = const_dt;
         }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -36,7 +36,7 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)
 #if defined(WARPX_DIM_1D_Z)
@@ -50,20 +50,20 @@ WarpX::ComputeDt ()
         // Computation of dt for FDTD algorithm
 #ifdef WARPX_DIM_RZ
         // - In RZ geometry
-        if (maxwell_solver_id == ElectromagneticSolverAlgo::Yee) {
+        if (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
             deltat = cfl * CylindricalYeeAlgorithm::ComputeMaxDt(dx,  n_rz_azimuthal_modes);
 #else
         // - In Cartesian geometry
         if (do_nodal) {
             deltat = cfl * CartesianNodalAlgorithm::ComputeMaxDt(dx);
-        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::Yee
-                    || maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+        } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee
+                    || electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
             deltat = cfl * CartesianYeeAlgorithm::ComputeMaxDt(dx);
-        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) {
+        } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC) {
             deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx);
 #endif
         } else {
-            if (maxwell_solver_id != ElectromagneticSolverAlgo::None){
+            if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None){
                 amrex::Abort(Utils::TextMsg::Err(
                     "ComputeDt: Unknown algorithm"));
             }
@@ -79,7 +79,7 @@ WarpX::ComputeDt ()
         }
     }
 
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::None) {
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
         for (int lev=0; lev<=max_level; lev++) {
             dt[lev] = const_dt;
         }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -153,7 +153,7 @@ WarpX::Evolve (int numsteps)
                     FillBoundaryB_avg(guard_cells.ng_FieldGather);
                 }
                 // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
-                if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD)
+                if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
                     FillBoundaryAux(guard_cells.ng_UpdateAux);
                 UpdateAuxilaryData();
                 FillBoundaryAux(guard_cells.ng_UpdateAux);
@@ -177,7 +177,7 @@ WarpX::Evolve (int numsteps)
         ExecutePythonCallback("particleinjection");
         // Electrostatic case: only gather fields and push particles,
         // deposition and calculation of fields done further below
-        if (maxwell_solver_id == MaxwellSolverAlgo::None)
+        if (maxwell_solver_id == ElectromagneticSolverAlgo::None)
         {
             const bool skip_deposition = true;
             PushParticlesandDepose(cur_time, skip_deposition);
@@ -279,7 +279,7 @@ WarpX::Evolve (int numsteps)
         m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
 
         // Non-Maxwell solver: particles can move by an arbitrary number of cells
-        if( maxwell_solver_id == MaxwellSolverAlgo::None )
+        if( maxwell_solver_id == ElectromagneticSolverAlgo::None )
         {
             mypc->Redistribute();
         } else
@@ -413,7 +413,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
     // Push E and B from {n} to {n+1}
     // (And update guard cells immediately afterwards)
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         if (use_hybrid_QED)
         {
             WarpX::Hybrid_QED_Push(dt);
@@ -486,7 +486,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
 void WarpX::SyncCurrentAndRho ()
 {
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         if (fft_periodic_single_box)
         {
@@ -530,7 +530,7 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
 #ifdef WARPX_USE_PSATD
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD,
+        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD,
         "multi-J algorithm not implemented for FDTD"
     );
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -153,7 +153,7 @@ WarpX::Evolve (int numsteps)
                     FillBoundaryB_avg(guard_cells.ng_FieldGather);
                 }
                 // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
-                if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
+                if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD)
                     FillBoundaryAux(guard_cells.ng_UpdateAux);
                 UpdateAuxilaryData();
                 FillBoundaryAux(guard_cells.ng_UpdateAux);
@@ -177,7 +177,7 @@ WarpX::Evolve (int numsteps)
         ExecutePythonCallback("particleinjection");
         // Electrostatic case: only gather fields and push particles,
         // deposition and calculation of fields done further below
-        if (maxwell_solver_id == ElectromagneticSolverAlgo::None)
+        if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None)
         {
             const bool skip_deposition = true;
             PushParticlesandDepose(cur_time, skip_deposition);
@@ -279,7 +279,7 @@ WarpX::Evolve (int numsteps)
         m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
 
         // Non-Maxwell solver: particles can move by an arbitrary number of cells
-        if( maxwell_solver_id == ElectromagneticSolverAlgo::None )
+        if( electromagnetic_solver_id == ElectromagneticSolverAlgo::None )
         {
             mypc->Redistribute();
         } else
@@ -413,7 +413,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
     // Push E and B from {n} to {n+1}
     // (And update guard cells immediately afterwards)
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         if (use_hybrid_QED)
         {
             WarpX::Hybrid_QED_Push(dt);
@@ -486,7 +486,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
 void WarpX::SyncCurrentAndRho ()
 {
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         if (fft_periodic_single_box)
         {
@@ -530,7 +530,7 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
 #ifdef WARPX_USE_PSATD
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD,
+        WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD,
         "multi-J algorithm not implemented for FDTD"
     );
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -177,7 +177,7 @@ WarpX::Evolve (int numsteps)
         ExecutePythonCallback("particleinjection");
         // Electrostatic case: only gather fields and push particles,
         // deposition and calculation of fields done further below
-        if (do_electrostatic != ElectrostaticSolverAlgo::None)
+        if (maxwell_solver_id == MaxwellSolverAlgo::None)
         {
             const bool skip_deposition = true;
             PushParticlesandDepose(cur_time, skip_deposition);
@@ -278,8 +278,8 @@ WarpX::Evolve (int numsteps)
 
         m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
 
-        // Electrostatic solver: particles can move by an arbitrary number of cells
-        if( do_electrostatic != ElectrostaticSolverAlgo::None )
+        // Non-Maxwell solver: particles can move by an arbitrary number of cells
+        if( maxwell_solver_id == MaxwellSolverAlgo::None )
         {
             mypc->Redistribute();
         } else

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -122,7 +122,7 @@ WarpX::Evolve (int numsteps)
         // Particles have p^{n} and x^{n}.
         // is_synchronized is true.
         if (is_synchronized) {
-            if (do_electrostatic == ElectrostaticSolverAlgo::None) {
+            if (electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
                 // Not called at each iteration, so exchange all guard cells
                 FillBoundaryE(guard_cells.ng_alloc_EB);
                 FillBoundaryB(guard_cells.ng_alloc_EB);
@@ -138,7 +138,7 @@ WarpX::Evolve (int numsteps)
             }
             is_synchronized = false;
         } else {
-            if (do_electrostatic == ElectrostaticSolverAlgo::None) {
+            if (electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
                 // Beyond one step, we have E^{n} and B^{n}.
                 // Particles have p^{n-1/2} and x^{n}.
 
@@ -309,7 +309,7 @@ WarpX::Evolve (int numsteps)
             mypc->SortParticlesByBin(sort_bin_size);
         }
 
-        if( do_electrostatic != ElectrostaticSolverAlgo::None ) {
+        if( electrostatic_solver_id != ElectrostaticSolverAlgo::None ) {
             ExecutePythonCallback("beforeEsolve");
             // Electrostatic solver:
             // For each species: deposit charge and add the associated space-charge
@@ -712,7 +712,7 @@ void
 WarpX::OneStep_sub1 (Real curtime)
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        do_electrostatic == ElectrostaticSolverAlgo::None,
+        electrostatic_solver_id == ElectrostaticSolverAlgo::None,
         "Electrostatic solver cannot be used with sub-cycling."
     );
 

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -69,7 +69,7 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
         }
     }
 
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+    if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame) {
         AddSpaceChargeFieldLabFrame();
     }
     else {
@@ -79,13 +79,13 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
         for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
             WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
             if (species.initialize_self_fields ||
-                (do_electrostatic == ElectrostaticSolverAlgo::Relativistic)) {
+                (electrostatic_solver_id == ElectrostaticSolverAlgo::Relativistic)) {
                 AddSpaceChargeField(species);
             }
         }
 
         // Add the field due to the boundary potentials
-        if (do_electrostatic == ElectrostaticSolverAlgo::Relativistic){
+        if (electrostatic_solver_id == ElectrostaticSolverAlgo::Relativistic){
             AddBoundaryField();
         }
     }
@@ -311,7 +311,7 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
 #if defined(AMREX_USE_EB)
     // EB: use AMReX to directly calculate the electric field since with EB's the
     // simple finite difference scheme in WarpX::computeE sometimes fails
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
+    if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame)
     {
         // TODO: maybe make this a helper function or pass Efield_fp directly
         amrex::Vector<

--- a/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
@@ -44,7 +44,7 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
 
     // Ensure that we are using the Yee solver
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        m_fdtd_algo == MaxwellSolverAlgo::Yee,
+        m_fdtd_algo == ElectromagneticSolverAlgo::Yee,
         "The Silver-Mueller boundary conditions can only be used with the Yee solver."
     );
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -46,7 +46,7 @@ void FiniteDifferenceSolver::ComputeDivE (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
 
         ComputeDivECylindrical <CylindricalYeeAlgorithm> ( Efield, divEfield );
 
@@ -55,11 +55,11 @@ void FiniteDifferenceSolver::ComputeDivE (
 
         ComputeDivECartesian <CartesianNodalAlgorithm> ( Efield, divEfield );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
 
         ComputeDivECartesian <CartesianYeeAlgorithm> ( Efield, divEfield );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         ComputeDivECartesian <CartesianCKCAlgorithm> ( Efield, divEfield );
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -66,11 +66,11 @@ void FiniteDifferenceSolver::EvolveB (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
         ignore_unused(Gfield, face_areas);
         EvolveBCylindrical <CylindricalYeeAlgorithm> ( Bfield, Efield, lev, dt );
 #else
-    if(m_do_nodal or m_fdtd_algo != MaxwellSolverAlgo::ECT){
+    if(m_do_nodal or m_fdtd_algo != ElectromagneticSolverAlgo::ECT){
         amrex::ignore_unused(face_areas);
     }
 
@@ -78,15 +78,15 @@ void FiniteDifferenceSolver::EvolveB (
 
         EvolveBCartesian <CartesianNodalAlgorithm> ( Bfield, Efield, Gfield, lev, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
 
         EvolveBCartesian <CartesianYeeAlgorithm> ( Bfield, Efield, Gfield, lev, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveBCartesian <CartesianCKCAlgorithm> ( Bfield, Efield, Gfield, lev, dt );
 #ifdef AMREX_USE_EB
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::ECT) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         EvolveBCartesianECT(Bfield, face_areas, area_mod, ECTRhofield, Venl, flag_info_cell,
                             borrowing, lev, dt);

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
@@ -57,11 +57,11 @@ void FiniteDifferenceSolver::EvolveBPML (
 
         EvolveBPMLCartesian <CartesianNodalAlgorithm> (Bfield, Efield, dt, dive_cleaning);
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee || m_fdtd_algo == MaxwellSolverAlgo::ECT) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee || m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         EvolveBPMLCartesian <CartesianYeeAlgorithm> (Bfield, Efield, dt, dive_cleaning);
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveBPMLCartesian <CartesianCKCAlgorithm> (Bfield, Efield, dt, dive_cleaning);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -56,7 +56,7 @@ void FiniteDifferenceSolver::EvolveE (
     int lev, amrex::Real const dt ) {
 
 #ifdef AMREX_USE_EB
-    if (m_fdtd_algo != MaxwellSolverAlgo::ECT) {
+    if (m_fdtd_algo != ElectromagneticSolverAlgo::ECT) {
         amrex::ignore_unused(face_areas, ECTRhofield);
     }
 #else
@@ -66,7 +66,7 @@ void FiniteDifferenceSolver::EvolveE (
     // Select algorithm (The choice of algorithm is a runtime option,
     // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
         ignore_unused(edge_lengths);
         EvolveECylindrical <CylindricalYeeAlgorithm> ( Efield, Bfield, Jfield, Ffield, lev, dt );
 #else
@@ -74,11 +74,11 @@ void FiniteDifferenceSolver::EvolveE (
 
         EvolveECartesian <CartesianNodalAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee || m_fdtd_algo == MaxwellSolverAlgo::ECT) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee || m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         EvolveECartesian <CartesianYeeAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveECartesian <CartesianCKCAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
@@ -54,7 +54,7 @@ void FiniteDifferenceSolver::EvolveECTRho (
     const int lev) {
 
 #if !defined(WARPX_DIM_RZ) and defined(AMREX_USE_EB)
-    if (m_fdtd_algo == MaxwellSolverAlgo::ECT) {
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         EvolveRhoCartesianECT(Efield, edge_lengths, face_areas, ECTRhofield, lev);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -64,12 +64,12 @@ void FiniteDifferenceSolver::EvolveEPML (
         EvolveEPMLCartesian <CartesianNodalAlgorithm> (
             Efield, Bfield, Jfield, edge_lengths, Ffield, sigba, dt, pml_has_particles );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee || m_fdtd_algo == MaxwellSolverAlgo::ECT) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee || m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         EvolveEPMLCartesian <CartesianYeeAlgorithm> (
             Efield, Bfield, Jfield,  edge_lengths, Ffield, sigba, dt, pml_has_particles );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveEPMLCartesian <CartesianCKCAlgorithm> (
             Efield, Bfield, Jfield,  edge_lengths, Ffield, sigba, dt, pml_has_particles );

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -53,7 +53,7 @@ void FiniteDifferenceSolver::EvolveF (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee){
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
 
         EvolveFCylindrical <CylindricalYeeAlgorithm> ( Ffield, Efield, rhofield, rhocomp, dt );
 
@@ -62,11 +62,11 @@ void FiniteDifferenceSolver::EvolveF (
 
         EvolveFCartesian <CartesianNodalAlgorithm> ( Ffield, Efield, rhofield, rhocomp, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
 
         EvolveFCartesian <CartesianYeeAlgorithm> ( Ffield, Efield, rhofield, rhocomp, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveFCartesian <CartesianCKCAlgorithm> ( Ffield, Efield, rhofield, rhocomp, dt );
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
@@ -55,11 +55,11 @@ void FiniteDifferenceSolver::EvolveFPML (
 
         EvolveFPMLCartesian <CartesianNodalAlgorithm> ( Ffield, Efield, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
 
         EvolveFPMLCartesian <CartesianYeeAlgorithm> ( Ffield, Efield, dt );
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         EvolveFPMLCartesian <CartesianCKCAlgorithm> ( Ffield, Efield, dt );
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveG.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveG.cpp
@@ -51,11 +51,11 @@ void FiniteDifferenceSolver::EvolveG (
     {
         EvolveGCartesian<CartesianNodalAlgorithm>(Gfield, Bfield, dt);
     }
-    else if (m_fdtd_algo == MaxwellSolverAlgo::Yee)
+    else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee)
     {
         EvolveGCartesian<CartesianYeeAlgorithm>(Gfield, Bfield, dt);
     }
-    else if (m_fdtd_algo == MaxwellSolverAlgo::CKC)
+    else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC)
     {
         EvolveGCartesian<CartesianCKCAlgorithm>(Gfield, Bfield, dt);
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
@@ -37,7 +37,7 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
     m_do_nodal = do_nodal;
 
     // return if not FDTD
-    if (fdtd_algo == MaxwellSolverAlgo::None || fdtd_algo == MaxwellSolverAlgo::PSATD)
+    if (fdtd_algo == ElectromagneticSolverAlgo::None || fdtd_algo == ElectromagneticSolverAlgo::PSATD)
         return;
 
     // Calculate coefficients of finite-difference stencil
@@ -45,7 +45,7 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
     m_dr = cell_size[0];
     m_nmodes = WarpX::GetInstance().n_rz_azimuthal_modes;
     m_rmin = WarpX::GetInstance().Geom(0).ProbLo(0);
-    if (fdtd_algo == MaxwellSolverAlgo::Yee) {
+    if (fdtd_algo == ElectromagneticSolverAlgo::Yee) {
         CylindricalYeeAlgorithm::InitializeStencilCoefficients( cell_size,
             m_h_stencil_coefs_r, m_h_stencil_coefs_z );
         m_stencil_coefs_r.resize(m_h_stencil_coefs_r.size());
@@ -67,12 +67,12 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
         CartesianNodalAlgorithm::InitializeStencilCoefficients( cell_size,
             m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );
 
-    } else if (fdtd_algo == MaxwellSolverAlgo::Yee || fdtd_algo == MaxwellSolverAlgo::ECT) {
+    } else if (fdtd_algo == ElectromagneticSolverAlgo::Yee || fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
         CartesianYeeAlgorithm::InitializeStencilCoefficients( cell_size,
             m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );
 
-    } else if (fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         CartesianCKCAlgorithm::InitializeStencilCoefficients( cell_size,
             m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
@@ -37,7 +37,7 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
     m_do_nodal = do_nodal;
 
     // return if not FDTD
-    if (fdtd_algo == MaxwellSolverAlgo::PSATD)
+    if (fdtd_algo == MaxwellSolverAlgo::None || fdtd_algo == MaxwellSolverAlgo::PSATD)
         return;
 
     // Calculate coefficients of finite-difference stencil

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -53,7 +53,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveE (
         !m_do_nodal, "macro E-push does not work for nodal");
 
 
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
 
         if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
 
@@ -68,7 +68,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveE (
 
         }
 
-    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
         // Note : EvolveE is the same for CKC and Yee.
         // In the templated Yee and CKC calls, the core operations for EvolveE is the same.

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -880,7 +880,7 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
     // ECTRhofield must be recomputed at the very end of the Efield update to ensure
     // that ECTRhofield is consistent with Efield
 #ifdef AMREX_USE_EB
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
         if (patch_type == PatchType::fine) {
             m_fdtd_solver_fp[lev]->EvolveECTRho(Efield_fp[lev], m_edge_lengths[lev],
                                                 m_face_areas[lev], ECTRhofield[lev], lev);

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -880,7 +880,7 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
     // ECTRhofield must be recomputed at the very end of the Efield update to ensure
     // that ECTRhofield is consistent with Efield
 #ifdef AMREX_USE_EB
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
         if (patch_type == PatchType::fine) {
             m_fdtd_solver_fp[lev]->EvolveECTRho(Efield_fp[lev], m_edge_lengths[lev],
                                                 m_face_areas[lev], ECTRhofield[lev], lev);

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1240,10 +1240,7 @@ void WarpX::InitializeEBGridData (int lev)
               "particles are close to embedded boundaries");
         }
 
-        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
+        if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD ) {
 
             auto const eb_fact = fieldEBFactory(lev);
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1240,7 +1240,8 @@ void WarpX::InitializeEBGridData (int lev)
               "particles are close to embedded boundaries");
         }
 
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
             WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
             WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -165,7 +165,7 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "Operation mode:       | Electrostatic" << "\n";
       amrex::Print() << "                      | - relativistic" << "\n";
     }
-    else if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::None) {
+    else if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
       amrex::Print() << "Operation mode:       | Electromagnetic" << "\n";
     }
     if (em_solver_medium == MediumForEM::Vacuum ){
@@ -218,18 +218,18 @@ WarpX::PrintMainPICparameters ()
     amrex::Print() << "Particle Shape Factor:| " << WarpX::nox << "\n";
     amrex::Print() << "-------------------------------------------------------------------------------\n";
     // Print solver's type: Yee, CKC, ECT
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee){
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee){
       amrex::Print() << "Maxwell Solver:       | Yee \n";
     }
-    else if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC){
+    else if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC){
       amrex::Print() << "Maxwell Solver:       | CKC \n";
     }
-    else if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT){
+    else if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT){
       amrex::Print() << "Maxwell Solver:       | ECT \n";
     }
   #ifdef WARPX_USE_PSATD
     // Print PSATD solver's configuration
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD){
       amrex::Print() << "Maxwell Solver:       | PSATD \n";
       }
     if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
@@ -295,7 +295,7 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "                      | - use_hybrid_QED = true \n";
     }
 
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD){
     // Print solver's order
       std::string psatd_nox_fft, psatd_noy_fft, psatd_noz_fft;
       psatd_nox_fft = (nox_fft == -1) ? "inf" : std::to_string(nox_fft);
@@ -307,11 +307,11 @@ WarpX::PrintMainPICparameters ()
         amrex::Print() << "                      | - psatd.noy = " << psatd_noy_fft << "\n";
         amrex::Print() << "                      | - psatd.noz = " << psatd_noz_fft << "\n";
       }
-      else if (dims=="2" and WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
+      else if (dims=="2" and WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD){
         amrex::Print() << "Spectral order:       | - psatd.nox = " << psatd_nox_fft << "\n";
         amrex::Print() << "                      | - psatd.noz = " << psatd_noz_fft << "\n";
       }
-      else if (dims=="1" and WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
+      else if (dims=="1" and WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD){
         amrex::Print() << "Spectral order:       | - psatd.noz = " << psatd_noz_fft << "\n";
       }
     }
@@ -867,7 +867,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
 #ifdef AMREX_USE_EB
         // We initialize ECTRhofield consistently with the Efield
-        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
             m_fdtd_solver_fp[lev]->EvolveECTRho(Efield_fp[lev], m_edge_lengths[lev],
                                                 m_face_areas[lev], ECTRhofield[lev], lev);
 
@@ -897,7 +897,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                                     'E',
                                                     lev);
 #ifdef AMREX_USE_EB
-           if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+           if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
                // We initialize ECTRhofield consistently with the Efield
                m_fdtd_solver_cp[lev]->EvolveECTRho(Efield_cp[lev], m_edge_lengths[lev],
                                                    m_face_areas[lev], ECTRhofield[lev], lev);
@@ -1240,10 +1240,10 @@ void WarpX::InitializeEBGridData (int lev)
               "particles are close to embedded boundaries");
         }
 
-        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::None ||
-            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
-            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
-            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
+            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
+            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
 
             auto const eb_fact = fieldEBFactory(lev);
 
@@ -1252,7 +1252,7 @@ void WarpX::InitializeEBGridData (int lev)
             ComputeFaceAreas(m_face_areas[lev], eb_fact);
             ScaleAreas(m_face_areas[lev], CellSize(lev));
 
-            if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
                 MarkCells();
                 ComputeFaceExtensions();
             }
@@ -1268,7 +1268,7 @@ void WarpX::InitializeEBGridData (int lev)
 
 void WarpX::CheckKnownIssues()
 {
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD &&
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD &&
         (std::any_of(do_pml_Lo[0].begin(),do_pml_Lo[0].end(),[](const auto& ee){return ee;}) ||
         std::any_of(do_pml_Hi[0].begin(),do_pml_Hi[0].end(),[](const auto& ee){return ee;})) )
         {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -157,11 +157,11 @@ WarpX::PrintMainPICparameters ()
                      WarpX::n_rz_azimuthal_modes << "\n";
     #endif // WARPX_USE_RZ
     //Print solver's operation mode (e.g., EM or electrostatic)
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+    if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame) {
       amrex::Print() << "Operation mode:       | Electrostatic" << "\n";
       amrex::Print() << "                      | - laboratory frame" << "\n";
     }
-    else if (do_electrostatic == ElectrostaticSolverAlgo::Relativistic){
+    else if (electrostatic_solver_id == ElectrostaticSolverAlgo::Relativistic){
       amrex::Print() << "Operation mode:       | Electrostatic" << "\n";
       amrex::Print() << "                      | - relativistic" << "\n";
     }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -165,7 +165,7 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "Operation mode:       | Electrostatic" << "\n";
       amrex::Print() << "                      | - relativistic" << "\n";
     }
-    else if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::None) {
+    else if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::None) {
       amrex::Print() << "Operation mode:       | Electromagnetic" << "\n";
     }
     if (em_solver_medium == MediumForEM::Vacuum ){
@@ -218,18 +218,18 @@ WarpX::PrintMainPICparameters ()
     amrex::Print() << "Particle Shape Factor:| " << WarpX::nox << "\n";
     amrex::Print() << "-------------------------------------------------------------------------------\n";
     // Print solver's type: Yee, CKC, ECT
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee){
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee){
       amrex::Print() << "Maxwell Solver:       | Yee \n";
     }
-    else if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
+    else if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC){
       amrex::Print() << "Maxwell Solver:       | CKC \n";
     }
-    else if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+    else if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT){
       amrex::Print() << "Maxwell Solver:       | ECT \n";
     }
   #ifdef WARPX_USE_PSATD
     // Print PSATD solver's configuration
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD){
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
       amrex::Print() << "Maxwell Solver:       | PSATD \n";
       }
     if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
@@ -295,7 +295,7 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "                      | - use_hybrid_QED = true \n";
     }
 
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD){
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
     // Print solver's order
       std::string psatd_nox_fft, psatd_noy_fft, psatd_noz_fft;
       psatd_nox_fft = (nox_fft == -1) ? "inf" : std::to_string(nox_fft);
@@ -307,11 +307,11 @@ WarpX::PrintMainPICparameters ()
         amrex::Print() << "                      | - psatd.noy = " << psatd_noy_fft << "\n";
         amrex::Print() << "                      | - psatd.noz = " << psatd_noz_fft << "\n";
       }
-      else if (dims=="2" and WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD){
+      else if (dims=="2" and WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
         amrex::Print() << "Spectral order:       | - psatd.nox = " << psatd_nox_fft << "\n";
         amrex::Print() << "                      | - psatd.noz = " << psatd_noz_fft << "\n";
       }
-      else if (dims=="1" and WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD){
+      else if (dims=="1" and WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD){
         amrex::Print() << "Spectral order:       | - psatd.noz = " << psatd_noz_fft << "\n";
       }
     }
@@ -867,7 +867,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
 #ifdef AMREX_USE_EB
         // We initialize ECTRhofield consistently with the Efield
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
             m_fdtd_solver_fp[lev]->EvolveECTRho(Efield_fp[lev], m_edge_lengths[lev],
                                                 m_face_areas[lev], ECTRhofield[lev], lev);
 
@@ -897,7 +897,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                                     'E',
                                                     lev);
 #ifdef AMREX_USE_EB
-           if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+           if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
                // We initialize ECTRhofield consistently with the Efield
                m_fdtd_solver_cp[lev]->EvolveECTRho(Efield_cp[lev], m_edge_lengths[lev],
                                                    m_face_areas[lev], ECTRhofield[lev], lev);
@@ -1240,10 +1240,10 @@ void WarpX::InitializeEBGridData (int lev)
               "particles are close to embedded boundaries");
         }
 
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::None ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
 
             auto const eb_fact = fieldEBFactory(lev);
 
@@ -1252,7 +1252,7 @@ void WarpX::InitializeEBGridData (int lev)
             ComputeFaceAreas(m_face_areas[lev], eb_fact);
             ScaleAreas(m_face_areas[lev], CellSize(lev));
 
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+            if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
                 MarkCells();
                 ComputeFaceExtensions();
             }
@@ -1268,7 +1268,7 @@ void WarpX::InitializeEBGridData (int lev)
 
 void WarpX::CheckKnownIssues()
 {
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD &&
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD &&
         (std::any_of(do_pml_Lo[0].begin(),do_pml_Lo[0].end(),[](const auto& ee){return ee;}) ||
         std::any_of(do_pml_Hi[0].begin(),do_pml_Hi[0].end(),[](const auto& ee){return ee;})) )
         {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -165,7 +165,7 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "Operation mode:       | Electrostatic" << "\n";
       amrex::Print() << "                      | - relativistic" << "\n";
     }
-    else{
+    else if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::None) {
       amrex::Print() << "Operation mode:       | Electromagnetic" << "\n";
     }
     if (em_solver_medium == MediumForEM::Vacuum ){
@@ -220,7 +220,7 @@ WarpX::PrintMainPICparameters ()
     // Print solver's type: Yee, CKC, ECT
     if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee){
       amrex::Print() << "Maxwell Solver:       | Yee \n";
-      }
+    }
     else if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
       amrex::Print() << "Maxwell Solver:       | CKC \n";
     }

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -36,7 +36,7 @@ public:
      * \param noy_fft order of PSATD in y direction
      * \param noz_fft order of PSATD in z direction
      * \param nci_corr_stencil stencil of NCI corrector
-     * \param maxwell_solver_id if of Maxwell solver
+     * \param electromagnetic_solver_id if of Maxwell solver
      * \param max_level max level of the simulation
      * \param v_galilean Velocity used in the Galilean PSATD scheme
      * \param v_comoving Velocity used in the comoving PSATD scheme
@@ -59,7 +59,7 @@ public:
         const int nox,
         const int nox_fft, const int noy_fft, const int noz_fft,
         const int nci_corr_stencil,
-        const int maxwell_solver_id,
+        const int electromagnetic_solver_id,
         const int max_level,
         const amrex::Vector<amrex::Real> v_galilean,
         const amrex::Vector<amrex::Real> v_comoving,

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -41,7 +41,6 @@ public:
      * \param v_galilean Velocity used in the Galilean PSATD scheme
      * \param v_comoving Velocity used in the comoving PSATD scheme
      * \param safe_guard_cells Run in safe mode, exchanging more guard cells, and more often in the PIC loop (for debugging).
-     * \param do_electrostatic Whether to run in electrostatic mode i.e. solving the Poisson equation instead of the Maxwell equations.
      * \param do_multi_J Whether to use the multi-J PSATD scheme
      * \param fft_do_time_averaging Whether to average the E and B field in time (with PSATD) before interpolating them onto the macro-particles
      * \param do_pml whether pml is turned on (only used by RZ PSATD)
@@ -65,7 +64,6 @@ public:
         const amrex::Vector<amrex::Real> v_galilean,
         const amrex::Vector<amrex::Real> v_comoving,
         const bool safe_guard_cells,
-        const int do_electrostatic,
         const int do_multi_J,
         const bool fft_do_time_averaging,
         const bool do_pml,

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -36,7 +36,7 @@ public:
      * \param noy_fft order of PSATD in y direction
      * \param noz_fft order of PSATD in z direction
      * \param nci_corr_stencil stencil of NCI corrector
-     * \param electromagnetic_solver_id if of Maxwell solver
+     * \param electromagnetic_solver_id Integer corresponding to the type of Maxwell solver
      * \param max_level max level of the simulation
      * \param v_galilean Velocity used in the Galilean PSATD scheme
      * \param v_comoving Velocity used in the comoving PSATD scheme

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -251,7 +251,7 @@ guardCellManager::Init (
         ng_FieldSolverG = ng_alloc_EB;
     }
 #ifdef WARPX_DIM_RZ
-    else if (maxwell_solver_id == MaxwellSolverAlgo::Yee) {
+    else if (maxwell_solver_id == MaxwellSolverAlgo::None || maxwell_solver_id == MaxwellSolverAlgo::Yee) {
         ng_FieldSolver  = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverF = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverG = CylindricalYeeAlgorithm::GetMaxGuardCell();
@@ -262,8 +262,9 @@ guardCellManager::Init (
             ng_FieldSolver  = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianNodalAlgorithm::GetMaxGuardCell();
-        } else if (maxwell_solver_id == MaxwellSolverAlgo::Yee
-                   || maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        } else if (maxwell_solver_id == MaxwellSolverAlgo::None ||
+                   maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+                   maxwell_solver_id == MaxwellSolverAlgo::ECT) {
             ng_FieldSolver  = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianYeeAlgorithm::GetMaxGuardCell();

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -250,7 +250,8 @@ guardCellManager::Init (
         ng_FieldSolverG = ng_alloc_EB;
     }
 #ifdef WARPX_DIM_RZ
-    else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None || electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
+    else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
+             electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
         ng_FieldSolver  = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverF = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverG = CylindricalYeeAlgorithm::GetMaxGuardCell();

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -47,7 +47,6 @@ guardCellManager::Init (
     const amrex::Vector<amrex::Real> v_galilean,
     const amrex::Vector<amrex::Real> v_comoving,
     const bool safe_guard_cells,
-    const int do_electrostatic,
     const int do_multi_J,
     const bool fft_do_time_averaging,
     const bool do_pml,
@@ -135,7 +134,7 @@ guardCellManager::Init (
     // Electromagnetic simulations: account for change in particle positions within half a time step
     // for current deposition and within one time step for charge deposition (since rho is needed
     // both at the beginning and at the end of the PIC iteration)
-    if (do_electrostatic == ElectrostaticSolverAlgo::None)
+    if (maxwell_solver_id != MaxwellSolverAlgo::None)
     {
         for (int i = 0; i < AMREX_SPACEDIM; i++)
         {

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -134,7 +134,7 @@ guardCellManager::Init (
     // Electromagnetic simulations: account for change in particle positions within half a time step
     // for current deposition and within one time step for charge deposition (since rho is needed
     // both at the beginning and at the end of the PIC iteration)
-    if (maxwell_solver_id != MaxwellSolverAlgo::None)
+    if (maxwell_solver_id != ElectromagneticSolverAlgo::None)
     {
         for (int i = 0; i < AMREX_SPACEDIM; i++)
         {
@@ -169,7 +169,7 @@ guardCellManager::Init (
     // After pushing particle
     int ng_alloc_F_int = (do_moving_window) ? 2 : 0;
     // CKC solver requires one additional guard cell
-    if (maxwell_solver_id == MaxwellSolverAlgo::CKC) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
     ng_alloc_F = IntVect(AMREX_D_DECL(ng_alloc_F_int, ng_alloc_F_int, ng_alloc_F_int));
 
     // Used if warpx.do_divb_cleaning = 1
@@ -177,7 +177,7 @@ guardCellManager::Init (
     // TODO Does the CKC solver require one additional guard cell (as for F)?
     ng_alloc_G = IntVect(AMREX_D_DECL(ng_alloc_G_int, ng_alloc_G_int, ng_alloc_G_int));
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         // The number of guard cells should be enough to contain the stencil of the FFT solver.
         //
@@ -244,13 +244,13 @@ guardCellManager::Init (
     }
 
     // Compute number of cells required for Field Solver
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         ng_FieldSolver = ng_alloc_EB;
         ng_FieldSolverF = ng_alloc_EB;
         ng_FieldSolverG = ng_alloc_EB;
     }
 #ifdef WARPX_DIM_RZ
-    else if (maxwell_solver_id == MaxwellSolverAlgo::None || maxwell_solver_id == MaxwellSolverAlgo::Yee) {
+    else if (maxwell_solver_id == ElectromagneticSolverAlgo::None || maxwell_solver_id == ElectromagneticSolverAlgo::Yee) {
         ng_FieldSolver  = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverF = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverG = CylindricalYeeAlgorithm::GetMaxGuardCell();
@@ -261,13 +261,13 @@ guardCellManager::Init (
             ng_FieldSolver  = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianNodalAlgorithm::GetMaxGuardCell();
-        } else if (maxwell_solver_id == MaxwellSolverAlgo::None ||
-                   maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-                   maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::None ||
+                   maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
+                   maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
             ng_FieldSolver  = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianYeeAlgorithm::GetMaxGuardCell();
-        } else if (maxwell_solver_id == MaxwellSolverAlgo::CKC) {
+        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) {
             ng_FieldSolver  = CartesianCKCAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianCKCAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianCKCAlgorithm::GetMaxGuardCell();
@@ -281,7 +281,7 @@ guardCellManager::Init (
     ng_alloc_F.max( ng_FieldSolverF );
     ng_alloc_G.max( ng_FieldSolverG );
 
-    if (do_moving_window && maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (do_moving_window && maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         ng_afterPushPSATD = ng_alloc_EB;
     }
 

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -42,7 +42,7 @@ guardCellManager::Init (
     const int nox,
     const int nox_fft, const int noy_fft, const int noz_fft,
     const int nci_corr_stencil,
-    const int maxwell_solver_id,
+    const int electromagnetic_solver_id,
     const int max_level,
     const amrex::Vector<amrex::Real> v_galilean,
     const amrex::Vector<amrex::Real> v_comoving,
@@ -134,7 +134,7 @@ guardCellManager::Init (
     // Electromagnetic simulations: account for change in particle positions within half a time step
     // for current deposition and within one time step for charge deposition (since rho is needed
     // both at the beginning and at the end of the PIC iteration)
-    if (maxwell_solver_id != ElectromagneticSolverAlgo::None)
+    if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None)
     {
         for (int i = 0; i < AMREX_SPACEDIM; i++)
         {
@@ -169,7 +169,7 @@ guardCellManager::Init (
     // After pushing particle
     int ng_alloc_F_int = (do_moving_window) ? 2 : 0;
     // CKC solver requires one additional guard cell
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC) ng_alloc_F_int = std::max( ng_alloc_F_int, 1 );
     ng_alloc_F = IntVect(AMREX_D_DECL(ng_alloc_F_int, ng_alloc_F_int, ng_alloc_F_int));
 
     // Used if warpx.do_divb_cleaning = 1
@@ -177,7 +177,7 @@ guardCellManager::Init (
     // TODO Does the CKC solver require one additional guard cell (as for F)?
     ng_alloc_G = IntVect(AMREX_D_DECL(ng_alloc_G_int, ng_alloc_G_int, ng_alloc_G_int));
 
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         // The number of guard cells should be enough to contain the stencil of the FFT solver.
         //
@@ -244,13 +244,13 @@ guardCellManager::Init (
     }
 
     // Compute number of cells required for Field Solver
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         ng_FieldSolver = ng_alloc_EB;
         ng_FieldSolverF = ng_alloc_EB;
         ng_FieldSolverG = ng_alloc_EB;
     }
 #ifdef WARPX_DIM_RZ
-    else if (maxwell_solver_id == ElectromagneticSolverAlgo::None || maxwell_solver_id == ElectromagneticSolverAlgo::Yee) {
+    else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None || electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
         ng_FieldSolver  = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverF = CylindricalYeeAlgorithm::GetMaxGuardCell();
         ng_FieldSolverG = CylindricalYeeAlgorithm::GetMaxGuardCell();
@@ -261,13 +261,13 @@ guardCellManager::Init (
             ng_FieldSolver  = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianNodalAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianNodalAlgorithm::GetMaxGuardCell();
-        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::None ||
-                   maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
-                   maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+        } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
+                   electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+                   electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
             ng_FieldSolver  = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianYeeAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianYeeAlgorithm::GetMaxGuardCell();
-        } else if (maxwell_solver_id == ElectromagneticSolverAlgo::CKC) {
+        } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC) {
             ng_FieldSolver  = CartesianCKCAlgorithm::GetMaxGuardCell();
             ng_FieldSolverF = CartesianCKCAlgorithm::GetMaxGuardCell();
             ng_FieldSolverG = CartesianCKCAlgorithm::GetMaxGuardCell();
@@ -281,7 +281,7 @@ guardCellManager::Init (
     ng_alloc_F.max( ng_FieldSolverF );
     ng_alloc_G.max( ng_FieldSolverG );
 
-    if (do_moving_window && maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (do_moving_window && electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         ng_afterPushPSATD = ng_alloc_EB;
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -65,7 +65,7 @@ void
 WarpX::UpdateAuxilaryDataStagToNodal ()
 {
 #ifndef WARPX_USE_PSATD
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
             "WarpX::UpdateAuxilaryDataStagToNodal: PSATD solver requires "
             "WarpX build with spectral solver support.");

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -65,7 +65,7 @@ void
 WarpX::UpdateAuxilaryDataStagToNodal ()
 {
 #ifndef WARPX_USE_PSATD
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( false,
             "WarpX::UpdateAuxilaryDataStagToNodal: PSATD solver requires "
             "WarpX build with spectral solver support.");

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -172,13 +172,13 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+            if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::None ||
+                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
+                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
+                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
                 RemakeMultiFab(m_face_areas[lev][idim], dm, false);
-                if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){
+                if(WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT){
                     RemakeMultiFab(Venl[lev][idim], dm, false);
                     RemakeMultiFab(m_flag_info_face[lev][idim], dm, false);
                     RemakeMultiFab(m_flag_ext_face[lev][idim], dm, false);
@@ -210,7 +210,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 #endif
 
 #ifdef WARPX_USE_PSATD
-        if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
             if (spectral_solver_fp[lev] != nullptr) {
                 // Get the cell-centered box
                 BoxArray realspace_ba = ba;   // Copy box
@@ -270,7 +270,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(rho_cp[lev], dm, false);
 
 #ifdef WARPX_USE_PSATD
-            if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+            if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
                 if (spectral_solver_cp[lev] != nullptr) {
                     BoxArray cba = ba;
                     cba.coarsen(refRatio(lev-1));

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -172,13 +172,13 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::None ||
-                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
-                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
-                WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
+            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
+                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
+                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
                 RemakeMultiFab(m_face_areas[lev][idim], dm, false);
-                if(WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT){
+                if(WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT){
                     RemakeMultiFab(Venl[lev][idim], dm, false);
                     RemakeMultiFab(m_flag_info_face[lev][idim], dm, false);
                     RemakeMultiFab(m_flag_ext_face[lev][idim], dm, false);
@@ -210,7 +210,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 #endif
 
 #ifdef WARPX_USE_PSATD
-        if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+        if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
             if (spectral_solver_fp[lev] != nullptr) {
                 // Get the cell-centered box
                 BoxArray realspace_ba = ba;   // Copy box
@@ -270,7 +270,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(rho_cp[lev], dm, false);
 
 #ifdef WARPX_USE_PSATD
-            if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
+            if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
                 if (spectral_solver_cp[lev] != nullptr) {
                     BoxArray cba = ba;
                     cba.coarsen(refRatio(lev-1));

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -172,9 +172,10 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
-                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC){
+            if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
+                WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
                 RemakeMultiFab(m_face_areas[lev][idim], dm, false);
                 if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT){

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -172,10 +172,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(current_store[lev][idim], dm, false);
 
 #ifdef AMREX_USE_EB
-            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
-                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
-                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
-                WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
+            if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false);
                 RemakeMultiFab(m_face_areas[lev][idim], dm, false);
                 if(WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT){

--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -34,7 +34,7 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
     amrex::IntVect n_updated_guards;
 
     // Update both valid cells and guard cells
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
         n_updated_guards = mf.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();
@@ -65,7 +65,7 @@ WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
     amrex::IntVect n_updated_guards;
 
     // Update both valid cells and guard cells
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
         n_updated_guards = dst.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();

--- a/Source/Parallelization/WarpXSumGuardCells.H
+++ b/Source/Parallelization/WarpXSumGuardCells.H
@@ -34,7 +34,7 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
     amrex::IntVect n_updated_guards;
 
     // Update both valid cells and guard cells
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         n_updated_guards = mf.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();
@@ -65,7 +65,7 @@ WarpXSumGuardCells(amrex::MultiFab& dst, amrex::MultiFab& src,
     amrex::IntVect n_updated_guards;
 
     // Update both valid cells and guard cells
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         n_updated_guards = dst.nGrowVect();
     else  // Update only the valid cells
         n_updated_guards = amrex::IntVect::TheZeroVector();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -536,7 +536,7 @@ MultiParticleContainer::GetZeroChargeDensity (const int lev)
 
     bool is_PSATD_RZ = false;
 #ifdef WARPX_DIM_RZ
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         is_PSATD_RZ = true;
 #endif
     if( !is_PSATD_RZ )

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -536,7 +536,7 @@ MultiParticleContainer::GetZeroChargeDensity (const int lev)
 
     bool is_PSATD_RZ = false;
 #ifdef WARPX_DIM_RZ
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
         is_PSATD_RZ = true;
 #endif
     if( !is_PSATD_RZ )

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2043,13 +2043,13 @@ PhysicalParticleContainer::Evolve (int lev,
                                        np_current, np-np_current, thread_num,
                                        lev, lev-1, dt, relative_time);
                     }
-                } // end of "if do_electrostatic == ElectrostaticSolverAlgo::None"
+                } // end of "if electrostatic_solver_id == ElectrostaticSolverAlgo::None"
             } // end of "if do_not_push"
 
             if (rho && ! skip_deposition && ! do_not_deposit) {
                 // Deposit charge after particle push, in component 1 of MultiFab rho.
                 // (Skipped for electrostatic solver, as this may lead to out-of-bounds)
-                if (WarpX::do_electrostatic == ElectrostaticSolverAlgo::None) {
+                if (WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
                     int* AMREX_RESTRICT ion_lev;
                     if (do_field_ionization){
                         ion_lev = pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -735,7 +735,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 
     bool is_PSATD_RZ = false;
 #ifdef WARPX_DIM_RZ
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         is_PSATD_RZ = true;
 #endif
     if( !is_PSATD_RZ )

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -735,7 +735,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 
     bool is_PSATD_RZ = false;
 #ifdef WARPX_DIM_RZ
-    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
         is_PSATD_RZ = true;
 #endif
     if( !is_PSATD_RZ )

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -36,7 +36,7 @@ struct MacroscopicSolverAlgo {
     };
 };
 
-struct MaxwellSolverAlgo {
+struct ElectromagneticSolverAlgo {
     enum {
         None = 0,
         Yee = 1,

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -38,10 +38,11 @@ struct MacroscopicSolverAlgo {
 
 struct MaxwellSolverAlgo {
     enum {
-        Yee = 0,
-        CKC = 1,
-        PSATD = 2,
-        ECT = 3
+        None = 0,
+        Yee = 1,
+        CKC = 2,
+        PSATD = 3,
+        ECT = 4
     };
 };
 

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -22,7 +22,7 @@
 // Define dictionary with correspondance between user-input strings,
 // and corresponding integer for use inside the code
 
-const std::map<std::string, int> maxwell_solver_algo_to_int = {
+const std::map<std::string, int> electromagnetic_solver_algo_to_int = {
     {"none",    ElectromagneticSolverAlgo::None },
     {"yee",     ElectromagneticSolverAlgo::Yee },
     {"ckc",     ElectromagneticSolverAlgo::CKC },
@@ -132,14 +132,14 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
     // Pick the right dictionary
     std::map<std::string, int> algo_to_int;
     if (0 == std::strcmp(pp_search_key, "maxwell_solver")) {
-        algo_to_int = maxwell_solver_algo_to_int;
+        algo_to_int = electromagnetic_solver_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "do_electrostatic")) {
         algo_to_int = electrostatic_solver_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "particle_pusher")) {
         algo_to_int = particle_pusher_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "current_deposition")) {
         algo_to_int = current_deposition_algo_to_int;
-        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
             algo_to_int["default"] = CurrentDepositionAlgo::Direct;
     } else if (0 == std::strcmp(pp_search_key, "charge_deposition")) {
         algo_to_int = charge_deposition_algo_to_int;

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -23,6 +23,7 @@
 // and corresponding integer for use inside the code
 
 const std::map<std::string, int> maxwell_solver_algo_to_int = {
+    {"none",    MaxwellSolverAlgo::None },
     {"yee",     MaxwellSolverAlgo::Yee },
     {"ckc",     MaxwellSolverAlgo::CKC },
     {"psatd",   MaxwellSolverAlgo::PSATD },

--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -23,12 +23,12 @@
 // and corresponding integer for use inside the code
 
 const std::map<std::string, int> maxwell_solver_algo_to_int = {
-    {"none",    MaxwellSolverAlgo::None },
-    {"yee",     MaxwellSolverAlgo::Yee },
-    {"ckc",     MaxwellSolverAlgo::CKC },
-    {"psatd",   MaxwellSolverAlgo::PSATD },
-    {"ect",     MaxwellSolverAlgo::ECT },
-    {"default", MaxwellSolverAlgo::Yee }
+    {"none",    ElectromagneticSolverAlgo::None },
+    {"yee",     ElectromagneticSolverAlgo::Yee },
+    {"ckc",     ElectromagneticSolverAlgo::CKC },
+    {"psatd",   ElectromagneticSolverAlgo::PSATD },
+    {"ect",     ElectromagneticSolverAlgo::ECT },
+    {"default", ElectromagneticSolverAlgo::Yee }
 };
 
 const std::map<std::string, int> electrostatic_solver_algo_to_int = {
@@ -139,7 +139,7 @@ GetAlgorithmInteger( amrex::ParmParse& pp, const char* pp_search_key ){
         algo_to_int = particle_pusher_algo_to_int;
     } else if (0 == std::strcmp(pp_search_key, "current_deposition")) {
         algo_to_int = current_deposition_algo_to_int;
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
             algo_to_int["default"] = CurrentDepositionAlgo::Direct;
     } else if (0 == std::strcmp(pp_search_key, "charge_deposition")) {
         algo_to_int = charge_deposition_algo_to_int;

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -75,7 +75,7 @@ void ParseGeometryInput()
 #ifdef WARPX_DIM_RZ
     ParmParse pp_algo("algo");
     int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
             "Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero");
@@ -305,7 +305,7 @@ void CheckGriddingForRZSpectral ()
     int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
 
     // only check for PSATD in RZ
-    if (maxwell_solver_id != MaxwellSolverAlgo::PSATD)
+    if (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
         return;
 
     int max_level;
@@ -448,7 +448,7 @@ void ReadBCParams ()
         }
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (maxwell_solver_id != MaxwellSolverAlgo::PSATD) ||
+            (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) ||
             (
                 WarpX::field_boundary_lo[idim] != FieldBoundaryType::PEC &&
                 WarpX::field_boundary_hi[idim] != FieldBoundaryType::PEC

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -74,8 +74,8 @@ void ParseGeometryInput()
 
 #ifdef WARPX_DIM_RZ
     ParmParse pp_algo("algo");
-    int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
-    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
+    int electromagnetic_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(prob_lo[0] == 0.,
             "Lower bound of radial coordinate (prob_lo[0]) with RZ PSATD solver must be zero");
@@ -302,10 +302,10 @@ void CheckGriddingForRZSpectral ()
     CheckDims();
 
     ParmParse pp_algo("algo");
-    int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+    int electromagnetic_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
 
     // only check for PSATD in RZ
-    if (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
+    if (electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD)
         return;
 
     int max_level;
@@ -393,7 +393,7 @@ void ReadBCParams ()
     ParmParse pp_geometry("geometry");
     ParmParse pp_warpx("warpx");
     ParmParse pp_algo("algo");
-    int maxwell_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+    int electromagnetic_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !pp_geometry.queryarr("is_periodic", geom_periodicity),
@@ -448,7 +448,7 @@ void ReadBCParams ()
         }
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) ||
+            (electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) ||
             (
                 WarpX::field_boundary_lo[idim] != FieldBoundaryType::PEC &&
                 WarpX::field_boundary_hi[idim] != FieldBoundaryType::PEC

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -733,7 +733,7 @@ public:
     static const amrex::iMultiFab* CurrentBufferMasks (int lev);
     static const amrex::iMultiFab* GatherBufferMasks (int lev);
 
-    static int do_electrostatic;
+    static int electrostatic_solver_id;
 
     // Parameters for lab frame electrostatic
     static amrex::Real self_fields_required_precision;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -155,7 +155,7 @@ public:
     //! Integer that corresponds to the particle push algorithm (Boris, Vay, Higuera-Cary)
     static short particle_pusher_algo;
     //! Integer that corresponds to the type of Maxwell solver (Yee, CKC, PSATD, ECT)
-    static short maxwell_solver_id;
+    static short electromagnetic_solver_id;
     /** Records a number corresponding to the load balance cost update strategy
      *  being used (0, 1, 2 corresponding to timers, heuristic, or gpuclock).
      */

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -182,7 +182,7 @@ Real WarpX::particle_slice_width_lab = 0.0_rt;
 
 bool WarpX::do_dynamic_scheduling = true;
 
-int WarpX::do_electrostatic;
+int WarpX::electrostatic_solver_id;
 Real WarpX::self_fields_required_precision = 1.e-11_rt;
 Real WarpX::self_fields_absolute_tolerance = 0.0_rt;
 int WarpX::self_fields_max_iters = 200;
@@ -687,18 +687,18 @@ WarpX::ReadParameters ()
                    "The boosted frame diagnostic currently only works if the moving window is in the z direction.");
         }
 
-        do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
+        electrostatic_solver_id = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
         // if an electrostatic solver is used, set the Maxwell solver to None
-        if (do_electrostatic != ElectrostaticSolverAlgo::None) {
+        if (electrostatic_solver_id != ElectrostaticSolverAlgo::None) {
             maxwell_solver_id = ElectromagneticSolverAlgo::None;
         }
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_electrostatic!=ElectrostaticSolverAlgo::None,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(electrostatic_solver_id!=ElectrostaticSolverAlgo::None,
         "Currently, the embedded boundary in RZ only works for electrostatic solvers.");
 #endif
 
-        if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame) {
+        if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame) {
             // Note that with the relativistic version, these parameters would be
             // input for each species.
             utils::parser::queryWithParser(
@@ -1958,7 +1958,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     }
 #endif
 
-    bool deposit_charge = do_dive_cleaning || (do_electrostatic == ElectrostaticSolverAlgo::LabFrame);
+    bool deposit_charge = do_dive_cleaning || (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame);
     if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         deposit_charge = do_dive_cleaning || update_with_rho || current_correction;
     }
@@ -1969,7 +1969,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         rho_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,rho_nodal_flag),dm,rho_ncomps,ngRho,tag("rho_fp"));
     }
 
-    if (do_electrostatic == ElectrostaticSolverAlgo::LabFrame)
+    if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame)
     {
         IntVect ngPhi = IntVect( AMREX_D_DECL(1,1,1) );
         phi_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba,phi_nodal_flag),dm,ncomps,ngPhi,tag("phi_fp"));

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -688,6 +688,10 @@ WarpX::ReadParameters ()
         }
 
         do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
+        // if an electrostatic solver is used, set the Maxwell solver to None
+        if (do_electrostatic != ElectrostaticSolverAlgo::None) {
+            maxwell_solver_id = MaxwellSolverAlgo::None;
+        }
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_electrostatic!=ElectrostaticSolverAlgo::None,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1915,9 +1915,10 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // EB info are needed only at the finest level
     if (lev == maxLevel())
     {
-        if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee
-           || WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC
-           || WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
+            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
             m_edge_lengths[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, Ex_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[x]"));
             m_edge_lengths[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, Ey_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[y]"));
             m_edge_lengths[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Ez_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[z]"));

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1720,7 +1720,6 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         WarpX::m_v_galilean,
         WarpX::m_v_comoving,
         safe_guard_cells,
-        WarpX::do_electrostatic,
         WarpX::do_multi_J,
         WarpX::fft_do_time_averaging,
         WarpX::isAnyBoundaryPML(),

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -694,8 +694,9 @@ WarpX::ReadParameters ()
         }
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(electrostatic_solver_id!=ElectrostaticSolverAlgo::None,
-        "Currently, the embedded boundary in RZ only works for electrostatic solvers.");
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        electromagnetic_solver_id==ElectromagneticSolverAlgo::None,
+        "Currently, the embedded boundary in RZ only works for electrostatic solvers (or no solver).");
 #endif
 
         if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame) {
@@ -1914,10 +1915,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // EB info are needed only at the finest level
     if (lev == maxLevel())
     {
-        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
-            WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
+        if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
             m_edge_lengths[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, Ex_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[x]"));
             m_edge_lengths[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, Ey_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[y]"));
             m_edge_lengths[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Ez_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[z]"));

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -367,7 +367,7 @@ WarpX::WarpX ()
         && WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic)
     {
 #ifdef AMREX_USE_GPU
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
             switch (WarpX::nox)
             {
                 case 1:
@@ -408,12 +408,12 @@ WarpX::WarpX ()
 
     // Allocate field solver objects
 #ifdef WARPX_USE_PSATD
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         spectral_solver_fp.resize(nlevs_max);
         spectral_solver_cp.resize(nlevs_max);
     }
 #endif
-    if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) {
         m_fdtd_solver_fp.resize(nlevs_max);
         m_fdtd_solver_cp.resize(nlevs_max);
     }
@@ -426,7 +426,7 @@ WarpX::WarpX ()
     // Sanity checks. Must be done after calling the MultiParticleContainer
     // constructor, as it reads additional parameters
     // (e.g., use_fdtd_nci_corr)
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         AMREX_ALWAYS_ASSERT(use_fdtd_nci_corr == 0);
         AMREX_ALWAYS_ASSERT(do_subcycling == 0);
     }
@@ -690,7 +690,7 @@ WarpX::ReadParameters ()
         do_electrostatic = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
         // if an electrostatic solver is used, set the Maxwell solver to None
         if (do_electrostatic != ElectrostaticSolverAlgo::None) {
-            maxwell_solver_id = MaxwellSolverAlgo::None;
+            maxwell_solver_id = ElectromagneticSolverAlgo::None;
         }
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
@@ -725,7 +725,7 @@ WarpX::ReadParameters ()
         // Filter currently not working with FDTD solver in RZ geometry: turn OFF by default
         // (see https://github.com/ECP-WarpX/WarpX/issues/1943)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id != MaxwellSolverAlgo::PSATD) WarpX::use_filter = false;
+        if (WarpX::maxwell_solver_id != ElectromagneticSolverAlgo::PSATD) WarpX::use_filter = false;
 #endif
 
         // Read filter and fill IntVect filter_npass_each_dir with
@@ -746,7 +746,7 @@ WarpX::ReadParameters ()
         // TODO When k-space filtering will be implemented also for Cartesian geometries,
         // this code block will have to be applied in all cases (remove #ifdef condition)
 #ifdef WARPX_DIM_RZ
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
             // With RZ spectral, only use k-space filtering
             use_kspace_filter = use_filter;
             use_filter = false;
@@ -818,7 +818,7 @@ WarpX::ReadParameters ()
             {
                 // SilverMueller is implemented for Yee
                 WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                    maxwell_solver_id == MaxwellSolverAlgo::Yee,
+                    maxwell_solver_id == ElectromagneticSolverAlgo::Yee,
                     "The Silver-Mueller boundary condition can only be used with the Yee solver.");
             }
         }
@@ -839,7 +839,7 @@ WarpX::ReadParameters ()
 
         // Default values of WarpX::do_pml_dive_cleaning and WarpX::do_pml_divb_cleaning:
         // false for FDTD solver, true for PSATD solver.
-        if (maxwell_solver_id != MaxwellSolverAlgo::PSATD)
+        if (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
         {
             do_pml_dive_cleaning = false;
             do_pml_divb_cleaning = false;
@@ -857,14 +857,14 @@ WarpX::ReadParameters ()
         // If WarpX::do_divb_cleaning = true, set also WarpX::do_pml_divb_cleaning = true
         // (possibly overwritten by users in the input file, see query below)
         // TODO Implement div(B) cleaning in PML with FDTD and remove second if condition
-        if (do_divb_cleaning && maxwell_solver_id == MaxwellSolverAlgo::PSATD) do_pml_divb_cleaning = true;
+        if (do_divb_cleaning && maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) do_pml_divb_cleaning = true;
 
         // Query input parameters to use div(E) and div(B) cleaning in PMLs
         pp_warpx.query("do_pml_dive_cleaning", do_pml_dive_cleaning);
         pp_warpx.query("do_pml_divb_cleaning", do_pml_divb_cleaning);
 
         // TODO Implement div(B) cleaning in PML with FDTD and remove ASSERT
-        if (maxwell_solver_id != MaxwellSolverAlgo::PSATD)
+        if (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD)
         {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 do_pml_divb_cleaning == false,
@@ -873,7 +873,7 @@ WarpX::ReadParameters ()
 
         // Divergence cleaning in PMLs for PSATD solver implemented only
         // for both div(E) and div(B) cleaning
-        if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+        if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 do_pml_dive_cleaning == do_pml_divb_cleaning,
@@ -887,7 +887,7 @@ WarpX::ReadParameters ()
         }
 
 #ifdef WARPX_DIM_RZ
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( isAnyBoundaryPML() == false || maxwell_solver_id == MaxwellSolverAlgo::PSATD,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( isAnyBoundaryPML() == false || maxwell_solver_id == ElectromagneticSolverAlgo::PSATD,
             "PML are not implemented in RZ geometry with FDTD; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( field_boundary_lo[1] != FieldBoundaryType::PML && field_boundary_hi[1] != FieldBoundaryType::PML,
             "PML are not implemented in RZ geometry along z; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
@@ -960,11 +960,11 @@ WarpX::ReadParameters ()
     {
         ParmParse pp_algo("algo");
 #ifdef WARPX_DIM_RZ
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( maxwell_solver_id != MaxwellSolverAlgo::CKC,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( maxwell_solver_id != ElectromagneticSolverAlgo::CKC,
             "algo.maxwell_solver = ckc is not (yet) available for RZ geometry");
 #endif
 #ifndef WARPX_USE_PSATD
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( maxwell_solver_id != MaxwellSolverAlgo::PSATD,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( maxwell_solver_id != ElectromagneticSolverAlgo::PSATD,
             "algo.maxwell_solver = psatd is not supported because WarpX was built without spectral solvers");
 #endif
 
@@ -979,7 +979,7 @@ WarpX::ReadParameters ()
                 "Error : Field boundary at r=0 must be ``none``. \n");
         }
 
-        if (maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+        if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
             // Force do_nodal=true (that is, not staggered) and
             // use same shape factors in all directions, for gathering
             do_nodal = true;
@@ -1159,7 +1159,7 @@ WarpX::ReadParameters ()
         }
     }
 
-    if (maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         ParmParse pp_psatd("psatd");
         pp_psatd.query("periodic_single_box_fft", fft_periodic_single_box);
@@ -1412,7 +1412,7 @@ WarpX::ReadParameters ()
         }
     }
 
-    if (maxwell_solver_id != MaxwellSolverAlgo::PSATD ) {
+    if (maxwell_solver_id != ElectromagneticSolverAlgo::PSATD ) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (WarpX::field_boundary_lo[idim] != FieldBoundaryType::Damped) &&
@@ -1674,7 +1674,7 @@ WarpX::ClearLevel (int lev)
     rho_cp[lev].reset();
 
 #ifdef WARPX_USE_PSATD
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         spectral_solver_fp[lev].reset();
         spectral_solver_cp[lev].reset();
     }
@@ -1827,7 +1827,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         G_nodal_flag = amrex::IntVect::TheNodeVector();
     }
 #ifdef WARPX_DIM_RZ
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Force cell-centered IndexType in r and z
         Ex_nodal_flag  = IntVect::TheCellVector();
         Ey_nodal_flag  = IntVect::TheCellVector();
@@ -1914,10 +1914,10 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // EB info are needed only at the finest level
     if (lev == maxLevel())
     {
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::None ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::CKC ||
-            WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::None ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::Yee ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::CKC ||
+            WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
             m_edge_lengths[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, Ex_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[x]"));
             m_edge_lengths[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, Ey_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[y]"));
             m_edge_lengths[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Ez_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[z]"));
@@ -1925,7 +1925,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             m_face_areas[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, By_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_face_areas[y]"));
             m_face_areas[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Bz_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_face_areas[z]"));
         }
-        if(WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT) {
+        if(WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::ECT) {
             m_edge_lengths[lev][0] = std::make_unique<MultiFab>(amrex::convert(ba, Ex_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[x]"));
             m_edge_lengths[lev][1] = std::make_unique<MultiFab>(amrex::convert(ba, Ey_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[y]"));
             m_edge_lengths[lev][2] = std::make_unique<MultiFab>(amrex::convert(ba, Ez_nodal_flag), dm, ncomps, guard_cells.ng_FieldSolver, tag("m_edge_lengths[z]"));
@@ -1959,7 +1959,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 #endif
 
     bool deposit_charge = do_dive_cleaning || (do_electrostatic == ElectrostaticSolverAlgo::LabFrame);
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD) {
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD) {
         deposit_charge = do_dive_cleaning || update_with_rho || current_correction;
     }
     if (deposit_charge)
@@ -1993,7 +1993,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         G_fp[lev] = std::make_unique<MultiFab>(amrex::convert(ba, G_nodal_flag), dm, ncomps, ngG, tag("G_fp"));
     }
 
-    if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+    if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         // Allocate and initialize the spectral solver
 #ifndef WARPX_USE_PSATD
@@ -2046,7 +2046,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                                  pml_flag_false);
 #   endif
 #endif
-    } // MaxwellSolverAlgo::PSATD
+    } // ElectromagneticSolverAlgo::PSATD
     else {
         m_fdtd_solver_fp[lev] = std::make_unique<FiniteDifferenceSolver>(maxwell_solver_id, dx, do_nodal);
     }
@@ -2155,7 +2155,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             }
         }
 
-        if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD)
+        if (WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD)
         {
             // Allocate and initialize the spectral solver
 #ifndef WARPX_USE_PSATD
@@ -2190,7 +2190,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                                      pml_flag_false);
 #   endif
 #endif
-        } // MaxwellSolverAlgo::PSATD
+        } // ElectromagneticSolverAlgo::PSATD
         else {
             m_fdtd_solver_cp[lev] = std::make_unique<FiniteDifferenceSolver>(maxwell_solver_id, cdx,
                                                                              do_nodal);
@@ -2509,7 +2509,7 @@ WarpX::ComputeDivB (amrex::MultiFab& divB, int const dcomp,
 void
 WarpX::ComputeDivE(amrex::MultiFab& divE, const int lev)
 {
-    if ( WarpX::maxwell_solver_id == MaxwellSolverAlgo::PSATD ) {
+    if ( WarpX::maxwell_solver_id == ElectromagneticSolverAlgo::PSATD ) {
 #ifdef WARPX_USE_PSATD
         spectral_solver_fp[lev]->ComputeSpectralDivE( lev, Efield_aux[lev], divE );
 #else


### PR DESCRIPTION
This PR is in preparation for adding more solver options to WarpX (specifically a hybrid solver). It generalizes a non-Maxwellian option for field solvers i.e. options other than explicit electromagnetic field evolutions. As a side benefit is also immediately allows simulations to be run with no field solver (untested).