### PR TITLE
Code cleanup: use `DepositCurrent()` in `AddSpaceChargeFieldLabFrame()`

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -204,29 +204,9 @@ WarpX::AddSpaceChargeFieldLabFrame ()
                                      "Error: RZ electrostatic only implemented for a single mode");
 #endif
 
-    // reset rho_fp before depositing charge density for this step
-    for (int lev = 0; lev <= max_level; lev++) {
-        rho_fp[lev]->setVal(0.);
-    }
-
     // Deposit particle charge density (source of Poisson solver)
-    bool const local = true;
-    bool const interpolate_across_levels = false;
-    bool const reset = false;
-    bool const do_rz_volume_scaling = false;
-    for (int ispecies=0; ispecies<mypc->nSpecies(); ispecies++){
-        WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
-        if (!species.do_not_deposit) {
-            species.DepositCharge( rho_fp,
-                                   local, reset, do_rz_volume_scaling, interpolate_across_levels
-                                  );
-        }
-    }
-#ifdef WARPX_DIM_RZ
-    for (int lev = 0; lev <= max_level; lev++) {
-        ApplyInverseVolumeScalingToChargeDensity(rho_fp[lev].get(), lev);
-    }
-#endif
+    mypc->DepositCharge(rho_fp, 0.0_rt);
+
     SyncRho(); // Apply filter, perform MPI exchange, interpolate across levels
 
     // beta is zero in lab frame

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -575,16 +575,15 @@ MultiParticleContainer::DepositCharge (
     // Push the particles in time, if needed
     if (relative_time != 0.) PushX(relative_time);
 
+    bool const local = true;
+    bool const reset = false;
+    bool const apply_boundary_and_scale_volume = false;
+    bool const interpolate_across_levels = false;
     // Call the deposition kernel for each species
     for (auto& pc : allcontainers)
     {
         if (pc->do_not_deposit) continue;
-
-        bool const local = true;
-        bool const reset = false;
-        bool const do_rz_volume_scaling = false;
-        bool const interpolate_across_levels = false;
-        pc->DepositCharge(rho, local, reset, do_rz_volume_scaling,
+        pc->DepositCharge(rho, local, reset, apply_boundary_and_scale_volume,
                               interpolate_across_levels);
     }
 


### PR DESCRIPTION
Simple code clean-up: Functionality in `AddSpaceChargeFieldLabFrame` is currently exactly duplicated in `MultiParticleContainer::DepositCharge`.