### PR TITLE
Work-Around: I/O w/ GCC 8.3

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -6,7 +6,7 @@ Dependencies
 WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
-- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 8, Clang 7, NVCC 11.0, MSVC 19.15 or newer
+- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 8.4+, Clang 7, NVCC 11.0, MSVC 19.15 or newer
 - `CMake 3.20.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -339,11 +339,9 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 
     for (auto& part_diag : particle_diags) {
         WarpXParticleContainer* pc = part_diag.getParticleContainer();
-        auto tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
-        if (isBTD) {
-            PinnedMemoryParticleContainer* pinned_pc = part_diag.getPinnedParticleContainer();
-            tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
-        }
+        auto tmp = isBTD ?
+            part_diag.getPinnedParticleContainer()->make_alike<amrex::PinnedArenaAllocator>() :
+            pc->make_alike<amrex::PinnedArenaAllocator>();
 
         Vector<std::string> real_names;
         Vector<std::string> int_names;

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -537,13 +537,14 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
 
     WarpXParticleContainer* pc = particle_diags[i].getParticleContainer();
     PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();
-    PinnedMemoryParticleContainer tmp;
-    if (isBTD || use_pinned_pc) {
-        if (!pinned_pc->isDefined()) continue; // Skip to the next particle container
-        tmp = pinned_pc->make_alike<amrex::PinnedArenaAllocator>();
-    } else {
-        tmp = pc->make_alike<amrex::PinnedArenaAllocator>();
-    }
+    if (isBTD || use_pinned_pc)
+        if (!pinned_pc->isDefined())
+            continue;  // Skip to the next particle container
+
+    PinnedMemoryParticleContainer tmp = (isBTD || use_pinned_pc) ?
+        pinned_pc->make_alike<amrex::PinnedArenaAllocator>() :
+        pc->make_alike<amrex::PinnedArenaAllocator>();
+
     // names of amrex::Real and int particle attributes in SoA data
     amrex::Vector<std::string> real_names;
     amrex::Vector<std::string> int_names;


### PR DESCRIPTION
Up to GCC 8.3, severe bugs skipping C++17-required copy elision are present in GCC. Apply work-arounds for issues seen on Lassen (LLNL).

```
Source/Diagnostics/WarpXOpenPMD.cpp(543): error: function "NamedComponentParticleContainer<T_Allocator>::operator=(const NamedComponentParticleContainer<T_Allocator> &) [with T_Allocator=amrex::PinnedArenaAllocator]"
Source/Particles/NamedComponentParticleContainer.H(100): here cannot be referenced -- it is a deleted function

Source/Diagnostics/WarpXOpenPMD.cpp(545): error: function "NamedComponentParticleContainer<T_Allocator>::operator=(const NamedComponentParticleContainer<T_Allocator> &) [with T_Allocator=amrex::PinnedArenaAllocator]"
Source/Particles/NamedComponentParticleContainer.H(100): here cannot be referenced -- it is a deleted function

2 errors detected in the compilation of "Source/Diagnostics/WarpXOpenPMD.cpp".
...

Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp(345): error: function "NamedComponentParticleContainer<T_Allocator>::operator=(const NamedComponentParticleContainer<T_Allocator> &) [with T_Allocator=amrex::PinnedArenaAllocator]"
Source/Particles/NamedComponentParticleContainer.H(100): here cannot be referenced -- it is a deleted function

...
Source/Particles/ParticleBoundaryBuffer.cpp(228): error: function "NamedComponentParticleContainer<T_Allocator>::operator=(const NamedComponentParticleContainer<T_Allocator> &) [with T_Allocator=amrex::PinnedArenaAllocator]"
Source/Particles/NamedComponentParticleContainer.H(100): here cannot be referenced -- it is a deleted function

1 error detected in the compilation of "Source/Particles/ParticleBoundaryBuffer.cpp".
```

(Implementing the copy operator in `NamedComponentParticleContainer` does not help, but might be good to be made explicit for the rule-of-five.)

X-ref:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521
- ...