### PR TITLE
Fix bug with MLMG solver, always pass ghost cells to `SumBoundary`

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -613,7 +613,9 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
     }
     if (!local) {
         const Geometry& gm = allcontainers[0]->Geom(lev);
-        ablastr::utils::communication::SumBoundary(*rho, WarpX::do_single_precision_comms, gm.periodicity());
+        ablastr::utils::communication::SumBoundary(
+            *rho, 0, rho->nComp(), rho->nGrowVect(), amrex::IntVect(0),
+            WarpX::do_single_precision_comms, gm.periodicity());
     }
 
     return rho;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -613,6 +613,8 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
     }
     if (!local) {
         const Geometry& gm = allcontainers[0]->Geom(lev);
+        // Possible performance optimization:
+        // pass less than `rho->nGrowVect()` in the fifth input variable `dst_ng`
         ablastr::utils::communication::SumBoundary(
             *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
             WarpX::do_single_precision_comms, gm.periodicity());

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -614,7 +614,7 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
     if (!local) {
         const Geometry& gm = allcontainers[0]->Geom(lev);
         ablastr::utils::communication::SumBoundary(
-            *rho, 0, rho->nComp(), rho->nGrowVect(), amrex::IntVect(0),
+            *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
             WarpX::do_single_precision_comms, gm.periodicity());
     }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1017,10 +1017,8 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
         // Exchange guard cells
         if (local == false) {
             ablastr::utils::communication::SumBoundary(
-                *rho[lev],
-                WarpX::do_single_precision_comms,
-                m_gdb->Geom(lev).periodicity()
-            );
+                *rho[lev], 0, rho[lev]->nComp(), rho[lev]->nGrowVect(), amrex::IntVect(0),
+                WarpX::do_single_precision_comms, m_gdb->Geom(lev).periodicity());
         }
 
 #ifndef WARPX_DIM_RZ
@@ -1112,7 +1110,11 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
     WarpX::GetInstance().ApplyInverseVolumeScalingToChargeDensity(rho.get(), lev);
 #endif
 
