### PR TITLE
Doc: Summit (OLCF) Quick Install + Torch

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -5,6 +5,8 @@ Summit (OLCF)
 
 The `Summit cluster <https://www.olcf.ornl.gov/summit/>`_ is located at OLCF.
 
+On Summit, each compute node provides six V100 GPUs (16GB) and two Power9 CPUs.
+
 
 Introduction
 ------------
@@ -16,110 +18,146 @@ If you are new to this system, **please see the following resources**:
 * `Jupyter service <https://jupyter.olcf.ornl.gov>`__
 * `Production directories <https://docs.olcf.ornl.gov/data/index.html#data-storage-and-transfers>`_:
 
+  * ``$HOME``: per-user directory, use only for inputs, source and scripts; backed up; mounted as read-only on compute nodes, that means you cannot run in it (50 GB quota)
   * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days, GPFS (recommended)
   * ``$MEMBERWORK/$proj/``: single user, purged every 90 days, GPFS (usually smaller quota)
   * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days, GPFS
-  * ``/ccs/$proj/``: another, non-GPFS, file system for software and smaller data.
-  * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
-    That means you cannot run in your ``$HOME``.
+  * ``/ccs/proj/$proj/``: another, non-GPFS, file system for software and smaller data.
+
+Note: the Alpine GPFS filesystem on Summit and the new Orion Lustre filesystem on Frontier are not mounted on each others machines.
+Use `Globus <https://www.globus.org>`__ to transfer data between them if needed.
 
 
-Installation
-------------
+.. _building-summit-preparation:
 
-Use the following commands to download the WarpX source code and switch to the correct branch:
+Preparation
+-----------
+
+Use the following commands to download the WarpX source code:
 
 .. code-block:: bash
 
    git clone https://github.com/ECP-WarpX/WarpX.git $HOME/src/warpx
 
-We use the following modules and environments on the system (``$HOME/summit_warpx.profile``).
-
-.. literalinclude:: ../../../../Tools/machines/summit-olcf/summit_warpx.profile.example
-   :language: bash
-   :caption: You can copy this file from ``Tools/machines/summit-olcf/summit_warpx.profile.example``.
-
-
-We recommend to store the above lines in a file, such as ``$HOME/summit_warpx.profile``, and load it into your shell after a login:
+We use system software modules, add environment hints and further dependencies via the file ``$HOME/summit_warpx.profile``.
+Create it now:
 
 .. code-block:: bash
 
-   source $HOME/summit_warpx.profile
+   cp $HOME/src/warpx/Tools/machines/summit-olcf/summit_warpx.profile.example $HOME/summit_warpx.profile
 
-For PSATD+RZ simulations, you will need to build BLAS++ and LAPACK++:
+.. dropdown:: Script Details
+   :color: light
+   :icon: info
+   :animate: fade-in-slide-down
 
-.. code-block:: bash
+   .. literalinclude:: ../../../../Tools/machines/summit-olcf/summit_warpx.profile.example
+      :language: bash
 
-  # BLAS++ (for PSATD+RZ)
-  git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
-  rm -rf src/blaspp-summit-build
-  cmake -S src/blaspp -B src/blaspp-summit-build -Duse_openmp=ON -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/summit/blaspp-master
-  cmake --build src/blaspp-summit-build --target install --parallel 10
-
-  # LAPACK++ (for PSATD+RZ)
-  git clone https://github.com/icl-utk-edu/lapackpp.git src/lapackpp
-  rm -rf src/lapackpp-summit-build
-  cmake -S src/lapackpp -B src/lapackpp-summit-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/summit/lapackpp-master
-  cmake --build src/lapackpp-summit-build --target install --parallel 10
-
-Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (:ref:`libEnsemble <libensemble>`):
+Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
+For example, if you are member of the project ``aph114``, then run ``vi $HOME/summit_warpx.profile``.
+Enter the edit mode by typing ``i`` and edit line 2 to read:
 
 .. code-block:: bash
 
