### PR TITLE
Move GotoNextLine helper function into ablastr 

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -7,7 +7,8 @@
 #include "BTD_Plotfile_Header_Impl.H"
 
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
+
+#include <ablastr/utils/text/StreamUtils.H>
 
 #include <AMReX.H>
 #include <AMReX_FileSystem.H>
@@ -71,7 +72,7 @@ BTDPlotfileHeaderImpl::ReadHeaderData ()
     for (int idim = 0; idim < m_spacedim; ++idim) {
         is >> m_prob_hi[idim];
     }
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
 
     is >> m_prob_domain;
 
@@ -232,7 +233,7 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
     for (int ifab = 0; ifab < m_ba.size(); ++ifab) {
         is >> m_FabOnDiskPrefix[ifab] >> m_fabname[ifab] >> m_fabhead[ifab];
     }
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
     char ch;
     is >> in_hash >> ch >> in_hash;
     m_minval.resize(m_ba.size());
@@ -243,7 +244,7 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
             if( ch != ',' ) amrex::Error("Expected a ',' got something else");
         }
     }
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
     is >> in_hash >> ch >> in_hash;
     m_maxval.resize(m_ba.size());
     for (int ifab = 0; ifab < m_ba.size(); ++ifab) {

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -17,7 +17,8 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
-#include "WarpX.H"
+
+#include <ablastr/utils/text/StreamUtils.H>
 
 #include <AMReX_BLassert.H>
 #include <AMReX_Config.H>
@@ -48,7 +49,7 @@ LaserParticleContainer::ReadHeader (std::istream& is)
         m_updated_position.resize(3);
         for (int i = 0; i < 3; ++i) {
             is >> m_updated_position[i];
-            WarpX::GotoNextLine(is);
+            ablastr::utils::text::goto_next_line(is);
         }
     }
 }
@@ -72,7 +73,7 @@ RigidInjectedParticleContainer::ReadHeader (std::istream& is)
     // Read quantities that are specific to rigid-injected species
     int nlevs;
     is >> nlevs;
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
 
     AMREX_ASSERT(zinject_plane_levels.size() == 0);
 
@@ -81,10 +82,10 @@ RigidInjectedParticleContainer::ReadHeader (std::istream& is)
         amrex::Real zinject_plane_tmp;
         is >> zinject_plane_tmp;
         zinject_plane_levels.push_back(zinject_plane_tmp);
-        WarpX::GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
     }
     is >> vzbeam_ave_boosted;
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
 }
 
 void
@@ -107,7 +108,7 @@ void
 PhysicalParticleContainer::ReadHeader (std::istream& is)
 {
     is >> charge >> mass;
-    WarpX::GotoNextLine(is);
+    ablastr::utils::text::goto_next_line(is);
 }
 
 void

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -19,6 +19,7 @@
 #include "Diagnostics/MultiDiagnostics.H"
 
 #include <ablastr/utils/Communication.H>
+#include <ablastr/utils/text/StreamUtils.H>
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
@@ -48,13 +49,6 @@ using namespace amrex;
 namespace
 {
     const std::string level_prefix {"Level_"};
-}
-
-void
-WarpX::GotoNextLine (std::istream& is)
-{
-    constexpr std::streamsize bl_ignore_max { 100000 };
-    is.ignore(bl_ignore_max, '\n');
 }
 
 amrex::DistributionMapping
@@ -116,7 +110,7 @@ WarpX::InitFromCheckpoint ()
 
         int nlevs;
         is >> nlevs;
-        GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
         finest_level = nlevs-1;
 
         std::getline(is, line);
@@ -171,10 +165,10 @@ WarpX::InitFromCheckpoint ()
 
         amrex::Real moving_window_x_checkpoint;
         is >> moving_window_x_checkpoint;
-        GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
 
         is >> is_synchronized;
-        GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
 
         amrex::Vector<amrex::Real> prob_lo( AMREX_SPACEDIM );
         std::getline(is, line);
