### PR TITLE
add option warpx.compute_max_step_from_btd to increase max_step to fill BTD

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -60,9 +60,11 @@ Overall simulation parameters
 * ``warpx.do_compute_max_step_from_btd`` (`integer`; 0 by default) optional
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
-    frame for all back-transformed diagnostics to be completed. The value of
-    ``max_step`` is overwritten, and printed to standard output. Currently
-    only works if the Lorentz boost and the moving window are along the z direction.
+    frame for all back-transformed diagnostics to be completed. If the current
+    value of ``max_step`` is too low to fill all BTD, the value of
+    ``max_step`` is overwritten with the new value and printed to standard output. 
+    Currently only works if the Lorentz boost and the moving window are along 
+    the z direction.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -61,8 +61,8 @@ Overall simulation parameters
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
     frame for all back-transformed diagnostics to be completed. If ``max_step``
-    or ``zmax_plasma_to_compute_max_step`` are not specified or the current 
-    value of ``max_step`` is too low to fill all BTD, the value of ``max_step`` 
+    or ``zmax_plasma_to_compute_max_step`` are not specified or the current
+    value of ``max_step`` is too low to fill all BTD, the value of ``max_step``
     is overwritten with the new value and printed to standard output.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -60,11 +60,10 @@ Overall simulation parameters
 * ``warpx.do_compute_max_step_from_btd`` (`integer`; 0 by default) optional
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
-    frame for all back-transformed diagnostics to be completed. If the current
-    value of ``max_step`` is too low to fill all BTD, the value of
-    ``max_step`` is overwritten with the new value and printed to standard output.
-    Currently only works if the Lorentz boost and the moving window are along
-    the z direction.
+    frame for all back-transformed diagnostics to be completed. If ``max_step``
+    or ``zmax_plasma_to_compute_max_step`` are not specified or the current 
+    value of ``max_step`` is too low to fill all BTD, the value of ``max_step`` 
+    is overwritten with the new value and printed to standard output.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -63,7 +63,7 @@ Overall simulation parameters
     frame for all back-transformed diagnostics to be completed. If ``max_step``,
     ``stop_time``, or ``warpx.zmax_plasma_to_compute_max_step`` are not specified,
     or the current values of ``max_step`` and/or ``stop_time`` are too low to fill
-    all BTD snapshots, the values of ``max_step`` and/or ``stop_time`` are 
+    all BTD snapshots, the values of ``max_step`` and/or ``stop_time`` are
     overwritten with the new values and printed to standard output.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -60,8 +60,8 @@ Overall simulation parameters
 * ``warpx.do_compute_max_step_from_btd`` (`integer`; 0 by default) optional
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
-    frame for all back-transformed diagnostics to be completed. The value of 
-    ``max_step`` is overwritten, and printed to standard output. Currently 
+    frame for all back-transformed diagnostics to be completed. The value of
+    ``max_step`` is overwritten, and printed to standard output. Currently
     only works if the Lorentz boost and the moving window are along the z direction.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -62,8 +62,8 @@ Overall simulation parameters
     automatically calculates the number of iterations required in the boosted
     frame for all back-transformed diagnostics to be completed. If the current
     value of ``max_step`` is too low to fill all BTD, the value of
-    ``max_step`` is overwritten with the new value and printed to standard output. 
-    Currently only works if the Lorentz boost and the moving window are along 
+    ``max_step`` is overwritten with the new value and printed to standard output.
+    Currently only works if the Lorentz boost and the moving window are along
     the z direction.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -60,10 +60,11 @@ Overall simulation parameters
 * ``warpx.compute_max_step_from_btd`` (`integer`; 0 by default) optional
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
-    frame for all back-transformed diagnostics to be completed. If ``max_step``
-    or ``zmax_plasma_to_compute_max_step`` are not specified or the current
-    value of ``max_step`` is too low to fill all BTD, the value of ``max_step``
-    is overwritten with the new value and printed to standard output.
+    frame for all back-transformed diagnostics to be completed. If ``max_step``,
+    ``stop_time``, or ``warpx.zmax_plasma_to_compute_max_step`` are not specified,
+    or the current values of ``max_step`` and/or ``stop_time`` are too low to fill
+    all BTD snapshots, the values of ``max_step`` and/or ``stop_time`` are 
+    overwritten with the new values and printed to standard output.
 
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -57,6 +57,13 @@ Overall simulation parameters
     printed to standard output. Currently only works if the Lorentz boost and
     the moving window are along the z direction.
 
