### PR TITLE
Update Crusher Modules to cce/15.0.0 and others accordingly

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -49,6 +49,18 @@ And since Crusher does not yet provide a module for them, install BLAS++ and LAP
 
 .. code-block:: bash
 
+   # c-blosc (I/O compression)
+   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git src/c-blosc
+   rm -rf src/c-blosc-crusher-build
+   cmake -S src/c-blosc -B src/c-blosc-crusher-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/crusher/c-blosc-1.21.1
+   cmake --build src/c-blosc-crusher-build --target install --parallel 10
+
+   # ADIOS2
+   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git src/adios2
+   rm -rf src/adios2-crusher-build
+   cmake -S src/adios2 -B src/adios2-crusher-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/crusher/adios2-2.8.3
+   cmake --build src/adios2-crusher-build --target install -j 10
+
    # BLAS++ (for PSATD+RZ)
    git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
    rm -rf src/blaspp-crusher-build

--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -6,9 +6,9 @@
 module load cpe/22.08
 module load cmake/3.23.2
 module load craype-accel-amd-gfx90a
-module load rocm/5.2.0
-module load cray-mpich
-module load cce/14.0.2  # must be loaded after rocm
+module load rocm/5.3.0
+module load cray-mpich/8.1.23
+module load cce/15.0.0  # must be loaded after rocm
 
 # optional: faster builds
 module load ccache
@@ -29,11 +29,19 @@ export LD_LIBRARY_PATH=$HOME/sw/crusher/lapackpp-master/lib64:$LD_LIBRARY_PATH
 #module load boost/1.78.0-cxx17
 
 # optional: for openPMD support
-module load adios2/2.8.1
-module load cray-hdf5-parallel/1.12.1.5
+#module load adios2/2.8.3
+# need to build adios manually currently
+export CMAKE_PREFIX_PATH=$HOME/sw/crusher/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$HOME/sw/crusher/adios2-2.8.3:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$HOME/sw/crusher/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/sw/crusher/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
+module load cray-hdf5-parallel/1.12.2.1
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.9.12.1
+
+# suggested by HPE
+module unload xalt/1.3.0
 
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand


### PR DESCRIPTION
Module changes were suggested by HPE on 2023/02/08 due to problems with building ImpactX on cce/14.0.2.
Hence we update WarpX dependencies accordingly, too.

We build `c-blosc` and `adios2` manually but this might change again with ticket `OLCFHELP-10863`.