### PR TITLE
 Clang-tidy CI test: add some performance checks in clang-tidy CI test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -65,6 +65,10 @@ Checks: '-*,
     modernize-use-nullptr,
     performance-faster-string-find,
     performance-for-range-copy,
+    performance-implicit-conversion-in-loop,
+    performance-inefficient-algorithm,
+    performance-inefficient-string-concatenation,
+    performance-inefficient-vector-operation,
     readability-non-const-parameter
     '
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -136,8 +136,8 @@ Diagnostics::BaseReadParameters ()
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             parser_str != "",
-            "Input error: cannot find parser string for " + var + " in file. "
-            + m_diag_name + ".particle_fields." + var + "(x,y,z,ux,uy,uz) is required"
+            std::string("Input error: cannot find parser string for ").append(var).append(" in file. ").append(
+                m_diag_name).append(".particle_fields.").append(var).append("(x,y,z,ux,uy,uz) is required");
         );
 
         m_pfield_strings.push_back(parser_str);
@@ -189,7 +189,7 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
-            m_varnames.push_back(fname + '_' + sname);
+            m_varnames.push_back(fname.append('_').append(sname));
         }
     }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -189,7 +189,7 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
-            m_varnames.push_back(fname.append('_').append(sname));
+            m_varnames.push_back(fname.append("_").append(sname));
         }
     }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -137,8 +137,7 @@ Diagnostics::BaseReadParameters ()
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             parser_str != "",
             std::string("Input error: cannot find parser string for ").append(var).append(" in file. ").append(
-                m_diag_name).append(".particle_fields.").append(var).append("(x,y,z,ux,uy,uz) is required");
-        );
+                m_diag_name).append(".particle_fields.").append(var).append("(x,y,z,ux,uy,uz) is required"));
 
         m_pfield_strings.push_back(parser_str);
 
@@ -189,7 +188,8 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
-            m_varnames.push_back(fname.append("_").append(sname));
+            const auto varname = fname + '_' + sname;
+            m_varnames.push_back(varname);
         }
     }
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -188,7 +188,8 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
-            const auto varname = fname + '_' + sname;
+            auto varname = fname;
+            varname.append("_").append(sname);
             m_varnames.push_back(varname);
         }
     }

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -211,7 +211,7 @@ FlushFormatCheckpoint::WriteDMaps (const std::string& dir, int nlev) const
         for (int lev = 0; lev < nlev; ++lev) {
             std::string DMFileName = dir;
             if (!DMFileName.empty() && DMFileName[DMFileName.size()-1] != '/') {DMFileName += '/';}
-            DMFileName = amrex::Concatenate(DMFileName + "Level_", lev, 1);
+            DMFileName = amrex::Concatenate(DMFileName.append("Level_"), lev, 1);
             DMFileName += "/DM";
 
             std::ofstream DMFile;

--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -95,10 +95,10 @@ SignalHandling::parseSignalNameToNumber (const std::string &str)
 
         signals_parser.setConstant(name_upper, sp.value);
         signals_parser.setConstant(name_lower, sp.value);
-        name_upper = "SIG" + name_upper;
-        name_lower = "sig" + name_lower;
-        signals_parser.setConstant(name_upper, sp.value);
-        signals_parser.setConstant(name_lower, sp.value);
+        const auto sig_name_upper = "SIG" + name_upper;
+        const auto sig_name_lower = "sig" + name_lower;
+        signals_parser.setConstant(sig_name_upper, sp.value);
+        signals_parser.setConstant(sig_name_lower, sp.value);
     }
 #endif // #if defined(__linux__) || defined(__APPLE__)
 

--- a/Source/ablastr/utils/msg_logger/MsgLogger.cpp
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.cpp
@@ -355,6 +355,7 @@ Logger::compute_msgs_with_counter_and_ranks(
     std::vector<MsgWithCounterAndRanks> msgs_with_counter_and_ranks;
 
     // Put messages of the gather rank in msgs_with_counter_and_ranks
+    msgs_with_counter_and_ranks.reserve(my_msg_map.size());
     for (const auto& el : my_msg_map)
     {
         msgs_with_counter_and_ranks.emplace_back(


### PR DESCRIPTION
This PR adds the following checks:
- [performance-implicit-conversion-in-loop](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-implicit-conversion-in-loop.html) 
- [performance-inefficient-algorithm](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-algorithm.html)
- [performance-inefficient-string-concatenation](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-string-concatenation.html)
- [performance-inefficient-vector-operation](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-vector-operation.html)