### PR TITLE
ROCm 5.2+

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -15,16 +15,19 @@ Please see installation instructions below.
 Optional dependencies include:
 
 - `MPI 3.0+ <https://www.mpi-forum.org/docs/>`__: for multi-node and/or multi-GPU execution
-- `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
-- `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution (currently not fully accelerated)
-- `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support
+- for on-node accelerated compute *one of either*:
+
+  - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution or
+  - `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_) or
+  - `ROCm 5.2+ (5.5+ recommended) <https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-rocm-installation-readme/>`__: for AMD GPU support
+- `FFTW3 <http://www.fftw.org>`_: for spectral solver (PSATD) support when running on CPU or SYCL
 
   - also needs the ``pkg-config`` tool on Unix
 - `BLAS++ <https://github.com/icl-utk-edu/blaspp>`_ and `LAPACK++ <https://github.com/icl-utk-edu/lapackpp>`_: for spectral solver (PSATD) support in RZ geometry
 - `Boost 1.66.0+ <https://www.boost.org/>`__: for QED lookup tables generation support
 - `openPMD-api 0.15.1+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support
 
-  - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
+  - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__, i.e., ADIOS2 and/or HDF5
 - `Ascent 0.8.0+ <https://ascent.readthedocs.io>`__: for in situ 3D visualization
 - `SENSEI 4.0.0+ <https://sensei-insitu.org>`__: for in situ analysis and visualization
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)

--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -144,6 +144,6 @@ Known System Issues
 
    January, 2023 (OLCFDEV-1284, AMD Ticket: ORNLA-130):
    We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
-   Reported to AMD and investigating.
+   Reported to AMD and fixed for the 5.5 release of ROCm.
 
-   Stay with the ROCm 5.2 module to avoid.
+   Upgrade ROCm or stay with the ROCm 5.2 module to avoid.

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -131,6 +131,6 @@ Known System Issues
 
    January, 2023 (OLCFDEV-1284, AMD Ticket: ORNLA-130):
    We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
-   Reported to AMD and fixed for the next release of ROCm.
+   Reported to AMD and fixed for the 5.5 release of ROCm.
 
-   Stay with the ROCm 5.2 module to avoid.
+   Upgrade ROCm or stay with the ROCm 5.2 module to avoid.

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -105,6 +105,6 @@ Known System Issues
 
    January, 2023:
    We discovered a regression in AMD ROCm, leading to 2x slower current deposition (and other slowdowns) in ROCm 5.3 and 5.4.
-   Reported to AMD and investigating.
+   Reported to AMD and fixed for the 5.5 release of ROCm.
 
-   Stay with the ROCm 5.2 module to avoid.
+   Upgrade ROCm or stay with the ROCm 5.2 module to avoid.

--- a/Source/FieldSolver/SpectralSolver/AnyFFT.H
+++ b/Source/FieldSolver/SpectralSolver/AnyFFT.H
@@ -17,7 +17,11 @@
 // cstddef: work-around for ROCm/rocFFT <=4.3.0
 // https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
 #  include <cstddef>
-#  include <rocfft/rocfft.h>
+#  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#    include <rocfft/rocfft.h>
+#  else
+#    include <rocfft.h>
+#  endif
 #else
 #  include <fftw3.h>
 #endif

--- a/Source/Utils/WarpXrocfftUtil.cpp
+++ b/Source/Utils/WarpXrocfftUtil.cpp
@@ -13,7 +13,11 @@
 // cstddef: work-around for ROCm/rocFFT <=4.3.0
 // https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
 #  include <cstddef>
-#  include <rocfft/rocfft.h>
+#  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#    include <rocfft/rocfft.h>
+#  else
+#    include <rocfft.h>
+#  endif
 #endif
 
 void


### PR DESCRIPTION
ROCm 5.2 is still used on:
- default for LUMI
- systems that do not have 5.5+ and want to avoid the performance regressions of atomics in 5.3 - 5.4

Follow-up to #3888: More careful include for old versions of rocFFT/ROCm.

cc @SeverinDiederichs 