### PR TITLE
Clang-tidy CI test: add modernize-avoid-bind check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: '-*,
     cppcoreguidelines-avoid-goto,
     misc-const-correctness,
+    modernize-avoid-bind,
     modernize-use-nullptr,
     performance-faster-string-find,
     performance-for-range-copy,


### PR DESCRIPTION
This PR adds modernize-avoid-bind check to clang-tidy CI test
