### PR TITLE
Doc: Perlmutter (NERSC) Install Helpers

### DIFF
--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -19,11 +19,11 @@ If you are new to this system, **please see the following resources**:
 * `Filesystems <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#data-and-storage>`_:
 
   * ``$HOME``: per-user directory, use only for inputs, source and scripts; backed up; mounted as read-only on compute nodes, that means you cannot run in it (50 GB quota)
-  * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days (recommended)
-  * ``$MEMBERWORK/$proj/``: single user, purged every 90 days (usually smaller quota, 50TB default quota)
-  * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days (50TB default quota)
+  * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days, Lustre (recommended)
+  * ``$MEMBERWORK/$proj/``: single user, purged every 90 days, Lustre (usually smaller quota, 50TB default quota)
+  * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days, Lustre (50TB default quota)
 
-Note: the Orion lustre filesystem on Frontier and the older Alpine GPFS filesystem on Summit are not mounted on each others machines.
+Note: the Orion Lustre filesystem on Frontier and the older Alpine GPFS filesystem on Summit are not mounted on each others machines.
 Use `Globus <https://www.globus.org>`__ to transfer data between them if needed.
 
 
@@ -132,13 +132,12 @@ If you already installed WarpX in the past and want to update it, start by getti
    git status
    git log     # press q to exit
 
-Remove the old Python install:
+And, if needed,
 
-.. code-block:: bash
+- :ref:`update the frontier_warpx.profile file <building-frontier-preparation>`,
+- log out and into the system, activate the now updated environment profile as usual,
+- :ref:`execute the dependency install scripts <building-frontier-preparation>`.
 
-   python3 -m pip uninstall -y pywarpx
-
-And, if needed, :ref:`update the frontier_warpx.profile file and execute the dependency install scripts <building-frontier-preparation>` above again.
 As a last step, clean the build directory ``rm -rf $HOME/src/warpx/build_frontier`` and rebuild WarpX.
 
 

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -14,17 +14,19 @@ If you are new to this system, **please see the following resources**:
 * `NERSC user guide <https://docs.nersc.gov/>`__
 * Batch system: `Slurm <https://docs.nersc.gov/systems/perlmutter/#running-jobs>`__
 * `Jupyter service <https://docs.nersc.gov/services/jupyter/>`__
-* `Production directories <https://docs.nersc.gov/filesystems/perlmutter-scratch/>`__:
+* `Filesystems <https://docs.nersc.gov/filesystems/>`__:
 
-  * ``$PSCRATCH``: per-user production directory, purged every 30 days (<TBD>TB)
-  * ``/global/cscratch1/sd/m3239``: shared production directory for users in the project ``m3239``, purged every 30 days (50TB)
-  * ``/global/cfs/cdirs/m3239/``: community file system for users in the project ``m3239`` (100TB)
+  * ``$HOME``: per-user directory, use only for inputs, source and scripts; backed up (40GB)
+  * ``${CFS}/m3239/``: `community file system <https://docs.nersc.gov/filesystems/community/>`__ for users in the project ``m3239`` (or equivalent); moderate performance (20TB default)
+  * ``$PSCRATCH``: per-user `production directory <https://docs.nersc.gov/filesystems/perlmutter-scratch/>`__; very fast for parallel jobs; purged every 8 weeks (20TB default)
 
 
-Installation
-------------
+.. _building-perlmutter-preparation:
 
-Use the following commands to download the WarpX source code and switch to the correct branch:
+Preparation
+-----------
+
+Use the following commands to download the WarpX source code:
 
 .. code-block:: bash
 
@@ -36,165 +38,109 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
 
    .. tab-item:: A100 GPUs
 
-      We use the following modules and environments on the system (``$HOME/perlmutter_gpu_warpx.profile``).
-
-      .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
-         :language: bash
-         :caption: You can copy this file from ``Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example``.
-
-      We recommend to store the above lines in a file, such as ``$HOME/perlmutter_gpu_warpx.profile``, and load it into your shell after a login:
+      We use system software modules, add environment hints and further dependencies via the file ``$HOME/perlmutter_gpu_warpx.profile``.
+      Create it now:
 
       .. code-block:: bash
 
