### PR TITLE
Sort  WarpX-tests.ini file

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2739,7 +2739,7 @@ buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
 runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
 dim = 2
-addToCompileString =
+addToCompileString = USE_EB=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
 restartTest = 1
 restartFileNum = 150

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1518,7 +1518,6 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
-
 [Langmuir_multi_psatd_Vay_deposition]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
@@ -2011,7 +2010,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/resampling/analysis_leveling_thinning.py
 
-
 [LoadExternalField3D]
 buildDir = .
 inputFile = Examples/Tests/LoadExternalField/inputs_3d
@@ -2308,7 +2306,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
-
 [particles_in_pml_2d_MR]
 buildDir = .
 inputFile = Examples/Tests/particles_in_pml/inputs_mr_2d
@@ -2394,7 +2391,6 @@ doVis = 0
 compareParticles = 1
 particleTypes = electron proton
 analysisRoutine = Examples/analysis_default_regression.py
-
 
 [Performance_works_1_uniform_rest_32ppc]
 buildDir = .
@@ -3292,6 +3288,66 @@ doVis = 0
 compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
+
+[Python_PlasmaAcceleration]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_plasma_acceleration.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_PlasmaAcceleration1d]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
+dim = 1
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_PlasmaAccelerationMR]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_plasma_acceleration_mr.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = beam
+analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_plasma_lens]
 buildDir = .

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -68,47 +68,31 @@ cmakeSetupOpts = -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON -DWarpX_LIB=ON
 
 # individual problems follow
 
-[pml_x_yee]
+[averaged_galilean_2d_psatd]
 buildDir = .
-inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_chk chk.file_min_digits=5
+inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_2d
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 1
-restartFileNum = 150
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
 useMPI = 1
-numprocs = 2
+numprocs = 1
 useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
-[pml_x_yee_eb]
+[averaged_galilean_2d_psatd_hybrid]
 buildDir = .
-inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
+inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_2d
+runtime_params = amr.max_grid_size_x=128 amr.max_grid_size_y=64 warpx.grid_type=hybrid psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
-restartTest = 1
-restartFileNum = 150
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
-
-[pml_x_ckc]
-buildDir = .
-inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=ckc
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -116,29 +100,14 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/pml/analysis_pml_ckc.py
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
-[pml_x_psatd]
+[averaged_galilean_3d_psatd]
 buildDir = .
-inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 1
-restartFileNum = 150
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
-
-[pml_psatd_dive_divb_cleaning]
-buildDir = .
-inputFile = Examples/Tests/pml/inputs_3d
-runtime_params = warpx.do_similar_dm_pml=0 warpx.abort_on_warning_threshold=medium ablastr.fillboundary_always_sync=1
+inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_3d
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -149,31 +118,53 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[averaged_galilean_3d_psatd_hybrid]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_3d
+runtime_params = warpx.grid_type=hybrid psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[background_mcc]
+buildDir = .
+inputFile = Examples/Physics_applications/capacitive_discharge/inputs_2d
+runtime_params = warpx.abort_on_warning_threshold = high
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons he_ions
 analysisRoutine = Examples/analysis_default_regression.py
 
-[pml_psatd_rz]
+[background_mcc_dp_psp]
 buildDir = .
-inputFile = Examples/Tests/pml/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/pml/analysis_pml_psatd_rz.py
-
-[silver_mueller_2d_x]
-buildDir = .
-inputFile = Examples/Tests/silver_mueller/inputs_2d_x
-runtime_params =
+inputFile = Examples/Physics_applications/capacitive_discharge/inputs_2d
+runtime_params = warpx.abort_on_warning_threshold = high
 dim = 2
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PRECISION=DOUBLE -DWarpX_PARTICLE_PRECISION=SINGLE -DWarpX_QED=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -181,12 +172,14 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+compareParticles = 1
+particleTypes = electrons he_ions
+analysisRoutine = Examples/analysis_default_regression.py
 
-[silver_mueller_2d_z]
+[bilinear_filter]
 buildDir = .
-inputFile = Examples/Tests/silver_mueller/inputs_2d_z
-runtime_params =
+inputFile = Examples/Tests/single_particle/inputs_2d
+runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -197,27 +190,11 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+analysisRoutine = Examples/Tests/single_particle/analysis_bilinear_filter.py
 
-[silver_mueller_1d]
+[BTD_rz]
 buildDir = .
-inputFile = Examples/Tests/silver_mueller/inputs_1d
-runtime_params =
-dim = 1
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=1
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
-
-[silver_mueller_rz_z]
-buildDir = .
-inputFile = Examples/Tests/silver_mueller/inputs_rz_z
+inputFile = Examples/Tests/btd_rz/inputs_rz_z_boosted_BTD
 runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
@@ -229,50 +206,168 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+analysisRoutine = Examples/Tests/btd_rz/analysis_BTD_laser_antenna.py
 
-[RigidInjection_lab]
+[collisionISO]
 buildDir = .
-inputFile = Examples/Tests/rigid_injection/inputs_2d_LabFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_LabFrame.py
-
-[RigidInjection_BTD]
-buildDir = .
-inputFile = Examples/Tests/rigid_injection/inputs_2d_BoostedFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 2
-addToCompileString = USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-doComparison = 0
-analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_BoostedFrame.py
-
-[LaserAcceleration_BTD]
-buildDir = .
-inputFile = Examples/Tests/boosted_diags/inputs_3d
+inputFile = Examples/Tests/collision/inputs_3d_isotropization
 runtime_params =
 dim = 3
-addToCompileString = USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_3d_isotropization.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
+[collisionRZ]
+buildDir = .
+inputFile = Examples/Tests/collision/inputs_rz
+runtime_params =
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=OFF
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_rz.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
+[collisionXYZ]
+buildDir = .
+inputFile = Examples/Tests/collision/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_3d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
+[collisionXZ]
+buildDir = .
+inputFile = Examples/Tests/collision/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
+[comoving_2d_psatd_hybrid]
+buildDir = .
+inputFile = Examples/Tests/comoving/inputs_2d_hybrid
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Deuterium_Deuterium_Fusion_3D]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+
+[Deuterium_Deuterium_Fusion_3D_intraspecies]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
+
+[Deuterium_Tritium_Fusion_3D]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_3d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+
+[Deuterium_Tritium_Fusion_RZ]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_rz
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=high
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+
+[dirichletbc]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_dirichlet_bc/inputs_2d
+runtime_params = warpx.abort_on_warning_threshold = medium
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -281,13 +376,28 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-doComparison = 0
-analysisRoutine = Examples/Tests/boosted_diags/analysis.py
+analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
 
-[nci_corrector]
+[divb_cleaning_3d]
 buildDir = .
-inputFile = Examples/Tests/nci_fdtd_stability/inputs_2d
-runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1
+inputFile = Examples/Tests/divb_cleaning/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/divb_cleaning/analysis.py
+
+[dive_cleaning_2d]
+buildDir = .
+inputFile = Examples/Tests/dive_cleaning/inputs_3d
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -298,16 +408,17 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-doComparison = 0
-analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
+analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
+analysisOutputImage = Comparison.png
 
-[nci_correctorMR]
+[dive_cleaning_3d]
 buildDir = .
-inputFile = Examples/Tests/nci_fdtd_stability/inputs_2d
-runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
-dim = 2
+inputFile = Examples/Tests/dive_cleaning/inputs_3d
+dim = 3
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -315,16 +426,241 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-doComparison = 0
-analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0
+analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
+analysisOutputImage = Comparison.png
 
-[ionization_lab]
+[ElectrostaticSphere]
 buildDir = .
-inputFile = Examples/Tests/ionization/inputs_2d_rt
+inputFile = Examples/Tests/electrostatic_sphere/inputs_3d
+runtime_params = warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
+
+[ElectrostaticSphereEB]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_3d
+runtime_params = warpx.abort_on_warning_threshold = medium
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
+
+[ElectrostaticSphereEB_mixedBCs]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_3d_mixed_BCs
+runtime_params = warpx.abort_on_warning_threshold = medium
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[ElectrostaticSphereEB_RZ]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_rz
+runtime_params = warpx.abort_on_warning_threshold = medium
+dim = 2
+addToCompileString = USE_EB=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
+
+[ElectrostaticSphereEB_RZ_MR]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_rz_mr
+runtime_params =  warpx.abort_on_warning_threshold = medium
+dim = 2
+addToCompileString = USE_EB=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
+
+[ElectrostaticSphereLabFrame]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere/inputs_3d
+runtime_params = warpx.do_electrostatic=labframe
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
+
+[ElectrostaticSphereRZ]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere/inputs_rz
+runtime_params = warpx.abort_on_warning_threshold = medium
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
+
+[embedded_boundary_cube]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_cube/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
+
+[embedded_boundary_cube_2d]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_cube/inputs_2d
 runtime_params =
 dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields_2d.py
