### PR TITLE
Clean main.cpp by moving some functions into WarpX constructor

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -300,8 +300,6 @@ void CheckDims ()
 void CheckGriddingForRZSpectral ()
 {
 #ifdef WARPX_DIM_RZ
-    // Ensure that geometry.dims is set properly.
-    CheckDims();
 
     const ParmParse pp_algo("algo");
     const int electromagnetic_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -252,6 +252,15 @@ WarpX::WarpX ()
 {
     m_instance = this;
 
+    ParseGeometryInput();
+
+    ConvertLabParamsToBoost();
+    ReadBCParams();
+
+#ifdef WARPX_DIM_RZ
+    CheckGriddingForRZSpectral();
+#endif
+
     ReadParameters();
 
     BackwardCompatibility();
@@ -498,8 +507,6 @@ WarpX::~WarpX ()
 void
 WarpX::ReadParameters ()
 {
-    // Ensure that geometry.dims is set properly.
-    CheckDims();
 
     {
         const ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -11,7 +11,6 @@
 #include "Initialization/WarpXAMReXInit.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXrocfftUtil.H"
-#include "Utils/WarpXUtil.H"
 
 #include <ablastr/parallelization/MPIInitHelpers.H>
 #include <ablastr/utils/timer/Timer.H>
@@ -23,18 +22,9 @@ int main(int argc, char* argv[])
 {
     ablastr::parallelization::mpi_init(argc, argv);
 
-    warpx::initialization::amrex_init(argc, argv);
-
     utils::rocfft::setup();
 
-    ParseGeometryInput();
-
-    ConvertLabParamsToBoost();
-    ReadBCParams();
-
-#ifdef WARPX_DIM_RZ
-    CheckGriddingForRZSpectral();
-#endif
+    warpx::initialization::amrex_init(argc, argv);
 
     {
         WARPX_PROFILE_VAR("main()", pmain);
@@ -60,9 +50,9 @@ int main(int argc, char* argv[])
         WARPX_PROFILE_VAR_STOP(pmain);
     }
 
-    utils::rocfft::cleanup();
-
     amrex::Finalize();
+
+    utils::rocfft::cleanup();
 
     ablastr::parallelization::mpi_finalize ();
 }


### PR DESCRIPTION
This PR moves some functions that manipulate WarpX inputfile into WarpX constructor. It also removes a redundant check of the dimensionality of the simulation.