### PR TITLE
Fix: rocFFT 5.5

### DIFF
--- a/Source/FieldSolver/SpectralSolver/AnyFFT.H
+++ b/Source/FieldSolver/SpectralSolver/AnyFFT.H
@@ -17,7 +17,7 @@
 // cstddef: work-around for ROCm/rocFFT <=4.3.0
 // https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
 #  include <cstddef>
-#  include <rocfft.h>
+#  include <rocfft/rocfft.h>
 #else
 #  include <fftw3.h>
 #endif

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -177,7 +177,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
                        {exteb_runtime_flag, qed_runtime_flag},
                        np_to_push,
                        [=] AMREX_GPU_DEVICE (long i, auto exteb_control,
-                                             [[maybe_unused]] auto qed_control) {
+                                             auto qed_control) {
             if (do_copy) copyAttribs(i);
             ParticleReal x, y, z;
             GetPosition(i, x, y, z);
@@ -210,6 +210,8 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
                 evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                            dt, p_optical_depth_BW[i]);
             }
+#else
+            amrex::ignore_unused(qed_control);
 #endif
 
             UpdatePositionPhoton( x, y, z, ux[i], uy[i], uz[i], dt );

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2751,7 +2751,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
                                 CompileTimeOptions<no_qed  ,has_qed>>{},
                        {exteb_runtime_flag, qed_runtime_flag},
                        np_to_push, [=] AMREX_GPU_DEVICE (long ip, auto exteb_control,
-                                                         [[maybe_unused]] auto qed_control)
+                                                         auto qed_control)
     {
         amrex::ParticleReal xp, yp, zp;
         getPosition(ip, xp, yp, zp);
@@ -2824,6 +2824,8 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
                            dt, p_optical_depth_QSR[ip]);
             }
         }
+#else
+            amrex::ignore_unused(qed_control);
 #endif
     });
 }

--- a/Source/Utils/WarpXrocfftUtil.cpp
+++ b/Source/Utils/WarpXrocfftUtil.cpp
@@ -13,7 +13,7 @@
 // cstddef: work-around for ROCm/rocFFT <=4.3.0
 // https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
 #  include <cstddef>
-#  include <rocfft.h>
+#  include <rocfft/rocfft.h>
 #endif
 
 void


### PR DESCRIPTION
```
/opt/rocm-5.5.0/include/rocfft.h:16:2: error: "This file is deprecated. Use the header file from /opt/rocm-5.5.0/include/rocfft/rocfft.h by using #include <rocfft/rocfft.h>" [-Werror,-W#warnings]
warning "This file is deprecated. Use the header file from /opt/rocm-5.5.0/include/rocfft/rocfft.h by using #include <rocfft/rocfft.h>"
 ^
```