### PR TITLE
Fix: NullifyMF Z-Box Check

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -234,13 +234,7 @@ void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax)
         const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev, 0._rt)[WARPX_ZINDEX];
         amrex::Real dz  = WarpX::CellSize(lev)[WARPX_ZINDEX];
         // Get box lower index in the z direction
-#if defined(WARPX_DIM_3D)
-        const int lo_ind = bx.loVect()[2];
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        const int lo_ind = bx.loVect()[1];
-#else
-        const int lo_ind = bx.loVect()[0];
-#endif
+        const int lo_ind = bx.loVect()[WARPX_ZINDEX];
         // Check if box intersect with [zmin, zmax]
         if ( (zmax>zmin_box && zmin<=zmax_box) ){
             Array4<Real> arr = mf[mfi].array();

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -230,9 +230,9 @@ void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax)
     for(amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
         const amrex::Box& bx = mfi.tilebox();
         // Get box lower and upper physical z bound, and dz
-        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev, 0._rt)[2];
-        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev, 0._rt)[2];
-        amrex::Real dz  = WarpX::CellSize(lev)[2];
+        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev, 0._rt)[WARPX_ZINDEX];
+        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev, 0._rt)[WARPX_ZINDEX];
+        amrex::Real dz  = WarpX::CellSize(lev)[WARPX_ZINDEX];
         // Get box lower index in the z direction
 #if defined(WARPX_DIM_3D)
         const int lo_ind = bx.loVect()[2];

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -230,9 +230,9 @@ void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax)
     for(amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
         const amrex::Box& bx = mfi.tilebox();
         // Get box lower and upper physical z bound, and dz
-        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev, 0._rt)[WARPX_ZINDEX];
-        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev, 0._rt)[WARPX_ZINDEX];
-        amrex::Real dz  = WarpX::CellSize(lev)[WARPX_ZINDEX];
+        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev, 0._rt)[2];
+        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev, 0._rt)[2];
+        amrex::Real dz = WarpX::CellSize(lev)[WARPX_ZINDEX];
         // Get box lower index in the z direction
         const int lo_ind = bx.loVect()[WARPX_ZINDEX];
         // Check if box intersect with [zmin, zmax]


### PR DESCRIPTION
The box check did not take the right Z component in non-3D geometries.

This results in our mirrors not being applied in some cases, depending on the concrete simulation dimensions used for the other components.