### PR TITLE
Diagnostics: Loop up to Finest Level

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -376,6 +376,11 @@ Diagnostics::InitDataAfterRestart ()
 void
 Diagnostics::InitData ()
 {
+    auto& warpx = WarpX::GetInstance();
+
+    // Get current finest level available
+    const int finest_level = warpx.finestLevel();
+
     // initialize member variables and arrays in base class::Diagnostics
     InitBaseData();
     // initialize member variables and arrays specific to each derived class
@@ -386,7 +391,7 @@ Diagnostics::InitData ()
         // This includes full diagnostics and BTD as well as cell-center functors for BTD.
         // Note that the cell-centered data for BTD is computed for all levels and hence
         // the corresponding functor is also initialized for all the levels
-        for (int lev = 0; lev < nmax_lev; ++lev) {
+        for (int lev = 0; lev <= finest_level; ++lev) {
             // allocate and initialize m_all_field_functors depending on diag type
             InitializeFieldFunctors(lev);
         }

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -706,6 +706,9 @@ FullDiagnostics::MovingWindowAndGalileanDomainShift (int step)
 {
     auto & warpx = WarpX::GetInstance();
 
+    // Get current finest level available
+    const int finest_level = warpx.finestLevel();
+
     // Account for galilean shift
     amrex::Real new_lo[AMREX_SPACEDIM];
     amrex::Real new_hi[AMREX_SPACEDIM];
@@ -735,7 +738,7 @@ FullDiagnostics::MovingWindowAndGalileanDomainShift (int step)
     }
 #endif
     // Update RealBox of geometry with galilean-shifted boundary.
-    for (int lev = 0; lev < nmax_lev; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev) {
         // Note that Full diagnostics has only one snapshot, m_num_buffers = 1
         // Thus here we set the prob domain for the 0th snapshot only.
         m_geom_output[0][lev].ProbDomain( amrex::RealBox(new_lo, new_hi) );


### PR DESCRIPTION
There are situations where the mesh refinement patch is outside the computational domain at the start of the simulation. In these situations, we need to use the current finest level available, rather than the maximum level set in the input, when we loop over mesh refinement levels.

This is an attempt to start implementing #3716.