### PR TITLE
Flux injection: move particle only after performing checks

### DIFF
--- a/Regression/Checksum/benchmarks_json/FluxInjection.json
+++ b/Regression/Checksum/benchmarks_json/FluxInjection.json
@@ -1,14 +1,14 @@
 {
   "electron": {
-    "particle_momentum_x": 1.7856085576594427e-42,
-    "particle_momentum_y": 1.7883824545080506e-42,
-    "particle_momentum_z": 4.565443974152731e-41,
-    "particle_position_x": 6992.343661648445,
-    "particle_position_y": 2049.9517671725316,
-    "particle_theta": 6536.38847902292,
-    "particle_weight": 3.240227722540627e-08
+    "particle_momentum_x": 1.7879471038093652e-42,
+    "particle_momentum_y": 1.7494821186739744e-42,
+    "particle_momentum_z": 4.5268277440986243e-41,
+    "particle_position_x": 6940.335850058893,
+    "particle_position_y": 2046.2539850460196,
+    "particle_theta": 6498.1356057858175,
+    "particle_weight": 3.219739901337792e-08
   },
   "lev=0": {
-    "Bz": 2.20886367779576e-47
+    "Bz": 2.1952258973082976e-47
   }
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1661,9 +1661,6 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 pu.y *= PhysConst::c;
                 pu.z *= PhysConst::c;
 
-                const amrex::Real t_fract = amrex::Random(engine)*dt;
-                UpdatePosition(ppos.x, ppos.y, ppos.z, pu.x, pu.y, pu.z, t_fract);
-
 #if defined(WARPX_DIM_3D)
                 if (!tile_realbox.contains(XDim3{ppos.x,ppos.y,ppos.z})) {
                     p.id() = -1;
@@ -1682,7 +1679,6 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                     continue;
                 }
 #endif
-
                 // Save the x and y values to use in the insideBounds checks.
                 // This is needed with WARPX_DIM_RZ since x and y are modified.
                 Real xb = ppos.x;
@@ -1726,8 +1722,10 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                     p.id() = -1;
                     continue;
                 }
-
                 Real dens = inj_rho->getDensity(ppos.x, ppos.y, ppos.z);
+
+                const amrex::Real t_fract = amrex::Random(engine)*dt;
+                UpdatePosition(ppos.x, ppos.y, ppos.z, pu.x, pu.y, pu.z, t_fract);
 
                 // Remove particle if density below threshold
                 if ( dens < density_min ){

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1679,12 +1679,17 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                     continue;
                 }
 #endif
-                // Save the x and y values to use in the insideBounds checks.
-                // This is needed with WARPX_DIM_RZ since x and y are modified.
-                Real xb = ppos.x;
-                Real yb = ppos.y;
+                // Lab-frame simulation
+                // If the particle is not within the species's
+                // xmin, xmax, ymin, ymax, zmin, zmax, go to
+                // the next generated particle.
+                if (!inj_pos->insideBounds(ppos.x, ppos.y, ppos.z)) {
+                    p.id() = -1;
+                    continue;
+                }
 
 #ifdef WARPX_DIM_RZ
+                // Conversion from cylindrical to Cartesian coordinates
                 // Replace the x and y, setting an angle theta.
                 // These x and y are used to get the momentum and density
                 Real theta;
@@ -1698,8 +1703,9 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 Real const cos_theta = std::cos(theta);
                 Real const sin_theta = std::sin(theta);
                 // Rotate the position
-                ppos.x = xb*cos_theta;
-                ppos.y = xb*sin_theta;
+                amrex::Real radial_position = ppos.x;
+                ppos.x = radial_position*cos_theta;
+                ppos.y = radial_position*sin_theta;
                 if (loc_flux_normal_axis != 2) {
                     // Rotate the momentum
                     // This because, when the flux direction is e.g. "r"
@@ -1712,21 +1718,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                     pu.y = sin_theta*ur + cos_theta*ut;
                 }
 #endif