+* ``warpx.do_compute_max_step_from_btd`` (`integer`; 0 by default) optional
+    Can be useful when computing back-transformed diagnostics.  If specified,
+    automatically calculates the number of iterations required in the boosted
+    frame for all back-transformed diagnostics to be completed. The value of 
+    ``max_step`` is overwritten, and printed to standard output. Currently 
+    only works if the Lorentz boost and the moving window are along the z direction.
+
 * ``warpx.random_seed`` (`string` or `int` > 0) optional
     If provided ``warpx.random_seed = random``, the random seed will be determined
     using `std::random_device` and `std::clock()`,

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -57,7 +57,7 @@ Overall simulation parameters
     printed to standard output. Currently only works if the Lorentz boost and
     the moving window are along the z direction.
 
-* ``warpx.do_compute_max_step_from_btd`` (`integer`; 0 by default) optional
+* ``warpx.compute_max_step_from_btd`` (`integer`; 0 by default) optional
     Can be useful when computing back-transformed diagnostics.  If specified,
     automatically calculates the number of iterations required in the boosted
     frame for all back-transformed diagnostics to be completed. If ``max_step``

--- a/Examples/Tests/btd_rz/inputs_rz_z_boosted_BTD
+++ b/Examples/Tests/btd_rz/inputs_rz_z_boosted_BTD
@@ -1,5 +1,5 @@
 # Maximum number of time steps
