### PR TITLE
Fix all the "modernize-loop-convert" issues found with clang-tidy

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -126,8 +126,8 @@ BTDPlotfileHeaderImpl::WriteHeader ()
     // number of components
     HeaderFile << m_varnames.size() << '\n';
     // write the component string
-    for (int icomp = 0; icomp < m_varnames.size(); ++icomp ) {
-        HeaderFile << m_varnames[icomp] << '\n';
+    for (const auto& vname : m_varnames) {
+        HeaderFile << vname << '\n';
     }
     // space dim
     HeaderFile << m_spacedim << '\n';
@@ -383,12 +383,12 @@ BTDSpeciesHeaderImpl::ReadHeader ()
     is >> m_spacedim;
     is >> m_num_output_real;
     m_real_comp_names.resize(m_num_output_real);
-    for (int i = 0; i < m_real_comp_names.size(); ++i) {
-        is >> m_real_comp_names[i];
+    for (auto& real_comp_name : m_real_comp_names) {
+        is >> real_comp_name;
     }
     is >> m_num_output_int;
-    for (int i = 0; i < m_int_comp_names.size(); ++i) {
-        is >> m_int_comp_names[i];
+    for (auto& int_comp_name : m_int_comp_names) {
+        is >> int_comp_name;
     }
     is >> m_is_checkpoint;
     is >> m_total_particles;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1445,15 +1445,17 @@ BTDiagnostics::UpdateTotalParticlesFlushed(int i_buffer)
 void
 BTDiagnostics::ResetTotalParticlesInBuffer(int i_buffer)
 {
-    for (int isp = 0; isp < m_totalParticles_in_buffer[i_buffer].size(); ++isp) {
-        m_totalParticles_in_buffer[i_buffer][isp] = 0;
-    }
+    std::fill(
+        m_totalParticles_in_buffer[i_buffer].begin(),
+        m_totalParticles_in_buffer[i_buffer].end(),
+        0);
 }
 
 void
 BTDiagnostics::ClearParticleBuffer(int i_buffer)
 {
-    for (int isp = 0; isp < m_particles_buffer[i_buffer].size(); ++isp) {
-        m_particles_buffer[i_buffer][isp]->clearParticles();
-    }
+    std::for_each(
+        m_particles_buffer[i_buffer].begin(),
+        m_particles_buffer[i_buffer].end(),
+        [](auto& pb){pb->clearParticles();});
 }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -187,9 +187,9 @@ Diagnostics::BaseReadParameters ()
 
     m_varnames = m_varnames_fields;
     // Generate names of averaged particle fields and append to m_varnames
-    for (int ivar=0; ivar<m_pfield_varnames.size(); ivar++) {
-        for (int ispec=0; ispec < int(m_pfield_species.size()); ispec++) {
-            m_varnames.push_back(m_pfield_varnames[ivar] + '_' + m_pfield_species[ispec]);
+    for (const auto& fname : m_pfield_varnames) {
+        for (const auto& sname : m_pfield_species) {
+            m_varnames.push_back(fname + '_' + sname);
         }
     }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -172,8 +172,8 @@ FlushFormatCheckpoint::CheckpointParticles (
     const std::string& dir,
     const amrex::Vector<ParticleDiag>& particle_diags) const
 {
-    for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
-        WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
+    for (auto& part_diag: particle_diags) {
+        WarpXParticleContainer* pc = part_diag.getParticleContainer();
 
         Vector<std::string> real_names;
         Vector<std::string> int_names;
@@ -200,7 +200,7 @@ FlushFormatCheckpoint::CheckpointParticles (
         auto runtime_inames = pc->getParticleRuntimeiComps();
         for (auto const& x : runtime_inames) { int_names[x.second+0] = x.first; }
 
-        pc->Checkpoint(dir, particle_diags[i].getSpeciesName(), true,
+        pc->Checkpoint(dir, part_diag.getSpeciesName(), true,
                        real_names, int_names);
     }
 }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -315,11 +315,11 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
                                     bool isBTD) const
 {
 
-    for (unsigned i = 0, n = particle_diags.size(); i < n; ++i) {
-        WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
+    for (auto& part_diag : particle_diags) {
+        WarpXParticleContainer* pc = part_diag.getParticleContainer();
         auto tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
         if (isBTD) {
-            PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
+            PinnedMemoryParticleContainer* pinned_pc = part_diag.getPinnedParticleContainer();
             tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
         }
 
@@ -344,7 +344,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         for (auto const& x : runtime_rnames) { real_names[x.second+PIdx::nattribs] = x.first; }
 
         // plot any "extra" fields by default
-        real_flags = particle_diags[i].m_plot_flags;
+        real_flags = part_diag.m_plot_flags;
         real_flags.resize(pc->NumRealComps(), 1);
 
         // and the names
@@ -356,17 +356,17 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         int_flags.resize(pc->NumIntComps(), 1);
 
         const auto mass = pc->AmIA<PhysicalSpecies::photon>() ? PhysConst::m_e : pc->getMass();
-        RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
-                                         particle_diags[i].m_random_fraction);
-        UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
-                                           particle_diags[i].m_uniform_stride);
-        ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
+        RandomFilter const random_filter(part_diag.m_do_random_filter,
+                                         part_diag.m_random_fraction);
+        UniformFilter const uniform_filter(part_diag.m_do_uniform_filter,
+                                           part_diag.m_uniform_stride);
+        ParserFilter parser_filter(part_diag.m_do_parser_filter,
                                    utils::parser::compileParser<ParticleDiag::m_nvars>
-                                       (particle_diags[i].m_particle_filter_parser.get()),
+                                       (part_diag.m_particle_filter_parser.get()),
                                    pc->getMass());
         parser_filter.m_units = InputUnits::SI;
-        GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
-                                             particle_diags[i].m_diag_domain);
+        GeometryFilter const geometry_filter(part_diag.m_do_geom_filter,
+                                             part_diag.m_diag_domain);
 
         if (!isBTD) {
             particlesConvertUnits(ConvertDirection::WarpX_to_SI, pc, mass);
@@ -380,14 +380,14 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
             }, true);
             particlesConvertUnits(ConvertDirection::SI_to_WarpX, pc, mass);
         } else {
-            PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
+            PinnedMemoryParticleContainer* pinned_pc = part_diag.getPinnedParticleContainer();
             tmp.copyParticles(*pinned_pc, true);
             particlesConvertUnits(ConvertDirection::WarpX_to_SI, &tmp, mass);
         }
         // real_names contains a list of all particle attributes.
         // real_flags & int_flags are 1 or 0, whether quantity is dumped or not.
         tmp.WritePlotFile(
-            dir, particle_diags[i].getSpeciesName(),
+            dir, part_diag.getSpeciesName(),
             real_flags, int_flags,
             real_names, int_names);
     }

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -122,9 +122,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& ist : istep) {
+            for (auto& istep_lev : istep) {
                 lis >> word;
-                ist = std::stoi(word);
+                istep_lev = std::stoi(word);
             }
         }
 
@@ -142,9 +142,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& tn : t_new) {
+            for (auto& t_new_lev : t_new) {
                 lis >> word;
-                tn = static_cast<Real>(std::stod(word));
+                t_new_lev = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -152,9 +152,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& to : t_old) {
+            for (auto& t_old_lev : t_old) {
                 lis >> word;
-                to = static_cast<Real>(std::stod(word));
+                t_old_lev = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -162,9 +162,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& tt : dt) {
+            for (auto& dt_lev : dt) {
                 lis >> word;
-                tt = static_cast<Real>(std::stod(word));
+                dt_lev = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -180,9 +180,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& plo : prob_lo) {
+            for (auto& prob_lo_comp : prob_lo) {
                 lis >> word;
-                plo = static_cast<Real>(std::stod(word));
+                prob_lo_comp = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -191,9 +191,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& phi : prob_hi) {
+            for (auto& prob_hi_comp : prob_hi) {
                 lis >> word;
-                phi = static_cast<Real>(std::stod(word));
+                prob_hi_comp = static_cast<Real>(std::stod(word));
             }
         }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -122,9 +122,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (auto& is : istep) {
+            for (auto& ist : istep) {
                 lis >> word;
-                is = std::stoi(word);
+                ist = std::stoi(word);
             }
         }
 

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -122,9 +122,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < istep.size(); ++i) {
+            for (auto& is : istep) {
                 lis >> word;
-                istep.at(i) = std::stoi(word);
+                is = std::stoi(word);
             }
         }
 
@@ -132,9 +132,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < nsubsteps.size(); ++i) {
+            for (auto& nsub : nsubsteps) {
                 lis >> word;
-                nsubsteps.at(i) = std::stoi(word);
+                nsub = std::stoi(word);
             }
         }
 
@@ -142,9 +142,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < t_new.size(); ++i) {
+            for (auto& tn : t_new) {
                 lis >> word;
-                t_new.at(i) = static_cast<Real>(std::stod(word));
+                tn = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -152,9 +152,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < t_old.size(); ++i) {
+            for (auto& to : t_old) {
                 lis >> word;
-                t_old.at(i) = static_cast<Real>(std::stod(word));
+                to = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -162,9 +162,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < dt.size(); ++i) {
+            for (auto& tt : dt) {
                 lis >> word;
-                dt.at(i) = static_cast<Real>(std::stod(word));
+                tt = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -180,9 +180,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < prob_lo.size(); ++i) {
+            for (auto& plo : prob_lo) {
                 lis >> word;
-                prob_lo.at(i) = static_cast<Real>(std::stod(word));
+                plo = static_cast<Real>(std::stod(word));
             }
         }
 
@@ -191,9 +191,9 @@ WarpX::InitFromCheckpoint ()
         {
             std::istringstream lis(line);
             lis.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-            for (int i = 0; i < prob_hi.size(); ++i) {
+            for (auto& phi : prob_hi) {
                 lis >> word;
-                prob_hi.at(i) = static_cast<Real>(std::stod(word));
+                phi = static_cast<Real>(std::stod(word));
             }
         }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -553,10 +553,10 @@ MultiParticleContainer::DepositCurrent (
     }
 
 #ifdef WARPX_DIM_RZ
-    for (auto& J_lv : J)
+    for (int lev = 0; lev < J.size(); ++lev)
     {
         WarpX::GetInstance().ApplyInverseVolumeScalingToCurrentDensity(
-            J_lv[0].get(), J_lv[1].get(), J_lv[2].get(), lev);
+            J[lev][0].get(), J[lev][1].get(), J[lev][2].get(), lev);
     }
 #endif
 }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -539,11 +539,11 @@ MultiParticleContainer::DepositCurrent (
     const amrex::Real dt, const amrex::Real relative_time)
 {
     // Reset the J arrays
-    for (auto& J_lv : J)
+    for (auto& J_lev : J)
     {
-        J_lv[0]->setVal(0.0_rt);
-        J_lv[1]->setVal(0.0_rt);
-        J_lv[2]->setVal(0.0_rt);
+        J_lev[0]->setVal(0.0_rt);
+        J_lev[1]->setVal(0.0_rt);
+        J_lev[2]->setVal(0.0_rt);
     }
 
     // Call the deposition kernel for each species
@@ -567,9 +567,9 @@ MultiParticleContainer::DepositCharge (
     const amrex::Real relative_time)
 {
     // Reset the rho array
-    for (auto& rho_lv : rho)
+    for (auto& rho_lev : rho)
     {
-        rho_lv->setVal(0.0_rt);
+        rho_lev->setVal(0.0_rt);
     }
 
     // Push the particles in time, if needed

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -539,11 +539,11 @@ MultiParticleContainer::DepositCurrent (
     const amrex::Real dt, const amrex::Real relative_time)
 {
     // Reset the J arrays
-    for (int lev = 0; lev < J.size(); ++lev)
+    for (auto& J_lv : J)
     {
-        J[lev][0]->setVal(0.0_rt);
-        J[lev][1]->setVal(0.0_rt);
-        J[lev][2]->setVal(0.0_rt);
+        J_lv[0]->setVal(0.0_rt);
+        J_lv[1]->setVal(0.0_rt);
+        J_lv[2]->setVal(0.0_rt);
     }
 
     // Call the deposition kernel for each species
@@ -553,9 +553,10 @@ MultiParticleContainer::DepositCurrent (
     }
 
 #ifdef WARPX_DIM_RZ
-    for (int lev = 0; lev < J.size(); ++lev)
+    for (auto& J_lv : J)
     {
-        WarpX::GetInstance().ApplyInverseVolumeScalingToCurrentDensity(J[lev][0].get(), J[lev][1].get(), J[lev][2].get(), lev);
+        WarpX::GetInstance().ApplyInverseVolumeScalingToCurrentDensity(
+            J_lv[0].get(), J_lv[1].get(), J_lv[2].get(), lev);
     }
 #endif
 }
@@ -566,9 +567,9 @@ MultiParticleContainer::DepositCharge (
     const amrex::Real relative_time)
 {
     // Reset the rho array
-    for (int lev = 0; lev < rho.size(); ++lev)
+    for (auto& rho_lv : rho)
     {
-        rho[lev]->setVal(0.0_rt);
+        rho_lv->setVal(0.0_rt);
     }
 
     // Push the particles in time, if needed
@@ -603,9 +604,9 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
 {
     std::unique_ptr<MultiFab> rho = GetZeroChargeDensity(lev);
 
-    for (unsigned i = 0, n = allcontainers.size(); i < n; ++i) {
-        if (allcontainers[i]->do_not_deposit) continue;
-        std::unique_ptr<MultiFab> rhoi = allcontainers[i]->GetChargeDensity(lev, true);
+    for (auto& container : allcontainers) {
+        if (container->do_not_deposit) continue;
+        std::unique_ptr<MultiFab> rhoi = container->GetChargeDensity(lev, true);
         MultiFab::Add(*rho, *rhoi, 0, 0, rho->nComp(), rho->nGrowVect());
     }
     if (!local) {

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -801,8 +801,8 @@ amrex::ParticleReal WarpXParticleContainer::sumParticleCharge(bool local) {
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             auto& wp = pti.GetAttribs(PIdx::w);
-            for (unsigned long i = 0; i < wp.size(); i++) {
-                total_charge += wp[i];
+            for (const auto& ww : wp) {
+                total_charge += ww;
             }
         }
     }


### PR DESCRIPTION
This PR fixes all the issues found with clang-tidy enabling the [modernize-loop-convert](https://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html) check