### PR TITLE
Allow 8-fold symmetry option

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -674,7 +674,7 @@ Particle initialization
       ``<species_name>.x/y/z_rms`` (standard deviation in `x/y/z`),
       ``<species_name>.x/y/z_cut`` (optional, particles with ``abs(x-x_m) > x_cut*x_rms`` are not injected, same for y and z. ``<species_name>.q_tot`` is the charge of the un-cut beam, so that cutting the distribution is likely to result in a lower total charge),
       and optional arguments ``<species_name>.do_symmetrize`` (whether to
-      symmetrize the beam) and ``<species_name>.symmetrization_order`` (Extent of symmetrization, default is 4, can be 4 or 8.
+      symmetrize the beam) and ``<species_name>.symmetrization_order`` (order of symmetrization, default is 4, can be 4 or 8).
       If ``<species_name>.do_symmetrize`` is 0, no symmetrization occurs.  If ``<species_name>.do_symmetrize`` is 1,
       then the beam is symmetrized according to the value of ``<species_name>.symmetrization_order``.
       If set to 4, symmetrization is in the x and y direction, (x,y) (-x,y) (x,-y) (-x,-y).

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -674,9 +674,11 @@ Particle initialization
       ``<species_name>.x/y/z_rms`` (standard deviation in `x/y/z`),
       ``<species_name>.x/y/z_cut`` (optional, particles with ``abs(x-x_m) > x_cut*x_rms`` are not injected, same for y and z. ``<species_name>.q_tot`` is the charge of the un-cut beam, so that cutting the distribution is likely to result in a lower total charge),
       and optional arguments ``<species_name>.do_symmetrize`` (whether to
-      symmetrize the beam) and ``<species_name>.symmetrization_order`` (Extent of symmetrization, default is 4.
+      symmetrize the beam) and ``<species_name>.symmetrization_order`` (Extent of symmetrization, default is 4, can be 4 or 8.
+      If ``<species_name>.do_symmetrize`` is 0, no symmetrization occurs.  If ``<species_name>.do_symmetrize`` is 1, 
+      then the beam is symmetrized according to the value of ``<species_name>.symmetrization_order``.
       If set to 4, symmetrization is in the x and y direction, (x,y) (-x,y) (x,-y) (-x,-y).  
-      If set to 8, symmetrization is also exchanging x and y, (y,x), (-y,x), (y,-x), (-y,-x)).
+      If set to 8, symmetrization is also done with x and y exchanged, (y,x), (-y,x), (y,-x), (-y,-x)).
 
     * ``external_file``: Inject macroparticles with properties (mass, charge, position, and momentum - :math:`\gamma \beta m c`) read from an external openPMD file.
       With it users can specify the additional arguments:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -675,9 +675,9 @@ Particle initialization
       ``<species_name>.x/y/z_cut`` (optional, particles with ``abs(x-x_m) > x_cut*x_rms`` are not injected, same for y and z. ``<species_name>.q_tot`` is the charge of the un-cut beam, so that cutting the distribution is likely to result in a lower total charge),
       and optional arguments ``<species_name>.do_symmetrize`` (whether to
       symmetrize the beam) and ``<species_name>.symmetrization_order`` (Extent of symmetrization, default is 4, can be 4 or 8.
-      If ``<species_name>.do_symmetrize`` is 0, no symmetrization occurs.  If ``<species_name>.do_symmetrize`` is 1, 
+      If ``<species_name>.do_symmetrize`` is 0, no symmetrization occurs.  If ``<species_name>.do_symmetrize`` is 1,
       then the beam is symmetrized according to the value of ``<species_name>.symmetrization_order``.
-      If set to 4, symmetrization is in the x and y direction, (x,y) (-x,y) (x,-y) (-x,-y).  
+      If set to 4, symmetrization is in the x and y direction, (x,y) (-x,y) (x,-y) (-x,-y).
       If set to 8, symmetrization is also done with x and y exchanged, (y,x), (-y,x), (y,-x), (-y,-x)).
 
     * ``external_file``: Inject macroparticles with properties (mass, charge, position, and momentum - :math:`\gamma \beta m c`) read from an external openPMD file.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -673,8 +673,10 @@ Particle initialization
       ``<species_name>.x/y/z_m`` (average position in `x/y/z`),
       ``<species_name>.x/y/z_rms`` (standard deviation in `x/y/z`),
       ``<species_name>.x/y/z_cut`` (optional, particles with ``abs(x-x_m) > x_cut*x_rms`` are not injected, same for y and z. ``<species_name>.q_tot`` is the charge of the un-cut beam, so that cutting the distribution is likely to result in a lower total charge),
