### PR TITLE
Replace unsed WARPX_DIM_2D with AMREX_SPACEDIM==2

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -140,7 +140,7 @@ bool WarpX::do_shared_mem_charge_deposition = false;
 bool WarpX::do_shared_mem_current_deposition = false;
 #if defined(WARPX_DIM_3D)
 amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(6,6,8));
-#elif defined(WARPX_DIM_2D)
+#elif (AMREX_SPACEDIM == 2)
 amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(14,14));
 #else
 //Have not experimented with good tilesize here because expect use case to be low

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -141,7 +141,7 @@ bool WarpX::do_shared_mem_current_deposition = false;
 #if defined(WARPX_DIM_3D)
 amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(6,6,8));
 #elif (AMREX_SPACEDIM == 2)
-amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(14,14));
+amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(14,14,0));
 #else
 //Have not experimented with good tilesize here because expect use case to be low
 amrex::IntVect WarpX::shared_tilesize(AMREX_D_DECL(1,1,1));


### PR DESCRIPTION
This PR replaces an occurence `#elif (WARPX_DIM_2D)` of with `#elif (AMREX_SPACEDIM == 2)` , since `WARPX_DIM_2D` is no longer used.

Update: we also need to change `AMREX_D_DECL(14,14)` into `AMREX_D_DECL(14,14,0)` , since `AMREX_D_DECL` always accepts 3 arguments. 