### PR TITLE
Allow const_dt with EM and check it for ES

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1529,6 +1529,13 @@ Numerics and algorithms
     The ratio between the actual timestep that is used in the simulation
     and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for `warpx.cfl=1`,
     the timestep will be exactly equal to the CFL limit.)
+    This parameter will only be used with the electromagnatic solver.
+
+* ``warpx.const_dt`` (`float`)
+    Allows direct specification of the time step size, in units of seconds.
+    When the electrostatic solver is being used, this must be supplied.
+    This can be used with the electromagnatic solver, overriding ``warpx.cfl``, but
+    it is up to the user to ensure that the CFL condition is met.
 
 * ``warpx.use_filter`` (`0` or `1`; default: `1`, except for RZ FDTD)
     Whether to smooth the charge and currents on the mesh, after depositing them from the macro-particles.

--- a/Examples/Tests/embedded_boundary_cube/inputs_3d
+++ b/Examples/Tests/embedded_boundary_cube/inputs_3d
@@ -6,7 +6,6 @@ amr.max_level = 0
 geometry.dims = 3
 geometry.prob_lo     = -0.8 -0.8 -0.8
 geometry.prob_hi     =  0.8  0.8  0.8
-warpx.const_dt = 1e-6
 warpx.cfl = 1
 
 boundary.field_lo = pec pec pec

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -34,6 +34,7 @@ WarpX::ComputeDt ()
 {
     // Handle cases where the timestep is not limited by the speed of light
     if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(const_dt_specified, "warpx.const_dt must be specified with the electrostatic solver.");
         for (int lev=0; lev<=max_level; lev++) {
             dt[lev] = const_dt;
         }
@@ -44,7 +45,9 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
+    if (const_dt_specified) {
+        deltat = const_dt;
+    } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)
 #if defined(WARPX_DIM_1D_Z)

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -46,7 +46,7 @@ WarpX::ComputeDt ()
     amrex::Real deltat = 0.;
 
     if (m_const_dt.has_value()) {
-        deltat = m_const_dt;
+        deltat = m_const_dt.value();
     } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -34,9 +34,9 @@ WarpX::ComputeDt ()
 {
     // Handle cases where the timestep is not limited by the speed of light
     if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(const_dt_specified, "warpx.const_dt must be specified with the electrostatic solver.");
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_const_dt.has_value(), "warpx.const_dt must be specified with the electrostatic solver.");
         for (int lev=0; lev<=max_level; lev++) {
-            dt[lev] = const_dt;
+            dt[lev] = m_const_dt;
         }
         return;
     }
@@ -45,8 +45,8 @@ WarpX::ComputeDt ()
     const amrex::Real* dx = geom[max_level].CellSize();
     amrex::Real deltat = 0.;
 
-    if (const_dt_specified) {
-        deltat = const_dt;
+    if (m_const_dt.has_value()) {
+        deltat = m_const_dt;
     } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         // Computation of dt for spectral algorithm
         // (determined by the minimum cell size in all directions)

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -36,7 +36,7 @@ WarpX::ComputeDt ()
     if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_const_dt.has_value(), "warpx.const_dt must be specified with the electrostatic solver.");
         for (int lev=0; lev<=max_level; lev++) {
-            dt[lev] = m_const_dt;
+            dt[lev] = m_const_dt.value();
         }
         return;
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1339,7 +1339,8 @@ private:
     int num_injected_species = -1;
     amrex::Vector<int> injected_plasma_species;
 
-    amrex::Real const_dt = amrex::Real(0.5e-11);
+    amrex::Real const_dt;
+    bool const_dt_specified;
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1339,7 +1339,7 @@ private:
     int num_injected_species = -1;
     amrex::Vector<int> injected_plasma_species;
 
-    amrex::Real std::optional<amrex::Real> m_const_dt;
+    std::optional<amrex::Real> m_const_dt;
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1339,8 +1339,7 @@ private:
     int num_injected_species = -1;
     amrex::Vector<int> injected_plasma_species;
 
-    amrex::Real const_dt;
-    bool const_dt_specified;
+    amrex::Real std::optional<amrex::Real> m_const_dt;
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -669,7 +669,7 @@ WarpX::ReadParameters ()
         pp_warpx.query("eb_potential(x,y,z,t)", m_poisson_boundary_handler.potential_eb_str);
         m_poisson_boundary_handler.buildParsers();
 
-        const_dt_specified = utils::parser::queryWithParser(pp_warpx, "const_dt", const_dt);
+        utils::parser::queryWithParser(pp_warpx, "const_dt", m_const_dt);
 
         // Filter currently not working with FDTD solver in RZ geometry: turn OFF by default
         // (see https://github.com/ECP-WarpX/WarpX/issues/1943)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -669,7 +669,7 @@ WarpX::ReadParameters ()
         pp_warpx.query("eb_potential(x,y,z,t)", m_poisson_boundary_handler.potential_eb_str);
         m_poisson_boundary_handler.buildParsers();
 
-        utils::parser::queryWithParser(pp_warpx, "const_dt", const_dt);
+        const_dt_specified = utils::parser::queryWithParser(pp_warpx, "const_dt", const_dt);
 
         // Filter currently not working with FDTD solver in RZ geometry: turn OFF by default
         // (see https://github.com/ECP-WarpX/WarpX/issues/1943)


### PR DESCRIPTION
This small PR allows more control of the time step for EM simulations and ensures that it is set for ES.