### PR TITLE
Docs: Make sbatch command consistent with the example file (Perlmutter)

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -256,7 +256,7 @@ To run a simulation, copy the lines above to a file ``perlmutter_gpu.sbatch`` an
 
 .. code-block:: bash
 
-   sbatch perlmutter.sbatch
+   sbatch perlmutter_gpu.sbatch
 
 to submit the job.
 


### PR DESCRIPTION
Just a tiny modification in the sbatch command line to make it consistent with the name of the GPU example file above.