-      and optional argument ``<species_name>.do_symmetrize`` (whether to
-      symmetrize the beam in the x and y directions).
+      and optional arguments ``<species_name>.do_symmetrize`` (whether to
+      symmetrize the beam) and ``<species_name>.symmetrization_order`` (Extent of symmetrization, default is 4.
+      If set to 4, symmetrization is in the x and y direction, (x,y) (-x,y) (x,-y) (-x,-y).  
+      If set to 8, symmetrization is also exchanging x and y, (y,x), (-y,x), (y,-x), (-y,-x)).
 
     * ``external_file``: Inject macroparticles with properties (mass, charge, position, and momentum - :math:`\gamma \beta m c`) read from an external openPMD file.
       With it users can specify the additional arguments:

--- a/Examples/Tests/multi_j/inputs_rz
+++ b/Examples/Tests/multi_j/inputs_rz
@@ -84,7 +84,7 @@ driver_back.npart = 1000000
 driver_back.q_tot = 1e-9
 driver_back.momentum_distribution_type = "at_rest"
 driver_back.initialize_self_fields = 0
-driver.do_symmetrize = 1
+driver_back.do_symmetrize = 1
 driver_back.symmetrization_order = 4
 
 plasma_e.species_type = electron

--- a/Examples/Tests/multi_j/inputs_rz
+++ b/Examples/Tests/multi_j/inputs_rz
@@ -69,7 +69,7 @@ driver.uz_th = 20.
 driver.zinject_plane = 2e-3
 driver.rigid_advance = true
 driver.initialize_self_fields = 0
-driver.do_symmetrize = 1
+driver.symmetrization_order = 4
 
 driver_back.species_type = positron
 driver_back.injection_style = "gaussian_beam"
@@ -83,7 +83,7 @@ driver_back.npart = 1000000
 driver_back.q_tot = 1e-9
 driver_back.momentum_distribution_type = "at_rest"
 driver_back.initialize_self_fields = 0
-driver_back.do_symmetrize = 1
+driver_back.symmetrization_order = 4
 
 plasma_e.species_type = electron
 plasma_e.injection_style = "NUniformPerCell"

--- a/Examples/Tests/multi_j/inputs_rz
+++ b/Examples/Tests/multi_j/inputs_rz
@@ -69,6 +69,7 @@ driver.uz_th = 20.
 driver.zinject_plane = 2e-3
 driver.rigid_advance = true
 driver.initialize_self_fields = 0
+driver.do_symmetrize = 1
 driver.symmetrization_order = 4
 
 driver_back.species_type = positron
@@ -83,6 +84,7 @@ driver_back.npart = 1000000
 driver_back.q_tot = 1e-9
 driver_back.momentum_distribution_type = "at_rest"
 driver_back.initialize_self_fields = 0
+driver.do_symmetrize = 1
 driver_back.symmetrization_order = 4
 
 plasma_e.species_type = electron

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -97,6 +97,7 @@ public:
     amrex::Real q_tot = 0.0;
     long npart;
     int do_symmetrize = 0;
+    int symmetrization_order = 4;
 
     bool external_file = false; //! initialize from an openPMD file
     amrex::Real z_shift = 0.0; //! additional z offset for particle positions

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -235,6 +235,10 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         utils::parser::getWithParser(pp_species_name, "q_tot", q_tot);
         utils::parser::getWithParser(pp_species_name, "npart", npart);
         pp_species_name.query("do_symmetrize", do_symmetrize);
+        pp_species_name.query("symmetrization_order", symmetrization_order);
+        std::set valid_symmetries = {4,8};
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( valid_symmetries.count(symmetrization_order),
+            "Error: Symmetrization only supported to orders 4 or 8 ");
         gaussian_beam = true;
         parseMomentum(pp_species_name);
 #if defined(WARPX_DIM_XZ)

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -200,7 +200,7 @@ public:
         const amrex::Real x_m, const amrex::Real y_m, const amrex::Real z_m,
         const amrex::Real x_rms, const amrex::Real y_rms, const amrex::Real z_rms,
         const amrex::Real x_cut, const amrex::Real y_cut, const amrex::Real z_cut,