-   python3 -m pip install --user --upgrade pip
-   python3 -m pip install --user virtualenv
-   python3 -m pip cache purge
-   rm -rf $HOME/sw/venvs/warpx
-   python3 -m venv $HOME/sw/venvs/warpx
-   source $HOME/sw/venvs/warpx/bin/activate
-   python3 -m pip install --upgrade pip
-   python3 -m pip install --upgrade wheel
-   python3 -m pip install --upgrade cython
-   python3 -m pip install --upgrade numpy
-   python3 -m pip install --upgrade pandas
-   python3 -m pip install --upgrade scipy
-   python3 -m pip install --upgrade mpi4py --no-binary mpi4py
-   python3 -m pip install --upgrade openpmd-api
-   python3 -m pip install --upgrade matplotlib==3.2.2  # does not try to build freetype itself
-   python3 -m pip install --upgrade yt
-   # WIP: issues with nlopt
-   # python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
+   export proj="aph114"
 
-Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+Exit the ``vi`` editor with ``Esc`` and then type ``:wq`` (write & quit).
+
+.. important::
+
+   Now, and as the first step on future logins to Summit, activate these environment settings:
+
+   .. code-block:: bash
+
+      source $HOME/summit_warpx.profile
+
+Finally, since Summit does not yet provide software modules for some of our dependencies, install them once:
+
+.. code-block:: bash
+
+   bash $HOME/src/warpx/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+
+.. dropdown:: Script Details
+   :color: light
+   :icon: info
+   :animate: fade-in-slide-down
+
+   .. literalinclude:: ../../../../Tools/machines/summit-olcf/install_gpu_dependencies.sh
+      :language: bash
+
+.. dropdown:: AI/ML Dependencies (Optional)
+   :animate: fade-in-slide-down
+
+   If you plan to run AI/ML workflows depending on pyTorch, run the next step as well.
+   This will take a while and should be skipped if not needed.
+
+   .. code-block:: bash
+
+      runNode bash $HOME/src/warpx/Tools/machines/summit-olcf/install_gpu_ml.sh
+
+   .. dropdown:: Script Details
+      :color: light
+      :icon: info
+      :animate: fade-in-slide-down
+
+      .. literalinclude:: ../../../../Tools/machines/summit-olcf/install_gpu_ml.sh
+         :language: bash
+
+
+.. _building-summit-compilation:
+
+Compilation
+-----------
+
+Use the following :ref:`cmake commands <building-cmake>` to compile:
 
 .. code-block:: bash
 
    cd $HOME/src/warpx
-   rm -rf build
+   rm -rf build_summit
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA
-   cmake --build build -j 6
+   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_summit -j 16
+   cmake --build build_summit -j 16 --target pip_install
 
-The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
+**That's it!**
+The WarpX application executables are now in ``$HOME/src/warpx/build_summit/bin/`` and we installed the ``pywarpx`` Python module.
 
