### PR TITLE
Fix recently re-introduced bug in ablastr::utils::text::automatic_text_wrap

### DIFF
--- a/Source/ablastr/utils/text/StringUtils.cpp
+++ b/Source/ablastr/utils/text/StringUtils.cpp
@@ -39,7 +39,8 @@ ablastr::utils::text::automatic_text_wrap(
                 }
                 else{
                     wrapped_text_lines.push_back(ss_line_out.str());
-                    ss_line_out = std::stringstream{word};
+                    ss_line_out.str("");
+                    ss_line_out << word;
                     counter = wlen;
                 }
             }


### PR DESCRIPTION
In https://github.com/ECP-WarpX/WarpX/pull/3864 I removed some duplicated code, but I also involuntary re-introduced a small bug that was fixed in https://github.com/ECP-WarpX/WarpX/pull/3110 . This PR fixes the bug.