### PR TITLE
Improve Python script to plot PSATD stencils

### DIFF
--- a/Tools/Algorithms/stencil.py
+++ b/Tools/Algorithms/stencil.py
@@ -3,9 +3,9 @@ Python script to compute the minimum number of guard cells for a given
 error threshold, based on the measurement of the PSATD stencil extent
 (that is, the minimum number of guard cells such that the stencil
 measure is not larger than the error threshold).
-Reference: https://arxiv.org/abs/2106.12919
+Reference: https://doi.org/10.1016/j.cpc.2022.108457
 
-Run the script simply with "python Stencil.py" (or with "run Stencil.py"
+Run the script simply with "python stencil.py" (or with "run stencil.py"
 using IPython). The user can modify the input parameters set in the main
 function at the end of the file.
 """
@@ -24,16 +24,14 @@ dp = np.finfo(np.float64).eps
 
 def get_Fornberg_coeffs(order, staggered):
     """
-    Compute the centered or staggered
-    Fornberg coefficients at finite order.
+    Compute the centered or staggered Fornberg coefficients at finite order.
 
     Parameters
     ----------
     order : int
         Finite order of the approximation.
     staggered : bool
-        Whether to compute the centered or staggered
-        Fornberg coefficients.
+        Whether to compute the centered or staggered Fornberg coefficients.
 
     Returns
     -------
@@ -60,8 +58,7 @@ def get_Fornberg_coeffs(order, staggered):
 
 def modified_k(kx, dx, order, staggered):
     """
-    Compute the centered or staggered
-    modified wave vector at finite order.
+    Compute the centered or staggered modified wave vector at finite order.
 
     Parameters
     ----------
@@ -72,8 +69,7 @@ def modified_k(kx, dx, order, staggered):
     order : int
         Finite order of the approximation.
     staggered : bool
-        Whether to compute the centered or staggered
-        modified wave vector.
+        Whether to compute the centered or staggered modified wave vector.
 
     Returns
     -------
@@ -100,18 +96,17 @@ def modified_k(kx, dx, order, staggered):
 
 def func_cosine(om, w_c, dt):
     """
-    Compute the leading spectral coefficient of the general
-    PSATD equations: theta_c**2*cos(om*dt), where
-    theta_c = exp(i*w_c*dt/2), w_c = v_gal*[kz]_c,
-    om_s = c*|[k]| (and [k] or [kz] denote the centered or
-    staggered modified wave vector or vector component).
+    Compute the leading spectral coefficient of the general PSATD equations:
+    theta_c**2*cos(om*dt), where theta_c = exp(i*w_c*dt/2), w_c = v_gal*[kz]_c,
+    om_s = c*|[k]| (and [k] or [kz] denote the centered or staggered modified
+    wave vector or vector component).
 
     Parameters
     ----------
     om : numpy.ndarray
         Array of centered or staggered modified frequencies.
     w_c : numpy.ndarray
-        Array of values of v_gal * [kz]_c.
+        Array of values of v_gal*[kz]_c.
     dt : float
         Time step.
 
@@ -131,13 +126,11 @@ def compute_stencils(coeff_nodal, coeff_stagg, axis):
     Parameters
     ----------
     coeff_nodal : numpy.ndarray
-        Leading spectral nodal coefficient of the general
-        PSATD equations.
+        Leading spectral nodal coefficient of the general PSATD equations.
     coeff_stagg : numpy.ndarray
-        Leading spectral staggered coefficient of the general
-        PSATD equations.
+        Leading spectral staggered coefficient of the general PSATD equations.
     axis : int
-        Axis or direction.
+        Axis or direction (must be 0, 1, or 2).
 
     Returns
     -------
@@ -248,9 +241,9 @@ def compute_all(dx, dy, dz, dt, nox, noy, noz, v_gal, nx=256, ny=256, nz=256):
 
 def compute_guard_cells(errmin, errmax, stencil):
     """
-    Compute the minimum number of guard cells for a given
-    error threshold (number of guard cells such that the
-    stencil measure is not larger than the error threshold).
+    Compute the minimum number of guard cells for a given error threshold
+    (number of guard cells such that the stencil measure is not larger
+    than the error threshold).
 
     Parameters
     ----------
@@ -345,17 +338,6 @@ def run_main(dx, dy, dz, dt, nox, noy, noz, gamma=1., galilean=False, path='.', 
         Path where figures are saved.
     name : str, optional (default = '')
         Common label for figure names.
-
-    Returns
-    -------
-    stencils : dict
-        Dictionary of nodal and staggered stencils along all directions.
-        Its element of the dictionary is a dictionary itself,
-        containing numpy.ndarray objects.
-        Keys: stencils.keys() = dict_keys(['x', 'y', 'z'])
-              stencils['x'].keys() = dict_keys(['nodal', 'stagg'])
-              stencils['y'].keys() = dict_keys(['nodal', 'stagg'])
-              stencils['z'].keys() = dict_keys(['nodal', 'stagg'])
     """
     # Galilean velocity (default = 0.)
     v_gal = 0.
@@ -440,7 +422,7 @@ def run_main(dx, dy, dz, dt, nox, noy, noz, gamma=1., galilean=False, path='.', 
     print(f'- between {gcmin_z_stagg} and {gcmax_z_stagg} ghost cells along z')
     print()
 
-    return stencils
+    return
 
 if __name__ == '__main__':
 
@@ -469,4 +451,4 @@ if __name__ == '__main__':
 
     # Run main function (some arguments are optional,
     # see definition of run_main function for help)
-    stencils = run_main(dx, dy, dz, dt, nox, noy, noz, gamma, galilean, path, name)
+    run_main(dx, dy, dz, dt, nox, noy, noz, gamma, galilean, path, name)

--- a/Tools/Algorithms/stencil.py
+++ b/Tools/Algorithms/stencil.py
@@ -261,8 +261,11 @@ def compute_guard_cells(errmin, errmax, stencil):
     v = next(d for d in diff if d < 0)
     gcmin = np.argwhere(diff == v)[0,0]
     diff = stencil - errmax
-    v = next(d for d in diff if d < 0)
-    gcmax = np.argwhere(diff == v)[0,0] - 1
+    try:
+        v = next(d for d in diff if d < 0)
+        gcmax = np.argwhere(diff == v)[0,0] - 1
+    except StopIteration:
+        gcmin, gcmax = compute_guard_cells(errmin, errmax*10, stencil)
     return (gcmin, gcmax)
 
 def plot_stencil(cells, stencil_nodal, stencil_stagg, label, path, name):

--- a/Tools/Algorithms/stencil.py
+++ b/Tools/Algorithms/stencil.py
@@ -427,7 +427,9 @@ def run_main(dx, dy, dz, dt, nox, noy, noz, gamma=1., galilean=False, path='.', 
         + '\nof each simulation grid, along x, y, and z.')
     print('\nIt is recommended to choose a number of ghost cells that corresponds to'
         + '\na truncation of the signal between single and double machine precision.'
-        + '\nThe more guard cells, the more accurate, yet expensive, results.')
+        + '\nThe more ghost cells, the more accurate, yet expensive, results.'
+        + '\nFor each stencil the region of accuracy between single and double precision'
+        + '\nis shaded to help you identify a suitable number of ghost cells.')
     print('\nFor a nodal simulation, choose:')
     print(f'- between {gcmin_x_nodal} and {gcmax_x_nodal} ghost cells along x')
     print(f'- between {gcmin_y_nodal} and {gcmax_y_nodal} ghost cells along y')


### PR DESCRIPTION
Improve the Python script to plot the PSATD stencil and predict the number of guard cells for a given simulation setup, since it is being used more and more often lately. Follow-up on #2364. Note that the script was moved from Tools/DevUtils/ to Tools/Algorithms/.

This is what the standard output looks like now (should be more explanatory than before):
```
Cell size:
- dx = 1e-06
- dy = 1e-06
- dz = 2e-06
- dz/dx = 2
- dz/dy = 2

Time step:
- dt = 1e-14
- c*dt/dx = 2.99792
- c*dt/dy = 2.99792
- c*dt/dz = 1.49896

Spectral order:
- nox = 8
- noy = 8
- noz = 16

Lorentz boost, Galilean velocity:
- gamma = 30
- v_gal = -2.99626e+08

Figures saved in /home/edoardo/Repo/LBL/WarpX/Tools/Algorithms/.

The plots show the extent of the signal to be truncated (y-axis)
by choosing a given number of cells (x-axis) for the ghost regions
of each simulation grid, along x, y, and z.

It is recommended to choose a number of ghost cells that corresponds to
a truncation of the signal between single and double machine precision.
The more ghost cells, the more accurate, yet expensive, results.
For each stencil the region of accuracy between single and double precision
is shaded to help you identify a suitable number of ghost cells.

For a nodal simulation, choose:
- between 22 and 40 ghost cells along x
- between 22 and 40 ghost cells along y
- between 18 and 39 ghost cells along z

For a staggered or hybrid simulation, choose:
- between 11 and 21 ghost cells along x
- between 11 and 21 ghost cells along y
- between 16 and 32 ghost cells along z
```

Moreover, the script produces the following kind of plots, highlighting the region of safe guard cells, assuming that we want to keep the truncation error between single and double machine precision:
<p align="center">
    <img src="https://user-images.githubusercontent.com/59625522/216442273-62762347-efed-4a59-936d-e8d30ac98e8a.png" width="600">
    <img src="https://user-images.githubusercontent.com/59625522/216442396-16f7c4bd-6c98-498f-a86b-2f922be9be63.png" width="600">
    <img src="https://user-images.githubusercontent.com/59625522/216442411-71abba72-675d-40e0-896b-ea4c359aac05.png" width="600">
</p>  