### PR TITLE
Doc: correct a formatting error in the  Fugaku page

### DIFF
--- a/Docs/source/install/hpc/fugaku.rst
+++ b/Docs/source/install/hpc/fugaku.rst
@@ -32,6 +32,7 @@ Compiling WarpX on Fugaku is more pratical on a compute node. Use the following 
 
 
 Then, load ``cmake`` and ``ninja`` using ``spack``:
+
 .. code-block:: bash
 
    . /vol0004/apps/oss/spack/share/spack/setup-env.sh


### PR DESCRIPTION
This PR corrects a formatting error in the documentation page related to the compilation of WarpX on the Fugaku supecomputer