### PR TITLE
Make double->float conversion in LaserProfileFromFile.cpp explicit using static_cast

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
@@ -307,7 +307,9 @@ WarpXLaserProfiles::FromFileLaserProfile::read_data_t_chunk(int t_begin, int t_e
         const int read_size = (i_last - i_first + 1)*m_params.nx*m_params.ny;
         series.flush();
         for (int j=0; j<read_size; j++) {
-            h_E_lasy_data[j] = Complex{ x_data.get()[j].real(), x_data.get()[j].imag() };
+            h_E_lasy_data[j] = Complex{
+                static_cast<amrex::Real>(x_data.get()[j].real()),
+                static_cast<amrex::Real>(x_data.get()[j].imag())};
         }
     }
     //Broadcast E_lasy_data


### PR DESCRIPTION
When I compiled WarpX in single precision, I got the following warning message:
```
/home/lfedeli/Projects/warpx/WarpX/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp: In member function ‘void WarpXLaserProfiles::FromFileLaserProfile::read_data_t_chunk(int, int)’:
/home/lfedeli/Projects/warpx/WarpX/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp:310:61: warning: narrowing conversion of ‘(x_data.std::shared_ptr<std::complex<double> >::<anonymous>.std::__shared_ptr<std::complex<double>, __gnu_cxx::_S_atomic>::get() + ((sizetype)(((long unsigned int)j) * 16)))->std::complex<double>::real()’ from ‘double’ to ‘float’ [-Wnarrowing]
  310 |             h_E_lasy_data[j] = Complex{ x_data.get()[j].real(), x_data.get()[j].imag() };
      |                                         ~~~~~~~~~~~~~~~~~~~~^~
/home/lfedeli/Projects/warpx/WarpX/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp:310:85: warning: narrowing conversion of ‘(x_data.std::shared_ptr<std::complex<double> >::<anonymous>.std::__shared_ptr<std::complex<double>, __gnu_cxx::_S_atomic>::get() + ((sizetype)(((long unsigned int)j) * 16)))->std::complex<double>::imag()’ from ‘double’ to ‘float’ [-Wnarrowing]
  310 |             h_E_lasy_data[j] = Complex{ x_data.get()[j].real(), x_data.get()[j].imag() };

```
This PR silences the warning by making the narrowing conversion explicit.