### PR TITLE
Add test for DD fusion with intra-species collisions

### DIFF
--- a/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
+++ b/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2019-2023
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Initialize a deuterium-deuterium thermal plasma as in section 4.1 of [1]
+# and check that the simulation reactivity matches the analytical value
+# plotted in figure 3b of [1].
+#
+# Reference:
+# [1] Higginson, D.P., Link, A. and Schmidt, A., 2019.
+#     A pairwise nuclear fusion algorithm for weighted particle-in-cell
+#     plasma simulations. Journal of Computational Physics, 388, pp.439-453.
+#     DOI: https://doi.org/10.1016/j.jcp.2019.03.020
+
+
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import yt
+
+import numpy as np
+import scipy.constants
+
+yt.funcs.mylog.setLevel(0)
+
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import checksumAPI
+
+# Name of the plotfile
+fn = sys.argv[1]
+
+# Load data from reduced diagnostics (physical time and neutron weights)
+time = np.loadtxt('./reduced_diags/particle_number.txt', usecols=1)
+neutron = np.loadtxt('./reduced_diags/particle_number.txt', usecols=9)
+
+# Compute reactivity [cm^3]/[s]
+dY_dt = np.abs(neutron[-1]-neutron[0])/(time[-1]-time[0])
+delta_ij = 1
+nD = 1e26
+V = (2e-3)**3
+sigma = dY_dt*(1+delta_ij)/(nD**2)/V*(1e2)**3
+
+# Compare checksums with benchmark
+test_name = os.path.split(os.getcwd())[1]
+checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
+++ b/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
@@ -21,10 +21,9 @@ import os
 import sys
 
 import matplotlib.pyplot as plt
-import yt
-
 import numpy as np
 import scipy.constants
+import yt
 
 yt.funcs.mylog.setLevel(0)
 

--- a/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
+++ b/Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
@@ -6,26 +6,27 @@
 #
 # License: BSD-3-Clause-LBNL
 #
-# Initialize a deuterium-deuterium thermal plasma as in section 4.1 of [1]
-# and check that the simulation reactivity matches the analytical value
-# plotted in figure 3b of [1].
+# Initialize a deuterium-deuterium thermal plasma similar to that in
+# section 4.1 of [1], with fusion multiplication factor 1e10,
+# 1e4 particles per cell, density 1e20/cm^3, temperature 20 keV.
+# Check that the simulation reactivity matches the analytical value
+# reported in Table VIII of [2], namely 2.603e-18 cm^3/s.
 #
 # Reference:
 # [1] Higginson, D.P., Link, A. and Schmidt, A., 2019.
 #     A pairwise nuclear fusion algorithm for weighted particle-in-cell
 #     plasma simulations. Journal of Computational Physics, 388, pp.439-453.
 #     DOI: https://doi.org/10.1016/j.jcp.2019.03.020
-
+#
+# [2] Bosch, H.S. and Hale, G.M., 1992.
+#     Improved formulas for fusion cross-sections and thermal reactivities.
+#     Nuclear fusion, 32(4), p.611.
+#     DOI: https://doi.org/10.1088/0029-5515/32/4/I07
 
 import os
 import sys
 
-import matplotlib.pyplot as plt
 import numpy as np
-import scipy.constants
-import yt
-
-yt.funcs.mylog.setLevel(0)
 
 sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
@@ -37,12 +38,17 @@ fn = sys.argv[1]
 time = np.loadtxt('./reduced_diags/particle_number.txt', usecols=1)
 neutron = np.loadtxt('./reduced_diags/particle_number.txt', usecols=9)
 
-# Compute reactivity [cm^3]/[s]
+# Compute reactivity in units of cm^3/s as in equation (61) of [1]
 dY_dt = np.abs(neutron[-1]-neutron[0])/(time[-1]-time[0])
-delta_ij = 1
-nD = 1e26
-V = (2e-3)**3
+delta_ij = 1 # reactants of the same species
+nD = 1e26 # density in 1/m^3
+V = (2e-3)**3 # simulation volume in m^3
 sigma = dY_dt*(1+delta_ij)/(nD**2)/V*(1e2)**3
+
+sigma_th = 2.603e-18
+error = np.abs(sigma-sigma_th)/sigma_th
+tolerance = 1e-2
+assert error < tolerance
 
 # Compare checksums with benchmark
 test_name = os.path.split(os.getcwd())[1]

