### PR TITLE
Clang tidy CI test: add some modernize checks to clang-tidy CI test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,20 @@ Checks: '-*,
     misc-const-correctness,
     modernize-avoid-bind,
     modernize-concat-nested-namespaces,
+    modernize-deprecated-headers,
+    modernize-deprecated-ios-base-aliases,
+    modernize-loop-convert,
+    modernize-make-shared,
+    modernize-make-unique,
+    modernize-pass-by-value,
+    modernize-raw-string-literal,
+    modernize-redundant-void-arg,
+    modernize-replace-auto-ptr,
+    modernize-replace-disallow-copy-and-assign-macro,
+    modernize-replace-random-shuffle,
+    modernize-return-braced-init-list,
+    modernize-shrink-to-fit,
+    modernize-unary-static-assert,
     modernize-use-nullptr,
     performance-faster-string-find,
     performance-for-range-copy,
@@ -23,5 +37,9 @@ Checks: '-*,
     performance-inefficient-vector-operation,
     readability-non-const-parameter
     '
+
+CheckOptions:
+- key:          modernize-pass-by-value.ValuesOnly
+  value:        'true'
 
 HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'

--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -21,7 +21,7 @@
 using namespace amrex::literals;
 
 BTDPlotfileHeaderImpl::BTDPlotfileHeaderImpl (std::string const & Headerfile_path)
-    : m_Header_path(Headerfile_path)
+    : m_Header_path{Headerfile_path}
 {
 
 }
@@ -177,7 +177,7 @@ BTDPlotfileHeaderImpl::WriteHeader ()
 
 
 BTDMultiFabHeaderImpl::BTDMultiFabHeaderImpl (std::string const & Headerfile_path)
-    : m_Header_path(Headerfile_path)
+    : m_Header_path{Headerfile_path}
 {
 
 }
@@ -353,7 +353,7 @@ BTDMultiFabHeaderImpl::CopyVec(amrex::Vector<amrex::Real>& dst,
 
 
 BTDSpeciesHeaderImpl::BTDSpeciesHeaderImpl (std::string const & Headerfile_path, std::string const& species_name)
-    : m_Header_path(Headerfile_path), m_species_name(species_name)
+    : m_Header_path{Headerfile_path}, m_species_name{species_name}
 {
 
 }

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -36,8 +36,10 @@ BackTransformFunctor::BackTransformFunctor (amrex::MultiFab const * mf_src, int 
                                             amrex::Vector< std::string > varnames,
                                             amrex::Vector< std::string > varnames_fields,
                                             const amrex::IntVect crse_ratio
-                                            )
-    : ComputeDiagFunctor(ncomp, crse_ratio), m_mf_src(mf_src), m_lev(lev), m_num_buffers(num_buffers), m_varnames(varnames), m_varnames_fields(varnames_fields)
+                                            ):
+    ComputeDiagFunctor(ncomp, crse_ratio),
+    m_mf_src{mf_src}, m_lev{lev}, m_num_buffers{num_buffers},
+    m_varnames{std::move(varnames)}, m_varnames_fields{std::move(varnames_fields)}
 {
     InitData();
 }

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
@@ -71,7 +71,7 @@ BackTransformParticleFunctor::BackTransformParticleFunctor (
                               WarpXParticleContainer *pc_src,
                               std::string species_name,
                               int num_buffers)
-    : m_pc_src(pc_src), m_species_name(species_name), m_num_buffers(num_buffers)
+    : m_pc_src{pc_src}, m_species_name{std::move(species_name)}, m_num_buffers{num_buffers}
 {
     InitData();
 }

--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -13,6 +13,8 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Parser.H>
 
