### PR TITLE
Bug fix with reduced diagnostic FieldProbe in 1d

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -362,7 +362,7 @@ bool FieldProbe::ProbeInDomain () const
      * and prob_hi[1] refer to z. This is a result of warpx.Geom(lev).
      */
 #if defined(WARPX_DIM_1D_Z)
-    return z_probe >= prob_lo[1] && z_probe < prob_hi[1];
+    return z_probe >= prob_lo[0] && z_probe < prob_hi[0];
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     return x_probe >= prob_lo[0] && x_probe < prob_hi[0] &&
            z_probe >= prob_lo[1] && z_probe < prob_hi[1];

--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
@@ -107,9 +107,12 @@ FieldProbeParticleContainer::AddNParticles (int lev,
         p.pos(1) = y[i];
         p.pos(2) = z[i];
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        amrex::ignore_unused(y) ;
+        amrex::ignore_unused(y);
         p.pos(0) = x[i];
         p.pos(1) = z[i];
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(x, y);
+        p.pos(0) = z[i];
 #endif
         // write position, cpu id, and particle id to particle
         pinned_tile.push_back(p);


### PR DESCRIPTION
The `FieldProbe` functionality doesn't currently work in 1d. This PR fixes that.