### PR TITLE
Correct sign of the `ChargeOnEB` diagnostic

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2793,25 +2793,25 @@ Reduced Diagnostics
         so the time of the diagnostic may be long
         depending on the simulation size.
 
-* ``ChargeOnEB``
-    This type computes the total surface charge on the embedded boundary
-    (in Coulombs), by using the formula
+    * ``ChargeOnEB``
+        This type computes the total surface charge on the embedded boundary
+        (in Coulombs), by using the formula
 
-    .. math::
+        .. math::
 
-        Q_{tot} = \epsilon_0 \iint dS \cdot E
+            Q_{tot} = \epsilon_0 \iint dS \cdot E
 
-    where the integral is performed over the surface of the embedded boundary.
+        where the integral is performed over the surface of the embedded boundary.
 
-    When providing ``<reduced_diags_name>.weighting_function(x,y,z)``, the
-    computed integral is weighted:
-    .. math::
+        When providing ``<reduced_diags_name>.weighting_function(x,y,z)``, the
+        computed integral is weighted:
+        .. math::
 
-        Q = \epsilon_0 \iint dS \cdot E \times weighting(x, y, z)
+            Q = \epsilon_0 \iint dS \cdot E \times weighting(x, y, z)
 
-    In particular, by choosing a weighting function which returns either
-    1 or 0, it is possible to compute the charge on only some part of the
-    embedded boundary.
+        In particular, by choosing a weighting function which returns either
+        1 or 0, it is possible to compute the charge on only some part of the
+        embedded boundary.
 
 * ``<reduced_diags_name>.intervals`` (`string`)
     Using the `Intervals Parser`_ syntax, this string defines the timesteps at which reduced

--- a/Examples/Tests/electrostatic_sphere_eb/analysis.py
+++ b/Examples/Tests/electrostatic_sphere_eb/analysis.py
@@ -16,7 +16,7 @@ from scipy.constants import epsilon_0
 # Theoretical charge on the embedded boundary, for sphere at potential phi_0
 phi_0 = 1. # V
 R = 0.1 # m
-q_th = -4*np.pi*epsilon_0*phi_0*R
+q_th = 4*np.pi*epsilon_0*phi_0*R
 print('Theoretical charge: ', q_th)
 
 data = np.loadtxt('diags/reducedfiles/eb_charge.txt')

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -173,9 +173,9 @@ void ChargeOnEB::ComputeDiags (const int step)
 
                 // Compute contribution to the surface integral $\int dS \cdot E$)
                 amrex::Real local_integral_contribution = 0;
-                local_integral_contribution += Ex_arr(i_c,j_n,k_n)*dSx*(dSx_fraction_arr(i,j,k)-dSx_fraction_arr(i+1,j,k));
-                local_integral_contribution += Ey_arr(i_n,j_c,k_n)*dSy*(dSy_fraction_arr(i,j,k)-dSy_fraction_arr(i,j+1,k));
-                local_integral_contribution += Ez_arr(i_n,j_n,k_c)*dSz*(dSz_fraction_arr(i,j,k)-dSz_fraction_arr(i,j,k+1));
+                local_integral_contribution += Ex_arr(i_c,j_n,k_n)*dSx*(dSx_fraction_arr(i+1,j,k)-dSx_fraction_arr(i,j,k));
+                local_integral_contribution += Ey_arr(i_n,j_c,k_n)*dSy*(dSy_fraction_arr(i,j+1,k)-dSy_fraction_arr(i,j,k));
+                local_integral_contribution += Ez_arr(i_n,j_n,k_c)*dSz*(dSz_fraction_arr(i,j,k+1)-dSz_fraction_arr(i,j,k));
 
                 // Add weighting if requested by user
                 if (do_parser_weighting) {


### PR DESCRIPTION
The `ChargeOnEB` diagnostic had the wrong sign: it computed $$-\epsilon_0 \oint E\cdot dS$$ instead of $$\epsilon_0 \oint E\cdot dS$$.

Fundamentally, this is because I had misunderstood the `eb_area_fraction` data, and thought that it represented the area covered by the EB, while it actually represents the opposite (uncovered area):
https://amrex-codes.github.io/amrex/docs_html/EB.html#embedded-boundary-data

I also updated the sign in the automated test. The charge on a sphere that is set to a positive potential is now also positive, which makes more sense. 😅 

I also properly indented the documentation for `ChargeOnEB`.