### PR TITLE
CI: macOS Cache Less

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,9 @@ jobs:
       # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
         path: |
-          /usr/local
+          /usr/local/bin
+          /usr/local/lib
+          /usr/local/share
           /Users/runner/Library/Caches/Homebrew
         key: brew-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}
         restore-keys: |


### PR DESCRIPTION
Cache only selected brew paths in macOS, not all of `/usr/local`, which contains more runner specific software.