+
+[embedded_boundary_cube_macroscopic]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_cube/inputs_3d
+runtime_params = algo.em_solver_medium=macroscopic macroscopic.epsilon=1.5*8.8541878128e-12  macroscopic.sigma=0 macroscopic.mu=1.25663706212e-06
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
+
+[embedded_boundary_python_API]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
+runtime_params =
+customRunCmd = python PICMI_inputs_EB_API.py
+dim = 3
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_python_api/analysis.py
+
+[embedded_boundary_rotated_cube]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_rotated_cube/inputs_3d
+runtime_params = warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields.py
+
+[embedded_boundary_rotated_cube_2d]
+buildDir = .
+inputFile = Examples/Tests/embedded_boundary_rotated_cube/inputs_2d
+runtime_params = warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields_2d.py
+
+[embedded_circle]
+buildDir = .
+inputFile = Examples/Tests/embedded_circle/inputs_2d
+runtime_params = warpx.abort_on_warning_threshold = high
+dim = 2
+addToCompileString = USE_EB=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -332,7 +668,331 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
+compareParticles = 1
+particleTypes = electrons ar_ions
+analysisRoutine = Examples/Tests/embedded_circle/analysis.py
+
+[FieldProbe]
+buildDir = .
+inputFile = Examples/Tests/field_probe/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/field_probe/analysis_field_probe.py
+
+[FluxInjection]
+buildDir = .
+inputFile = Examples/Tests/flux_injection/inputs_rz
+runtime_params = warpx.abort_on_warning_threshold = high
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron
+analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_rz.py
+
+[FluxInjection3D]
+buildDir = .
+inputFile = Examples/Tests/flux_injection/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_3d.py
+
+[galilean_2d_psatd]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
+runtime_params = warpx.grid_type=collocated algo.current_deposition=direct psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_2d_psatd_current_correction]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
+runtime_params = psatd.periodic_single_box_fft=0 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE amr.max_grid_size=64 amr.blocking_factor=64
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_2d_psatd_current_correction_psb]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
+runtime_params = psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_2d_psatd_hybrid]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_2d_hybrid
+runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[galilean_3d_psatd]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
+runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_3d_psatd_current_correction]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
+runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 warpx.numprocs=1 1 2 psatd.periodic_single_box_fft=0 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_3d_psatd_current_correction_psb]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
+runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 warpx.numprocs=1 1 1 psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_rz_psatd]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_rz_psatd_current_correction_psb]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
+runtime_params = psatd.periodic_single_box_fft=1 psatd.current_correction=1 electrons.random_theta=0 ions.random_theta=0
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[galilean_rz_psatd_current_correction]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
+runtime_params = psatd.periodic_single_box_fft=0 psatd.current_correction=1 electrons.random_theta=0 ions.random_theta=0 amr.max_grid_size=32 amr.blocking_factor=32
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
+
+[hard_edged_plasma_lens]
+buildDir = .
+inputFile = Examples/Tests/plasma_lens/inputs_lattice_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/plasma_lens/analysis.py
+
+[hard_edged_quadrupoles]
+buildDir = .
+inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron
+analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
+
+[hard_edged_quadrupoles_boosted]
+buildDir = .
+inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_boosted_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron
+analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
+
+[hard_edged_quadrupoles_moving]
+buildDir = .
+inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_moving_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron
+analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
+
+[initial_distribution]
+buildDir = .
+inputFile = Examples/Tests/initial_distribution/inputs
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/initial_distribution/analysis_distribution.py
+aux1File = Tools/PostProcessing/read_raw_data.py
 
 [ionization_boost]
 buildDir = .
@@ -350,28 +1010,10 @@ compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
 
-[Python_ionization]
+[ionization_lab]
 buildDir = .
-inputFile = Examples/Tests/ionization/PICMI_inputs_2d.py
+inputFile = Examples/Tests/ionization/inputs_2d_rt
 runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
-
-[bilinear_filter]
-buildDir = .
-inputFile = Examples/Tests/single_particle/inputs_2d
-runtime_params = warpx.use_filter=1 warpx.filter_npass_each_dir=1 5
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -382,7 +1024,24 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-analysisRoutine = Examples/Tests/single_particle/analysis_bilinear_filter.py
+analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
+
+[ion_stopping]
+buildDir = .
+inputFile = Examples/Tests/ion_stopping/inputs_3d
+runtime_params = warpx.cfl=0.7
+dim = 3
+addToCompileString =
+cmakeSetupOpts =
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+analysisRoutine = Examples/Tests/ion_stopping/analysis_ion_stopping.py
 
 [Langmuir_multi]
 buildDir = .
@@ -403,13 +1062,13 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
-[Langmuir_multi_single_precision]
+[Langmuir_multi_1d]
 buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 3
-addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
+inputFile = Examples/Tests/langmuir/inputs_1d
+runtime_params = algo.current_deposition=esirkepov diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
+dim = 1
+addToCompileString = USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -419,255 +1078,8 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_multiJ]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.5773502691896258 algo.current_deposition=direct psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = Langmuir_multi_psatd_multiJ.png
-
-[Langmuir_multi_psatd_multiJ_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.5773502691896258 algo.current_deposition=direct psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium warpx.grid_type=collocated
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = Langmuir_multi_psatd_multiJ_nodal.png
-
-[Langmuir_multi_psatd_div_cleaning]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_current_correction]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd algo.current_deposition=esirkepov psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_current_correction_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd algo.current_deposition=direct psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.grid_type=collocated diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_Vay_deposition]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_Vay_deposition_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.grid_type=collocated algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_momentum_conserving]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_psatd_single_precision]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
-dim = 3
-addToCompileString = USE_PSATD=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON -DWarpX_PRECISION=SINGLE
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
-
-[Langmuir_multi_2d_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = warpx.grid_type=collocated algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
+analysisRoutine = Examples/Tests/langmuir/analysis_1d.py
+analysisOutputImage = langmuir_multi_1d_analysis.png
 
 [Langmuir_multi_2d_MR]
 buildDir = .
@@ -726,13 +1138,13 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
 
-[Langmuir_multi_2d_psatd]
+[Langmuir_multi_2d_nodal]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = warpx.grid_type=collocated algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
 dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -745,48 +1157,10 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
-[Langmuir_multi_2d_psatd_multiJ]
+[Langmuir_multi_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.7071067811865475 psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_psatd_multiJ.png
-
-[Langmuir_multi_2d_psatd_multiJ_nodal]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.7071067811865475 psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium warpx.grid_type=collocated
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_psatd_multiJ_nodal.png
-
-[Langmuir_multi_2d_psatd_momentum_conserving]
-buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = algo.maxwell_solver=psatd diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -840,6 +1214,82 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
+[Langmuir_multi_2d_psatd_momentum_conserving]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d
+runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+[Langmuir_multi_2d_psatd_multiJ]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.7071067811865475 psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
+analysisOutputImage = Langmuir_multi_2d_psatd_multiJ.png
+
+[Langmuir_multi_2d_psatd_multiJ_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.7071067811865475 psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium warpx.grid_type=collocated
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
+analysisOutputImage = Langmuir_multi_2d_psatd_multiJ_nodal.png
+
+[Langmuir_multi_2d_psatd_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d
+runtime_params = algo.maxwell_solver=psatd warpx.grid_type=collocated algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
 [Langmuir_multi_2d_psatd_Vay_deposition]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_2d
@@ -878,13 +1328,13 @@ particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
-[Langmuir_multi_2d_psatd_nodal]
+[Langmuir_multi_nodal]
 buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_2d
-runtime_params = algo.maxwell_solver=psatd warpx.grid_type=collocated algo.current_deposition=direct diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -894,16 +1344,16 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
 
-[Langmuir_multi_1d]
+[Langmuir_multi_psatd]
 buildDir = .
-inputFile = Examples/Tests/langmuir/inputs_1d
-runtime_params = algo.current_deposition=esirkepov diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz
-dim = 1
-addToCompileString = USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -913,8 +1363,199 @@ compileTest = 0
 doVis = 0
 compareParticles = 1
 particleTypes = electrons positrons
-analysisRoutine = Examples/Tests/langmuir/analysis_1d.py
-analysisOutputImage = langmuir_multi_1d_analysis.png
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_current_correction]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd algo.current_deposition=esirkepov psatd.periodic_single_box_fft=1 psatd.current_correction=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_current_correction_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd algo.current_deposition=direct psatd.periodic_single_box_fft=1 psatd.current_correction=1 warpx.grid_type=collocated diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_div_cleaning]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258  psatd.update_with_rho = 1  algo.current_deposition = direct  warpx.do_dive_cleaning = 1  warpx.do_divb_cleaning = 1  diag1.intervals = 0, 38:40:1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz part_per_cell rho divE F warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_momentum_conserving]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd algo.field_gathering=momentum-conserving warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_multiJ]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.5773502691896258 algo.current_deposition=direct psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = Langmuir_multi_psatd_multiJ.png
+
+[Langmuir_multi_psatd_multiJ_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl=0.5773502691896258 algo.current_deposition=direct psatd.update_with_rho=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=2 psatd.solution_type=first-order psatd.J_in_time=linear warpx.abort_on_warning_threshold=medium warpx.grid_type=collocated
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = Langmuir_multi_psatd_multiJ_nodal.png
+
+[Langmuir_multi_psatd_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_single_precision]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON -DWarpX_PRECISION=SINGLE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+
+[Langmuir_multi_psatd_Vay_deposition]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
+
+[Langmuir_multi_psatd_Vay_deposition_nodal]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = algo.maxwell_solver=psatd warpx.grid_type=collocated algo.current_deposition=vay diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.5773502691896258
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_rz]
 buildDir = .
@@ -935,41 +1576,6 @@ particleTypes = electrons ions
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[FluxInjection]
-buildDir = .
-inputFile = Examples/Tests/flux_injection/inputs_rz
-runtime_params = warpx.abort_on_warning_threshold = high
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
-analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_rz.py
-
-[FluxInjection3D]
-buildDir = .
-inputFile = Examples/Tests/flux_injection/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts =
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_3d.py
 
 [Langmuir_multi_rz_psatd]
 buildDir = .
@@ -1031,15 +1637,13 @@ analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_multiJ_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
-[Python_Langmuir_rz_multimode]
+[Langmuir_multi_single_precision]
 buildDir = .
