### PR TITLE
CI: Source Checks on ubuntu 22.04

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   style:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Updated Doxygen from 1.8.17 to 1.9.1

Follow-up to #3546

Note: RTD still builds with a 1.8* Doxygen