### PR TITLE
Fix continuous injection of lasers

### DIFF
--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -129,8 +129,12 @@ private:
     // Inject the laser antenna during the simulation, if it started
     // outside of the simulation domain and enters it.
     void ContinuousInjection(const amrex::RealBox& injection_box) override;
-    // Update position of the antenna
-    void UpdateContinuousInjectionPosition(amrex::Real dt) override;
+
+    /**
+     * \brief  Update antenna position for continuous injection of lasers
+     *         in a boosted frame
+     */
+    void UpdateAntennaPosition (const amrex::Real dt) override;
 
     // Unique (smart) pointer to the laser profile
     std::unique_ptr<WarpXLaserProfiles::ILaserProfile> m_up_laser_profile;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -319,12 +319,8 @@ LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
     }
 }
 
-/* \brief update position of the antenna if running in boosted frame.
- * \param dt time step (level 0).
- * The up-to-date antenna position is stored in updated_position.
- */
 void
-LaserParticleContainer::UpdateContinuousInjectionPosition (Real dt)
+LaserParticleContainer::UpdateAntennaPosition (const amrex::Real dt)
 {
     if (!m_enabled) return;
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -71,21 +71,21 @@ public:
     ~MultiParticleContainer() {}
 
     WarpXParticleContainer&
-    GetParticleContainer (int ispecies) const {return *allcontainers[ispecies];}
+    GetParticleContainer (int index) const {return *allcontainers[index];}
 
     WarpXParticleContainer*
-    GetParticleContainerPtr (int ispecies) const {return allcontainers[ispecies].get();}
+    GetParticleContainerPtr (int index) const {return allcontainers[index].get();}
 
     WarpXParticleContainer&
     GetParticleContainerFromName (const std::string& name) const;
 
 #ifdef WARPX_USE_OPENPMD
-    std::unique_ptr<WarpXParticleContainer>& GetUniqueContainer(int ispecies) {
-      return  allcontainers[ispecies];
+    std::unique_ptr<WarpXParticleContainer>& GetUniqueContainer(int index) {
+      return  allcontainers[index];
     }
 #endif
-    std::array<amrex::ParticleReal, 3> meanParticleVelocity(int ispecies) {
-        return allcontainers[ispecies]->meanParticleVelocity();
+    std::array<amrex::ParticleReal, 3> meanParticleVelocity(int index) {
+        return allcontainers[index]->meanParticleVelocity();
     }
 
     void AllocData ();

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -235,6 +235,8 @@ public:
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
     int nSpecies() const {return species_names.size();}
+    int nLasers() const {return lasers_names.size();}
+    int nContainers() const {return allcontainers.size();}
 
     /** Whether back-transformed diagnostics need to be performed for any plasma species.
      *

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -234,9 +234,9 @@ public:
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
-    int nSpecies() const {return species_names.size();}
-    int nLasers() const {return lasers_names.size();}
-    int nContainers() const {return allcontainers.size();}
+    int nSpecies () const {return species_names.size();}
+    int nLasers () const {return lasers_names.size();}
+    int nContainers () const {return allcontainers.size();}
 
     /** Whether back-transformed diagnostics need to be performed for any plasma species.
      *

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -266,8 +266,13 @@ public:
     // simulation domain after some iterations, due to flowing plasma and/or
     // moving window).
     void ContinuousInjection(const amrex::RealBox& injection_box) const;
-    // Update injection position for continuously-injected species.
-    void UpdateContinuousInjectionPosition(amrex::Real dt) const;
+
+    /**
+     * \brief  Update antenna position for continuous injection of lasers
+     *         in a boosted frame. Empty function for containers other than lasers.
+     */
+    void UpdateAntennaPosition(const amrex::Real dt) const;
+
     int doContinuousInjection() const;
 
     // Inject particles from a surface during the simulation

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -734,17 +734,12 @@ MultiParticleContainer::ContinuousInjection (const RealBox& injection_box) const
     }
 }
 
-/* \brief Update position of continuous injection parameters.
- * \param dt: simulation time step (level 0)
- * All classes inherited from WarpXParticleContainer do not have
- * a position to update (PhysicalParticleContainer does not do anything).
- */
 void
-MultiParticleContainer::UpdateContinuousInjectionPosition (Real dt) const
+MultiParticleContainer::UpdateAntennaPosition (const amrex::Real dt) const
 {
     for (auto& pc : allcontainers){
         if (pc->do_continuous_injection){
-            pc->UpdateContinuousInjectionPosition(dt);
+            pc->UpdateAntennaPosition(dt);
         }
     }
 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -246,8 +246,13 @@ public:
     // LaserParticleContainer: implemented.
     // RigidInjectedParticleContainer: not implemented.
     virtual void ContinuousInjection(const amrex::RealBox& /*injection_box*/) {}
-    // Update optional sub-class-specific injection location.
-    virtual void UpdateContinuousInjectionPosition(amrex::Real /*dt*/) {}
+
+    /**
+     * \brief Update antenna position for continuous injection of lasers
+     *        in a boosted frame. Empty function for containers other than lasers.
+     */
+    virtual void UpdateAntennaPosition(const amrex::Real /*dt*/) {}
+
     bool doContinuousInjection() const {return do_continuous_injection;}
 
     // Inject a continuous flux of particles from a defined plane

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -81,7 +81,7 @@ WarpX::UpdateCurrentInjectionPosition (amrex::Real a_dt)
 
             PlasmaInjector* plasma_injector = pc.GetPlasmaInjector();
 
-            amrex::Real v_bulk = 0._rt;
+            amrex::Real v_shift = 0._rt;
             if (plasma_injector != nullptr)
             {
                 amrex::XDim3 u_bulk = plasma_injector->getInjectorMomentumHost()->getBulkMomentum(
@@ -95,7 +95,7 @@ WarpX::UpdateCurrentInjectionPosition (amrex::Real a_dt)
 #else // 3D
                 amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.x, u_bulk.y, u_bulk.z};
 #endif
-                amrex::Real v_bulk = PhysConst::c * u_bulk_vec[dir] / std::sqrt(1._rt + u_bulk_vec[dir]*u_bulk_vec[dir]);
+                v_shift = PhysConst::c * u_bulk_vec[dir] / std::sqrt(1._rt + u_bulk_vec[dir]*u_bulk_vec[dir]);
             }
 
             // In boosted-frame simulations, the plasma has moved since the last
@@ -105,26 +105,26 @@ WarpX::UpdateCurrentInjectionPosition (amrex::Real a_dt)
             // v' = (v-c*beta)/(1-v*beta/c)
             if (WarpX::gamma_boost > 1._rt)
             {
-                v_bulk = (v_bulk - PhysConst::c*WarpX::beta_boost)
-                         / (1._rt - v_bulk*WarpX::beta_boost/PhysConst::c);
+                v_shift = (v_shift - PhysConst::c*WarpX::beta_boost)
+                          / (1._rt - v_shift*WarpX::beta_boost/PhysConst::c);
 #if defined(WARPX_DIM_3D)
-                v_bulk *= WarpX::boost_direction[dir];
+                v_shift *= WarpX::boost_direction[dir];
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 // In 2D, dir=0 corresponds to x and dir=1 corresponds to z.
                 // This needs to be converted to access boost_direction,
                 // which has always 3 components.
-                v_bulk *= WarpX::boost_direction[2*dir];
+                v_shift *= WarpX::boost_direction[2*dir];
 #elif defined(WARPX_DIM_1D_Z)
                 // In 1D, dir=0 corresponds to z.
                 // This needs to be converted to access boost_direction,
                 // which has always 3 components.
-                v_bulk *= WarpX::boost_direction[2];
+                v_shift *= WarpX::boost_direction[2];
                 amrex::ignore_unused(dir);
 #endif
             }
 
             // Update current injection position
-            pc.m_current_injection_position += v_bulk * a_dt;
+            pc.m_current_injection_position += v_shift * a_dt;
         }
     }
 }

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -356,9 +356,9 @@ WarpX::MoveWindow (const int step, bool move_j)
         }
     }
 
