### PR TITLE
CI: Unbreak macOS Python3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,9 +36,9 @@ jobs:
       run: |
         brew --cache
         set +e
-        rm -rf /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3.11 /usr/local/bin/python3.11 /usr/local/bin/python3.11-config
         brew unlink gcc
         brew update
+        brew install --overwrite python
         brew install ccache
         brew install fftw
         brew install libomp


### PR DESCRIPTION
```
==> Pouring python@3.10--3.10.9.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/idle3
Target /usr/local/bin/idle3
already exists. You may want to remove it:
  rm '/usr/local/bin/idle3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.10

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.10
```