-warpx.zmax_plasma_to_compute_max_step = 500e-6
+warpx.compute_max_step_from_btd = 1
 # number of grid points
 amr.n_cell = 32 256
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -160,8 +160,8 @@ void BTDiagnostics::DerivedInitData ()
     const int final_snapshot_fill_iteration = final_snapshot_starting_step + num_buffers * m_buffer_size - 1;
     if (final_snapshot_fill_iteration > warpx.maxStep()) {
         if (warpx.do_compute_max_step_from_btd) {
-            warpx.maxStep = final_snapshot_fill_iteration;
-            Print()<<"max_step insufficient to fill all BTD snapshots. Automatically increased to: "
+            warpx.updateMaxStep(final_snapshot_fill_iteration);
+            amrex::Print()<<"max_step insufficient to fill all BTD snapshots. Automatically increased to: "
                 <<final_snapshot_fill_iteration<<std::endl;
         } else {
             std::string warn_string =

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -171,20 +171,18 @@ void BTDiagnostics::DerivedInitData ()
                 << final_snapshot_fill_time << std::endl;
 
         } else if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.stopTime() == std::numeric_limits<amrex::Real>::max()) {
-            amrex::Print()<<"max_step unspecified.  Setting to "
+            amrex::Print()<<"max_step unspecified and stop time unspecified.  Setting max step to "
                 <<final_snapshot_fill_iteration<< " to fill all BTD snapshots." << std::endl;
             warpx.updateMaxStep(final_snapshot_fill_iteration);
-            amrex::Print()<<"stop_time unspecified.  Setting to "
-                <<final_snapshot_fill_time<< " to fill all BTD snapshots." << std::endl;
-            warpx.updateMaxStep(final_snapshot_fill_time);
-
         }
 
     } else if (final_snapshot_fill_iteration > warpx.maxStep() || final_snapshot_fill_time > warpx.stopTime()) {
         std::string warn_string =
             "\nSimulation might not run long enough to fill all BTD snapshots.\n"
             "Final step: " + std::to_string(warpx.maxStep()) + "\n"
-            "Last BTD snapshot fills around step: " + std::to_string(final_snapshot_fill_iteration);
+            "Stop time: " + std::to_string(warpx.stopTime()) + "\n"
+            "Last BTD snapshot fills around step: " + std::to_string(final_snapshot_fill_iteration) + "\n"
+            " or time: " + std::to_string(final_snapshot_fill_time) + "\n";
         ablastr::warn_manager::WMRecordWarning(
             "BTD", warn_string,
             ablastr::warn_manager::WarnPriority::low);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -159,13 +159,19 @@ void BTDiagnostics::DerivedInitData ()
     const int final_snapshot_starting_step = static_cast<int>(std::ceil(final_snapshot_iteration / warpx.gamma_boost / (1._rt+warpx.beta_boost) * m_dt_snapshots_lab / dt_boosted_frame));
     const int final_snapshot_fill_iteration = final_snapshot_starting_step + num_buffers * m_buffer_size - 1;
     if (final_snapshot_fill_iteration > warpx.maxStep()) {
-        std::string warn_string =
-            "\nSimulation might not run long enough to fill all BTD snapshots.\n"
-            "Final step: " + std::to_string(warpx.maxStep()) + "\n"
-            "Last BTD snapshot fills around step: " + std::to_string(final_snapshot_fill_iteration);
-        ablastr::warn_manager::WMRecordWarning(
-            "BTD", warn_string,
-            ablastr::warn_manager::WarnPriority::low);
+        if (warpx.do_compute_max_step_from_btd) {
+            warpx.maxStep = final_snapshot_fill_iteration;
+            Print()<<"max_step insufficient to fill all BTD snapshots. Automatically increased to: "
+                <<final_snapshot_fill_iteration<<std::endl;
+        } else {
+            std::string warn_string =
+                "\nSimulation might not run long enough to fill all BTD snapshots.\n"
+                "Final step: " + std::to_string(warpx.maxStep()) + "\n"
+                "Last BTD snapshot fills around step: " + std::to_string(final_snapshot_fill_iteration);
+            ablastr::warn_manager::WMRecordWarning(
+                "BTD", warn_string,
+                ablastr::warn_manager::WarnPriority::low);
+        }
     }
 #ifdef WARPX_DIM_RZ
     UpdateVarnamesForRZopenPMD();

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -158,6 +158,7 @@ void BTDiagnostics::DerivedInitData ()
     // j >= i / gamma / (1+beta) * dt_snapshot / dt_boosted_frame
     const int final_snapshot_starting_step = static_cast<int>(std::ceil(final_snapshot_iteration / warpx.gamma_boost / (1._rt+warpx.beta_boost) * m_dt_snapshots_lab / dt_boosted_frame));
     const int final_snapshot_fill_iteration = final_snapshot_starting_step + num_buffers * m_buffer_size - 1;
+
     if (final_snapshot_fill_iteration > warpx.maxStep()) {
         if (warpx.do_compute_max_step_from_btd) {
             warpx.updateMaxStep(final_snapshot_fill_iteration);
@@ -172,6 +173,10 @@ void BTDiagnostics::DerivedInitData ()
                 "BTD", warn_string,
                 ablastr::warn_manager::WarnPriority::low);
         }
+    } else if (warpx.maxStep() == INT_MAX && warpx.do_compute_max_step_from_btd) {
+            warpx.updateMaxStep(final_snapshot_fill_iteration);
+            amrex::Print()<<"max_step unspecified.  Setting to "
+                <<final_snapshot_fill_iteration<< " to fill all BTD snapshots." << std::endl;
     }
 #ifdef WARPX_DIM_RZ
     UpdateVarnamesForRZopenPMD();

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -173,7 +173,7 @@ void BTDiagnostics::DerivedInitData ()
                 "BTD", warn_string,
                 ablastr::warn_manager::WarnPriority::low);
         }
