### PR TITLE
Update Intel compiler installation

### DIFF
--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -14,10 +14,13 @@ echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
-wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
-  | sudo apt-key add -
-echo "deb https://apt.repos.intel.com/oneapi all main" \
-  | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository:
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
 sudo apt-get update
 
@@ -33,7 +36,7 @@ do
         build-essential \
         ccache          \
         cmake           \
-        intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
+        intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel \
         g++ gfortran    \
         libopenmpi-dev  \
         openmpi-bin     \


### PR DESCRIPTION
oneAPI 2023.2.0 has been released and there are some changes to the names.
