### PR TITLE
ChargeOnEB: use atomic add on CPU, instead of `omp critical`

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -190,10 +190,7 @@ void ChargeOnEB::ComputeDiags (const int step)
                 // Given that only a tiny fraction of the cells have a non-zero contribution
                 // (the ones that intersect with the EB), it is not clear whether ReduceOpSum
                 // or AtomicAdd would be faster. However, the implementation with AtomicAdd is easier.
-#ifdef AMREX_USE_OMP
-#pragma omp critical
-#endif
-                amrex::Gpu::Atomic::AddNoRet( surface_integral_pointer, local_integral_contribution );
+                amrex::HostDevice::Atomic::Add( surface_integral_pointer, local_integral_contribution );
         });
     }
 


### PR DESCRIPTION
This PR implements the [suggestion by @WeiqunZhang](https://github.com/ECP-WarpX/WarpX/pull/3804#discussion_r1160159485) to use atomic add instead of `omp critical` in the charge-on-eb diagnostic.