### PR TITLE
Fix Bucket __getattr__

### DIFF
--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -38,7 +38,7 @@ class Bucket(object):
         try:
             return self.argvattrs[name]
         except KeyError:
-            return object.__getattr__(self, name)
+            return object.__getattribute__(self, name)
 
     def check_consistency(self, vname, value, errmsg):
         if vname in self.argvattrs:


### PR DESCRIPTION
This is a small fix in the Python interface code that had incorrect Python code. Note that this bit of code has never been used since this error had not been noticed.

The `object` class has no attribute `__getattr__`. The appropriate attribute to use is `__getattribute__`.