-    } else if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.do_compute_max_step_from_btd) {
+    } else if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.compute_max_step_from_btd) {
             warpx.updateMaxStep(final_snapshot_fill_iteration);
             amrex::Print()<<"max_step unspecified.  Setting to "
                 <<final_snapshot_fill_iteration<< " to fill all BTD snapshots." << std::endl;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -42,7 +42,7 @@
 #include <cmath>
 #include <cstdio>
 #include <memory>
-#include <string>
+#include <sstream>
 #include <vector>
 
 using namespace amrex::literals;
@@ -165,26 +165,28 @@ void BTDiagnostics::DerivedInitData ()
             amrex::Print()<<"max_step insufficient to fill all BTD snapshots. Automatically increased to: "
                 << final_snapshot_fill_iteration << std::endl;
 
-        } else if (final_snapshot_fill_time > warpx.stopTime()) {
+        }
+        if (final_snapshot_fill_time > warpx.stopTime()) {
             warpx.updateStopTime(final_snapshot_fill_time);
             amrex::Print()<<"stop_time insufficient to fill all BTD snapshots. Automatically increased to: "
                 << final_snapshot_fill_time << std::endl;
 
-        } else if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.stopTime() == std::numeric_limits<amrex::Real>::max()) {
+        }
+        if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.stopTime() == std::numeric_limits<amrex::Real>::max()) {
             amrex::Print()<<"max_step unspecified and stop time unspecified.  Setting max step to "
                 <<final_snapshot_fill_iteration<< " to fill all BTD snapshots." << std::endl;
             warpx.updateMaxStep(final_snapshot_fill_iteration);
         }
 
     } else if (final_snapshot_fill_iteration > warpx.maxStep() || final_snapshot_fill_time > warpx.stopTime()) {
-        std::string warn_string =
-            "\nSimulation might not run long enough to fill all BTD snapshots.\n"
-            "Final step: " + std::to_string(warpx.maxStep()) + "\n"
-            "Stop time: " + std::to_string(warpx.stopTime()) + "\n"
-            "Last BTD snapshot fills around step: " + std::to_string(final_snapshot_fill_iteration) + "\n"
-            " or time: " + std::to_string(final_snapshot_fill_time) + "\n";
+        std::stringstream warn_string;
+            warn_string << "\nSimulation might not run long enough to fill all BTD snapshots.\n"
+            << "Final step: " << warpx.maxStep() << "\n"
+            <<"Stop time: " << warpx.stopTime() << "\n"
+            <<"Last BTD snapshot fills around step: " << final_snapshot_fill_iteration << "\n"
+            <<" or time: " << final_snapshot_fill_time << "\n";
         ablastr::warn_manager::WMRecordWarning(
-            "BTD", warn_string,
+            "BTD", warn_string.str(),
             ablastr::warn_manager::WarnPriority::low);
     }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -173,7 +173,7 @@ void BTDiagnostics::DerivedInitData ()
                 "BTD", warn_string,
                 ablastr::warn_manager::WarnPriority::low);
         }