-         source $HOME/perlmutter_gpu_warpx.profile
+         cp $HOME/src/warpx/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example $HOME/perlmutter_gpu_warpx.profile
 
-      And since Perlmutter does not yet provide a module for them, install ADIOS2, BLAS++ and LAPACK++:
+      .. dropdown:: Script Details
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
+
+         .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+            :language: bash
+
+      Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
+      Perlmutter GPU projects must end in ``..._g``.
+      For example, if you are member of the project ``m3239``, then run ``nano $HOME/perlmutter_gpu_warpx.profile`` and edit line 2 to read:
 
       .. code-block:: bash
 
-        # c-blosc (I/O compression)
-        git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git src/c-blosc
-        rm -rf src/c-blosc-pm-build
-        cmake -S src/c-blosc -B src/c-blosc-pm-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1
-        cmake --build src/c-blosc-pm-build --target install --parallel 16
+         export proj="m3239_g"
 
-        # ADIOS2
-        git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git src/adios2
-        rm -rf src/adios2-pm-build
-        cmake -S src/adios2 -B src/adios2-pm-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3
-        cmake --build src/adios2-pm-build --target install -j 16
+      Exit the ``nano`` editor with ``Ctrl`` + ``O`` (save) and then ``Ctrl`` + ``X`` (exit).
 
-        # BLAS++ (for PSATD+RZ)
-        git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
-        rm -rf src/blaspp-pm-build
-        CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master
-        cmake --build src/blaspp-pm-build --target install --parallel 16
+      .. important::
 
-        # LAPACK++ (for PSATD+RZ)
-        git clone https://github.com/icl-utk-edu/lapackpp.git src/lapackpp
-        rm -rf src/lapackpp-pm-build
-        CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-pm-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master
-        cmake --build src/lapackpp-pm-build --target install --parallel 16
+         Now, and as the first step on future logins to Perlmutter, activate these environment settings:
 
-      Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):
+         .. code-block:: bash
 
-     .. code-block:: bash
+            source $HOME/perlmutter_gpu_warpx.profile
 
-        python3 -m pip install --user --upgrade pip
-        python3 -m pip install --user virtualenv
-        python3 -m pip cache purge
-        rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
-        python3 -m venv ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
-        source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx/bin/activate
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade cython
-        python3 -m pip install --upgrade numpy
-        python3 -m pip install --upgrade pandas
-        python3 -m pip install --upgrade scipy
-        MPICC="cc -target-accel=nvidia80 -shared" python3 -m pip install --upgrade mpi4py --no-build-isolation --no-binary mpi4py
-        python3 -m pip install --upgrade openpmd-api
-        python3 -m pip install --upgrade matplotlib
-        python3 -m pip install --upgrade yt
-        # optional: for libEnsemble
-        python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
-        # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
-        python3 -m pip install --upgrade torch  # CUDA 11.7 compatible wheel
-        python3 -m pip install -r $HOME/src/warpx/Tools/optimas/requirements.txt
+      Finally, since Perlmutter does not yet provide software modules for some of our dependencies, install them once:
 
-     Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+      .. code-block:: bash
 
-     .. code-block:: bash
+         bash $HOME/src/warpx/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
 
-        cd $HOME/src/warpx
-        rm -rf build
+      .. dropdown:: Script Details
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
 
-        cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON
-        cmake --build build -j 16
+         .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+            :language: bash
 
 
    .. tab-item:: CPU Nodes
 
-      We use the following modules and environments on the system (``$HOME/perlmutter_cpu_warpx.profile``).
-
-      .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
-         :language: bash
-         :caption: You can copy this file from ``Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example``.
-
-      We recommend to store the above lines in a file, such as ``$HOME/perlmutter_cpu_warpx.profile``, and load it into your shell after a login:
+      We use system software modules, add environment hints and further dependencies via the file ``$HOME/perlmutter_cpu_warpx.profile``.
+      Create it now:
 
       .. code-block:: bash
 
