### PR TITLE
Fix a Bug in 1D ES

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -859,10 +859,9 @@ WarpX::computePhiTriDiagonal (const amrex::Vector<std::unique_ptr<amrex::MultiFa
 
     }
 
-    // Copy phi1d to phi, including the x guard cell
-    const IntVect xghost(AMREX_D_DECL(1,0,0));
-    phi[lev]->ParallelCopy(phi1d_mf, 0, 0, 1, xghost, xghost, Geom(lev).periodicity());
-
+    // Copy phi1d to phi
+    phi[lev]->ParallelCopy(phi1d_mf, 0, 0, 1);
+    phi[lev]->FillBoundary(Geom(lev).periodicity());
 }
 
 void ElectrostaticSolver::PoissonBoundaryHandler::definePhiBCs ( )


### PR DESCRIPTION
After the tri-diagonal solve, the data in the special single-box MultiFab need to be copied back to the normal MultiFab.  However, when there was a bug for periodic boundary.  The issue is the special MultiFab is really special.  It has a nodal Box that grows the original nodal Box by 1 node in the lower boundary and 2 (why 2?) nodes in the upper boundary and these grown nodes are considered valid nodes, even though they do not have valid data.  Therefore amrex::ParallelCopy with periodicity does not work in this case.  For example, for a domain with 96 cells, the data at nodes 1 and 2 of the normal MultiFab could be written with the invalid data at nodes 97 and 98 of the special MultiFab.  This bug is fixed by replacing it with a ParallelCopy without periodicity followed by a FillBoundary.