### PR TITLE
Fix typo in Adastra cluster documentation

### DIFF
--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -37,7 +37,7 @@ Use the following commands to download the WarpX source code and switch to the c
 
 We use the following modules and environments on the system (``$HOME/adastra_warpx.profile``).
 
-.. literalinclude:: ../../../../Tools/machines/frontier-olcf/adastra_warpx.profile.example
+.. literalinclude:: ../../../../Tools/machines/adastra-cines/adastra_warpx.profile.example
    :language: bash
    :caption: You can copy this file from ``Tools/machines/adastra-cines/adastra_warpx.profile.example``.
 


### PR DESCRIPTION
I was a bit slow to test and review #3852, sorry about that.

But I've tested the compilation and usage of the code on Adastra and it worked as expected.

I just found this typo, which prevented the `adastra_warpx.profile` file from being displayed in the documentation.