-
-                // Lab-frame simulation
-                // If the particle is not within the species's
-                // xmin, xmax, ymin, ymax, zmin, zmax, go to
-                // the next generated particle.
-
-                if (!inj_pos->insideBounds(xb, yb, ppos.z)) {
-                    p.id() = -1;
-                    continue;
-                }
                 Real dens = inj_rho->getDensity(ppos.x, ppos.y, ppos.z);
-
-                const amrex::Real t_fract = amrex::Random(engine)*dt;
-                UpdatePosition(ppos.x, ppos.y, ppos.z, pu.x, pu.y, pu.z, t_fract);
-
                 // Remove particle if density below threshold
                 if ( dens < density_min ){
                     p.id() = -1;
@@ -1767,11 +1759,11 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // the radius ; thus, the calculation is finalized here
                 if (loc_flux_normal_axis != 1) {
                     if (radially_weighted) {
-                         weight *= 2._rt*MathConst::pi*xb;
+                         weight *= 2._rt*MathConst::pi*radial_position;
                     } else {
                          // This is not correct since it might shift the particle
                          // out of the local grid
-                         ppos.x = std::sqrt(xb*rmax);
+                         ppos.x = std::sqrt(radial_position*rmax);
                          weight *= dx[0];
                     }
                 }
@@ -1781,15 +1773,21 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 pa[PIdx::uy][ip] = pu.y;
                 pa[PIdx::uz][ip] = pu.z;
 
+                // Update particle position by a random `t_fract`
+                // so as to produce a continuous-looking flow of particles
+                const amrex::Real t_fract = amrex::Random(engine)*dt;
+                UpdatePosition(ppos.x, ppos.y, ppos.z, pu.x, pu.y, pu.z, t_fract);
+
 #if defined(WARPX_DIM_3D)
                 p.pos(0) = ppos.x;
                 p.pos(1) = ppos.y;
                 p.pos(2) = ppos.z;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-#ifdef WARPX_DIM_RZ
-                pa[PIdx::theta][ip] = theta;
-#endif
-                p.pos(0) = xb;
+#elif defined(WARPX_DIM_RZ)
+                pa[PIdx::theta][ip] = std::atan2(y, x);
+                p.pos(0) = std::sqrt(ppos.x*ppos.x + ppos.y*ppos.y);
+                p.pos(1) = ppos.z;
+#elif defined(WARPX_DIM_XZ)
+                p.pos(0) = ppos.x;
                 p.pos(1) = ppos.z;
 #else
                 p.pos(0) = ppos.z;


### PR DESCRIPTION
In the flux injection, we push the position of the injected particles forward by a random time, which is evenly sampled between 0 and `dt` - right after creating the particle. (This is in order to produce a continuous-looking flow of particles, as opposed to a set of discrete packets of particles, separated by `v*dt`.)

This PR moves this push (i.e. the call to `UpdatePosition`) **after** a certain number of operations:
- Checking that the particle is within the local tile. (This is check is maybe not strictly needed, since we have a call to a global `Redistribute` at the end of the `AddPlasmaFlux`.) I think that we should move the particle only **after** performing this check. Otherwise, particles may get systematically removed if the injection plane is very close to the boundary of a local subdomain. (Even though the injection is inside the subdomain, particles will exit the subdomain after being pushed, and will therefore be removed.) This probably what is causing issue #3446.
- Calculating the flux of particle. (`dens = inj_rho->getDensity(ppos.x, ppos.y, ppos.z);`) In the case where the user-specified flux is position-dependent (and given by a 3D function of space - e.g. a parsed expression), I think it would be more intuitive to the user if this expression is evaluated at the position of the injection plane, rather than at the position of the injected particle **after** it has been pushed.
- For RZ simulations: Converting the position of the particles from cylindrical to Cartesian. My understanding is that the function `UpdatePosition` expects its argument to be in Cartesian coordinates. 