### PR TITLE
CI & Bug Fixes: 1D & 2D Compile

### DIFF
--- a/.github/workflows/dependencies/gcc12.sh
+++ b/.github/workflows/dependencies/gcc12.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The WarpX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    ccache              \
+    cmake               \
+    g++-12              \
+    gnupg               \
+    libboost-math-dev   \
+    libfftw3-dev        \
+    libfftw3-mpi-dev    \
+    libhdf5-openmpi-dev \
+    libopenmpi-dev      \
+    ninja-build         \
+    pkg-config          \
+    wget

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
         cmake --build build_RZ -j 2
         ./build_RZ/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_rz
 
-  build_2D_rz:
+  build_1D_2D:
     name: GCC 1D & 2D w/ MPI
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -80,7 +80,7 @@ jobs:
           -GNinja                      \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_DIMS=1               \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_PSATD=ON             \
           -DWarpX_QED_TABLE_GEN=ON
         cmake --build build_1D -j 2
@@ -90,7 +90,7 @@ jobs:
           -GNinja                      \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_DIMS=2               \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_PSATD=ON             \
           -DWarpX_QED_TABLE_GEN=ON
         cmake --build build_2D -j 2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,6 +49,53 @@ jobs:
         cmake --build build_RZ -j 2
         ./build_RZ/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_rz
 
+  build_2D_rz:
+    name: GCC 1D & 2D w/ MPI
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false
+    env:
+      CXXFLAGS: "-Werror"
+      CXX: "g++-12"
+      CC: "gcc-12"
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: |
+        .github/workflows/dependencies/gcc12.sh
+    - name: CCache Cache
+      uses: actions/cache@v3
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: |
+          ~/.ccache
+          ~/.cache/ccache
+        key: ccache-openmp-1D-2D-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        restore-keys: |
+          ccache-openmp-1D-2D-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
+          ccache-openmp-1D-2D-
+    - name: build WarpX
+      run: |
+        cmake -S . -B build_1D         \
+          -GNinja                      \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_DIMS=1               \
+          -DWarpX_EB=ON                \
+          -DWarpX_PSATD=ON             \
+          -DWarpX_QED_TABLE_GEN=ON
+        cmake --build build_1D -j 2
+        ./build_1D/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_1d
+
+        cmake -S . -B build_2D         \
+          -GNinja                      \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_DIMS=2               \
+          -DWarpX_EB=ON                \
+          -DWarpX_PSATD=ON             \
+          -DWarpX_QED_TABLE_GEN=ON
+        cmake --build build_2D -j 2
+        ./build_2D/bin/warpx Examples/Physics_applications/laser_acceleration/inputs_2d
+
   build_gcc_ablastr:
     name: GCC ABLASTR w/o MPI
     runs-on: ubuntu-20.04

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1007,8 +1007,8 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
 #if defined(WARPX_DIM_1D_Z)
                 amrex::Real x = 0._rt;
                 amrex::Real y = 0._rt;
-                amrex::Real fac_z = (1._rt - z_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
+                amrex::Real fac_z = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;

--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -62,12 +62,22 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
 
     constexpr int spacedim = AMREX_SPACEDIM;
 
+#if defined(WARPX_DIM_1D_Z)
+    const Real zlo_global = geom.ProbLo(0);
+    const Real dz         = geom.CellSize(0);
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     const Real xlo_global = geom.ProbLo(0);
     const Real dx         = geom.CellSize(0);
-    const Real ylo_global = (spacedim == 3) ? geom.ProbLo(1) : amrex::Real(0.);
-    const Real dy         = (spacedim == 3) ? geom.CellSize(1) : amrex::Real(0.);
-    const Real zlo_global = (spacedim == 3) ? geom.ProbLo(2) : geom.ProbLo(1);
-    const Real dz         = (spacedim == 3) ? geom.CellSize(2) : geom.CellSize(1);
+    const Real zlo_global = geom.ProbLo(1);
+    const Real dz         = geom.CellSize(1);
+#elif defined(WARPX_DIM_3D)
+    const Real xlo_global = geom.ProbLo(0);
+    const Real dx         = geom.CellSize(0);
+    const Real ylo_global = geom.ProbLo(1);
+    const Real dy         = geom.CellSize(1);
+    const Real zlo_global = geom.ProbLo(2);
+    const Real dz         = geom.CellSize(2);
+#endif
 
     const auto arrNumPartCreation = src_FAB->array();
     Gpu::DeviceVector<Index> offsets(ncells);
@@ -91,14 +101,24 @@ Index filterCreateTransformFromFAB (DstTile& dst1, DstTile& dst2, const amrex::B
         {
             const IntVect iv = box.atOffset(i);
             const int j = iv[0];
-            const int k = iv[1];
+            const int k = (spacedim >= 2) ? iv[1] : 0;
             const int l = (spacedim == 3) ? iv[2] : 0;
 
             // Currently all particles are created on nodes. This makes it useless
             // to use N>1 (for now).
-            const Real x = xlo_global + j*dx;
-            const Real y = ylo_global + k*dy;
-            const Real z = (spacedim == 3) ? zlo_global + l*dz : zlo_global + k*dz;
+#if defined(WARPX_DIM_1D_Z)
+            Real const x = 0.0;
+            Real const y = 0.0;
+            Real const z = zlo_global + j*dz;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+            Real const x = xlo_global + j*dx;
+            Real const y = 0.0;
+            Real const z = zlo_global + k*dz;
+#elif defined(WARPX_DIM_3D)
+            Real const x = xlo_global + j*dx;
+            Real const y = ylo_global + k*dy;
+            Real const z = zlo_global + l*dz;
+#endif
 
             for (int n = 0; n < N; ++n)
             {


### PR DESCRIPTION
Add a modern CI entry that compiles 1D and 2D with `-Werror` and many warnings enabled.