-    // Loop over species
-    const int n_species = mypc->nSpecies();
-    for (int i=0; i<n_species; i++)
+    // Loop over species (particles and lasers)
+    const int n_containers = mypc->nContainers();
+    for (int i=0; i<n_containers; i++)
     {
         WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -53,22 +53,19 @@
 using namespace amrex;
 
 void
-WarpX::UpdatePlasmaInjectionPosition (amrex::Real a_dt)
+WarpX::UpdateCurrentInjectionPosition (amrex::Real a_dt)
 {
     const int dir = moving_window_dir;
 
-    // Loop over species
-    const int n_species = mypc->nSpecies();
-    for (int i=0; i<n_species; i++)
+    // Loop over species (particles and lasers)
+    const int n_containers = mypc->nContainers();
+    for (int i=0; i<n_containers; i++)
     {
         WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
 
         // Continuously inject plasma in new cells (by default only on level 0)
         if (pc.doContinuousInjection())
         {
-            PlasmaInjector* plasma_injector = pc.GetPlasmaInjector();
-            if (plasma_injector == nullptr) continue;
-
             // Get bulk momentum and velocity of plasma
             // 1D: dir=0 is z
             // 2D: dir=0 is x, dir=1 is z
@@ -81,17 +78,25 @@ WarpX::UpdatePlasmaInjectionPosition (amrex::Real a_dt)
 #else // 3D
             current_injection_position[dir] = pc.m_current_injection_position;
 #endif
-            amrex::XDim3 u_bulk = plasma_injector->getInjectorMomentumHost()->getBulkMomentum(current_injection_position[0],
-                                                                                              current_injection_position[1],
-                                                                                              current_injection_position[2]);
+
+            PlasmaInjector* plasma_injector = pc.GetPlasmaInjector();
+
+            amrex::Real v_bulk = 0._rt;
+            if (plasma_injector != nullptr)
+            {
+                amrex::XDim3 u_bulk = plasma_injector->getInjectorMomentumHost()->getBulkMomentum(
+                    current_injection_position[0],
+                    current_injection_position[1],
+                    current_injection_position[2]);
 #if defined(WARPX_DIM_1D_Z)
-            amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.z};
+                amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.z};
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-            amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.x, u_bulk.z};
+                amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.x, u_bulk.z};
 #else // 3D
-            amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.x, u_bulk.y, u_bulk.z};
+                amrex::Vector<amrex::Real> u_bulk_vec = {u_bulk.x, u_bulk.y, u_bulk.z};
 #endif