-inputFile = Examples/Tests/langmuir/PICMI_inputs_rz.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_rz.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
-target = pip_install
+inputFile = Examples/Tests/langmuir/inputs_3d
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 3
+addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1048,91 +1652,14 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-particleTypes = electrons protons
-analysisRoutine = Examples/analysis_default_regression.py
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
+analysisOutputImage = langmuir_multi_analysis.png
 
-[Python_restart_runtime_components]
+[Larmor]
 buildDir = .
-inputFile = Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_runtime_component_analyze.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 1
-restartFileNum = 5
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
-
-[Python_id_cpu_read]
-buildDir = .
-inputFile = Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_id_cpu_read.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
-
-[Python_restart_eb]
-buildDir = .
-inputFile = Examples/Tests/restart_eb/PICMI_inputs_restart_eb.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_restart_eb.py
-dim = 3
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 1
-restartFileNum = 30
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/restart/analysis_restart.py
-
-[LaserInjection]
-buildDir = .
-inputFile = Examples/Tests/laser_injection/inputs_3d_rt
-runtime_params = max_step=20
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/laser_injection/analysis_laser.py
-analysisOutputImage = laser_analysis.png
-
-[LaserInjection_2d]
-buildDir = .
-inputFile = Examples/Tests/laser_injection/inputs_2d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+inputFile = Examples/Tests/larmor/inputs_2d_mr
+runtime_params = max_step=10
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1143,25 +1670,7 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/laser_injection/analysis_2d.py
-
-[LaserInjection_1d]
-buildDir = .
-inputFile = Examples/Tests/laser_injection/inputs_1d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 1
-addToCompileString = USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/laser_injection/analysis_1d.py
+analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAcceleration]
 buildDir = .
@@ -1170,26 +1679,6 @@ runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_LaserAcceleration]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_3d.py
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1219,48 +1708,10 @@ compareParticles = 1
 particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
-[Python_LaserAcceleration_1d]
+[LaserAccelerationBoost]
 buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_1d.py
-dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserAcceleration_single_precision_comms]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
-runtime_params = warpx.do_single_precision_comms=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/analysis_default_regression.py
-
-[subcyclingMR]
-buildDir = .
-inputFile = Examples/Tests/subcycling/inputs_2d
-runtime_params = warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_boost
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 512 max_step=300
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1271,8 +1722,25 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
+
+[LaserAcceleration_BTD]
+buildDir = .
+inputFile = Examples/Tests/boosted_diags/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+doComparison = 0
+analysisRoutine = Examples/Tests/boosted_diags/analysis.py
 
 [LaserAccelerationMR]
 buildDir = .
@@ -1292,15 +1760,13 @@ compareParticles = 1
 particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
-[Python_LaserAccelerationMR]
+[LaserAccelerationRZ]
 buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_rz
+runtime_params = diag1.dump_rz_modes=1 warpx.abort_on_warning_threshold=high
 dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1312,10 +1778,82 @@ compareParticles = 1
 particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
-[RefinedInjection]
+[LaserAccelerationRZ_opmd]
 buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
-runtime_params = warpx.refine_plasma=1 amr.ref_ratio_vect = 2 1
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_rz
+runtime_params = diag1.format=openpmd diag1.openpmd_backend=h5 max_step=20 diag1.fields_to_plot=Er Bt Bz jr jt jz rho part_per_cell part_per_grid rho_beam rho_electrons warpx.abort_on_warning_threshold=high
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons beam
+outputFile = LaserAccelerationRZ_opmd_plt
+analysisRoutine = Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
+
+[LaserAcceleration_single_precision_comms]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_3d
+runtime_params = warpx.do_single_precision_comms=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[LaserInjection]
+buildDir = .
+inputFile = Examples/Tests/laser_injection/inputs_3d_rt
+runtime_params = max_step=20
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/laser_injection/analysis_laser.py
+analysisOutputImage = laser_analysis.png
+
+[LaserInjection_1d]
+buildDir = .
+inputFile = Examples/Tests/laser_injection/inputs_1d_rt
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 1
+addToCompileString = USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/laser_injection/analysis_1d.py
+
+[LaserInjection_2d]
+buildDir = .
+inputFile = Examples/Tests/laser_injection/inputs_2d_rt
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1326,14 +1864,227 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
-analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
+compareParticles = 0
+analysisRoutine = Examples/Tests/laser_injection/analysis_2d.py
 
-[PlasmaAccelerationMR]
+[LaserInjectionFromBINARYFile]
+buildDir = .
+inputFile = Examples/Tests/laser_injection_from_file/analysis_2d_binary.py
+aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test_binary
+customRunCmd = ./analysis_2d_binary.py
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+selfTest = 1
+stSuccessString = Passed
+doVis = 0
+
+[LaserInjectionFromLASYFile]
+buildDir = .
+inputFile = Examples/Tests/laser_injection_from_file/analysis_3d.py
+aux1File = Examples/Tests/laser_injection_from_file/inputs.3d_test
+customRunCmd = ./analysis_3d.py
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+selfTest = 1
+stSuccessString = Passed
+doVis = 0
+
+[LaserInjectionFromLASYFile_1d]
+buildDir = .
+inputFile = Examples/Tests/laser_injection_from_file/analysis_1d.py
+aux1File = Examples/Tests/laser_injection_from_file/inputs.1d_test
+customRunCmd = ./analysis_1d.py
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 1
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=1
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+selfTest = 1
+stSuccessString = Passed
+doVis = 0
+
+[LaserInjectionFromLASYFile_2d]
+buildDir = .
+inputFile = Examples/Tests/laser_injection_from_file/analysis_2d.py
+aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test
+customRunCmd = ./analysis_2d.py
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+selfTest = 1
+stSuccessString = Passed
+doVis = 0
+
+[LaserInjectionFromLASYFile_RZ]
+buildDir = .
+inputFile = Examples/Tests/laser_injection_from_file/analysis_RZ.py
+aux1File = Examples/Tests/laser_injection_from_file/inputs.RZ_test
+customRunCmd = ./analysis_RZ.py
+runtime_params = warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+selfTest = 1
+stSuccessString = Passed
+doVis = 0
+
+[LaserIonAcc2d]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_ion/inputs
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=384 512 max_step=100
+dim = 2
+addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[LaserOnFine]
+buildDir = .
+inputFile = Examples/Tests/laser_on_fine/inputs_2d
+runtime_params = max_step=50
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[leveling_thinning]
+buildDir = .
+inputFile = Examples/Tests/resampling/inputs_leveling_thinning
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/resampling/analysis_leveling_thinning.py
+
+
+[LoadExternalField3D]
+buildDir = .
+inputFile = Examples/Tests/LoadExternalField/inputs_3d
+runtime_params = warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = proton
+analysisRoutine = Examples/Tests/LoadExternalField/analysis_3d.py
+
+[LoadExternalFieldRZ]
+buildDir = .
+inputFile = Examples/Tests/LoadExternalField/inputs_rz
+runtime_params = warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = proton
+analysisRoutine = Examples/Tests/LoadExternalField/analysis_rz.py
+
+[magnetostatic_eb_3d]
+buildDir = .
+inputFile = Examples/Tests/magnetostatic_eb/inputs_3d
+runtime_params =  warpx.abort_on_warning_threshold = medium
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 2
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Maxwell_Hybrid_QED_solver]
+buildDir = .
+inputFile = Examples/Tests/maxwell_hybrid_qed/inputs_2d
+runtime_params = warpx.cfl=0.7071067811865475
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/maxwell_hybrid_qed/analysis_Maxwell_QED_Hybrid.py
+
+[momentum-conserving-gather]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1348,105 +2099,28 @@ compareParticles = 1
 particleTypes = beam driver plasma_e
 analysisRoutine = Examples/analysis_default_regression.py
 
-[Python_Langmuir]
+[multi_J_rz_psatd]
 buildDir = .
-inputFile = Examples/Tests/langmuir/PICMI_inputs_3d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_3d.py
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
+inputFile = Examples/Tests/multi_j/inputs_rz
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=medium psatd.J_in_time=linear
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
 restartTest = 0
 useMPI = 1
-numprocs = 1
+numprocs = 2
 useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-particleTypes = electrons
+particleTypes = driver plasma_e plasma_p
 analysisRoutine = Examples/analysis_default_regression.py
 
-[uniform_plasma_restart]
+[nci_corrector]
 buildDir = .
-inputFile = Examples/Physics_applications/uniform_plasma/inputs_3d
-runtime_params = chk.file_prefix=uniform_plasma_restart_chk chk.file_min_digits=5
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 1
-restartFileNum = 6
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
-analysisRoutine = Examples/Tests/restart/analysis_restart.py
-
-[restart]
-buildDir = .
-inputFile = Examples/Tests/restart/inputs
-runtime_params = chk.file_prefix=restart_chk chk.file_min_digits=5
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 1
-restartFileNum = 5
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
-analysisRoutine = Examples/Tests/restart/analysis_restart.py
-
-[restart_psatd]
-buildDir = .
-inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 1
-restartFileNum = 5
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
-analysisRoutine = Examples/Tests/restart/analysis_restart.py
-
-[restart_psatd_time_avg]
-buildDir = .
-inputFile = Examples/Tests/restart/inputs
-runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 1
-restartFileNum = 5
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
-analysisRoutine = Examples/Tests/restart/analysis_restart.py
-
-[space_charge_initialization_2d]
-buildDir = .
-inputFile = Examples/Tests/space_charge_initialization/inputs_3d
+inputFile = Examples/Tests/nci_fdtd_stability/inputs_2d
+runtime_params = amr.max_level=0 particles.use_fdtd_nci_corr=1
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1457,17 +2131,16 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
-analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
+doComparison = 0
+analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
 
