### PR TITLE
Explicitly check field `IndexType` appropriateness when using hybrid-PIC solver

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -129,12 +129,12 @@ void HybridPICModel::InitData ()
     const bool appropriate_grids = (
 #if   defined(WARPX_DIM_1D_Z)
         // AMReX convention: x = missing dimension, y = missing dimension, z = only dimension
-        Ex_stag == IntVect(1) && Ey_stag = IntVect(1) && Ez_stag == IntVect(0) &&
-        Bx_stag == IntVect(0) && By_stag = IntVect(0) && Bz_stag == IntVect(1) &&
+        Ex_stag == IntVect(1) && Ey_stag == IntVect(1) && Ez_stag == IntVect(0) &&
+        Bx_stag == IntVect(0) && By_stag == IntVect(0) && Bz_stag == IntVect(1) &&
 #elif   defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         // AMReX convention: x = first dimension, y = missing dimension, z = second dimension
-        Ex_stag == IntVect(0,1) && Ey_stag = IntVect(1,1) && Ez_stag == IntVect(1,0) &&
-        Bx_stag == IntVect(1,0) && By_stag = IntVect(0,0) && Bz_stag == IntVect(0,1) &&
+        Ex_stag == IntVect(0,1) && Ey_stag == IntVect(1,1) && Ez_stag == IntVect(1,0) &&
+        Bx_stag == IntVect(1,0) && By_stag == IntVect(0,0) && Bz_stag == IntVect(0,1) &&
 #elif defined(WARPX_DIM_3D)
         Ex_stag == IntVect(0,1,1) && Ey_stag == IntVect(1,0,1) && Ez_stag == IntVect(1,1,0) &&
         Bx_stag == IntVect(1,0,0) && By_stag == IntVect(0,1,0) && Bz_stag == IntVect(0,0,1) &&

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -125,6 +125,26 @@ void HybridPICModel::InitData ()
     amrex::IntVect Ey_stag = warpx.getEfield_fp(0,1).ixType().toIntVect();
     amrex::IntVect Ez_stag = warpx.getEfield_fp(0,2).ixType().toIntVect();
 
+    // Check that the grid types are appropriate
+    const bool appropriate_grids = (
+#if   defined(WARPX_DIM_1D_Z)
+        // AMReX convention: x = missing dimension, y = missing dimension, z = only dimension
+        Ex_stag == IntVect(1) && Ey_stag = IntVect(1) && Ez_stag == IntVect(0) &&
+        Bx_stag == IntVect(0) && By_stag = IntVect(0) && Bz_stag == IntVect(1) &&
+#elif   defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        // AMReX convention: x = first dimension, y = missing dimension, z = second dimension
+        Ex_stag == IntVect(0,1) && Ey_stag = IntVect(1,1) && Ez_stag == IntVect(1,0) &&
+        Bx_stag == IntVect(1,0) && By_stag = IntVect(0,0) && Bz_stag == IntVect(0,1) &&
+#elif defined(WARPX_DIM_3D)
+        Ex_stag == IntVect(0,1,1) && Ey_stag == IntVect(1,0,1) && Ez_stag == IntVect(1,1,0) &&
+        Bx_stag == IntVect(1,0,0) && By_stag == IntVect(0,1,0) && Bz_stag == IntVect(0,0,1) &&
+#endif
+        Jx_stag == Ex_stag && Jy_stag == Ey_stag && Jz_stag == Ez_stag
+    );
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        appropriate_grids,
+        "Ohm's law E-solve only works with staggered (Yee) grids.");
+
     // copy data to device
     for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         Jx_IndexType[idim]    = Jx_stag[idim];

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -198,12 +198,6 @@ void FiniteDifferenceSolver::HybridPICSolveE (
     int lev, HybridPICModel const* hybrid_model,
     DtType a_dt_type )
 {
-
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        WarpX::grid_type == GridType::Staggered,
-        "Ohm's law E-solve only works with a staggered (Yee) grid.");
-
-
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
     if (m_fdtd_algo == ElectromagneticSolverAlgo::HybridPIC) {


### PR DESCRIPTION
I moved the sanity check of the grid types to the initialization of the hybrid-PIC model rather than checking at every call. This is okay since the grid staggering (reused at every step) is set in the same function that checks if they are appropriate.