### PR TITLE
Fix wrong executable and missing Werror flag in CI test

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -106,6 +106,11 @@ jobs:
           ccache-openmp-3D-RZ-SP-
     - name: build WarpX
       run: |
+
+        # we need to define this *after* having installed the dependencies,
+        # because the compilation of blaspp raises warnings.
+        export CXXFLAGS="-Werror"
+
         cmake -S . -B build                 \
           -GNinja                           \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -118,7 +118,7 @@ jobs:
 
         cmake --build build -j 2
         ./build/bin/warpx.3d Examples/Physics_applications/laser_acceleration/inputs_3d
-        ./build/bin/warpx.3d Examples/Physics_applications/laser_acceleration/inputs_rz
+        ./build/bin/warpx.rz Examples/Physics_applications/laser_acceleration/inputs_rz
 
   build_gcc_ablastr:
     name: GCC ABLASTR w/o MPI


### PR DESCRIPTION
In recently introduced CI test `warpx.3d` is used to run a RZ simulation, leading to a fail of the test. This PR fixes the bug.

It also adds back the flag `-Werror` to compile WarpX in a particular case where it was removed to allow the compilation of the required dependency `blaspp` (which raises warnings)