-[space_charge_initialization]
+[nci_correctorMR]
 buildDir = .
-inputFile = Examples/Tests/space_charge_initialization/inputs_3d
-dim = 3
+inputFile = Examples/Tests/nci_fdtd_stability/inputs_2d
+runtime_params = amr.max_level=1 particles.use_fdtd_nci_corr=1 amr.n_cell=64 64 warpx.fine_tag_lo=-20.e-6 -20.e-6 warpx.fine_tag_hi=20.e-6 20.e-6
+dim = 2
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1475,28 +2148,8 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
-compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
-analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
-
-[relativistic_space_charge_initialization]
-buildDir = .
-inputFile = Examples/Tests/relativistic_space_charge_initialization/inputs_3d
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
-analysisRoutine = Examples/Tests/relativistic_space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
+doComparison = 0
+analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
 
 [parabolic_channel_initialization_2d_single_precision]
 buildDir = .
@@ -1515,9 +2168,115 @@ compareParticles = 0
 runtime_params = warpx.do_dynamic_scheduling=0
 analysisRoutine = Examples/Tests/initial_plasma_profile/analysis.py
 
-[divb_cleaning_3d]
+[particle_absorption]
 buildDir = .
-inputFile = Examples/Tests/divb_cleaning/inputs_3d
+inputFile = Examples/Tests/particle_boundary_process/inputs_absorption
+runtime_params =
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/particle_boundary_process/analysis_absorption.py
+
+[particle_boundaries_3d]
+buildDir = .
+inputFile = Examples/Tests/boundaries/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+analysisRoutine = Examples/Tests/boundaries/analysis.py
+
+[particle_fields_diags]
+buildDir = .
+inputFile = Examples/Tests/particle_fields_diags/inputs
+aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString = USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags.py
+
+[particle_fields_diags_single_precision]
+buildDir = .
+inputFile = Examples/Tests/particle_fields_diags/inputs
+aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE USE_OPENPMD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE -DWarpX_OPENPMD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags_single.py
+
+[particle_pusher]
+buildDir = .
+inputFile = Examples/Tests/particle_pusher/inputs_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine =  Examples/Tests/particle_pusher/analysis_pusher.py
+
+[particle_scrape]
+buildDir = .
+inputFile = Examples/Tests/particle_boundary_scrape/inputs_scrape
+runtime_params =
+dim = 3
+addToCompileString = USE_EB=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
+
+[particles_in_pml]
+buildDir = .
+inputFile = Examples/Tests/particles_in_pml/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
@@ -1530,43 +2289,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-analysisRoutine = Examples/Tests/divb_cleaning/analysis.py
-
-[dive_cleaning_2d]
-buildDir = .
-inputFile = Examples/Tests/dive_cleaning/inputs_3d
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
-analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
-analysisOutputImage = Comparison.png
-
-[dive_cleaning_3d]
-buildDir = .
-inputFile = Examples/Tests/dive_cleaning/inputs_3d
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
-analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
-analysisOutputImage = Comparison.png
+analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
 [particles_in_pml_2d]
 buildDir = .
@@ -1603,24 +2326,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
-[particles_in_pml]
-buildDir = .
-inputFile = Examples/Tests/particles_in_pml/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
-
-
 [particles_in_pml_3d_MR]
 buildDir = .
 inputFile = Examples/Tests/particles_in_pml/inputs_mr_3d
@@ -1637,6 +2342,167 @@ compileTest = 0
 doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
+
+[PEC_field]
+buildDir = .
+inputFile = Examples/Tests/pec/inputs_field_PEC_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/pec/analysis_pec.py
+
+[PEC_field_mr]
+buildDir = .
+inputFile = Examples/Tests/pec/inputs_field_PEC_mr_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/pec/analysis_pec_mr.py
+
+[PEC_particle]
+buildDir = .
+inputFile = Examples/Tests/pec/inputs_particle_PEC_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electron proton
+analysisRoutine = Examples/analysis_default_regression.py
+
+
+[Performance_works_1_uniform_rest_32ppc]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_1_uniform_rest_32ppc
+runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine =
+
+[Performance_works_2_uniform_rest_1ppc]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_2_uniform_rest_1ppc
+runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine =
+
+[Performance_works_3_uniform_drift_4ppc]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_3_uniform_drift_4ppc
+runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine =
+
+[Performance_works_4_labdiags_2ppc]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_4_labdiags_2ppc
+runtime_params = amr.n_cell=64 64 64 max_step=10 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine =
+
+[Performance_works_5_loadimbalance]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_5_loadimbalance
+runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine =
+
+[Performance_works_6_output_2ppc]
+buildDir = .
+inputFile = Examples/Tests/performance_tests/automated_test_6_output_2ppc
+runtime_params = amr.n_cell=64 64 64 max_step=10
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons ions
+analysisRoutine =
 
 [photon_pusher]
 buildDir = .
@@ -1655,9 +2521,74 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/photon_pusher/analysis_photon_pusher.py
 
-[radiation_reaction]
+[PlasmaAccelerationBoost2d]
 buildDir = .
-inputFile = Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
+inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 256 max_step=20
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[PlasmaAccelerationBoost3d]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=5
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[PlasmaAccelerationBoost3d_hybrid]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=25 warpx.grid_type=hybrid warpx.do_current_centering=0
+dim = 3
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[PlasmaAccelerationMR]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = beam driver plasma_e
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Plasma_lens]
+buildDir = .
+inputFile = Examples/Tests/plasma_lens/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
@@ -1669,8 +2600,816 @@ useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/plasma_lens/analysis.py
+
+[Plasma_lens_boosted]
+buildDir = .
+inputFile = Examples/Tests/plasma_lens/inputs_boosted_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/plasma_lens/analysis.py
+
+[Plasma_lens_short]
+buildDir = .
+inputFile = Examples/Tests/plasma_lens/inputs_short_3d
+runtime_params =
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/plasma_lens/analysis.py
+
+[PlasmaMirror]
+buildDir = .
+inputFile = Examples/Physics_applications/plasma_mirror/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=256 128 max_step=20
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[pml_psatd_dive_divb_cleaning]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_3d
+runtime_params = warpx.do_similar_dm_pml=0 warpx.abort_on_warning_threshold=medium ablastr.fillboundary_always_sync=1
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[pml_psatd_rz]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_rz
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pml/analysis_pml_psatd_rz.py
+
+[pml_x_ckc]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=ckc
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pml/analysis_pml_ckc.py
+
+[pml_x_psatd]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_2d
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 1
+restartFileNum = 150
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
+
+[pml_x_yee]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_chk chk.file_min_digits=5
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 1
+restartFileNum = 150
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
+
+[pml_x_yee_eb]
+buildDir = .
+inputFile = Examples/Tests/pml/inputs_2d
+runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
+restartTest = 1
+restartFileNum = 150
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
+
+[Proton_Boron_Fusion_2D]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_2d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
+
+[Proton_Boron_Fusion_3D]
+buildDir = .
+inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_3d
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
+
+[Python_background_mcc]
+buildDir = .
+inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
 compareParticles = 0
-analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
+analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_2d.py
+
+[Python_background_mcc_1d]
+buildDir = .
+inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_1d.py --test --pythonsolver
+dim = 1
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
+
+[Python_background_mcc_1d_tridiag]
+buildDir = .
+inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_1d.py --test
+dim = 1
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
+
+[Python_collisionXZ]
+buildDir = .
+inputFile = Examples/Tests/collision/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
+aux1File = Regression/PostProcessingUtils/post_processing_utils.py
+
+[Python_dirichletbc]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_dirichlet_bc/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
+
+[Python_ElectrostaticSphereEB]
+buildDir = .
+inputFile = Examples/Tests/electrostatic_sphere_eb/PICMI_inputs_3d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_3d.py
+dim = 3
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
+
+[Python_gaussian_beam]
+buildDir = .
+inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
+customRunCmd = python3 PICMI_inputs_gaussian_beam.py
+runtime_params =
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_gaussian_beam_no_field_output]
+buildDir = .
+inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
+customRunCmd = python3 PICMI_inputs_gaussian_beam.py --fields_to_plot none
+runtime_params =
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine =
+
+[Python_gaussian_beam_opmd]
+buildDir = .
+inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
+customRunCmd = python3 PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+runtime_params =
+dim = 3
+addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine =
+
+[Python_gaussian_beam_opmd_no_field_output]
+buildDir = .
+inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
+customRunCmd = python PICMI_inputs_gaussian_beam.py --diagformat=openpmd --fields_to_plot none
+runtime_params =
+dim = 3
+addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine =
+
+[Python_id_cpu_read]
+buildDir = .
+inputFile = Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_id_cpu_read.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+
+[Python_ionization]
+buildDir = .
+inputFile = Examples/Tests/ionization/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
+
+[Python_Langmuir]
+buildDir = .
+inputFile = Examples/Tests/langmuir/PICMI_inputs_3d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_3d.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_Langmuir_2d]
+buildDir = .
+inputFile = Examples/Tests/langmuir/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_Langmuir_rz_multimode]
+buildDir = .
+inputFile = Examples/Tests/langmuir/PICMI_inputs_rz.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_rz.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons protons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_LaserAcceleration]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_3d.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_LaserAcceleration_1d]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_1d.py
+dim = 1
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_LaserAccelerationMR]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_LaserAccelerationRZ]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_rz.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_rz.py
+dim = 2
+addToCompileString = USE_RZ=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons beam
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_magnetostatic_eb_3d]
+buildDir = .
+inputFile = Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_3d.py
+dim = 3
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF -DWarpX_EB=ON
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+analysisRoutine =  Examples/analysis_default_regression.py
+
+[Python_magnetostatic_eb_rz]
+buildDir = .
+inputFile = Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_rz.py
+dim = 2
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF -DWarpX_EB=ON
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+analysisRoutine = Examples/Tests/magnetostatic_eb/analysis_rz.py
+
+[Python_particle_attr_access]
+buildDir = .
+inputFile = Examples/Tests/particle_data_python/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/particle_data_python/analysis.py
+
+[Python_particle_attr_access_unique]
+buildDir = .
+inputFile = Examples/Tests/particle_data_python/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py --unique
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/particle_data_python/analysis.py
+
+[Python_particle_reflection]
+buildDir = .
+inputFile = Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_reflection.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/particle_boundary_process/analysis_reflection.py
+
+[Python_particle_scrape]
+buildDir = .
+inputFile = Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_scrape.py
+dim = 3
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
+
+[Python_pass_mpi_comm]
+buildDir = .
+inputFile = Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
+
+[Python_plasma_lens]
+buildDir = .
+inputFile = Examples/Tests/plasma_lens/PICMI_inputs_3d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_3d.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/plasma_lens/analysis.py
+
+[Python_prev_positions]
+buildDir = .
+inputFile = Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_prev_pos_2d.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Python_reduced_diags_loadbalancecosts_timers]
+buildDir = .
+inputFile = Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
+customRunCmd = python3 PICMI_inputs_loadbalancecosts.py
+dim = 3
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+
+[Python_restart_eb]
+buildDir = .
+inputFile = Examples/Tests/restart_eb/PICMI_inputs_restart_eb.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_restart_eb.py
+dim = 3
+addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 1
+restartFileNum = 30
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+
+[Python_restart_runtime_components]
+buildDir = .
+inputFile = Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_runtime_component_analyze.py
+dim = 2
+addToCompileString = USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
+target = pip_install
+restartTest = 1
+restartFileNum = 5
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+
+[Python_wrappers]
+buildDir = .
+inputFile = Examples/Tests/python_wrappers/PICMI_inputs_2d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_2d.py
+dim = 2
+addToCompileString = USE_PSATD=TRUE USE_PYTHON_MAIN=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_APP=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/analysis_default_regression.py
 
 [qed_breit_wheeler_2d]
 buildDir = .
