### PR TITLE
Fix the writing of raw rho_fp

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -575,9 +575,10 @@ FlushFormatPlotfile::WriteAllRawFields(
         }
         if (warpx.get_pointer_rho_fp(lev))
         {
-            // Use the component 1 of `rho_fp`, i.e. rho_new for time synchronization
-            // If nComp > 1, this is the upper half of the list of components.
-            const MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, warpx.getrho_fp(lev).nComp()/2, warpx.getrho_fp(lev).nComp()/2);
+            // rho_fp will have either ncomps or 2*ncomps (2 being the old and new). When 2, return the new so
+            // there is time synchronization.
+            const int nstart = warpx.getrho_fp(lev).nComp() - warpx.ncomps;
+            const MultiFab rho_new(warpx.getrho_fp(lev), amrex::make_alias, nstart, warpx.ncomps);
             WriteRawMF(rho_new, dm, raw_pltname, default_level_prefix, "rho_fp", lev, plot_raw_fields_guards);
         }
         if (warpx.get_pointer_phi_fp(lev) != nullptr) {


### PR DESCRIPTION
PR #4035 changed the number of components in the rho_fp MultiFab, but the writing of rho_fp raw fields was assuming that the number of components was 2*ncomps. This PR fixes this and writes out the correct number of components.