### PR TITLE
Clang tidy CI test: add a couple of performance checks to clang-tidy CI test 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,8 @@ Checks: '-*,
     performance-inefficient-algorithm,
     performance-inefficient-string-concatenation,
     performance-inefficient-vector-operation,
+    performance-move-const-arg,
+    performance-move-constructor-init,
     readability-non-const-parameter
     '
 


### PR DESCRIPTION
This PR adds the following checks to the clang-tidy CI test:

 - [performance-move-const-arg](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-move-const-arg.html)
 - [performance-move-constructor-init](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-move-constructor-init.html)
