### PR TITLE
Clean up documentation

### DIFF
--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -112,7 +112,9 @@ Bilinear filter
 
 The multi-pass bilinear filter (applied on the current density) is implemented in ``Source/Filter/``, and class ``WarpX`` holds an instance of this class in member variable ``WarpX::bilinear_filter``. For performance reasons (to avoid creating too many guard cells), this filter is directly applied in communication routines, see ``WarpX::AddCurrentFromFineLevelandSumBoundary`` above and
 
-.. doxygenfunction:: WarpX::ApplyFilterandSumBoundaryJ
+.. doxygenfunction:: WarpX::ApplyFilterJ(const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3>> &current, const int lev, const int idim)
+
+.. doxygenfunction:: WarpX::SumBoundaryJ(const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3>> &current, const int lev, const int idim, const amrex::Periodicity &period)
 
 Godfrey's anti-NCI filter for FDTD simulations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -96,7 +96,6 @@ Data Analysis
    dataanalysis/visit
    dataanalysis/visualpic
    dataanalysis/picviewer
-   dataanalysis/backtransformed_diags
    dataanalysis/reduced_diags
 
 Theory

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -762,7 +762,7 @@ Particle initialization
 
     * ``maxwell_boltzmann``: Maxwell-Boltzmann distribution that takes a dimensionless
       temperature parameter :math:`\theta` as an input, where :math:`\theta = \frac{k_\mathrm{B} \cdot T}{m \cdot c^2}`,
-      "math:`T` is the temperature in Kelvin, :math:`k_\mathrm{B}` is the Boltzmann constant, :math:`c` is the speed of light, and :math:`m` is the mass of the species.
+      :math:`T` is the temperature in Kelvin, :math:`k_\mathrm{B}` is the Boltzmann constant, :math:`c` is the speed of light, and :math:`m` is the mass of the species.
       Theta is specified by a combination of ``<species_name>.theta_distribution_type``, ``<species_name>.theta``, and ``<species_name>.theta_function(x,y,z)`` (see below).
       For values of :math:`\theta > 0.01`, errors due to ignored relativistic terms exceed 1%.
       Temperatures less than zero are not allowed.

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -102,10 +102,6 @@ ElectrostaticFieldDiagnostic
 
 Lab-frame diagnostics diagnostics are used when running boosted-frame simulations.
 
