### PR TITLE
Slurm & LSF: How to Checkpoint & Terminate

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -195,16 +195,15 @@ We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal
 
 .. tip::
 
-   For example, the following logic can be added to `Slurm batch scripts <https://docs.gwdg.de/doku.php?id=en:services:application_services:high_performance_computing:running_jobs_slurm:signals>`__ (`signal name to number mapping here <https://en.wikipedia.org/wiki/Signal_(IPC)#Default_action>`__) to write a checkpoint 6 min prior to walltime and gracefully shut down 1 min prior to walltime:
+   For example, the following logic can be added to `Slurm batch scripts <https://docs.gwdg.de/doku.php?id=en:services:application_services:high_performance_computing:running_jobs_slurm:signals>`__ (`signal name to number mapping here <https://en.wikipedia.org/wiki/Signal_(IPC)#Default_action>`__) to gracefully shut down 6 min prior to walltime.
+   If you have a checkpoint diagnostics in your inputs file, this automatically will write a checkpoint due to the default ``<diag_name>.dump_last_timestep = 1`` option in WarpX.
 
    .. code-block:: bash
 
       #SBATCH --signal=B:1@360
-      #SBATCH --signal=B:2@60
 
-      srun ...                        \
-        warpx.checkpoint_signals=HUP  \
-        warpx.break_signals=INT       \
+      srun ...                   \
+        warpx.break_signals=HUP  \
         > output.txt
 
    For `LSF batch systems <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=options-wa>`__, the equivalent job script lines are:
@@ -212,11 +211,9 @@ We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal
    .. code-block:: bash
 
       #BSUB -wa 'HUP' -wt '6'
-      #BSUB -wa 'INT' -wt '1'
 
-      jsrun ...                       \
-        warpx.checkpoint_signals=HUP  \
-        warpx.break_signals=INT       \
+      jsrun ...                  \
+        warpx.break_signals=HUP  \
         > output.txt
 
 .. _running-cpp-parameters-box:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -193,6 +193,19 @@ We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal
 
    The ``FPE`` signal should not be overwritten in WarpX, as it is `controlled by AMReX <https://amrex-codes.github.io/amrex/docs_html/Debugging.html#breaking-into-debuggers>`__ for :ref:`debug workflows that catch invalid floating-point operations <debugging_warpx>`.
 
+.. tip::
+
+   For example, the following logic can be added to `Slurm batch scripts <https://docs.gwdg.de/doku.php?id=en:services:application_services:high_performance_computing:running_jobs_slurm:signals>`__ (`signal name to number mapping here <https://en.wikipedia.org/wiki/Signal_(IPC)#Default_action>`__) to write a checkpoint 6 min prior to walltime and gracefully shut down 1 min prior to walltime:
+
+   .. code-block:: bash
+
+      #SBATCH --signal=B:1@360
+      #SBATCH --signal=B:2@60
+
+      srun ...                        \
+        warpx.checkpoint_signals=HUP  \
+        warpx.break_signals=INT       \
+        > output.txt
 
 .. _running-cpp-parameters-box:
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -207,6 +207,18 @@ We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal
         warpx.break_signals=INT       \
         > output.txt
 
+   For `LSF batch systems <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=options-wa>`__, the equivalent job script lines are:
+
+   .. code-block:: bash
+
+      #BSUB -wa 'HUP' -wt '6'
+      #BSUB -wa 'INT' -wt '1'
+
+      jsrun ...                       \
+        warpx.checkpoint_signals=HUP  \
+        warpx.break_signals=INT       \
+        > output.txt
+
 .. _running-cpp-parameters-box:
 
 Setting up the field mesh


### PR DESCRIPTION
Add a first concrete example how to gracefully checkpoint and terminate a WarpX simulation that runs into an HPC system's walltime.

If this works well, we will add this to all HPC templates.