### PR TITLE
Allow `FieldProbe` in RZ geometry

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2659,7 +2659,8 @@ Reduced Diagnostics
         to file. The electromagnetic field components are interpolated to the measurement point
         by default, but can they be saved as non-averaged by setting
         ``<reduced_diags_name>.raw_fields = true``, in which case the raw fields for the cell
-        containing the measurement point are saved.
+        containing the measurement point are saved. In RZ geometry, this only saves the
+        0'th azimuthal mode component of the fields.
         The interpolation order can be set by specifying ``<reduced_diags_name>.interp_order``,
         otherwise it is set to ``1``.
         Integrated electric and magnetic field components can instead be obtained by specifying

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -66,7 +66,7 @@ public:
      */
 
     //! noutputs is 11 for particle id + (x, y, z, Ex, Ey, Ez, Bx, By, Bz, S)
-    static constexpr int noutputs = FieldProbePIdx::nattribs + 3 + 1;
+    static const int noutputs = 11;
 
 private:
     amrex::Real x_probe = 0._rt;

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -51,12 +51,6 @@ FieldProbe::FieldProbe (std::string rd_name)
 : ReducedDiags{rd_name}, m_probe(&WarpX::GetInstance())
 {
 
-    // RZ coordinate is not working
-#if (defined WARPX_DIM_RZ)
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
-        "FieldProbe reduced diagnostics does not work for RZ coordinate.");
-#endif
-
     // read number of levels
     int nLevel = 0;
     const amrex::ParmParse pp_amr("amr");

--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.H
@@ -19,13 +19,20 @@
  * This enumerated struct is used to index the field probe particle
  * values that are being stored as SoA data. Nattribs
  * is enumerated to give the number of attributes stored.
+ * The strange insertion of `theta` below is due to the use of
+ * GetParticlePosition for the field probe locations, which reads the probe
+ * theta value from PIdx::theta = 4.
  */
 struct FieldProbePIdx
 {
     enum
     {
         Ex = 0, Ey, Ez,
-        Bx, By, Bz,
+        Bx,
+#ifdef WARPX_DIM_RZ
+        theta,      ///< RZ needs all three position components
+#endif
+        By, Bz,
         S, //!< the Poynting vector
         nattribs
     };


### PR DESCRIPTION
Currently the `FieldProbe` reduced diagnostic is not supported in RZ. This PR adds support for it. The one tricky thing is that `FieldProbePIdx != PIdx` which causes a problem with getting the probe positions in `GetParticlePosition()` which uses `m_theta = soa.GetRealData(PIdx::theta).dataPtr() + a_offset;`. So we need to ensure `PIdx::theta == FieldProbePIdx::theta`.

Fixes #4031.