### PR TITLE
fix zmax_plasma_... calculation upon restart

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -379,7 +379,7 @@ WarpX::InitData ()
     // needs to start from the initial zmin_domain_boost,
     // even if restarting from a checkpoint file
     if (do_compute_max_step_from_zmax) {
-      zmin_domain_boost_step_0 = geom[0].ProbLo(WARPX_ZINDEX);
+        zmin_domain_boost_step_0 = geom[0].ProbLo(WARPX_ZINDEX);
     }
     if (restart_chkfile.empty())
     {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -375,7 +375,7 @@ WarpX::InitData ()
 
     Print() << utils::logo::get_logo();
 
-    // WarpX::computeMaxStepBoostAccelerator 
+    // WarpX::computeMaxStepBoostAccelerator
     // needs to start from the initial zmin_domain_boost,
     // even if restarting from a checkpoint file
     if (do_compute_max_step_from_zmax) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -549,7 +549,7 @@ void
 WarpX::ComputeMaxStep ()
 {
     if (do_compute_max_step_from_zmax) {
-        computeMaxStepBoostAccelerator(geom[0]);
+        computeMaxStepBoostAccelerator();
     }
 }
 
@@ -560,7 +560,7 @@ WarpX::ComputeMaxStep ()
  * simulation box passes input parameter zmax_plasma_to_compute_max_step.
  */
 void
-WarpX::computeMaxStepBoostAccelerator(const amrex::Geometry& a_geom){
+WarpX::computeMaxStepBoostAccelerator() {
     // Sanity checks: can use zmax_plasma_to_compute_max_step only if
     // the moving window and the boost are all in z direction.
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -578,7 +578,8 @@ WarpX::computeMaxStepBoostAccelerator(const amrex::Geometry& a_geom){
 
     // Lower end of the simulation domain. All quantities are given in boosted
     // frame except zmax_plasma_to_compute_max_step.
-    const Real zmin_domain_boost = a_geom.ProbLo(WARPX_ZINDEX);
+
+    const Real zmin_domain_boost = geom[0].ProbLo(WARPX_ZINDEX);
     // End of the plasma: Transform input argument
     // zmax_plasma_to_compute_max_step to boosted frame.
     const Real len_plasma_boost = zmax_plasma_to_compute_max_step/gamma_boost;
@@ -596,7 +597,9 @@ WarpX::computeMaxStepBoostAccelerator(const amrex::Geometry& a_geom){
         computed_max_step =
             static_cast<int>(interaction_time_boost/dt[maxLevel()]);
     }
-    max_step = computed_max_step;
+    // computed_max_step is the number of steps from restart to terminal condition, so
+    // max step = restart step + computed_max_step
+    max_step = istep[0] + computed_max_step;
     Print()<<"max_step computed in computeMaxStepBoostAccelerator: "
            <<computed_max_step<<std::endl;
 }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -294,6 +294,9 @@ public:
     //! the maximum number of iterations is computed automatically so that the lower end of the
     //! simulation domain along z reaches #zmax_plasma_to_compute_max_step in the boosted frame
     static bool do_compute_max_step_from_zmax;
+    //! store initial value of zmin_domain_boost because WarpX::computeMaxStepBoostAccelerator 
+    //! needs the initial value of zmin_domain_boost, even if restarting from a checkpoint file
+    static amrex::Real zmin_domain_boost_step_0;
 
     //! If true, the code will compute max_step from the back transformed diagnostics
     static bool compute_max_step_from_btd;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -294,7 +294,7 @@ public:
     //! the maximum number of iterations is computed automatically so that the lower end of the
     //! simulation domain along z reaches #zmax_plasma_to_compute_max_step in the boosted frame
     static bool do_compute_max_step_from_zmax;
-    //! store initial value of zmin_domain_boost because WarpX::computeMaxStepBoostAccelerator 
+    //! store initial value of zmin_domain_boost because WarpX::computeMaxStepBoostAccelerator
     //! needs the initial value of zmin_domain_boost, even if restarting from a checkpoint file
     static amrex::Real zmin_domain_boost_step_0;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -552,7 +552,7 @@ public:
      */
     void ComputeMaxStep ();
     // Compute max_step automatically for simulations in a boosted frame.
-    void computeMaxStepBoostAccelerator(const amrex::Geometry& geom);
+    void computeMaxStepBoostAccelerator();
 
     /** \brief Move the moving window
      * \param step Time step

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -116,6 +116,7 @@ Vector<int> WarpX::boost_direction = {0,0,0};
 bool WarpX::do_compute_max_step_from_zmax = false;
 bool WarpX::compute_max_step_from_btd = false;
 Real WarpX::zmax_plasma_to_compute_max_step = 0._rt;
+Real WarpX::zmin_domain_boost_step_0 = 0._rt;
 
 short WarpX::current_deposition_algo;
 short WarpX::charge_deposition_algo;


### PR DESCRIPTION
This PR fixes the ``max_step`` determined by ``WarpX::computeMaxStepBoostAccelerator`` when performing a restart from a checkpoint file.

Previously, the code on the attached example would output 
``max_step computed in computeMaxStepBoostAccelerator: 513
``
initially, and then upon restart,
``max_step computed in computeMaxStepBoostAccelerator: 488
``
With this fix, the max_step computed upon restart remains the same value of 513

[inputs_2D.txt](https://github.com/ECP-WarpX/WarpX/files/10904149/inputs_2D.txt)


