### PR TITLE
Remove unnecessary #include from ablastr/particles/DepositCharge.H

### DIFF
--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -13,9 +13,6 @@
 #include "Particles/ShapeFactors.H"
 #include "Particles/Deposition/ChargeDeposition.H"
 #include "ablastr/utils/TextMsg.H"
-#ifdef WARPX_DIM_RZ
-#   include "Utils/WarpX_Complex.H"
-#endif
 
 #include <AMReX.H>
 


### PR DESCRIPTION
It seems to me that this `#include` directive is not actually needed here. 
In case it **is** actually needed I would suggest adding a comment to explain why.