@@ -1680,24 +3419,6 @@ runtime_params = warpx.abort_on_warning_threshold = high
 dim = 2
 addToCompileString = QED=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_QED=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_yt.py
-
-[qed_breit_wheeler_3d]
-buildDir = .
-inputFile = Examples/Tests/qed/breit_wheeler/inputs_3d
-aux1File = Examples/Tests/qed/breit_wheeler/analysis_core.py
-runtime_params = warpx.abort_on_warning_threshold = high
-dim = 3
-addToCompileString = QED=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -1726,6 +3447,24 @@ doVis = 0
 compareParticles = 0
 outputFile = qed_breit_wheeler_2d_opmd_plt
 analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_opmd.py
+
+[qed_breit_wheeler_3d]
+buildDir = .
+inputFile = Examples/Tests/qed/breit_wheeler/inputs_3d
+aux1File = Examples/Tests/qed/breit_wheeler/analysis_core.py
+runtime_params = warpx.abort_on_warning_threshold = high
+dim = 3
+addToCompileString = QED=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_QED=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_yt.py
 
 [qed_breit_wheeler_3d_opmd]
 buildDir = .
@@ -1844,285 +3583,13 @@ compileTest = 0
 doVis = 0
 analysisRoutine = Examples/Tests/qed/schwinger/analysis_schwinger.py
 
-[particle_pusher]
+[radiation_reaction]
 buildDir = .
-inputFile = Examples/Tests/particle_pusher/inputs_3d
+inputFile = Examples/Tests/radiation_reaction/test_const_B_analytical/inputs_3d
 runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine =  Examples/Tests/particle_pusher/analysis_pusher.py
-
-[Python_gaussian_beam]
-buildDir = .
-inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
-customRunCmd = python3 PICMI_inputs_gaussian_beam.py
-runtime_params =
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_gaussian_beam_opmd]
-buildDir = .
-inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
-customRunCmd = python3 PICMI_inputs_gaussian_beam.py --diagformat=openpmd
-runtime_params =
-dim = 3
-addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine =
-
-[Python_gaussian_beam_no_field_output]
-buildDir = .
-inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
-customRunCmd = python3 PICMI_inputs_gaussian_beam.py --fields_to_plot none
-runtime_params =
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine =
-
-[Python_gaussian_beam_opmd_no_field_output]
-buildDir = .
-inputFile = Examples/Tests/gaussian_beam/PICMI_inputs_gaussian_beam.py
-customRunCmd = python PICMI_inputs_gaussian_beam.py --diagformat=openpmd --fields_to_plot none
-runtime_params =
-dim = 3
-addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine =
-
-[PlasmaAccelerationBoost2d]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 256 max_step=20
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_PlasmaAcceleration]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_plasma_acceleration.py
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_PlasmaAccelerationMR]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_plasma_acceleration_mr.py
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_PlasmaAcceleration1d]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_1d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_plasma_acceleration_1d.py
-dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[PlasmaAccelerationBoost3d]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=5
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[PlasmaAccelerationBoost3d_hybrid]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=25 warpx.grid_type=hybrid warpx.do_current_centering=0
-dim = 3
-addToCompileString =
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[PlasmaMirror]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_mirror/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=256 128 max_step=20
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserIonAcc2d]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_ion/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=384 512 max_step=100
-dim = 2
-addToCompileString = USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[momentum-conserving-gather]
-buildDir = .
-inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam driver plasma_e
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserAccelerationRZ]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/inputs_rz
-runtime_params = diag1.dump_rz_modes=1 warpx.abort_on_warning_threshold=high
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserAccelerationRZ_opmd]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/inputs_rz
-runtime_params = diag1.format=openpmd diag1.openpmd_backend=h5 max_step=20 diag1.fields_to_plot=Er Bt Bz jr jt jz rho part_per_cell part_per_grid rho_beam rho_electrons warpx.abort_on_warning_threshold=high
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2131,427 +3598,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-particleTypes = electrons beam
-outputFile = LaserAccelerationRZ_opmd_plt
-analysisRoutine = Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
-
-[Python_LaserAccelerationRZ]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/PICMI_inputs_rz.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_rz.py
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_Langmuir_2d]
-buildDir = .
-inputFile = Examples/Tests/langmuir/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserOnFine]
-buildDir = .
-inputFile = Examples/Tests/laser_on_fine/inputs_2d
-runtime_params = max_step=50
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[RepellingParticles]
-buildDir = .
-inputFile = Examples/Tests/repelling_particles/inputs_2d
-runtime_params =
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/repelling_particles/analysis_repelling.py
-
-[Larmor]
-buildDir = .
-inputFile = Examples/Tests/larmor/inputs_2d_mr
-runtime_params = max_step=10
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Uniform_2d]
-buildDir = .
-inputFile = Examples/Physics_applications/uniform_plasma/inputs_2d
-runtime_params =
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserAccelerationBoost]
-buildDir = .
-inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 512 max_step=300
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[LaserInjectionFromLASYFile]
-buildDir = .
-inputFile = Examples/Tests/laser_injection_from_file/analysis_3d.py
-aux1File = Examples/Tests/laser_injection_from_file/inputs.3d_test
-customRunCmd = ./analysis_3d.py
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-selfTest = 1
-stSuccessString = Passed
-doVis = 0
-
-[LaserInjectionFromLASYFile_2d]
-buildDir = .
-inputFile = Examples/Tests/laser_injection_from_file/analysis_2d.py
-aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test
-customRunCmd = ./analysis_2d.py
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-selfTest = 1
-stSuccessString = Passed
-doVis = 0
-
-[LaserInjectionFromLASYFile_RZ]
-buildDir = .
-inputFile = Examples/Tests/laser_injection_from_file/analysis_RZ.py
-aux1File = Examples/Tests/laser_injection_from_file/inputs.RZ_test
-customRunCmd = ./analysis_RZ.py
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-selfTest = 1
-stSuccessString = Passed
-doVis = 0
-
-[LaserInjectionFromLASYFile_1d]
-buildDir = .
-inputFile = Examples/Tests/laser_injection_from_file/analysis_1d.py
-aux1File = Examples/Tests/laser_injection_from_file/inputs.1d_test
-customRunCmd = ./analysis_1d.py
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 1
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=1
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-selfTest = 1
-stSuccessString = Passed
-doVis = 0
-
-[LaserInjectionFromBINARYFile]
-buildDir = .
-inputFile = Examples/Tests/laser_injection_from_file/analysis_2d_binary.py
-aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test_binary
-customRunCmd = ./analysis_2d_binary.py
-runtime_params = warpx.do_dynamic_scheduling=0
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-selfTest = 1
-stSuccessString = Passed
-doVis = 0
-
-[collisionXYZ]
-buildDir = .
-inputFile = Examples/Tests/collision/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/collision/analysis_collision_3d.py
-aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[collisionISO]
-buildDir = .
-inputFile = Examples/Tests/collision/inputs_3d_isotropization
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/collision/analysis_collision_3d_isotropization.py
-aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[collisionXZ]
-buildDir = .
-inputFile = Examples/Tests/collision/inputs_2d
-runtime_params =
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
-aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[Python_collisionXZ]
-buildDir = .
-inputFile = Examples/Tests/collision/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
-aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[collisionRZ]
-buildDir = .
-inputFile = Examples/Tests/collision/inputs_rz
-runtime_params =
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=OFF
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/collision/analysis_collision_rz.py
-aux1File = Regression/PostProcessingUtils/post_processing_utils.py
-
-[Proton_Boron_Fusion_3D]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
-
-[Proton_Boron_Fusion_2D]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
-
-[Deuterium_Tritium_Fusion_3D]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
-
-[Deuterium_Deuterium_Fusion_3D]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
-
-[Deuterium_Deuterium_Fusion_3D_intraspecies]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
-
-[Deuterium_Tritium_Fusion_RZ]
-buildDir = .
-inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=high
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
-
-[Maxwell_Hybrid_QED_solver]
-buildDir = .
-inputFile = Examples/Tests/maxwell_hybrid_qed/inputs_2d
-runtime_params = warpx.cfl=0.7071067811865475
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/maxwell_hybrid_qed/analysis_Maxwell_QED_Hybrid.py
+analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
 
 [reduced_diags]
 buildDir = .
