### PR TITLE
RZ PSATD: tell users that number of cells in r should be a power of 2

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -328,6 +328,9 @@ void CheckGriddingForRZSpectral ()
     }
     blocking_factor_x[0] = k;
     max_grid_size_x[0] = k;
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_cell[0] == k,
+        "With RZ spectral, the number of cells in r must be a power of 2.");
+
 
     for (int lev=1 ; lev <= max_level ; lev++) {
         // For this to be correct, this needs to read in any user specified refinement ratios.


### PR DESCRIPTION
In RZ PSATD, it seems that the function `CheckGriddingForRZSpectral` tries to set the `blocking_factor` as close as possible to `n_r` (the number of cells in `r`), in order to prevent domain decomposition along `r`.

However, if `n_r` is not exactly equal to the `blocking_factor`, the user gets an error message saying `domain size not divisible by blocking_factor`. This can confuse users, as they may not know what to change in the input script. (Changing the `blocking_factor` in the input script will not help, since it is overwritten by `CheckGriddingForRZSpectral`).

Overall, it seems that the user needs to set `n_r` to a power of 2, so that it can be exactly equal to the `blocking_factor`. This PR adds a corresponding warning message.