### PR TITLE
Crusher (OLCF): ADIOS 2.8.3

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -49,18 +49,6 @@ And since Crusher does not yet provide a module for them, install BLAS++ and LAP
 
 .. code-block:: bash
 
-   # c-blosc (I/O compression)
-   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git src/c-blosc
-   rm -rf src/c-blosc-crusher-build
-   cmake -S src/c-blosc -B src/c-blosc-crusher-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/crusher/c-blosc-1.21.1
-   cmake --build src/c-blosc-crusher-build --target install --parallel 10
-
-   # ADIOS2
-   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git src/adios2
-   rm -rf src/adios2-crusher-build
-   cmake -S src/adios2 -B src/adios2-crusher-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=$HOME/sw/crusher/adios2-2.8.3
-   cmake --build src/adios2-crusher-build --target install -j 10
-
    # BLAS++ (for PSATD+RZ)
    git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
    rm -rf src/blaspp-crusher-build

--- a/Tools/machines/crusher-olcf/crusher_warpx.profile.example
+++ b/Tools/machines/crusher-olcf/crusher_warpx.profile.example
@@ -29,12 +29,7 @@ export LD_LIBRARY_PATH=$HOME/sw/crusher/lapackpp-master/lib64:$LD_LIBRARY_PATH
 #module load boost/1.78.0-cxx17
 
 # optional: for openPMD support
-#module load adios2/2.8.3
-# need to build adios manually currently
-export CMAKE_PREFIX_PATH=$HOME/sw/crusher/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=$HOME/sw/crusher/adios2-2.8.3:$CMAKE_PREFIX_PATH
-export LD_LIBRARY_PATH=$HOME/sw/crusher/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/sw/crusher/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
+module load adios2/2.8.3
 module load cray-hdf5-parallel/1.12.2.1
 
 # optional: for Python bindings or libEnsemble


### PR DESCRIPTION
New module for `adios2/2.8.3` received :tada:

:heavy_check_mark: Includes compressors like c-blosc 
:heavy_check_mark: Compile-tested 