### PR TITLE
Implement thread-safe ChargeOnEB diagnostic

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -121,6 +121,9 @@ void ChargeOnEB::ComputeDiags (const int step)
     amrex::Real* surface_integral_pointer = surface_integral.data();
 
     // Loop over boxes
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
     for (amrex::MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
       const amrex::Box & box = mfi.tilebox( amrex::IntVect::TheCellVector() );
@@ -187,6 +190,9 @@ void ChargeOnEB::ComputeDiags (const int step)
                 // Given that only a tiny fraction of the cells have a non-zero contribution
                 // (the ones that intersect with the EB), it is not clear whether ReduceOpSum
                 // or AtomicAdd would be faster. However, the implementation with AtomicAdd is easier.
+#ifdef AMREX_USE_OMP
+#pragma omp critical
+#endif
                 amrex::Gpu::Atomic::AddNoRet( surface_integral_pointer, local_integral_contribution );
         });
     }

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -120,9 +120,6 @@ void ChargeOnEB::ComputeDiags (const int step)
     amrex::Gpu::Buffer<amrex::Real> surface_integral({0.0_rt});
     amrex::Real* surface_integral_pointer = surface_integral.data();
 
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
     // Loop over boxes
     for (amrex::MFIter mfi(Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {


### PR DESCRIPTION
With the current implementation, the `ChargeOnEB` diagnostic is not thread-safe (when using OpenMP threads). This is because different threads can simultaneously update the `surface_integral_pointer`, leading to potential race conditions. I indeed observed errors in practice when using this diagnostic.

~~This PR simply removes the use of threads. In a future PR, we could also change the update of `surface_integral_pointer` to make it thread-safe.~~

The new implementation is thread-safe, at the cost of adding a few `#ifdef`.