### PR TITLE
WarpX class: move a couple of function definitions from WarpX.H to WarpX.cpp

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -529,27 +529,9 @@ public:
 
     static amrex::LayoutData<amrex::Real>* getCosts (int lev);
 
-    void setLoadBalanceEfficiency (const int lev, const amrex::Real efficiency)
-    {
-        if (m_instance)
-        {
-            m_instance->load_balance_efficiency[lev] = efficiency;
-        } else
-        {
-            return;
-        }
-    }
+    void setLoadBalanceEfficiency (const int lev, const amrex::Real efficiency);
 
-    amrex::Real getLoadBalanceEfficiency (const int lev)
-    {
-        if (m_instance)
-        {
-            return m_instance->load_balance_efficiency[lev];
-        } else
-        {
-            return -1;
-        }
-    }
+    amrex::Real getLoadBalanceEfficiency (const int lev);
 
     static amrex::IntVect filter_npass_each_dir;
     BilinearFilter bilinear_filter;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2883,6 +2883,30 @@ WarpX::getCosts (int lev)
 }
 
 void
+WarpX::setLoadBalanceEfficiency (const int lev, const amrex::Real efficiency)
+    {
+        if (m_instance)
+        {
+            m_instance->load_balance_efficiency[lev] = efficiency;
+        } else
+        {
+            return;
+        }
+    }
+
+amrex::Real
+WarpX::getLoadBalanceEfficiency (const int lev)
+    {
+        if (m_instance)
+        {
+            return m_instance->load_balance_efficiency[lev];
+        } else
+        {
+            return -1;
+        }
+    }
+
+void
 WarpX::BuildBufferMasks ()
 {
     for (int lev = 1; lev <= maxLevel(); ++lev)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2884,27 +2884,27 @@ WarpX::getCosts (int lev)
 
 void
 WarpX::setLoadBalanceEfficiency (const int lev, const amrex::Real efficiency)
+{
+    if (m_instance)
     {
-        if (m_instance)
-        {
-            m_instance->load_balance_efficiency[lev] = efficiency;
-        } else
-        {
-            return;
-        }
+        m_instance->load_balance_efficiency[lev] = efficiency;
+    } else
+    {
+        return;
     }
+}
 
 amrex::Real
 WarpX::getLoadBalanceEfficiency (const int lev)
+{
+    if (m_instance)
     {
-        if (m_instance)
-        {
-            return m_instance->load_balance_efficiency[lev];
-        } else
-        {
-            return -1;
-        }
+        return m_instance->load_balance_efficiency[lev];
+    } else
+    {
+        return -1;
     }
+}
 
 void
 WarpX::BuildBufferMasks ()


### PR DESCRIPTION
This PR moves the definition of a couple of functions from the header to the cpp file of the WarpX class