### PR TITLE
Remove superfluous #include from LatticeElements

### DIFF
--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.H
@@ -12,7 +12,6 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
-#include <AMReX_Vector.H>
 #include <AMReX_GpuContainers.H>
 
 #include <string>

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.cpp
@@ -5,8 +5,6 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "HardEdgedPlasmaLens.H"
-#include "Utils/WarpXUtil.H"
-#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.H
@@ -12,7 +12,6 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
-#include <AMReX_Vector.H>
 #include <AMReX_GpuContainers.H>
 
 #include <string>

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.cpp
@@ -5,8 +5,6 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "HardEdgedQuadrupole.H"
-#include "Utils/WarpXUtil.H"
-#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>

--- a/Source/AcceleratorLattice/LatticeElements/HardEdged_K.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdged_K.H
@@ -10,7 +10,6 @@
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_REAL.H>
-#include <AMReX_Vector.H>
 
 /**
  * \brief Calculate the residence correction, the fraction of the time step the particle

--- a/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.cpp
@@ -5,8 +5,6 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "LatticeElementBase.H"
-#include "Utils/WarpXUtil.H"
-#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>


### PR DESCRIPTION
This PR removes some superfluous `#include` directives from LatticeElements source files.