### PR TITLE
fix `chi_min` and `chi_max` in `ParticleExtrema` red diags

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -403,6 +403,11 @@ void ParticleExtrema::ComputeDiags (int step)
                 const MultiFab & By = warpx.getBfield(lev,1);
                 const MultiFab & Bz = warpx.getBfield(lev,2);
 
+                // declare reduce_op
+                ReduceOps<ReduceOpMin, ReduceOpMax> reduce_op;
+                ReduceData<Real, Real> reduce_data(reduce_op);
+                using ReduceTuple = typename decltype(reduce_data)::Type;
+                
                 // Loop over boxes
                 for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
                 {
@@ -433,10 +438,7 @@ void ParticleExtrema::ComputeDiags (int step)
                     const IndexType by_type = By[pti].box().ixType();
                     const IndexType bz_type = Bz[pti].box().ixType();
 
-                    // declare reduce_op
-                    ReduceOps<ReduceOpMin, ReduceOpMax> reduce_op;
-                    ReduceData<Real, Real> reduce_data(reduce_op);
-                    using ReduceTuple = typename decltype(reduce_data)::Type;
+                    // evaluate reduce_op
                     reduce_op.eval(pti.numParticles(), reduce_data,
                     [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
                     {
@@ -466,14 +468,15 @@ void ParticleExtrema::ComputeDiags (int step)
                         }
                         return {chi,chi};
                     });
-                    chimin[lev] = get<0>(reduce_data.value());
-                    chimax[lev] = get<1>(reduce_data.value());
+                    auto val = reduce_data.value();
+                    chimin[lev] = get<0>(val);
+                    chimax[lev] = get<1>(val);
                 }
                 chimin_f = *std::min_element(chimin.begin(), chimin.end());
                 chimax_f = *std::max_element(chimax.begin(), chimax.end());
             }
-            ParallelDescriptor::ReduceRealMin(chimin_f);
-            ParallelDescriptor::ReduceRealMax(chimax_f);
+            ParallelDescriptor::ReduceRealMin(chimin_f, ParallelDescriptor::IOProcessorNumber());
+            ParallelDescriptor::ReduceRealMax(chimax_f, ParallelDescriptor::IOProcessorNumber());
         }
 #endif
 

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -472,9 +472,9 @@ void ParticleExtrema::ComputeDiags (int step)
                 auto val = reduce_data.value();
                 chimin[lev] = get<0>(val);
                 chimax[lev] = get<1>(val);
-                chimin_f = *std::min_element(chimin.begin(), chimin.end());
-                chimax_f = *std::max_element(chimax.begin(), chimax.end());
             }
+            chimin_f = *std::min_element(chimin.begin(), chimin.end());
+            chimax_f = *std::max_element(chimax.begin(), chimax.end());
             ParallelDescriptor::ReduceRealMin(chimin_f, ParallelDescriptor::IOProcessorNumber());
             ParallelDescriptor::ReduceRealMax(chimax_f, ParallelDescriptor::IOProcessorNumber());
         }

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -468,10 +468,10 @@ void ParticleExtrema::ComputeDiags (int step)
                         }
                         return {chi,chi};
                     });
-                    auto val = reduce_data.value();
-                    chimin[lev] = get<0>(val);
-                    chimax[lev] = get<1>(val);
                 }
+                auto val = reduce_data.value();
+                chimin[lev] = get<0>(val);
+                chimax[lev] = get<1>(val);
                 chimin_f = *std::min_element(chimin.begin(), chimin.end());
                 chimax_f = *std::max_element(chimax.begin(), chimax.end());
             }

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -407,7 +407,7 @@ void ParticleExtrema::ComputeDiags (int step)
                 ReduceOps<ReduceOpMin, ReduceOpMax> reduce_op;
                 ReduceData<Real, Real> reduce_data(reduce_op);
                 using ReduceTuple = typename decltype(reduce_data)::Type;
-                
+
                 // Loop over boxes
                 for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
                 {


### PR DESCRIPTION
This PR fixes the computation of `chi_min` and `chi_max` in the `ParticleExtrema` reduced diagnostic. 
Based on a conversation with @WeiqunZhang and @EZoni on Slack, the modifications consist in the following:
* the values resulting from the reduce operations are extracted outside of the loop over the boxes
* final min and max values are computed outside of the loop over mesh refinement levels 
* added `ParallelDescriptor::IOProcessorNumber()` to perform MPI_Reduce instead of MPI_Allreduce,  so that only the I/O process has the reduction result.





