### PR TITLE
Docs: Fix HTML5 for Install Logos

### DIFF
--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -6,7 +6,7 @@ Users
 .. raw:: html
 
    <style>
-   .rst-content .section>img {
+   .rst-content section>img {
        width: 30px;
        margin-bottom: 0;
        margin-top: 0;


### PR DESCRIPTION
With the update tot HTML5 in docutils, we need to modernize our CSS code that does fancy logos in the user install section.

Follow-up to #3546