### PR TITLE
GetExternalEBField: Use AMReX's CompileTimeOption ParallelFor

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -369,7 +369,6 @@ void ParticleExtrema::ComputeDiags (int step)
         // compute chimin and chimax
         Real chimin_f = 0.0_rt;
         Real chimax_f = 0.0_rt;
-        GetExternalEBField get_externalEB;
 
         if (myspc.DoQED())
         {


### PR DESCRIPTION
This greatly improves the performance on AMD and Intel GPUs when GetExternalEBField is not used.