### PR TITLE
Parameters doc: clean duplicated predefined density profile option

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -813,10 +813,6 @@ Particle initialization
     Whether particle's weight is varied with their radius. This only applies to cylindrical geometry.
     The only valid value is true.
 
-    * ``predefined``: use one of WarpX predefined plasma profiles. It requires additional
-      arguments ``<species_name>.predefined_profile_name`` and
-      ``<species_name>.predefined_profile_params`` (see below).
-
 * ``<species_name>.momentum_distribution_type`` (`string`)
     Distribution of the normalized momentum (`u=p/mc`) for this species. The options are:
 


### PR DESCRIPTION
This option is defined twice in the doc. One time in the right place:

https://github.com/ECP-WarpX/WarpX/blob/7771d25e8cb7ec8115c4e0cec24eee13a5bf9032/Docs/source/usage/parameters.rst#L796-L799

and one time in the wrong place (removed by this PR).