### PR TITLE
Docs: add ``photon_species`` input param and fix typo

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -546,6 +546,10 @@ Particle initialization
     The name of each species. This is then used in the rest of the input deck ;
     in this documentation we use `<species_name>` as a placeholder.
 
+* ``particles.photon_species`` (`strings`, separated by spaces)
+    List of species that are photon species, if any. 
+    **This is required when compiling with QED=TRUE.**
+
 * ``particles.use_fdtd_nci_corr`` (`0` or `1`) optional (default `0`)
     Whether to activate the FDTD Numerical Cherenkov Instability corrector.
     Not currently available in the RZ configuration.
@@ -2637,7 +2641,7 @@ Lookup tables store pre-computed values for functions used by the QED modules.
 
         * ``qed_qs.tab_em_frac_min`` (`float`): minimum value to be considered for the second axis of lookup table 2
 
-        * ``qed_bw.save_table_in`` (`string`): where to save the lookup table
+        * ``qed_qs.save_table_in`` (`string`): where to save the lookup table
 
     * ``load``: a lookup table is loaded from a pre-generated binary file. The following parameter
       must be specified:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -547,7 +547,7 @@ Particle initialization
     in this documentation we use `<species_name>` as a placeholder.
 
 * ``particles.photon_species`` (`strings`, separated by spaces)
-    List of species that are photon species, if any. 
+    List of species that are photon species, if any.
     **This is required when compiling with QED=TRUE.**
 
 * ``particles.use_fdtd_nci_corr`` (`0` or `1`) optional (default `0`)


### PR DESCRIPTION
This PR makes the following changes to the _Input Parameters_ page of the documentation:
- Adds the input parameter ``particles.photon_species`` to the _Particle Initialization_ section.
- Fixes a typo in the section _Lookup tables and other settings for QED modules_ under the bullet point 
concerning ``qed_qs.lookup_table_mode`` (from ``qed_bw.save_table_in`` to ``qed_qs.save_table_in``).