### PR TITLE
RigidInjection: properly transform zinject to boosted frame

### DIFF
--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -71,7 +71,11 @@ RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_cor
 
 void RigidInjectedParticleContainer::InitData()
 {
-    zinject_plane_levels.resize(finestLevel()+1, zinject_plane/WarpX::gamma_boost);
+    // Perform Lorentz transform of `z_inject_plane`
+    const amrex::Real t_boost = WarpX::GetInstance().gett_new(0);
+    amrex::Real zinject_plane_boost = zinject_plane/WarpX::gamma_boost
+                                    - WarpX::beta_boost*t_boost;
+    zinject_plane_levels.resize(finestLevel()+1, zinject_plane_boost);
 
     AddParticles(0); // Note - add on level 0
 


### PR DESCRIPTION
When the simulation starts with `t_boost` different than 0, the injection position needs to be transformed differently.