### PR TITLE
Doc: HPC QED & Multi-Dim

### DIFF
--- a/Docs/source/install/batch/pbs.rst
+++ b/Docs/source/install/batch/pbs.rst
@@ -1,7 +1,7 @@
 Job Submission
 ''''''''''''''
 
-* ``qsub your_job_script.pbs``
+* ``qsub your_job_script.qsub``
 
 
 Job Control

--- a/Docs/source/install/hpc.rst
+++ b/Docs/source/install/hpc.rst
@@ -46,8 +46,8 @@ This section documents quick-start guides for a selection of supercomputers that
    hpc/ookami
    hpc/perlmutter
    hpc/quartz
-   hpc/summit
    hpc/spock
+   hpc/summit
    hpc/taurus
 
 .. tip::

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -63,7 +63,7 @@ And since Adastra does not yet provide a module for them, install c-blosc and AD
    # ADIOS2
    git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git src/adios2
    rm -rf src/adios2-pm-build
-   cmake -S src/adios2 -B src/adios2-pm-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/sw/adastra/gpu//adios2-2.8.3
+   cmake -S src/adios2 -B src/adios2-pm-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/sw/adastra/gpu/adios2-2.8.3
    cmake --build src/adios2-pm-build --target install -j 16
 
 Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
@@ -73,7 +73,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=HIP
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
    cmake --build build -j 32
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -68,7 +68,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON
+   cmake -S . -B build -DWarpX_DIMS="1;2;RZ;3" -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON
    cmake --build build -j 10
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -98,7 +98,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_frontier
 
-   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_frontier -j 16
    cmake --build build_frontier -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/fugaku.rst
+++ b/Docs/source/install/hpc/fugaku.rst
@@ -82,6 +82,7 @@ Finally, ``cd`` into the directory ``$HOME/src/warpx`` and use the following com
    export CXXFLAGS="-Nclang"
 
    cmake -S . -B build -DWarpX_COMPUTE=OMP \
+   -DWarpX_DIMS="1;2;3" \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_CXX_FLAGS_RELEASE="-Ofast -mllvm -polly -mllvm -polly-parallel" \
    -DAMReX_DIFFERENT_COMPILER=ON \

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -50,11 +50,12 @@ Create it now:
      :language: bash
 
 Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
-For example, if you are member of the project ``strawberry``, then run ``vi $HOME/hpc3_gpu_warpx.profile`` and edit line 2 to read:
+For example, if you are member of the project ``plasma``, then run ``vi $HOME/hpc3_gpu_warpx.profile``.
+Enter the edit mode by typing ``i`` and edit line 2 to read:
 
 .. code-block:: bash
 
-   export proj="strawberry"
+   export proj="plasma"
 
 Exit the ``vi`` editor with ``Esc`` and then type ``:wq`` (write & quit).
 
@@ -93,7 +94,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 16
    cmake --build build -j 16 --target pip_install
 
@@ -144,7 +145,7 @@ Running
 The batch script below can be used to run a WarpX simulation on multiple nodes (change ``-N`` accordingly) on the supercomputer HPC3 at UCI.
 This partition as up to `32 nodes <https://rcic.uci.edu/hpc3/slurm.html#memmap>`__ with four V100 GPUs (16 GB each) per node.
 
-Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<proj>`` could be ``strawberry``.
+Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<proj>`` could be ``plasma``.
 Note that we run one MPI rank per GPU.
 
 .. literalinclude:: ../../../../Tools/machines/hpc3-uci/hpc3_gpu.sbatch

--- a/Docs/source/install/hpc/juwels.rst
+++ b/Docs/source/install/hpc/juwels.rst
@@ -57,7 +57,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_MPI_THREAD_MULTIPLE=OFF
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_MPI_THREAD_MULTIPLE=OFF
    cmake --build build -j 16
 
 The other :ref:`general compile-time options <install-developers>` apply as usual.

--- a/Docs/source/install/hpc/lassen.rst
+++ b/Docs/source/install/hpc/lassen.rst
@@ -82,7 +82,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
 
    rm -rf build_lassen
-   cmake -S . -B build_lassen -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_PSATD=ON
+   cmake -S . -B build_lassen -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
    cmake --build build_lassen -j 10
 
 The other :ref:`general compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -99,7 +99,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON
+   cmake -S . -B build -DWarpX_DIMS="1;2;RZ;3" -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
    cmake --build build -j 12
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -70,13 +70,13 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=HIP
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
    cmake --build build -j 16
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
 
 **That's it!**
-A 3D WarpX executable is now in ``build/bin/`` and :ref:`can be run <running-cpp-lumi>` with a :ref:`3D example inputs file <usage-examples>`.
+WarpX executables are now in ``build/bin/`` and :ref:`can be run <running-cpp-lumi>` with matching :ref:`example inputs files <usage-examples>`.
 Most people execute the binary directly or copy it out to a location in ``/scratch/<project>``.
 
 

--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -124,14 +124,14 @@ Then we build WarpX:
 
 .. code-block:: bash
 
-    cmake -S . -B build
+    cmake -S . -B build -DWarpX_DIMS="1;2;RZ;3"
     cmake --build build -j 6
 
 Or if we need to compile with CUDA:
 
 .. code-block:: bash
 
-    cmake -S . -B build -DWarpX_COMPUTE=CUDA
+    cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3"
     cmake --build build -j 6
 
 **That's it!**
@@ -154,7 +154,7 @@ Then we compile WarpX as in the previous section (with or without CUDA) adding `
 
 .. code-block:: bash
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_LIB=ON
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_LIB=ON
    cmake --build build --target pip_install -j 6
 
 This builds WarpX for 3D geometry.

--- a/Docs/source/install/hpc/ookami.rst
+++ b/Docs/source/install/hpc/ookami.rst
@@ -53,11 +53,11 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=OMP
+   cmake -S . -B build -DWarpX_COMPUTE=OMP -DWarpX_DIMS="1;2;3"
    cmake --build build -j 10
 
    # or (currently better performance)
-   cmake -S . -B build -DWarpX_COMPUTE=NOACC
+   cmake -S . -B build -DWarpX_COMPUTE=NOACC -DWarpX_DIMS="1;2;3"
    cmake --build build -j 10
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -151,7 +151,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_gpu
 
-         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_gpu -j 16
          cmake --build build_pm_gpu -j 16 --target pip_install
 
@@ -165,7 +165,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_cpu
 
-         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_cpu -j 16
          cmake --build build_pm_cpu -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/quartz.rst
+++ b/Docs/source/install/hpc/quartz.rst
@@ -48,7 +48,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
    cmake --build build -j 6
 
 The other :ref:`general compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/spock.rst
+++ b/Docs/source/install/hpc/spock.rst
@@ -51,7 +51,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
    cmake --build build -j 10
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -123,7 +123,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_summit
 
-   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_summit -j 16
    cmake --build build_summit -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/taurus.rst
+++ b/Docs/source/install/hpc/taurus.rst
@@ -50,7 +50,7 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_COMPUTE=CUDA
+   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_COMPUTE=CUDA
    cmake --build build -j 16
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.


### PR DESCRIPTION
Update HPC machine instructions to enable multi-dims, PSATD and QED table non-defaults for all machines where these dependencies are met. This ensures users will get an as-feature-complete-as-possible install.