### PR TITLE
Docs: Frontier/Crusher ROCm 5.3/4 Perf

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -142,7 +142,7 @@ Known System Issues
 
 .. warning::
 
-   January, 2023 (OLCFDEV-XXXX):
+   January, 2023 (OLCFDEV-1284, AMD Ticket: ORNLA-130):
    We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
    Reported to AMD and investigating.
 

--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -139,3 +139,11 @@ Known System Issues
    .. code-block:: bash
 
       export ROCFFT_RTC_CACHE_PATH=/dev/null
+
+.. warning::
+
+   January, 2023 (OLCFDEV-XXXX):
+   We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
+   Reported to AMD and investigating.
+
+   Stay with the ROCm 5.2 module to avoid.

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -136,7 +136,7 @@ Known System Issues
 
 .. warning::
 
-   January, 2023 (OLCFDEV-XXXX):
+   January, 2023 (OLCFDEV-1284, AMD Ticket: ORNLA-130):
    We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
    Reported to AMD and investigating.
 

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -133,3 +133,11 @@ Known System Issues
    .. code-block:: bash
 
       export ROCFFT_RTC_CACHE_PATH=/dev/null
+
+.. warning::
+
+   January, 2023 (OLCFDEV-XXXX):
+   We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
+   Reported to AMD and investigating.
+
+   Stay with the ROCm 5.2 module to avoid.

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -100,3 +100,11 @@ Known System Issues
       #export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
       # or, less invasive:
       export FI_MR_CACHE_MONITOR=memhooks  # alternative cache monitor
+
+.. warning::
+
+   January, 2023:
+   We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
+   Reported to AMD and investigating.
+
+   Stay with the ROCm 5.2 module to avoid.


### PR DESCRIPTION
Document the performance regressions in ROCm 5.3/4

Measured by @WeiqunZhang :
```
|  rocm | CurrentDeposition |
|-------+-------------------|
| 5.1.0 |            0.4943 |
| 5.2.0 |            0.4948 |
| 5.3.0 |            0.9449 |
| 5.4.0 |            0.9439 |
```

cc @lucafedeli88 FYI for LUMI et al.