### PR TITLE
PSATD: call FFT of rho with explicit spectral index

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -546,6 +546,9 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         "multi-J algorithm not implemented for FDTD"
     );
 
+    const int rho_mid = spectral_solver_fp[0]->m_spectral_index.rho_mid;
+    const int rho_new = spectral_solver_fp[0]->m_spectral_index.rho_new;
+
     // Push particle from x^{n} to x^{n+1}
     //               from p^{n-1/2} to p^{n+1/2}
     const bool skip_deposition = true;
@@ -571,7 +574,7 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         // Filter, exchange boundary, and interpolate across levels
         SyncRho();
         // Forward FFT of rho
-        PSATDForwardTransformRho(rho_fp, rho_cp, 0, 1);
+        PSATDForwardTransformRho(rho_fp, rho_cp, 0, rho_new);
     }
 
     // 4) Deposit J at relative time -dt with time step dt
@@ -635,7 +638,8 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
             // Filter, exchange boundary, and interpolate across levels
             SyncRho();
             // Forward FFT of rho
-            PSATDForwardTransformRho(rho_fp, rho_cp, 0, 1);
+            const int rho_idx = (rho_in_time == RhoInTime::Linear) ? rho_new : rho_mid;
+            PSATDForwardTransformRho(rho_fp, rho_cp, 0, rho_idx);
         }
 
         if (WarpX::current_correction)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1209,6 +1209,14 @@ WarpX::ReadParameters ()
         J_in_time = GetAlgorithmInteger(pp_psatd, "J_in_time");
         rho_in_time = GetAlgorithmInteger(pp_psatd, "rho_in_time");
 
+        if (psatd_solution_type != PSATDSolutionType::FirstOrder || do_multi_J == false)
+        {
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                rho_in_time == RhoInTime::Linear,
+                "psatd.rho_in_time=constant not yet implemented, "
+                "except for psatd.solution_type=first-order and warpx.do_multi_J=1");
+        }
+
         // Current correction activated by default, unless a charge-conserving
         // current deposition (Esirkepov, Vay) or the div(E) cleaning scheme
         // are used


### PR DESCRIPTION
Make the spectral index of rho (currently `rho_old` or `rho_new`) more evident when calling `PSATDForwardTransformRho`, replacing the old hidden logic
```cpp
    int dst_comp;
    if (rho_in_time == RhoInTime::Constant)
    {
        dst_comp = Idx.rho_mid;
    }
    else // rho_in_time == RhoInTime::Linear
    {
        dst_comp = (dcomp == 0) ? Idx.rho_old : Idx.rho_new;
    }
```

Note that rho constant in time, which corresponds to the spectral index `rho_mid`, is not yet implemented, so we now abort in case a user sets `psatd.rho_in_time=constant` (which should not happen anyways, because `constant` is not among the possible values listed for `psatd.rho_in_time` in the docs).