### PR TITLE
Docs: Install Dep Scripts Build Dirs

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -16,7 +16,7 @@ If you are new to this system, **please see the following resources**:
 * `Summit user guide <https://docs.olcf.ornl.gov/systems/summit_user_guide.html>`_
 * Batch system: `LSF <https://docs.olcf.ornl.gov/systems/summit_user_guide.html#running-jobs>`_
 * `Jupyter service <https://jupyter.olcf.ornl.gov>`__
-* `Production directories <https://docs.olcf.ornl.gov/data/index.html#data-storage-and-transfers>`_:
+* `Filesystems <https://docs.olcf.ornl.gov/data/index.html#data-storage-and-transfers>`_:
 
   * ``$HOME``: per-user directory, use only for inputs, source and scripts; backed up; mounted as read-only on compute nodes, that means you cannot run in it (50 GB quota)
   * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days, GPFS (recommended)

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -31,7 +31,9 @@ fi
 
 # Remove old dependencies #####################################################
 #
-rm -rf ${HOME}/sw/frontier/gpu
+SW_DIR="${HOME}/sw/frontier/gpu"
+rm -rf ${SW_DIR}
+mkdir -p ${SW_DIR}
 
 # remove common user mistakes in python, located in .local instead of a venv
 python3 -m pip uninstall -qq -y pywarpx
@@ -54,8 +56,9 @@ else
   git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-frontier-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-frontier-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${HOME}/sw/frontier/gpu/blaspp-master
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-frontier-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
 cmake --build $HOME/src/blaspp-frontier-gpu-build --target install --parallel 16
+rm -rf $HOME/src/blaspp-frontier-gpu-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -69,8 +72,9 @@ else
   git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-frontier-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${HOME}/sw/frontier/gpu/lapackpp-master
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-frontier-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
 cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 16
+rm -rf $HOME/src/lapackpp-frontier-gpu-build
 
 
 # Python ######################################################################
@@ -78,9 +82,9 @@ cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
 python3 -m pip cache purge
-rm -rf ${HOME}/sw/frontier/gpu/venvs/warpx-frontier
-python3 -m venv ${HOME}/sw/frontier/gpu/venvs/warpx-frontier
-source ${HOME}/sw/frontier/gpu/venvs/warpx-frontier/bin/activate
+rm -rf ${SW_DIR}/venvs/warpx-frontier
+python3 -m venv ${SW_DIR}/venvs/warpx-frontier
+source ${SW_DIR}/venvs/warpx-frontier/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade cython

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -31,7 +31,9 @@ fi
 
 # Remove old dependencies #####################################################
 #
-rm -rf ${CFS}/${proj}/${USER}/sw/perlmutter/cpu
+SW_DIR="${CFS}/${proj}/${USER}/sw/perlmutter/cpu"
+rm -rf ${SW_DIR}
+mkdir -p ${SW_DIR}
 
 # remove common user mistakes in python, located in .local instead of a venv
 python3 -m pip uninstall -qq -y pywarpx
@@ -53,8 +55,9 @@ else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
 rm -rf $HOME/src/c-blosc-pm-cpu-build
-cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1
+cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
 cmake --build $HOME/src/c-blosc-pm-cpu-build --target install --parallel 16
+rm -rf $HOME/src/c-blosc-pm-cpu-build
 
 # ADIOS2
 if [ -d $HOME/src/adios2 ]
@@ -67,8 +70,9 @@ else
   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 rm -rf $HOME/src/adios2-pm-cpu-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
 cmake --build $HOME/src/adios2-pm-cpu-build --target install -j 16
+rm -rf $HOME/src/adios2-pm-cpu-build
 
 # BLAS++ (for PSATD+RZ)
 if [ -d $HOME/src/blaspp ]
@@ -82,8 +86,9 @@ else
   git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-cpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
 cmake --build $HOME/src/blaspp-pm-cpu-build --target install --parallel 16
