### PR TITLE
Docs: Debian/Ubuntu no-MPI

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -60,29 +60,27 @@ Conda (Linux/macOS/Windows)
       conda install -n base conda-libmamba-solver
       conda config --set solver libmamba
 
-With MPI (only Linux/macOS):
+.. tab-set::
 
-.. code-block:: bash
+   .. tab-item:: With MPI (only Linux/macOS)
 
-   conda create -n warpx-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp "openpmd-api=*=mpi_mpich*" python numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba ninja mpich pip virtualenv
-   source activate warpx-dev
+      .. code-block:: bash
 
-Without MPI:
+         conda create -n warpx-cpu-mpich-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp "openpmd-api=*=mpi_mpich*" python numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba ninja mpich pip virtualenv
+         source activate warpx-cpu-mpich-dev
 
-.. code-block:: bash
+         # compile WarpX with -DWarpX_MPI=ON
+         # for pip, use: export WARPX_MPI=ON
 
-   conda create -n warpx-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp openpmd-api python numpy pandas scipy yt fftw pkg-config matplotlib mamba ninja pip virtualenv
-   source activate warpx-dev
+   .. tab-item:: Without MPI
 
-   # compile WarpX with -DWarpX_MPI=OFF
+      .. code-block:: bash
 
-For legacy ``GNUmake`` builds, after each ``source activate warpx-dev``, you also need to set:
+         conda create -n warpx-cpu-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp openpmd-api python numpy pandas scipy yt fftw pkg-config matplotlib mamba ninja pip virtualenv
+         source activate warpx-cpu-dev
 
-.. code-block:: bash
-
-   export FFTW_HOME=${CONDA_PREFIX}
-   export BLASPP_HOME=${CONDA_PREFIX}
-   export LAPACKPP_HOME=${CONDA_PREFIX}
+         # compile WarpX with -DWarpX_MPI=OFF
+         # for pip, use: export WARPX_MPI=OFF
 
 .. tip::
 
@@ -141,13 +139,8 @@ In new terminal sessions, re-activate the environment with
 again.
 Replace ``openmp`` with the equivalent you chose.
 
-For legacy ``GNUmake`` builds, after each ``source activate warpx-openmp-dev``, you also need to set:
-
-.. code-block:: bash
-
-   export FFTW_HOME=${SPACK_ENV}/.spack-env/view
-   export BLASPP_HOME=${SPACK_ENV}/.spack-env/view
-   export LAPACKPP_HOME=${SPACK_ENV}/.spack-env/view
+Compile WarpX with ``-DWarpX_MPI=ON``.
+For ``pip``, use ``export WARPX_MPI=ON``.
 
 
 Brew (macOS/Linux)
@@ -184,17 +177,43 @@ If you also want to compile with PSATD in RZ, you need to manually install BLAS+
    cmake-easyinstall --prefix=/usr/local git+https://github.com/icl-utk-edu/lapackpp.git \
        -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
 
+Compile WarpX with ``-DWarpX_MPI=ON``.
+For ``pip``, use ``export WARPX_MPI=ON``.
+
 
 Apt (Debian/Ubuntu)
 ^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+.. tab-set::
 
-   sudo apt update
-   sudo apt install build-essential ccache cmake g++ git libfftw3-mpi-dev libfftw3-dev libhdf5-openmpi-dev libopenmpi-dev pkg-config python3 python3-matplotlib python3-numpy python3-pandas python3-pip python3-scipy python3-venv
+   .. tab-item:: With MPI (only Linux/macOS)
 
-   # optional:
-   # for CUDA, either install
-   #   https://developer.nvidia.com/cuda-downloads (preferred)
-   # or, if your Debian/Ubuntu is new enough, use the packages
-   #   sudo apt install nvidia-cuda-dev libcub-dev
+      .. code-block:: bash
+
+         sudo apt update
+         sudo apt install build-essential ccache cmake g++ git libfftw3-mpi-dev libfftw3-dev libhdf5-openmpi-dev libopenmpi-dev pkg-config python3 python3-matplotlib python3-numpy python3-pandas python3-pip python3-scipy python3-venv
+
+         # optional:
+         # for CUDA, either install
+         #   https://developer.nvidia.com/cuda-downloads (preferred)
+         # or, if your Debian/Ubuntu is new enough, use the packages
+         #   sudo apt install nvidia-cuda-dev libcub-dev
+
+         # compile WarpX with -DWarpX_MPI=ON
+         # for pip, use: export WARPX_MPI=ON
+
+   .. tab-item:: Without MPI
+
+      .. code-block:: bash
+
+         sudo apt update
+         sudo apt install build-essential ccache cmake g++ git libfftw3-dev libfftw3-dev libhdf5-dev pkg-config python3 python3-matplotlib python3-numpy python3-pandas python3-pip python3-scipy python3-venv
+
+         # optional:
+         # for CUDA, either install
+         #   https://developer.nvidia.com/cuda-downloads (preferred)
+         # or, if your Debian/Ubuntu is new enough, use the packages
+         #   sudo apt install nvidia-cuda-dev libcub-dev
+
+         # compile WarpX with -DWarpX_MPI=OFF
+         # for pip, use: export WARPX_MPI=OFF

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -41,14 +41,16 @@ Optional dependencies include:
   - `lasy <https://lasydoc.readthedocs.io>`__
   - see our ``requirements.txt`` file for compatible versions
 
