### PR TITLE
`SyncRho`: Pass References To Charge MultiFabs

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -504,12 +504,12 @@ void WarpX::SyncCurrentAndRho ()
             {
                 // TODO Replace current_cp with current_cp_vay once Vay deposition is implemented with MR
                 SyncCurrent(current_fp_vay, current_cp);
-                SyncRho();
+                SyncRho(rho_fp, rho_cp);
             }
             else
             {
                 SyncCurrent(current_fp, current_cp);
-                SyncRho();
+                SyncRho(rho_fp, rho_cp);
             }
         }
         else // no periodic single box
@@ -521,7 +521,7 @@ void WarpX::SyncCurrentAndRho ()
                 current_deposition_algo != CurrentDepositionAlgo::Vay)
             {
                 SyncCurrent(current_fp, current_cp);
-                SyncRho();
+                SyncRho(rho_fp, rho_cp);
             }
 
             if (current_deposition_algo == CurrentDepositionAlgo::Vay)
@@ -535,7 +535,7 @@ void WarpX::SyncCurrentAndRho ()
     else // FDTD
     {
         SyncCurrent(current_fp, current_cp);
-        SyncRho();
+        SyncRho(rho_fp, rho_cp);
     }
 }
 
@@ -572,7 +572,7 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         // (dt[0] denotes the time step on mesh refinement level 0)
         mypc->DepositCharge(rho_fp, -dt[0]);
         // Filter, exchange boundary, and interpolate across levels
-        SyncRho();
+        SyncRho(rho_fp, rho_cp);
         // Forward FFT of rho
         PSATDForwardTransformRho(rho_fp, rho_cp, 0, 1);
     }
@@ -636,7 +636,7 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
             // Deposit rho at relative time t_depose_charge
             mypc->DepositCharge(rho_fp, t_depose_charge);
             // Filter, exchange boundary, and interpolate across levels
-            SyncRho();
+            SyncRho(rho_fp, rho_cp);
             // Forward FFT of rho
             PSATDForwardTransformRho(rho_fp, rho_cp, 0, 1);
         }

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -207,7 +207,7 @@ WarpX::AddSpaceChargeFieldLabFrame ()
     // Deposit particle charge density (source of Poisson solver)
     mypc->DepositCharge(rho_fp, 0.0_rt);
 
-    SyncRho(); // Apply filter, perform MPI exchange, interpolate across levels
+    SyncRho(rho_fp, rho_cp); // Apply filter, perform MPI exchange, interpolate across levels
 
     // beta is zero in lab frame
     // Todo: use simpler finite difference form with beta=0

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -734,7 +734,7 @@ WarpX::PushPSATD ()
 
             // Synchronize J and rho
             SyncCurrent(current_fp, current_cp);
-            SyncRho();
+            SyncRho(rho_fp, rho_cp);
         }
         else if (current_deposition_algo == CurrentDepositionAlgo::Vay)
         {
@@ -755,7 +755,7 @@ WarpX::PushPSATD ()
             // TODO This works only without mesh refinement
             const int lev = 0;
             SumBoundaryJ(current_fp, lev, Geom(lev).periodicity());
-            SyncRho();
+            SyncRho(rho_fp, rho_cp);
         }
 
         // FFT of J and rho (if used)

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -902,20 +902,22 @@ WarpX::SyncCurrent (
 }
 
 void
-WarpX::SyncRho ()
+WarpX::SyncRho (
+    const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
+    const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp)
 {
     WARPX_PROFILE("WarpX::SyncRho()");
 
-    if (!rho_fp[0]) return;
-    const int ncomp = rho_fp[0]->nComp();
+    if (!charge_fp[0]) return;
+    const int ncomp = charge_fp[0]->nComp();
 
     // Restrict fine patch onto the coarse patch,
     // before summing the guard cells of the fine patch
     for (int lev = 1; lev <= finest_level; ++lev)
     {
-        rho_cp[lev]->setVal(0.0);
+        charge_cp[lev]->setVal(0.0);
         const IntVect& refinement_ratio = refRatio(lev-1);
-        ablastr::coarsen::average::Coarsen(*rho_cp[lev], *rho_fp[lev], refinement_ratio );
+        ablastr::coarsen::average::Coarsen(*charge_cp[lev], *charge_fp[lev], refinement_ratio );
     }
 
     // For each level
@@ -923,7 +925,7 @@ WarpX::SyncRho ()
     // - add the coarse patch/buffer of `lev+1` into the fine patch of `lev`
     // - sum guard cells of the coarse patch of `lev+1` and fine patch of `lev`
     for (int lev=0; lev <= finest_level; ++lev) {
-        AddRhoFromFineLevelandSumBoundary(rho_fp, rho_cp, lev, 0, ncomp);
+        AddRhoFromFineLevelandSumBoundary(charge_fp, charge_cp, lev, 0, ncomp);
     }
 }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -903,7 +903,7 @@ WarpX::SyncCurrent (
 
 void
 WarpX::SyncRho () {
-    SyncRho(rho_fp, rho_cp);   
+    SyncRho(rho_fp, rho_cp);
 }
 
 void

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -902,6 +902,11 @@ WarpX::SyncCurrent (
 }
 
 void
+WarpX::SyncRho () {
+    SyncRho(rho_fp, rho_cp);   
+}
+
+void
 WarpX::SyncRho (
     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp)

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -701,11 +701,9 @@ namespace
         WarpX& warpx = WarpX::GetInstance();
         warpx.FillBoundaryB(warpx.getngEB());
     }
-    void warpx_SyncRho (
-        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
-        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp) {
+    void warpx_SyncRho () {
         WarpX& warpx = WarpX::GetInstance();
-        warpx.SyncRho(charge_fp, charge_cp);
+        warpx.SyncRho();
     }
     void warpx_SyncCurrent (
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -701,9 +701,11 @@ namespace
         WarpX& warpx = WarpX::GetInstance();
         warpx.FillBoundaryB(warpx.getngEB());
     }
-    void warpx_SyncRho () {
+    void warpx_SyncRho (
+        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
+        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp) {
         WarpX& warpx = WarpX::GetInstance();
-        warpx.SyncRho();
+        warpx.SyncRho(charge_fp, charge_cp);
     }
     void warpx_SyncCurrent (
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -776,7 +776,9 @@ public:
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp);
 
-    void SyncRho ();
+    void SyncRho (
+        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
+        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp);
 
     amrex::Vector<int> getnsubsteps () const {return nsubsteps;}
     int getnsubsteps (int lev) const {return nsubsteps[lev];}

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -776,6 +776,8 @@ public:
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_fp,
         const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& J_cp);
 
+    void SyncRho ();
+
     void SyncRho (
         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp);


### PR DESCRIPTION
This PR is similar to #3277. It allows to call `SyncRho` on arbitrary multifabs. 

This would be useful in order to cleanup the relativistic Poisson solver. (Related PRs: #3807,  #2446)

It would also be useful for the charge density field diagnostic (and species-wise charge density diagnostic), which currently deposits `rho` in a different multifab than `rho_fp` and `rho_cp`.