### PR TITLE
Spack: OpenMP w/o GPU

### DIFF
--- a/Tools/machines/desktop/spack-macos-openmp.yaml
+++ b/Tools/machines/desktop/spack-macos-openmp.yaml
@@ -16,14 +16,14 @@ spack:
   specs:
   - adios2 ~fortran
   - ascent +adios2 +python ~fortran
-  - blaspp
+  - blaspp ~cuda +openmp ~rocm
   - boost
   - ccache
   - cmake
   - conduit ~fortran
   - fftw
   - hdf5 ~fortran
-  - lapackpp
+  - lapackpp ~cuda ~rocm ^blaspp ~cuda +openmp ~rocm
   - mpi
   - llvm-openmp
   - pkgconfig
@@ -57,7 +57,7 @@ spack:
 
   packages:
     all:
-      variants: +mpi ~fortran
+      variants: +mpi ~fortran ~cuda ~rocm
       # BLAS/LAPACK: the default (accelerate) pulls veclibfort@0.4.2 for
       #              py-numpy, which fails to build on M1
       # MPI: the default (openmpi) triggers annoying firewall warnings when

--- a/Tools/machines/desktop/spack-ubuntu-openmp.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-openmp.yaml
@@ -15,14 +15,14 @@
 spack:
   specs:
   - adios2
-  - blaspp
+  - blaspp ~cuda +openmp ~rocm
   - boost
   - ccache
   - cmake
   - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
   - fftw
   - hdf5
-  - lapackpp
+  - lapackpp ~cuda ~rocm ^blaspp ~cuda +openmp ~rocm
   - mpi
   - pkgconfig
   - python
@@ -49,7 +49,7 @@ spack:
 
   packages:
     all:
-      variants: +mpi ~fortran
+      variants: +mpi ~fortran ~cuda ~rocm
     # default blocks at HDF5 1.8, resulting in unmergable solution
     conduit:
       variants: ~hdf5_compat


### PR DESCRIPTION
Spack desktop environments:
Make sure that we are explicit about not matching GPU packages if we want to build a pure OpenMP version on a GPU-enabled machine.

X-ref: #3733