### PR TITLE
Doc: Fix Builds, Disable all but HTML

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,6 @@
 requirements_file: Docs/requirements.txt
 
 formats:
+  - htmlzip
+#  - pdf
+#  - epub

--- a/Docs/source/latex_theory/allbibs.bib
+++ b/Docs/source/latex_theory/allbibs.bib
@@ -420,7 +420,7 @@ journal = {Journal of Computational Physics},
 keywords = {Numerical methods},
 number = {5},
 pages = {1803--1814},
-title = {{Particle-in-Cell modelling of laser{\{}{\^{a}}{\}}plasma interaction using Fourier decomposition}},
+title = {{Particle-in-Cell modelling of laser-plasma interaction using Fourier decomposition}},
 url = {http://www.sciencedirect.com/science/article/pii/S0021999108005950},
 volume = {228},
 year = {2009}
@@ -1280,11 +1280,10 @@ year = {2000}
 
 author = {Davidson, A. and Tableman, A. and An, W. and Tsung, F.S. and Lu, W. and Vieira, J. and Fonseca, R.A. and Silva, L.O. and Mori, W.B.},
 doi = {10.1016/j.jcp.2014.10.064},
-file = {:Users/jlvay/Library/Application Support/Mendeley Desktop/Downloaded/Davidson et al. - 2015 - Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in ϕ into.pdf:pdf},
 issn = {00219991},
 journal = {Journal of Computational Physics},
 pages = {1063--1077},
-title = {{Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in ϕ into OSIRIS}},
+title = {{Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in \Phi into OSIRIS}},
 volume = {281},
 year = {2015}
 }

--- a/Docs/source/theory/boosted_frame.rst
+++ b/Docs/source/theory/boosted_frame.rst
@@ -292,7 +292,7 @@ Cowan, B, D Bruhwiler, E Cormier-Michel, E Esarey, C G R Geddes, P Messmer, and 
 
    <div id="ref-DavidsonJCP2015">
 
-Davidson, A., A. Tableman, W. An, F.S. Tsung, W. Lu, J. Vieira, R.A. Fonseca, L.O. Silva, and W.B. Mori. 2015. “Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in ϕ into OSIRIS.” *Journal of Computational Physics* 281: 1063–77. https://doi.org/10.1016/j.jcp.2014.10.064.
+Davidson, A., A. Tableman, W. An, F.S. Tsung, W. Lu, J. Vieira, R.A. Fonseca, L.O. Silva, and W.B. Mori. 2015. “Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in :math:`\Phi` into OSIRIS.” *Journal of Computational Physics* 281: 1063–77. https://doi.org/10.1016/j.jcp.2014.10.064.
 
 .. raw:: html
 
@@ -452,7 +452,7 @@ Lehe, R., M. Kirchen, B. B. Godfrey, A. R. Maier, and J.-L. Vay. 2016. “Elimin
 
    <div id="ref-LifschitzJCP2009">
 
-Lifschitz, A F, X Davoine, E Lefebvre, J Faure, C Rechatin, and V Malka. 2009. “Particle-in-Cell modelling of laser{â}plasma interaction using Fourier decomposition.” *Journal of Computational Physics* 228 (5): 1803–14. https://doi.org/http://dx.doi.org/10.1016/j.jcp.2008.11.017.
+Lifschitz, A F, X Davoine, E Lefebvre, J Faure, C Rechatin, and V Malka. 2009. “Particle-in-Cell modelling of laser-plasma interaction using Fourier decomposition.” *Journal of Computational Physics* 228 (5): 1803–14. https://doi.org/http://dx.doi.org/10.1016/j.jcp.2008.11.017.
 
 .. raw:: html
 

--- a/Docs/source/theory/intro.rst
+++ b/Docs/source/theory/intro.rst
@@ -109,7 +109,7 @@ Cowan, Benjamin M, David L Bruhwiler, Estelle Cormier-Michel, Eric Esarey, Camer
 
    <div id="ref-DavidsonJCP2015">
 
-Davidson, A., A. Tableman, W. An, F.S. Tsung, W. Lu, J. Vieira, R.A. Fonseca, L.O. Silva, and W.B. Mori. 2015. “Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in ϕ into OSIRIS.” *Journal of Computational Physics* 281: 1063–77. https://doi.org/10.1016/j.jcp.2014.10.064.
+Davidson, A., A. Tableman, W. An, F.S. Tsung, W. Lu, J. Vieira, R.A. Fonseca, L.O. Silva, and W.B. Mori. 2015. “Implementation of a hybrid particle code with a PIC description in r–z and a gridless description in :math:`\Phi` into OSIRIS.” *Journal of Computational Physics* 281: 1063–77. https://doi.org/10.1016/j.jcp.2014.10.064.
 
 .. raw:: html
 
@@ -209,7 +209,7 @@ Lehe, Rémi, Manuel Kirchen, Igor A. Andriyash, Brendan B. Godfrey, and Jean-Luc
 
    <div id="ref-LifschitzJCP2009">
 
