### PR TITLE
2D/RZ Embedded Boundaries Bug Fix

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3053,7 +3053,7 @@ inputFile = Examples/Modules/embedded_boundary_cube/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON -DCMAKE_BUILD_TYPE=Debug
 restartTest = 0
 useMPI = 1
 numprocs = 1

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3053,7 +3053,7 @@ inputFile = Examples/Modules/embedded_boundary_cube/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON -DCMAKE_BUILD_TYPE=Debug
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 1

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -976,10 +976,10 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
        amrex::Array4<amrex::Real> const& Sz = face_areas[2]->array(mfi);
 
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-       const amrex::Dim3 lx_lo = lx.begin;
-       const amrex::Dim3 lx_hi = lx.end;
-       const amrex::Dim3 lz_lo = lz.begin;
-       const amrex::Dim3 lz_hi = lz.end;
+       const amrex::Dim3 lx_lo = amrex::lbound(lx);
+       const amrex::Dim3 lx_hi = amrex::ubound(lx);
+       const amrex::Dim3 lz_lo = amrex::lbound(lz);
+       const amrex::Dim3 lz_hi = amrex::ubound(lz);
 #endif
 
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
@@ -1032,10 +1032,10 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 if((field=='E' and ly(i, j, k)<=0) or (field=='B' and Sy(i, j, k)<=0))  return;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ey is associated with a mesh node, so we need to check if  the mesh node is covered
-                if((field=='E' and (lx(std::min(i  , lx_hi.x-1), std::min(j  , lx_hi.y-1), k)<=0
-                                 || lx(std::max(i-1, lx_lo.x  ), std::min(j  , lx_hi.y-1), k)<=0
-                                 || lz(std::min(i  , lz_hi.x-1), std::min(j  , lz_hi.y-1), k)<=0
-                                 || lz(std::min(i  , lz_hi.x-1), std::max(j-1, lz_lo.y  ), k)<=0)) or
+                if((field=='E' and (lx(std::min(i  , lx_hi.x), std::min(j  , lx_hi.y), k)<=0
+                                 || lx(std::max(i-1, lx_lo.x), std::min(j  , lx_hi.y), k)<=0
+                                 || lz(std::min(i  , lz_hi.x), std::min(j  , lz_hi.y), k)<=0
+                                 || lz(std::min(i  , lz_hi.x), std::max(j-1, lz_lo.y), k)<=0)) or
                    (field=='B' and Sy(i,j,k)<=0)) return;
 #endif
 #endif

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -956,6 +956,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
     amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
     amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
     amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
+
     for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
        const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
@@ -973,6 +974,13 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
        amrex::Array4<amrex::Real> const& Sx = face_areas[0]->array(mfi);
        amrex::Array4<amrex::Real> const& Sy = face_areas[1]->array(mfi);
        amrex::Array4<amrex::Real> const& Sz = face_areas[2]->array(mfi);
+
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+       const amrex::Dim3 lx_lo = lx.begin;
+       const amrex::Dim3 lx_hi = lx.end;
+       const amrex::Dim3 lz_lo = lz.begin;
+       const amrex::Dim3 lz_hi = lz.end;
+#endif
 
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         amrex::ignore_unused(ly, Sx, Sz);
@@ -1024,7 +1032,10 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 if((field=='E' and ly(i, j, k)<=0) or (field=='B' and Sy(i, j, k)<=0))  return;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ey is associated with a mesh node, so we need to check if  the mesh node is covered
-                if((field=='E' and (lx(i, j, k)<=0 || lx(i-1, j, k)<=0 || lz(i, j, k)<=0 || lz(i, j-1, k)<=0)) or
+                if((field=='E' and (lx(std::min(i  , lx_hi.x-1), std::min(j  , lx_hi.y-1), k)<=0
+                                 || lx(std::max(i-1, lx_lo.x  ), std::min(j  , lx_hi.y-1), k)<=0
+                                 || lz(std::min(i  , lz_hi.x-1), std::min(j  , lz_hi.y-1), k)<=0
+                                 || lz(std::min(i  , lz_hi.x-1), std::max(j-1, lz_lo.y  ), k)<=0)) or
                    (field=='B' and Sy(i,j,k)<=0)) return;
 #endif
 #endif


### PR DESCRIPTION
While investigating some of the CI failures appearing in #3484, I noticed that the CI test `embedded_boundary_cube_2d` fails also on the `development` branch, when running in debug mode.

There seems to be an out-of-bound access here:
https://github.com/ECP-WarpX/WarpX/blob/ada6fc49cf16f40d1764d3a95c8338126360f329/Source/Initialization/WarpXInitData.cpp#L1027

The bug is somehow triggered by the changes in #3484, but since it happens on the `development` branch too, I believe it is independent of those changes.

To-do:
- [x] Add debug flag to CI test (trigger crash)
- [x] Fix bug
- [x] Remove debug flag from CI test 