### PR TITLE
Explicitly delete NamedComponentParticleContainer's copy constructor

### DIFF
--- a/Source/Particles/NamedComponentParticleContainer.H
+++ b/Source/Particles/NamedComponentParticleContainer.H
@@ -94,6 +94,11 @@ public:
     particle_runtime_comps(p_rcomps),
     particle_runtime_icomps(p_ricomps) {}
 
+    /** Copy constructor for NamedComponentParticleContainer */
+    NamedComponentParticleContainer ( const NamedComponentParticleContainer &) = delete;
+    /** Copy operator for NamedComponentParticleContainer */
+    NamedComponentParticleContainer& operator= ( const NamedComponentParticleContainer & ) = delete;
+
     /** Move constructor for NamedComponentParticleContainer */
     NamedComponentParticleContainer ( NamedComponentParticleContainer && ) = default;
     /** Move operator for NamedComponentParticleContainer */


### PR DESCRIPTION
Fulfill the [rule-of-five](https://en.cppreference.com/w/cpp/language/rule_of_three).
The original AMReX PCs that this class wraps are also only move-able, but not copy-able.