@@ -2571,28 +3618,10 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
 
-[reduced_diags_single_precision]
-buildDir = .
-inputFile = Examples/Tests/reduced_diags/inputs
-aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
-
-[reduced_diags_loadbalancecosts_timers]
+[reduced_diags_loadbalancecosts_heuristic]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Heuristic
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2606,15 +3635,13 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
-[Python_reduced_diags_loadbalancecosts_timers]
+[reduced_diags_loadbalancecosts_timers]
 buildDir = .
-inputFile = Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
+inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
-customRunCmd = python3 PICMI_inputs_loadbalancecosts.py
 dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
+addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
-target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2642,10 +3669,45 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
-[reduced_diags_loadbalancecosts_heuristic]
+[reduced_diags_single_precision]
 buildDir = .
-inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Heuristic
+inputFile = Examples/Tests/reduced_diags/inputs
+aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 3
+addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
+
+[RefinedInjection]
+buildDir = .
+inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d
+runtime_params = warpx.refine_plasma=1 amr.ref_ratio_vect = 2 1
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons beam
+analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
+
+[relativistic_space_charge_initialization]
+buildDir = .
+inputFile = Examples/Tests/relativistic_space_charge_initialization/inputs_3d
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2657,16 +3719,90 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+runtime_params = warpx.do_dynamic_scheduling=0
+analysisRoutine = Examples/Tests/relativistic_space_charge_initialization/analysis.py
+analysisOutputImage = Comparison.png
 
-[particle_fields_diags]
+[RepellingParticles]
 buildDir = .
-inputFile = Examples/Tests/particle_fields_diags/inputs
-aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+inputFile = Examples/Tests/repelling_particles/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/repelling_particles/analysis_repelling.py
+
+[restart]
+buildDir = .
+inputFile = Examples/Tests/restart/inputs
+runtime_params = chk.file_prefix=restart_chk chk.file_min_digits=5
 dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 1
+restartFileNum = 5
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = beam
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+
+[restart_psatd]
+buildDir = .
+inputFile = Examples/Tests/restart/inputs
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 1
+restartFileNum = 5
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = beam
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+
+[restart_psatd_time_avg]
+buildDir = .
+inputFile = Examples/Tests/restart/inputs
+runtime_params = algo.maxwell_solver=psatd psatd.use_default_v_galilean=1 particles.use_fdtd_nci_corr=0 chk.file_prefix=restart_psatd_time_avg_chk chk.file_min_digits=5 boundary.field_lo=periodic periodic damped boundary.field_hi=periodic periodic damped psatd.do_time_averaging=1 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 1
+restartFileNum = 5
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = beam
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+
+[RigidInjection_BTD]
+buildDir = .
+inputFile = Examples/Tests/rigid_injection/inputs_2d_BoostedFrame
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+dim = 2
 addToCompileString = USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
@@ -2675,509 +3811,13 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags.py
+doComparison = 0
+analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_BoostedFrame.py
 
-[particle_fields_diags_single_precision]
+[RigidInjection_lab]
 buildDir = .
-inputFile = Examples/Tests/particle_fields_diags/inputs
-aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
+inputFile = Examples/Tests/rigid_injection/inputs_2d_LabFrame
 runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags_single.py
-
-[galilean_2d_psatd]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
-runtime_params = warpx.grid_type=collocated algo.current_deposition=direct psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_2d_psatd_current_correction_psb]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
-runtime_params = psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_2d_psatd_current_correction]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_2d
-runtime_params = psatd.periodic_single_box_fft=0 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE amr.max_grid_size=64 amr.blocking_factor=64
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_2d_psatd_hybrid]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_2d_hybrid
-runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[comoving_2d_psatd_hybrid]
-buildDir = .
-inputFile = Examples/Tests/comoving/inputs_2d_hybrid
-runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions beam
-analysisRoutine = Examples/analysis_default_regression.py
-
-[galilean_rz_psatd]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_rz_psatd_current_correction_psb]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
-runtime_params = psatd.periodic_single_box_fft=1 psatd.current_correction=1 electrons.random_theta=0 ions.random_theta=0
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_rz_psatd_current_correction]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
-runtime_params = psatd.periodic_single_box_fft=0 psatd.current_correction=1 electrons.random_theta=0 ions.random_theta=0 amr.max_grid_size=32 amr.blocking_factor=32
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_3d_psatd]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
-runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_3d_psatd_current_correction_psb]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
-runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 warpx.numprocs=1 1 1 psatd.periodic_single_box_fft=1 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[galilean_3d_psatd_current_correction]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
-runtime_params = psatd.v_galilean=0. 0. 0.99498743710662 warpx.numprocs=1 1 2 psatd.periodic_single_box_fft=0 psatd.update_with_rho=0 psatd.current_correction=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz jx jy jz rho divE
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[averaged_galilean_2d_psatd]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_2d
-runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[averaged_galilean_2d_psatd_hybrid]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_2d
-runtime_params = amr.max_grid_size_x=128 amr.max_grid_size_y=64 warpx.grid_type=hybrid psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[averaged_galilean_3d_psatd]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_3d
-runtime_params = psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[averaged_galilean_3d_psatd_hybrid]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_avg_3d
-runtime_params = warpx.grid_type=hybrid psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
-
-[multi_J_rz_psatd]
-buildDir = .
-inputFile = Examples/Tests/multi_j/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=medium psatd.J_in_time=linear
-dim = 2
-addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = driver plasma_e plasma_p
-analysisRoutine = Examples/analysis_default_regression.py
-
-[ElectrostaticSphereEB]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_3d
-runtime_params = warpx.abort_on_warning_threshold = medium
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
-
-[ElectrostaticSphereEB_RZ]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_rz
-runtime_params = warpx.abort_on_warning_threshold = medium
-dim = 2
-addToCompileString = USE_EB=TRUE USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
-
-[ElectrostaticSphereEB_RZ_MR]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_rz_mr
-runtime_params =  warpx.abort_on_warning_threshold = medium
-dim = 2
-addToCompileString = USE_EB=TRUE USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
-
-[Python_ElectrostaticSphereEB]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere_eb/PICMI_inputs_3d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_3d.py
-dim = 3
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
-
-[ElectrostaticSphereEB_mixedBCs]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere_eb/inputs_3d_mixed_BCs
-runtime_params = warpx.abort_on_warning_threshold = medium
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[ElectrostaticSphere]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere/inputs_3d
-runtime_params = warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
-
-[ElectrostaticSphereRZ]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere/inputs_rz
-runtime_params = warpx.abort_on_warning_threshold = medium
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
-
-[ElectrostaticSphereLabFrame]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_sphere/inputs_3d
-runtime_params = warpx.do_electrostatic=labframe
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
-
-[FieldProbe]
-buildDir = .
-inputFile = Examples/Tests/field_probe/inputs_2d
-runtime_params =
-dim = 2
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/field_probe/analysis_field_probe.py
-
-[embedded_circle]
-buildDir = .
-inputFile = Examples/Tests/embedded_circle/inputs_2d
-runtime_params = warpx.abort_on_warning_threshold = high
-dim = 2
-addToCompileString = USE_EB=TRUE USE_OPENPMD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ar_ions
-analysisRoutine = Examples/Tests/embedded_circle/analysis.py
-
-[initial_distribution]
-buildDir = .
-inputFile = Examples/Tests/initial_distribution/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/initial_distribution/analysis_distribution.py
-aux1File = Tools/PostProcessing/read_raw_data.py
-
-[leveling_thinning]
-buildDir = .
-inputFile = Examples/Tests/resampling/inputs_leveling_thinning
-runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -3189,731 +3829,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-analysisRoutine = Examples/Tests/resampling/analysis_leveling_thinning.py
-
-[particle_boundaries_3d]
-buildDir = .
-inputFile = Examples/Tests/boundaries/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-analysisRoutine = Examples/Tests/boundaries/analysis.py
-
-[embedded_boundary_cube]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_cube/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
-
-[embedded_boundary_cube_macroscopic]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_cube/inputs_3d
-runtime_params = algo.em_solver_medium=macroscopic macroscopic.epsilon=1.5*8.8541878128e-12  macroscopic.sigma=0 macroscopic.mu=1.25663706212e-06
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
-
-[embedded_boundary_cube_2d]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_cube/inputs_2d
-runtime_params =
-dim = 2
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields_2d.py
-
-[embedded_boundary_rotated_cube]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_rotated_cube/inputs_3d
-runtime_params = warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields.py
-
-[embedded_boundary_rotated_cube_2d]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_rotated_cube/inputs_2d
-runtime_params = warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields_2d.py
-
-[dirichletbc]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_dirichlet_bc/inputs_2d
-runtime_params = warpx.abort_on_warning_threshold = medium
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
-
-[Python_dirichletbc]
-buildDir = .
-inputFile = Examples/Tests/electrostatic_dirichlet_bc/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
-
-[PEC_field]
-buildDir = .
-inputFile = Examples/Tests/pec/inputs_field_PEC_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/pec/analysis_pec.py
-
-[PEC_field_mr]
-buildDir = .
-inputFile = Examples/Tests/pec/inputs_field_PEC_mr_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/pec/analysis_pec_mr.py
-
-[PEC_particle]
-buildDir = .
-inputFile = Examples/Tests/pec/inputs_particle_PEC_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron proton
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_pass_mpi_comm]
-buildDir = .
-inputFile = Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
-
-[Plasma_lens]
-buildDir = .
-inputFile = Examples/Tests/plasma_lens/inputs_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-
-[Plasma_lens_boosted]
-buildDir = .
-inputFile = Examples/Tests/plasma_lens/inputs_boosted_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-
-[Plasma_lens_short]
-buildDir = .
-inputFile = Examples/Tests/plasma_lens/inputs_short_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-
-[Python_plasma_lens]
-buildDir = .
-inputFile = Examples/Tests/plasma_lens/PICMI_inputs_3d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_3d.py
-dim = 3
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-
-[hard_edged_quadrupoles]
-buildDir = .
-inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
-analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
-
-[hard_edged_quadrupoles_moving]
-buildDir = .
-inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_moving_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
-analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
-
-[hard_edged_quadrupoles_boosted]
-buildDir = .
-inputFile = Examples/Tests/AcceleratorLattice/inputs_quad_boosted_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
-analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
-
-[hard_edged_plasma_lens]
-buildDir = .
-inputFile = Examples/Tests/plasma_lens/inputs_lattice_3d
-runtime_params =
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/plasma_lens/analysis.py
-
-[background_mcc]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/inputs_2d
-runtime_params = warpx.abort_on_warning_threshold = high
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons he_ions
-analysisRoutine = Examples/analysis_default_regression.py
-
-[background_mcc_dp_psp]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/inputs_2d
-runtime_params = warpx.abort_on_warning_threshold = high
-dim = 2
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PRECISION=DOUBLE -DWarpX_PARTICLE_PRECISION=SINGLE -DWarpX_QED=OFF
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons he_ions
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Python_background_mcc]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_2d.py
-
-[Python_background_mcc_1d]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_1d.py --test --pythonsolver
-dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
-
-[Python_background_mcc_1d_tridiag]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_1d.py --test
-dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
-
-[particle_absorption]
-buildDir = .
-inputFile = Examples/Tests/particle_boundary_process/inputs_absorption
-runtime_params =
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/particle_boundary_process/analysis_absorption.py
-
-[particle_scrape]
-buildDir = .
-inputFile = Examples/Tests/particle_boundary_scrape/inputs_scrape
-runtime_params =
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
-
-[Python_particle_scrape]
-buildDir = .
-inputFile = Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_scrape.py
-dim = 3
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
-
-[Python_particle_reflection]
-buildDir = .
-inputFile = Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_reflection.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/particle_boundary_process/analysis_reflection.py
-
-[Python_particle_attr_access]
-buildDir = .
-inputFile = Examples/Tests/particle_data_python/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/particle_data_python/analysis.py
-
-[Python_particle_attr_access_unique]
-buildDir = .
-inputFile = Examples/Tests/particle_data_python/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py --unique
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/particle_data_python/analysis.py
-
-[Python_prev_positions]
-buildDir = .
-inputFile = Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_prev_pos_2d.py
-dim = 2
-addToCompileString = USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-analysisRoutine = Examples/analysis_default_regression.py
-
-[Performance_works_1_uniform_rest_32ppc]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_1_uniform_rest_32ppc
-runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine =
-
-[Performance_works_2_uniform_rest_1ppc]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_2_uniform_rest_1ppc
-runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
-analysisRoutine =
-
-[Performance_works_3_uniform_drift_4ppc]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_3_uniform_drift_4ppc
-runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine =
-
-[Performance_works_4_labdiags_2ppc]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_4_labdiags_2ppc
-runtime_params = amr.n_cell=64 64 64 max_step=10 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine =
-
-[Performance_works_5_loadimbalance]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_5_loadimbalance
-runtime_params = amr.max_grid_size=32 amr.n_cell=32 32 32 max_step=5 diagnostics.diags_names=diag1 diag1.intervals=0 diag1.diag_type=Full
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine =
-
-[Performance_works_6_output_2ppc]
-buildDir = .
-inputFile = Examples/Tests/performance_tests/automated_test_6_output_2ppc
-runtime_params = amr.n_cell=64 64 64 max_step=10
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine =
-
-[Python_wrappers]
-buildDir = .
-inputFile = Examples/Tests/python_wrappers/PICMI_inputs_2d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_2d.py
-dim = 2
-addToCompileString = USE_PSATD=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/analysis_default_regression.py
-
-[embedded_boundary_python_API]
-buildDir = .
-inputFile = Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
-runtime_params =
-customRunCmd = python PICMI_inputs_EB_API.py
-dim = 3
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON -DWarpX_APP=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Tests/embedded_boundary_python_api/analysis.py
+analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_LabFrame.py
 
 [scraping]
 buildDir = .
