### PR TITLE
Fix: Laser-Ion Example Gather

### DIFF
--- a/Examples/Physics_applications/laser_ion/inputs
+++ b/Examples/Physics_applications/laser_ion/inputs
@@ -34,6 +34,10 @@ boundary.field_hi = pml pml
 # Order of particle shape factors
 algo.particle_shape = 3
 
+# improved plasma stability for 2D with very low initial target temperature
+# when using Esirkepov current deposition with energy-conserving field gather
+interpolation.galerkin_scheme = 0
+
 # numerical tuning
 warpx.cfl = 0.999
 warpx.use_filter = 1          # bilinear current/charge filter

--- a/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
+++ b/Regression/Checksum/benchmarks_json/LaserIonAcc2d.json
@@ -1,33 +1,34 @@
 {
   "electrons": {
-    "particle_momentum_x": 3.924978793639722e-19,
+    "particle_momentum_x": 3.856058278845215e-19,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.6531781161630182e-18,
-    "particle_position_x": 0.008174406825176781,
-    "particle_position_y": 0.030854054377836164,
-    "particle_weight": 2.6494574815747686e+17
+    "particle_momentum_z": 1.633111056849423e-18,
+    "particle_position_x": 0.008155341094488198,
+    "particle_position_y": 0.03087362289643631,
+    "particle_weight": 2.6462205036771795e+17
   },
   "hydrogen": {
-    "particle_momentum_x": 2.2282828780834146e-18,
-    "particle_momentum_z": 1.0851862321717955e-18,
-    "particle_orig_x": 0.008197167968750002,
-    "particle_orig_z": 0.036522314453125,
-    "particle_position_x": 0.008196791928459133,
-    "particle_position_y": 0.03652051811944703,
-    "particle_weight": 2.7152730477070458e+17
+    "particle_momentum_x": 2.237944099185357e-18,
+    "particle_momentum_z": 1.0744000122946915e-18,
+    "particle_orig_x": 0.007768349609375002,
+    "particle_orig_z": 0.035127407226562504,
+    "particle_position_x": 0.007767975241766832,
+    "particle_position_y": 0.03512562609400349,
+    "particle_weight": 2.68584931046923e+17
   },
   "lev=0": {
     "Bx": 0.0,
-    "By": 11404616.733041402,
+    "By": 11399442.711372176,
     "Bz": 0.0,
-    "Ex": 2032977227921656.0,
+    "Ex": 2033057399920464.5,
     "Ey": 0.0,
-    "Ez": 317987205247174.75,
-    "jx": 1.6377970880819999e+19,
+    "Ez": 339244862686685.9,
+    "jx": 1.6477362358927364e+19,
     "jy": 0.0,
-    "jz": 8.817456212655565e+18,
-    "rho": 60944064977.941765,
-    "rho_electrons": 17448235212566.305,
-    "rho_hydrogen": 17441805684524.002
+    "jz": 9.633815033523364e+18,
+    "rho": 68121082972.17873,
+    "rho_electrons": 17448735668294.348,
+    "rho_hydrogen": 17441797017887.941
   }
 }
+


### PR DESCRIPTION
Guarantee improved plasma stability for 2D with very low initial target temperature when using Esirkepov current deposition with energy-conserving field gather (default).

Thank you to @joshualudwig8 for raising this!