### PR TITLE
Fix the  issues found with "modernize-use-equals-default" clang-tidy check

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -39,12 +39,14 @@ FlushFormatSensei::FlushFormatSensei (amrex::AmrMesh *amr_mesh,
 #endif
 }
 
+#ifdef AMREX_USE_SENSEI_INSITU
 FlushFormatSensei::~FlushFormatSensei ()
 {
-#ifdef AMREX_USE_SENSEI_INSITU
     delete m_insitu_bridge;
-#endif
 }
+#else
+FlushFormatSensei::~FlushFormatSensei () = default;
+#endif
 
 void
 FlushFormatSensei::WriteToFile (

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -512,9 +512,9 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
     amrex::Gpu::synchronize();
 }
 
+#ifdef AMREX_USE_GPU
 PlasmaInjector::~PlasmaInjector ()
 {
-#ifdef AMREX_USE_GPU
     if (d_inj_pos) {
         amrex::The_Arena()->free(d_inj_pos);
     }
@@ -524,8 +524,10 @@ PlasmaInjector::~PlasmaInjector ()
     if (d_inj_mom) {
         amrex::The_Arena()->free(d_inj_mom);
     }
-#endif
 }
+#else
+PlasmaInjector::~PlasmaInjector () = default;
+#endif
 
 // Depending on injection type at runtime, initialize inj_rho
 // so that inj_rho->getDensity calls


### PR DESCRIPTION
This PR fixes all the issues found with clang-tidy enabling the [modernize-use-equals-default](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html) check