### PR TITLE
Adding radial weighting at r=0 for Jr if nodal

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -1227,9 +1227,6 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     const Real dr = dx[0];
 
     constexpr int NODE = amrex::IndexType::NODE;
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Jx->ixType().toIntVect()[0] != NODE,
-        "Jr should never node-centered in r");
-
 
     for ( MFIter mfi(*Jx, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
@@ -1255,6 +1252,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         const int irmin = lo.x;
 
         // For ishift, 1 means cell centered, 0 means node centered
+        int const ishift_r = (rminr > rmin ? 1 : 0);
         int const ishift_t = (rmint > rmin ? 1 : 0);
         int const ishift_z = (rminz > rmin ? 1 : 0);
 
@@ -1281,29 +1279,36 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
         {
             // Wrap the current density deposited in the guard cells around
             // to the cells above the axis.
-            // Note that Jr(i==0) is at 1/2 dr.
-            if (rmin == 0. && 0 <= i && i < ngJ[0]) {
-                Jr_arr(i,j,0,0) -= Jr_arr(-1-i,j,0,0);
+            // If Jr is node centered, Jr[0] is located on the boundary.
+            // If Jr is cell centered, Jr[0] is at 1/2 dr.
+            if (rmin == 0. && 1-ishift_r <= i && i < ngJ[0]-ishift_r) {
+                Jr_arr(i,j,0,0) -= Jr_arr(-ishift_r-i,j,0,0);
             }
             // Apply the inverse volume scaling
-            // Since Jr is never node centered in r, no need for distinction
-            // between on axis and off-axis factors
+            // Jr is forced to zero on axis
             const amrex::Real r = amrex::Math::abs(rminr + (i - irmin)*dr);
-            Jr_arr(i,j,0,0) /= (2.*MathConst::pi*r);
+            if (r == 0.) {
+                Jr_arr(i,j,0,0) = 0.;
+            } else {
+                Jr_arr(i,j,0,0) /= (2.*MathConst::pi*r);
+            }
 
             for (int imode=1 ; imode < nmodes ; imode++) {
                 // Wrap the current density deposited in the guard cells around
                 // to the cells above the axis.
-                // Note that Jr(i==0) is at 1/2 dr.
-                if (rmin == 0. && 0 <= i && i < ngJ[0]) {
-                    Jr_arr(i,j,0,2*imode-1) += std::pow(-1, imode+1)*Jr_arr(-1-i,j,0,2*imode-1);
-                    Jr_arr(i,j,0,2*imode) += std::pow(-1, imode+1)*Jr_arr(-1-i,j,0,2*imode);
+                if (rmin == 0. && 1-ishift_r <= i && i < ngJ[0]-ishift_r) {
+                    Jr_arr(i,j,0,2*imode-1) += std::pow(-1, imode+1)*Jr_arr(-ishift_r-i,j,0,2*imode-1);
+                    Jr_arr(i,j,0,2*imode) += std::pow(-1, imode+1)*Jr_arr(-ishift_r-i,j,0,2*imode);
                 }
                 // Apply the inverse volume scaling
-                // Since Jr is never node centered in r, no need for distinction
-                // between on axis and off-axis factors
-                Jr_arr(i,j,0,2*imode-1) /= (2.*MathConst::pi*r);
-                Jr_arr(i,j,0,2*imode) /= (2.*MathConst::pi*r);
+                // Jr is forced to zero on axis.
+                if (r == 0.) {
+                    Jr_arr(i,j,0,2*imode-1) = 0.;
+                    Jr_arr(i,j,0,2*imode) = 0.;
+                } else {
+                    Jr_arr(i,j,0,2*imode-1) /= (2.*MathConst::pi*r);
+                    Jr_arr(i,j,0,2*imode) /= (2.*MathConst::pi*r);
+                }
             }
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)


### PR DESCRIPTION
In case of nodal currents, as in the magnetostatic solver, during radial current weighting, the case of handling the radial current at r=0 needs to be handled.  This adds in this logic and pins the radial current to zero at r=0 similarly to how Jt is pinned to zero at r=0.