-    if (local == false) { ablastr::utils::communication::SumBoundary(*rho, WarpX::do_single_precision_comms, gm.periodicity()); }
+    if (local == false) {
+        ablastr::utils::communication::SumBoundary(
+            *rho, 0, rho->nComp(), rho->nGrowVect(), amrex::IntVect(0),
+            WarpX::do_single_precision_comms, gm.periodicity());
+    }
 
 #ifndef WARPX_DIM_RZ
     // Reflect density over PEC boundaries, if needed.

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1016,6 +1016,8 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
 
         // Exchange guard cells
         if (local == false) {
+            // Possible performance optimization:
+            // pass less than `rho[lev]->nGrowVect()` in the fifth input variable `dst_ng`
             ablastr::utils::communication::SumBoundary(
                 *rho[lev], 0, rho[lev]->nComp(), rho[lev]->nGrowVect(), rho[lev]->nGrowVect(),
                 WarpX::do_single_precision_comms, m_gdb->Geom(lev).periodicity());
@@ -1111,6 +1113,8 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 #endif
 
     if (local == false) {
+        // Possible performance optimization:
+        // pass less than `rho->nGrowVect()` in the fifth input variable `dst_ng`
         ablastr::utils::communication::SumBoundary(
             *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
             WarpX::do_single_precision_comms, gm.periodicity());

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1017,7 +1017,7 @@ WarpXParticleContainer::DepositCharge (amrex::Vector<std::unique_ptr<amrex::Mult
         // Exchange guard cells
         if (local == false) {
             ablastr::utils::communication::SumBoundary(
-                *rho[lev], 0, rho[lev]->nComp(), rho[lev]->nGrowVect(), amrex::IntVect(0),
+                *rho[lev], 0, rho[lev]->nComp(), rho[lev]->nGrowVect(), rho[lev]->nGrowVect(),
                 WarpX::do_single_precision_comms, m_gdb->Geom(lev).periodicity());
         }
 
@@ -1112,7 +1112,7 @@ WarpXParticleContainer::GetChargeDensity (int lev, bool local)
 
     if (local == false) {
         ablastr::utils::communication::SumBoundary(
-            *rho, 0, rho->nComp(), rho->nGrowVect(), amrex::IntVect(0),
+            *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
             WarpX::do_single_precision_comms, gm.periodicity());
     }
 

--- a/Source/ablastr/utils/Communication.H
+++ b/Source/ablastr/utils/Communication.H
@@ -82,16 +82,6 @@ void
 FillBoundary(amrex::Vector<amrex::MultiFab *> const &mf, bool do_single_precision_comms,
              const amrex::Periodicity &period);
 
-void SumBoundary (amrex::MultiFab &mf,
-                  bool do_single_precision_comms,
-                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
-
-void SumBoundary (amrex::MultiFab &mf,
-                  int start_comp,
-                  int num_comps, amrex::IntVect ng,
-                  bool do_single_precision_comms,
-                  const amrex::Periodicity &period = amrex::Periodicity::NonPeriodic());
-
 void
 SumBoundary (amrex::MultiFab &mf,
              int start_comp,

--- a/Source/ablastr/utils/Communication.cpp
+++ b/Source/ablastr/utils/Communication.cpp
@@ -139,56 +139,6 @@ void FillBoundary (amrex::iMultiFab&         imf,
     imf.FillBoundary(ng, period);
 }
 
-void SumBoundary (amrex::MultiFab &mf, bool do_single_precision_comms, const amrex::Periodicity &period)
-{
-    BL_PROFILE("ablastr::utils::communication::SumBoundary");
-
-    if (do_single_precision_comms)
-    {
-        amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
-                                                                 mf.DistributionMap(),
-                                                                 mf.nComp(),
-                                                                 mf.nGrowVect());
-
-        mixedCopy(mf_tmp, mf, 0, 0, mf.nComp(), mf.nGrowVect());
-
-        mf_tmp.SumBoundary(period);
-
-        mixedCopy(mf, mf_tmp, 0, 0, mf.nComp(), mf.nGrowVect());
-    }
-    else
-    {
-        mf.SumBoundary(period);
-    }
-}
-
-void SumBoundary(amrex::MultiFab &mf,
-                 int start_comp,
-                 int num_comps,
-                 amrex::IntVect ng,
-                 bool do_single_precision_comms,
-                 const amrex::Periodicity &period)
-{
-    BL_PROFILE("ablastr::utils::communication::SumBoundary");
-
-    if (do_single_precision_comms)
-    {
-        amrex::FabArray<amrex::BaseFab<comm_float_type> > mf_tmp(mf.boxArray(),
-                                                                 mf.DistributionMap(),
-                                                                 num_comps,
-                                                                 ng);
-        mixedCopy(mf_tmp, mf, start_comp, 0, num_comps, ng);
-
-        mf_tmp.SumBoundary(0, num_comps, ng, period);
-
-        mixedCopy(mf, mf_tmp, 0, start_comp, num_comps, ng);
-    }
-    else
-    {
-        mf.SumBoundary(start_comp, num_comps, ng, period);
-    }
-}
-
 void
 SumBoundary (amrex::MultiFab &mf,
              int start_comp,


### PR DESCRIPTION
Following up on a bug raised by @aeriforme related to the convergence of the MLMG solver, and based on a comment posted on Slack by @WeiqunZhang (channel #general, May 30, 2023),

> There are three versions of `SumBoundary`'s in ablastr/utils/Communication.cpp. Their differences are about the number of ghost cells included in the operation. I think we should remove two of them and force us to explicitly think and state the number of source and destination ghost cells.

let's try to keep only the most general version of `SumBoundary` (the last one among the three shown below)
https://github.com/ECP-WarpX/WarpX/blob/f30799b6f0ffe2a31aa388856c9b66835b384257/Source/ablastr/utils/Communication.H#L85-L102
and request that developers pass the number of source and destination ghost cells explicitly, each time.

@aeriforme @WeiqunZhang 
Do you have a workflow to test this PR on the MLMG convergence bug? Did you expect `SumBoundary` to be called in many other parts of the code? I found only a few instances related to the deposition of the charge density rho, and I'm not sure which one(s) of these should use `rho->nGrowVect()` instead of `amrex::IntVect(0)` as `dst_ng` in order to fix the MLMG convergence bug. Do you know?

@ax3l @RemiLehe 
Please feel free to comment or suggest alternative solutions.
Here I'm trying to implement @WeiqunZhang's idea above.