### PR TITLE
Bug fix: the electric field for ionization in quasi-cylindrical geometry

### DIFF
--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -96,13 +96,13 @@ struct IonizationFilterFunc
 
             amrex::ParticleReal ex = 0._rt, ey = 0._rt, ez = 0._rt;
             amrex::ParticleReal bx = 0._rt, by = 0._rt, bz = 0._rt;
-            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,
                            m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                            m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                            m_dx_arr, m_xyzmin_arr, m_lo, m_n_rz_azimuthal_modes,
                            m_nox, m_galerkin_interpolation);
+            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             // Compute electric field amplitude in the particle's frame of
             // reference (particularly important when in boosted frame).


### PR DESCRIPTION

[inputs_rz.txt](https://github.com/ECP-WarpX/WarpX/files/12091413/inputs_rz.txt)
       I have found a bug in the calculation of the electric field for ionization in quasi-cylindrical geometry. When ionization is performed using an external electric field in the quasi-cylindrical geometry, the value of the external electric field for ionization is incorrectly calculated. The bug is in file “Source\Particles\ElementaryProcess\Ionization.H”. I have fixed this bug.
       The reason for this bug is that when calculating the electric field, the program first reads the external electric field in the Cartesian coordinate system and then reads the electric field on the grid. After the external electric field is read, it will become the initial value of the "Electric Field on the Particles". When reading the electric field on the grid in the quasi-cylindrical geometry, the initial value will perform wrong coordinate conversion(Convert Er and Et to Ex and Ey).
	In the following, I will show this bug. I set up a laser on the grid and an external electromagnetic field at the same time. The two laser have the same parameters except for a phase difference of pi. The intensity of the single laser is strong enough to ionize ions. Theoretically, the two laser beams cancel each other and the ions can not be ionized. But after the simulation, I find that ions are still be ionized and generate a lot of electrons (as shown in Figure A). Then I use the modified code to simulate (the same input.file), and no ionized electrons are produced(as shown in Figure B).
	I have attached the input file. 
[inputs_rz.txt](https://github.com/ECP-WarpX/WarpX/files/12091416/inputs_rz.txt)
![pull_request](https://github.com/ECP-WarpX/WarpX/assets/139459631/d0871b25-bba8-40d5-b015-a02c0074bc58)


