### PR TITLE
[mini] Print full json file if checksum CI fails

### DIFF
--- a/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D.json
@@ -1,6 +1,6 @@
 {
   "deuterium_1": {
-    "particle_momentum_x": 1.0,
+    "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 2.63689606713025e-13,
     "particle_position_x": 40960140.72983793,

--- a/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D.json
+++ b/Regression/Checksum/benchmarks_json/Deuterium_Deuterium_Fusion_3D.json
@@ -1,6 +1,6 @@
 {
   "deuterium_1": {
-    "particle_momentum_x": 0.0,
+    "particle_momentum_x": 1.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 2.63689606713025e-13,
     "particle_position_x": 40960140.72983793,

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -140,9 +140,9 @@ class Checksum:
                   "have different outer keys:")
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("Plotfile : %s" % self.data.keys())
-            print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+            print("\n----------------\nNew file for " + self.test_name + ":")
             print(json.dumps(self.data, indent=2))
-            print("\n\n----------------\n")
+            print("----------------")
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -155,9 +155,9 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("Plotfile  inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
-                print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+                print("\n----------------\nNew file for " + self.test_name + ":")
                 print(json.dumps(self.data, indent=2))
-                print("\n\n----------------\n")
+                print("----------------")
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -184,7 +184,7 @@ class Checksum:
                         rel_err = abs_err / np.abs(x)
                         print("Relative error: {:.2e}".format(rel_err))
         if checksums_differ:
-            print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+            print("\n----------------\nNew file for " + self.test_name + ":")
             print(json.dumps(self.data, indent=2))
-            print("\n\n----------------\n")
+            print("----------------")
             sys.exit(1)

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -10,6 +10,7 @@ import sys
 
 from benchmark import Benchmark
 import numpy as np
+import json
 import yt
 
 yt.funcs.mylog.setLevel(50)
@@ -139,6 +140,9 @@ class Checksum:
                   "have different outer keys:")
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("Plotfile : %s" % self.data.keys())
+            print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+            print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n")
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -151,6 +155,9 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("Plotfile  inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
+                print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+                print(json.dumps(self.data, indent=2))
+                print("\n\n----------------\n")
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -177,4 +184,7 @@ class Checksum:
                         rel_err = abs_err / np.abs(x)
                         print("Relative error: {:.2e}".format(rel_err))
         if checksums_differ:
+            print("\n\n----------------\n\nNew file for" + self.test_name + ":")
+            print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n")
             sys.exit(1)

--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -6,11 +6,11 @@
  License: BSD-3-Clause-LBNL
  """
 
+import json
 import sys
 
 from benchmark import Benchmark
 import numpy as np
-import json
 import yt
 
 yt.funcs.mylog.setLevel(50)


### PR DESCRIPTION
This makes it easier to reset benchmarks when we now the new version is correct.