@@ -3932,22 +3848,175 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Tests/scraping/analysis_rz.py
 
-[ion_stopping]
+[silver_mueller_1d]
 buildDir = .
-inputFile = Examples/Tests/ion_stopping/inputs_3d
-runtime_params = warpx.cfl=0.7
-dim = 3
+inputFile = Examples/Tests/silver_mueller/inputs_1d
+runtime_params =
+dim = 1
 addToCompileString =
-cmakeSetupOpts =
+cmakeSetupOpts = -DWarpX_DIMS=1
 restartTest = 0
 useMPI = 1
-numprocs = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+
+[silver_mueller_2d_x]
+buildDir = .
+inputFile = Examples/Tests/silver_mueller/inputs_2d_x
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+
+[silver_mueller_2d_z]
+buildDir = .
+inputFile = Examples/Tests/silver_mueller/inputs_2d_z
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+
+[silver_mueller_rz_z]
+buildDir = .
+inputFile = Examples/Tests/silver_mueller/inputs_rz_z
+runtime_params =
+dim = 2
+addToCompileString = USE_RZ=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=RZ
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
+
+[space_charge_initialization]
+buildDir = .
+inputFile = Examples/Tests/space_charge_initialization/inputs_3d
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0
+analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
+analysisOutputImage = Comparison.png
+
+[space_charge_initialization_2d]
+buildDir = .
+inputFile = Examples/Tests/space_charge_initialization/inputs_3d
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
+analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
+analysisOutputImage = Comparison.png
+
+[subcyclingMR]
+buildDir = .
+inputFile = Examples/Tests/subcycling/inputs_2d
+runtime_params = warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[Uniform_2d]
+buildDir = .
+inputFile = Examples/Physics_applications/uniform_plasma/inputs_2d
+runtime_params =
+dim = 2
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+analysisRoutine = Examples/analysis_default_regression.py
+
+[uniform_plasma_restart]
+buildDir = .
+inputFile = Examples/Physics_applications/uniform_plasma/inputs_3d
+runtime_params = chk.file_prefix=uniform_plasma_restart_chk chk.file_min_digits=5
+dim = 3
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=3
+restartTest = 1
+restartFileNum = 6
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+particleTypes = electrons
+analysisRoutine = Examples/Tests/restart/analysis_restart.py
+
+[uniform_plasma_multiJ]
+buildDir = .
+inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
+runtime_params = psatd.solution_type=first-order psatd.J_in_time=constant psatd.rho_in_time=constant warpx.do_dive_cleaning=1 warpx.do_divb_cleaning=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=1 diag1.fields_to_plot=Bx By Bz divE Ex Ey Ez F G jx jy jz rho warpx.abort_on_warning_threshold=medium
+dim = 3
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 2
 useOMP = 1
 numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 1
-analysisRoutine = Examples/Tests/ion_stopping/analysis_ion_stopping.py
+particleTypes = electrons ions
+analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_multiJ.py
 
 [VayDeposition2D]
 buildDir = .
@@ -3984,130 +4053,3 @@ doVis = 0
 compareParticles = 1
 particleTypes = electron ion
 analysisRoutine = Examples/Tests/vay_deposition/analysis.py
-
-[BTD_rz]
-buildDir = .
-inputFile = Examples/Tests/btd_rz/inputs_rz_z_boosted_BTD
-runtime_params =
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-analysisRoutine = Examples/Tests/btd_rz/analysis_BTD_laser_antenna.py
-
-[uniform_plasma_multiJ]
-buildDir = .
-inputFile = Examples/Tests/nci_psatd_stability/inputs_3d
-runtime_params = psatd.solution_type=first-order psatd.J_in_time=constant psatd.rho_in_time=constant warpx.do_dive_cleaning=1 warpx.do_divb_cleaning=1 warpx.do_multi_J=1 warpx.do_multi_J_n_depositions=1 diag1.fields_to_plot=Bx By Bz divE Ex Ey Ez F G jx jy jz rho warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString = USE_PSATD=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
-analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_multiJ.py
-
-[LoadExternalFieldRZ]
-buildDir = .
-inputFile = Examples/Tests/LoadExternalField/inputs_rz
-runtime_params = warpx.abort_on_warning_threshold=medium
-dim = 2
-addToCompileString = USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
-analysisRoutine = Examples/Tests/LoadExternalField/analysis_rz.py
-
-[LoadExternalField3D]
-buildDir = .
-inputFile = Examples/Tests/LoadExternalField/inputs_3d
-runtime_params = warpx.abort_on_warning_threshold=medium
-dim = 3
-addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
-analysisRoutine = Examples/Tests/LoadExternalField/analysis_3d.py
-
-[Python_magnetostatic_eb_rz]
-buildDir = .
-inputFile = Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_rz.py
-dim = 2
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE USE_RZ=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF -DWarpX_EB=ON
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
-analysisRoutine = Examples/Tests/magnetostatic_eb/analysis_rz.py
-
-[Python_magnetostatic_eb_3d]
-buildDir = .
-inputFile = Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_3d.py
-dim = 3
-addToCompileString = USE_EB=TRUE USE_PYTHON_MAIN=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_APP=OFF -DWarpX_EB=ON
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 1
-numthreads = 2
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
-analysisRoutine =  Examples/analysis_default_regression.py
-
-[magnetostatic_eb_3d]
-buildDir = .
-inputFile = Examples/Tests/magnetostatic_eb/inputs_3d
-runtime_params =  warpx.abort_on_warning_threshold = medium
-dim = 3
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
-restartTest = 0
-useMPI = 1
-numprocs = 1
-useOMP = 2
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/analysis_default_regression.py


