### PR TITLE
Move StringUtils.H to ablastr

### DIFF
--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -14,4 +14,3 @@ target_sources(WarpX
 
 add_subdirectory(Logo)
 add_subdirectory(Parser)
-add_subdirectory(Strings)

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -14,6 +14,5 @@ include $(WARPX_HOME)/Source/Utils/Algorithms/Make.package
 include $(WARPX_HOME)/Source/Utils/Logo/Make.package
 include $(WARPX_HOME)/Source/Utils/Parser/Make.package
 include $(WARPX_HOME)/Source/Utils/Physics/Make.package
-include $(WARPX_HOME)/Source/Utils/Strings/Make.package
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Utils

--- a/Source/Utils/Parser/IntervalsParser.cpp
+++ b/Source/Utils/Parser/IntervalsParser.cpp
@@ -8,8 +8,8 @@
 
 #include "IntervalsParser.H"
 
+#include "ablastr/utils/text/StringUtils.H"
 #include "ParserUtils.H"
-#include "Utils/Strings/StringUtils.H"
 #include "Utils/TextMsg.H"
 
 #include <AMReX_Utility.H>
@@ -18,11 +18,10 @@
 
 utils::parser::SliceParser::SliceParser (const std::string& instr, const bool isBTD)
 {
-    namespace utils_str = utils::strings;
-
     m_isBTD = isBTD;
     // split string and trim whitespaces
-    auto insplit = utils_str::split<std::vector<std::string>>(instr, m_separator, true);
+    auto insplit = ablastr::utils::text::split_string<std::vector<std::string>>(
+        instr, m_separator, true);
 
     if(insplit.size() == 1){ // no colon in input string. The input is the period.
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!m_isBTD, "must specify interval stop for BTD");
@@ -92,12 +91,11 @@ int utils::parser::SliceParser::numContained () const {
 utils::parser::IntervalsParser::IntervalsParser (
     const std::vector<std::string>& instr_vec)
 {
-    namespace utils_str = utils::strings;
-
     std::string inconcatenated;
     for (const auto& instr_element : instr_vec) inconcatenated +=instr_element;
 
-    auto insplit = utils_str::split<std::vector<std::string>>(inconcatenated, m_separator);
+    auto insplit = ablastr::utils::text::split_string<std::vector<std::string>>(
+        inconcatenated, m_separator);
 
     for(const auto& inslc : insplit)
     {
@@ -159,7 +157,8 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
     std::string inconcatenated;
     for (const auto& instr_element : instr_vec) inconcatenated +=instr_element;
 
-    auto const insplit = utils::strings::split<std::vector<std::string>>(inconcatenated, std::string(1,m_separator));
+    auto const insplit = ablastr::utils::text::split_string<std::vector<std::string>>(
+        inconcatenated, std::string(1,m_separator));
 
     // parse the Intervals string into Slices and store each slice in m_slices,
     // in order of increasing Slice start value

--- a/Source/Utils/Strings/Make.package
+++ b/Source/Utils/Strings/Make.package
@@ -1,3 +1,0 @@
-CEXE_sources += StringUtils.cpp
-
-VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Utils/Strings

--- a/Source/ablastr/utils/CMakeLists.txt
+++ b/Source/ablastr/utils/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(ablastr
 )
 
 add_subdirectory(msg_logger)
+add_subdirectory(text)
 add_subdirectory(timer)

--- a/Source/ablastr/utils/Make.package
+++ b/Source/ablastr/utils/Make.package
@@ -6,4 +6,5 @@ CEXE_sources += UsedInputsFile.cpp
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/utils
 
 include $(WARPX_HOME)/Source/ablastr/utils/msg_logger/Make.package
+include $(WARPX_HOME)/Source/ablastr/utils/text/Make.package
 include $(WARPX_HOME)/Source/ablastr/utils/timer/Make.package

--- a/Source/ablastr/utils/TextMsg.H
+++ b/Source/ablastr/utils/TextMsg.H
@@ -12,22 +12,7 @@
 #include <vector>
 
 
-namespace ablastr::utils
-{
-    /** \brief This function performs automatic text wrapping on a string,
-     *  returning an array of strings each not exceeding the maximum line length
-     *  (unless the text contains a word exceeding the maximum line length).
-     *
-     * @param[in] text the string containing the text to be wrapped
-     * @param[in] max_line_length the maximum line length
-     * @return an std::vector containing the lines of the wrapped text
-     */
-    std::vector< std::string >
-    automatic_text_wrap (
-        const std::string& text,
-        const int max_line_length);
-
-namespace TextMsg
+namespace ablastr::utils::TextMsg
 {
     /** \brief This function formats a text message as an error message,
     *   adding the '### ERROR: ' prefix and (by default) performing text wrapping
@@ -67,8 +52,7 @@ namespace TextMsg
     void
     Assert (const char *ex, const char *file, const int line, const std::string &msg);
 
-} // namespace TextMsg
-} // namespace ablastr::utils
+} // namespace ablastr::utils::TextMsg
 
 #define ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(EX,MSG) (EX)?((void)0) : ablastr::utils::TextMsg::Assert( # EX , __FILE__, __LINE__ , MSG)
 

--- a/Source/ablastr/utils/TextMsg.cpp
+++ b/Source/ablastr/utils/TextMsg.cpp
@@ -7,6 +7,8 @@
 
 #include "TextMsg.H"
 
+#include "ablastr/utils/text/StringUtils.H"
+
 #include <AMReX.H>
 
 #include <algorithm>
@@ -35,7 +37,7 @@ namespace
             return msg_prefix + msg + "\n";
         }
 
-        const auto wrapped_text = ablastr::utils::automatic_text_wrap(
+        const auto wrapped_text = ablastr::utils::text::automatic_text_wrap(
             msg, msg_line_length);
 
         std::stringstream ss_out;
@@ -76,47 +78,4 @@ ablastr::utils::TextMsg::Assert (const char* ex, const char* file, const int lin
 {
     const auto n_msg = "\n" + Err(msg);
     amrex::Assert(ex , file, line , n_msg.c_str());
-}
-
-std::vector< std::string >
-ablastr::utils::automatic_text_wrap (
-    const std::string& text, const int max_line_length)
-{
-
-    auto ss_text = std::stringstream{text};
-    auto wrapped_text_lines = std::vector< std::string >{};
-
-    std::string line;
-    while(std::getline(ss_text, line,'\n')){
-
-        auto ss_line = std::stringstream{line};
-        int counter = 0;
-        std::stringstream ss_line_out;
-        std::string word;
-
-        while (ss_line >> word){
-            const auto wlen = static_cast<int>(word.length());
-
-            if(counter == 0){
-                ss_line_out << word;
-                counter += wlen;
-            }
-            else{
-                if (counter + wlen < max_line_length){
-                    ss_line_out << " " << word;
-                    counter += (wlen+1);
-                }
-                else{
-                    wrapped_text_lines.push_back(ss_line_out.str());
-                    ss_line_out.str("");
-                    ss_line_out << word;
-                    counter = wlen;
-                }
-            }
-        }
-
-        wrapped_text_lines.push_back(ss_line_out.str());
-    }
-
-    return wrapped_text_lines;
 }

--- a/Source/ablastr/utils/text/CMakeLists.txt
+++ b/Source/ablastr/utils/text/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(WarpX
+target_sources(ablastr
   PRIVATE
     StringUtils.cpp
 )

--- a/Source/ablastr/utils/text/Make.package
+++ b/Source/ablastr/utils/text/Make.package
@@ -1,0 +1,3 @@
+CEXE_sources += StringUtils.cpp
+
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/utils/text

--- a/Source/ablastr/utils/text/StringUtils.H
+++ b/Source/ablastr/utils/text/StringUtils.H
@@ -6,15 +6,15 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#ifndef WARPX_UTILS_STRINGS_STRINGUTILS_H_
-#define WARPX_UTILS_STRINGS_STRINGUTILS_H_
+#ifndef ABLASTR_UTILS_TEXT_STRINGUTILS_H_
+#define ABLASTR_UTILS_TEXT_STRINGUTILS_H_
 
 #include <AMReX_Utility.H>
 
 #include <string>
 #include <vector>
 
-namespace utils::strings
+namespace ablastr::utils::text
 {
     /** \brief Splits a string using a string separator. This is somewhat similar to
      *  amrex::Tokenize. The main difference is that, if the separator ":" is used,
@@ -31,7 +31,7 @@ namespace utils::strings
      * @return cont the split string
      */
     template <typename Container>
-    auto split (std::string const& instr, std::string const& separator,
+    auto split_string (std::string const& instr, std::string const& separator,
                   bool const trim = false, std::string const& trim_space = " \t")
     {
         Container cont;
@@ -65,4 +65,4 @@ namespace utils::strings
 
 }
 
-#endif //WARPX_UTILS_STRINGS_STRINGUTILS_H_
+#endif // ABLASTR_UTILS_TEXT_STRINGUTILS_H_

--- a/Source/ablastr/utils/text/StringUtils.cpp
+++ b/Source/ablastr/utils/text/StringUtils.cpp
@@ -10,7 +10,8 @@
 
 #include <sstream>
 
-std::vector<std::string> automatic_text_wrap(
+std::vector<std::string>
+ablastr::utils::text::automatic_text_wrap(
     const std::string& text, const int max_line_length){
 
     auto ss_text = std::stringstream{text};

--- a/Source/ablastr/warn_manager/WarnManager.cpp
+++ b/Source/ablastr/warn_manager/WarnManager.cpp
@@ -8,6 +8,7 @@
 #include "WarnManager.H"
 
 #include "ablastr/utils/msg_logger/MsgLogger.H"
+#include "ablastr/utils/text/StringUtils.H"
 #include "ablastr/utils/TextMsg.H"
 
 #include <AMReX_ParallelDescriptor.H>
@@ -287,7 +288,7 @@ WarnManager::MsgFormatter(
     const auto prefix = "*" + std::string(tab_size, ' ');
     const auto prefix_length = static_cast<int>(prefix.length());
 
-    const auto wrapped_text = ablastr::utils::automatic_text_wrap(
+    const auto wrapped_text = ablastr::utils::text::automatic_text_wrap(
         msg, line_size-prefix_length);
 
     std::stringstream ss_out;


### PR DESCRIPTION
This PR moves `StringUtils.H` to ablastr, as suggested some time ago by @ax3l  (https://github.com/ECP-WarpX/WarpX/pull/3404 ).
It also removes some code duplication.