### PR TITLE
RZ FDTD: fix bug w/ div(E) cleaning (extra c2)

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -169,7 +169,6 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
         Box const& tf  = mfi.tilebox(Ffield->ixType().toIntVect());
 
         Real constexpr inv_epsilon0 = 1./PhysConst::ep0;
-        Real constexpr c2 = PhysConst::c * PhysConst::c;
 
         // Use the right shift in components:
         // - the first WarpX::ncomps (2*n_rz_azimuthal_modes-1) components correspond to rho old (i.e. rhocomp=0)
@@ -195,7 +194,7 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
                             + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
                             + m * Et( i, j, 0, 2*m )/r
                             + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 2*m-1) ); // Real part
-                        F(i, j, 0, 2*m  ) += c2 * dt *(
+                        F(i, j, 0, 2*m  ) += dt *(
                             - rho(i, j, 0, rho_shift + 2*m-1) * inv_epsilon0
                             + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
                             - m * Et( i, j, 0, 2*m-1 )/r


### PR DESCRIPTION
There seems to be an extra factor $c^2$ in the imaginary part of RZ modes higher than 0 (imaginary part means fourth component `2*m` for $m \geq 1$) for the F update equation with the FDTD solver.