### PR TITLE
Doc: Perlmutter 80 GB GPUs

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -160,6 +160,12 @@ To run a simulation, copy the lines above to a file ``perlmutter.sbatch`` and ru
 
 to submit the job.
 
+A100 GPUs (80 GB)
+^^^^^^^^^^^^^^^^^
+
+Perlmutter has 256 nodes that provide 80 GB HBM per A100 GPU.
+Replace ``-C gpu`` with ``-C gpu&hbm80g`` in the above job script to use these large-memory GPUs.
+
 
 .. _post-processing-perlmutter:
 

--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-# Copyright 2021-2022 Axel Huebl, Kevin Gott
+# Copyright 2021-2023 Axel Huebl, Kevin Gott
 #
 # This file is part of WarpX.
 #
@@ -12,7 +12,10 @@
 #    note: <proj> must end on _g
 #SBATCH -A <proj>
 #SBATCH -q regular
+# A100 40GB (most nodes)
 #SBATCH -C gpu
+# A100 80GB (256 nodes)
+#S BATCH -C gpu&hbm80g
 #SBATCH --exclusive
 #SBATCH --gpu-bind=none
 #SBATCH --gpus-per-node=4


### PR DESCRIPTION
Perlmutter (NERSC) now has 256 nodes with A100 that have 80 GB instead of 40 GB. Nice!