### PR TITLE
Move MPIInitHelpers into ablastr

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -23,7 +23,6 @@
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/Algorithms/LinearInterpolation.H"
 #include "Utils/Logo/GetLogo.H"
-#include "Utils/MPIInitHelpers.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -32,6 +31,7 @@
 #include "Utils/WarpXUtil.H"
 #include "Python/WarpX_py.H"
 
+#include <ablastr/parallelization/MPIInitHelpers.H>
 #include <ablastr/utils/Communication.H>
 #include <ablastr/utils/UsedInputsFile.H>
 #include <ablastr/warn_manager/WarnManager.H>
@@ -377,7 +377,7 @@ void
 WarpX::InitData ()
 {
     WARPX_PROFILE("WarpX::InitData()");
-    utils::warpx_check_mpi_thread_level();
+    ablastr::parallelization::check_mpi_thread_level();
 
 #ifdef WARPX_QED
     Print() << "PICSAR (" << WarpX::PicsarVersion() << ")\n";

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -3,7 +3,6 @@ foreach(D IN LISTS WarpX_DIMS)
     target_sources(WarpX_${SD}
       PRIVATE
         Interpolate.cpp
-        MPIInitHelpers.cpp
         ParticleUtils.cpp
         RelativeCellPosition.cpp
         WarpXAlgorithmSelection.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -6,7 +6,6 @@ CEXE_sources += WarpXVersion.cpp
 CEXE_sources += WarpXAlgorithmSelection.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += IntervalsParser.cpp
-CEXE_sources += MPIInitHelpers.cpp
 CEXE_sources += RelativeCellPosition.cpp
 CEXE_sources += ParticleUtils.cpp
 

--- a/Source/ablastr/CMakeLists.txt
+++ b/Source/ablastr/CMakeLists.txt
@@ -1,6 +1,6 @@
 #add_subdirectory(fields)
 add_subdirectory(coarsen)
-#add_subdirectory(parallelization)
+add_subdirectory(parallelization)
 #add_subdirectory(particles)
 #add_subdirectory(profiler)
 add_subdirectory(utils)

--- a/Source/ablastr/parallelization/CMakeLists.txt
+++ b/Source/ablastr/parallelization/CMakeLists.txt
@@ -1,0 +1,7 @@
+foreach(D IN LISTS WarpX_DIMS)
+    warpx_set_suffix_dims(SD ${D})
+    target_sources(ablastr_${SD}
+      PRIVATE
+        MPIInitHelpers.cpp
+    )
+endforeach()

--- a/Source/ablastr/parallelization/MPIInitHelpers.H
+++ b/Source/ablastr/parallelization/MPIInitHelpers.H
@@ -1,45 +1,45 @@
 /* Copyright 2020 Axel Huebl
  *
- * This file is part of WarpX.
+ * This file is part of ABLASTR.
  *
  * License: BSD-3-Clause-LBNL
  */
-#ifndef WARPX_MPI_INIT_HELPERS_H_
-#define WARPX_MPI_INIT_HELPERS_H_
+#ifndef ABLASTR_MPI_INIT_HELPERS_H_
+#define ABLASTR_MPI_INIT_HELPERS_H_
 
 #include <utility>
 
-namespace utils
+namespace ablastr::parallelization
 {
     /** Return the required MPI threading
      *
      * @return the MPI_THREAD_* level required for MPI_Init_thread
      */
     int
-    warpx_mpi_thread_required ();
+    mpi_thread_required ();
 
     /** Initialize MPI
      *
      * @return pair(required, provided) of MPI thread level from MPI_Init_thread
      */
     std::pair< int, int >
-    warpx_mpi_init (int argc, char* argv[]);
+    mpi_init (int argc, char* argv[]);
 
     /** Finalize MPI
      *
      * This function is simply a wrapper around MPI_Finalize(). It is a no-op if
-     * WarpX is compiled without MPI support.
+     * ABLASTR is compiled without MPI support.
      */
     void
-    warpx_mpi_finalize ();
+    mpi_finalize ();
 
     /** Check if the requested MPI thread level is valid
      *
      * Prints warnings and notes otherwise.
      */
     void
-    warpx_check_mpi_thread_level ();
+    check_mpi_thread_level ();
 
-} // namespace utils
+} // namespace ablastr::parallelization
 
-#endif // WARPX_MPI_INIT_HELPERS_H_
+#endif // ABLASTR_MPI_INIT_HELPERS_H_

--- a/Source/ablastr/parallelization/MPIInitHelpers.cpp
+++ b/Source/ablastr/parallelization/MPIInitHelpers.cpp
@@ -1,6 +1,6 @@
 /* Copyright 2020 Axel Huebl
  *
- * This file is part of WarpX.
+ * This file is part of ABLASTR.
  *
  * License: BSD-3-Clause-LBNL
  */
@@ -20,10 +20,10 @@
 #include <utility>
 #include <sstream>
 
-namespace utils
+namespace ablastr::parallelization
 {
     int
-    warpx_mpi_thread_required ()
+    mpi_thread_required ()
     {
         int thread_required = -1;
 #ifdef AMREX_USE_MPI
@@ -39,9 +39,9 @@ namespace utils
     }
 
     std::pair< int, int >
-    warpx_mpi_init (int argc, char* argv[])
+    mpi_init (int argc, char* argv[])
     {
-        const int thread_required = warpx_mpi_thread_required();
+        const int thread_required = mpi_thread_required();
 #ifdef AMREX_USE_MPI
         int thread_provided = -1;
         MPI_Init_thread(&argc, &argv, thread_required, &thread_provided);
@@ -54,7 +54,7 @@ namespace utils
 
 
     void
-    warpx_mpi_finalize ()
+    mpi_finalize ()
     {
 #ifdef AMREX_USE_MPI
         MPI_Finalize();
@@ -62,10 +62,10 @@ namespace utils
     }
 
     void
-    warpx_check_mpi_thread_level ()
+    check_mpi_thread_level ()
     {
 #ifdef AMREX_USE_MPI
-        const int thread_required = warpx_mpi_thread_required();
+        const int thread_required = mpi_thread_required();
         int thread_provided = -1;
         MPI_Query_thread(&thread_provided);
         auto mtn = amrex::ParallelDescriptor::mpi_level_to_string;
@@ -90,4 +90,4 @@ namespace utils
 #endif
     }
 
-} // namespace utils
+} // namespace ablastr::parallelization

--- a/Source/ablastr/parallelization/Make.package
+++ b/Source/ablastr/parallelization/Make.package
@@ -1,1 +1,3 @@
+CEXE_sources += MPIInitHelpers.cpp
+
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/parallelization

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -14,14 +14,15 @@
 #include "Utils/WarpXrocfftUtil.H"
 #include "Utils/WarpXUtil.H"
 
-#include <ablastr/warn_manager/WarnManager.H>
+#include <ablastr/parallelization/MPIInitHelpers.H>
 #include <ablastr/utils/timer/Timer.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX_Print.H>
 
 int main(int argc, char* argv[])
 {
-    utils::warpx_mpi_init(argc, argv);
+    ablastr::parallelization::mpi_init(argc, argv);
 
     warpx_amrex_init(argc, argv);
 
@@ -64,5 +65,5 @@ int main(int argc, char* argv[])
 
     amrex::Finalize();
 
-    utils::warpx_mpi_finalize ();
+    ablastr::parallelization::warpx_mpi_finalize ();
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -64,5 +64,5 @@ int main(int argc, char* argv[])
 
     amrex::Finalize();
 
-    ablastr::parallelization::warpx_mpi_finalize ();
+    ablastr::parallelization::mpi_finalize ();
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -9,7 +9,6 @@
 #include "WarpX.H"
 
 #include "Initialization/WarpXAMReXInit.H"
-#include "Utils/MPIInitHelpers.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXrocfftUtil.H"
 #include "Utils/WarpXUtil.H"


### PR DESCRIPTION
This PR moves moves `MPIInitHelpers.cpp` and `MPIInitHelpers.H` into `ablastr`, since they are sufficiently general to be shared with other codes