### PR TITLE
Allow using different types for coordinates and values in {bi,tri}-linear interpolation functions

### DIFF
--- a/Source/Utils/Algorithms/LinearInterpolation.H
+++ b/Source/Utils/Algorithms/LinearInterpolation.H
@@ -19,7 +19,7 @@ namespace utils::algorithms
      * (x0, f0) and (x1, f1)
      */
     template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    auto linear_interp(
+    constexpr auto linear_interp(
         TCoord x0, TCoord x1,
         TVal f0, TVal f1,
         TCoord x)
@@ -33,13 +33,13 @@ namespace utils::algorithms
      * (x0, y0, f00), (x0, y1, f01), (x1, y0, f10), (x1, y1, f11).
      */
     template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    auto bilinear_interp(
+    constexpr auto bilinear_interp(
         TCoord x0, TCoord x1, TCoord y0, TCoord y1,
         TVal f00, TVal f01, TVal f10, TVal f11,
         TCoord x, TCoord y)
     {
-        const T fx0 = linear_interp(x0, x1, f00, f10, x);
-        const T fx1 = linear_interp(x0, x1, f01, f11, x);
+        const auto fx0 = linear_interp(x0, x1, f00, f10, x);
+        const auto fx1 = linear_interp(x0, x1, f01, f11, x);
         return linear_interp(y0, y1, fx0, fx1, y);
     }
 
@@ -50,14 +50,14 @@ namespace utils::algorithms
      * (x1, y0, z0, f100), (x1, y0, z1, f101), (x1, y1, z0, f110), (x1, y1, z1, f111)
      */
     template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    auto trilinear_interp(
+    constexpr auto trilinear_interp(
         TCoord x0, TCoord x1, TCoord y0, TCoord y1, TCoord z0, TCoord z1,
         TVal f000, TVal f001, TVal f010, TVal f011, TVal f100, TVal f101, TVal f110, TVal f111,
         TCoord x, TCoord y, TCoord z)
     {
-        const T fxy0 = bilinear_interp(
+        const auto fxy0 = bilinear_interp(
             x0, x1, y0, y1, f000, f010, f100, f110, x, y);
-        const T fxy1 = bilinear_interp(
+        const auto fxy1 = bilinear_interp(
             x0, x1, y0, y1, f001, f011, f101, f111, x, y);
         return linear_interp(z0, z1, fxy0, fxy1, z);
     }

--- a/Source/Utils/Algorithms/LinearInterpolation.H
+++ b/Source/Utils/Algorithms/LinearInterpolation.H
@@ -18,8 +18,11 @@ namespace utils::algorithms
      * Performs a linear interpolation at x given the 2 points
      * (x0, f0) and (x1, f1)
      */
-    template<typename T> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    T linear_interp(T x0, T x1, T f0, T f1, T x)
+    template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    auto linear_interp(
+        TCoord x0, TCoord x1,
+        TVal f0, TVal f1,
+        TCoord x)
     {
         return ((x1-x)*f0 + (x-x0)*f1)/(x1-x0);
     }
@@ -29,8 +32,11 @@ namespace utils::algorithms
      * Performs a bilinear interpolation at (x,y) given the 4 points
      * (x0, y0, f00), (x0, y1, f01), (x1, y0, f10), (x1, y1, f11).
      */
-    template<typename T> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    T bilinear_interp(T x0, T x1, T y0, T y1, T f00, T f01, T f10, T f11, T x, T y)
+    template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    auto bilinear_interp(
+        TCoord x0, TCoord x1, TCoord y0, TCoord y1,
+        TVal f00, TVal f01, TVal f10, TVal f11,
+        TCoord x, TCoord y)
     {
         const T fx0 = linear_interp(x0, x1, f00, f10, x);
         const T fx1 = linear_interp(x0, x1, f01, f11, x);
@@ -43,10 +49,11 @@ namespace utils::algorithms
      * (x0, y0, z0, f000), (x0, y0, z1, f001), (x0, y1, z0, f010), (x0, y1, z1, f011),
      * (x1, y0, z0, f100), (x1, y0, z1, f101), (x1, y1, z0, f110), (x1, y1, z1, f111)
      */
-    template<typename T> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    T trilinear_interp(T x0, T x1,T y0, T y1, T z0, T z1,
-        T f000, T f001, T f010, T f011, T f100, T f101, T f110, T f111,
-        T x, T y, T z)
+    template<typename TCoord, typename TVal> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    auto trilinear_interp(
+        TCoord x0, TCoord x1, TCoord y0, TCoord y1, TCoord z0, TCoord z1,
+        TVal f000, TVal f001, TVal f010, TVal f011, TVal f100, TVal f101, TVal f110, TVal f111,
+        TCoord x, TCoord y, TCoord z)
     {
         const T fxy0 = bilinear_interp(
             x0, x1, y0, y1, f000, f010, f100, f110, x, y);


### PR DESCRIPTION
This PR changes the {bi,tri}-linear inteporlation functions adding the possibility to use arguments of different types for coordinates and values.