+#include <utility>
+
 namespace ElectrostaticSolver {
 
     struct PhiCalculatorEB {
@@ -101,7 +103,7 @@ namespace ElectrostaticSolver {
 
       public:
         EBCalcEfromPhiPerLevel(amrex::Vector<amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> > e_field)
-                : m_e_field(e_field) {}
+                : m_e_field(std::move(e_field)) {}
 
         void operator()(amrex::MLMG & mlmg, int const lev) {
             using namespace amrex::literals;

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -122,7 +122,7 @@ struct CartesianCKCAlgorithm {
      */
     static amrex::IntVect GetMaxGuardCell () {
         // The ckc solver requires one guard cell in each dimension
-        return (amrex::IntVect(AMREX_D_DECL(1,1,1)));
+        return amrex::IntVect{AMREX_D_DECL(1,1,1)};
     }
 
     /**

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
@@ -60,7 +60,7 @@ struct CartesianNodalAlgorithm {
      */
     static amrex::IntVect GetMaxGuardCell () {
         // The nodal solver requires one guard cell in each dimension
-        return (amrex::IntVect(AMREX_D_DECL(1,1,1)));
+        return amrex::IntVect{AMREX_D_DECL(1,1,1)};
     }
 
     /**

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -60,7 +60,7 @@ struct CartesianYeeAlgorithm {
      */
     static amrex::IntVect GetMaxGuardCell () {
         // The yee solver requires one guard cell in each dimension
-        return (amrex::IntVect(AMREX_D_DECL(1,1,1)));
+        return amrex::IntVect{AMREX_D_DECL(1,1,1)};
     }
 
     /**

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -65,7 +65,7 @@ struct CylindricalYeeAlgorithm {
      */
     static amrex::IntVect GetMaxGuardCell () {
         // The cylindrical solver requires one guard cell in each dimension
-        return (amrex::IntVect(AMREX_D_DECL(1,1,1)));
+        return amrex::IntVect{AMREX_D_DECL(1,1,1)};
     }
 
     /** Applies the differential operator `1/r * d(rF)/dr`,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmComoving.cpp
@@ -32,18 +32,18 @@ PsatdAlgorithmComoving::PsatdAlgorithmComoving (const SpectralKSpace& spectral_k
                                                 const amrex::Real dt,
                                                 const bool update_with_rho)
      // Members initialization
-     : SpectralBaseAlgorithm(spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, grid_type),
+     : SpectralBaseAlgorithm{spectral_kspace, dm, spectral_index, norder_x, norder_y, norder_z, grid_type},
        // Initialize the infinite-order k vectors (the argument n_order = -1 selects
        // the infinite order option, the argument grid_type=GridType::Staggered is then irrelevant)
-       kx_vec(spectral_kspace.getModifiedKComponent(dm, 0, -1, GridType::Staggered)),
+       kx_vec{spectral_kspace.getModifiedKComponent(dm, 0, -1, GridType::Staggered)},
 #if defined(WARPX_DIM_3D)
-       ky_vec(spectral_kspace.getModifiedKComponent(dm, 1, -1, GridType::Staggered)),
-       kz_vec(spectral_kspace.getModifiedKComponent(dm, 2, -1, GridType::Staggered)),
+       ky_vec{spectral_kspace.getModifiedKComponent(dm, 1, -1, GridType::Staggered)},
+       kz_vec{spectral_kspace.getModifiedKComponent(dm, 2, -1, GridType::Staggered)},
 #else
-       kz_vec(spectral_kspace.getModifiedKComponent(dm, 1, -1, GridType::Staggered)),
+       kz_vec{spectral_kspace.getModifiedKComponent(dm, 1, -1, GridType::Staggered)},
 #endif
-       m_v_comoving(v_comoving),
-       m_dt(dt)
+       m_v_comoving{v_comoving},
+       m_dt{dt}
 {
     amrex::ignore_unused(update_with_rho);
 

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -331,7 +331,7 @@ struct InjectorMomentumBoltzmann
     {
         using namespace amrex::literals;
         amrex::Real u[3];
-        for (int idim = 0; idim < 3; ++idim) u[idim] = 0.0_rt;
+        for (auto& el : u) el = 0.0_rt;
         const amrex::Real beta = velocity(x,y,z);
         int const dir = velocity.direction();
         const amrex::Real gamma = static_cast<amrex::Real>(1._rt/sqrt(1._rt-beta*beta));
@@ -432,7 +432,7 @@ struct InjectorMomentumJuttner
     {
         using namespace amrex::literals;
         amrex::Real u[3];
-        for (int idim = 0; idim < 3; ++idim) u[idim] = 0.0_rt;
+        for (auto& el : u) el = 0.0_rt;
         amrex::Real const beta = velocity(x,y,z);
         int const dir = velocity.direction();
         amrex::Real const gamma = static_cast<amrex::Real>(1._rt/sqrt(1._rt-beta*beta));

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -55,7 +55,7 @@ namespace {
 }
 
 PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name)
-    : species_id(ispecies), species_name(name)
+    : species_id{ispecies}, species_name{name}
 {
     using namespace amrex::literals;
 

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -113,7 +113,7 @@ public:
                     const amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight
                     ) const
     {
-        if (n_total_pairs == 0) return {};
+        if (n_total_pairs == 0) return {m_num_product_species, 0};
 
         // Compute offset array and allocate memory for the produced species
         amrex::Gpu::DeviceVector<index_type> offsets(n_total_pairs);

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -113,7 +113,7 @@ public:
                     const amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight
                     ) const
     {
-        if (n_total_pairs == 0) return amrex::Vector<int>(m_num_product_species, 0);
+        if (n_total_pairs == 0) return {};
 
         // Compute offset array and allocate memory for the produced species
         amrex::Gpu::DeviceVector<index_type> offsets(n_total_pairs);
@@ -297,7 +297,7 @@ public:
                     const amrex::ParticleReal* /*p_pair_reaction_weight*/
                     ) const
     {
-        return amrex::Vector<int>();
+        return {};
     }
 };
 

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -38,7 +38,7 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 BreitWheelerGetOpticalDepth
 BreitWheelerEngine::build_optical_depth_functor () const
 {
-    return BreitWheelerGetOpticalDepth();
+    return {};
 }
 
 BreitWheelerEvolveOpticalDepth
@@ -46,8 +46,7 @@ BreitWheelerEngine::build_evolve_functor () const
 {
     AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
 
-    return BreitWheelerEvolveOpticalDepth(m_dndt_table.get_view(),
-        m_bw_minimum_chi_phot);
+    return {m_dndt_table.get_view(), m_bw_minimum_chi_phot};
 }
 
 BreitWheelerGeneratePairs
@@ -55,7 +54,7 @@ BreitWheelerEngine::build_pair_functor () const
 {
     AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
 
-    return BreitWheelerGeneratePairs(m_pair_prod_table.get_view());
+    return {m_pair_prod_table.get_view()};
 }
 
 bool BreitWheelerEngine::are_lookup_tables_initialized () const

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
@@ -38,22 +38,21 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 QuantumSynchrotronGetOpticalDepth
 QuantumSynchrotronEngine::build_optical_depth_functor ()
 {
-    return QuantumSynchrotronGetOpticalDepth();
+    return {};
 }
 
 QuantumSynchrotronEvolveOpticalDepth QuantumSynchrotronEngine::build_evolve_functor ()
 {
     AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
 
-    return QuantumSynchrotronEvolveOpticalDepth(m_dndt_table.get_view(),
-        m_qs_minimum_chi_part);
+    return {m_dndt_table.get_view(), m_qs_minimum_chi_part};
 }
 
 QuantumSynchrotronPhotonEmission QuantumSynchrotronEngine::build_phot_em_functor ()
 {
     AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
 
-    return QuantumSynchrotronPhotonEmission(m_phot_em_table.get_view());
+    return {m_phot_em_table.get_view()};
 
 }
 

--- a/Source/Particles/NamedComponentParticleContainer.H
+++ b/Source/Particles/NamedComponentParticleContainer.H
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 /** Particle Attributes stored in amrex::ParticleContainer's struct of array
  */
@@ -89,10 +90,10 @@ public:
         std::map<std::string, int> p_rcomps,
         std::map<std::string, int> p_ricomps)
     : amrex::ParticleContainer<0,0,PIdx::nattribs,0,T_Allocator>(std::move(pc)),
-    particle_comps(p_comps),
-    particle_icomps(p_icomps),
-    particle_runtime_comps(p_rcomps),
-    particle_runtime_icomps(p_ricomps) {}
+    particle_comps(std::move(p_comps)),
+    particle_icomps(std::move(p_icomps)),
+    particle_runtime_comps(std::move(p_rcomps)),
+    particle_runtime_icomps(std::move(p_ricomps)) {}
 
     /** Copy constructor for NamedComponentParticleContainer */
     NamedComponentParticleContainer ( const NamedComponentParticleContainer &) = delete;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2897,13 +2897,13 @@ PhysicalParticleContainer::getIonizationFunc (const WarpXParIter& pti,
 {
     WARPX_PROFILE("PhysicalParticleContainer::getIonizationFunc()");
 
-    return IonizationFilterFunc(pti, lev, ngEB, Ex, Ey, Ez, Bx, By, Bz,
+    return {pti, lev, ngEB, Ex, Ey, Ez, Bx, By, Bz,
                                 ionization_energies.dataPtr(),
                                 adk_prefactor.dataPtr(),
                                 adk_exp_prefactor.dataPtr(),
                                 adk_power.dataPtr(),
                                 particle_icomps["ionizationLevel"],
-                                ion_atomic_number);
+                                ion_atomic_number};
 }
 
 PlasmaInjector* PhysicalParticleContainer::GetPlasmaInjector ()

--- a/Source/Utils/ParticleUtils.cpp
+++ b/Source/Utils/ParticleUtils.cpp
@@ -53,12 +53,12 @@ namespace ParticleUtils {
         ParticleBins bins;
         bins.build(np, particle_ptr, cbx,
             // Pass lambda function that returns the cell index
-            [=] AMREX_GPU_DEVICE (const ParticleType& p) noexcept -> IntVect
+            [=] AMREX_GPU_DEVICE (const ParticleType& p) noexcept
             {
-                return IntVect(AMREX_D_DECL(
+                return IntVect{AMREX_D_DECL(
                                    static_cast<int>((p.pos(0)-plo[0])*dxi[0] - lo.x),
                                    static_cast<int>((p.pos(1)-plo[1])*dxi[1] - lo.y),
-                                   static_cast<int>((p.pos(2)-plo[2])*dxi[2] - lo.z)));
+                                   static_cast<int>((p.pos(2)-plo[2])*dxi[2] - lo.z))};
             });
 
         return bins;

--- a/Source/Utils/WarpXVersion.cpp
+++ b/Source/Utils/WarpXVersion.cpp
@@ -18,7 +18,7 @@ WarpX::Version ()
     version = std::string(WARPX_GIT_VERSION);
 #endif
     if( version.empty() )
-        return std::string("Unknown");
+        return {"Unknown"};
     else
         return version;
 }
@@ -31,7 +31,7 @@ WarpX::PicsarVersion ()
     version = std::string(PICSAR_GIT_VERSION);
 #endif
     if( version.empty() )
-        return std::string("Unknown");
+        return {"Unknown"};
     else
         return version;
 }

--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -16,7 +16,7 @@
 
 // For sigaction() et al.
 #if defined(__linux__) || defined(__APPLE__)
-#   include <signal.h>
+#   include <csignal>
 #endif
 
 namespace ablastr::utils {
@@ -121,8 +121,8 @@ SignalHandling::InitSignalHandling ()
         signal_received_flags[signal_number] = false;
 
         bool signal_active = false;
-        for (int signal_request = 0; signal_request < SIGNAL_REQUESTS_SIZE; ++signal_request) {
-            signal_active |= signal_conf_requests[signal_request][signal_number];
+        for (const auto& request : signal_conf_requests) {
+            signal_active |= request[signal_number];
         }
         if (signal_active) {
             // at least one signal action is configured
@@ -162,8 +162,9 @@ SignalHandling::CheckSignals ()
             const bool signal_received = signal_received_flags[signal_number].exchange(false);
 
             if (signal_received) {
-                for (int signal_request = 0; signal_request < SIGNAL_REQUESTS_SIZE; ++signal_request) {
-                    signal_actions_requested[signal_request] |= signal_conf_requests[signal_request][signal_number];
+                int signal_request = 0;
+                for (const auto& request : signal_conf_requests) {
+                    signal_actions_requested[signal_request++] |= request[signal_number];
                 }
             }
         }

--- a/clang_tidy_wrapper
+++ b/clang_tidy_wrapper
@@ -1,0 +1,5 @@
+#!/bin/bash
+REGEX="[a-z_A-Z0-9\/]*WarpX\/Source[a-z_A-Z0-9\/]+.cpp"
+if [[ $4 =~ $REGEX ]];then
+  clang-tidy-14 $@
+fi

--- a/clang_tidy_wrapper
+++ b/clang_tidy_wrapper
@@ -1,5 +1,0 @@
-#!/bin/bash
-REGEX="[a-z_A-Z0-9\/]*WarpX\/Source[a-z_A-Z0-9\/]+.cpp"
-if [[ $4 =~ $REGEX ]];then
-  clang-tidy-14 $@
-fi


### PR DESCRIPTION
Specifically, this PR adds the following checks:

- [modernize-deprecated-headers](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-deprecated-headers.html)
- [modernize-deprecated-ios-base-aliases](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-deprecated-ios-base-aliases.html)
- [modernize-loop-convert](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-loop-convert.html)
- [modernize-make-shared](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-make-shared.html)
- [modernize-make-unique](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-make-unique.html)
- [modernize-pass-by-value](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-pass-by-value.html)
- [modernize-raw-string-literal](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-raw-string-literal.html)
- [modernize-redundant-void-arg](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-redundant-void-arg.html)
- [modernize-replace-auto-ptr](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-replace-auto-ptr.html)
- [modernize-replace-disallow-copy-and-assign-macro](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-replace-disallow-copy-and-assign-macro.html)
- [modernize-replace-random-shuffle](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-replace-random-shuffle.html)
- [modernize-return-braced-init-list](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-return-braced-init-list.html)
- [modernize-shrink-to-fit](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-shrink-to-fit.html)
- [modernize-unary-static-assert](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-unary-static-assert.html)
   
with the additional option:

 ```
CheckOptions:
- key:          modernize-pass-by-value.ValuesOnly
  value:        'true'
 ```
    