@@ -203,7 +197,7 @@ WarpX::InitFromCheckpoint ()
         for (int lev = 0; lev < nlevs; ++lev) {
             BoxArray ba;
             ba.readFrom(is);
-            GotoNextLine(is);
+            ablastr::utils::text::goto_next_line(is);
             const DistributionMapping dm = GetRestartDMap(restart_chkfile, ba, lev);
             SetBoxArray(lev, ba);
             SetDistributionMap(lev, dm);
@@ -215,19 +209,19 @@ WarpX::InitFromCheckpoint ()
         for (int i=0; i<n_species; i++)
         {
              is >> mypc->GetParticleContainer(i).m_current_injection_position;
-             GotoNextLine(is);
+             ablastr::utils::text::goto_next_line(is);
         }
 
         int do_moving_window_before_restart;
         is >> do_moving_window_before_restart;
-        GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
 
         if (do_moving_window_before_restart) {
             moving_window_x = moving_window_x_checkpoint;
         }
 
         is >> time_of_last_gal_shift;
-        GotoNextLine(is);
+        ablastr::utils::text::goto_next_line(is);
 
 
         auto & warpx = WarpX::GetInstance();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -109,8 +109,6 @@ public:
                          amrex::Real external_field=0.0, bool useparser = false,
                          amrex::ParserExecutor<3> const& field_parser={});
 
-    static void GotoNextLine (std::istream& is);
-
     //! Author of an input file / simulation setup
     static std::string authors;
 

--- a/Source/ablastr/utils/text/CMakeLists.txt
+++ b/Source/ablastr/utils/text/CMakeLists.txt
@@ -2,6 +2,7 @@ foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(ablastr_${SD}
       PRIVATE
+        StreamUtils.cpp
         StringUtils.cpp
     )
 endforeach()

--- a/Source/ablastr/utils/text/Make.package
+++ b/Source/ablastr/utils/text/Make.package
@@ -1,3 +1,4 @@
+CEXE_sources += StreamUtils.cpp
 CEXE_sources += StringUtils.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/utils/text

--- a/Source/ablastr/utils/text/StreamUtils.H
+++ b/Source/ablastr/utils/text/StreamUtils.H
@@ -1,0 +1,24 @@
+/* Copyright 2023
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef ABLASTR_UTILS_TEXT_STREAMUTILS_H_
+#define ABLASTR_UTILS_TEXT_STREAMUTILS_H_
+
+#include <iostream>
+
+namespace ablastr::utils::text
+{
+    /**
+    * \brief This function drops the rest of the current line of
+    * the input stream "is"
+    *
+    * @param[in,out] is the input stream
+    */
+    void goto_next_line (std::istream& is);
+}
+
+#endif //ABLASTR_UTILS_TEXT_STREAMUTILS_H_

--- a/Source/ablastr/utils/text/StreamUtils.H
+++ b/Source/ablastr/utils/text/StreamUtils.H
@@ -8,7 +8,7 @@
 #ifndef ABLASTR_UTILS_TEXT_STREAMUTILS_H_
 #define ABLASTR_UTILS_TEXT_STREAMUTILS_H_
 
-#include <iostream>
+#include <istream>
 
 namespace ablastr::utils::text
 {

--- a/Source/ablastr/utils/text/StreamUtils.cpp
+++ b/Source/ablastr/utils/text/StreamUtils.cpp
@@ -5,7 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include <StreamUtils.H>
+#include "StreamUtils.H"
 
 #include <limits>
 

--- a/Source/ablastr/utils/text/StreamUtils.cpp
+++ b/Source/ablastr/utils/text/StreamUtils.cpp
@@ -1,0 +1,16 @@
+/* Copyright 2023
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include <StreamUtils.H>
+
+#include <limits>
+
+void
+ablastr::utils::text::goto_next_line (std::istream& is)
+{
+    is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+}

--- a/Source/ablastr/utils/text/StreamUtils.cpp
+++ b/Source/ablastr/utils/text/StreamUtils.cpp
@@ -7,6 +7,7 @@
 
 #include "StreamUtils.H"
 
+#include <ios>
 #include <limits>
 
 void


### PR DESCRIPTION
This PR moves the static function `WarpX::GotoNextLine (std::istream& is)` into the `ablastr` library (as a free function). It also changes the first argument of `is.ignore` from `constexpr std::streamsize bl_ignore_max { 100000 };`  to  `std::numeric_limits<std::streamsize>::max()` 

