### PR TITLE
Remove field probe raw_fields option

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2655,14 +2655,11 @@ Reduced Diagnostics
         the value of the Poynting Vector :math:`|S|` of the electromagnetic fields,
         at mesh refinement levels from  0 to :math:`n`, at point (:math:`x`, :math:`y`, :math:`z`).
 
-        Note: the norms are always interpolated to the measurement point before they are written
-        to file. The electromagnetic field components are interpolated to the measurement point
-        by default, but can they be saved as non-averaged by setting
-        ``<reduced_diags_name>.raw_fields = true``, in which case the raw fields for the cell
-        containing the measurement point are saved. In RZ geometry, this only saves the
-        0'th azimuthal mode component of the fields.
+        The fields are always interpolated to the measurement point.
         The interpolation order can be set by specifying ``<reduced_diags_name>.interp_order``,
-        otherwise it is set to ``1``.
+        defaulting to ``1``.
+        In RZ geometry, this only saves the
+        0'th azimuthal mode component of the fields.
         Integrated electric and magnetic field components can instead be obtained by specifying
         ``<reduced_diags_name>.integrate == true``.
         In a *moving window* simulation, the FieldProbe can be set to follow the moving frame by specifying ``<reduced_diags_name>.do_moving_window_FP = 1`` (default 0).

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.H
@@ -109,9 +109,6 @@ private:
     //! particle shape used for field gather
     int interp_order = 1;
 
-    //! Judges whether to gather raw fields or interpolated data
-    bool raw_fields = false;
-
     //! Judges whether to follow a moving window
     bool do_moving_window_FP = false;
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -377,8 +377,6 @@ void FieldProbe::ComputeDiags (int step)
     // loop over refinement levels
     for (int lev = 0; lev < nLevel; ++lev)
     {
-        const amrex::Geometry& gm = warpx.Geom(lev);
-        const auto prob_lo = gm.ProbLo();
         amrex::Real const dt = WarpX::GetInstance().getdt(lev);
         // Calculates particle movement in moving window sims
         amrex::Real move_dist = 0.0;

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -141,8 +141,7 @@ FieldProbe::FieldProbe (std::string rd_name)
     bool raw_fields;
     const bool raw_fields_specified = pp_rd_name.query("raw_fields", raw_fields);
     if (raw_fields_specified) {
-        WARPX_ABORT_WITH_MESSAGE("The field probe raw_fields options is obsolete. " +
-                                 "To get the equivalent, set interp_order = 0");
+        WARPX_ABORT_WITH_MESSAGE("The field probe raw_fields options is obsolete. To get the equivalent, set interp_order = 0");
     }
 
     if (WarpX::gamma_boost > 1.0_rt)

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -460,18 +460,6 @@ void FieldProbe::ComputeDiags (int step)
             }
             if( ProbeInDomain() )
             {
-                const auto cell_size = gm.CellSizeArray();
-                const int i_probe = static_cast<int>(amrex::Math::floor((x_probe - prob_lo[0]) / cell_size[0]));
-#if defined(WARPX_DIM_1D_Z)
-                const int j_probe = 0;
-                const int k_probe = 0;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const int j_probe = static_cast<int>(amrex::Math::floor((z_probe - prob_lo[1]) / cell_size[1]));
-                const int k_probe = 0;
-#elif defined(WARPX_DIM_3D)
-                const int j_probe = static_cast<int>(amrex::Math::floor((y_probe - prob_lo[1]) / cell_size[1]));
-                const int k_probe = static_cast<int>(amrex::Math::floor((z_probe - prob_lo[2]) / cell_size[2]));
-#endif
                 const auto &arrEx = Ex[pti].array();
                 const auto &arrEy = Ey[pti].array();
                 const auto &arrEz = Ez[pti].array();

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -135,9 +135,15 @@ FieldProbe::FieldProbe (std::string rd_name)
         );
     }
     pp_rd_name.query("integrate", m_field_probe_integrate);
-    pp_rd_name.query("raw_fields", raw_fields);
     utils::parser::queryWithParser(pp_rd_name, "interp_order", interp_order);
     pp_rd_name.query("do_moving_window_FP", do_moving_window_FP);
+
+    bool raw_fields;
+    const bool raw_fields_specified = pp_rd_name.query("raw_fields", raw_fields);
+    if (raw_fields_specified) {
+        WARPX_ABORT_WITH_MESSAGE("The field probe raw_fields options is obsolete. " +
+                                 "To get the equivalent, set interp_order = 0");
+    }
 
     if (WarpX::gamma_boost > 1.0_rt)
     {
@@ -501,7 +507,6 @@ void FieldProbe::ComputeDiags (int step)
                 // Temporarily defining modes and interp outside ParallelFor to avoid GPU compilation errors.
                 const int temp_modes = WarpX::n_rz_azimuthal_modes;
                 const int temp_interp_order = interp_order;
-                const bool temp_raw_fields = raw_fields;
                 const bool temp_field_probe_integrate = m_field_probe_integrate;
 
                 // Interpolating to the probe positions for each particle
@@ -514,17 +519,7 @@ void FieldProbe::ComputeDiags (int step)
                     amrex::ParticleReal Bxp = 0._prt, Byp = 0._prt, Bzp = 0._prt;
 
                     // first gather E and B to the particle positions
-                    if (temp_raw_fields)
-                    {
-                        Exp = arrEx(i_probe, j_probe, k_probe);
-                        Eyp = arrEy(i_probe, j_probe, k_probe);
-                        Ezp = arrEz(i_probe, j_probe, k_probe);
-                        Bxp = arrBx(i_probe, j_probe, k_probe);
-                        Byp = arrBy(i_probe, j_probe, k_probe);
-                        Bzp = arrBz(i_probe, j_probe, k_probe);
-                    }
-                    else
-                        doGatherShapeN(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                    doGatherShapeN(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                    arrEx, arrEy, arrEz, arrBx, arrBy, arrBz,
                                    Extype, Eytype, Eztype, Bxtype, Bytype, Bztype,
                                    dx_arr, xyzmin_arr, lo, temp_modes,


### PR DESCRIPTION
This PR addresses the issue raised in #4065 and removes the `raw_fields` option.

X-ref:
- #4057
- #3746
- ...
- #2430