### PR TITLE
CMake: ADIOS1 off by default

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -11,6 +11,7 @@ function(find_openpmd)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
         # see https://openpmd-api.readthedocs.io/en/0.14.3/dev/buildoptions.html
+        set(openPMD_USE_ADIOS1      OFF           CACHE INTERNAL "")
         set(openPMD_USE_MPI         ${WarpX_MPI}  CACHE INTERNAL "")
         set(openPMD_USE_PYTHON      OFF           CACHE INTERNAL "")
         set(openPMD_BUILD_CLI_TOOLS OFF           CACHE INTERNAL "")


### PR DESCRIPTION
We will deprecate ADIOS1 and will not build it by default anymore in the upcoming release. Since we only use ADIOS2 in WarpX and builds are sometimes fragile with ADIOS1, we just disable it now in superbuilds already.

Related to #3541 (fixes the defaults on macOS with the 0.14.5 release :) )