### PR TITLE
[WIP] Doc: Perlmutter E4S Modules

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -36,62 +36,27 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
    :language: bash
    :caption: You can copy this file from ``Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example``.
 
-We recommend to store the above lines in a file, such as ``$HOME/perlmutter_warpx.profile``, and load it into your shell after a login:
+We recommend to store the above lines in a file, such as ``$HOME/perlmutter_warpx.profile``.
+Change the line that reads ``export proj="<yourProject>_g"  # change me`` to your NERSC project, e.g.,
+
+.. code-block:: bash
+
+   export proj="m3239_g"
+
+and load it into your shell *after each login*:
 
 .. code-block:: bash
 
    source $HOME/perlmutter_warpx.profile
 
-And since Perlmutter does not yet provide a module for them, install ADIOS2, BLAS++ and LAPACK++:
+*Only once on first setup*, we need to install packages not provided by NERSC:
 
 .. code-block:: bash
 
-   # c-blosc (I/O compression)
-   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git src/c-blosc
-   rm -rf src/c-blosc-pm-build
-   cmake -S src/c-blosc -B src/c-blosc-pm-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/c-blosc-1.21.1
-   cmake --build src/c-blosc-pm-build --target install --parallel 16
+   # this might take around 15min
+   spack install
 
-   # ADIOS2
-   git clone -b v2.7.1 https://github.com/ornladios/ADIOS2.git src/adios2
-   rm -rf src/adios2-pm-build
-   cmake -S src/adios2 -B src/adios2-pm-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/adios2-2.7.1
-   cmake --build src/adios2-pm-build --target install -j 16
-
-   # BLAS++ (for PSATD+RZ)
-   git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
-   rm -rf src/blaspp-pm-build
-   CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/blaspp-master
-   cmake --build src/blaspp-pm-build --target install --parallel 16
-
-   # LAPACK++ (for PSATD+RZ)
-   git clone https://github.com/icl-utk-edu/lapackpp.git src/lapackpp
-   rm -rf src/lapackpp-pm-build
-   CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-pm-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/perlmutter/lapackpp-master
-   cmake --build src/lapackpp-pm-build --target install --parallel 16
-
-Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):
-
-.. code-block:: bash
-
-   python3 -m pip install --user --upgrade pip
-   python3 -m pip install --user virtualenv
-   python3 -m pip cache purge
-   rm -rf $HOME/sw/perlmutter/venvs/warpx
-   python3 -m venv $HOME/sw/perlmutter/venvs/warpx
-   source $HOME/sw/perlmutter/venvs/warpx/bin/activate
-   python3 -m pip install --upgrade pip
-   python3 -m pip install --upgrade wheel
-   python3 -m pip install --upgrade cython
-   python3 -m pip install --upgrade numpy
-   python3 -m pip install --upgrade pandas
-   python3 -m pip install --upgrade scipy
-   MPICC="cc -target-accel=nvidia80 -shared" python3 -m pip install --upgrade mpi4py --no-build-isolation --no-binary mpi4py
-   python3 -m pip install --upgrade openpmd-api
-   python3 -m pip install --upgrade matplotlib
-   python3 -m pip install --upgrade yt
-   # optional: for libEnsemble
-   python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
+   python3 -m pip install h5py libensemble matplotlib nlopt openpmd-api openpmd-viewer pandas pytest scipy yt
 
 Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
 

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -4,11 +4,11 @@ export proj="<yourProject>_g"  # change me
 # load E4S & Spack
 module load e4s/22.05
 
-mySWenvDir="/global/common/software/${proj%_g}/$USER/spack-envs/warpx-perlmutter-cuda"
+mySWenvDir="/global/common/software/${proj%_g}/$USER/spack-22.05-envs/warpx-perlmutter-cuda"
 if [ ! -d "${mySWenvDir}" ]
   spack env create -d ${mySWenvDir} spack-perlmutter-cuda.yaml
 fi
-spack env activate ${mySWenvDir}
+spack env activate -d ${mySWenvDir}
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>

--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -1,31 +1,14 @@
 # please set your project account
-#export proj="<yourProject>_g"  # change me
+export proj="<yourProject>_g"  # change me
 
-# required dependencies
-module load cmake/3.22.0
+# load E4S & Spack
+module load e4s/22.05
 
-# optional: for QED support with detailed tables
-#module load boost/1.78.0-gnu  # missing
-
-# optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.1
-export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/adios2-2.7.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/blaspp-master:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=$HOME/sw/perlmutter/lapackpp-master:$CMAKE_PREFIX_PATH
-
-export LD_LIBRARY_PATH=$HOME/sw/perlmutter/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/sw/perlmutter/adios2-2.7.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/sw/perlmutter/blaspp-master/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/sw/perlmutter/lapackpp-master/lib64:$LD_LIBRARY_PATH
-
-# optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
-
-if [ -d "$HOME/sw/perlmutter/venvs/warpx" ]
-then
-  source $HOME/sw/perlmutter/venvs/warpx/bin/activate
+mySWenvDir="/global/common/software/${proj%_g}/$USER/spack-envs/warpx-perlmutter-cuda"
+if [ ! -d "${mySWenvDir}" ]
+  spack env create -d ${mySWenvDir} spack-perlmutter-cuda.yaml
 fi
