### PR TITLE
Doc: HPC Machines Source Py Env

### DIFF
--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -76,6 +76,7 @@ Finally, since Frontier does not yet provide software modules for some of our de
 .. code-block:: bash
 
    bash $HOME/src/warpx/Tools/machines/frontier-olcf/install_dependencies.sh
+   source $HOME/sw/frontier/gpu/venvs/warpx-frontier/bin/activate
 
 .. dropdown:: Script Details
    :color: light

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -72,6 +72,7 @@ Finally, since HPC3 does not yet provide software modules for some of our depend
 .. code-block:: bash
 
    bash $HOME/src/warpx/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+   source $HOME/sw/hpc3/gpu/venvs/warpx-gpu/bin/activate
 
 .. dropdown:: Script Details
    :color: light

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -76,6 +76,7 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
       .. code-block:: bash
 
          bash $HOME/src/warpx/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+         source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx/bin/activate
 
       .. dropdown:: Script Details
          :color: light
@@ -125,6 +126,7 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
       .. code-block:: bash
 
          bash $HOME/src/warpx/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+         source ${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx/bin/activate
 
       .. dropdown:: Script Details
          :color: light

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -77,6 +77,7 @@ Finally, since Summit does not yet provide software modules for some of our depe
 .. code-block:: bash
 
    bash $HOME/src/warpx/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+   source /ccs/proj/$proj/${USER}/sw/summit/gpu/venvs/warpx-summit/bin/activate
 
 .. dropdown:: Script Details
    :color: light


### PR DESCRIPTION
Make sure the Python environment is active on very first dependency install, before we start compiling.

Seen by @berceanu in https://github.com/ECP-WarpX/WarpX/pull/4012#discussion_r1238960385