-LabFrameParticleDiagnostic
-""""""""""""""""""""""""""
-.. autoclass:: pywarpx.picmi.LabFrameParticleDiagnostic
-
 LabFrameFieldDiagnostic
 """""""""""""""""""""""
 .. autoclass:: pywarpx.picmi.LabFrameFieldDiagnostic
@@ -258,12 +254,6 @@ simulation objects (particles, fields and memory buffers) as well as general pro
 
 .. autofunction:: pywarpx.picmi.Simulation.extension.finalize
 
-.. autofunction:: pywarpx.picmi.Simulation.extension.getistep
-
-.. autofunction:: pywarpx.picmi.Simulation.extension.gett_new
-
-.. autofunction:: pywarpx.picmi.Simulation.extension.evolve
-
 .. autofunction:: pywarpx.picmi.Simulation.extension.getProbLo
 
 .. autofunction:: pywarpx.picmi.Simulation.extension.getProbHi
@@ -306,8 +296,6 @@ with scraped particle data.
 .. autofunction:: pywarpx.picmi.Simulation.extension.get_species_charge_sum
 
 .. autofunction:: pywarpx.picmi.Simulation.extension.depositChargeDensity
-
-.. autofunction:: pywarpx.picmi.Simulation.extension.get_particle_boundary_buffer_size
 
 .. autofunction:: pywarpx.picmi.Simulation.extension.get_particle_boundary_buffer_size
 

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -26,7 +26,7 @@ using namespace amrex;
      * \param[in] fboundary  Value containing boundary type
      * \param[in] dir        direction
      *
-     * \param[out] result 1 if the boundary type is PEC else 0
+     * \returns 1 if the boundary type is PEC else 0
      */
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool is_boundary_PEC (amrex::GpuArray<int, 3> const& fboundary, int dir) {

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -26,7 +26,7 @@ using namespace amrex;
      * \param[in] fboundary  Value containing boundary type
      * \param[in] dir        direction
      *
-     * \param[out] 1 if the boundary type is PEC else 0
+     * \param[out] result 1 if the boundary type is PEC else 0
      */
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool is_boundary_PEC (amrex::GpuArray<int, 3> const& fboundary, int dir) {

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -245,7 +245,8 @@ class BTDSpeciesHeaderImpl
 {
 public:
     /** Constructor.
-     * \param[in] string containing path of Headerfile
+     * \param[in] Headerfile_path string containing path of Headerfile
+     * \param[in] species_name string containing species name
      */
     BTDSpeciesHeaderImpl (std::string const& Headerfile_path, std::string const& species_name);
     ~BTDSpeciesHeaderImpl () = default;
@@ -256,7 +257,7 @@ public:
     /** Set data Index of the data-file, DATAXXXXX, that the particles belong to*/
     void set_DataIndex (const int lev, const int box_id, const int data_index);
     /** Add new_particles to existing to obtain the total number of particles of the species.
-        \param[in] new_particles, total particles in the new buffer
+        \param[in] new_particles total particles in the new buffer
      */
     void AddTotalParticles (const int new_particles) { m_total_particles += new_particles;}
     /** Increment number of boxes in a box array by 1, with every flush. */
@@ -310,7 +311,7 @@ class BTDParticleDataHeaderImpl
 {
 public:
     /** Constructor.
-     * \param[in] string containing path of Headerfile
+     * \param[in] Headerfile_path containing path of Headerfile
      */
     BTDParticleDataHeaderImpl (std::string const& Headerfile_path);
     /** Destructor */
@@ -326,14 +327,14 @@ public:
      */
     void IncreaseBoxArraySize ( const int add_size) { m_ba_size += add_size;}
     /** Returns box corresponding to the ith box in the BoxArray, m_ba.
-     *  \param[in] int ibox, index of the box in the BoxArray.
+     *  \param[in] ibox, index of the box in the BoxArray.
      */
     amrex::Box ba_box (int ibox) {return m_ba[ibox]; }
     /** Resize boxArray, m_ba, to size, m_ba_size. */
     void ResizeBoxArray () { m_ba.resize(m_ba_size); }
     /** Set Box indices of the ith-box in Box Array, m_ba, to the new Box, ba_box.
-     *  \param[in] int ibox, index of the ith box in BoxArray, m_ba.
-     *  \param[in] amrex::Box box dimensions corresponding to the ith Fab.
+     *  \param[in] ibox, index of the ith box in BoxArray, m_ba.
+     *  \param[in] box dimensions corresponding to the ith Fab.
      */
     void SetBox (int ibox, amrex::Box ba_box) { m_ba.set(ibox, ba_box); }
     /** Size of BoxArray, m_ba*/

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.H
@@ -327,14 +327,14 @@ public:
      */
     void IncreaseBoxArraySize ( const int add_size) { m_ba_size += add_size;}
     /** Returns box corresponding to the ith box in the BoxArray, m_ba.
-     *  \param[in] ibox, index of the box in the BoxArray.
+     *  \param[in] ibox index of the box in the BoxArray.
      */
     amrex::Box ba_box (int ibox) {return m_ba[ibox]; }
     /** Resize boxArray, m_ba, to size, m_ba_size. */
     void ResizeBoxArray () { m_ba.resize(m_ba_size); }
     /** Set Box indices of the ith-box in Box Array, m_ba, to the new Box, ba_box.
-     *  \param[in] ibox, index of the ith box in BoxArray, m_ba.
-     *  \param[in] box dimensions corresponding to the ith Fab.
+     *  \param[in] ibox index of the ith box in BoxArray, m_ba.
+     *  \param[in] ba_box dimensions corresponding to the ith Fab.
      */
     void SetBox (int ibox, amrex::Box ba_box) { m_ba.set(ibox, ba_box); }
     /** Size of BoxArray, m_ba*/

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -42,6 +42,7 @@ public:
                         and store in destination multifab.
      * \param[in] num_buffers number of user-defined snapshots in the back-transformed lab-frame
      * \param[in] varnames names of the field-components as defined by the user for back-transformed diagnostics.
+     * \param[in] varnames_fields base names of field-components for the RZ modes
      * \param[in] crse_ratio the coarsening ratio for fields
      */
     BackTransformFunctor ( const amrex::MultiFab * const mf_src, const int lev,

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -30,6 +30,7 @@ struct SelectParticles
      * @param[in] tmp_particle_data  temporary particle data
      * @param[in] current_z_boost    current z-position of the slice in boosted frame
      * @param[in] old_z_boost        previous z-position of the slice in boosted frame
+     * @param[in] a_offset           index offset for particles to be selected
      */
     SelectParticles( const WarpXParIter& a_pti, TmpParticles& tmp_particle_data,
                      amrex::Real current_z_boost, amrex::Real old_z_boost,
@@ -40,7 +41,8 @@ struct SelectParticles
      * for Lorentz transformation in obtaining the lab-frame data. The particles that
      * with positions that correspond to the specific z-slice in boosted frame are selected.
      *
-     * @param[in] SrcData particle tile data
+     * @tparam SrcData type of source data
+     * @param[in] src SrcData particle tile data
      * @param[in] i       particle index
      * @return 1 if particles is selected for transformation, else 0
      */
@@ -85,6 +87,7 @@ struct LorentzTransformParticles
      * @param[in] t_boost            time in boosted frame
      * @param[in] dt                 timestep in boosted-frame
      * @param[in] t_lab              time in lab-frame
+     * @param[in] a_offset           index offset for particles to be transformed
      */
     LorentzTransformParticles ( const WarpXParIter& a_pti, TmpParticles& tmp_particle_data,
                                 amrex::Real t_boost, amrex::Real dt,
@@ -94,8 +97,8 @@ struct LorentzTransformParticles
      * \brief Functor call. This method computes the Lorentz-transform for particle
      * attributes to obtain the lab-frame snapshot data.
      *
-     * @param[out] DstData particle tile data that stores the transformed particle data
-     * @param[in] SrcData particle tile data that is selected for transformation
+     * @param[out] dst DstData particle tile data that stores the transformed particle data
+     * @param[in] src SrcData particle tile data that is selected for transformation
      * @param[in] i_src particle index of the source particles
      * @param[in] i_dst particle index of the target particles (transformed data).
      */
@@ -206,6 +209,7 @@ public:
      * \param[in] z_slice_in_domain  if the z-slice at current_z_boost is within the bounds of
      *            the boosted-frame and lab-frame domain. The particles are transformed
      *            only if this value is true.
+     * \param[in] old_z_boost        previous z-position of the slice in boosted frame
      * \param[in] current_z_boost    z co-ordinate of the slice selected in boosted-frame.
      * \param[in] t_lab              current time in lab-frame for snapshot, i_buffer.
      * \param[in] snapshot_full      if the current snapshot, with index, i_buffer, is

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
@@ -30,9 +30,10 @@ public:
      *         back-transformed diagnostics, that are unused for regular diagnostics.
      *
      * \param[in] i_buffer           index of the snapshot
-     * \param[in] z_slice_in_domain  if the z-slice at current_z_boost is within the bounds of
+     * \param[in] ZSliceInDomain     if the z-slice at current_z_boost is within the bounds of
      *            the boosted-frame and lab-frame domain. The particles are transformed
      *            only if this value is true.
+     * \param[in] old_z_boost        old z co-ordinate of the slice selected in boosted-frame.
      * \param[in] current_z_boost    z co-ordinate of the slice selected in boosted-frame.
      * \param[in] t_lab              current time in lab-frame for snapshot, i_buffer.
      * \param[in] snapshot_full      if the current snapshot, with index, i_buffer, is
@@ -50,6 +51,7 @@ public:
                                       }
     /** Compute particle attributes and store the result in pc_dst particle container.
      *  \param[out] pc_dst  output particle container where the result is stored.
+     *  \param[out] totalParticlesInBuffer total number of particles in the container
      *  \param[in] i_buffer snapshot index for which the particle buffer is processed
      */
     virtual void operator () (PinnedMemoryParticleContainer& pc_dst, int &totalParticlesInBuffer, int i_buffer = 0) const = 0;

--- a/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.H
@@ -19,6 +19,8 @@ public:
      * \param[in] lev level of multifab.
      * \param[in] crse_ratio for interpolating field values from simulation MultiFabs
                   to the output diagnostic MultiFab, mf_dst.
+     * \param[in] convertRZmodes2cartesian whether to generate the result in Cartesian coordinates
+     *            (summing over modes)
      * \param[in] ncomp Number of component of mf_src to cell-center in dst multifab.
      */
     DivBFunctor(const std::array<const amrex::MultiFab* const, 3> arr_mf_src, const int lev, amrex::IntVect crse_ratio,

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -44,11 +44,12 @@ public:
         bool isLastBTDFlush = false,
         const amrex::Vector<int>& totalParticlesFlushedAlready = amrex::Vector<int>() ) const override;
 
+#ifdef AMREX_USE_ASCENT
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
+     * \param[in] a_bp_mesh (NEEDS DESCRIPTION)
      * Only compile if AMREX_USE_ASCENT because we need to pass a conduit class
      */
-#ifdef AMREX_USE_ASCENT
     void WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags, conduit::Node& a_bp_mesh) const;
 #endif
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -47,7 +47,7 @@ public:
 #ifdef AMREX_USE_ASCENT
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
-     * \param[in] a_bp_mesh (NEEDS DESCRIPTION)
+     * \param[out] a_bp_mesh blueprint mesh generated from the container
      * Only compile if AMREX_USE_ASCENT because we need to pass a conduit class
      */
     void WriteParticles(const amrex::Vector<ParticleDiag>& particle_diags, conduit::Node& a_bp_mesh) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -48,6 +48,7 @@ public:
     /** \brief Write particles data to file.
      * \param[in] filename name of output directory
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
+     * \param[in] isBTD whether this is a back-transformed diagnostic
      */
     void WriteParticles(const std::string& filename,
                         const amrex::Vector<ParticleDiag>& particle_diags,

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -54,7 +54,7 @@ private:
       */
     void InitializeBufferData ( int i_buffer, int lev ) override;
     /** Initialize functors that store pointers to the RZ fields requested by the user.
-     * \parm[in] lev level on which the vector of unique_ptrs to field functors is initialized.
+     * \param[in] lev level on which the vector of unique_ptrs to field functors is initialized.
      */
     void InitializeFieldFunctorsRZopenPMD (int lev) override;
     /** Append m_all_field_functors[lev] with all modes of all components of E B and j

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -145,7 +145,7 @@ public:
    *
    * @param varnames variable names in each multifab
    * @param mf multifab for each level
-   * @param geometry for each level
+   * @param geom for each level
    * @param output_levels the finest level to output, <= maxLevel
    * @param iteration the current iteration or reconstructed labframe station number
    * @param time the current simulation time in the lab frame

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -106,6 +106,8 @@ public:
    * @param filetype file backend, e.g. "bp" or "h5"
    * @param operator_type openPMD-api backend operator (compressor) for ADIOS2
    * @param operator_parameters openPMD-api backend operator parameters for ADIOS2
+   * @param engine_type ADIOS engine for output
+   * @param engine_parameters map of parameters for the engine
    * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
    */
   WarpXOpenPMDPlot (openPMD::IterationEncoding ie,
@@ -262,6 +264,7 @@ private:
    * @param[in] write_int_comp The int attribute ids, from WarpX
    * @param[in] int_comp_names The int attribute names, from WarpX
    * @param[in] np  Number of particles
+   * @param[in] isBTD whether this is a back-transformed diagnostic
    */
   void SetupRealProperties (ParticleContainer const * pc,
                openPMD::ParticleSpecies& currSpecies,

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1103,8 +1103,8 @@ WarpXOpenPMDPlot::SetConstParticleRecordsEDPIC (
 /*
  * Set up parameter for mesh container using the geometry (from level 0)
  *
- * @param [IN] meshes: openPMD-api mesh container
- * @param [IN] full_geom: field geometry
+ * @param [in] meshes: openPMD-api mesh container
+ * @param [in] full_geom: field geometry
  *
  */
 void
@@ -1177,9 +1177,9 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
 
 /*
  * Setup component properties  for a field mesh
- * @param [IN]: mesh          a mesh field
- * @param [IN]: full_geom     geometry for the mesh
- * @param [IN]: mesh_comp     a component for the mesh
+ * @param [in]: mesh          a mesh field
+ * @param [in]: full_geom     geometry for the mesh
+ * @param [in]: mesh_comp     a component for the mesh
  */
 void
 WarpXOpenPMDPlot::SetupMeshComp (openPMD::Mesh& mesh,

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -101,10 +101,10 @@ class FiniteDifferenceSolver
           * \param[out] Efield  vector of electric field MultiFabs updated at a given level
           * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
           * \param[in] Jfield   vector of current density MultiFabs at a given level
+          * \param[in] edge_lengths length of edges along embedded boundaries
           * \param[in] dt       timestep of the simulation
           * \param[in] macroscopic_properties contains user-defined properties of the medium.
           */
-
         void MacroscopicEvolveE ( std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Jfield,

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.H
@@ -41,9 +41,12 @@ class SpectralFieldIndex
          *
          * \param[in] update_with_rho whether rho is used in the field update equations
          * \param[in] time_averaging  whether the time averaging algorithm is used
-         * \param[in] do_multi_J      whether the multi-J algorithm is used (hence two currents
+         * \param[in] J_in_time       the multi-J algorithm used (hence two currents
          *                            computed at the beginning and the end of the time interval
          *                            instead of one current computed at half time)
+         * \param[in] rho_in_time     the multi-rho algorithm used (hence two densities
+         *                            computed at the beginning and the end of the time interval
+         *                            instead of one density computed at half time)
          * \param[in] dive_cleaning   whether to use div(E) cleaning to account for errors in
          *                            Gauss law (new field F in the update equations)
          * \param[in] divb_cleaning   whether to use div(B) cleaning to account for errors in

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -140,10 +140,6 @@ class SpectralSolver
          * declared in the base class SpectralBaseAlgorithm and defined in its
          * derived classes, from objects of class SpectralSolver through the private
          * unique pointer \c algorithm.
-         *
-         * \param[in]     lev     The mesh refinement level
-         * \param[in,out] current Array of unique pointers to \c MultiFab storing
-         *                        the three components of the current density
          */
         void VayDeposition ()
         {

--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -58,7 +58,6 @@ public:
      * member variables of the laser profile class.
      *
      * @param[in] ppl should be amrex::ParmParse(laser_name)
-     * @param[in] ppc should be amrex::ParmParse("my_constants")
      * @param[in] params common laser profile parameters
      */
     virtual void

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -47,6 +47,8 @@ public:
      * \param do_pml_in_domain whether pml is done in the domain (only used by RZ PSATD)
      * \param pml_ncell number of cells on the pml layer (only used by RZ PSATD)
      * \param ref_ratios mesh refinement ratios between mesh-refinement levels
+     * \param use_filter whether filtering will be done
+     * \param bilinear_filter_stencil_length the size of the stencil for filtering
      */
     void Init(
         const amrex::Real dt,

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -192,6 +192,7 @@ public:
 
     /** Perform all binary collisions within a tile
      *
+     * \param[in] dt time step size
      * \param[in] lev the mesh-refinement level
      * \param[in] mfi iterator for multifab
      * \param species_1 first species container

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -111,8 +111,9 @@ public:
      * @param mypc Container of species involved
      *
      */
-    void doCollisions (amrex::Real /*cur_time*/, amrex::Real dt, MultiParticleContainer* mypc) override
+    void doCollisions (amrex::Real cur_time, amrex::Real dt, MultiParticleContainer* mypc) override
     {
+        amrex::ignore_unused(cur_time);
 
         auto& species1 = mypc->GetParticleContainerFromName(m_species_names[0]);
         auto& species2 = mypc->GetParticleContainerFromName(m_species_names[1]);

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
@@ -21,6 +21,8 @@
  *
  * @param[in] E_kin_star the kinetic energy of the reactants in their center of mass frame, in SI units.
  * @param[in] fusion_type indicates which fusion reaction to calculate the cross-section for
+ * @param[in] m1 mass of the incoming particle
+ * @param[in] m2 mass of the target particle
  * @return The total cross section in SI units (square meters).
  */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -68,6 +68,7 @@ CollisionHandler::CollisionHandler(MultiParticleContainer const * const mypc)
 /** Perform all collisions
  *
  * @param cur_time Current time
+ * @param dt time step size
  * @param mypc MultiParticleContainer calling this method
  *
  */

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -36,7 +36,6 @@ using namespace amrex::literals;
                          ion_lev is a null pointer.
  * \param jx_fab,jy_fab,jz_fab FArrayBox of current density, either full array or tile.
  * \param np_to_depose Number of particles for which current is deposited.
- * \param dt           Time step for particle level
  * \param relative_time Time at which to deposit J, relative to the time of the
  *                      current positions of the particles. When different than 0,
  *                      the particle position will be temporarily modified to match

--- a/Source/Particles/Pusher/PushSelector.H
+++ b/Source/Particles/Pusher/PushSelector.H
@@ -33,7 +33,7 @@
  * \param Bx, By, Bz                Magnetic field on particles.
  * \param ion_lev                   Ionization level of this particle (0 if ioniziation not on)
  * \param m                         Mass of this species.
- * \param q                         Charge of this species.
+ * \param a_q                       Charge of this species.
  * \param pusher_algo               0: Boris, 1: Vay, 2: HigueraCary
  * \param do_crr                    Whether to do the classical radiation reaction
  * \param do_copy                   Whether to copy the old x and u for the BTD

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -279,7 +279,7 @@ public:
      */
     void AddNParticles (int lev,
                         int n, const amrex::ParticleReal* x, const amrex::ParticleReal* y, const amrex::ParticleReal* z,
-                        const amrex::ParticleReal* vx, const amrex::ParticleReal* vy, const amrex::ParticleReal* vz,
+                        const amrex::ParticleReal* ux, const amrex::ParticleReal* uy, const amrex::ParticleReal* uz,
                         const int nattr_real, const amrex::ParticleReal* attr_real,
                         const int nattr_int, const int* attr_int,
                         int uniqueparticles, amrex::Long id=-1);
@@ -293,9 +293,6 @@ public:
     static void BackwardCompatibility ();
 
     /** \brief Apply particle BC.
-     *
-     * \param[in] boundary_conditions Type of boundary conditions. For now, only absorbing or none
-     * are supported
      */
     void ApplyBoundaryConditions ();
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -144,9 +144,9 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
                                        int n, const amrex::ParticleReal* x,
                                        const amrex::ParticleReal* y,
                                        const amrex::ParticleReal* z,
-                                       const amrex::ParticleReal* vx,
-                                       const amrex::ParticleReal* vy,
-                                       const amrex::ParticleReal* vz,
+                                       const amrex::ParticleReal* ux,
+                                       const amrex::ParticleReal* uy,
+                                       const amrex::ParticleReal* uz,
                                        const int nattr_real, const amrex::ParticleReal* attr_real,
                                        const int nattr_int, const int* attr_int,
                                        int uniqueparticles, amrex::Long id)
@@ -226,9 +226,9 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
     if (np > 0)
     {
         pinned_tile.push_back_real(PIdx::w , weight.data(), weight.data() + np);
-        pinned_tile.push_back_real(PIdx::ux,     vx + ibegin,     vx + iend);
-        pinned_tile.push_back_real(PIdx::uy,     vy + ibegin,     vy + iend);
-        pinned_tile.push_back_real(PIdx::uz,     vz + ibegin,     vz + iend);
+        pinned_tile.push_back_real(PIdx::ux,     ux + ibegin,     ux + iend);
+        pinned_tile.push_back_real(PIdx::uy,     uy + ibegin,     uy + iend);
+        pinned_tile.push_back_real(PIdx::uz,     uz + ibegin,     uz + iend);
 
         if ( (NumRuntimeRealComps()>0) || (NumRuntimeIntComps()>0) ){
             DefineAndReturnParticleTile(0, 0, 0);

--- a/Source/Utils/Parser/IntervalsParser.H
+++ b/Source/Utils/Parser/IntervalsParser.H
@@ -31,6 +31,7 @@ namespace utils::parser
         * Any of these integers may be omitted in which case it will be equal to their default value
         * (0 for the starting point, std::numeric_limits<int>::max() for the stopping point and 1 for
         * the period). For example SliceParser(":1000:") is equivalent to SliceParser("0:1000:1").
+        * @param[in] isBTD whether this is a back-transformed diagnostic
         */
         SliceParser (const std::string& instr, bool isBTD=false);
 

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -60,6 +60,7 @@ namespace ParticleUtils {
      *
      * @param[in] u2 square of particle speed (i.e. u dot u where u = gamma*v)
      * @param[in] m, M mass of projectile and target, respectively
+     * @param[out] gamma relativistic factor of the particle
      * @param[out] energy particle energy in eV
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -83,7 +83,7 @@ namespace ParticleUtils {
      * \brief Perform a Lorentz transformation of the given velocity
      * to a frame moving with velocity (Vx, Vy, Vz) relative to the present one.
      *
-     * @param[in/out] ux,uy,uz components of velocity vector in the current
+     * @param[in,out] ux,uy,uz components of velocity vector in the current
                       frame - importantly these quantities are gamma * velocity
      * @param[in] Vx,Vy,Vz velocity of the new frame relative to the current one,
                       NOT gamma*velocity!
@@ -151,7 +151,7 @@ namespace ParticleUtils {
      * random velocity vector with given magnitude. This is used in isotropic
      * collision events.
      *
-     * @param[in/out] ux, uy, uz colliding particle's velocity
+     * @param[in,out] ux, uy, uz colliding particle's velocity
      * @param[in] vp velocity magnitude of the colliding particle after collision.
      * @param[in] engine the random-engine
      */

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -370,6 +370,7 @@ public:
      * \param[in] scomp The starting component to be aliased
      * \param[in] ncomp The number of components to alias
      * \param[in] name The name of the MultiFab to use in the map
+     * \param[in] initial_value optional initial value for MultiFab
      */
     static void AliasInitMultiFab (
         std::unique_ptr<amrex::MultiFab>& mf,
@@ -588,7 +589,7 @@ public:
     /** apply QED correction on electric field for level lev and patch type patch_type
      *
      * \param lev mesh refinement level
-     * \param dt patch_type which MR patch: PatchType::fine or PatchType::coarse
+     * \param patch_type which MR patch: PatchType::fine or PatchType::coarse
      * \param dt time step
      */
     void Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real dt);
@@ -918,7 +919,7 @@ public:
      * EBs such as edge lengths, face areas, distance to EB, etc. It also
      * appropriately communicates EB data to guard cells.
      *
-     * \param[in] lev, level of the Multifabs that is initialized
+     * \param[in] lev level of the Multifabs that is initialized
      */
     void InitializeEBGridData(int lev);
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -322,13 +322,13 @@ public:
      * to the map of MultiFabs (used to ease the access to MultiFabs from the Python
      * interface
      *
-     * \param mf[out] The MultiFab unique pointer to be allocated
-     * \param ba[in] The BoxArray describing the MultiFab
-     * \param dm[in] The DistributionMapping describing the MultiFab
-     * \param ncomp[in] The number of components in the MultiFab
-     * \param ngrow[in] The number of guard cells in the MultiFab
-     * \param name[in] The name of the MultiFab to use in the map
-     * \param initial_value[in] The optional initial value
+     * \param[out] mf The MultiFab unique pointer to be allocated
+     * \param[in] ba The BoxArray describing the MultiFab
+     * \param[in] dm The DistributionMapping describing the MultiFab
+     * \param[in] ncomp The number of components in the MultiFab
+     * \param[in] ngrow The number of guard cells in the MultiFab
+     * \param[in] name The name of the MultiFab to use in the map
+     * \param[in] initial_value The optional initial value
      */
     static void AllocInitMultiFab (
         std::unique_ptr<amrex::MultiFab>& mf,
@@ -345,13 +345,13 @@ public:
      * to the map of MultiFabs (used to ease the access to MultiFabs from the Python
      * interface
      *
-     * \param mf[out] The iMultiFab unique pointer to be allocated
-     * \param ba[in] The BoxArray describing the iMultiFab
-     * \param dm[in] The DistributionMapping describing the iMultiFab
-     * \param ncomp[in] The number of components in the iMultiFab
-     * \param ngrow[in] The number of guard cells in the iMultiFab
-     * \param name[in] The name of the iMultiFab to use in the map
-     * \param initial_value[in] The optional initial value
+     * \param[out] mf The iMultiFab unique pointer to be allocated
+     * \param[in] ba The BoxArray describing the iMultiFab
+     * \param[in] dm The DistributionMapping describing the iMultiFab
+     * \param[in] ncomp The number of components in the iMultiFab
+     * \param[in] ngrow The number of guard cells in the iMultiFab
+     * \param[in] name The name of the iMultiFab to use in the map
+     * \param[in] initial_value The optional initial value
      */
     static void AllocInitMultiFab (
         std::unique_ptr<amrex::iMultiFab>& mf,
@@ -365,11 +365,11 @@ public:
     /**
      * \brief
      * Create an alias of a MultiFab, adding the alias to the MultiFab map
-     * \param mf[out] The MultiFab to create
-     * \param mf_to_alias[in] The MultiFab to alias
-     * \param scomp[in] The starting component to be aliased
-     * \param ncomp[in] The number of components to alias
-     * \param name[in] The name of the MultiFab to use in the map
+     * \param[out] mf The MultiFab to create
+     * \param[in] mf_to_alias The MultiFab to alias
+     * \param[in] scomp The starting component to be aliased
+     * \param[in] ncomp The number of components to alias
+     * \param[in] name The name of the MultiFab to use in the map
      */
     static void AliasInitMultiFab (
         std::unique_ptr<amrex::MultiFab>& mf,
@@ -389,7 +389,7 @@ public:
      * \brief
      * Add the MultiFab to the map of MultiFabs
      * \param name The name of the MultiFab use to reference the MultiFab
-     * \parame mf The MultiFab to be added to the map (via a pointer to it)
+     * \param mf The MultiFab to be added to the map (via a pointer to it)
      */
     static void AddToMultiFabMap(const std::string name, const std::unique_ptr<amrex::MultiFab>& mf) {
         multifab_map[name] = mf.get();
@@ -399,7 +399,7 @@ public:
      * \brief
      * Add the iMultiFab to the map of MultiFabs
      * \param name The name of the iMultiFab use to reference the iMultiFab
-     * \parame mf The iMultiFab to be added to the map (via a pointer to it)
+     * \param mf The iMultiFab to be added to the map (via a pointer to it)
      */
     static void AddToMultiFabMap(const std::string name, const std::unique_ptr<amrex::iMultiFab>& mf) {
         imultifab_map[name] = mf.get();
@@ -891,16 +891,16 @@ public:
      * on the staggered yee-grid or cell-centered grid, in the interior cells
      * and guard cells.
      *
-     * \param[in] mfx, x-component of the field to be initialized
-     * \param[in] mfy, y-component of the field to be initialized
-     * \param[in] mfz, z-component of the field to be initialized
-     * \param[in] xfield_parser, parser function to initialize x-field
-     * \param[in] yfield_parser, parser function to initialize y-field
-     * \param[in] zfield_parser, parser function to initialize z-field
-     * \param[in] edge_lengths, edge lengths information
-     * \param[in] face_areas, face areas information
-     * \param[in] field, flag indicating which field is being initialized ('E' for electric, 'B' for magnetic)
-     * \param[in] lev, level of the Multifabs that is initialized
+     * \param[in] mfx x-component of the field to be initialized
+     * \param[in] mfy y-component of the field to be initialized
+     * \param[in] mfz z-component of the field to be initialized
+     * \param[in] xfield_parser parser function to initialize x-field
+     * \param[in] yfield_parser parser function to initialize y-field
+     * \param[in] zfield_parser parser function to initialize z-field
+     * \param[in] edge_lengths edge lengths information
+     * \param[in] face_areas face areas information
+     * \param[in] field flag indicating which field is being initialized ('E' for electric, 'B' for magnetic)
+     * \param[in] lev level of the Multifabs that is initialized
      */
     void InitializeExternalFieldsOnGridUsingParser (
          amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
@@ -1243,7 +1243,7 @@ private:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_face_areas;
 
     /** EB: for every mesh face flag_info_face contains a:
-     *           * 0 if the face needs to be extended
+     *          * 0 if the face needs to be extended
      *          * 1 if the face is large enough to lend area to other faces
      *          * 2 if the face is actually intruded by other face
      * It is initialized in WarpX::MarkCells

--- a/Source/ablastr/constant.H
+++ b/Source/ablastr/constant.H
@@ -57,9 +57,9 @@ namespace ablastr::constant
 
         //! reduced Planck Constant = h / tau [J*s]
         static constexpr auto hbar = 1.054571817e-34_rt;
-        //! fine-structure constant = mu0/(4*MathConst::pi)*q_e*q_e*c/hbar [dimensionless]
+        //! fine-structure constant = mu0/(4*pi)*q_e*q_e*c/hbar [dimensionless]
         static constexpr auto alpha = 0.007297352573748943_rt;
-        //! classical electron radius = 1./(4*MathConst::pi*ep0) * q_e*q_e/(m_e*c*c) [m]
+        //! classical electron radius = 1./(4*pi*ep0) * q_e*q_e/(m_e*c*c) [m]
         static constexpr auto r_e = 2.817940326204929e-15_rt;
         //! xi: nonlinearity parameter of Heisenberg-Euler effective theory = (2.*alpha*alpha*ep0*ep0*hbar*hbar*hbar)/(45.*m_e*m_e*m_e*m_e*c*c*c*c*c)
         static constexpr double xi = 1.3050122447005176e-52;


### PR DESCRIPTION
I was testing the build of the documentation and noticed that there were many warnings being reported, both in the rst files and in the documenting comments in the source code. I had a few spare minutes so I went through and fixed them. Most of the warnings were from arguments to function methods being missed. There were also a number of syntax problems in the comments. This PR touches many places in the C++, but nearly all are in the comments.

The CI tests already build the docs checking for errors. Could this be changed so that it fails on warnings as well? This can be done by added the `-W` option when running Sphinx. This will help reduce comment creep, where the comments become outdated over time and they are not updated along with the associated code.

Another comment is that there are several different styles of comments. For example, some use "\param" and some "@param" for arguments. Also, some use "[in]" and "[out]" while many others do not. Is it worth making it consistent?