### PR TITLE
Fix handling of name passed into SetTag

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -349,7 +349,7 @@ public:
         const amrex::DistributionMapping& dm,
         const int ncomp,
         const amrex::IntVect& ngrow,
-        const std::string name,
+        const std::string& name,
         std::optional<const amrex::Real> initial_value = {});
 
     /**
@@ -372,7 +372,7 @@ public:
         const amrex::DistributionMapping& dm,
         const int ncomp,
         const amrex::IntVect& ngrow,
-        const std::string name,
+        const std::string& name,
         std::optional<const int> initial_value = {});
 
     /**
@@ -390,7 +390,7 @@ public:
         const amrex::MultiFab& mf_to_alias,
         const int scomp,
         const int ncomp,
-        const std::string name,
+        const std::string& name,
         std::optional<const amrex::Real> initial_value);
 
     // Maps of all of the MultiFabs and iMultiFabs used (this can include MFs from other classes)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -405,7 +405,7 @@ public:
      * \param name The name of the MultiFab use to reference the MultiFab
      * \param mf The MultiFab to be added to the map (via a pointer to it)
      */
-    static void AddToMultiFabMap(const std::string name, const std::unique_ptr<amrex::MultiFab>& mf) {
+    static void AddToMultiFabMap(const std::string& name, const std::unique_ptr<amrex::MultiFab>& mf) {
         multifab_map[name] = mf.get();
     }
 
@@ -415,7 +415,7 @@ public:
      * \param name The name of the iMultiFab use to reference the iMultiFab
      * \param mf The iMultiFab to be added to the map (via a pointer to it)
      */
-    static void AddToMultiFabMap(const std::string name, const std::unique_ptr<amrex::iMultiFab>& mf) {
+    static void AddToMultiFabMap(const std::string& name, const std::unique_ptr<amrex::iMultiFab>& mf) {
         imultifab_map[name] = mf.get();
     }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2958,10 +2958,10 @@ WarpX::AllocInitMultiFab (
     const amrex::DistributionMapping& dm,
     const int ncomp,
     const amrex::IntVect& ngrow,
-    const std::string name,
+    const std::string& name,
     std::optional<const amrex::Real> initial_value)
 {
-    const auto tag = amrex::MFInfo().SetTag(std::move(name));
+    const auto tag = amrex::MFInfo().SetTag(name);
     mf = std::make_unique<amrex::MultiFab>(ba, dm, ncomp, ngrow, tag);
     if (initial_value) {
         mf->setVal(*initial_value);
@@ -2976,10 +2976,10 @@ WarpX::AllocInitMultiFab (
     const amrex::DistributionMapping& dm,
     const int ncomp,
     const amrex::IntVect& ngrow,
-    const std::string name,
+    const std::string& name,
     std::optional<const int> initial_value)
 {
-    const auto tag = amrex::MFInfo().SetTag(std::move(name));
+    const auto tag = amrex::MFInfo().SetTag(name);
     mf = std::make_unique<amrex::iMultiFab>(ba, dm, ncomp, ngrow, tag);
     if (initial_value) {
         mf->setVal(*initial_value);
@@ -2993,7 +2993,7 @@ WarpX::AliasInitMultiFab (
     const amrex::MultiFab& mf_to_alias,
     const int scomp,
     const int ncomp,
-    const std::string name,
+    const std::string& name,
     std::optional<const amrex::Real> initial_value)
 {
     mf = std::make_unique<amrex::MultiFab>(mf_to_alias, amrex::make_alias, scomp, ncomp);


### PR DESCRIPTION
This PR does some clean up of the handling of the `name` variable that is passed into `SetTag` during the creation of MultiFabs. This fixes a compilation error that arises due to recent changes in AMReX. As Weiqun says, "Top level const as function parameter is bad" so the `name` was changed to `const std::string&`.

Note that PR https://github.com/AMReX-Codes/amrex/pull/3188 in AMReX would also fix the compilation error, but it is good to also clean up the code here.