+spack env activate ${mySWenvDir}
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>
@@ -46,8 +29,8 @@ export AMREX_CUDA_ARCH=8.0
 #export CFLAGS="-march=znver3"
 
 # compiler environment hints
-export CC=cc
-export CXX=CC
-export FC=ftn
+export CC=$(which gcc)
+export CXX=$(which g++)
+export FC=$(which gfortran)
 export CUDACXX=$(which nvcc)
-export CUDAHOSTCXX=CC
+export CUDAHOSTCXX=${CXX}

--- a/Tools/machines/perlmutter-nersc/spack-perlmutter-cuda.yaml
+++ b/Tools/machines/perlmutter-nersc/spack-perlmutter-cuda.yaml
@@ -47,7 +47,7 @@ spack:
   - cmake
   - cuda
   - hdf5
-  - lapackpp
+  - lapackpp ^blaspp+cuda
   - mpi
   - pkgconfig
   - python

--- a/Tools/machines/perlmutter-nersc/spack-perlmutter-cuda.yaml
+++ b/Tools/machines/perlmutter-nersc/spack-perlmutter-cuda.yaml
@@ -1,0 +1,91 @@
+# This is a Spack environment file.
+#
+# This environment can be used to install all dependencies to build the manual
+# locally.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https://spack.readthedocs.io/en/latest/environments.html
+#
+# Inside the directory of this file
+#   spack env create -d /global/common/software/${proj%_g}/$USER/spack-envs/warpx-perlmutter-cuda spack-perlmutter-cuda.yaml
+#   spack env activate /global/common/software/${proj%_g}/$USER/spack-envs/warpx-perlmutter-cuda
+#   spack install  # only needed the first time
+#
+spack:
+  # the top part is using the official template to chain the E4S modules at NERSC
+  #   https://docs.nersc.gov/applications/e4s/spack_environments/
+  #   https://github.com/NERSC/spack-infrastructure/blob/main/spack-configs/perlmutter-user-spack/spack.yaml
+  config:
+    concretization: together
+    build_stage: $env/var/spack/stage
+    misc_cache: $env/var/spack/misc_cache
+    concretizer: clingo
+    install_tree: $env/opt/spack
+
+  # Perlmutter compiler and package preferences
+  include:
+  - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
+  - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
+
+  mirrors:
+    perlmutter-spack-develop: file:///global/common/software/spackecp/mirrors/perlmutter-spack-develop
+    perlmutter-e4s-22.05: file:///global/common/software/spackecp/mirrors/perlmutter-e4s-22.05
+
+  # Spack Chaining, if you want to use existing software stack
+  upstreams:
+    perlmutter-e4s-22.05:
+      install_tree: /global/common/software/spackecp/perlmutter/e4s-22.05/default/spack/opt/spack
+
+  # these are the WarpX dependencies
+  specs:
+  # https://github.com/ornladios/ADIOS2/issues/3332
+  - adios2 ~cuda
+  - blaspp
+  - boost
+  - ccache
+  - cmake
+  - cuda
+  - hdf5
+  - lapackpp
+  - mpi
+  - pkgconfig
+  - python
+  - py-cython
+  - py-mpi4py
+  - py-numpy
+  - py-pip
+  - py-setuptools
+  - py-wheel
+# Ascent does not build as of 22.05 (cannot find MPI)
+#  - ascent +adios2 +python ~fortran ~shared
+#  - conduit ~fortran
+#  - vtk-m ~shared
+# saving time
+#  - sensei +ascent ~catalyst +python
+# CUDA Python dev
+#  - py-cupy
+#  - py-numba
+# This always enables DevilRay, which builds too long on CUDA and we mainly use VTK-m
+#  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+# skipped to save time: 3D post-processing
+#  - paraview +adios2 +python3 +qt
+# skipped to save time, because they are faster installed via pip afterwards
+#  python3 -m pip install h5py libensemble matplotlib nlopt openpmd-api openpmd-viewer pandas pytest scipy yt
+#  - nlopt
+#  - openpmd-api +python
+#  - py-h5py
+#  - py-libensemble +nlopt
+#  - py-matplotlib +animation +fonts +latex +movies
+#  - py-openpmd-viewer +numba +jupyter
+#  - py-pandas
+#  - py-pytest
+#  - py-pyqt5
+#  - py-scipy
+#  - py-yt
+
+  packages:
+    all:
+      # note: add +cuda cuda_arch=80
+      #       or respective CUDA capability instead of 80 to variants below
+      variants:: +mpi ~fortran +cuda cuda_arch=80


### PR DESCRIPTION
This is a major overhaul of the module setup on Perlmutter (NERSC).
We switch to use E4S and Spack now to deploy a whole environment with way less manual steps.

This also solves the issue that the default modules at NERSC are more and more incomplete, now even lacking `boost` and never providing CCache et al. for productivity.

## To Do

- [x] spack environment for CUDA
    - note: issue to concretize blaspp - can be solved by manually using `lapackpp^blaspp+cuda`
- [ ] update manual pages

## References
- https://docs.nersc.gov/applications/e4s/
- https://docs.nersc.gov/applications/e4s/spack_environments/
- https://github.com/NERSC/spack-infrastructure/blob/main/spack-configs/perlmutter-user-spack/spack.yaml