### PR TITLE
Field Probe reduced diag: harmonize header format

### DIFF
--- a/Examples/Tests/field_probe/analysis_field_probe.py
+++ b/Examples/Tests/field_probe/analysis_field_probe.py
@@ -24,7 +24,7 @@ filename = "diags/reducedfiles/FP_line.txt"
 
 # Open data file
 df = pd.read_csv(filename, sep=' ')
-df.columns = df.columns.str.replace('#','')
+df.columns = df.columns.str.replace('#', '', n=1)
 df = df.sort_values(by=['[2]part_x_lev0(m)'])
 
 # Select position and Intensity of timestep 500

--- a/Examples/Tests/field_probe/analysis_field_probe.py
+++ b/Examples/Tests/field_probe/analysis_field_probe.py
@@ -24,11 +24,11 @@ filename = "diags/reducedfiles/FP_line.txt"
 
 # Open data file
 df = pd.read_csv(filename, sep=' ')
-df = df.sort_values(by=['[2]part_x_lev0-(m)'])
+df = df.sort_values(by=['[2]part_x_lev0(m)'])
 
 # Select position and Intensity of timestep 500
-x = df.query('`[0]step()` == 500')['[2]part_x_lev0-(m)']
-S = df.query('`[0]step()` == 500')['[11]part_S_lev0-(W*s/m^2)']
+x = df.query('`[0]step()` == 500')['[2]part_x_lev0(m)']
+S = df.query('`[0]step()` == 500')['[11]part_S_lev0(W*s/m^2)']
 xvals = x.to_numpy()
 svals = S.to_numpy()
 

--- a/Examples/Tests/field_probe/analysis_field_probe.py
+++ b/Examples/Tests/field_probe/analysis_field_probe.py
@@ -24,6 +24,7 @@ filename = "diags/reducedfiles/FP_line.txt"
 
 # Open data file
 df = pd.read_csv(filename, sep=' ')
+df.columns = df.columns.str.replace('#','')
 df = df.sort_values(by=['[2]part_x_lev0(m)'])
 
 # Select position and Intensity of timestep 500

--- a/Examples/Tests/field_probe/analysis_field_probe.py
+++ b/Examples/Tests/field_probe/analysis_field_probe.py
@@ -24,7 +24,6 @@ filename = "diags/reducedfiles/FP_line.txt"
 
 # Open data file
 df = pd.read_csv(filename, sep=' ')
-df.columns = df.columns.str.replace('#', '', n=1)
 df = df.sort_values(by=['[2]part_x_lev0(m)'])
 
 # Select position and Intensity of timestep 500

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -164,6 +164,7 @@ FieldProbe::FieldProbe (std::string rd_name)
 
             // write header row
             int c = 0;
+            ofs << "#";
             ofs << "[" << c++ << "]step()";
             ofs << m_sep;
             ofs << "[" << c++ << "]time(s)";
@@ -174,36 +175,36 @@ FieldProbe::FieldProbe (std::string rd_name)
             {
                 u_map =
                 {
-                    {FieldProbePIdx::Ex , "-(V*s/m)"},
-                    {FieldProbePIdx::Ey , "-(V*s/m)"},
-                    {FieldProbePIdx::Ez , "-(V*s/m)"},
-                    {FieldProbePIdx::Bx , "-(T*s)"},
-                    {FieldProbePIdx::By , "-(T*s)"},
-                    {FieldProbePIdx::Bz , "-(T*s)"},
-                    {FieldProbePIdx::S , "-(W*s/m^2)"}
+                    {FieldProbePIdx::Ex , "(V*s/m)"},
+                    {FieldProbePIdx::Ey , "(V*s/m)"},
+                    {FieldProbePIdx::Ez , "(V*s/m)"},
+                    {FieldProbePIdx::Bx , "(T*s)"},
+                    {FieldProbePIdx::By , "(T*s)"},
+                    {FieldProbePIdx::Bz , "(T*s)"},
+                    {FieldProbePIdx::S , "(W*s/m^2)"}
                 };
             }
             else
             {
                 u_map =
                 {
-                    {FieldProbePIdx::Ex , "-(V/m)"},
-                    {FieldProbePIdx::Ey , "-(V/m)"},
-                    {FieldProbePIdx::Ez , "-(V/m)"},
-                    {FieldProbePIdx::Bx , "-(T)"},
-                    {FieldProbePIdx::By , "-(T)"},
-                    {FieldProbePIdx::Bz , "-(T)"},
-                    {FieldProbePIdx::S , "-(W/m^2)"}
+                    {FieldProbePIdx::Ex , "(V/m)"},
+                    {FieldProbePIdx::Ey , "(V/m)"},
+                    {FieldProbePIdx::Ez , "(V/m)"},
+                    {FieldProbePIdx::Bx , "(T)"},
+                    {FieldProbePIdx::By , "(T)"},
+                    {FieldProbePIdx::Bz , "(T)"},
+                    {FieldProbePIdx::S , "(W/m^2)"}
                 };
             }
             for (int lev = 0; lev < nLevel; ++lev)
             {
                 ofs << m_sep;
-                ofs << "[" << c++ << "]part_x_lev" + std::to_string(lev) + "-(m)";
+                ofs << "[" << c++ << "]part_x_lev" + std::to_string(lev) + "(m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]part_y_lev" + std::to_string(lev) + "-(m)";
+                ofs << "[" << c++ << "]part_y_lev" + std::to_string(lev) + "(m)";
                 ofs << m_sep;
-                ofs << "[" << c++ << "]part_z_lev" + std::to_string(lev) + "-(m)";
+                ofs << "[" << c++ << "]part_z_lev" + std::to_string(lev) + "(m)";
                 ofs << m_sep;
                 ofs << "[" << c++ << "]part_Ex_lev" + std::to_string(lev) + u_map[FieldProbePIdx::Ex];
                 ofs << m_sep;

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -164,7 +164,10 @@ FieldProbe::FieldProbe (std::string rd_name)
 
             // write header row
             int c = 0;
-            ofs << "#";
+            // No "#" symbol in FieldProbe header, because the recommended way to read FieldProbe
+            // output is to use pandas, which requires reading the header rather than treating it as a
+            // commented line.
+            // ofs << "#";
             ofs << "[" << c++ << "]step()";
             ofs << m_sep;
             ofs << "[" << c++ << "]time(s)";


### PR DESCRIPTION
I propose here to use the same format for the field probe headers as for the other reduced diagnostics headers. In particular, adding the `#` symbol fixes my workflow based on numpy's `genfromtext()`.