### PR TITLE
Add write_diagonstics_on_restart input option

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3116,6 +3116,9 @@ The checkpoint capability can be turned with regular diagnostics: ``<diag_name>.
     Name of the checkpoint file to restart from. Returns an error if the folder does not exist
     or if it is not properly formatted.
 
+* ``warpx.write_diagonstics_on_restart`` (`bool`) optional (default `false`)
+    When `true`, write the diagnostics after restart at the time of the restart.
+
 Intervals parser
 ----------------
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -453,7 +453,9 @@ WarpX::InitData ()
         // looks at field values will see the composite of the field
         // solution and any external field
         AddExternalFields();
+    }
 
+    if (restart_chkfile.empty() || write_diagonstics_on_restart) {
         // Write full diagnostics before the first iteration.
         multi_diags->FilterComputePackFlush( -1 );
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -457,13 +457,13 @@ WarpX::InitData ()
 
     if (restart_chkfile.empty() || write_diagonstics_on_restart) {
         // Write full diagnostics before the first iteration.
-        multi_diags->FilterComputePackFlush( -1 );
+        multi_diags->FilterComputePackFlush(istep[0] - 1);
 
         // Write reduced diagnostics before the first iteration.
         if (reduced_diags->m_plot_rd != 0)
         {
-            reduced_diags->ComputeDiags(-1);
-            reduced_diags->WriteToFile(-1);
+            reduced_diags->ComputeDiags(istep[0] - 1);
+            reduced_diags->WriteToFile(istep[0] - 1);
         }
     }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1535,6 +1535,7 @@ private:
 
     std::string restart_chkfile;
 
+    /** When `true`, write the diagnostics after restart at the time of the restart. */
     bool write_diagonstics_on_restart = false;
 
     amrex::VisMF::Header::Version plotfile_headerversion  = amrex::VisMF::Header::Version_v1;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1535,6 +1535,8 @@ private:
 
     std::string restart_chkfile;
 
+    bool write_diagonstics_on_restart = false;
+
     amrex::VisMF::Header::Version plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
     amrex::VisMF::Header::Version slice_plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -603,6 +603,8 @@ WarpX::ReadParameters ()
             }
         }
 
+        pp_warpx.query("write_diagonstics_on_restart", write_diagonstics_on_restart);
+
         pp_warpx.queryarr("checkpoint_signals", signals_in);
 #if defined(__linux__) || defined(__APPLE__)
         for (const std::string &str : signals_in) {


### PR DESCRIPTION
This PR adds the `warpx.write_diagonstics_on_restart` input parameter, which does as it says when true. Sometimes it is convenient to have the code rewrite the diagnostics at the time of the restart, for instance if the restart is being done in a different directory than the original simulation. This mirrors the AMReX parameter `amr.plotfile_on_restart` but is more general since is works for diagnostics of any format and the reduced diagnostics.