-        const amrex::Real q_tot, long npart, const int do_symmetrize);
+        const amrex::Real q_tot, long npart, const int do_symmetrize, const int symmetrization_order);
 
     /** Load a particle beam from an external file
      * @param[in] q_tot total charge of the particle species to be initialized

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -868,6 +868,7 @@ PhysicalParticleContainer::AddParticles (int lev)
                         plasma_injector->z_cut,
                         plasma_injector->q_tot,
                         plasma_injector->npart,
+                        plasma_injector->do_symmetrize,
                         plasma_injector->symmetrization_order);
 
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -445,7 +445,8 @@ PhysicalParticleContainer::AddGaussianBeam (
     const Real x_rms, const Real y_rms, const Real z_rms,
     const Real x_cut, const Real y_cut, const Real z_cut,
     const Real q_tot, long npart,
-    const int do_symmetrize) {
+    const int do_symmetrize,
+    const int symmetrization_order) {
 
     // Declare temporary vectors on the CPU
     Gpu::HostVector<ParticleReal> particle_x;
@@ -458,10 +459,11 @@ PhysicalParticleContainer::AddGaussianBeam (
     int np = 0;
 
     if (ParallelDescriptor::IOProcessor()) {
-        // If do_symmetrize, create 4x fewer particles, and
-        // Replicate each particle 4 times (x,y) (-x,y) (x,-y) (-x,-y)
+        // If do_symmetrize, create either 4x or 8x fewer particles, and
+        // Replicate each particle either 4 times (x,y) (-x,y) (x,-y) (-x,-y)
+        // or 8 times, additionally (y,x), (-y,x), (y,-x), (-y,-x)
         if (do_symmetrize){
-            npart /= 4;
+            npart /= symmetrization_order;
         }
         for (long i = 0; i < npart; ++i) {
 #if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
@@ -488,7 +490,41 @@ PhysicalParticleContainer::AddGaussianBeam (
                 u.x *= PhysConst::c;
                 u.y *= PhysConst::c;
                 u.z *= PhysConst::c;
-                if (do_symmetrize){
+                if (do_symmetrize && symmetrization_order == 8){
+                    // Add eight particles to the beam:
+                    CheckAndAddParticle(x, y, z, u.x, u.y, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(x, -y, z, u.x, -u.y, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-x, y, z, -u.x, u.y, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-x, -y, z, -u.x, -u.y, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(y, x, z, u.y, u.x, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-y, x, z, -u.y, u.x, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(y, -x, z, u.y, -u.x, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                    CheckAndAddParticle(-y, -x, z, -u.y, -u.x, u.z, weight/8._rt,
+                                        particle_x,  particle_y,  particle_z,
+                                        particle_ux, particle_uy, particle_uz,
+                                        particle_w);
+                } else if (do_symmetrize && symmetrization_order == 4){
                     // Add four particles to the beam:
                     CheckAndAddParticle(x, y, z, u.x, u.y, u.z, weight/4._rt,
                                         particle_x,  particle_y,  particle_z,
@@ -832,7 +868,7 @@ PhysicalParticleContainer::AddParticles (int lev)
                         plasma_injector->z_cut,
                         plasma_injector->q_tot,
                         plasma_injector->npart,
-                        plasma_injector->do_symmetrize);
+                        plasma_injector->symmetrization_order);
 
 
         return;


### PR DESCRIPTION
This PR extends the beam symmetrization functionality.  It was observed that initial beam emittances in `x` and `y` were different due to statistical noise.  To eliminate the possible effect of the initial emittance value on emittance growth, 8-fold beam symmetry ensures that initial emittances in the `x`- and `y`- directions are the same.

This PR adds an additional optional parameter ``warpx.symmetrization_order``, which can currently be 4 or 8 and defaults to 4.  If ``warpx.do_symmetrize=1``, then the value of ``warpx.symmetrization_order`` determines whether the beam is symmetrized in x and y only (``warpx.symmetrization_order=4``, ``(x,y) (-x,y) (x,-y) (-x,-y)``) or is symmetrized in `x`,`y`, and across diagonals (``warpx.symmetrization_order=8``, also ``(y,x), (-y,x), (y,-x), (-y,-x)``).

With order 4, an example input script
[inputs_rz.txt](https://github.com/ECP-WarpX/WarpX/files/11021726/inputs_rz.txt)
leads to the following initial emittance values:
`emitt_x = 9.46075997990898e-07, emitt_y = 1.1325899636804437e-06`
WIth order 8, the initial emittance values are:
`emitt_x = 1.0348160840903872e-06, emitt_y = 1.0348160840903872e-06`