### PR TITLE
Disable Multi-Line Support in amrex::ParmParse

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -110,7 +110,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach 10b6cb26d0ac359922276ce08eeb728a14624b70 && cd -
+        cd ../amrex && git checkout --detach abc6696d6eca0e37f87c01f895b36abfa8bf9175 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-11-nvcc:

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 10b6cb26d0ac359922276ce08eeb728a14624b70
+branch = abc6696d6eca0e37f87c01f895b36abfa8bf9175
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 10b6cb26d0ac359922276ce08eeb728a14624b70
+branch = abc6696d6eca0e37f87c01f895b36abfa8bf9175
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -63,6 +63,8 @@ namespace warpx::initialization
     amrex::AMReX*
     amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
     {
+        amrex::ParmParse::setMultiLineSupport(false);
+
         return amrex::Initialize(
             argc,
             argv,

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -243,7 +243,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "10b6cb26d0ac359922276ce08eeb728a14624b70"
+set(WarpX_amrex_branch "abc6696d6eca0e37f87c01f895b36abfa8bf9175"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -71,7 +71,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 10b6cb26d0ac359922276ce08eeb728a14624b70 && cd -
+cd amrex && git checkout --detach abc6696d6eca0e37f87c01f895b36abfa8bf9175 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 # openPMD-example-datasets contains various required data sets


### PR DESCRIPTION
By disabling the multi-line support, we can avoid mistakes like

    algo.current_deposition = direct

    # galilean
    psatd.use_default_v_galilean  # Forgot = 1

Here, `psatd.use_default_v_galilean` is silently ignored because with the multi-line support it becomes part of the values for the previous definition (i.e., `algo.current_deposition = direct psatd.use_default_v_galilean`). This case will now abort. Note that using multiple lines in a pair of double quotes is still supported. For example,

    electrons.density_function(x,y,z) = "nc*n0*(
            if(abs(z)<=r0, 1.0, if(abs(z)<r0+Lcut, exp((-abs(z)+r0)/L), 0.0)) )"
    hydrogen.density_function(x,y,z) = "nc*n0*(
            if(abs(z)<=r0, 1.0, if(abs(z)<r0+Lcut, exp((-abs(z)+r0)/L), 0.0)) )"