### PR TITLE
Fix: RTD urllib3

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,19 @@
 #
 # License: BSD-3-Clause-LBNL
 
-requirements_file: Docs/requirements.txt
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: Docs/source/conf.py
+
+python:
+   install:
+   - requirements: Docs/requirements.txt
 
 formats:
   - htmlzip


### PR DESCRIPTION
Use a newer Ubuntu that ships a recent OpenSSL when building Sphinx with RTD. This migrates a broken dependency for urllib3 in version 3+.

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/envs/3883/lib/python3.7/site-packages/sphinx/builders/linkcheck.py", line 18, in <module>
    from requests import Response
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/envs/3883/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/envs/3883/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168
```

X-ref: https://github.com/urllib3/urllib3/issues/2168