-For a full PICMI install, follow the :ref:`instructions for Python (PICMI) bindings <building-cmake-python>`.
-We only prefix it to request a node for the compilation (``runNode``), so we can compile faster:
+Now, you can :ref:`submit Summit compute jobs <running-cpp-summit>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
+Or, you can use the WarpX executables to submit Summit jobs (:ref:`example inputs <usage-examples>`).
+For executables, you can reference their location in your :ref:`job script <running-cpp-summit>` or copy them to a location in ``$PROJWORK/$proj/``.
+
+
+.. _building-summit-update:
+
+Update WarpX & Dependencies
+---------------------------
+
+If you already installed WarpX in the past and want to update it, start by getting the latest source code:
 
 .. code-block:: bash
 
-   # PICMI build
    cd $HOME/src/warpx
 
-   # install or update dependencies
-   python3 -m pip install -r requirements.txt
+   # read the output of this command - does it look ok?
+   git status
 
-   # compile parallel PICMI interfaces in 3D, 2D, 1D and RZ
-   runNode WARPX_MPI=ON WARPX_COMPUTE=CUDA WARPX_PSATD=ON BUILD_PARALLEL=32 python3 -m pip install --force-reinstall --no-deps -v .
+   # get the latest WarpX source code
+   git fetch
+   git pull
 
-Or, if you are *developing*, do a quick PICMI install of a *single geometry* (see: :ref:`WarpX_DIMS <building-cmake-options>`) using:
+   # read the output of these commands - do they look ok?
+   git status
+   git log     # press q to exit
 
-.. code-block:: bash
+And, if needed,
 
-   # find dependencies & configure
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS=RZ
+- :ref:`update the summit_warpx.profile file <building-summit-preparation>`,
+- log out and into the system, activate the now updated environment profile as usual,
+- :ref:`execute the dependency install scripts <building-summit-preparation>`.
 
-   # build and then call "python3 -m pip install ..."
-   cmake --build build --target pip_install -j 6
+As a last step, clean the build directory ``rm -rf $HOME/src/warpx/build_summit`` and rebuild WarpX.
 
 
 .. _running-cpp-summit:

--- a/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+++ b/Tools/machines/summit-olcf/install_gpu_dependencies.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Copyright 2023 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# Author: Axel Huebl
+# License: BSD-3-Clause-LBNL
+
+# Exit on first error encountered #############################################
+#
+set -eu -o pipefail
+
+
+# Check: ######################################################################
+#
+#   Was perlmutter_gpu_warpx.profile sourced and configured correctly?
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your summit_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
+
+
+# Check $proj variable is correct and has a corresponding PROJWORK directory ##
+#
+if [ ! -d "${PROJWORK}/${proj}/" ]
+then
+    echo "WARNING: The directory $PROJWORK/$proj/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your summit_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Check $proj variable is correct and has a corresponding Software directory ##
+#
+if [ ! -d "/ccs/proj/${proj}/" ]
+then
+    echo "WARNING: The directory /ccs/proj/$proj/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your summit_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Remove old dependencies #####################################################
+#
+SW_DIR="/ccs/proj/${proj}/${USER}/sw/summit/gpu/"
+rm -rf ${SW_DIR}
+mkdir -p ${SW_DIR}
+
+# remove common user mistakes in python, located in .local instead of a venv
+python3 -m pip uninstall -qq -y pywarpx
+python3 -m pip uninstall -qq -y warpx
+python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
+
+
+# General extra dependencies ##################################################
+#
+
+# BLAS++ (for PSATD+RZ)
+if [ -d $HOME/src/blaspp ]
+then
+  cd $HOME/src/blaspp
+  git fetch
+  git checkout main
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
+fi
+rm -rf $HOME/src/blaspp-summit-build
+cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-summit-build -Duse_openmp=ON -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
+cmake --build $HOME/src/blaspp-summit-build --target install --parallel 10
+
+# LAPACK++ (for PSATD+RZ)
+if [ -d $HOME/src/lapackpp ]
+then
+  cd $HOME/src/lapackpp
+  git fetch
+  git checkout master
+  git pull
+  cd -
+else
+  git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
+fi
+rm -rf $HOME/src/lapackpp-summit-build
+cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-summit-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
+cmake --build $HOME/src/lapackpp-summit-build --target install --parallel 10
+
+
+# Python ######################################################################
+#
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade virtualenv
+python3 -m pip cache purge
+rm -rf ${SW_DIR}/venvs/warpx-summit
+python3 -m venv ${SW_DIR}/gpu/venvs/warpx-summit
+source ${SW_DIR}/venvs/warpx-summit/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade wheel
+python3 -m pip install --upgrade cython
+python3 -m pip install --upgrade numpy
+python3 -m pip install --upgrade pandas
+python3 -m pip install --upgrade scipy
+python3 -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py
+python3 -m pip install --upgrade openpmd-api
+python3 -m pip install --upgrade matplotlib==3.2.2  # does not try to build freetype itself
+python3 -m pip install --upgrade yt
+
+# install or update WarpX dependencies such as picmistandard
+python3 -m pip install --upgrade -r $HOME/src/warpx/requirements.txt
+
+# for ML dependencies, see install_gpu_ml.sh

--- a/Tools/machines/summit-olcf/install_gpu_ml.sh
+++ b/Tools/machines/summit-olcf/install_gpu_ml.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Copyright 2023 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# Author: Axel Huebl
+# License: BSD-3-Clause-LBNL
+
+# Exit on first error encountered #############################################
+#
+set -eu -o pipefail
+
+
+# Check: ######################################################################
+#
+#   Was perlmutter_gpu_warpx.profile sourced and configured correctly?
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your summit_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
+
+
+# Check $proj variable is correct and has a corresponding PROJWORK directory ##
+#
+if [ ! -d "${PROJWORK}/${proj}/" ]
+then
+    echo "WARNING: The directory $PROJWORK/$proj/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your summit_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Check $proj variable is correct and has a corresponding Software directory ##
+#
+if [ ! -d "/ccs/proj/${proj}/" ]
+then
+    echo "WARNING: The directory /ccs/proj/$proj/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your summit_warpx.profile file to continue!"
+    exit
+fi
+
+
+# Remove old dependencies #####################################################
+#
+# remove common user mistakes in python, located in .local instead of a venv
+python3 -m pip uninstall -qqq -y torch 2>/dev/null || true
+
+
+# Python ML ###################################################################
+#
+# for basic python dependencies, see install_gpu_dependencies.sh
+
+# optional: for libEnsemble - WIP: issues with nlopt
+# python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
+
+# optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
+#   pytorch
+if [ -d /ccs/proj/${proj}/${USER}/src/pytorch ]
+then
+  cd /ccs/proj/${proj}/${USER}/src/pytorch
+  git fetch
+  git checkout .
+  git checkout v2.0.1
+  cd -
+else
+  git clone -b v2.0.1 --recurse-submodules https://github.com/pytorch/pytorch.git /ccs/proj/${proj}/${USER}/src/pytorch
+fi
+cd /ccs/proj/${proj}/${USER}/src/pytorch
+rm -rf build
+python3 -m pip install -r requirements.txt
+#   patch to avoid compile issues
+#   https://github.com/pytorch/pytorch/issues/97497#issuecomment-1499069641
+#   https://github.com/pytorch/pytorch/pull/98511
+wget -q -O - https://github.com/pytorch/pytorch/pull/98511.patch | git apply
+USE_CUDA=1 BLAS=OpenBLAS MAX_JOBS=64 ATEN_AVX512_256=OFF BUILD_TEST=0 python3 setup.py develop
+#   (optional) If using torch.compile with inductor/triton, install the matching version of triton
+#make triton
+cd -
+#  optimas dependencies
+python3 -m pip install -r $HOME/src/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -1,5 +1,9 @@
 # please set your project account
-#export proj=<yourProject>
+export proj=""  # change me!
+
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # optional: just an additional text editor
 module load nano
@@ -11,12 +15,13 @@ module load cuda/11.3.1
 
 # optional: faster re-builds
 module load ccache
+module load ninja
 
 # optional: for PSATD in RZ geometry support
-export CMAKE_PREFIX_PATH=$HOME/sw/summit/blaspp-master:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=$HOME/sw/summit/lapackpp-master:$CMAKE_PREFIX_PATH
-export LD_LIBRARY_PATH=$HOME/sw/summit/blaspp-master/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/sw/summit/lapackpp-master/lib64:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=/ccs/proj/$proj/${USER}/sw/summit/gpu/blaspp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=/ccs/proj/$proj/${USER}/sw/summit/gpu/lapackpp-master:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=/ccs/proj/$proj/${USER}/sw/summit/gpu/blaspp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/ccs/proj/$proj/${USER}/sw/summit/gpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
 module load boost/1.76.0
@@ -46,9 +51,12 @@ module load openblas/0.3.5-omp
 export BLAS=${OLCF_OPENBLAS_ROOT}/lib/libopenblas.so
 export LAPACK=${OLCF_OPENBLAS_ROOT}/lib/libopenblas.so
 
-if [ -d "$HOME/sw/venvs/warpx" ]
+# dependency for pyTorch
+module load magma
+
+if [ -d "/ccs/proj/$proj/${USER}/sw/summit/gpu/venvs/warpx-summit" ]
 then
-  source $HOME/sw/venvs/warpx/bin/activate
+  source /ccs/proj/$proj/${USER}/sw/summit/gpu/venvs/warpx-summit/bin/activate
 fi
 
 # an alias to request an interactive batch node for two hours
@@ -56,7 +64,7 @@ fi
 alias getNode="bsub -q debug -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
 # an alias to run a command on a batch node for up to 30min
 #   usage: nrun <command>
-alias runNode="bsub -q debug -P $proj -W 0:30 -nnodes 1 -I"
+alias runNode="bsub -q debug -P $proj -W 2:00 -nnodes 1 -I"
 
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand


### PR DESCRIPTION
This streamlines the Summit (OLCF) docs to use install helper scripts (see: #3985 #3986). It also adds a step to install pyTorch on ppc64le with CUDA acceleration, consistent with our main environment for our codes.

- [x] tested