### PR TITLE
Docs: Update Crusher (OLCF) Submission

### DIFF
--- a/Tools/machines/crusher-olcf/submit.sh
+++ b/Tools/machines/crusher-olcf/submit.sh
@@ -7,7 +7,8 @@
 #SBATCH -t 00:10:00
 #SBATCH -p batch
 #SBATCH --ntasks-per-node=8
-#SBATCH --cpus-per-task=8
+# broken since 01/2023
+#S BATCH --cpus-per-task=8
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=closest
 #SBATCH -N 1


### PR DESCRIPTION
Update the Crusher (OLCF) job submission template as seen since the last system update by Weiqun.

> now I get
>   srun: error: Unable to create step for job 238051: More
>   processors requested than permitted.
> It seems that after the most recent shutdown of crusher a few days
> ago, -c 8 no longer works. The mapping without -c 8 is probably
> still fine, because I can see 64 unique GPUs, assuming we can trust
> HIP's uuid.

I checked the Frontier template and that one currently does not yet configure these options.

## Tests

- [x] with the option set: fails
- [x] without the option: works