-Lifschitz, A F, X Davoine, E Lefebvre, J Faure, C Rechatin, and V Malka. 2009. “Particle-in-Cell modelling of laser{â}plasma interaction using Fourier decomposition.” *Journal of Computational Physics* 228 (5): 1803–14. https://doi.org/http://dx.doi.org/10.1016/j.jcp.2008.11.017.
+Lifschitz, A F, X Davoine, E Lefebvre, J Faure, C Rechatin, and V Malka. 2009. “Particle-in-Cell modelling of laser-plasma interaction using Fourier decomposition.” *Journal of Computational Physics* 228 (5): 1803–14. https://doi.org/http://dx.doi.org/10.1016/j.jcp.2008.11.017.
 
 .. raw:: html
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2211,9 +2211,9 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 * ``<diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)`` (parser `string`)
    Parser function to be calculated for each particle per cell. The averaged field written is
 
-        .. math::
+   .. math::
 
-            \texttt{<field_name>_<species>} = \frac{\sum_{i=1}^N w_i \, f(x_i,y_i,z_i,u_{x,i},u_{y,i},u_{z,i})}{\sum_{i=1}^N w_i}
+      \texttt{<field_name>_<species>} = \frac{\sum_{i=1}^N w_i \, f(x_i,y_i,z_i,u_{x,i},u_{y,i},u_{z,i})}{\sum_{i=1}^N w_i}
 
    where :math:`w_i` is the particle weight, :math:`f()` is the parser function, and :math:`(x_i,y_i,z_i)` are particle positions in units of a meter. The sums are over all particles of type ``<species>`` in a cell (ignoring the particle shape factor) that satisfy ``<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)``.
    When ``<diag_name>.particle_fields.<field_name>.do_average`` is `0`, the division by the sum over particle weights is not done.
@@ -2229,7 +2229,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     When ``<diag_name>.plot_raw_fields = 1``, then the raw (i.e. non-averaged)
     fields are also saved in the output files.
     Only works with ``<diag_name>.format = plotfile``.
-    See `this section <https://yt-project.org/doc/examining/loading_data.html#viewing-raw-fields-in-warpx>`_
+    See `this section <https://yt-project.org/doc/examining/loading_data.html#viewing-raw-fields-in-warpx>`__
     in the yt documentation for more details on how to view raw fields.
 
 * ``<diag_name>.plot_raw_fields_guards`` (`0` or `1`) optional (default `0`)

--- a/Docs/source/usage/pwfa.rst
+++ b/Docs/source/usage/pwfa.rst
@@ -8,16 +8,16 @@ For illustration purposes the setup can be explored with **WarpX** using the exa
 The simulation setup consists of 4 particle species: drive beam (driver), witness beam (beam), plasma electrons (plasma_e), and plasma ions (plasma_p).
 The species physical parameters are summarized in the following table.
 
-======== ============================================================
+======== ================================================================================================================
 Species  Parameters
-======== ============================================================
-driver   :math:`\gamma` = 48923; N = 2x10^8; σz = 4.0 μm; σx = 2.0 μm
-beam     :math:`\gamma` = 48923; N = 6x10^5; σz = 1.0 mm; σx = 0.5 μm
-plasma_e n = 1x10^23 m^-3; w = 70 μm; lr = 8 mm; L = 200 mm
-plasma_p n = 1x10^23 m^-3; w = 70 μm; lr = 8 mm; L = 200 mm
-======== ============================================================
+======== ================================================================================================================
+driver   :math:`\gamma` = 48923; N = 2x10^8; :math:`\sigma_z` = 4.0 um; :math:`\sigma_x` = 2.0 um
+beam     :math:`\gamma` = 48923; N = 6x10^5; :math:`\sigma_z` = 1.0 mm; :math:`\sigma_x` = 0.5 um
+plasma_e n = 1x10^23 m^-3; w = 70 um; lr = 8 mm; L = 200 mm
+plasma_p n = 1x10^23 m^-3; w = 70 um; lr = 8 mm; L = 200 mm
+======== ================================================================================================================
 
-Where :math:`\gamma` is the beam relativistic Lorentz factor, N is the number of particles, and σx, σy, σz are the beam widths (root-mean-squares of particle positions) in the transverse (x,y) and longitudinal directions.
+Where :math:`\gamma` is the beam relativistic Lorentz factor, N is the number of particles, and :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_z` are the beam widths (root-mean-squares of particle positions) in the transverse (x,y) and longitudinal directions.
 
 The plasma, of total length L, has a density profile that consists of a lr long linear up-ramp, ranging from 0 to peak value n, is uniform within a transverse width of w and after the up-ramp.
 
@@ -127,4 +127,4 @@ Maximum grid size and blocking factor
 -------------------------------------
 
     These parameters are carfully chosen to improve the code parallelization, load-balancing and performance (:doc:`parameters`) for each numerical configuration.
-    They define the smallest and largest number of cells that can be contained in each simulation box and are carefully defined in the `AMReX <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html?highlight=blocking_factor>`_ documentation.
+    They define the smallest and largest number of cells that can be contained in each simulation box and are carefully defined in the `AMReX <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html?highlight=blocking_factor>`__ documentation.


### PR DESCRIPTION
PDF builds are brittle from auto-converted doc files we include in the theory sections.

Disable PDF, fix other build errors for HTML.

Not seen in CI, because:
> Additional formats like PDF and EPUB aren’t built, to reduce build time.
https://docs.readthedocs.io/en/stable/guides/pull-requests.html