### PR TITLE
Fix: Unused Cost GPUClock

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -985,7 +985,7 @@ void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
     WARPX_ABORT_WITH_MESSAGE("Vay deposition not implemented in cartesian 1D geometry");
 #endif
 
-#if !defined(AMREX_USE_GPU)
+#if !defined(WARPX_USE_GPUCLOCK)
     amrex::ignore_unused(cost, load_balance_costs_update_algo);
 #endif
 


### PR DESCRIPTION
By default, seems unused on ROCm.