### PR TITLE
Doc: Button to Copy Code Blocks

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -18,6 +18,7 @@ picmistandard==0.25.0
 pygments
 recommonmark
 sphinx>=5.3
+sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=1.1.1
 sphinxcontrib-bibtex

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -47,6 +47,7 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'sphinx_copybutton',
     'sphinx_design',
     'breathe',
     'sphinxcontrib.bibtex'

--- a/Docs/spack.yaml
+++ b/Docs/spack.yaml
@@ -23,5 +23,6 @@ spack:
   - py-breathe
   - py-recommonmark
   - py-pygments
+  - py-sphinx-copybutton
   - py-sphinx-design
   - py-sphinx-rtd-theme


### PR DESCRIPTION
Add a copy button to every code block in the docs.
Improves user experience for long code lines and eliminates the need to scroll horizontally in some lines & screen resolutions.

Suggested by @RTSandberg :ok_hand: 