### PR TITLE
Prevent implicit capture on GPU for RZ sims with flux injection

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1482,6 +1482,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
 #ifdef WARPX_DIM_RZ
     const int nmodes = WarpX::n_rz_azimuthal_modes;
+    const bool rz_random_theta = m_rz_random_theta;
     bool radially_weighted = plasma_injector->radially_weighted;
 #endif
 
@@ -1793,7 +1794,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
                 // Replace the x and y, setting an angle theta.
                 // These x and y are used to get the momentum and density
                 Real theta;
-                if (nmodes == 1 && m_rz_random_theta) {
+                if (nmodes == 1 && rz_random_theta) {
                     // With only 1 mode, the angle doesn't matter so
                     // choose it randomly.
                     theta = 2._prt*MathConst::pi*amrex::Random(engine);


### PR DESCRIPTION
After #3585, WarpX crashes on GPU for RZ simulations with flux plasma injection, with:
```
an illegal memory access was encountered !!!
```
(e.g. for this example: https://github.com/ECP-WarpX/WarpX/blob/development/Examples/Tests/flux_injection/inputs_rz) 

This was due to an implicit capture from the variable `m_rz_random_theta`. This PR fixes it.