### PR TITLE
Add reduced diag precision input parameter

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2984,6 +2984,9 @@ Reduced Diagnostics
     The separator between row values in the output file.
     The default separator is a whitespace.
 
+* ``<reduced_diags_name>.precision`` (`integer`) optional (default `14`)
+    The precision used when writing out the data to the text files.
+
 Lookup tables and other settings for QED modules
 ------------------------------------------------
 

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.H
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.H
@@ -42,6 +42,9 @@ public:
     /// separator in the output file
     std::string m_sep = " ";
 
+    /// precision for data in the output file
+    int m_precision = 14;
+
     /// output data
     std::vector<amrex::Real> m_data;
 

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -66,6 +66,9 @@ ReducedDiags::ReducedDiags (std::string rd_name)
 
     // read separator
     pp_rd_name.query("separator", m_sep);
+
+    // precision of data in the output file
+    pp_rd_name.query("precision", m_precision);
 }
 // end constructor
 
@@ -107,7 +110,7 @@ void ReducedDiags::WriteToFile (int step) const
     ofs << m_sep;
 
     // set precision
-    ofs << std::fixed << std::setprecision(14) << std::scientific;
+    ofs << std::fixed << std::setprecision(m_precision) << std::scientific;
 
     // write time
     ofs << WarpX::GetInstance().gett_new(0);

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -9,6 +9,7 @@
 
 #include "WarpX.H"
 #include "Utils/Parser/IntervalsParser.H"
+#include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
 
 #include <AMReX.H>
@@ -68,7 +69,7 @@ ReducedDiags::ReducedDiags (std::string rd_name)
     pp_rd_name.query("separator", m_sep);
 
     // precision of data in the output file
-    pp_rd_name.query("precision", m_precision);
+    utils::parser::queryWithParser(pp_rd_name, "precision", m_precision);
 }
 // end constructor
 


### PR DESCRIPTION
This adds a parameter that allows the user to control the precision of the data written to the reduced diagnostics output files.