### PR TITLE
Lattice: Line Docs & Rename

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1481,6 +1481,9 @@ Note that elements of the same type cannot overlap each other.
     A list of names (one name per lattice element), in the order that they
     appear in the lattice.
 
+* ``lattice.reverse`` (``boolean``) optional (default: ``false``)
+    Reverse the list of elements in the lattice.
+
 * ``<element_name>.type`` (``string``)
     Indicates the element type for this lattice element. This should be one of:
 
@@ -1516,6 +1519,15 @@ Note that elements of the same type cannot overlap each other.
 
             * ``<element_name>.dBdx`` (``float``, in Tesla/meter) optional (default: 0.) the magnetic field gradient
               The field applied to the particles will be `Bx = dBdx*y` and `By = -dBdx*x`.
+
+        * ``line`` a sub-lattice (line) of elements to append to the lattice.
+
+            * ``<element_name>.elements`` (``list of strings``) optional (default: no elements)
+              A list of names (one name per lattice element), in the order that they appear in the lattice.
+
+            * ``<element_name>.reverse`` (``boolean``) optional (default: ``false``)
+              Reverse the list of elements in the line before appending to the lattice.
+
 
 .. _running-cpp-parameters-collision:
 

--- a/Examples/Tests/AcceleratorLattice/analysis.py
+++ b/Examples/Tests/AcceleratorLattice/analysis.py
@@ -62,7 +62,7 @@ def read_lattice(rootname, z_location):
             quad_lengths.append(length)
             quad_strengths_E.append(float(ds.parameters.get(f'{element}.dEdx')))
             z_location += length
-        elif element_type == 'lattice':
+        elif element_type == 'line':
             z_location = read_lattice(element, z_location)
     return z_location
 

--- a/Examples/Tests/AcceleratorLattice/inputs_quad_3d
+++ b/Examples/Tests/AcceleratorLattice/inputs_quad_3d
@@ -23,13 +23,13 @@ electron.single_particle_pos = 0.05 0.0 0.0
 electron.single_particle_u = 0.0 0.0 0.1  # gamma*beta
 electron.single_particle_weight = 1.0
 
-lattice.elements = lattice1 lattice2
+lattice.elements = line1 line2
 
-lattice1.type = lattice
-lattice1.elements = drift1 quad1
+line1.type = line
+line1.elements = drift1 quad1
 
-lattice2.type = lattice
-lattice2.elements = drift2 quad2
+line2.type = line
+line2.elements = drift2 quad2
 
 drift1.type = drift
 drift1.ds = 0.2

--- a/Source/AcceleratorLattice/AcceleratorLattice.cpp
+++ b/Source/AcceleratorLattice/AcceleratorLattice.cpp
@@ -44,8 +44,9 @@ AcceleratorLattice::ReadLattice (std::string const & root_name, amrex::ParticleR
     bool reverse = false;
     pp_lattice.queryAdd("reverse", reverse);
 
-    if (reverse)
+    if (reverse) {
         std::reverse(lattice_elements.begin(), lattice_elements.end());
+    }
 
     // Loop through lattice elements
     for (std::string const & element_name : lattice_elements) {

--- a/Source/AcceleratorLattice/AcceleratorLattice.cpp
+++ b/Source/AcceleratorLattice/AcceleratorLattice.cpp
@@ -1,7 +1,10 @@
-/* Copyright 2022 David Grote
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
  * This file is part of WarpX.
  *
+ * Authors: David Grote, Axel HUebl
  * License: BSD-3-Clause-LBNL
  */
 #include "AcceleratorLattice.H"
@@ -10,6 +13,9 @@
 #include "LatticeElements/HardEdgedPlasmaLens.H"
 
 #include <AMReX_REAL.H>
+
+#include <algorithm>
+
 
 AcceleratorLattice::AcceleratorLattice ()
 {
@@ -35,6 +41,12 @@ AcceleratorLattice::ReadLattice (std::string const & root_name, amrex::ParticleR
         m_lattice_defined = true;
     }
 
+    bool reverse = false;
+    pp_lattice.queryAdd("reverse", reverse);
+
+    if (reverse)
+        std::reverse(lattice_elements.begin(), lattice_elements.end());
+
     // Loop through lattice elements
     for (std::string const & element_name : lattice_elements) {
         // Check the element type
@@ -52,7 +64,7 @@ AcceleratorLattice::ReadLattice (std::string const & root_name, amrex::ParticleR
         else if (element_type == "plasmalens") {
             h_plasmalens.AddElement(pp_element, z_location);
         }
-        else if (element_type == "lattice") {
+        else if (element_type == "line") {
             ReadLattice(element_name, z_location);
         }
         else {


### PR DESCRIPTION
Rename the `lattice` element type to `line` and add documentation for it.

Follow-up to #3063

In sync with ImpactX:
- https://github.com/ECP-WarpX/impactx/pull/335