### PR TITLE
Perlmutter (NERSC): New Boost Module

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_warpx.profile.example
@@ -5,7 +5,7 @@
 module load cmake/3.22.0
 
 # optional: for QED support with detailed tables
-#module load boost/1.78.0-gnu  # missing
+export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-22.05/78535/spack/opt/spack/cray-sles15-zen3/gcc-11.2.0/boost-1.79.0-lmdngktoeuwdi6ty55noznunah2mvk5w
 
 # optional: for openPMD and PSATD+RZ support
 module load cray-hdf5-parallel/1.12.2.1


### PR DESCRIPTION
Just like #3619, stolen from E4S-22.05 deployment path.

```console
$ spack spec /lmdngkt
boost@1.79.0%gcc@11.2.0+atomic+chrono~clanglibcpp~container~context~contract~coroutine+date_time~debug+exception~fiber+filesystem+graph~graph_parallel~icu+iostreams~json+locale+log+math~mpi+multithreaded~nowide~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded~stacktrace+system~taggedlayout+test+thread+timer~type_erasure~versionedlayout+wave cxxstd=17 patches=57a8401,a440f96 visibility=hidden arch=cray-sles15-zen3
```

cc @SahelHakimi @lucafedeli88 