### PR TITLE
Impose t_lab in Lorentz Transformation for externally loaded particles

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -194,7 +194,8 @@ public:
     void AddPlasmaFlux (amrex::Real dt);
 
     void MapParticletoBoostedFrame (amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
-                                    amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz);
+                                    amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
+                                    amrex::ParticleReal t_lab = 0._prt);
 
     void AddGaussianBeam (
         const amrex::Real x_m, const amrex::Real y_m, const amrex::Real z_m,
@@ -219,7 +220,8 @@ public:
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_ux,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uy,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uz,
-        amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w);
+        amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w,
+        amrex::ParticleReal t_lab= 0._prt);
 
     /**
      * \brief Default initialize runtime attributes in a tile. This routine does not initialize the

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -434,7 +434,6 @@ void PhysicalParticleContainer::MapParticletoBoostedFrame (
     }
     constexpr int lev = 0;
     const amrex::Real t0 = WarpX::GetInstance().gett_new(lev);
-    //amrex::Print() << Utils::TextMsg::Info("getInstance_time = " + std::to_string(t0* std::pow(10.0, 15)));
     z = zpr - (tpr-t0)*vzpr;
 
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -427,13 +427,13 @@ void PhysicalParticleContainer::MapParticletoBoostedFrame (
         uz = -uz;
     }
 
-    // Move the particles to where they will be at t = 0 in the boosted frame
-    if (boost_adjust_transverse_positions) {
-        x = xpr - tpr*vxpr;
-        y = ypr - tpr*vypr;
-    }
+    //Move the particles to where they will be at t = t0, the current simulation time in the boosted frame
     constexpr int lev = 0;
     const amrex::Real t0 = WarpX::GetInstance().gett_new(lev);
+    if (boost_adjust_transverse_positions) {
+        x = xpr - (tpr-t0)*vxpr;
+        y = ypr - (tpr-t0)*vypr;
+    }
     z = zpr - (tpr-t0)*vzpr;
 
 }


### PR DESCRIPTION
Currently, starting a simulation using gamma boost will set t_lab=0 for all species. We would want to perform the Lorentz Transformation by imposing t_lab from the openPMD file when the species is loaded externally and set t_lab=0 by default for handwritten species.
t_lab is the time of the snapshot where the species is extracted (openPMD file's metadata).