### PR TITLE
Fix two "Inconsistent nullness checks" of costs pointer (for load balancing)  found with CodeQL 

### DIFF
--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -31,6 +31,7 @@
 #include <iomanip>
 #include <istream>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace amrex;
@@ -76,19 +77,19 @@ void LoadBalanceCosts::ComputeDiags (int step)
     // get a reference to WarpX instance
     auto& warpx = WarpX::GetInstance();
 
-    const amrex::LayoutData<amrex::Real>* cost = warpx.getCosts(0);
-
     // judge if the diags should be done
     // costs is initialized only if we're doing load balance
     if (!m_intervals.contains(step+1) ||
-          !warpx.get_load_balance_intervals().isActivated() ) { return; }
+        !warpx.get_load_balance_intervals().isActivated() ) { return; }
 
     // get number of boxes over all levels
     auto nLevels = warpx.finestLevel() + 1;
     int nBoxes = 0;
     for (int lev = 0; lev < nLevels; ++lev)
     {
-        cost = warpx.getCosts(lev);
+        const auto cost = warpx.getCosts(lev);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            cost, "ERROR: costs are not initialized on level " + std::to_string(lev) + " !");
         nBoxes += cost->size();
     }
 


### PR DESCRIPTION
@ax3l , nerd sniping works