### PR TITLE
Clang-tidy CI test: add performance-faster-string-find check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: '-*,
     cppcoreguidelines-avoid-goto,
     misc-const-correctness,
     modernize-use-nullptr,
+    performance-faster-string-find,
     performance-for-range-copy,
     readability-non-const-parameter
     '

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -203,7 +203,7 @@ namespace detail
         std::string component_name = openPMD::RecordComponent::SCALAR;
 
         // we use "_" as separator in names to group vector records
-        const std::size_t startComp = fullName.find_last_of("_");
+        const std::size_t startComp = fullName.find_last_of('_');
         if( startComp != std::string::npos ) {  // non-scalar
             record_name = fullName.substr(0, startComp);
             component_name = fullName.substr(startComp + 1u);


### PR DESCRIPTION
This PR adds performance-faster-string-find check to clang-tidy CI test