### PR TITLE
Serialization: replace std::vector<char>.insert with std::copy to avoid issues with g++12

### DIFF
--- a/Source/ablastr/utils/Serialization.H
+++ b/Source/ablastr/utils/Serialization.H
@@ -35,7 +35,7 @@ namespace ablastr::utils::serialization
             const auto length = static_cast<int>(val.size());
 
             put_in(length, vec);
-            vec.insert(vec.end(), c_str, c_str + length);
+            std::copy(c_str, c_str + length, std::back_inserter(vec));
         }
         else
         {
@@ -43,7 +43,7 @@ namespace ablastr::utils::serialization
                 "Cannot serialize non-trivally copyable types, except std::string.");
 
             const auto *ptr_val = reinterpret_cast<const char *>(&val);
-            vec.insert(vec.end(), ptr_val, ptr_val + sizeof(T));
+            std::copy(ptr_val, ptr_val + sizeof(T), std::back_inserter(vec));
         }
     }
 


### PR DESCRIPTION
This PR is a workaround to prevent g++ 12 from raising the following warning:
```
 In file included from /usr/include/c++/12/bits/stl_tree.h:63,
                 from /usr/include/c++/12/map:60,
                 from /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/mpicxx.h:42,
                 from /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:2887,
                 from /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_ccse-mpi.H:14,
                 from /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX.H:9,
                 from /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/utils/msg_logger/MsgLogger.H:11,
                 from /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/utils/msg_logger/MsgLogger.cpp:8:
In static member function 'static _Tp* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(const _Tp*, const _Tp*, _Tp*) [with _Tp = char; bool _IsMove = true]',
    inlined from '_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = true; _II = char*; _OI = char*]' at /usr/include/c++/12/bits/stl_algobase.h:495:30,
    inlined from '_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = true; _II = char*; _OI = char*]' at /usr/include/c++/12/bits/stl_algobase.h:522:42,
    inlined from '_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = true; _II = char*; _OI = char*]' at /usr/include/c++/12/bits/stl_algobase.h:529:31,
    inlined from '_OI std::copy(_II, _II, _OI) [with _II = move_iterator<char*>; _OI = char*]' at /usr/include/c++/12/bits/stl_algobase.h:620:7,
    inlined from 'static _ForwardIterator std::__uninitialized_copy<true>::__uninit_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = std::move_iterator<char*>; _ForwardIterator = char*]' at /usr/include/c++/12/bits/stl_uninitialized.h:147:27,
    inlined from '_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = move_iterator<char*>; _ForwardIterator = char*]' at /usr/include/c++/12/bits/stl_uninitialized.h:185:15,
    inlined from '_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, allocator<_Tp>&) [with _InputIterator = move_iterator<char*>; _ForwardIterator = char*; _Tp = char]' at /usr/include/c++/12/bits/stl_uninitialized.h:372:37,
    inlined from '_ForwardIterator std::__uninitialized_move_if_noexcept_a(_InputIterator, _InputIterator, _ForwardIterator, _Allocator&) [with _InputIterator = char*; _ForwardIterator = char*; _Allocator = allocator<char>]' at /usr/include/c++/12/bits/stl_uninitialized.h:397:2,
    inlined from 'void std::vector<_Tp, _Alloc>::_M_range_insert(iterator, _ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const char*; _Tp = char; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/vector.tcc:801:9,
    inlined from 'void std::vector<_Tp, _Alloc>::_M_insert_dispatch(iterator, _InputIterator, _InputIterator, std::__false_type) [with _InputIterator = const char*; _Tp = char; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/stl_vector.h:1779:19,
    inlined from 'std::vector<_Tp, _Alloc>::iterator std::vector<_Tp, _Alloc>::insert(const_iterator, _InputIterator, _InputIterator) [with _InputIterator = const char*; <template-parameter-2-2> = void; _Tp = char; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/stl_vector.h:1481:22,
    inlined from 'void ablastr::utils::serialization::put_in(const T&, std::vector<char>&) [with T = int]' at /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/utils/Serialization.H:46:23,
    inlined from 'void ablastr::utils::serialization::put_in(const T&, std::vector<char>&) [with T = std::__cxx11::basic_string<char>]' at /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/utils/Serialization.H:37:19,
    inlined from 'std::vector<char> ablastr::utils::msg_logger::Msg::serialize() const' at /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/utils/msg_logger/MsgLogger.cpp:132:20:
/usr/include/c++/12/bits/stl_algobase.h:431:30: warning: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' writing 1 or more bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  431 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |   
```