### PR TITLE
Replace 3 occurrencess of NULL with std::nullptr

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -257,7 +257,7 @@ SpectralFieldDataRZ::FABZForwardTransform (amrex::MFIter const & mfi, amrex::Box
         }
     }
 #elif defined(AMREX_USE_HIP)
-    rocfft_execution_info execinfo = std::nullptr;
+    rocfft_execution_info execinfo = nullptr;
     rocfft_status result = rocfft_execution_info_create(&execinfo);
     std::size_t buffersize = 0;
     result = rocfft_plan_get_work_buffer_size(forward_plan[mfi], &buffersize);
@@ -370,7 +370,7 @@ SpectralFieldDataRZ::FABZBackwardTransform (amrex::MFIter const & mfi, amrex::Bo
         }
     }
 #elif defined(AMREX_USE_HIP)
-    rocfft_execution_info execinfo = std::nullptr;
+    rocfft_execution_info execinfo = nullptr;
     rocfft_status result = rocfft_execution_info_create(&execinfo);
     std::size_t buffersize = 0;
     result = rocfft_plan_get_work_buffer_size(forward_plan[mfi], &buffersize);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -257,7 +257,7 @@ SpectralFieldDataRZ::FABZForwardTransform (amrex::MFIter const & mfi, amrex::Box
         }
     }
 #elif defined(AMREX_USE_HIP)
-    rocfft_execution_info execinfo = NULL;
+    rocfft_execution_info execinfo = std::nullptr;
     rocfft_status result = rocfft_execution_info_create(&execinfo);
     std::size_t buffersize = 0;
     result = rocfft_plan_get_work_buffer_size(forward_plan[mfi], &buffersize);
@@ -370,7 +370,7 @@ SpectralFieldDataRZ::FABZBackwardTransform (amrex::MFIter const & mfi, amrex::Bo
         }
     }
 #elif defined(AMREX_USE_HIP)
-    rocfft_execution_info execinfo = NULL;
+    rocfft_execution_info execinfo = std::nullptr;
     rocfft_status result = rocfft_execution_info_create(&execinfo);
     std::size_t buffersize = 0;
     result = rocfft_plan_get_work_buffer_size(forward_plan[mfi], &buffersize);

--- a/Source/FieldSolver/SpectralSolver/WrapRocFFT.cpp
+++ b/Source/FieldSolver/SpectralSolver/WrapRocFFT.cpp
@@ -65,7 +65,7 @@ namespace AnyFFT
 
     void Execute (FFTplan& fft_plan)
     {
-        rocfft_execution_info execinfo = NULL;
+        rocfft_execution_info execinfo = std::nullptr;
         rocfft_status result = rocfft_execution_info_create(&execinfo);
         assert_rocfft_status("rocfft_execution_info_create", result);
 

--- a/Source/FieldSolver/SpectralSolver/WrapRocFFT.cpp
+++ b/Source/FieldSolver/SpectralSolver/WrapRocFFT.cpp
@@ -65,7 +65,7 @@ namespace AnyFFT
 
     void Execute (FFTplan& fft_plan)
     {
-        rocfft_execution_info execinfo = std::nullptr;
+        rocfft_execution_info execinfo = nullptr;
         rocfft_status result = rocfft_execution_info_create(&execinfo);
         assert_rocfft_status("rocfft_execution_info_create", result);
 


### PR DESCRIPTION
This PR replaces all the occurrences of  `NULL` in  WarpX with `std::nullptr`