### PR TITLE
1D ES: Remove an unnecessary FillBoundary

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -861,7 +861,6 @@ WarpX::computePhiTriDiagonal (const amrex::Vector<std::unique_ptr<amrex::MultiFa
 
     // Copy phi1d to phi
     phi[lev]->ParallelCopy(phi1d_mf, 0, 0, 1);
-    phi[lev]->FillBoundary(Geom(lev).periodicity());
 }
 
 void ElectrostaticSolver::PoissonBoundaryHandler::definePhiBCs ( )


### PR DESCRIPTION
There is no need to fill the ghost nodes of phi, because the stencil used to compute cell-centered E field from nodal values of phi does not use ghost nodes.