### PR TITLE
remove spaces from headers in `FieldMaximum`, `RhoMaximum` and `ParticleNumber` red diags

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -74,21 +74,21 @@ FieldMaximum::FieldMaximum (std::string rd_name)
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_Ex_lev" + std::to_string(lev) + " (V/m)";
+                ofs << "[" << c++ << "]max_Ex_lev" + std::to_string(lev) + "(V/m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_Ey_lev" + std::to_string(lev) + " (V/m)";
+                ofs << "[" << c++ << "]max_Ey_lev" + std::to_string(lev) + "(V/m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_Ez_lev" + std::to_string(lev) + " (V/m)";
+                ofs << "[" << c++ << "]max_Ez_lev" + std::to_string(lev) + "(V/m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_|E|_lev" + std::to_string(lev) + " (V/m)";
+                ofs << "[" << c++ << "]max_|E|_lev" + std::to_string(lev) + "(V/m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_Bx_lev" + std::to_string(lev) + " (T)";
+                ofs << "[" << c++ << "]max_Bx_lev" + std::to_string(lev) + "(T)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_By_lev" + std::to_string(lev) + " (T)";
+                ofs << "[" << c++ << "]max_By_lev" + std::to_string(lev) + "(T)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_Bz_lev" + std::to_string(lev) + " (T)";
+                ofs << "[" << c++ << "]max_Bz_lev" + std::to_string(lev) + "(T)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_|B|_lev" + std::to_string(lev) + " (T)";
+                ofs << "[" << c++ << "]max_|B|_lev" + std::to_string(lev) + "(T)";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -59,21 +59,21 @@ ParticleNumber::ParticleNumber (std::string rd_name)
             ofs << m_sep;
             ofs << "[" << c++ << "]time(s)";
             ofs << m_sep;
-            ofs << "[" << c++ << "]total macroparticles()";
+            ofs << "[" << c++ << "]total_macroparticles()";
             // Column number of first species macroparticle number
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" << c++ << "]" << species_names[i] + " macroparticles()";
+                ofs << "[" << c++ << "]" << species_names[i] + "_macroparticles()";
             }
             // Column number of total weight (summed over all species)
             ofs << m_sep;
-            ofs << "[" << c++ << "]total weight()";
+            ofs << "[" << c++ << "]total_weight()";
             // Column number of first species weight
             for (int i = 0; i < nSpecies; ++i)
             {
                 ofs << m_sep;
-                ofs << "[" << c++ << "]" << species_names[i] + " weight()";
+                ofs << "[" << c++ << "]" << species_names[i] + "_weight()";
             }
             ofs << std::endl;
             // close file

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -103,14 +103,14 @@ RhoMaximum::RhoMaximum (std::string rd_name)
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" << c++ << "]max_rho_lev" + std::to_string(lev) + " (C/m^3)";
+                ofs << "[" << c++ << "]max_rho_lev" + std::to_string(lev) + "(C/m^3)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]min_rho_lev" + std::to_string(lev) + " (C/m^3)";
+                ofs << "[" << c++ << "]min_rho_lev" + std::to_string(lev) + "(C/m^3)";
                 for (int i = 0; i < n_charged_species; ++i)
                 {
                     ofs << m_sep;
                     ofs << "[" << c++ << "]max_" + species_names[indices_charged_species[i]]
-                                         + "_|rho|_lev" + std::to_string(lev) + " (C/m^3)";
+                                         + "_|rho|_lev" + std::to_string(lev) + "(C/m^3)";
                 }
             }
             ofs << std::endl;


### PR DESCRIPTION
This PR removes the white spaces in the headers of the `FieldMaximum`, `RhoMaximum` and `ParticleNumber` reduced diagnostics. 
The white spaces separated the name of the quantity saved in that column and its units.  
The new behavior is consistent with the other reduced diagnostics. 
Example: from `[2]max_Ex_lev0 (V/m)` to `[2]max_Ex_lev0(V/m)`.