### PR TITLE
Clean loadbalance params

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -467,13 +467,23 @@ Distribution across MPI ranks and parallelization
     Particle weight factor used in `Heuristic` strategy for costs update; if running on GPU,
     the particle weight is set to a value determined from single-GPU tests on Summit,
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
-    If running on CPU, the default value is `0.9`.
+    If running on CPU, the default value is `0.9`. If running on GPU, the default value is
+
+    |      | Particle shape factor ||
+    |      | 1 | 2 | 3 |
+    | FDTD/CKC | 0.599 | 0.732 | 0.855 |
+    | PSATD | 0.425 | 0.595 | 0.75 |
 
 * ``algo.costs_heuristic_cells_wt`` (`float`) optional
     Cell weight factor used in `Heuristic` strategy for costs update; if running on GPU,
     the cell weight is set to a value determined from single-GPU tests on Summit,
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
-    If running on CPU, the default value is `0.1`.
+    If running on CPU, the default value is `0.1`. If running on GPU, the default value is
+
+    |      | Particle shape factor ||
+    |      | 1 | 2 | 3 |
+    | FDTD/CKC | 0.401 | 0.268 | 0.145 |
+    | PSATD | 0.575 | 0.405 | 0.25 |
 
 * ``warpx.do_dynamic_scheduling`` (`0` or `1`) optional (default `1`)
     Whether to activate OpenMP dynamic scheduling.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -469,10 +469,15 @@ Distribution across MPI ranks and parallelization
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
     If running on CPU, the default value is `0.9`. If running on GPU, the default value is
 
-    |      | Particle shape factor ||
-    |      | 1 | 2 | 3 |
+    +----------+-----------------------+
+    |          | Particle shape factor |
+    +----------+-------+-------+-------+
+    |          | 1     | 2     | 3     |
+    +==========+=======+=======+=======+
     | FDTD/CKC | 0.599 | 0.732 | 0.855 |
-    | PSATD | 0.425 | 0.595 | 0.75 |
+    +----------+-------+-------+-------+
+    | PSATD    | 0.425 | 0.595 | 0.75  |
+    +----------+-------+-------+-------+
 
 * ``algo.costs_heuristic_cells_wt`` (`float`) optional
     Cell weight factor used in `Heuristic` strategy for costs update; if running on GPU,
@@ -480,10 +485,15 @@ Distribution across MPI ranks and parallelization
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
     If running on CPU, the default value is `0.1`. If running on GPU, the default value is
 
-    |      | Particle shape factor ||
-    |      | 1 | 2 | 3 |
+    +----------+-----------------------+
+    |          | Particle shape factor |
+    +----------+-------+-------+-------+
+    |          | 1     | 2     | 3     |
+    +==========+=======+=======+=======+
     | FDTD/CKC | 0.401 | 0.268 | 0.145 |
-    | PSATD | 0.575 | 0.405 | 0.25 |
+    +----------+-------+-------+-------+
+    | PSATD    | 0.575 | 0.405 | 0.25  |
+    +----------+-------+-------+-------+
 
 * ``warpx.do_dynamic_scheduling`` (`0` or `1`) optional (default `1`)
     Whether to activate OpenMP dynamic scheduling.

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -981,14 +981,18 @@ WarpX::ReadParameters ()
         load_balance_intervals = utils::parser::IntervalsParser(
             load_balance_intervals_string_vec);
         pp_algo.query("load_balance_with_sfc", load_balance_with_sfc);
-        pp_algo.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
+        // Knapsack factor only used with non-SFC strategy
+        if (!load_balance_with_sfc)
+            pp_algo.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
         utils::parser::queryWithParser(pp_algo, "load_balance_efficiency_ratio_threshold",
                         load_balance_efficiency_ratio_threshold);
         load_balance_costs_update_algo = GetAlgorithmInteger(pp_algo, "load_balance_costs_update");
-        utils::parser::queryWithParser(
-            pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
-        utils::parser::queryWithParser(
-            pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
+        if (WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic) {
+            utils::parser::queryWithParser(
+                pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
+            utils::parser::queryWithParser(
+                pp_algo, "costs_heuristic_particles_wt", costs_heuristic_particles_wt);
+        }
 
         // Parse algo.particle_shape and check that input is acceptable
         // (do this only if there is at least one particle or laser species)


### PR DESCRIPTION
- Added default values of `algo.costs_heuristic_particles_wt` and `algo.costs_heuristic_cells_wt` to documentation.
- Only read in knapsack factor and heuristic weight params if they will actually be used.