-    } else if (warpx.maxStep() == INT_MAX && warpx.do_compute_max_step_from_btd) {
+    } else if (warpx.maxStep() == std::numeric_limits<int>::max() && warpx.do_compute_max_step_from_btd) {
             warpx.updateMaxStep(final_snapshot_fill_iteration);
             amrex::Print()<<"max_step unspecified.  Setting to "
                 <<final_snapshot_fill_iteration<< " to fill all BTD snapshots." << std::endl;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -160,7 +160,7 @@ void BTDiagnostics::DerivedInitData ()
     const int final_snapshot_fill_iteration = final_snapshot_starting_step + num_buffers * m_buffer_size - 1;
 
     if (final_snapshot_fill_iteration > warpx.maxStep()) {
-        if (warpx.do_compute_max_step_from_btd) {
+        if (warpx.compute_max_step_from_btd) {
             warpx.updateMaxStep(final_snapshot_fill_iteration);
             amrex::Print()<<"max_step insufficient to fill all BTD snapshots. Automatically increased to: "
                 <<final_snapshot_fill_iteration<<std::endl;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -295,6 +295,9 @@ public:
     //! simulation domain along z reaches #zmax_plasma_to_compute_max_step in the boosted frame
     static bool do_compute_max_step_from_zmax;
 
+    //! If true, the code will compute max_step from the back transformed diagnostics
+    static bool do_compute_max_step_from_btd;
+
     static bool do_dynamic_scheduling;
     static bool refine_plasma;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -784,6 +784,7 @@ public:
     int maxStep () const {return max_step;}
     void updateMaxStep (int const new_max_step) {max_step = new_max_step;}
     amrex::Real stopTime () const {return stop_time;}
+    void updateStopTime (int amrex::Real new_stop_time) {stop_time = new_stop_time;}
 
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,
         amrex::Vector<amrex::MultiFab>& mf_avg, const amrex::IntVect ngrow) const;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -296,7 +296,7 @@ public:
     static bool do_compute_max_step_from_zmax;
 
     //! If true, the code will compute max_step from the back transformed diagnostics
-    static bool do_compute_max_step_from_btd;
+    static bool compute_max_step_from_btd;
 
     static bool do_dynamic_scheduling;
     static bool refine_plasma;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -782,6 +782,7 @@ public:
     bool getis_synchronized() const {return is_synchronized;}
 
     int maxStep () const {return max_step;}
+    void updateMaxStep (int const new_max_step) {max_step = new_max_step;}
     amrex::Real stopTime () const {return stop_time;}
 
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -782,9 +782,9 @@ public:
     bool getis_synchronized() const {return is_synchronized;}
 
     int maxStep () const {return max_step;}
-    void updateMaxStep (int const new_max_step) {max_step = new_max_step;}
+    void updateMaxStep (const int new_max_step) {max_step = new_max_step;}
     amrex::Real stopTime () const {return stop_time;}
-    void updateStopTime (int amrex::Real new_stop_time) {stop_time = new_stop_time;}
+    void updateStopTime (const amrex::Real new_stop_time) {stop_time = new_stop_time;}
 
     void AverageAndPackFields( amrex::Vector<std::string>& varnames,
         amrex::Vector<amrex::MultiFab>& mf_avg, const amrex::IntVect ngrow) const;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -114,6 +114,7 @@ Real WarpX::gamma_boost = 1._rt;
 Real WarpX::beta_boost = 0._rt;
 Vector<int> WarpX::boost_direction = {0,0,0};
 bool WarpX::do_compute_max_step_from_zmax = false;
+bool WarpX::do_compute_max_step_from_btd = false;
 Real WarpX::zmax_plasma_to_compute_max_step = 0._rt;
 
 short WarpX::current_deposition_algo;
@@ -621,6 +622,9 @@ WarpX::ReadParameters ()
         do_compute_max_step_from_zmax = utils::parser::queryWithParser(
             pp_warpx, "zmax_plasma_to_compute_max_step",
             zmax_plasma_to_compute_max_step);
+
+        pp_warpx.query("do_compute_max_step_from_btd",
+            do_compute_max_step_from_btd);
 
         pp_warpx.query("do_moving_window", do_moving_window);
         if (do_moving_window)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -114,7 +114,7 @@ Real WarpX::gamma_boost = 1._rt;
 Real WarpX::beta_boost = 0._rt;
 Vector<int> WarpX::boost_direction = {0,0,0};
 bool WarpX::do_compute_max_step_from_zmax = false;
-bool WarpX::do_compute_max_step_from_btd = false;
+bool WarpX::compute_max_step_from_btd = false;
 Real WarpX::zmax_plasma_to_compute_max_step = 0._rt;
 
 short WarpX::current_deposition_algo;
@@ -623,8 +623,8 @@ WarpX::ReadParameters ()
             pp_warpx, "zmax_plasma_to_compute_max_step",
             zmax_plasma_to_compute_max_step);
 
-        pp_warpx.query("do_compute_max_step_from_btd",
-            do_compute_max_step_from_btd);
+        pp_warpx.query("compute_max_step_from_btd",
+            compute_max_step_from_btd);
 
         pp_warpx.query("do_moving_window", do_moving_window);
         if (do_moving_window)


### PR DESCRIPTION
This PR adds an extra boolean flag ``warpx.compute_max_step_from_btd`` that allows the WarpX to automatically set or increase ``max_step`` as necessary to fill all BTD snapshots.  Previously users had to guess a sufficient ``max_step`` or ``zmax_plasma_to_compute_max_step`` to fill all BTD snapshots.  If incorrect, a warning was printed when ``max_step`` was insufficient to fill all BTD snapshots and gave the value that would probably fill all snapshots, but this two-run setup complicates simulation workflows.  This PR simplifies the work needed to fill all BTD snapshots.

TODO
- [x] add CI test / example input