### PR TITLE
Charge on EB: Use `fp` field instead of `aux`

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -93,9 +93,9 @@ void ChargeOnEB::ComputeDiags (const int step)
     int const lev = 0;
 
     // get MultiFab data at lev
-    const amrex::MultiFab & Ex = warpx.getEfield(lev,0);
-    const amrex::MultiFab & Ey = warpx.getEfield(lev,1);
-    const amrex::MultiFab & Ez = warpx.getEfield(lev,2);
+    const amrex::MultiFab & Ex = warpx.getEfield_fp(lev,0);
+    const amrex::MultiFab & Ey = warpx.getEfield_fp(lev,1);
+    const amrex::MultiFab & Ez = warpx.getEfield_fp(lev,2);
 
     // get EB structures
     amrex::EBFArrayBoxFactory const& eb_box_factory = warpx.fieldEBFactory(lev);


### PR DESCRIPTION
When computing the `ChargeOnEB`, we use the electric field. However, the current PR is using the `aux` version of `E`. This is not ideal, since the typical PIC loop is:
```
loop over iterations:
   - Compute aux from fp
   - Update fp (using the Maxwell equations or the Poisson equation)
   - Run the reduced diagnostics
```
Therefore, when computing the reduced diagnostics, the `aux` field is outdated by one step. In addition, when using momentum-conserving gather, the `aux` field is a smoothed version of `fp`, and it is more accurate to compute the above diagnostic from the unsmoothed version.

Therefore, the current PR uses the `fp` fields instead of the `aux` fields.

This PR should not affect the automated test, which uses `energy-conserving` gather - since `fp` and `aux` are actually the same array (on level 0) when using `energy-conserving` gather.