### PR TITLE
Remove WarpX::GetInstance call from ParserFilter functor

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -158,7 +158,7 @@ FlushFormatOpenPMD::WriteToFile (
         varnames, mf, geom, output_levels, output_iteration, time, isBTD, full_BTD_snapshot);
 
     // particles: all (reside only on locally finest level)
-    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, use_pinned_pc, isBTD, isLastBTDFlush, totalParticlesFlushedAlready);
+    m_OpenPMDPlotWriter->WriteOpenPMDParticles(particle_diags, time, use_pinned_pc, isBTD, isLastBTDFlush, totalParticlesFlushedAlready);
 
     // signal that no further updates will be written to this iteration
     m_OpenPMDPlotWriter->CloseStep(isBTD, isLastBTDFlush);

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -48,7 +48,7 @@ public:
     /** \brief Write particles data to file.
      * \param[in] filename name of output directory
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
-     * \param[in] time the simulation time
+     * \param[in] time the simulation time on the coarsest level
      * \param[in] isBTD whether this is a back-transformed diagnostic
      */
     void WriteParticles(const std::string& filename,

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -48,10 +48,12 @@ public:
     /** \brief Write particles data to file.
      * \param[in] filename name of output directory
      * \param[in] particle_diags Each element of this vector handles output of 1 species.
+     * \param[in] time the simulation time
      * \param[in] isBTD whether this is a back-transformed diagnostic
      */
     void WriteParticles(const std::string& filename,
                         const amrex::Vector<ParticleDiag>& particle_diags,
+                        const amrex::Real time,
                         bool isBTD = false) const;
 
     ~FlushFormatPlotfile() {}

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -99,7 +99,7 @@ FlushFormatPlotfile::WriteToFile (
 
     WriteAllRawFields(plot_raw_fields, nlev, filename, plot_raw_fields_guards);
 
-    WriteParticles(filename, particle_diags, isBTD);
+    WriteParticles(filename, particle_diags, time, isBTD);
 
     WriteJobInfo(filename);
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -339,7 +339,7 @@ FlushFormatPlotfile::WriteWarpXHeader(
 void
 FlushFormatPlotfile::WriteParticles(const std::string& dir,
                                     const amrex::Vector<ParticleDiag>& particle_diags,
-                                    bool isBTD) const
+                                    const amrex::Real time, bool isBTD) const
 {
 
     for (auto& part_diag : particle_diags) {
@@ -388,7 +388,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         ParserFilter parser_filter(part_diag.m_do_parser_filter,
                                    utils::parser::compileParser<ParticleDiag::m_nvars>
                                        (part_diag.m_particle_filter_parser.get()),
-                                   pc->getMass());
+                                   pc->getMass(), time);
         parser_filter.m_units = InputUnits::SI;
         GeometryFilter const geometry_filter(part_diag.m_do_geom_filter,
                                              part_diag.m_diag_domain);

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -136,6 +136,7 @@ public:
 
   void WriteOpenPMDParticles (
               const amrex::Vector<ParticleDiag>& particle_diags,
+              const amrex::Real time,
               const bool use_pinned_pc = false,
               const bool isBTD = false,
               const bool isLastBTDFlush = false,

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -514,7 +514,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
 
 void
 WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& particle_diags,
-                  const bool use_pinned_pc, const bool isBTD, const bool isLastBTDFlush,
+                  const amrex::Real time, const bool use_pinned_pc,
+                  const bool isBTD, const bool isLastBTDFlush,
                   const amrex::Vector<int>& totalParticlesFlushedAlready)
 {
   WARPX_PROFILE("WarpXOpenPMDPlot::WriteOpenPMDParticles()");
@@ -575,7 +576,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
       ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
                                 utils::parser::compileParser<ParticleDiag::m_nvars>
                                      (particle_diags[i].m_particle_filter_parser.get()),
-                                 pc->getMass());
+                                 pc->getMass(), time);
       parser_filter.m_units = InputUnits::SI;
       GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                            particle_diags[i].m_diag_domain);

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -90,7 +90,7 @@ struct ParserFilter
      * \param a_is_active whether the test is active
      * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a boolean for selected particle
      * \param a_mass mass of the particle species
-     * \param time simulation time
+     * \param time simulation time on the coarsest level
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
         const amrex::Real a_mass, const amrex::Real time):
@@ -138,7 +138,7 @@ public:
     amrex::ParserExecutor<7> const m_function_partparser;
     /** Mass of particle species */
     amrex::ParticleReal m_mass;
-    /** Store physical time. */
+    /** Store physical time on the coarsest level. */
     amrex::ParticleReal m_t;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -10,7 +10,6 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXConst.H"
-#include "WarpX.H"
 
 #include <AMReX_Gpu.H>
 #include <AMReX_Parser.H>
@@ -91,14 +90,15 @@ struct ParserFilter
      * \param a_is_active whether the test is active
      * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a boolean for selected particle
      * \param a_mass mass of the particle species
+     * \param time simulation time
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
-                 amrex::Real a_mass)
-        : m_is_active(a_is_active), m_function_partparser(a_filter_parser), m_mass(a_mass)
-    {
-        m_t = WarpX::GetInstance().gett_new(0);
-        m_units = InputUnits::WarpX;
-    }
+        const amrex::Real a_mass, const amrex::Real time):
+            m_is_active{a_is_active},
+            m_function_partparser{a_filter_parser},
+            m_mass{a_mass},
+            m_t{time},
+            m_units{InputUnits::WarpX}{}
 
     /**
      * \brief return 1 if the particle is selected by the parser
@@ -136,10 +136,10 @@ private:
 public:
     /** Parser function with 7 input variables, t,x,y,z,ux,uy,uz */
     amrex::ParserExecutor<7> const m_function_partparser;
-    /** Store physical time. */
-    amrex::ParticleReal m_t;
     /** Mass of particle species */
     amrex::ParticleReal m_mass;
+    /** Store physical time. */
+    amrex::ParticleReal m_t;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;
 };


### PR DESCRIPTION
This PR removes the call to `WarpX::GetInstance` from ParserFilter functor. As a consequence, `time` has to be passed as an argument.