### PR TITLE
Prevent `E_ext_particle` and `B_ext_particle` use with hybrid-PIC solver

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1327,6 +1327,15 @@ void WarpX::CheckKnownIssues()
             "The hybrid-PIC algorithm involves multifabs that are not yet "
             "properly redistributed during load balancing events."
         );
+
+        const bool external_particle_field_used = (
+            mypc->m_B_ext_particle_s != "none" || mypc->m_E_ext_particle_s != "none"
+        );
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !external_particle_field_used,
+            "The hybrid-PIC algorithm does not work with external fields "
+            "applied directly to particles."
+        );
     }
 }
 


### PR DESCRIPTION
This PR adds a simulation abort if a user attempts to use an external field applied directly to the particles with the hybrid-PIC solver since the non-linearity of the hybrid-PIC's Ohm's law approach does not allow such a straight forward superposition of fields.

This is a follow-up PR to #3665.