### PR TITLE
Updated gitignore with vscode-specific folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ cmake-build-*/
 .kdev?/
 *.kdev?
 
+##########
+# VsCode #
+##########
+.vscode
+
 # File-based project format:
 *.iws
 


### PR DESCRIPTION
Very small PR to facilitate VSCode users.
It adds the `.vscode` folder to the `.gitignore`.