+If you are on a high-performance computing (HPC) system, then :ref:`please see our separate HPC documentation <install-hpc>`.
 
-Install
--------
-
+For all other systems, we recommend to use a **package dependency manager**:
 Pick *one* of the installation methods below to install all dependencies for WarpX development in a consistent manner.
 
+
 Conda (Linux/macOS/Windows)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
+
+`Conda <https://conda.io>`__/`Mamba <https://mamba.readthedocs.io>`__ are cross-compatible, user-level package managers.
 
 .. tip::
 
@@ -60,6 +62,13 @@ Conda (Linux/macOS/Windows)
       conda install -n base conda-libmamba-solver
       conda config --set solver libmamba
 
+   We recommend to deactivate that conda self-activates its ``base`` environment.
+   This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
+
+   .. code-block:: bash
+
+      conda config --set auto_activate_base false
+
 .. tab-set::
 
    .. tab-item:: With MPI (only Linux/macOS)
@@ -67,7 +76,7 @@ Conda (Linux/macOS/Windows)
       .. code-block:: bash
 
          conda create -n warpx-cpu-mpich-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp "openpmd-api=*=mpi_mpich*" python numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba ninja mpich pip virtualenv
-         source activate warpx-cpu-mpich-dev
+         conda activate warpx-cpu-mpich-dev
 
          # compile WarpX with -DWarpX_MPI=ON
          # for pip, use: export WARPX_MPI=ON
@@ -77,23 +86,17 @@ Conda (Linux/macOS/Windows)
       .. code-block:: bash
 
          conda create -n warpx-cpu-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp openpmd-api python numpy pandas scipy yt fftw pkg-config matplotlib mamba ninja pip virtualenv
-         source activate warpx-cpu-dev
+         conda activate warpx-cpu-dev
 
          # compile WarpX with -DWarpX_MPI=OFF
          # for pip, use: export WARPX_MPI=OFF
 
-.. tip::
 
-   A general option to deactivate that conda self-activates its base environment.
-   This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
+Spack (Linux/macOS)
+-------------------
 
-   .. code-block:: bash
-
-      conda config --set auto_activate_base false
-
-
-Spack (macOS/Linux)
-^^^^^^^^^^^^^^^^^^^
+`Spack <https://spack.readthedocs.io>`__ is a user-level package manager.
+It is primarily written for Linux, with slightly less support for macOS, and future support for Windows.
 
 First, download a `WarpX Spack desktop development environment <https://github.com/ECP-WarpX/WarpX/blob/development/Tools/machines/desktop>`__ of your choice.
 For most desktop developments, pick the OpenMP environment for CPUs unless you have a supported GPU.
@@ -144,7 +147,9 @@ For ``pip``, use ``export WARPX_MPI=ON``.
 
 
 Brew (macOS/Linux)
-^^^^^^^^^^^^^^^^^^
+------------------
+
+`Homebrew (Brew) <https://brew.sh>`__ is a user-level package manager primarily for `Apple macOS <https://en.wikipedia.org/wiki/MacOS>`__, but also supports Linux.
 
 .. code-block:: bash
 
@@ -181,8 +186,10 @@ Compile WarpX with ``-DWarpX_MPI=ON``.
 For ``pip``, use ``export WARPX_MPI=ON``.
 
 
-Apt (Debian/Ubuntu)
-^^^^^^^^^^^^^^^^^^^
+APT (Debian/Ubuntu Linux)
+-------------------------
+
+The `Advanced Package Tool (APT) <https://en.wikipedia.org/wiki/APT_(software)>`__ is a system-level package manager on Debian-based Linux distributions, including Ubuntu.
 
 .. tab-set::
 

--- a/Docs/source/install/hpc/fugaku.rst
+++ b/Docs/source/install/hpc/fugaku.rst
@@ -48,6 +48,7 @@ Then, load ``cmake`` and ``ninja`` using ``spack``:
 At this point we need to download and compile the libraries required for OpenPMD support:
 
 .. code-block:: bash
+
    export CC=$(which mpifcc)
    export CXX=$(which mpiFCC)
    export CFLAGS="-O3 -Nclang -Nlibomp -Klib -g -DNDEBUG"

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -53,6 +53,13 @@ A package for WarpX is available via the `Conda <https://conda.io>`_ package man
       conda install -n base conda-libmamba-solver
       conda config --set solver libmamba
 
+   We recommend to deactivate that conda self-activates its ``base`` environment.
+   This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
+
+   .. code-block:: bash
+
+      conda config --set auto_activate_base false
+
 .. code-block:: bash
 
    conda create -n warpx -c conda-forge warpx
@@ -61,15 +68,6 @@ A package for WarpX is available via the `Conda <https://conda.io>`_ package man
 .. note::
 
    The ``warpx`` `conda package <https://anaconda.org/conda-forge/warpx>`__ does not yet provide GPU support.
-
-.. tip::
-
-   A general option to deactivate that conda self-activates its base environment.
-   This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
-
-   .. code-block:: bash
-
-      conda config --set auto_activate_base false
 
 
 .. _install-spack:


### PR DESCRIPTION
Add details how to install dependencies with `apt` w/o MPI. Add details how to compile w/ and w/o MPI.

First seen as a question in #3952.