+rm -rf $HOME/src/blaspp-pm-cpu-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -97,8 +102,9 @@ else
   git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-cpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
 cmake --build $HOME/src/lapackpp-pm-cpu-build --target install --parallel 16
+rm -rf $HOME/src/lapackpp-pm-cpu-build
 
 
 # Python ######################################################################
@@ -106,9 +112,9 @@ cmake --build $HOME/src/lapackpp-pm-cpu-build --target install --parallel 16
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
 python3 -m pip cache purge
-rm -rf ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx
-python3 -m venv ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx
-source ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
+rm -rf ${SW_DIR}/venvs/warpx
+python3 -m venv ${SW_DIR}/venvs/warpx
+source ${SW_DIR}/venvs/warpx/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade cython

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -31,7 +31,9 @@ fi
 
 # Remove old dependencies #####################################################
 #
-rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu
+SW_DIR="${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu"
+rm -rf ${SW_DIR}
+mkdir -p ${SW_DIR}
 
 # remove common user mistakes in python, located in .local instead of a venv
 python3 -m pip uninstall -qq -y pywarpx
@@ -53,8 +55,9 @@ else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
 rm -rf $HOME/src/c-blosc-pm-gpu-build
-cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1
+cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
 cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 16
+rm -rf $HOME/src/c-blosc-pm-gpu-build
 
 # ADIOS2
 if [ -d $HOME/src/adios2 ]
@@ -67,8 +70,9 @@ else
   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 rm -rf $HOME/src/adios2-pm-gpu-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
 cmake --build $HOME/src/adios2-pm-gpu-build --target install -j 16
+rm -rf $HOME/src/adios2-pm-gpu-build
 
 # BLAS++ (for PSATD+RZ)
 if [ -d $HOME/src/blaspp ]
@@ -82,8 +86,9 @@ else
   git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
 cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 16
+rm -rf $HOME/src/blaspp-pm-gpu-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -97,8 +102,9 @@ else
   git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
 cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
+rm -rf $HOME/src/lapackpp-pm-gpu-build
 
 
 # Python ######################################################################
@@ -106,9 +112,9 @@ cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
 python3 -m pip cache purge
-rm -rf ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
-python3 -m venv ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx
-source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx/bin/activate
+rm -rf ${SW_DIR}/venvs/warpx
+python3 -m venv ${SW_DIR}/venvs/warpx
+source ${SW_DIR}/venvs/warpx/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade cython

--- a/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+++ b/Tools/machines/summit-olcf/install_gpu_dependencies.sh
@@ -69,6 +69,7 @@ fi
 rm -rf $HOME/src/blaspp-summit-build
 cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-summit-build -Duse_openmp=ON -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
 cmake --build $HOME/src/blaspp-summit-build --target install --parallel 10
+rm -rf $HOME/src/blaspp-summit-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -84,6 +85,7 @@ fi
 rm -rf $HOME/src/lapackpp-summit-build
 cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-summit-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
 cmake --build $HOME/src/lapackpp-summit-build --target install --parallel 10
+rm -rf $HOME/src/lapackpp-summit-build
 
 
 # Python ######################################################################

--- a/Tools/machines/summit-olcf/install_gpu_ml.sh
+++ b/Tools/machines/summit-olcf/install_gpu_ml.sh
@@ -74,6 +74,7 @@ wget -q -O - https://github.com/pytorch/pytorch/pull/98511.patch | git apply
 USE_CUDA=1 BLAS=OpenBLAS MAX_JOBS=64 ATEN_AVX512_256=OFF BUILD_TEST=0 python3 setup.py develop
 #   (optional) If using torch.compile with inductor/triton, install the matching version of triton
 #make triton
+rm -rf build
 cd -
 
 # optional: optimas dependencies (based on libEnsemble & ax->botorch->gpytorch->pytorch)


### PR DESCRIPTION
Clean the temporary build directories of dependencies immediately after successful install, to save on FS quotas.

Follows #3985 #3986 etc.