--- a/Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
+++ b/Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
@@ -1,0 +1,81 @@
+# algo
+algo.particle_shape = 3
+
+# amr
+amr.max_level = 0
+amr.n_cell = 8 8 8
+
+# boundary
+boundary.field_hi = periodic periodic periodic
+boundary.field_lo = periodic periodic periodic
+
+# collisions
+collisions.collision_names = dd_collision
+
+# dd_collision
+dd_collision.fusion_multiplier = 1e10
+dd_collision.product_species = helium3 neutron
+dd_collision.species = deuterium deuterium
+dd_collision.type = nuclearfusion
+
+# deuterium
+deuterium.density = 1e26
+deuterium.do_not_deposit = 1
+deuterium.do_not_push = 1
+deuterium.injection_style = "NRandomPerCell"
+deuterium.momentum_distribution_type = "gaussian"
+deuterium.num_particles_per_cell = 20000
+deuterium.profile = constant
+deuterium.species_type = deuterium
+deuterium.ux_m = 0.
+deuterium.uy_m = 0.
+deuterium.uz_m = 0.
+deuterium.ux_th = 0.003182336054828087
+deuterium.uy_th = 0.003182336054828087
+deuterium.uz_th = 0.003182336054828087
+deuterium.xmax =  1e-3
+deuterium.xmin = -1e-3
+deuterium.ymax =  1e-3
+deuterium.ymin = -1e-3
+deuterium.zmax =  1e-3
+deuterium.zmin = -1e-3
+
+# diag
+diag1.diag_type = Full
+diag1.fields_to_plot = rho rho_deuterium rho_helium3
+diag1.intervals = 1
+
+# diagnostics
+diagnostics.diags_names = diag1
+
+# geometry
+geometry.dims = 3
+geometry.prob_hi =  1e-3  1e-3  1e-3
+geometry.prob_lo = -1e-3 -1e-3 -1e-3
+
+# helium3
+helium3.do_not_deposit = 1
+helium3.do_not_push = 1
+helium3.species_type = helium3
+
+# max_step
+max_step = 10
+
+# neutron
+neutron.do_not_deposit = 1
+neutron.do_not_push = 1
+neutron.species_type = neutron
+
+# particle_number
+particle_number.type = ParticleNumber
+particle_number.intervals = 1
+particle_number.path = "./reduced_diags/"
+
+# particles
+particles.species_names = deuterium helium3 neutron
+
+# warpx
+warpx.cfl = 1.0
+warpx.numprocs = 1 1 1
+warpx.reduced_diags_names = particle_number
+warpx.verbose = 1

--- a/Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
+++ b/Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
@@ -1,3 +1,13 @@
+# Initialize a deuterium-deuterium thermal plasma similar to that in
+# section 4.1 of [1], with fusion multiplication factor 1e10,
+# 1e4 particles per cell, density 1e20/cm^3, temperature 20 keV.
+#
+# Reference:
+# [1] Higginson, D.P., Link, A. and Schmidt, A., 2019.
+#     A pairwise nuclear fusion algorithm for weighted particle-in-cell
+#     plasma simulations. Journal of Computational Physics, 388, pp.439-453.
+#     DOI: https://doi.org/10.1016/j.jcp.2019.03.020
+
 # algo
 algo.particle_shape = 3
 
@@ -24,15 +34,18 @@ deuterium.do_not_deposit = 1
 deuterium.do_not_push = 1
 deuterium.injection_style = "NRandomPerCell"
 deuterium.momentum_distribution_type = "gaussian"
-deuterium.num_particles_per_cell = 20000
+deuterium.num_particles_per_cell = 10000
 deuterium.profile = constant
 deuterium.species_type = deuterium
 deuterium.ux_m = 0.
 deuterium.uy_m = 0.
 deuterium.uz_m = 0.
-deuterium.ux_th = 0.003182336054828087
-deuterium.uy_th = 0.003182336054828087
-deuterium.uz_th = 0.003182336054828087
+# the standard deviation for the thermal momentum distribution is computed
+# from the plasma temperature as sqrt(kB*T/(mD*c**2)), where kB*T = 20 keV
+# and mD = 2.01410177812 u = 2.01410177812 * 931.49410242 MeV/c**2
+deuterium.ux_th = 0.003265007901313691
+deuterium.uy_th = 0.003265007901313691
+deuterium.uz_th = 0.003265007901313691
 deuterium.xmax =  1e-3
 deuterium.xmin = -1e-3
 deuterium.ymax =  1e-3

