### PR TITLE
Correct typo: seperate --> separate

### DIFF
--- a/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
+++ b/Examples/Physics_applications/plasma_acceleration/PICMI_inputs_plasma_acceleration_mr.py
@@ -32,7 +32,7 @@ grid = picmi.Cartesian3DGrid(number_of_cells = [nx, ny, nz],
                              #refined_regions = [[1, [-25e-6, -25e-6, -200.e-6], [25e-6, 25e-6, 200.e-6]]],  # as argument
                              warpx_max_grid_size=128, warpx_blocking_factor=16)
 
-# --- As a seperate function call (instead of refined_regions argument)
+# --- As a separate function call (instead of refined_regions argument)
 grid.add_refined_region(level = 1,
                         lo = [-25e-6, -25e-6, -200.e-6],
                         hi = [25e-6, 25e-6, 200.e-6])

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.H
@@ -46,7 +46,7 @@ class HankelTransform
                                     amrex::FArrayBox      & F, int const F_icomp);
 
     private:
-        // Even though nk == nr always, use a seperate variable for clarity.
+        // Even though nk == nr always, use a separate variable for clarity.
         int m_nr, m_nk;
 
         RealVector m_kr;


### PR DESCRIPTION
This tiny PR corrects all the occurrences of "seperate" in the code