### PR TITLE
CMake: Lib Symlink w/ Complex Paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,23 +401,21 @@ install(TARGETS ${WarpX_INSTALL_TARGET_NAMES}
 # this is currently expected by Python bindings
 if(WarpX_LIB)
     if(WarpX_DIMS STREQUAL RZ)
-        set(lib_suffix "rz")
+        set(lib_dim "rz")
     else()
-        set(lib_suffix "${WarpX_DIMS}d")
-    endif()
-    if(WIN32)
-        set(mod_ext "dll")
-    else()
-        set(mod_ext "so")
+        set(lib_dim "${WarpX_DIMS}d")
     endif()
     if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
         set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
     else()
         set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
     endif()
+    # escape spaces for generated cmake_install.cmake file
+    file(TO_CMAKE_PATH "${ABS_INSTALL_LIB_DIR}" ABS_INSTALL_LIB_DIR)
+
     install(CODE "file(CREATE_LINK
         $<TARGET_FILE_NAME:shared>
-        ${ABS_INSTALL_LIB_DIR}/libwarpx.${lib_suffix}.${mod_ext}
+        \"${ABS_INSTALL_LIB_DIR}/libwarpx.${lib_dim}$<TARGET_FILE_SUFFIX:shared>\"
         COPY_ON_ERROR SYMBOLIC)")
 endif()
 


### PR DESCRIPTION
Fix the symlink of the installed shared WarpX library for complex paths, e.g., on Windows, with spaces and parentheses.

First seen in ImpactX in https://github.com/ECP-WarpX/impactx/pull/208