### PR TITLE
Fix max_grid_size for RZ PSATD

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -322,14 +322,15 @@ void CheckGriddingForRZSpectral ()
     Vector<int> max_grid_size_x(max_level+1);
 
     // Set the radial block size to be the power of 2 greater than or equal to
-    // the number of grid cells. The blocking_factor must be a power of 2
-    // and the max_grid_size should be a multiple of the blocking_factor.
+    // the number of grid cells. The blocking factor must be a power of 2
+    // and the max_grid_size must be a multiple of the blocking_factor unless
+    // it is less than the blocking factor.
     int k = 1;
     while (k < n_cell[0]) {
         k *= 2;
     }
     blocking_factor_x[0] = k;
-    max_grid_size_x[0] = k;
+    max_grid_size_x[0] = n_cell[0];
 
     for (int lev=1 ; lev <= max_level ; lev++) {
         // For this to be correct, this needs to read in any user specified refinement ratios.


### PR DESCRIPTION
This PR sets max_grid_size_x = n_cell[0]. When using RZ PSATD, all of the radial dimension must be in the same block, so the values of blocking factor and max grid size are modified so this happens. The code was setting the max grid size to be equal to the blocking factor but this fails in cases when the number of grid cells is not a power of 2. The blocking factor must be a power of 2 and the max grid size must be a integer multiple of the blocking factor unless it is less than the blocking factor. By setting the max grid size equal to the blocking factor, amrex checks whether the number of grid cells is a multiple of the blocking factor and this fails when the number of cells is not a power of 2. By setting the max grid size equal to the number of grid cells the check is skipped since the max grid size will be less than the blocking factor.

This PR solves an issue brought up in issue #4038.