### PR TITLE
Abort when using Vay Deposition with yee or ckc

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1553,8 +1553,7 @@ Numerics and algorithms
     Available options are: ``direct``, ``esirkepov``, and ``vay``. The default choice
     is ``esirkepov`` for FDTD maxwell solvers and ``direct`` for standard or
     Galilean PSATD solver (that is, with ``algo.maxwell_solver = psatd``).
-    Note that ``vay`` is only available for ``algo.maxwell_solver = psatd`` and not available for
-    ``algo.maxwell_solver = yee`` or ``algo.maxwell_solver = ckc``.
+    Note that ``vay`` is only available for ``algo.maxwell_solver = psatd``.
 
     1. ``direct``
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1553,6 +1553,8 @@ Numerics and algorithms
     Available options are: ``direct``, ``esirkepov``, and ``vay``. The default choice
     is ``esirkepov`` for FDTD maxwell solvers and ``direct`` for standard or
     Galilean PSATD solver (that is, with ``algo.maxwell_solver = psatd``).
+    Note that ``vay`` is only available for ``algo.maxwell_solver = psatd`` and not available for
+    ``algo.maxwell_solver = yee`` or ``algo.maxwell_solver = ckc``.
 
     1. ``direct``
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -917,12 +917,15 @@ WarpX::PushParticlesandDepose (int lev, amrex::Real cur_time, DtType a_dt_type, 
         current_y = current_fp_nodal[lev][1].get();
         current_z = current_fp_nodal[lev][2].get();
     }
-    else if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
+#ifdef PSATD
+    else if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay and
+             electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {
         current_x = current_fp_vay[lev][0].get();
         current_y = current_fp_vay[lev][1].get();
         current_z = current_fp_vay[lev][2].get();
     }
+#endif
     else
     {
         current_x = current_fp[lev][0].get();

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -917,15 +917,13 @@ WarpX::PushParticlesandDepose (int lev, amrex::Real cur_time, DtType a_dt_type, 
         current_y = current_fp_nodal[lev][1].get();
         current_z = current_fp_nodal[lev][2].get();
     }
-#ifdef PSATD
-    else if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay and
-             electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
+    else if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
     {
+        // Note that Vay deposition is supported only for PSATD and the code currently aborts otherwise
         current_x = current_fp_vay[lev][0].get();
         current_y = current_fp_vay[lev][1].get();
         current_z = current_fp_vay[lev][2].get();
     }
-#endif
     else
     {
         current_x = current_fp[lev][0].get();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -954,6 +954,12 @@ WarpX::ReadParameters ()
             maxLevel() <= 0,
             "Vay deposition not implemented with mesh refinement");
 
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !(WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay and
+             (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+              electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC)),
+            "Vay deposition not implemented with ckc or yee");
+
         field_gathering_algo = GetAlgorithmInteger(pp_algo, "field_gathering");
         if (field_gathering_algo == GatheringAlgo::MomentumConserving) {
             // Use same shape factors in all directions, for gathering

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -954,11 +954,11 @@ WarpX::ReadParameters ()
             maxLevel() <= 0,
             "Vay deposition not implemented with mesh refinement");
 
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            !(WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay and
-             (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
-              electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC)),
-            "Vay deposition not implemented with ckc or yee");
+        if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) {
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD,
+                "Vay deposition is implemented only for PSATD");
+        }
 
         field_gathering_algo = GetAlgorithmInteger(pp_algo, "field_gathering");
         if (field_gathering_algo == GatheringAlgo::MomentumConserving) {


### PR DESCRIPTION
Vay deposition is currently only implemented for PSATD and does not work with yee/ckc