### PR TITLE
Load Balance & Regrid: Cost Guards

### DIFF
--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -113,7 +113,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
         costs[lev] = std::make_unique<LayoutData<Real>>(*warpx.getCosts(lev));
     }
 
-    if (warpx.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+    if (costs && warpx.load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
     {
         warpx.ComputeCostsHeuristic(costs);
     }

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -56,7 +56,7 @@ WarpX::LoadBalance ()
     AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
 
 #ifdef AMREX_USE_MPI
-    if (load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
+    if (costs && load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
     {
         // compute the costs on a per-rank basis
         ComputeCostsHeuristic(costs);


### PR DESCRIPTION
This is adding guards if the `cost` array was already defined. Not sure if sensible, seen via similar error-prune patterns in the code.

Related to #3738