### PR TITLE
amrex.the_arena_is_managed=0

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -161,7 +161,13 @@ Overall simulation parameters
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
     This will cause severe performance drops.
     Note that even with this set to ``1`` WarpX will not catch all out-of-memory events yet when operating close to maximum device memory.
-    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`_.
+    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__.
+
+* ``amrex.the_arena_is_managed``  (``0`` or ``1``; default is ``0`` for false)
+    When running on GPUs, device memory that is accessed from the host will automatically be transferred with managed memory.
+    This is useful for convenience during development, but has sometimes severe performance and memory footprint implications if relied on (and sometimes vendor bugs).
+    For all regular WarpX operations, we therefore do explicit memory transfers without the need for managed memory and thus changed the AMReX default to false.
+    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__.
 
 Signal Handling
 ^^^^^^^^^^^^^^^

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -26,6 +26,9 @@ namespace {
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
         pp_amrex.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
+        bool the_arena_is_managed = false; // AMReX' default: true
+        pp_amrex.queryAdd("the_arena_is_managed", the_arena_is_managed);
+
         // Work-around:
         // If warpx.numprocs is used for the domain decomposition, we will not use blocking factor
         // to generate grids. Nonetheless, AMReX has asserts in place that validate that the


### PR DESCRIPTION
Disable managed memory by default for performance and non-bugness.

Please disable explicitly if needed for some of the current scripting tasks, e.g., in the current Python bindings.
```py
# Set up simulation
sim = picmi.Simulation(
    solver = solver,
    max_steps = max_steps,
    # ...
    warpx_amrex_the_arena_is_managed=1  # overwrite the new default if needed
)
```

Close #2009

Tests:
- [x] 3D LWFA test w/o and w/ openPMD ran (CUDA 11.7)