### PR TITLE
Fix calculation of b0 in binary collisions

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/Coulomb/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/UpdateMomentumPerezElastic.H
@@ -106,6 +106,7 @@ void UpdateMomentumPerezElastic (
         // Compute b0
         T_PR const b0 = amrex::Math::abs(q1*q2) * inv_c2 /
                (T_PR(4.0)*MathConst::pi*PhysConst::ep0) * gc/mass_g *
+               ( m1*g1s*m2*g2s/(p1sm*p1sm*inv_c2) + T_PR(1.0) ) *
                ( m1*g1s*m2*g2s/(p1sm*p1sm*inv_c2) + T_PR(1.0) );
 
         // Compute the minimal impact parameter


### PR DESCRIPTION
I believe there is a typo in the calculation of b0 in the binary collisions.
Looking at Eq. 22 from the Pérez paper (https://pubs.aip.org/aip/pop/article/19/8/083104/108747/Improved-modeling-of-relativistic-collisions-and)
![Screenshot 2023-05-16 at 17 09 22](https://github.com/ECP-WarpX/WarpX/assets/65728274/2fc15a16-bfbd-42f6-ad26-53af5a4c8620)

the square of the last term seems to be missing. 

This PR fixes the equation.
