### PR TITLE
ADIOS2: Fix BTD Particle Resize w/ Empty Ranks

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -744,29 +744,19 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
     m_Series->flush();
 
     // dump individual particles
-    bool contributed_particles = false;
+    bool contributed_particles = false;  // did the local MPI rank contribute particles?
     for (auto currentLevel = 0; currentLevel <= pc->finestLevel(); currentLevel++) {
         uint64_t offset = static_cast<uint64_t>( counter.m_ParticleOffsetAtRank[currentLevel] );
         // For BTD, the offset include the number of particles already flushed
         if (isBTD) offset += ParticleFlushOffset;
-        // int num_tiles = pc->numLocalTilesAtLevel(currentLevel);
         for (ParticleIter pti(*pc, currentLevel); pti.isValid(); ++pti) {
-        // for (auto pti = pc->MakeMFIter(currentLevel); pti.isValid(); ++pti) {  // does not skip empty tiles but lacks all particle methods
             auto const numParticleOnTile = pti.numParticles();
             uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
 
             // Do not call storeChunk() with zero-sized particle tiles:
             //   https://github.com/openPMD/openPMD-api/issues/1147
             //   https://github.com/ECP-WarpX/WarpX/pull/1898#discussion_r745008290
-            // unless we append in ADIOS2:
-            //   https://github.com/ECP-WarpX/WarpX/issues/3389
-            //   https://github.com/ornladios/ADIOS2/issues/3455
-            //   BP4 (ADIOS 2.8): last MPI rank's `Put` meta-data wins
-            //   BP5 (ADIOS 2.8): everyone has to write an empty block
-            bool write_empty_blocks = false;
-            if (m_Series->backend() == "ADIOS2")
-                write_empty_blocks = isBTD;
-            if (numParticleOnTile == 0 && !write_empty_blocks) continue;
+            if (numParticleOnTile == 0) continue;
 
             contributed_particles = true;
 
@@ -850,13 +840,54 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
         } // pti
     } // currentLevel
 
-    // work-around for BTD particle resize
+    // work-around for BTD particle resize in ADIOS2
+    //
+    // This issues an empty ADIOS2 Put to make sure the new global shape
+    // meta-data is committed for each variable.
+    //
+    // Refs.:
     //   https://github.com/ECP-WarpX/WarpX/issues/3389
     //   https://github.com/ornladios/ADIOS2/issues/3455
     //   BP4 (ADIOS 2.8): last MPI rank's `Put` meta-data wins
     //   BP5 (ADIOS 2.8): everyone has to write an empty block
-    if (!contributed_particles && isBTD && m_Series->backend() == "ADIOS2") {
-        // do empty Put calls for ADIOS2.
+    if (is_resizing_flush && !contributed_particles && isBTD && m_Series->backend() == "ADIOS2") {
+        for( auto & [record_name, record] : currSpecies ) {
+            for( auto & [comp_name, comp] : record ) {
+                if (comp.constant()) continue;
+
+                auto dtype = comp.getDatatype();
+                switch (dtype) {
+                    case openPMD::Datatype::FLOAT :
+                        [[fallthrough]];
+                    case openPMD::Datatype::DOUBLE : {
+                        auto empty_data = std::make_shared<amrex::ParticleReal>();
+                        comp.storeChunk(empty_data, {uint64_t(0)}, {uint64_t(0)});
+                        break;
+                    }
+                    case openPMD::Datatype::UINT : {
+                        auto empty_data = std::make_shared<unsigned int>();
+                        comp.storeChunk(empty_data, {uint64_t(0)}, {uint64_t(0)});
+                        break;
+                    }
+                    case openPMD::Datatype::ULONG : {
+                        auto empty_data = std::make_shared<unsigned long>();
+                        comp.storeChunk(empty_data, {uint64_t(0)}, {uint64_t(0)});
+                        break;
+                    }
+                    case openPMD::Datatype::ULONGLONG : {
+                        auto empty_data = std::make_shared<unsigned long long>();
+                        comp.storeChunk(empty_data, {uint64_t(0)}, {uint64_t(0)});
+                        break;
+                    }
+                    default : {
+                        std::string msg = "WarpX openPMD ADIOS2 work-around has unknown dtype: ";
+                        msg += datatypeToString(dtype);
+                        amrex::Abort(msg);
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     m_Series->flush();

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -754,7 +754,16 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
 
             // Do not call storeChunk() with zero-sized particle tiles:
             //   https://github.com/openPMD/openPMD-api/issues/1147
-            if (numParticleOnTile == 0) continue;
+            //   https://github.com/ECP-WarpX/WarpX/pull/1898#discussion_r745008290
+            // unless we append in ADIOS2:
+            //   https://github.com/ECP-WarpX/WarpX/issues/3389
+            //   https://github.com/ornladios/ADIOS2/issues/3455
+            //   BP4 (ADIOS 2.8): last MPI rank's `Put` meta-data wins
+            //   BP5 (ADIOS 2.8): everyone has to write an empty block
+            bool write_empty_blocks = false;
+            if (m_Series->backend() == "ADIOS2")
+                write_empty_blocks = isBTD;
+            if (numParticleOnTile == 0 && !write_empty_blocks) continue;
 
             // get position and particle ID from aos
             // note: this implementation iterates the AoS 4x...


### PR DESCRIPTION
For ADIOS2 BP4 and BP5 particle BTD writes, setting an update of a variable's (openPMD record's) shape is not sufficient to drop all meta-data on disk. In situations where the last write to a BTD stage only adds further particles from a few ranks, we need to pad with zero-block writes so ADIOS2 `Put` gets called.

Backend details:
- BP4 (as of ADIOS 2.8): last MPI rank's `Put` meta-data wins
- BP5 (as of ADIOS 2.8): everyone has to write an empty block

## Tests

6 MPI ranks w/ CUDA on Summit  with read-back as in https://github.com/ECP-WarpX/WarpX/issues/3389

- Inputs: [inputs.txt](https://github.com/ECP-WarpX/WarpX/files/10552060/inputs.6.txt)
- Run: `jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" ./warpx.RZ.MPI.CUDA.DP.PDP.OPMD.PSATD.QED inputs.txt`
- Test command: `python3 -c "from openpmd_viewer import OpenPMDTimeSeries; ts = OpenPMDTimeSeries('./diags/diag_btd/'); ts.get_particle(['x'], iteration=1)"`

Results:
- [x] reproduced on `development`
- [x] same test, with PR applied, passed
- [ ] same test, with PR applied, and with compression operators (blosc) enabled, passed
  - [x] ADIOS 2.7.1: fails during write
  - [x] ADIOS 2.8.1: fails during write
  - [x] ADIOS 2.8.3 w/ c-blosc 1.21.0: fails during write https://github.com/ornladios/ADIOS2/issues/3460
  - [x] ADIOS `master` as of `98bef0ee88838c034832a1e280dfd555841462dc` w/ c-blosc 2.6.1: also fails

Requires this patch in openPMD-viewer: https://github.com/openPMD/openPMD-viewer/pull/355

## Related Issues

- fix #3389
- https://github.com/ECP-WarpX/WarpX/pull/1898#discussion_r745008290
- https://github.com/ornladios/ADIOS2/issues/3455
- https://github.com/openPMD/openPMD-api/issues/1147