--- a/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D_intraspecies.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D_intraspecies.json
@@ -1,0 +1,34 @@
+{
+  "deuterium": {
+    "particle_momentum_x": 2.606581199078705e-14,
+    "particle_momentum_y": 2.6063885197386058e-14,
+    "particle_momentum_z": 2.6066384398903162e-14,
+    "particle_position_x": 5120.373484010292,
+    "particle_position_y": 5119.798967969537,
+    "particle_position_z": 5120.237053312875,
+    "particle_weight": 7.999999990814913e+17
+  },
+  "helium3": {
+    "particle_momentum_x": 4.587432584203096e-15,
+    "particle_momentum_y": 4.6119268863920545e-15,
+    "particle_momentum_z": 4.58526309777229e-15,
+    "particle_position_x": 125.20673188550892,
+    "particle_position_y": 125.43161343196122,
+    "particle_position_z": 125.04234990545633,
+    "particle_weight": 459254544.5269769
+  },
+  "lev=0": {
+    "rho": 0.0,
+    "rho_deuterium": 8203144356.661577,
+    "rho_helium3": 9.418328323832759
+  },
+  "neutron": {
+    "particle_momentum_x": 4.552319246928933e-15,
+    "particle_momentum_y": 4.573173817933005e-15,
+    "particle_momentum_z": 4.54992637726847e-15,
+    "particle_position_x": 125.20673188550892,
+    "particle_position_y": 125.43161343196122,
+    "particle_position_z": 125.04234990545633,
+    "particle_weight": 459254544.5269769
+  }
+}

--- a/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D_intraspecies.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D_intraspecies.json
@@ -1,34 +1,34 @@
 {
   "deuterium": {
-    "particle_momentum_x": 2.606581199078705e-14,
-    "particle_momentum_y": 2.6063885197386058e-14,
-    "particle_momentum_z": 2.6066384398903162e-14,
-    "particle_position_x": 5120.373484010292,
-    "particle_position_y": 5119.798967969537,
-    "particle_position_z": 5120.237053312875,
-    "particle_weight": 7.999999990814913e+17
+    "particle_momentum_x": 1.3370046499332103e-14,
+    "particle_momentum_y": 1.3364310231320824e-14,
+    "particle_momentum_z": 1.3372728873714894e-14,
+    "particle_position_x": 2560.1613417364665,
+    "particle_position_y": 2560.082464065988,
+    "particle_position_z": 2560.0018477161034,
+    "particle_weight": 7.999999989895393e+17
   },
   "helium3": {
-    "particle_momentum_x": 4.587432584203096e-15,
-    "particle_momentum_y": 4.6119268863920545e-15,
-    "particle_momentum_z": 4.58526309777229e-15,
-    "particle_position_x": 125.20673188550892,
-    "particle_position_y": 125.43161343196122,
-    "particle_position_z": 125.04234990545633,
-    "particle_weight": 459254544.5269769
+    "particle_momentum_x": 2.2800935865848323e-15,
+    "particle_momentum_y": 2.2864983116288316e-15,
+    "particle_momentum_z": 2.290487090201156e-15,
+    "particle_position_x": 62.07326392385665,
+    "particle_position_y": 62.074468969610855,
+    "particle_position_z": 62.07087662970013,
+    "particle_weight": 505230602.2536906
   },
   "lev=0": {
     "rho": 0.0,
-    "rho_deuterium": 8203144356.661577,
-    "rho_helium3": 9.418328323832759
+    "rho_deuterium": 8203144355.71876,
+    "rho_helium3": 10.36119892112141
   },
   "neutron": {
-    "particle_momentum_x": 4.552319246928933e-15,
-    "particle_momentum_y": 4.573173817933005e-15,
-    "particle_momentum_z": 4.54992637726847e-15,
-    "particle_position_x": 125.20673188550892,
-    "particle_position_y": 125.43161343196122,
-    "particle_position_z": 125.04234990545633,
-    "particle_weight": 459254544.5269769
+    "particle_momentum_x": 2.2625878931428226e-15,
+    "particle_momentum_y": 2.2652096393691827e-15,
+    "particle_momentum_z": 2.27105060559148e-15,
+    "particle_position_x": 62.07326392385665,
+    "particle_position_y": 62.074468969610855,
+    "particle_position_z": 62.07087662970013,
+    "particle_weight": 505230602.2536906
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2358,6 +2358,22 @@ compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 
+[Deuterium_Deuterium_Fusion_3D_intraspecies]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
+
 [Deuterium_Tritium_Fusion_RZ]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_rz


### PR DESCRIPTION
Add test for DD fusion with intra-species collisions, based on the following two references:
- Higginson, D.P., Link, A. and Schmidt, A., 2019. A pairwise nuclear fusion algorithm for weighted particle-in-cell plasma simulations. Journal of Computational Physics, 388, pp.439-453. DOI: https://doi.org/10.1016/j.jcp.2019.03.020
- Bosch, H.S. and Hale, G.M., 1992. Improved formulas for fusion cross-sections and thermal reactivities. Nuclear fusion, 32(4), p.611. DOI: https://doi.org/10.1088/0029-5515/32/4/I07