### PR TITLE
Clean Species Physical Properties

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -568,11 +568,11 @@ Particle initialization
     Type of physical species.
     Currently, the accepted species are
     ``"electron"``, ``"positron"``, ``"muon"``, ``"antimuon"``, ``"photon"``, ``"neutron"``, ``"proton"`` , ``"alpha"``,
-    ``"hydrogen1"`` (a.k.a. ``"protium"``), ``"hydrogen2"`` (a.k.a. ``"deuterium"``), ``"hydrogen3"`` (a.k.a.``"tritium"``),
+    ``"hydrogen1"`` (a.k.a. ``"protium"``), ``"hydrogen2"`` (a.k.a. ``"deuterium"``), ``"hydrogen3"`` (a.k.a. ``"tritium"``),
     ``"helium"``, ``"helium3"``, ``"helium4"``,
-    ``"lithium"``, ``"lithium6"``, ``"lithium7"``, ``"beryllium"``, ``"boron"``, ``"boron10"``, ``"boron11"``,
-    ``"carbon"``, ``"carbon12"``, ``"carbon13"``, ``"nitrogen"``, ``"nitrogen14"``, ``"nitrogen15"``,
-    ``"oxygen"``, ``"oxygen16"``, ``"oxygen17"``, ``"oxygen18"``, ``"fluorine"``, ``"neon"``, ``"neon20"``,
+    ``"lithium"``, ``"lithium6"``, ``"lithium7"``, ``"beryllium"``, ``"beryllium9"``, ``"boron"``, ``"boron10"``, ``"boron11"``,
+    ``"carbon"``, ``"carbon12"``, ``"carbon13"``, ``"carbon14"``, ``"nitrogen"``, ``"nitrogen14"``, ``"nitrogen15"``,
+    ``"oxygen"``, ``"oxygen16"``, ``"oxygen17"``, ``"oxygen18"``, ``"fluorine"``, ``"fluorine19"``, ``"neon"``, ``"neon20"``,
     ``"neon21"``, ``"neon22"``, ``"aluminium"``, ``"argon"``, ``"copper"``, ``"xenon"`` and ``"gold"``.
     The difference between ``"proton"`` and ``"hydrogen1"`` is that the mass of the latter includes also the mass
     of the bound electron (same for ``"alpha"`` and ``"helium4"``). When only the name of an element is specified, the mass

--- a/Source/Particles/SpeciesPhysicalProperties.cpp
+++ b/Source/Particles/SpeciesPhysicalProperties.cpp
@@ -40,7 +40,6 @@ namespace {
         {"tritium"    , PhysicalSpecies::hydrogen3},
         {"proton"     , PhysicalSpecies::proton},
         {"helium"     , PhysicalSpecies::helium},
-        {"alpha"      , PhysicalSpecies::alpha},
         {"helium3"    , PhysicalSpecies::helium3},
         {"helium4"    , PhysicalSpecies::helium4},
         {"alpha"      , PhysicalSpecies::alpha},
@@ -255,6 +254,9 @@ namespace {
         {PhysicalSpecies::neon22, Properties{
              amrex::Real(21.991385114) * PhysConst::m_u,
              amrex::Real(10) * PhysConst::q_e}},
+        {PhysicalSpecies::aluminium, Properties{
+             amrex::Real(26.98153853) * PhysConst::m_u,
+             amrex::Real(13) * PhysConst::q_e}},
         {PhysicalSpecies::argon, Properties{
              amrex::Real(39.948) * PhysConst::m_u,
              amrex::Real(18) * PhysConst::q_e}},


### PR DESCRIPTION
This fixes a couple of minor omissions regarding the species physical properties:
- `alpha` was listed twice in the `string_to_species` map.
- The properties of aluminium were not given. This currently leads to a crash if one tries to use aluminium. I've added the data using the NIST database, following what was done in #3090.
- beryllium9, carbon14 and fluorine19 were not included in the documentation.