-         source $HOME/perlmutter_cpu_warpx.profile
+         cp $HOME/src/warpx/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example $HOME/perlmutter_cpu_warpx.profile
 
-      And since Perlmutter does not yet provide a module for them, install ADIOS2, BLAS++ and LAPACK++:
+      .. dropdown:: Script Details
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
+
+         .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
+            :language: bash
+
+      Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
+      For example, if you are member of the project ``m3239``, then run ``nano $HOME/perlmutter_cpu_warpx.profile`` and edit line 2 to read:
 
       .. code-block:: bash
 
-        # c-blosc (I/O compression)
-        git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git src/c-blosc
-        rm -rf src/c-blosc-pm-build
-        cmake -S src/c-blosc -B src/c-blosc-pm-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1
-        cmake --build src/c-blosc-pm-build --target install --parallel 16
+         export proj="m3239"
 
-        # ADIOS2
-        git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git src/adios2
-        rm -rf src/adios2-pm-build
-        cmake -S src/adios2 -B src/adios2-pm-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/adios2-2.8.3
-        cmake --build src/adios2-pm-build --target install -j 16
+      Exit the ``nano`` editor with ``Ctrl`` + ``O`` (save) and then ``Ctrl`` + ``X`` (exit).
 
-        # BLAS++ (for PSATD+RZ)
-        git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
-        rm -rf src/blaspp-pm-build
-        CXX=$(which CC) cmake -S src/blaspp -B src/blaspp-pm-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/blaspp-master
-        cmake --build src/blaspp-pm-build --target install --parallel 16
+      .. important::
 
-        # LAPACK++ (for PSATD+RZ)
-        git clone https://github.com/icl-utk-edu/lapackpp.git src/lapackpp
-        rm -rf src/lapackpp-pm-build
-        CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S src/lapackpp -B src/lapackpp-pm-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/lapackpp-master
-        cmake --build src/lapackpp-pm-build --target install --parallel 16
+         Now, and as the first step on future logins to Perlmutter, activate these environment settings:
 
-      Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):
+         .. code-block:: bash
 
-     .. code-block:: bash
+            source $HOME/perlmutter_cpu_warpx.profile
 
