### PR TITLE
Fix bugs related to azimuthal modes for multi-J algo in RZ geometry

### DIFF
--- a/Regression/Checksum/benchmarks_json/multi_J_rz_psatd.json
+++ b/Regression/Checksum/benchmarks_json/multi_J_rz_psatd.json
@@ -1,4 +1,15 @@
 {
+  "lev=0": {
+    "Bt": 24080.41671546337,
+    "Er": 4536303784778.673,
+    "Ez": 4298815071343.0728,
+    "jr": 361182004529074.8,
+    "jz": 1802215706551553.8,
+    "rho": 4884623.9573680265,
+    "rho_driver": 6288266.101815153,
+    "rho_plasma_e": 49568366.405371524,
+    "rho_plasma_p": 50769182.21072973
+  },
   "driver": {
     "particle_momentum_x": 8.723405122353729e-16,
     "particle_momentum_y": 8.719285567351437e-16,
@@ -8,33 +19,22 @@
     "particle_theta": 1570790.0436095877,
     "particle_weight": 6241484108.424456
   },
-  "lev=0": {
-    "Bt": 24045.34926330333,
-    "Er": 4530500183998.0205,
-    "Ez": 4297045713383.818,
-    "jr": 361149490291532.8,
-    "jz": 1805428826325930.2,
-    "rho": 4895064.444869195,
-    "rho_driver": 6288266.101815153,
-    "rho_plasma_e": 49569825.13450765,
-    "rho_plasma_p": 50769176.974483095
-  },
-  "plasma_e": {
-    "particle_momentum_x": 6.649609416554171e-20,
-    "particle_momentum_y": 6.724424134488497e-20,
-    "particle_momentum_z": 2.81433599356851e-20,
-    "particle_position_x": 1.14233458508442,
-    "particle_position_y": 0.6140029351346352,
-    "particle_theta": 20188.939948727293,
+  "plasma_p": {
+    "particle_momentum_x": 6.650539058831456e-20,
+    "particle_momentum_y": 6.776260514923786e-20,
+    "particle_momentum_z": 5.470216831432835e-20,
+    "particle_position_x": 1.1365201443471713,
+    "particle_position_y": 0.6152066517828133,
+    "particle_theta": 20286.92798337582,
     "particle_weight": 1002457942911.3788
   },
-  "plasma_p": {
-    "particle_momentum_x": 6.635739630451454e-20,
-    "particle_momentum_y": 6.761235868190358e-20,
-    "particle_momentum_z": 5.475884783890083e-20,
-    "particle_position_x": 1.1365201524804165,
-    "particle_position_y": 0.6152066555308389,
-    "particle_theta": 20286.92798337582,
+  "plasma_e": {
+    "particle_momentum_x": 6.655027717314839e-20,
+    "particle_momentum_y": 6.730480164464723e-20,
+    "particle_momentum_z": 2.807381166958142e-20,
+    "particle_position_x": 1.1423427658689635,
+    "particle_position_y": 0.6140113094028803,
+    "particle_theta": 20188.939948727297,
     "particle_weight": 1002457942911.3788
   }
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -408,14 +408,14 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
 
                 if (om != 0.0_rt)
                 {
-                    X5(i,j,k) = c2 / ep0 * (S_ck(i,j,k) / om2 - (1._rt - C(i,j,k)) / (om4 * dt)
+                    X5(i,j,k,mode) = c2 / ep0 * (S_ck(i,j,k,mode) / om2 - (1._rt - C(i,j,k,mode)) / (om4 * dt)
                                             - 0.5_rt * dt / om2);
-                    X6(i,j,k) = c2 / ep0 * ((1._rt - C(i,j,k)) / (om4 * dt) - 0.5_rt * dt / om2);
+                    X6(i,j,k,mode) = c2 / ep0 * ((1._rt - C(i,j,k,mode)) / (om4 * dt) - 0.5_rt * dt / om2);
                 }
                 else
                 {
-                    X5(i,j,k) = - c2 * dt3 / (8._rt * ep0);
-                    X6(i,j,k) = - c2 * dt3 / (24._rt * ep0);
+                    X5(i,j,k,mode) = - c2 * dt3 / (8._rt * ep0);
+                    X6(i,j,k,mode) = - c2 * dt3 / (24._rt * ep0);
                 }
             }
         });

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -382,7 +382,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
             amrex::Real const k_norm = std::sqrt(kr*kr + kz*kz);
 
             // Calculate coefficients
-            constexpr amrex::Real c = PhysConst::c * PhysConst::c;
+            constexpr amrex::Real c = PhysConst::c;
             constexpr amrex::Real ep0 = PhysConst::ep0;
             if (k_norm != 0){
                 C(i,j,k,mode) = std::cos(c*k_norm*dt);
@@ -400,7 +400,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
 
             if (time_averaging && J_linear)
             {
-                constexpr amrex::Real c2 = PhysConst::c;
+                constexpr amrex::Real c2 = PhysConst::c * PhysConst::c;
                 const amrex::Real dt3 = dt * dt * dt;
                 const amrex::Real om  = c * k_norm;
                 const amrex::Real om2 = om * om;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -382,7 +382,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
             amrex::Real const k_norm = std::sqrt(kr*kr + kz*kz);
 
             // Calculate coefficients
-            constexpr amrex::Real c = PhysConst::c;
+            constexpr amrex::Real c = PhysConst::c * PhysConst::c;
             constexpr amrex::Real ep0 = PhysConst::ep0;
             if (k_norm != 0){
                 C(i,j,k,mode) = std::cos(c*k_norm*dt);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -73,9 +73,14 @@ class SpectralFieldDataRZ
          */
         void CopySpectralDataComp (const int src_comp, const int dest_comp)
         {
-            // The last two arguments represent the number of components and
-            // the number of ghost cells to perform this operation
-            Copy(fields, fields, src_comp, dest_comp, n_rz_azimuthal_modes, 0);
+            const int nmodes = n_rz_azimuthal_modes;
+            for (int imode=0 ; imode < nmodes ; imode++)
+            {
+                const int shift_comp = imode * m_n_fields;
+                // The last two arguments represent the number of components and
+                // the number of ghost cells to perform this operation
+                Copy(fields, fields, src_comp + shift_comp, dest_comp + shift_comp, 1, 0);
+            }
         }
 
         /**

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -73,8 +73,7 @@ class SpectralFieldDataRZ
          */
         void CopySpectralDataComp (const int src_comp, const int dest_comp)
         {
-            const int nmodes = n_rz_azimuthal_modes;
-            for (int imode=0 ; imode < nmodes ; imode++)
+            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;
                 // The last two arguments represent the number of components and
@@ -90,8 +89,7 @@ class SpectralFieldDataRZ
          */
         void ZeroOutDataComp(const int icomp)
         {
-            const int nmodes = n_rz_azimuthal_modes;
-            for (int imode=0 ; imode < nmodes ; imode++)
+            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;
                 // The last argument represents the number of components to perform this operation
@@ -107,8 +105,7 @@ class SpectralFieldDataRZ
          */
         void ScaleDataComp(const int icomp, const amrex::Real scale_factor)
         {
-            const int nmodes = n_rz_azimuthal_modes;
-            for (int imode=0 ; imode < nmodes ; imode++)
+            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;
                 // The last argument represents the number of components to perform this operation

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -90,8 +90,13 @@ class SpectralFieldDataRZ
          */
         void ZeroOutDataComp(const int icomp)
         {
-            // The last argument represents the number of components to perform this operation
-            fields.setVal(0., icomp, n_rz_azimuthal_modes);
+            const int nmodes = n_rz_azimuthal_modes;
+            for (int imode=0 ; imode < nmodes ; imode++)
+            {
+                const int shift_comp = imode * m_n_fields;
+                // The last argument represents the number of components to perform this operation
+                fields.setVal(0., icomp + shift_comp, 1);
+            }
         }
 
         /**

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -73,6 +73,10 @@ class SpectralFieldDataRZ
          */
         void CopySpectralDataComp (const int src_comp, const int dest_comp)
         {
+            // In spectral space fields of each mode are grouped together, so that the index
+            // of a field for a specific mode is given by field_index + mode*n_fields.
+            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+            // shift, given by imode * m_n_fields.
             for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;
@@ -89,6 +93,10 @@ class SpectralFieldDataRZ
          */
         void ZeroOutDataComp(const int icomp)
         {
+            // In spectral space fields of each mode are grouped together, so that the index
+            // of a field for a specific mode is given by field_index + mode*n_fields.
+            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+            // shift, given by imode * m_n_fields.
             for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;
@@ -105,6 +113,10 @@ class SpectralFieldDataRZ
          */
         void ScaleDataComp(const int icomp, const amrex::Real scale_factor)
         {
+            // In spectral space fields of each mode are grouped together, so that the index
+            // of a field for a specific mode is given by field_index + mode*n_fields.
+            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+            // shift, given by imode * m_n_fields.
             for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
             {
                 const int shift_comp = imode * m_n_fields;

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -107,8 +107,13 @@ class SpectralFieldDataRZ
          */
         void ScaleDataComp(const int icomp, const amrex::Real scale_factor)
         {
-            // The last argument represents the number of components to perform this operation
-            fields.mult(scale_factor, icomp, n_rz_azimuthal_modes);
+            const int nmodes = n_rz_azimuthal_modes;
+            for (int imode=0 ; imode < nmodes ; imode++)
+            {
+                const int shift_comp = imode * m_n_fields;
+                // The last argument represents the number of components to perform this operation
+                fields.mult(scale_factor, icomp + shift_comp, 1);
+            }
         }
 
         void InitFilter (amrex::IntVect const & filter_npass_each_dir, bool const compensation,


### PR DESCRIPTION
For reference, this is how all fields, with modes, are stored in spectral space:
https://github.com/ECP-WarpX/WarpX/blob/f85998603fecd102e6f5ed06ecc08cf85b9a8bfb/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp#L37-L43

Added capability to loop over all azimuthal modes in `CopySpectralDataComp`, `ZeroOutDataComp` and `ScaleDataComp` by taking into account the shift `mode*n_fields`.

This PR fixes a few bugs in RZ with:
- multi-J PSATD solver w/o averaging;
- multi-J PSATD solver w/ averaging.
