### PR TITLE
CI: unbreak macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         brew --cache
         set +e
-        rm -rf /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11
+        rm -rf /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3.11
         brew unlink gcc
         brew update
         brew install ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         brew --cache
         set +e
-        rm -rf /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3.11
+        rm -rf /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3.11 /usr/local/bin/python3.11 /usr/local/bin/python3.11-config
         brew unlink gcc
         brew update
         brew install ccache


### PR DESCRIPTION
Follow up with #3520, fix more macOS dependencies (break seen on last commit on `development`, see [here](https://github.com/ECP-WarpX/WarpX/actions/runs/3451750100/jobs/5761188799), and recent PRs).