### PR TITLE
Clang tidy CI test: exclude bugprone_easily_swappable_parameters check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: '-*,
     bugprone-branch-clone,
+    -bugprone-easily-swappable-parameters,
     cppcoreguidelines-avoid-goto,
     misc-const-correctness,
     modernize-avoid-bind,


### PR DESCRIPTION
This PR explicitly excludes the following check from clang-tidy CI test:
- [bugprone-easily-swappable-parameters](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/easily-swappable-parameters.html)

The reason is that it leads to too many issues and I think that we don't want to fix this potential issue for now
(see https://github.com/ECP-WarpX/WarpX/pull/4049).