### PR TITLE
precommit: make sure isort output is compatible with black

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,3 +36,6 @@ indent_size = unset
 # isort config
 force_sort_within_sections = true
 known_first_party = amrex,impactx,picmistandard,pywarpx,warpx
+# same as the "black" multi-line import style
+multi_line_output = 3
+include_trailing_comma = True

--- a/Examples/Tests/laser_injection_from_file/analysis_from_RZ_file.py
+++ b/Examples/Tests/laser_injection_from_file/analysis_from_RZ_file.py
@@ -148,8 +148,10 @@ def launch_analysis(executable):
 def main() :
 
     from lasy.laser import Laser
-    from lasy.profiles import (CombinedLongitudinalTransverseProfile,
-                               GaussianProfile)
+    from lasy.profiles import (
+        CombinedLongitudinalTransverseProfile,
+        GaussianProfile,
+    )
     from lasy.profiles.longitudinal import GaussianLongitudinalProfile
     from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
 

--- a/Tools/LibEnsemble/run_libensemble_on_warpx.py
+++ b/Tools/LibEnsemble/run_libensemble_on_warpx.py
@@ -43,8 +43,11 @@ else:
 import all_machine_specs
 from libensemble import libE_logger
 from libensemble.executors.mpi_executor import MPIExecutor
-from libensemble.tools import (add_unique_random_streams, parse_args,
-                               save_libE_output)
+from libensemble.tools import (
+    add_unique_random_streams,
+    parse_args,
+    save_libE_output,
+)
 
 # Import machine-specific run parameters
 if machine == 'local':

--- a/Tools/PerformanceTests/run_automated.py
+++ b/Tools/PerformanceTests/run_automated.py
@@ -13,8 +13,12 @@ import shutil
 import sys
 import time
 
-from functions_perftest import (extract_dataframe, get_file_content,
-                                run_batch_nnode, store_git_hash)
+from functions_perftest import (
+    extract_dataframe,
+    get_file_content,
+    run_batch_nnode,
+    store_git_hash,
+)
 import git
 import pandas as pd
 
@@ -22,14 +26,28 @@ import pandas as pd
 # machine-specific file
 if os.getenv("LMOD_SYSTEM_NAME") == 'summit':
     machine = 'summit'
-    from summit import (executable_name, get_batch_string, get_config_command,
-                        get_run_string, get_submit_job_command, get_test_list,
-                        process_analysis, time_min)
+    from summit import (
+        executable_name,
+        get_batch_string,
+        get_config_command,
+        get_run_string,
+        get_submit_job_command,
+        get_test_list,
+        process_analysis,
+        time_min,
+    )
 if os.getenv("NERSC_HOST") == 'cori':
     machine = 'cori'
-    from cori import (executable_name, get_batch_string, get_config_command,
-                      get_run_string, get_submit_job_command, get_test_list,
-                      process_analysis, time_min)
+    from cori import (
+        executable_name,
+        get_batch_string,
+        get_config_command,
+        get_run_string,
+        get_submit_job_command,
+        get_test_list,
+        process_analysis,
+        time_min,
+    )
 
 # typical use: python run_automated.py --n_node_list='1,8,16,32' --automated
 # Assume warpx, picsar, amrex and perf_logs repos ar in the same directory and


### PR DESCRIPTION
It was observed recently that isort and black pre-commit filters were incompatible.  This PR adds some configuration options to make the isort output compatible with what black expects