### PR TITLE
Fix Intel CI: dpcpp -> icpx

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -157,8 +157,8 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
-        export CXX=$(which dpcpp)
-        export CC=$(which clang)
+        export CXX=$(which icpx)
+        export CC=$(which icx)
 
         cmake -S . -B build_sp         \
           -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -159,6 +159,7 @@ jobs:
         set -e
         export CXX=$(which icpx)
         export CC=$(which icx)
+        export CXXFLAGS="-fsycl ${CXXFLAGS}"
 
         cmake -S . -B build_sp         \
           -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \


### PR DESCRIPTION
Intel has deprecated `dpcpp`.  We are supposed to use `icpx -fsycl` now for SYCL code.