-            amrex::Real v_bulk = PhysConst::c * u_bulk_vec[dir] / std::sqrt(1._rt + u_bulk_vec[dir]*u_bulk_vec[dir]);
+                amrex::Real v_bulk = PhysConst::c * u_bulk_vec[dir] / std::sqrt(1._rt + u_bulk_vec[dir]*u_bulk_vec[dir]);
+            }
 
             // In boosted-frame simulations, the plasma has moved since the last
             // call to this function, and injection position needs to be updated.
@@ -142,13 +147,11 @@ WarpX::MoveWindow (const int step, bool move_j)
     moving_window_x += (moving_window_v - WarpX::beta_boost * PhysConst::c)/(1 - moving_window_v * WarpX::beta_boost / PhysConst::c) * dt[0];
     const int dir = moving_window_dir;
 
-    // Update warpx.current_injection_position,
-    // PhysicalParticleContainer uses this injection position
-    UpdatePlasmaInjectionPosition( dt[0] );
-    // Update injection position for WarpXParticleContainer in mypc,
-    // nothing to do for PhysicalParticleContainer,
-    // need to update the antenna position for LaserParticleContainer.
-    mypc->UpdateContinuousInjectionPosition( dt[0] );
+    // Update current injection position for all containers
+    UpdateCurrentInjectionPosition(dt[0]);
+    // Update antenna position for all lasers
+    // FIXME Make this specific to lasers only
+    mypc->UpdateContinuousInjectionPosition(dt[0]);
 
     // compute the number of cells to shift on the base level
     amrex::Real new_lo[AMREX_SPACEDIM];

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -53,7 +53,7 @@
 using namespace amrex;
 
 void
-WarpX::UpdateCurrentInjectionPosition (amrex::Real a_dt)
+WarpX::UpdateInjectionPosition (const amrex::Real a_dt)
 {
     const int dir = moving_window_dir;
 
@@ -148,10 +148,10 @@ WarpX::MoveWindow (const int step, bool move_j)
     const int dir = moving_window_dir;
 
     // Update current injection position for all containers
-    UpdateCurrentInjectionPosition(dt[0]);
+    UpdateInjectionPosition(dt[0]);
     // Update antenna position for all lasers
-    // FIXME Make this specific to lasers only
-    mypc->UpdateContinuousInjectionPosition(dt[0]);
+    // TODO Make this specific to lasers only
+    mypc->UpdateAntennaPosition(dt[0]);
 
     // compute the number of cells to shift on the base level
     amrex::Real new_lo[AMREX_SPACEDIM];

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -605,7 +605,7 @@ public:
      * In doding so, only positions attributes are changed while fields remain unchanged.
      */
     void ShiftGalileanBoundary ();
-    void UpdatePlasmaInjectionPosition (amrex::Real dt);
+    void UpdateCurrentInjectionPosition (amrex::Real dt);
     void ResetProbDomain (const amrex::RealBox& rb);
     void EvolveE (         amrex::Real dt);
     void EvolveE (int lev, amrex::Real dt);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -605,7 +605,13 @@ public:
      * In doding so, only positions attributes are changed while fields remain unchanged.
      */
     void ShiftGalileanBoundary ();
-    void UpdateCurrentInjectionPosition (amrex::Real dt);
+
+    /**
+     * \brief Update injection position for continuous injection of
+     *        particles and lasers (loops over species and lasers).
+     */
+    void UpdateInjectionPosition (const amrex::Real dt);
+
     void ResetProbDomain (const amrex::RealBox& rb);
     void EvolveE (         amrex::Real dt);
     void EvolveE (int lev, amrex::Real dt);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -279,10 +279,11 @@ WarpX::WarpX ()
     t_old.resize(nlevs_max, std::numeric_limits<Real>::lowest());
     dt.resize(nlevs_max, std::numeric_limits<Real>::max());
 
-    // Loop over species and set current injection position per species
+    // Loop over species (particles and lasers)
+    // and set current injection position per species
     mypc = std::make_unique<MultiParticleContainer>(this);
-    const int n_species = mypc->nSpecies();
-    for (int i=0; i<n_species; i++)
+    const int n_containers = mypc->nContainers();
+    for (int i=0; i<n_containers; i++)
     {
         WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
 


### PR DESCRIPTION
Fix #4095. Define new member functions `nLasers` and `nContainers` in class `MultiParticleContainer` and loop over all containers, not just over all "species" (`nSpecies`), when doing continuous injection.