### PR TITLE
Doc: HPC3 (UCI) HDF5 & GPU Visibility

### DIFF
--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -94,7 +94,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DGPUS_PER_SOCKET=${GPUS_PER_SOCKET} -DGPUS_PER_NODE=${GPUS_PER_NODE} -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 16
    cmake --build build -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -94,7 +94,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DGPUS_PER_SOCKET=${GPUS_PER_SOCKET} -DGPUS_PER_NODE=${GPUS_PER_NODE} -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 16
    cmake --build build -j 16 --target pip_install
 

--- a/Tools/machines/hpc3-uci/hpc3_gpu.sbatch
+++ b/Tools/machines/hpc3-uci/hpc3_gpu.sbatch
@@ -30,6 +30,7 @@ INPUTS=inputs_rz
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # run
-mpirun -np ${SLURM_NTASKS}  \
-  ${EXE} ${INPUTS}          \
+mpirun -np ${SLURM_NTASKS} bash -c "
+    export CUDA_VISIBLE_DEVICES=\${SLURM_LOCALID};
+    ${EXE} ${INPUTS}" \
   > output.txt

--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -16,7 +16,7 @@ module load boost/1.78.0/gcc.11.2.0
 
 # optional: for openPMD and PSATD+RZ support
 module load OpenBLAS/0.3.21
-module load hdf5/1.14.0/gcc.11.2.0-openmpi.4.1.2
+module load hdf5/1.13.1/gcc.11.2.0-openmpi.4.1.2
 export CMAKE_PREFIX_PATH=${HOME}/sw/hpc3/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${HOME}/sw/hpc3/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${HOME}/sw/hpc3/gpu/blaspp-master:$CMAKE_PREFIX_PATH
@@ -45,6 +45,11 @@ alias getNode="salloc -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
 alias runNode="srun -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
+
+# Slurm is not well configured to properly address GPU visibility
+# per MPI rank. Thus, we define the node layouts here.
+export GPUS_PER_SOCKET=2
+export GPUS_PER_NODE=4
 
 # optimize CUDA compilation for V100
 export AMREX_CUDA_ARCH=7.0

--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -46,11 +46,6 @@ alias getNode="salloc -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
 #   usage: runNode <command>
 alias runNode="srun -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
 
-# Slurm is not well configured to properly address GPU visibility
-# per MPI rank. Thus, we define the node layouts here.
-export GPUS_PER_SOCKET=2
-export GPUS_PER_NODE=4
-
 # optimize CUDA compilation for V100
 export AMREX_CUDA_ARCH=7.0
 


### PR DESCRIPTION
Switch the HDF5 module to one that is picked up well by our build logic.

Slurm is not well configured to properly address GPU visibility per MPI rank. Thus, we define the node layouts during compile-time.

Related to tests by @floresv299 in https://github.com/ECP-WarpX/WarpX/issues/3938#issuecomment-1601556070