### PR TITLE
update ci to use ascent 0.9.1

### DIFF
--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -39,7 +39,7 @@ jobs:
       CC: gcc
       CMAKE_PREFIX_PATH: /ascent/install/lib/cmake/
     container:
-      image: alpinedav/ascent:0.9.0
+      image: alpinedav/ascent:0.9.1
     steps:
     - uses: actions/checkout@v3
     - name: Configure


### PR DESCRIPTION
Updates CI Testing to use Ascent 0.9.1 release.