### PR TITLE
Moving Window: Fix the logic to shift F and G fields when doing divE and divB cleaning in pml

### DIFF
--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -233,12 +233,23 @@ WarpX::MoveWindow (const int step, bool move_j)
             }
         }
 
-        // Shift scalar field F with div(E) cleaning
+        // Shift scalar field F with div(E) cleaning in valid domain
         // TODO: shift F from pml_rz for RZ geometry with PSATD, once implemented
         if (do_dive_cleaning)
         {
             // Fine grid
             shiftMF(*F_fp[lev], geom[lev], num_shift, dir, lev, do_update_cost);
+            if (lev > 0)
+            {
+                // Coarse grid
+                shiftMF(*F_cp[lev], geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
+            }
+        }
+
+        // Shift scalar field F with div(E) cleaning in pml region
+        if (do_pml_dive_cleaning)
+        {
+            // Fine grid
             if (do_pml && pml[lev]->ok())
             {
                 amrex::MultiFab* pml_F = pml[lev]->GetF_fp();
@@ -247,7 +258,6 @@ WarpX::MoveWindow (const int step, bool move_j)
             if (lev > 0)
             {
                 // Coarse grid
-                shiftMF(*F_cp[lev], geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
                 if (do_pml && pml[lev]->ok())
                 {
                     amrex::MultiFab* pml_F = pml[lev]->GetF_cp();
@@ -256,12 +266,23 @@ WarpX::MoveWindow (const int step, bool move_j)
             }
         }
 
-        // Shift scalar field G with div(B) cleaning
+        // Shift scalar field G with div(B) cleaning in valid domain
         // TODO: shift G from pml_rz for RZ geometry with PSATD, once implemented
         if (do_divb_cleaning)
         {
             // Fine grid
             shiftMF(*G_fp[lev], geom[lev], num_shift, dir, lev, do_update_cost);
+            if (lev > 0)
+            {
+                // Coarse grid
+                shiftMF(*G_cp[lev], geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
+            }
+        }
+
+        // Shift scalar field G with div(B) cleaning in pml region
+        if (do_pml_divb_cleaning)
+        {
+            // Fine grid
             if (do_pml && pml[lev]->ok())
             {
                 amrex::MultiFab* pml_G = pml[lev]->GetG_fp();
@@ -270,7 +291,6 @@ WarpX::MoveWindow (const int step, bool move_j)
             if (lev > 0)
             {
                 // Coarse grid
-                shiftMF(*G_cp[lev], geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
                 if (do_pml && pml[lev]->ok())
                 {
                     amrex::MultiFab* pml_G = pml[lev]->GetG_cp();


### PR DESCRIPTION
This PR fixes the logic to shift `F` and `G` fields when doing divE and divB cleaning in `pml` in simulations with moving window. Prior to this fix, shifts to `F` and `G` were applied by checking if `do_dive_cleaning` and `do_divb_cleaning` is `true` everywhere including in the pml region. However, in some cases, particularly with the PSATD solver, we need to do this only in the pml region. This PR fixes the logic to enable that.

Here is a result from test done with the psatd solver and mesh refinement in 2D with and without the fixes in the PR: 
![fixed_logic_mr](https://user-images.githubusercontent.com/89051199/235016592-010465f1-a840-48da-96fa-138097d865d1.gif)
