### PR TITLE
Doc: Update openPMD tutorials link

### DIFF
--- a/Docs/source/dataanalysis/openpmdviewer.rst
+++ b/Docs/source/dataanalysis/openpmdviewer.rst
@@ -65,4 +65,4 @@ by using the command:
     ts.slider()
 
 You can also access the particle and field data as numpy arrays with the methods ``ts.get_field`` and ``ts.get_particle``.
-See the openPMD-viewer tutorials `here <https://github.com/openPMD/openPMD-viewer/tree/master/tutorials>`_ for more info.
+See the openPMD-viewer tutorials `here <https://github.com/openPMD/openPMD-viewer/tree/dev/docs/source/tutorials>`_ for more info.


### PR DESCRIPTION
Changed the link for the openPMD tutorials because the previous one is broken.