### PR TITLE
Refactor update of auxiliary data for electrostatic solver

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -156,7 +156,7 @@ WarpX::Evolve (int numsteps)
                     FillBoundaryAux(guard_cells.ng_UpdateAux);
             }
             UpdateAuxilaryData();
-            FillBoundaryAux(guard_cells.ng_UpdateAux);            
+            FillBoundaryAux(guard_cells.ng_UpdateAux);
         }
 
         // Run multi-physics modules:

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -125,9 +125,9 @@ WarpX::Evolve (int numsteps)
                 // Not called at each iteration, so exchange all guard cells
                 FillBoundaryE(guard_cells.ng_alloc_EB);
                 FillBoundaryB(guard_cells.ng_alloc_EB);
-                UpdateAuxilaryData();
-                FillBoundaryAux(guard_cells.ng_UpdateAux);
             }
+            UpdateAuxilaryData();
+            FillBoundaryAux(guard_cells.ng_UpdateAux);
             // on first step, push p by -0.5*dt
             for (int lev = 0; lev <= finest_level; ++lev)
             {
@@ -154,9 +154,9 @@ WarpX::Evolve (int numsteps)
                 // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
                 if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD)
                     FillBoundaryAux(guard_cells.ng_UpdateAux);
-                UpdateAuxilaryData();
-                FillBoundaryAux(guard_cells.ng_UpdateAux);
             }
+            UpdateAuxilaryData();
+            FillBoundaryAux(guard_cells.ng_UpdateAux);            
         }
 
         // Run multi-physics modules:

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -89,12 +89,6 @@ WarpX::ComputeSpaceChargeField (bool const reset_fields)
             AddBoundaryField();
         }
     }
-    // Transfer fields from 'fp' array to 'aux' array.
-    // This is needed when using momentum conservation
-    // since they are different arrays in that case.
-    UpdateAuxilaryData();
-    FillBoundaryAux(guard_cells.ng_UpdateAux);
-
 }
 
 /* Compute the potential `phi` by solving the Poisson equation with the


### PR DESCRIPTION
In the current version of WarpX, the update of the auxiliary data (i.e. interpolating across levels ; interpolating from a staggering grid to a nodal grid when using the momentum-conserving algorithm) is done in a different parts of the code, for the electrostatic and electromagnetic solver.

This PR simplifies this by always doing the update of the auxiliary data in the same part of the code, for both the electrostatic and electromagnetic solver. 