### PR TITLE
Enable the use of `FieldProbe` default parameter values

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2110,8 +2110,8 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     def _handle_field_probe(self, **kw):
         """Utility function to grab required inputs for a field probe from kw"""
         self.probe_geometry = kw.pop("probe_geometry")
-        self.x_probe = kw.pop("x_probe")
-        self.y_probe = kw.pop("y_probe")
+        self.x_probe = kw.pop("x_probe", None)
+        self.y_probe = kw.pop("y_probe", None)
         self.z_probe = kw.pop("z_probe")
 
         self.interp_order = kw.pop("interp_order", None)
@@ -2122,20 +2122,20 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
             self.resolution = kw.pop("resolution")
 
         if self.probe_geometry.lower() == 'line':
-            self.x1_probe = kw.pop("x1_probe")
-            self.y1_probe = kw.pop("y1_probe")
+            self.x1_probe = kw.pop("x1_probe", None)
+            self.y1_probe = kw.pop("y1_probe", None)
             self.z1_probe = kw.pop("z1_probe")
 
         if self.probe_geometry.lower() == 'plane':
             self.detector_radius = kw.pop("detector_radius")
 
-            self.target_normal_x = kw.pop("target_normal_x")
-            self.target_normal_y = kw.pop("target_normal_y")
-            self.target_normal_z = kw.pop("target_normal_z")
+            self.target_normal_x = kw.pop("target_normal_x", None)
+            self.target_normal_y = kw.pop("target_normal_y", None)
+            self.target_normal_z = kw.pop("target_normal_z", None)
 
-            self.target_up_x = kw.pop("target_up_x")
-            self.target_up_y = kw.pop("target_up_y")
-            self.target_up_z = kw.pop("target_up_z")
+            self.target_up_x = kw.pop("target_up_x", None)
+            self.target_up_y = kw.pop("target_up_y", None)
+            self.target_up_z = kw.pop("target_up_z", None)
 
         return kw
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+using namespace amrex::literals;
+
 /**
  * This enumeration is used for assigning structural geometry levels (point vs line vs plane)
  */
@@ -67,10 +69,17 @@ public:
     static constexpr int noutputs = FieldProbePIdx::nattribs + 3;
 
 private:
-    amrex::Real x_probe, y_probe, z_probe;
-    amrex::Real x1_probe, y1_probe, z1_probe;
-    amrex::Real target_normal_x, target_normal_y, target_normal_z;
-    amrex::Real target_up_x, target_up_y, target_up_z;
+    amrex::Real x_probe = 0._rt;
+    amrex::Real y_probe = 0._rt;
+    amrex::Real x1_probe = 0._rt;
+    amrex::Real y1_probe = 0._rt;
+    amrex::Real target_normal_x = 0._rt;
+    amrex::Real target_normal_y = 1._rt;
+    amrex::Real target_normal_z = 0._rt;
+    amrex::Real target_up_x = 0._rt;
+    amrex::Real target_up_y = 0._rt;
+    amrex::Real target_up_z = 1._rt;
+    amrex::Real z_probe, z1_probe;
     amrex::Real detector_radius;
 
     //! counts number of particles for all MPI ranks

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -86,8 +86,6 @@ FieldProbe::FieldProbe (std::string rd_name)
     if (m_probe_geometry_str == "Point")
     {
         m_probe_geometry = DetectorGeometry::Point;
-        x_probe = 0._rt;
-        y_probe = 0._rt;
 #if !defined(WARPX_DIM_1D_Z)
         utils::parser::getWithParser(
             pp_rd_name, "x_probe", x_probe);
@@ -102,17 +100,13 @@ FieldProbe::FieldProbe (std::string rd_name)
     else if (m_probe_geometry_str == "Line")
     {
         m_probe_geometry = DetectorGeometry::Line;
-        x_probe = 0._rt;
-        x1_probe = 0._rt;
-        y_probe = 0._rt;
-        y1_probe = 0._rt;
 #if !defined(WARPX_DIM_1D_Z)
-        utils::parser::getWithParser(pp_rd_name, "x_probe", x_probe);
-        utils::parser::getWithParser(pp_rd_name, "x1_probe", x1_probe);
+        utils::parser::queryWithParser(pp_rd_name, "x_probe", x_probe);
+        utils::parser::queryWithParser(pp_rd_name, "x1_probe", x1_probe);
 #endif
 #if defined(WARPX_DIM_3D)
-        utils::parser::getWithParser(pp_rd_name, "y_probe", y_probe);
-        utils::parser::getWithParser(pp_rd_name, "y1_probe", y1_probe);
+        utils::parser::queryWithParser(pp_rd_name, "y_probe", y_probe);
+        utils::parser::queryWithParser(pp_rd_name, "y1_probe", y1_probe);
 #endif
         utils::parser::getWithParser(pp_rd_name, "z_probe", z_probe);
         utils::parser::getWithParser(pp_rd_name, "z1_probe", z1_probe);
@@ -125,23 +119,18 @@ FieldProbe::FieldProbe (std::string rd_name)
             "ERROR: Plane probe should be used in a 2D or 3D simulation only"));
 #endif
         m_probe_geometry = DetectorGeometry::Plane;
-        y_probe = 0._rt;
-        target_normal_x = 0._rt;
-        target_normal_y = 1._rt;
-        target_normal_z = 0._rt;
-        target_up_y = 0._rt;
 #if defined(WARPX_DIM_3D)
-        utils::parser::getWithParser(pp_rd_name, "y_probe", y_probe);
-        utils::parser::getWithParser(pp_rd_name, "target_normal_x", target_normal_x);
-        utils::parser::getWithParser(pp_rd_name, "target_normal_y", target_normal_y);
-        utils::parser::getWithParser(pp_rd_name, "target_normal_z", target_normal_z);
-        utils::parser::getWithParser(pp_rd_name, "target_up_y", target_up_y);
+        utils::parser::queryWithParser(pp_rd_name, "y_probe", y_probe);
+        utils::parser::queryWithParser(pp_rd_name, "target_normal_x", target_normal_x);
+        utils::parser::queryWithParser(pp_rd_name, "target_normal_y", target_normal_y);
+        utils::parser::queryWithParser(pp_rd_name, "target_normal_z", target_normal_z);
+        utils::parser::queryWithParser(pp_rd_name, "target_up_y", target_up_y);
 #endif
-        utils::parser::getWithParser(pp_rd_name, "x_probe", x_probe);
+        utils::parser::queryWithParser(pp_rd_name, "x_probe", x_probe);
         utils::parser::getWithParser(pp_rd_name, "z_probe", z_probe);
-        utils::parser::getWithParser(pp_rd_name, "target_up_x", target_up_x);
-        utils::parser::getWithParser(pp_rd_name, "target_up_z", target_up_z);
-        utils::parser::getWithParser(pp_rd_name, "detector_radius", detector_radius);
+        utils::parser::queryWithParser(pp_rd_name, "target_up_x", target_up_x);
+        utils::parser::queryWithParser(pp_rd_name, "target_up_z", target_up_z);
+        utils::parser::queryWithParser(pp_rd_name, "detector_radius", detector_radius);
         utils::parser::getWithParser(pp_rd_name, "resolution", m_resolution);
     }
     else


### PR DESCRIPTION
The reduced diagnostic `FieldProbe` currently assigns default values to various parameters but the diagnostic initialization uses `utils::parser::getWithParser()` to extract user provided values for these parameters - which errors if the keyword is not in the input file. This PR switches those instances to using `utils::parser::queryWithParser()` which allows the default values to be used if the user didn't specify an alternative value.