### PR TITLE
Docs: Spack Binary Caches

### DIFF
--- a/Docs/source/developers/gnumake/spack.rst
+++ b/Docs/source/developers/gnumake/spack.rst
@@ -4,7 +4,7 @@ Building WarpX with Spack
 =========================
 
 As mentioned in the :ref:`install section <install-users>`, WarpX can be installed using Spack.
-From the `Spack web page <https://spack.io>`_: "Spack is a package management tool designed to support multiple versions and configurations of software on a wide variety of platforms and environments."
+From the `Spack web page <https://spack.io>`__: "Spack is a package management tool designed to support multiple versions and configurations of software on a wide variety of platforms and environments."
 
 .. note::
 
@@ -17,6 +17,13 @@ From the `Spack web page <https://spack.io>`_: "Spack is a package management to
 
 Spack is available from `github <https://github.com/spack/spack>`_.
 Spack only needs to be cloned and can be used right away - there are no installation steps.
+You can add `binary caches <https://spack.io/spack-binary-packages/>`__ for faster builds:
+
+.. code-block:: bash
+
+   spack mirror add rolling https://binaries.spack.io/develop
+   spack buildcache keys --install --trust
+
 Do not miss out on `the official Spack tutorial <https://spack-tutorial.readthedocs.io/>`_ if you are new to Spack.
 
 The spack command, ``spack/bin/spack``, can be used directly or ``spack/bin`` can be added to your ``PATH`` environment variable.

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -83,8 +83,8 @@ For legacy ``GNUmake`` builds, after each ``source activate warpx-dev``, you als
 Spack (macOS/Linux)
 ^^^^^^^^^^^^^^^^^^^
 
-First, download a `Spack desktop development environment <https://github.com/ECP-WarpX/WarpX/blob/development/Tools/machines/desktop>`__ of your choice.
-For most desktop development, pick the OpenMP environment for CPUs unless you have a supported GPU.
+First, download a `WarpX Spack desktop development environment <https://github.com/ECP-WarpX/WarpX/blob/development/Tools/machines/desktop>`__ of your choice.
+For most desktop developments, pick the OpenMP environment for CPUs unless you have a supported GPU.
 
 * **Debian/Ubuntu** Linux:
 
@@ -95,6 +95,15 @@ For most desktop development, pick the OpenMP environment for CPUs unless you ha
 * **macOS**: first, prepare with ``brew install gpg2; brew install gcc``
 
   * OpenMP: ``system=macos; compute=openmp``
+
+If you already `installed Spack <https://spack.io>`__, we recommend to activate its `binary caches <https://spack.io/spack-binary-packages/>`__ for faster builds:
+
+.. code-block:: bash
+
+   spack mirror add rolling https://binaries.spack.io/develop
+   spack buildcache keys --install --trust
+
+Now install the WarpX dependencies in a new WarpX development environment:
 
 .. code-block:: bash
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -62,7 +62,12 @@ The package ``warpx`` installs executables and the package ``py-warpx`` includes
 
 .. code-block:: bash
 
-   # optional:            -mpi ^warpx dims=2 compute=cuda
+   # optional: activate Spack binary caches
+   spack mirror add rolling https://binaries.spack.io/develop
+   spack buildcache keys --install --trust
+
+   # see `spack info py-warpx` for build options.
+   # optional arguments:  -mpi ^warpx dims=2 compute=cuda
    spack install py-warpx
    spack load py-warpx
 


### PR DESCRIPTION
Spack now has binary caches for some popular platforms (not yet macOS). They are for rolling (`development`) and stable releases.

Since Spack's official docs will point users to install the rolling release of Spack, we will document to use the rolling binary cache.