### PR TITLE
Deposition: Fix LB Cost Segfault

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -202,7 +202,7 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
         }
         );
 #if defined(WARPX_USE_GPUCLOCK)
-        if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+        if(cost && load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
             amrex::Gpu::streamSynchronize();
             *cost += *cost_real;
             amrex::The_Managed_Arena()->free(cost_real);

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -326,7 +326,7 @@ void doDepositionShapeN(const GetParticlePosition& GetPosition,
         }
     );
 #if defined(WARPX_USE_GPUCLOCK)
-    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+    if(cost && load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
         amrex::Gpu::streamSynchronize();
         *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);
@@ -700,7 +700,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
         }
     );
 #if defined(WARPX_USE_GPUCLOCK)
-    if( load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
+    if(cost && load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::GpuClock) {
         amrex::Gpu::streamSynchronize();
         *cost += *cost_real;
         amrex::The_Managed_Arena()->free(cost_real);


### PR DESCRIPTION
We sometimes call depositions before the load balance cost arrays are allocated, e.g., during initialization. In this case, we need to avoid writing into invalid memory.

Fix #3721

Introduced in #1406