### PR TITLE
include std::set, int template parameter

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -38,6 +38,7 @@
 #include <cctype>
 #include <map>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -236,7 +237,7 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
         utils::parser::getWithParser(pp_species_name, "npart", npart);
         pp_species_name.query("do_symmetrize", do_symmetrize);
         pp_species_name.query("symmetrization_order", symmetrization_order);
-        std::set valid_symmetries = {4,8};
+        std::set<int> valid_symmetries = {4,8};
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( valid_symmetries.count(symmetrization_order),
             "Error: Symmetrization only supported to orders 4 or 8 ");
         gaussian_beam = true;


### PR DESCRIPTION
This PR fixes an issue introduced in #3768, where `std::set` is used without explicitly including the `set` library.  It also adds an explicit type value for the set keys, `std::set<int>`.  The previous PR could be build on some machines but not others (e.g. Summit).