### PR TITLE
Clang-tidy CI test: add readability-non-const-parameter check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 Checks: '-*,
     cppcoreguidelines-avoid-goto,
     misc-const-correctness,
-    modernize-use-nullptr
+    modernize-use-nullptr,
+    readability-non-const-parameter
     '
 
 HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'


### PR DESCRIPTION
This PR adds readability-non-const-parameter check to clang-tidy CI tests