### PR TITLE
Use makeParser function for laser field parsing option

### DIFF
--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -64,7 +64,6 @@ public:
     virtual void
     init (
         const amrex::ParmParse& ppl,
-        const amrex::ParmParse& ppc,
         CommonLaserParameters params) = 0;
 
     /** Update Laser Profile
@@ -109,7 +108,6 @@ public:
     void
     init (
         const amrex::ParmParse& ppl,
-        const amrex::ParmParse& ppc,
         CommonLaserParameters params) override final;
 
     //No update needed
@@ -152,7 +150,6 @@ public:
     void
     init (
         const amrex::ParmParse& ppl,
-        const amrex::ParmParse& ppc,
         CommonLaserParameters params) override final;
 
     //No update needed
@@ -187,7 +184,6 @@ public:
     void
     init (
         const amrex::ParmParse& ppl,
-        const amrex::ParmParse& ppc,
         CommonLaserParameters params) override final;
 
     //No update needed
@@ -223,7 +219,6 @@ public:
     void
     init (
         const amrex::ParmParse& ppl,
-        const amrex::ParmParse& ppc,
         CommonLaserParameters params) override final;
 
     /** \brief Reads new field data chunk from file if needed

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFieldFunction.cpp
@@ -27,33 +27,12 @@ using namespace amrex;
 void
 WarpXLaserProfiles::FieldFunctionLaserProfile::init (
     const amrex::ParmParse& ppl,
-    const amrex::ParmParse& ppc,
     CommonLaserParameters /*params*/)
 {
     // Parse the properties of the parse_field_function profile
-    ppl.get("field_function(X,Y,t)", m_params.field_function);
-    m_parser.define(m_params.field_function);
-    m_parser.registerVariables({"X","Y","t"});
-
-    std::set<std::string> symbols = m_parser.symbols();
-    symbols.erase("X");
-    symbols.erase("Y");
-    symbols.erase("t"); // after removing variables, we are left with constants
-    for (auto it = symbols.begin(); it != symbols.end(); ) {
-        Real v;
-        if (utils::parser::queryWithParser(ppc, it->c_str(), v)) {
-            m_parser.setConstant(*it, v);
-            it = symbols.erase(it);
-        } else {
-            ++it;
-        }
-    }
-
-    std::stringstream ss;
-    for (auto const& s : symbols) ss << " " << s;
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(symbols.empty(),
-        "Laser Profile: Unknown symbols " + ss.str());
-
+    utils::parser::Store_parserString(
+            ppl, "field_function(X,Y,t)", m_params.field_function);
+    m_parser = utils::parser::makeParser(m_params.field_function,{"X","Y","t"});
 }
 
 void

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -45,7 +45,6 @@ using namespace amrex;
 void
 WarpXLaserProfiles::FromTXYEFileLaserProfile::init (
     const amrex::ParmParse& ppl,
-    const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
 {
     if (!std::numeric_limits< double >::is_iec559)

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -32,7 +32,6 @@ using namespace amrex;
 void
 WarpXLaserProfiles::GaussianLaserProfile::init (
     const amrex::ParmParse& ppl,
-    const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
 {
     //Copy common params

--- a/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileHarris.cpp
@@ -22,7 +22,6 @@ using namespace amrex;
 void
 WarpXLaserProfiles::HarrisLaserProfile::init (
     const amrex::ParmParse& ppl,
-    const amrex::ParmParse& /* ppc */,
     CommonLaserParameters params)
 {
     // Parse the properties of the Harris profile

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -249,7 +249,7 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     common_params.e_max = m_e_max;
     common_params.p_X = m_p_X;
     common_params.nvec = m_nvec;
-    m_up_laser_profile->init(pp_laser_name, ParmParse{"my_constants"}, common_params);
+    m_up_laser_profile->init(pp_laser_name, common_params);
 }
 
 /* \brief Check if laser particles enter the box, and inject if necessary.


### PR DESCRIPTION
Among other possible consequences, we currently cannot use WarpX constants like `clight` and `pi` inside the laser field parser.