### PR TITLE
Fix segfault in interpolation with anisotropic ref ratio

### DIFF
--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -20,6 +20,12 @@ void warpx_interp (int j, int k, int l,
 {
     using namespace amrex;
 
+    // Pad arr_coarse with zeros beyond ghost cells for out-of-bound accesses
+    const auto arr_coarse_zeropad = [arr_coarse] (const int jj, const int kk, const int ll) noexcept
+    {
+        return arr_coarse.contains(jj,kk,ll) ? arr_coarse(jj,kk,ll) : 0.0_rt;
+    };
+
     // NOTE Indices (j,k,l) in the following refer to (z,-,-) in 1D, (x,z,-) in 2D, and (x,y,z) in 3D
 
     // Refinement ratio
@@ -57,7 +63,7 @@ void warpx_interp (int j, int k, int l,
                                           / static_cast<amrex::Real>(rk);
                 wl = (sl == 0) ? 1.0_rt : (rl - amrex::Math::abs(l - (lc + ll) * rl))
                                           / static_cast<amrex::Real>(rl);
-                res += wj * wk * wl * arr_coarse(jc+jj,kc+kk,lc+ll);
+                res += wj * wk * wl * arr_coarse_zeropad(jc+jj,kc+kk,lc+ll);
             }
         }
     }

--- a/Source/ablastr/coarsen/average.cpp
+++ b/Source/ablastr/coarsen/average.cpp
@@ -105,11 +105,7 @@ namespace ablastr::coarsen::average
                                            "source MultiFab and destination MultiFab have different IndexType");
 
         // Number of guard cells to fill on coarse patch and number of components
-        amrex::IntVect ngrow = mf_src.nGrowVect();
-        for (int l=0; l < AMREX_SPACEDIM; ++l) {
-             if (crse_ratio[l] > 1)  ngrow[l] = (ngrow[l] + 1) / crse_ratio[l];
-        }
-
+        const amrex::IntVect ngrow = (mf_src.nGrowVect() + crse_ratio-1) / crse_ratio; // round up int division
         const int ncomp = mf_src.nComp();
 
         Loop(mf_dst, mf_src, ncomp, ngrow, crse_ratio);

--- a/Source/ablastr/coarsen/average.cpp
+++ b/Source/ablastr/coarsen/average.cpp
@@ -105,11 +105,9 @@ namespace ablastr::coarsen::average
                                            "source MultiFab and destination MultiFab have different IndexType");
 
         // Number of guard cells to fill on coarse patch and number of components
-    amrex::IntVect ngrow;
-
-        for ( int l = 0; l < AMREX_SPACEDIM; ++l ) {
-            if ( crse_ratio[l] == 1 ) ngrow[l] = mf_src.nGrowVect()[l]; // no coarsening
-            else              ngrow[l] = (mf_src.nGrowVect()[l] + 1) / crse_ratio[l];
+        amrex::IntVect ngrow = mf_src.nGrowVect();
+        for (int l=0; l < AMREX_SPACEDIM; ++l) {
+             if (crse_ratio[l] > 1)  ngrow[l] = (ngrow[l] + 1) / crse_ratio[l];
         }
 
         const int ncomp = mf_src.nComp();

--- a/Source/ablastr/coarsen/average.cpp
+++ b/Source/ablastr/coarsen/average.cpp
@@ -105,7 +105,7 @@ namespace ablastr::coarsen::average
                                            "source MultiFab and destination MultiFab have different IndexType");
 
         // Number of guard cells to fill on coarse patch and number of components
-	amrex::IntVect ngrow;
+    amrex::IntVect ngrow;
 
         for ( int l = 0; l < AMREX_SPACEDIM; ++l ) {
             if ( crse_ratio[l] == 1 ) ngrow[l] = mf_src.nGrowVect()[l]; // no coarsening

--- a/Source/ablastr/coarsen/average.cpp
+++ b/Source/ablastr/coarsen/average.cpp
@@ -105,7 +105,13 @@ namespace ablastr::coarsen::average
                                            "source MultiFab and destination MultiFab have different IndexType");
 
         // Number of guard cells to fill on coarse patch and number of components
-        const amrex::IntVect ngrow = (mf_src.nGrowVect() + 1) / crse_ratio;
+	amrex::IntVect ngrow;
+
+        for ( int l = 0; l < AMREX_SPACEDIM; ++l ) {
+            if ( crse_ratio[l] == 1 ) ngrow[l] = mf_src.nGrowVect()[l]; // no coarsening
+            else              ngrow[l] = (mf_src.nGrowVect()[l] + 1) / crse_ratio[l];
+        }
+
         const int ncomp = mf_src.nComp();
 
         Loop(mf_dst, mf_src, ncomp, ngrow, crse_ratio);


### PR DESCRIPTION
This PR fixes segfault at two interpolation routines that use anisotropic refinement ratio.
