### PR TITLE
CI: add RZ Langmuir test w/ multi-J PSATD

### DIFF
--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
@@ -1,0 +1,27 @@
+{
+  "electrons": {
+    "particle_momentum_x": 1.2841277705836573e-20,
+    "particle_momentum_y": 1.2783168246225546e-20,
+    "particle_momentum_z": 2.796719719686361e-20,
+    "particle_position_x": 0.5289998172531857,
+    "particle_position_y": 0.5888000000000001,
+    "particle_theta": 92506.29869360026,
+    "particle_weight": 81147583679.15044
+  },
+  "ions": {
+    "particle_momentum_x": 8.810504331931339e-22,
+    "particle_momentum_y": 8.848010425045236e-22,
+    "particle_momentum_z": 1.836516101267013e-21,
+    "particle_position_x": 0.5290000098037566,
+    "particle_position_y": 0.5888,
+    "particle_theta": 92089.14050622113,
+    "particle_weight": 81147583679.15044
+  },
+  "lev=0": {
+    "By": 5.366866795696419,
+    "Ex": 456124220403.9228,
+    "Ez": 639546653780.4882,
+    "jx": 901415161791532.9,
+    "jz": 1256863522753809.2
+  }
+}

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
@@ -1,27 +1,27 @@
 {
   "electrons": {
-    "particle_momentum_x": 1.2841272585740702e-20,
-    "particle_momentum_y": 1.2783167197907674e-20,
-    "particle_momentum_z": 2.796722362195713e-20,
-    "particle_position_x": 0.5289998172619089,
-    "particle_position_y": 0.5888,
-    "particle_theta": 92506.29869360026,
+    "particle_momentum_x": 2.8457118087033763e-20,
+    "particle_momentum_y": 2.8457118087033763e-20,
+    "particle_momentum_z": 5.593444724391368e-20,
+    "particle_position_x": 1.0579996345238136,
+    "particle_position_y": 1.1776000000000002,
+    "particle_theta": 184976.97544336706,
     "particle_weight": 81147583679.15044
   },
   "ions": {
-    "particle_momentum_x": 8.810528233036977e-22,
-    "particle_momentum_y": 8.848095695191374e-22,
-    "particle_momentum_z": 1.8364912134452272e-21,
-    "particle_position_x": 0.5290000098037575,
-    "particle_position_y": 0.5888000000000001,
-    "particle_theta": 92089.14050622113,
+    "particle_momentum_x": 1.96023307304804e-21,
+    "particle_momentum_y": 1.9602330730480405e-21,
+    "particle_momentum_z": 3.672982426891405e-21,
+    "particle_position_x": 1.0580000196075106,
+    "particle_position_y": 1.1776,
+    "particle_theta": 184976.97544336706,
     "particle_weight": 81147583679.15044
   },
   "lev=0": {
-    "By": 5.367231023011016,
-    "Ex": 456121788659.2767,
-    "Ez": 639548611111.2725,
-    "jx": 901414924550957.0,
-    "jz": 1256864596867530.0
+    "Bt": 5.367231023016254,
+    "Er": 456121788659.2861,
+    "Ez": 639548611111.296,
+    "jr": 901414924550968.9,
+    "jz": 1256864596867525.0
   }
 }

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_multiJ.json
@@ -1,27 +1,27 @@
 {
   "electrons": {
-    "particle_momentum_x": 1.2841277705836573e-20,
-    "particle_momentum_y": 1.2783168246225546e-20,
-    "particle_momentum_z": 2.796719719686361e-20,
-    "particle_position_x": 0.5289998172531857,
-    "particle_position_y": 0.5888000000000001,
+    "particle_momentum_x": 1.2841272585740702e-20,
+    "particle_momentum_y": 1.2783167197907674e-20,
+    "particle_momentum_z": 2.796722362195713e-20,
+    "particle_position_x": 0.5289998172619089,
+    "particle_position_y": 0.5888,
     "particle_theta": 92506.29869360026,
     "particle_weight": 81147583679.15044
   },
   "ions": {
-    "particle_momentum_x": 8.810504331931339e-22,
-    "particle_momentum_y": 8.848010425045236e-22,
-    "particle_momentum_z": 1.836516101267013e-21,
-    "particle_position_x": 0.5290000098037566,
-    "particle_position_y": 0.5888,
+    "particle_momentum_x": 8.810528233036977e-22,
+    "particle_momentum_y": 8.848095695191374e-22,
+    "particle_momentum_z": 1.8364912134452272e-21,
+    "particle_position_x": 0.5290000098037575,
+    "particle_position_y": 0.5888000000000001,
     "particle_theta": 92089.14050622113,
     "particle_weight": 81147583679.15044
   },
   "lev=0": {
-    "By": 5.366866795696419,
-    "Ex": 456124220403.9228,
-    "Ez": 639546653780.4882,
-    "jx": 901415161791532.9,
-    "jz": 1256863522753809.2
+    "By": 5.367231023011016,
+    "Ex": 456121788659.2767,
+    "Ez": 639548611111.2725,
+    "jx": 901414924550957.0,
+    "jz": 1256864596867530.0
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -995,8 +995,8 @@ aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
 [Langmuir_multi_rz_psatd_multiJ]
 buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_2d_multi_rz_rt
-runtime_params = amr.max_grid_size=32 algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=4 warpx.use_filter=1
+inputFile = Examples/Tests/langmuir/inputs_rz
+runtime_params = amr.max_grid_size=32 algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 warpx.n_rz_azimuthal_modes=2 electrons.random_theta=0 electrons.num_particles_per_cell_each_dim=2 4 2 ions.random_theta=0 ions.num_particles_per_cell_each_dim=2 4 2 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=4 warpx.use_filter=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -1009,7 +1009,7 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons ions
-analysisRoutine = Examples/Tests/langmuir/analysis_langmuir_multi_rz.py
+analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_multiJ_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -993,6 +993,26 @@ analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
+[Langmuir_multi_rz_psatd_multiJ]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d_multi_rz_rt
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=4 warpx.use_filter=1
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/langmuir/analysis_langmuir_multi_rz.py
+analysisOutputImage = Langmuir_multi_rz_psatd_multiJ_analysis.png
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
 [Python_Langmuir_rz_multimode]
 buildDir = .
 inputFile = Examples/Tests/langmuir/PICMI_inputs_rz.py

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -996,7 +996,7 @@ aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 [Langmuir_multi_rz_psatd_multiJ]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_2d_multi_rz_rt
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=4 warpx.use_filter=1
+runtime_params = amr.max_grid_size=32 algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.ions.variables=w ux uy uz diag1.dump_rz_modes=0 algo.current_deposition=direct warpx.do_dive_cleaning=0 psatd.update_with_rho=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=4 warpx.use_filter=1
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON


### PR DESCRIPTION
Follow-up after #3363. Add RZ Langmuir test with multi-J PSATD (4 depositions). The existing test was a PWFA test, in the lab frame, performing only regression analysis with the checksum benchmarks, while the Langmuir test added here also compares simulation vs. theory.

- [x] Merge first #3764