### PR TITLE
Clang-tidy CI test: add performance-for-range-copy check [🚀🚀 PR #4000 🚀🚀]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 Checks: '-*,
     cppcoreguidelines-avoid-goto,
     misc-const-correctness,
-    modernize-use-nullptr
+    modernize-use-nullptr,
+    performance-for-range-copy
     '
 
 HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'


### PR DESCRIPTION
This PR adds performance-for-range-copy check to clang-tidy CI test