### PR DESCRIPTION
This PR sorts the tests in `WarpX-tests.ini` file alphabetically.
FYI, we have 225 tests:

```
[averaged_galilean_2d_psatd]
[averaged_galilean_2d_psatd_hybrid]
[averaged_galilean_3d_psatd]
[averaged_galilean_3d_psatd_hybrid]
[background_mcc]
[background_mcc_dp_psp]
[bilinear_filter]
[BTD_rz]
[collisionISO]
[collisionRZ]
[collisionXYZ]
[collisionXZ]
[comoving_2d_psatd_hybrid]
[Deuterium_Deuterium_Fusion_3D]
[Deuterium_Deuterium_Fusion_3D_intraspecies]
[Deuterium_Tritium_Fusion_3D]
[Deuterium_Tritium_Fusion_RZ]
[dirichletbc]
[divb_cleaning_3d]
[dive_cleaning_2d]
[dive_cleaning_3d]
[ElectrostaticSphere]
[ElectrostaticSphereEB]
[ElectrostaticSphereEB_mixedBCs]
[ElectrostaticSphereEB_RZ]
[ElectrostaticSphereEB_RZ_MR]
[ElectrostaticSphereLabFrame]
[ElectrostaticSphereRZ]
[embedded_boundary_cube]
[embedded_boundary_cube_2d]
[embedded_boundary_cube_macroscopic]
[embedded_boundary_python_API]
[embedded_boundary_rotated_cube]
[embedded_boundary_rotated_cube_2d]
[embedded_circle]
[FieldProbe]
[FluxInjection]
[FluxInjection3D]
[galilean_2d_psatd]
[galilean_2d_psatd_current_correction]
[galilean_2d_psatd_current_correction_psb]
[galilean_2d_psatd_hybrid]
[galilean_3d_psatd]
[galilean_3d_psatd_current_correction]
[galilean_3d_psatd_current_correction_psb]
[galilean_rz_psatd]
[galilean_rz_psatd_current_correction]
[galilean_rz_psatd_current_correction_psb]
[hard_edged_plasma_lens]
[hard_edged_quadrupoles]
[hard_edged_quadrupoles_boosted]
[hard_edged_quadrupoles_moving]
[initial_distribution]
[ionization_boost]
[ionization_lab]
[ion_stopping]
[Langmuir_multi]
[Langmuir_multi_1d]
[Langmuir_multi_2d_MR]
[Langmuir_multi_2d_MR_anisotropic]
[Langmuir_multi_2d_MR_psatd]
[Langmuir_multi_2d_nodal]
[Langmuir_multi_2d_psatd]
[Langmuir_multi_2d_psatd_current_correction]
[Langmuir_multi_2d_psatd_current_correction_nodal]
[Langmuir_multi_2d_psatd_momentum_conserving]
[Langmuir_multi_2d_psatd_multiJ]
[Langmuir_multi_2d_psatd_multiJ_nodal]
[Langmuir_multi_2d_psatd_nodal]
[Langmuir_multi_2d_psatd_Vay_deposition]
[Langmuir_multi_2d_psatd_Vay_deposition_nodal]
[Langmuir_multi_nodal]
[Langmuir_multi_psatd]
[Langmuir_multi_psatd_current_correction]
[Langmuir_multi_psatd_current_correction_nodal]
[Langmuir_multi_psatd_div_cleaning]
[Langmuir_multi_psatd_momentum_conserving]
[Langmuir_multi_psatd_multiJ]
[Langmuir_multi_psatd_multiJ_nodal]
[Langmuir_multi_psatd_nodal]
[Langmuir_multi_psatd_single_precision]
[Langmuir_multi_psatd_Vay_deposition]
[Langmuir_multi_psatd_Vay_deposition_nodal]
[Langmuir_multi_rz]
[Langmuir_multi_rz_psatd]
[Langmuir_multi_rz_psatd_current_correction]
[Langmuir_multi_rz_psatd_multiJ]
[Langmuir_multi_single_precision]
[Larmor]
[LaserAcceleration]
[LaserAcceleration_1d]
[LaserAccelerationBoost]
[LaserAcceleration_BTD]
[LaserAccelerationMR]
[LaserAccelerationRZ]
[LaserAccelerationRZ_opmd]
[LaserAcceleration_single_precision_comms]
[LaserInjection]
[LaserInjection_1d]
[LaserInjection_2d]
[LaserInjectionFromBINARYFile]
[LaserInjectionFromLASYFile]
[LaserInjectionFromLASYFile_1d]
[LaserInjectionFromLASYFile_2d]
[LaserInjectionFromLASYFile_RZ]
[LaserIonAcc2d]
[LaserOnFine]
[leveling_thinning]
[LoadExternalField3D]
[LoadExternalFieldRZ]
[magnetostatic_eb_3d]
[Maxwell_Hybrid_QED_solver]
[momentum-conserving-gather]
[multi_J_rz_psatd]
[nci_corrector]
[nci_correctorMR]
[parabolic_channel_initialization_2d_single_precision]
[particle_absorption]
[particle_boundaries_3d]
[particle_fields_diags]
[particle_fields_diags_single_precision]
[particle_pusher]
[particle_scrape]
[particles_in_pml]
[particles_in_pml_2d]
[particles_in_pml_2d_MR]
[particles_in_pml_3d_MR]
[PEC_field]
[PEC_field_mr]
[PEC_particle]
[Performance_works_1_uniform_rest_32ppc]
[Performance_works_2_uniform_rest_1ppc]
[Performance_works_3_uniform_drift_4ppc]
[Performance_works_4_labdiags_2ppc]
[Performance_works_5_loadimbalance]
[Performance_works_6_output_2ppc]
[photon_pusher]
[PlasmaAccelerationBoost2d]
[PlasmaAccelerationBoost3d]
[PlasmaAccelerationBoost3d_hybrid]
[PlasmaAccelerationMR]
[Plasma_lens]
[Plasma_lens_boosted]
[Plasma_lens_short]
[PlasmaMirror]
[pml_psatd_dive_divb_cleaning]
[pml_psatd_rz]
[pml_x_ckc]
[pml_x_psatd]
[pml_x_yee]
[pml_x_yee_eb]
[Proton_Boron_Fusion_2D]
[Proton_Boron_Fusion_3D]
[Python_background_mcc]
[Python_background_mcc_1d]
[Python_background_mcc_1d_tridiag]
[Python_collisionXZ]
[Python_dirichletbc]
[Python_ElectrostaticSphereEB]
[Python_gaussian_beam]
[Python_gaussian_beam_no_field_output]
[Python_gaussian_beam_opmd]
[Python_gaussian_beam_opmd_no_field_output]
[Python_id_cpu_read]
[Python_ionization]
[Python_Langmuir]
[Python_Langmuir_2d]
[Python_Langmuir_rz_multimode]
[Python_LaserAcceleration]
[Python_LaserAcceleration_1d]
[Python_LaserAccelerationMR]
[Python_LaserAccelerationRZ]
[Python_magnetostatic_eb_3d]
[Python_magnetostatic_eb_rz]
[Python_particle_attr_access]
[Python_particle_attr_access_unique]
[Python_particle_reflection]
[Python_particle_scrape]
[Python_pass_mpi_comm]
[Python_PlasmaAcceleration]
[Python_PlasmaAcceleration1d]
[Python_PlasmaAccelerationMR]
[Python_plasma_lens]
[Python_prev_positions]
[Python_reduced_diags_loadbalancecosts_timers]
[Python_restart_eb]
[Python_restart_runtime_components]
[Python_wrappers]
[qed_breit_wheeler_2d]
[qed_breit_wheeler_2d_opmd]
[qed_breit_wheeler_3d]
[qed_breit_wheeler_3d_opmd]
[qed_quantum_sync_2d]
[qed_quantum_sync_3d]
[qed_schwinger1]
[qed_schwinger2]
[qed_schwinger3]
[qed_schwinger4]
[radiation_reaction]
[reduced_diags]
[reduced_diags_loadbalancecosts_heuristic]
[reduced_diags_loadbalancecosts_timers]
[reduced_diags_loadbalancecosts_timers_psatd]
[reduced_diags_single_precision]
[RefinedInjection]
[relativistic_space_charge_initialization]
[RepellingParticles]
[restart]
[restart_psatd]
[restart_psatd_time_avg]
[RigidInjection_BTD]
[RigidInjection_lab]
[scraping]
[silver_mueller_1d]
[silver_mueller_2d_x]
[silver_mueller_2d_z]
[silver_mueller_rz_z]
[space_charge_initialization]
[space_charge_initialization_2d]
[subcyclingMR]
[Uniform_2d]
[uniform_plasma_multiJ]
[uniform_plasma_restart]
[VayDeposition2D]
[VayDeposition3D]
```