### PR TITLE
For ReducedDiags, write header on restart if file does not exist

### DIFF
--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -77,7 +77,7 @@ BeamRelevant::BeamRelevant (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -59,7 +59,7 @@ ChargeOnEB::ChargeOnEB (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -46,7 +46,7 @@ FieldEnergy::FieldEnergy (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -61,7 +61,7 @@ FieldMaximum::FieldMaximum (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
@@ -58,7 +58,7 @@ FieldMomentum::FieldMomentum (std::string rd_name)
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
-        if (m_IsNotRestart)
+        if (m_write_header)
         {
             // Open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -157,7 +157,7 @@ FieldProbe::FieldProbe (std::string rd_name)
                                      "Field probe interp_order should be less than or equal to algo.particle_shape");
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -64,7 +64,7 @@ FieldReduction::FieldReduction (std::string rd_name)
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceEfficiency.cpp
@@ -34,7 +34,7 @@ LoadBalanceEfficiency::LoadBalanceEfficiency (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleEnergy.cpp
@@ -54,7 +54,7 @@ ParticleEnergy::ParticleEnergy (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -122,7 +122,7 @@ ParticleExtrema::ParticleExtrema (std::string rd_name)
 
         if (ParallelDescriptor::IOProcessor())
         {
-            if ( m_IsNotRestart )
+            if ( m_write_header )
             {
                 // open file
                 std::ofstream ofs;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -123,7 +123,7 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ParticleMomentum.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleMomentum.cpp
@@ -52,7 +52,7 @@ ParticleMomentum::ParticleMomentum (std::string rd_name)
 
     if (ParallelDescriptor::IOProcessor())
     {
-        if (m_IsNotRestart)
+        if (m_write_header)
         {
             // Open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleNumber.cpp
@@ -48,7 +48,7 @@ ParticleNumber::ParticleNumber (std::string rd_name)
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.H
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.H
@@ -36,8 +36,8 @@ public:
     /// output intervals
     utils::parser::IntervalsParser m_intervals;
 
-    /// check if it is a restart run
-    int m_IsNotRestart = 1;
+    /// check if header should be written
+    bool m_write_header = false;
 
     /// separator in the output file
     std::string m_sep = " ";

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -40,19 +40,21 @@ ReducedDiags::ReducedDiags (std::string rd_name)
     std::string restart_chkfile = "";
     const ParmParse pp_amr("amr");
     pp_amr.query("restart", restart_chkfile);
-    m_IsNotRestart = restart_chkfile.empty();
+    bool IsNotRestart = restart_chkfile.empty();
 
     if (ParallelDescriptor::IOProcessor())
     {
         // create folder
         constexpr int permission_flag_rwxrxrx = 0755;
-        if (!UtilCreateDirectory(m_path, permission_flag_rwxrxrx))
-        { CreateDirectoryFailed(m_path); }
+        if (!amrex::UtilCreateDirectory(m_path, permission_flag_rwxrxrx))
+        { amrex::CreateDirectoryFailed(m_path); }
 
         // replace / create output file
-        if ( m_IsNotRestart ) // not a restart
+        std::string rd_full_file_name = m_path + m_rd_name + "." + m_extension;
+        m_write_header = IsNotRestart || !amrex::FileExists(rd_full_file_name); // not a restart or file doesn't exist
+        if (m_write_header)
         {
-            std::ofstream ofs{m_path+m_rd_name+"."+m_extension, std::ios::trunc};
+            std::ofstream ofs{rd_full_file_name, std::ios::trunc};
             ofs.close();
         }
     }

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -90,7 +90,7 @@ RhoMaximum::RhoMaximum (std::string rd_name)
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
-        if ( m_IsNotRestart )
+        if ( m_write_header )
         {
             // open file
             std::ofstream ofs{m_path + m_rd_name + "." + m_extension, std::ofstream::out};


### PR DESCRIPTION
This is a little nicety needed since sometimes restarts will be done in a new place so new reduced diags files are written.