### PR TITLE
Fix add_particles to account for theta attribute with RZ

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -683,14 +683,22 @@ class LibWarpX():
                     maxlen, val, self._numpy_particlereal_dtype
                 )
 
-        # --- The -3 is because the comps include the velocites
-        nattr = self.get_nattr_species(species_name) - 3
+        # --- The number of built in attributes
+        # --- The three velocities
+        built_in_attrs = 3
+        if self.geometry_dim == 'rz':
+            # --- With RZ, there is also theta
+            built_in_attrs += 1
+
+        # --- The number of extra attributes (including the weight)
+        nattr = self.get_nattr_species(species_name) - built_in_attrs
         attr = np.zeros((maxlen, nattr), self._numpy_particlereal_dtype)
         attr[:,0] = w
 
+        # --- Note that the velocities are handled separately and not included in attr
+        # --- (even though they are stored as attributes in the C++)
         for key, vals in kwargs.items():
-            # --- The -3 is because components 1 to 3 are velocities
-            attr[:,self.get_particle_comp_index(species_name, key)-3] = vals
+            attr[:,self.get_particle_comp_index(species_name, key) - built_in_attrs] = vals
 
         nattr_int = 0
         attr_int = np.empty([0], ctypes.c_int)

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -157,7 +157,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
                                      "Too many real attributes specified");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nattr_int <= NumIntComps(),
                                      "Too many integer attributes specified");
-    
+
     int ibegin, iend;
     if (uniqueparticles) {
         ibegin = 0;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -153,6 +153,11 @@ WarpXParticleContainer::AddNParticles (int /*lev*/,
 {
     using namespace amrex::literals;
 
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE((PIdx::nattribs + nattr_real - 1) <= NumRealComps(),
+                                     "Too many real attributes specified");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nattr_int <= NumIntComps(),
+                                     "Too many integer attributes specified");
+    
     int ibegin, iend;
     if (uniqueparticles) {
         ibegin = 0;


### PR DESCRIPTION
In the Python routine `add_particles`, when handling the real attributes, it was taking into account that the velocities are included in the attributes. However, when using RZ, `theta` is also an attribute and this was not being accounted for. This was leading to a seg fault when using `add_particles` with RZ. This PR fixes the issue.

This PR also adds assertions to avoid seg faults in similar circumstances.