### PR TITLE
Update required PICMI version

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -11,7 +11,7 @@ docutils>=0.17.1
 
 # PICMI API docs
 # note: keep in sync with version in ../requirements.txt
-picmistandard==0.23.2
+picmistandard==0.24.0
 # for development against an unreleased PICMI version, use:
 # picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -59,7 +59,7 @@ setup(name = 'pywarpx',
       package_dir = {'pywarpx': 'pywarpx'},
       description = """Wrapper of WarpX""",
       package_data = package_data,
-      install_requires = ['numpy', 'picmistandard==0.23.2', 'periodictable'],
+      install_requires = ['numpy', 'picmistandard==0.24.0', 'periodictable'],
       python_requires = '>=3.7',
       zip_safe=False
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ periodictable~=1.5
 
 # PICMI
 # note: don't forget to update the version in Docs/requirements.txt, too
-picmistandard==0.23.2
+picmistandard==0.24.0
 #   for development against an unreleased PICMI version, use:
 #picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 


### PR DESCRIPTION
Because of [recent changes in WarpX](https://github.com/ECP-WarpX/WarpX/pull/3773), the required version is now 0.24.0.