### PR TITLE
Correct typo in a comment in WarpX.H

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -162,7 +162,7 @@ public:
      *  being used (0, 1, 2 corresponding to timers, heuristic, or gpuclock).
      */
     static short load_balance_costs_update_algo;
-    //! Integer that corresponds to electromagnetic Maxwell solver (vaccum - 0, macroscopic - 1)
+    //! Integer that corresponds to electromagnetic Maxwell solver (vacuum - 0, macroscopic - 1)
     static int em_solver_medium;
     /** Integer that correspond to macroscopic Maxwell solver algorithm
      *  (BackwardEuler - 0, Lax-Wendroff - 1)


### PR DESCRIPTION
This PR simply corrects a typo (vaccum --> vacuum)