### PR TITLE
Doc: rocFFT 5.4+ defaults to in-memory

### DIFF
--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -130,7 +130,7 @@ Known System Issues
 .. warning::
 
    Sep 2nd, 2022:
-   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   rocFFT in ROCm 5.1-5.3 tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/#runtime-compilation>`__ in the home area by default.
    This does not scale, disable it via:
 
    .. code-block:: bash

--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -133,7 +133,7 @@ Known System Issues
 .. warning::
 
    Sep 2nd, 2022 (OLCFDEV-1079):
-   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   rocFFT in ROCm 5.1-5.3 tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/#runtime-compilation>`__ in the home area by default.
    This does not scale, disable it via:
 
    .. code-block:: bash

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -120,7 +120,7 @@ Known System Issues
 .. warning::
 
    Sep 2nd, 2022 (OLCFDEV-1079):
-   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   rocFFT in ROCm 5.1-5.3 tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/#runtime-compilation>`__ in the home area by default.
    This does not scale, disable it via:
 
    .. code-block:: bash

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -132,7 +132,7 @@ Known System Issues
 .. warning::
 
    May 2023:
-   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   rocFFT in ROCm 5.1-5.3 tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/#runtime-compilation>`__ in the home area by default.
    This does not scale, disable it via:
 
    .. code-block:: bash


### PR DESCRIPTION
The JIT cache is now in-memory for ROCm 5.4+. We should potentially disable this work-around once we update modules, so we can make use of faster calls to JITed kernels again.

X-ref:
- https://github.com/ROCmSoftwarePlatform/rocFFT/issues/414
- [LinkedIn comment by Steve Leung](https://www.linkedin.com/feed/update/urn:li:activity:7069391251745193984?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7069391251745193984%2C7071642285452529664%29&replyUrn=urn%3Ali%3Acomment%3A%28activity%3A7069391251745193984%2C7071654773120266240%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287071642285452529664%2Curn%3Ali%3Aactivity%3A7069391251745193984%29&dashReplyUrn=urn%3Ali%3Afsd_comment%3A%287071654773120266240%2Curn%3Ali%3Aactivity%3A7069391251745193984%29)