### PR TITLE
Load balancing bug fix: remake MultiFabs for Vay deposition, current centering, time averaging

### DIFF
--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -173,6 +173,13 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             if (current_deposition_algo == CurrentDepositionAlgo::Vay) {
                 RemakeMultiFab(current_fp_vay[lev][idim], dm, false);
             }
+            if (do_current_centering) {
+                RemakeMultiFab(current_fp_nodal[lev][idim], dm, false);
+            }
+            if (fft_do_time_averaging) {
+                RemakeMultiFab(Efield_avg_fp[lev][idim], dm, true);
+                RemakeMultiFab(Bfield_avg_fp[lev][idim], dm, true);
+            }
 #ifdef AMREX_USE_EB
             if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
                 WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
@@ -266,8 +273,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 RemakeMultiFab(Bfield_cp[lev][idim], dm, true);
                 RemakeMultiFab(Efield_cp[lev][idim], dm, true);
                 RemakeMultiFab(current_cp[lev][idim], dm, false);
-                if (current_deposition_algo == CurrentDepositionAlgo::Vay) {
-                    RemakeMultiFab(current_fp_vay[lev][idim], dm, false);
+                if (fft_do_time_averaging) {
+                    RemakeMultiFab(Efield_avg_cp[lev][idim], dm, true);
+                    RemakeMultiFab(Bfield_avg_cp[lev][idim], dm, true);
                 }
             }
             RemakeMultiFab(F_cp[lev], dm, true);

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -1,6 +1,6 @@
 /* Copyright 2019 Andrew Myers, Ann Almgren, Axel Huebl
  * David Grote, Maxence Thevenet, Michael Rowan
- * Remi Lehe, Weiqun Zhang, levinem
+ * Remi Lehe, Weiqun Zhang, levinem, Revathi Jambunathan
  *
  * This file is part of WarpX.
  *
@@ -170,7 +170,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
             RemakeMultiFab(Efield_fp[lev][idim], dm, true);
             RemakeMultiFab(current_fp[lev][idim], dm, false);
             RemakeMultiFab(current_store[lev][idim], dm, false);
-
+            if (current_deposition_algo == CurrentDepositionAlgo::Vay) {
+                RemakeMultiFab(current_fp_vay[lev][idim], dm, false);
+            }
 #ifdef AMREX_USE_EB
             if (WarpX::maxwell_solver_id == MaxwellSolverAlgo::Yee ||
                 WarpX::maxwell_solver_id == MaxwellSolverAlgo::ECT ||
@@ -264,6 +266,9 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 RemakeMultiFab(Bfield_cp[lev][idim], dm, true);
                 RemakeMultiFab(Efield_cp[lev][idim], dm, true);
                 RemakeMultiFab(current_cp[lev][idim], dm, false);
+                if (current_deposition_algo == CurrentDepositionAlgo::Vay) {
+                    RemakeMultiFab(current_fp_vay[lev][idim], dm, false);
+                }
             }
             RemakeMultiFab(F_cp[lev], dm, true);
             RemakeMultiFab(rho_cp[lev], dm, false);


### PR DESCRIPTION
Additional MultiFabs for
- Vay deposition
- current centering
- time averaging

need to be allocated after load-balancing, otherwise the simulation crashes. 

Thanks to @hklion for reporting this and testing it as well.