-        python3 -m pip install --user --upgrade pip
-        python3 -m pip install --user virtualenv
-        python3 -m pip cache purge
-        rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/venvs/warpx
-        python3 -m venv ${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/venvs/warpx
-        source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade cython
-        python3 -m pip install --upgrade numpy
-        python3 -m pip install --upgrade pandas
-        python3 -m pip install --upgrade scipy
-        MPICC="cc -shared" python3 -m pip install --upgrade mpi4py --no-build-isolation --no-binary mpi4py
-        python3 -m pip install --upgrade openpmd-api
-        python3 -m pip install --upgrade matplotlib
-        python3 -m pip install --upgrade yt
-        # optional: for libEnsemble
-        python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
+      Finally, since Perlmutter does not yet provide software modules for some of our dependencies, install them once:
 
-     Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+      .. code-block:: bash
 
-     .. code-block:: bash
+         bash $HOME/src/warpx/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
 
-        cd $HOME/src/warpx
-        rm -rf build
+      .. dropdown:: Script Details
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
 
-        cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON
-        cmake --build build -j 16
+         .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+            :language: bash
 
-The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
 
-**That's it!**
-A 3D WarpX executable is now in ``build/bin/`` and :ref:`can be run <running-cpp-perlmutter>` with a :ref:`3D example inputs file <usage-examples>`.
-Most people execute the binary directly or copy it out to a location in ``$PSCRATCH``.
+.. _building-perlmutter-compilation:
 
-For a *full PICMI install*, follow the :ref:`instructions for Python (PICMI) bindings <building-cmake-python>`:
+Compilation
+-----------
+
+Use the following :ref:`cmake commands <building-cmake>` to compile:
 
 .. tab-set::
 
@@ -202,34 +148,64 @@ For a *full PICMI install*, follow the :ref:`instructions for Python (PICMI) bin
 
       .. code-block:: bash
 
-         export WARPX_COMPUTE=CUDA
+         cd $HOME/src/warpx
+         rm -rf build_pm_gpu
+
+         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_pm_gpu -j 16
+         cmake --build build_pm_gpu -j 16 --target pip_install
+
+      **That's it!**
+      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_gpu/bin/`` and we installed the ``pywarpx`` Python module.
 
    .. tab-item:: CPU Nodes
 
       .. code-block:: bash
 
-         export WARPX_COMPUTE=OMP
+         cd $HOME/src/warpx
+         rm -rf build_pm_cpu
+
+         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_pm_cpu -j 16
+         cmake --build build_pm_cpu -j 16 --target pip_install
+
+      **That's it!**
+      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_cpu/bin/`` and we installed the ``pywarpx`` Python module.
+
+Now, you can :ref:`submit Perlmutter compute jobs <running-cpp-perlmutter>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
+Or, you can use the WarpX executables to submit Perlmutter jobs (:ref:`example inputs <usage-examples>`).
+For executables, you can reference their location in your :ref:`job script <running-cpp-perlmutter>` or copy them to a location in ``$PSCRATCH``.
+
+
+.. _building-perlmutter-update:
+
+Update WarpX & Dependencies
+---------------------------
+
+If you already installed WarpX in the past and want to update it, start by getting the latest source code:
 
 .. code-block:: bash
 
-   # PICMI build
    cd $HOME/src/warpx
 
-   # install or update dependencies
-   python3 -m pip install -r requirements.txt
+   # read the output of this command - does it look ok?
+   git status
 
-   # compile parallel PICMI interfaces in 3D, 2D, 1D and RZ
-   WARPX_MPI=ON WARPX_PSATD=ON BUILD_PARALLEL=16 python3 -m pip install --force-reinstall --no-deps -v .
+   # get the latest WarpX source code
+   git fetch
+   git pull
 
-Or, if you are *developing*, do a quick PICMI install of a *single geometry* (see: :ref:`WarpX_DIMS <building-cmake-options>`) using:
+   # read the output of these commands - do they look ok?
+   git status
+   git log # press q to exit
 
-.. code-block:: bash
+And, if needed,
 
-   # find dependencies & configure
-   cmake -S . -B build -DWarpX_COMPUTE=${WARPX_COMPUTE} -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS=RZ
+- :ref:`update the perlmutter_gpu_warpx.profile or perlmutter_cpu_warpx files <building-perlmutter-preparation>`,
+- log out and into the system, activate the now updated environment profile as usual,
+- :ref:`execute the dependency install scripts <building-perlmutter-preparation>`.
 
-   # build and then call "python3 -m pip install ..."
-   cmake --build build --target pip_install -j 16
+As a last step, clean the build directory ``rm -rf $HOME/src/warpx/build_pm_*`` and rebuild WarpX.
 
 
 .. _running-cpp-perlmutter:
@@ -237,45 +213,42 @@ Or, if you are *developing*, do a quick PICMI install of a *single geometry* (se
 Running
 -------
 
-.. _running-cpp-perlmutter-A100-GPUs:
+.. tab-set::
 
-A100 GPUs (40 GB)
-^^^^^^^^^^^^^^^^^
+   .. tab-item:: A100 (40GB) GPUs
 
-The batch script below can be used to run a WarpX simulation on multiple nodes (change ``-N`` accordingly) on the supercomputer Perlmutter at NERSC.
-This partition as up to `1536 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__.
+      The batch script below can be used to run a WarpX simulation on multiple nodes (change ``-N`` accordingly) on the supercomputer Perlmutter at NERSC.
+      This partition as up to `1536 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__.
 
-Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<input file>`` could be ``plasma_mirror_inputs``.
-Note that we run one MPI rank per GPU.
+      Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<input file>`` could be ``plasma_mirror_inputs``.
+      Note that we run one MPI rank per GPU.
 
-.. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
-   :language: bash
-   :caption: You can copy this file from ``Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch``.
+      .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
+         :language: bash
+         :caption: You can copy this file from ``$HOME/src/warpx/Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch``.
 
-To run a simulation, copy the lines above to a file ``perlmutter_gpu.sbatch`` and run
+      To run a simulation, copy the lines above to a file ``perlmutter_gpu.sbatch`` and run
 
-.. code-block:: bash
+      .. code-block:: bash
 
-   sbatch perlmutter_gpu.sbatch
+         sbatch perlmutter_gpu.sbatch
 
-to submit the job.
+      to submit the job.
 
-A100 GPUs (80 GB)
-^^^^^^^^^^^^^^^^^
 
-Perlmutter has `256 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__ that provide 80 GB HBM per A100 GPU.
-Replace ``-C gpu`` with ``-C gpu&hbm80g`` in the above job script to use these large-memory GPUs.
+   .. tab-item:: A100 (80GB) GPUs
 
-.. _running-cpp-perlmutter-CPUs:
+      Perlmutter has `256 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__ that provide 80 GB HBM per A100 GPU.
+      In the A100 (40GB) batch script, replace ``-C gpu`` with ``-C gpu&hbm80g`` to use these large-memory GPUs.
 
-CPUs: 2x AMD EPYC 7763
-^^^^^^^^^^^^^^^^^^^^^^
 
-The Perlmutter CPU partition as up to `3072 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__.
+   .. tab-item:: CPU Nodes
 
-.. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch
-   :language: bash
-   :caption: You can copy this file from ``Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch``.
+      The Perlmutter CPU partition as up to `3072 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__, each with 2x AMD EPYC 7763 CPUs.
+
+      .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch
+         :language: bash
+         :caption: You can copy this file from ``$HOME/src/warpx/Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch``.
 
 
 .. _post-processing-perlmutter:

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -3,7 +3,7 @@ export proj=""  # change me!
 
 # remembers the location of this script
 export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-if [ -z "${proj}" ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
 module load cmake/3.23.2
@@ -35,9 +35,9 @@ module load hdf5/1.14.0
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.9.13.1
 
-if [ -d "${HOME}/sw/frontier/gpu/venvs/warpx" ]
+if [ -d "${HOME}/sw/frontier/gpu/venvs/warpx-frontier" ]
 then
-  source ${HOME}/sw/frontier/gpu/venvs/warpx/bin/activate
+  source ${HOME}/sw/frontier/gpu/venvs/warpx-frontier/bin/activate
 fi
 
 # fix system defaults: do not escape $ with a \ on tab completion

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -15,7 +15,7 @@ set -eu -o pipefail
 # Check: ######################################################################
 #
 #   Was perlmutter_gpu_warpx.profile sourced and configured correctly?
-if [ -z "${proj}" ]; then echo "WARNING: The 'proj' variable is not yet set in your frontier_warpx.profile file! Please edit its line 2 to continue!"; return; fi
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your frontier_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
 
 
 # Check $proj variable is correct and has a corresponding CFS directory #######
@@ -47,6 +47,7 @@ if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
   git fetch
+  git checkout master
   git pull
   cd -
 else
@@ -61,6 +62,7 @@ if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
   git fetch
+  git checkout master
   git pull
   cd -
 else
@@ -76,9 +78,9 @@ cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
 python3 -m pip cache purge
-rm -rf ${HOME}/sw/frontier/gpu/venvs/warpx
-python3 -m venv ${HOME}/sw/frontier/gpu/venvs/warpx
-source ${HOME}/sw/frontier/gpu/venvs/warpx/bin/activate
+rm -rf ${HOME}/sw/frontier/gpu/venvs/warpx-frontier
+python3 -m venv ${HOME}/sw/frontier/gpu/venvs/warpx-frontier
+source ${HOME}/sw/frontier/gpu/venvs/warpx-frontier/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade cython

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Copyright 2023 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# Author: Axel Huebl
+# License: BSD-3-Clause-LBNL
+
+# Exit on first error encountered #############################################
+#
+set -eu -o pipefail
+
+
+# Check: ######################################################################
+#
+#   Was perlmutter_cpu_warpx.profile sourced and configured correctly?
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your perlmutter_cpu_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
+
+
+# Check $proj variable is correct and has a corresponding CFS directory #######
+#
+if [ ! -d "${CFS}/${proj}/" ]
+then
+    echo "WARNING: The directory ${CFS}/${proj}/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your perlmutter_cpu_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Remove old dependencies #####################################################
+#
+rm -rf ${CFS}/${proj}/${USER}/sw/perlmutter/cpu
+
+# remove common user mistakes in python, located in .local instead of a venv
+python3 -m pip uninstall -qq -y pywarpx
+python3 -m pip uninstall -qq -y warpx
+python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
+
+
+# General extra dependencies ##################################################
+#
+
+# c-blosc (I/O compression)
+if [ -d $HOME/src/c-blosc ]
+then
+  cd $HOME/src/c-blosc
+  git fetch
+  git checkout v1.21.1
+  cd -
+else
+  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
+fi
+rm -rf $HOME/src/c-blosc-pm-cpu-build
+cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1
+cmake --build $HOME/src/c-blosc-pm-cpu-build --target install --parallel 16
+
+# ADIOS2
+if [ -d $HOME/src/adios2 ]
+then
+  cd $HOME/src/adios2
+  git fetch
+  git checkout v2.8.3
+  cd -
+else
+  git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
+fi
+rm -rf $HOME/src/adios2-pm-cpu-build
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3
+cmake --build $HOME/src/adios2-pm-cpu-build --target install -j 16
+
+# BLAS++ (for PSATD+RZ)
+if [ -d $HOME/src/blaspp ]
+then
+  cd $HOME/src/blaspp
+  git fetch
+  git checkout master
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
+fi
+rm -rf $HOME/src/blaspp-pm-cpu-build
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master
+cmake --build $HOME/src/blaspp-pm-cpu-build --target install --parallel 16
+
+# LAPACK++ (for PSATD+RZ)
+if [ -d $HOME/src/lapackpp ]
+then
+  cd $HOME/src/lapackpp
+  git fetch
+  git checkout master
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
+fi
+rm -rf $HOME/src/lapackpp-pm-cpu-build
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master
+cmake --build $HOME/src/lapackpp-pm-cpu-build --target install --parallel 16
+
+
+# Python ######################################################################
+#
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade virtualenv
+python3 -m pip cache purge
+rm -rf ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx
+python3 -m venv ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx
+source ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade wheel
+python3 -m pip install --upgrade cython
+python3 -m pip install --upgrade numpy
+python3 -m pip install --upgrade pandas
+python3 -m pip install --upgrade scipy
+MPICC="cc -shared" python3 -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py
+python3 -m pip install --upgrade openpmd-api
+python3 -m pip install --upgrade matplotlib
+python3 -m pip install --upgrade yt
+# install or update WarpX dependencies such as picmistandard
+python3 -m pip install --upgrade -r $HOME/src/warpx/requirements.txt
+# optional: for libEnsemble
+python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Copyright 2023 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# Author: Axel Huebl
+# License: BSD-3-Clause-LBNL
+
+# Exit on first error encountered #############################################
+#
+set -eu -o pipefail
+
+
+# Check: ######################################################################
+#
+#   Was perlmutter_gpu_warpx.profile sourced and configured correctly?
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your perlmutter_gpu_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
+
+
+# Check $proj variable is correct and has a corresponding CFS directory #######
+#
+if [ ! -d "${CFS}/${proj%_g}/" ]
+then
+    echo "WARNING: The directory ${CFS}/${proj%_g}/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your perlmutter_gpu_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Remove old dependencies #####################################################
+#
+rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu
+
+# remove common user mistakes in python, located in .local instead of a venv
+python3 -m pip uninstall -qq -y pywarpx
+python3 -m pip uninstall -qq -y warpx
+python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
+
+
+# General extra dependencies ##################################################
+#
+
+# c-blosc (I/O compression)
+if [ -d $HOME/src/c-blosc ]
+then
+  cd $HOME/src/c-blosc
+  git fetch
+  git checkout v1.21.1
+  cd -
+else
+  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
+fi
+rm -rf $HOME/src/c-blosc-pm-gpu-build
+cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1
+cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 16
+
+# ADIOS2
+if [ -d $HOME/src/adios2 ]
+then
+  cd $HOME/src/adios2
+  git fetch
+  git checkout v2.8.3
+  cd -
+else
+  git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
+fi
+rm -rf $HOME/src/adios2-pm-gpu-build
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3
+cmake --build $HOME/src/adios2-pm-gpu-build --target install -j 16
+
+# BLAS++ (for PSATD+RZ)
+if [ -d $HOME/src/blaspp ]
+then
+  cd $HOME/src/blaspp
+  git fetch
+  git checkout master
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
+fi
+rm -rf $HOME/src/blaspp-pm-gpu-build
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master
+cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 16
+
+# LAPACK++ (for PSATD+RZ)
+if [ -d $HOME/src/lapackpp ]
+then
+  cd $HOME/src/lapackpp
+  git fetch
+  git checkout master
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
+fi
+rm -rf $HOME/src/lapackpp-pm-gpu-build
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master
+cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
+
+
+# Python ######################################################################
+#
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade virtualenv
+python3 -m pip cache purge
+rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
+python3 -m venv ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
+source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade wheel
+python3 -m pip install --upgrade cython
+python3 -m pip install --upgrade numpy
+python3 -m pip install --upgrade pandas
+python3 -m pip install --upgrade scipy
+MPICC="cc -target-accel=nvidia80 -shared" python3 -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py
+python3 -m pip install --upgrade openpmd-api
+python3 -m pip install --upgrade matplotlib
+python3 -m pip install --upgrade yt
+# install or update WarpX dependencies such as picmistandard
+python3 -m pip install --upgrade -r $HOME/src/warpx/requirements.txt
+# optional: for libEnsemble
+python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
+# optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
+python3 -m pip install --upgrade torch  # CUDA 11.7 compatible wheel
+python3 -m pip install -r $HOME/src/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
@@ -1,5 +1,9 @@
 # please set your project account
-#export proj="<yourProject>"  # change me
+export proj=""  # change me!
+
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
 module load cpu
@@ -11,15 +15,15 @@ export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-22.05/78535/sp
 
 # optional: for openPMD and PSATD+RZ support
 module load cray-hdf5-parallel/1.12.2.1
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/blaspp-master:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/lapackpp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master:$CMAKE_PREFIX_PATH
 
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/blaspp-master/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
 # optional: CCache
 export PATH=/global/common/software/spackecp/perlmutter/e4s-22.05/78535/spack/opt/spack/cray-sles15-zen3/gcc-11.2.0/ccache-4.5.1-ybl7xefvggn6hov4dsdxxnztji74tolj/bin:$PATH
@@ -27,9 +31,9 @@ export PATH=/global/common/software/spackecp/perlmutter/e4s-22.05/78535/spack/op
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.9.13.1
 
-if [ -d "${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/venvs/warpx" ]
+if [ -d "${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx" ]
 then
-  source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
+  source ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
 fi
 
 # an alias to request an interactive batch node for one hour

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -1,5 +1,9 @@
 # please set your project account
-#export proj="<yourProject>_g"  # change me
+export proj=""  # change me! GPU projects must end in "..._g"
+
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
 module load cmake/3.22.0


### PR DESCRIPTION
Based on user feedback, this streamlines the HPC dependency installation docs and makes sure one does not forget to configure the `$proj` environment variable during setup.

The new structure is would then be used blueprint for other systems.

Contains a few follow-up updates to the equivalent Frontier profile #3986.

- [x] compilation workflows tested after downtime
- [x] runtime tested on the head node