### PR TITLE
Doc: Latest HDF5 on Summit

### DIFF
--- a/Docs/source/maintenance/performance_tests.rst
+++ b/Docs/source/maintenance/performance_tests.rst
@@ -48,7 +48,7 @@ Then, in ``$AUTOMATED_PERF_TESTS``, create a file ``run_automated_performance_te
    module load lapackpp/2021.04.00
    module load boost/1.76.0
    module load adios2/2.7.1
-   module load hdf5/1.12.1
+   module load hdf5/1.12.2
 
    module unload darshan-runtime
 

--- a/Docs/source/maintenance/performance_tests.rst
+++ b/Docs/source/maintenance/performance_tests.rst
@@ -48,7 +48,7 @@ Then, in ``$AUTOMATED_PERF_TESTS``, create a file ``run_automated_performance_te
    module load lapackpp/2021.04.00
    module load boost/1.76.0
    module load adios2/2.7.1
-   module load hdf5/1.10.7
+   module load hdf5/1.12.1
 
    module unload darshan-runtime
 

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -23,7 +23,7 @@ module load boost/1.76.0
 
 # optional: for openPMD support
 module load adios2/2.7.1
-module load hdf5/1.10.7
+module load hdf5/1.12.1
 
 # optional: for openPMD support (GNUmake only)
 #module load ums

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -23,7 +23,7 @@ module load boost/1.76.0
 
 # optional: for openPMD support
 module load adios2/2.7.1
-module load hdf5/1.12.1
+module load hdf5/1.12.2
 
 # optional: for openPMD support (GNUmake only)
 #module load ums


### PR DESCRIPTION
Update the Summit docs to use the latest available HDF5 module (~v1.12.1~ *TBD*).

- [x] wait for `OLCFHELP-11922`

Switching to hdf5/1.12.2 for performance, but there is also hdf5/1.14.0 now, which we can try for new vol logic and subfiling :)