### PR TITLE
Assert for Diag Type

### DIFF
--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -67,6 +67,9 @@ MultiDiagnostics::ReadParameters ()
         ParmParse pp_diag_name(diags_names[i]);
         std::string diag_type_str;
         pp_diag_name.get("diag_type", diag_type_str);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            diag_type_str == "Full" || diag_type_str == "BackTransformed" || diag_type_str == "BoundaryScraping",
+            "<diag>.diag_type must be Full or BackTransformed or BoundaryScraping");
         if (diag_type_str == "Full") diags_types[i] = DiagTypes::Full;
         if (diag_type_str == "BackTransformed") diags_types[i] = DiagTypes::BackTransformed;
         if (diag_type_str == "BoundaryScraping") diags_types[i] = DiagTypes::BoundaryScraping;


### PR DESCRIPTION
Many times, we can have a typo in setting diag_type
For example : BackTranformed  instead of BackTransformed

and the results will be incorrect. 
This PR asserts that the user-input matches the three available diagnostic types

