### PR TITLE
[WIP] CI: improve analysis for test using div(E) cleaning

### DIFF
--- a/Examples/Tests/langmuir/analysis_3d.py
+++ b/Examples/Tests/langmuir/analysis_3d.py
@@ -149,43 +149,21 @@ print("tolerance_rel: " + str(tolerance_rel))
 
 assert( error_rel < tolerance_rel )
 
-# Check relative L-infinity spatial norm of rho/epsilon_0 - div(E)
-# with current correction (and periodic single box option) or with Vay current deposition
-if current_correction:
-    tolerance = 1e-9
-elif vay_deposition:
-    tolerance = 1e-3
-if current_correction or vay_deposition:
+# Check charge conservation (div(E) = rho/epsilon_0), with:
+# - current correction (with periodic single box option),
+# - Vay current deposition,
+# - div(E) cleaning with F.
+if current_correction or vay_deposition or div_cleaning:
+    if current_correction:
+        tolerance = 1e-9
+    elif vay_deposition:
+        tolerance = 1e-3
+    elif div_cleaning:
+        tolerance = 1e-2
     rho  = data[('boxlib','rho')].to_ndarray()
     divE = data[('boxlib','divE')].to_ndarray()
-    error_rel = np.amax( np.abs( divE - rho/epsilon_0 ) ) / np.amax( np.abs( rho/epsilon_0 ) )
+    error_rel = np.amax(np.abs(divE-rho/epsilon_0)) / np.amax(np.abs(rho/epsilon_0))
     print("Check charge conservation:")
-    print("error_rel = {}".format(error_rel))
-    print("tolerance = {}".format(tolerance))
-    assert( error_rel < tolerance )
-
-if div_cleaning:
-    ds_old = yt.load('Langmuir_multi_psatd_div_cleaning_plt000038')
-    ds_mid = yt.load('Langmuir_multi_psatd_div_cleaning_plt000039')
-    ds_new = yt.load(fn) # this is the last plotfile
-
-    ad_old = ds_old.covering_grid(level = 0, left_edge = ds_old.domain_left_edge, dims = ds_old.domain_dimensions)
-    ad_mid = ds_mid.covering_grid(level = 0, left_edge = ds_mid.domain_left_edge, dims = ds_mid.domain_dimensions)
-    ad_new = ds_new.covering_grid(level = 0, left_edge = ds_new.domain_left_edge, dims = ds_new.domain_dimensions)
-
-    rho   = ad_mid['rho'].v.squeeze()
-    divE  = ad_mid['divE'].v.squeeze()
-    F_old = ad_old['F'].v.squeeze()
-    F_new = ad_new['F'].v.squeeze()
-
-    # Check max norm of error on dF/dt = div(E) - rho/epsilon_0
-    # (the time interval between the old and new data is 2*dt)
-    dt = 1.203645751e-15
-    x = F_new - F_old
-    y = (divE - rho/epsilon_0) * 2 * dt
-    error_rel = np.amax(np.abs(x - y)) / np.amax(np.abs(y))
-    tolerance = 1e-2
-    print("Check div(E) cleaning:")
     print("error_rel = {}".format(error_rel))
     print("tolerance = {}".format(tolerance))
     assert(error_rel < tolerance)

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1441,7 +1441,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_multi_psatd_div_cleaning]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F warpx.abort_on_warning_threshold=medium
+runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON


### PR DESCRIPTION
For CI tests using the div(E) cleaning method, we can simply check charge conservation in the same way as we do for current correction or Vay deposition. Errors on div(E)=rho are supposed to be propagated away through the field F. 

Thank you to @oshapoval for pointing this out!