### PR TITLE
main.cpp: change warpx_amrex_init into warpx::initialization::amrex_init

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.H
+++ b/Source/Initialization/WarpXAMReXInit.H
@@ -11,24 +11,28 @@
 
 #include <AMReX_BaseFwd.H>
 
-/** Call amrex::Initialize
- *
- * This function calls amrex::Initialize and overwrites AMReX' defaults.
- * Note: AMReX defines a placeholder/"mock-up" for MPI_Comm and
- * MPI_COMM_WORLD in serial builds
- *
- * @param[in] argc number of arguments from main()
- * @param[in] argv argument strings from main()
- * @param[in] build_parm_parse build the input file parser (AMReX' default: true)
- * @param[in] mpi_comm the MPI communicator to use (AMReX' default: MPI_COMM_WORLD)
- * @returns pointer to an AMReX* object, forwarded from amrex::Initialize
- */
-amrex::AMReX*
-warpx_amrex_init(
-    int& argc,
-    char**& argv,
-    bool const build_parm_parse = true,
-    MPI_Comm const mpi_comm = MPI_COMM_WORLD
-);
+namespace warpx::initialization
+{
 
+    /** Call amrex::Initialize
+     *
+     * This function calls amrex::Initialize and overwrites AMReX' defaults.
+     * Note: AMReX defines a placeholder/"mock-up" for MPI_Comm and
+     * MPI_COMM_WORLD in serial builds
+     *
+     * @param[in] argc number of arguments from main()
+     * @param[in] argv argument strings from main()
+     * @param[in] build_parm_parse build the input file parser (AMReX' default: true)
+     * @param[in] mpi_comm the MPI communicator to use (AMReX' default: MPI_COMM_WORLD)
+     * @returns pointer to an AMReX* object, forwarded from amrex::Initialize
+     */
+    amrex::AMReX*
+    amrex_init(
+        int& argc,
+        char**& argv,
+        bool const build_parm_parse = true,
+        MPI_Comm const mpi_comm = MPI_COMM_WORLD
+    );
+
+}
 #endif

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -12,6 +12,9 @@
 
 #include <memory>
 
+namespace warpx::initialization
+{
+
 namespace {
     /** Overwrite defaults in AMReX Inputs
      *
@@ -57,13 +60,15 @@ namespace {
 }
 
 amrex::AMReX*
-warpx_amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
+amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
 {
     return amrex::Initialize(
         argc,
         argv,
         build_parm_parse,
         mpi_comm,
-        overwrite_amrex_parser_defaults
+        ::overwrite_amrex_parser_defaults
     );
+}
+
 }

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -12,9 +12,6 @@
 
 #include <memory>
 
-namespace warpx::initialization
-{
-
 namespace {
     /** Overwrite defaults in AMReX Inputs
      *
@@ -59,16 +56,20 @@ namespace {
     }
 }
 
-amrex::AMReX*
-amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
+
+namespace warpx::initialization
 {
-    return amrex::Initialize(
-        argc,
-        argv,
-        build_parm_parse,
-        mpi_comm,
-        ::overwrite_amrex_parser_defaults
-    );
-}
+
+    amrex::AMReX*
+    amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
+    {
+        return amrex::Initialize(
+            argc,
+            argv,
+            build_parm_parse,
+            mpi_comm,
+            ::overwrite_amrex_parser_defaults
+        );
+    }
 
 }

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -150,12 +150,12 @@ namespace
 
     void amrex_init (int argc, char* argv[])
     {
-        warpx_amrex_init(argc, argv);
+        warpx::initialization::amrex_init(argc, argv);
     }
 
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
-        warpx_amrex_init(argc, argv, true, mpicomm);
+        warpx::initialization::amrex_init(argc, argv, true, mpicomm);
     }
 
     void amrex_finalize (int /*finalize_mpi*/)

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
 {
     ablastr::parallelization::mpi_init(argc, argv);
 
-    warpx_amrex_init(argc, argv);
+    warpx::initialization::amrex_init(argc, argv);
 
     utils::rocfft::setup();
 


### PR DESCRIPTION
This PR is an initial step to refactor some parts of WarpX. This specific change is inspired by what is done in ImpactX