### PR TITLE
CI: fix bug in NVCC GNUMake yml file

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -110,7 +110,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd amrex && git checkout --detach 6d30e83c944e4e6167178f2d145df2a3e67d2b24 && cd -
+        cd ../amrex && git checkout --detach 6d30e83c944e4e6167178f2d145df2a3e67d2b24 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-11-nvcc:


### PR DESCRIPTION
We found out that the CI build "NVCC 11.8.0 GNUMake" was not using the version of AMReX that we thought it would use. The `cd amrex` command was wrong, hence the specific AMReX commit hash was not checked out and the latest version of AMReX was used, instead of the desired one.

Thank you to @WeiqunZhang and @atmyers for help with debugging.