### PR TITLE
Docs: Conda MPI Variants

### DIFF
--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -43,6 +43,8 @@ A package for WarpX is available via the `Conda <https://conda.io>`_ package man
 
 .. code-block:: bash
 
+   # optional:        for OpenMPI support    =*=mpi_openmpi*
+   # optional:          for MPICH support    =*=mpi_mpich
    conda create -n warpx -c conda-forge warpx
    conda activate warpx
 


### PR DESCRIPTION
Document how to install the MPI variants of WarpX with conda/mamba.

Seen in https://github.com/ECP-WarpX/WarpX/issues/3631#issuecomment-1401357414