### PR TITLE
Adding Amrex Bucket into WarpX Python interface.

### DIFF
--- a/Python/pywarpx/Amrex.py
+++ b/Python/pywarpx/Amrex.py
@@ -1,0 +1,9 @@
+# Copyright 2022 S. Eric CLark, LLNL
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+from .Bucket import Bucket
+
+amrex = Bucket('amrex')

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -10,6 +10,7 @@ import re
 from . import Particles
 from .Algo import algo
 from .Amr import amr
+from .Amrex import amrex
 from .Boundary import boundary
 from .Bucket import Bucket
 from .Collisions import collisions, collisions_list
@@ -40,6 +41,7 @@ class WarpX(Bucket):
         argv += warpx.attrlist()
         argv += my_constants.attrlist()
         argv += amr.attrlist()
+        argv += amrex.attrlist()
         argv += geometry.attrlist()
         argv += boundary.attrlist()
         argv += algo.attrlist()

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -6,6 +6,7 @@
 
 from .Algo import algo
 from .Amr import amr
+from .Amrex import amrex
 from .Boundary import boundary
 from .Collisions import collisions
 from .Constants import my_constants

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1476,6 +1476,12 @@ class Simulation(picmistandard.PICMI_Simulation):
     warpx_amr_restart: string, optional
         The name of the restart to use
 
+    warpx_amrex_the_arena_is_managed: bool, optional
+        Whether to use managed memory in the AMReX Arena
+
+    warpx_amrex_the_arena_init_size: long int, optional
+        The amount of memory in bytes to allocate in the Arena.
+
     warpx_zmax_plasma_to_compute_max_step: float, optional
         Sets the simulation run time based on the maximum z value
 
@@ -1515,6 +1521,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.use_fdtd_nci_corr = kw.pop('warpx_use_fdtd_nci_corr', None)
         self.amr_check_input = kw.pop('warpx_amr_check_input', None)
         self.amr_restart = kw.pop('warpx_amr_restart', None)
+        self.amrex_the_arena_is_managed = kw.pop('warpx_amrex_the_arena_is_managed', None)
+        self.amrex_the_arena_init_size = kw.pop('warpx_amrex_the_arena_init_size', None)
         self.zmax_plasma_to_compute_max_step = kw.pop('warpx_zmax_plasma_to_compute_max_step', None)
 
         self.collisions = kw.pop('warpx_collisions', None)
@@ -1609,6 +1617,12 @@ class Simulation(picmistandard.PICMI_Simulation):
 
         if self.amr_restart:
             pywarpx.amr.restart = self.amr_restart
+
+        if self.amrex_the_arena_is_managed is not None:
+            pywarpx.amrex.the_arena_is_managed = self.amrex_the_arena_is_managed
+
+        if self.amrex_the_arena_init_size is not None:
+            pywarpx.amrex.the_arena_init_size = self.amrex_the_arena_init_size
 
     def initialize_warpx(self, mpi_comm=None):
         if self.warpx_initialized:


### PR DESCRIPTION
This PR adds the Amrex bucket into the Python WarpX interface to allow setting of Amrex parameters from the PICMI input scripts.

- [x] PICMI-like options used
- [x] user-facing documentation