### PR TITLE
Update inputs files in WarpX

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -110,7 +110,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach 10b6cb26d0ac359922276ce08eeb728a14624b70 && cd -
+        cd ../amrex && git checkout --detach 587542a395e4bd1991c3e731b289ca89fe43746e && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-11-nvcc:

--- a/Examples/Tests/electrostatic_sphere_eb/inputs_3d
+++ b/Examples/Tests/electrostatic_sphere_eb/inputs_3d
@@ -33,5 +33,5 @@ eb_charge.type = ChargeOnEB
 eb_charge.intervals = 1
 eb_charge_one_eighth.type = ChargeOnEB
 eb_charge_one_eighth.intervals = 1
-// Select only one eighth of the sphere
+# Select only one eighth of the sphere
 eb_charge_one_eighth.weighting_function(x,y,z) = (x>0)*(y<0)*(z>0)

--- a/Examples/Tests/embedded_boundary_rotated_cube/inputs_2d
+++ b/Examples/Tests/embedded_boundary_rotated_cube/inputs_2d
@@ -33,9 +33,9 @@ my_constants.mu_0 = 1.25663706212e-06
 warpx.B_ext_grid_init_style = parse_B_ext_grid_function
 
 warpx.Bx_external_grid_function(x,y,z) = 0
-warpx.By_external_grid_function(x,y,z) = mu_0 *
-                                         cos(m * pi / Lx * (x*cos(-theta)+z*sin(-theta) - Lx / 2 - x_cent)) *
-                                         cos(p * pi / Lz * (-x*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent))
+warpx.By_external_grid_function(x,y,z) = "mu_0 *
+                                          cos(m * pi / Lx * (x*cos(-theta)+z*sin(-theta) - Lx / 2 - x_cent)) *
+                                          cos(p * pi / Lz * (-x*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent))"
 warpx.Bz_external_grid_function(x,y,z) = 0
 
 diagnostics.diags_names = diag1

--- a/Examples/Tests/embedded_boundary_rotated_cube/inputs_3d
+++ b/Examples/Tests/embedded_boundary_rotated_cube/inputs_3d
@@ -37,12 +37,12 @@ my_constants.h_2 = (m * pi / Lx) ** 2 + (n * pi / Ly) ** 2 + (p * pi / Lz) ** 2
 my_constants.mu_0 = 1.25663706212e-06
 
 warpx.B_ext_grid_init_style = parse_B_ext_grid_function
-warpx.Bx_external_grid_function(x,y,z) = -2/h_2 * mu_0 * (m * pi / Lx) * (p * pi / Lz) *
+warpx.Bx_external_grid_function(x,y,z) = "-2/h_2 * mu_0 * (m * pi / Lx) * (p * pi / Lz) *
                                           sin(m * pi / Lx * (x - Lx / 2 - x_cent)) *
                                           cos(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
-                                          cos(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent))
+                                          cos(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent))"
 
-warpx.By_external_grid_function(x,y,z) = -2/h_2 * mu_0 * (n * pi / Ly) * (p * pi / Lz) *
+warpx.By_external_grid_function(x,y,z) = "-2/h_2 * mu_0 * (n * pi / Ly) * (p * pi / Lz) *
                                           cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
                                           sin(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
                                           cos(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
@@ -51,18 +51,18 @@ warpx.By_external_grid_function(x,y,z) = -2/h_2 * mu_0 * (n * pi / Ly) * (p * pi
                                           cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
                                           cos(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
                                           sin(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
-                                          sin(theta)
+                                          sin(theta)"
 
-warpx.Bz_external_grid_function(x,y,z) = mu_0 *
-                                         cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
-                                         cos(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
-                                         sin(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
-                                         cos(theta) -
-                                         2/h_2 * mu_0 * (n * pi / Ly) * (p * pi / Lz) *
-                                         cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
-                                         sin(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
-                                         cos(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
-                                         sin(theta)
+warpx.Bz_external_grid_function(x,y,z) = "mu_0 *
+                                          cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
+                                          cos(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
+                                          sin(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
+                                          cos(theta) -
+                                          2/h_2 * mu_0 * (n * pi / Ly) * (p * pi / Lz) *
+                                          cos(m * pi / Lx * (x - Lx / 2 - x_cent)) *
+                                          sin(n * pi / Ly * (y*cos(-theta)-z*sin(-theta) - Ly / 2 - y_cent)) *
+                                          cos(p * pi / Lz * (y*sin(-theta)+z*cos(-theta) - Lz / 2 - z_cent)) *
+                                          sin(theta)"
 
 
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nuclear_fusion/inputs_proton_boron_2d
+++ b/Examples/Tests/nuclear_fusion/inputs_proton_boron_2d
@@ -29,7 +29,7 @@ algo.particle_shape = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.species_names = proton1 boron1 alpha1 proton2 boron2 alpha2 proton3 boron3 alpha3
+particles.species_names = proton1 boron1 alpha1 proton2 boron2 alpha2 proton3 boron3 alpha3 \
                           proton4 boron4 alpha4 proton5 boron5 alpha5
 
 my_constants.m_b11 =  11.00930536*m_u # Boron 11 mass

--- a/Examples/Tests/nuclear_fusion/inputs_proton_boron_3d
+++ b/Examples/Tests/nuclear_fusion/inputs_proton_boron_3d
@@ -29,7 +29,7 @@ algo.particle_shape = 1
 #################################
 ############ PLASMA #############
 #################################
-particles.species_names = proton1 boron1 alpha1 proton2 boron2 alpha2 proton3 boron3 alpha3
+particles.species_names = proton1 boron1 alpha1 proton2 boron2 alpha2 proton3 boron3 alpha3 \
                           proton4 boron4 alpha4 proton5 boron5 alpha5
 
 my_constants.m_b11 = 11.00930536*m_u # Boron 11 mass

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 10b6cb26d0ac359922276ce08eeb728a14624b70
+branch = 587542a395e4bd1991c3e731b289ca89fe43746e
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 10b6cb26d0ac359922276ce08eeb728a14624b70
+branch = 587542a395e4bd1991c3e731b289ca89fe43746e
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -243,7 +243,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "10b6cb26d0ac359922276ce08eeb728a14624b70"
+set(WarpX_amrex_branch "587542a395e4bd1991c3e731b289ca89fe43746e"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -71,7 +71,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 10b6cb26d0ac359922276ce08eeb728a14624b70 && cd -
+cd amrex && git checkout --detach 587542a395e4bd1991c3e731b289ca89fe43746e && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 # openPMD-example-datasets contains various required data sets


### PR DESCRIPTION
Due to the recent changes in amrex::ParmParse, we must use the line continuation character '\' for values spanning multiple lines. For Parser expression, we could either double quotes to enclose the whole string or use `\` as line continuation.

The old style multi-line values were removed in AMReX to avoid mistakes like
```
    algo.current_deposition = direct

    # galilean
    psatd.use_default_v_galilean  # Forgot = 1

    # multi-line
    #   preferred
    some.function(x,y,z) = "x*x + sin(y)
        + z*z"
    #   old-school
    some.other(x,y,z) = x*x + sin(y)  \
        + z*z
```
Here, `psatd.use_default_v_galilean` is silently ignored because with the old style multi-line support it becomes part of the values for the previous definition (i.e., `algo.current_deposition = direct psatd.use_default_v_galilean`). This case will now abort.