### PR TITLE
CI: Retry Apt Repos

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -74,6 +74,7 @@ jobs:
       set -eu -o pipefail
       cat /proc/cpuinfo | grep "model name" | sort -u
       df -h
+      echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
       sudo apt update
       sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
         openmpi-bin libopenmpi-dev \

--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
 wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
@@ -19,15 +24,21 @@ sudo apt-get update
 df -h
 # Install and reduce disk space
 # https://github.com/ECP-WarpX/WarpX/pull/1566#issuecomment-790934878
-sudo apt-get install -y --no-install-recommends \
-    build-essential \
-    ccache          \
-    cmake           \
-    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
-    g++ gfortran    \
-    libopenmpi-dev  \
-    openmpi-bin  && \
-sudo apt-get clean
+tries=0
+while [[ ${tries} -lt 5 ]]
+do
+    sudo apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache          \
+        cmake           \
+        intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
+        g++ gfortran    \
+        libopenmpi-dev  \
+        openmpi-bin     \
+        && { sudo apt-get clean; tries=6; }     \
+        || { sleep 10; tries=$(( tries + 1 )); }
+done
+if [[ ${tries} -eq 5 ]]; then exit 1; fi
 
 du -sh /opt/intel/oneapi/
 du -sh /opt/intel/oneapi/*/*

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/gcc12.sh
+++ b/.github/workflows/dependencies/gcc12.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
 wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key \
   | sudo apt-key add -

--- a/.github/workflows/dependencies/nvcc11-0.sh
+++ b/.github/workflows/dependencies/nvcc11-0.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/nvcc11-8.sh
+++ b/.github/workflows/dependencies/nvcc11-8.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/pyfull.sh
+++ b/.github/workflows/dependencies/pyfull.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \


### PR DESCRIPTION
Since Intel Repos are often out-of-sync with each others for apt packages provided (checksum errors), we try to pause and retry up to five times to get them installed.

Also set apt retries to 3 for `apt update`.