### PR TITLE
[WIP] Improved docs for lasy usage

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1227,7 +1227,7 @@ Laser initialization
       though ``<laser_name>.wavelength`` and ``<laser_name>.e_max`` should be included in the laser
       function, they still have to be specified as they are used for numerical purposes.
     - ``"from_file"``: the electric field of the laser is read from an external file. Currently both
-      the `lasy <https://lasydoc.readthedocs.io/en/latest/>`_ format as well as a custom binary format are supported. It requires to provide
+      the `lasy format <https://lasydoc.readthedocs.io/en/latest/>`_ as well as a custom binary format are supported. It requires to provide
       the name of the file to load setting the additional parameter ``<laser_name>.binary_file_name`` or ``<laser_name>.lasy_file_name`` (`string`).
       It accepts an optional parameter ``<laser_name>.time_chunk_size`` (`int`), supported for both lasy and binary files;
       this allows to read only time_chunk_size timesteps from the file. New timesteps are read as soon as they are needed.

--- a/Docs/source/usage/workflows.rst
+++ b/Docs/source/usage/workflows.rst
@@ -14,3 +14,4 @@ This section collects typical user workflows and best practices for WarpX.
    workflows/plot_distribution_mapping
    workflows/psatd_stencil
    workflows/archiving
+   workflows/lasy_usage

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -141,6 +141,7 @@ Customize your laser profile by using NumPy arrays
 -------------------
 
 Profile defined from a NumPy array directly (only supported for 3D arrays):
+
 .. code-block:: python
 
     from lasy.laser import Laser

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -1,0 +1,188 @@
+Create a custom laser using lasy package
+==================================
+
+LASY (LAser SYmple manipulator) is a Python package that can be used to define complex laser pulse profiles 
+for which either the analytical form or the experimental measurement is known. 
+Most of the contents of this user guide can be found in `lasy docs <https://lasydoc.readthedocs.io/en/latest/>`_ and one can see examples at ``Examples/Tests/laser_injection_from_file``.
+
+Install lasy package and dependencies
+-------------------
+
+To install the code you will need to first clone the repository to your local machine. Change into the new directory and then run the install command as given below.
+
+.. code-block:: python
+
+    git clone https://github.com/LASY-org/lasy.git
+    cd lasy
+    python3 -m pip install -v .
+
+Run your first example
+-------------------
+
+We will try a simple example by generating a Gaussian pulse at focus.
+
+First let's load the required functions from the library:
+
+.. code-block:: python
+
+    from lasy.laser import Laser
+    from lasy.profiles import GaussianProfile
+
+Next, we define the physical parameters of the laser pulse and create the laser profile object:
+
+.. code-block:: python
+    wavelength     = 1.e-6    # Laser wavelength in meters
+    polarization   = (1,0)    # Linearly polarized in the x direction
+    energy         = 1.0      # Energy of the laser pulse in joules
+    spot_size      = 12e-6    # Waist of the laser pulse in meters
+    pulse_duration = 10e-15   # Pulse duration of the laser in seconds
+    t_peak         = 0.0      # Location of the peak of the laser pulse in time
+
+    laser_profile = GaussianProfile(wavelength, polarization, energy, spot_size, pulse_duration, t_peak)
+
+Now we create a full laser object containing the above physical parameters together with the computational settings:
+
+.. code-block:: python
+    dimensions     = "xyt"                              # Use 3D geometry
+    lo             = (-25e-6, -25e-6, -20e-15)          # Lower bounds of the simulation box
+    hi             = (+25e-6, +25e-6, +20e-15)          # Upper bounds of the simulation box
+    num_points     = (100, 100, 100)                    # Number of points (nx,ny,nt) in each dimension
+
+    laser = Laser(dimensions, lo, hi, num_points, laser_profile)
+    laser.normalize(energy, kind="energy")              # Optionnal: normalize energy of the laser pulse contained in grid
+
+Finally, we create a lasy file containing the laser profile, using openPMD standard:
+
+.. code-block:: python
+    file_prefix    = 'gaussianlaser3d' # The file name will start with this prefix
+    file_format    = 'h5'          # Format to be used for the output file
+
+    laser.write_to_file(file_prefix, file_format)
+
+or simply:
+.. code-block:: python
+    laser.write_to_file("gaussianlaser3d")  # Use h5 format by default
+
+
+That's it! The laser pulse profile has been created and the complexe envelope is now stored in a lasy file called ``gaussianlaser3d.h5`` and can be used with either a 3D,2D,RZ or 1D WarpX executable!
+Now let's take a look at the laser parameters that need to be specified in the inputs parameters:
+
+.. code-block:: python
+    #######################################################################################################################################
+    ######################################################## INPUTS FILE ################################################################## 
+    #######################################################################################################################################
+    lasers.names        = lasy_laser
+    lasy_laser.profile      = from_file                     # Specify that we want to read the lasy file instead of a handwritten laser
+    lasy_laser.lasy_file_name = "gaussianlaser3d.h5"        # Name of the lasy file
+    lasy_laser.time_chunk_size = 50                         # Read the lasy file in time chunks (accepts a value between 2 and nt)
+    lasy_laser.position     = 0. 0. 0.                      # This point is on the laser plane
+    lasy_laser.direction    = 0. 0. 1.                      # The plane normal direction
+    lasy_laser.polarization = 0. 1. 0.                      # The main polarization vector
+    lasy_laser.e_max        = 1.e14                         # Maximum amplitude of the laser field (in V/m)
+    lasy_laser.wavelength = 1.0e-6                          # The wavelength of the laser (in meters)
+    lasy_laser.delay = 0.0                                  # Delay (>0) or anticipate (<0) the laser by a specific amount of time
+
+    # Other inputs parameters
+
+or inside a PICMI script:
+
+.. code-block:: python
+    
+
+
+
+Customize your laser profile by using combined longitunal and transverse profiles
+-------------------
+
+lasy allows you to define a custom laser pulse profile using different longitunal and transverse profiles.
+
+.. code-block:: python
+    from lasy.laser import Laser
+    from lasy.profiles import (
+        CombinedLongitudinalTransverseProfile,
+        GaussianProfile,
+    )
+    from lasy.profiles.longitudinal import GaussianLongitudinalProfile
+    from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
+
+    # Units
+    um = 1.e-6
+    fs = 1.e-15
+
+    # Parameters of the Laguerre Gaussian beam
+    wavelength = 1.*um
+    w0 = 12.*um
+    tt = 10.*fs
+    t_c = 20.*fs
+    laser_energy = 1.0
+    pol = (1, 0)
+    
+    # Create a Laguerre Gaussian laser in RZ geometry
+    profile = CombinedLongitudinalTransverseProfile(
+    wavelength,pol,laser_energy,
+    GaussianLongitudinalProfile(wavelength, tt, t_peak=0),
+    LaguerreGaussianTransverseProfile(w0, p=0, m=1),
+    )
+    dim = "rt"
+    lo = (0e-6, -20e-15)
+    hi = (+25e-6, +20e-15)
+    npoints = (100,100)
+    laser = Laser(dim, lo, hi, npoints, profile, n_azimuthal_modes=2)
+    laser.normalize(laser_energy, kind="energy")
+    laser.write_to_file("laguerrelaserRZ")
+
+Customize your laser profile by using NumPy arrays
+-------------------
+
+Profile defined from a NumPy array directly (only supported for 3D arrays):
+.. code-block:: python
+    from lasy.laser import Laser
+    from lasy.profiles import FromArrayProfile
+
+    # Units
+    um = 1.e-6
+
+    # Parameters of the Laguerre Gaussian beam
+    wavelength = 1.*um
+    pol = (1, 0)
+
+    # Array of the electric field of the laser pulse.
+    E_field = custom_numpy_array 
+    # Python dictionary containing the axes vectors. Keys are ‘x’, ‘y’, ‘t’. Values are the 1D arrays of each axis. array.shape = (axes[‘x’].size, axes[‘y’].size, axes[‘t’].size)
+    axes
+    laser_profile = FromArrayProfile(wavelength, pol, E_field, axes, axes_order=['x', 'y', 't'])
+
+    dimensions     = "xyt"                              # Use 3D geometry
+    lo             = (-25e-6, -25e-6, -20e-15)          # Lower bounds of the simulation box
+    hi             = (+25e-6, +25e-6, +20e-15)          # Upper bounds of the simulation box
+    num_points     = (100, 100, 100)                    # Number of points (nx,ny,nt) in each dimension
+
+    laser = Laser(dimensions, lo, hi, num_points, laser_profile)
+    laser.write_to_file("numpylaser3D")
+
+Customize your laser profile by using an openPMD file
+-------------------
+Profile defined from an openPMD file:
+
+.. code-block:: python
+    from lasy.laser import Laser
+    from lasy.profiles import FromOpenPMDProfile
+
+    # Parameters of the Laguerre Gaussian beam
+    pol = (1, 0)
+
+    # Load the external openPMD file containing the laser pulse.
+    path = './diags/' # Path to openPMDTimeSeries
+    iteration = 450
+    field = 'E'
+
+    FromOpenPMDProfile(path, iteration, pol, field)
+
+    dimensions     = "xyt"                              # Use 3D geometry
+    lo             = (-25e-6, -25e-6, -20e-15)          # Lower bounds of the simulation box
+    hi             = (+25e-6, +25e-6, +20e-15)          # Upper bounds of the simulation box
+    num_points     = (100, 100, 100)                    # Number of points (nx,ny,nt) in each dimension
+
+    laser = Laser(dimensions, lo, hi, num_points, laser_profile)
+    laser.write_to_file("openPMDlaser3D")
+    

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -167,7 +167,7 @@ Profile defined from a NumPy array directly (only supported for 3D arrays):
     num_points     = (100, 100, 100)                    # Number of points (nx,ny,nt) in each dimension
 
     laser = Laser(dimensions, lo, hi, num_points, laser_profile)
-    laser.write_to_file("numpylaser3D")
+    laser.write_to_file("numpylaser3d")
 
 Customize your laser profile by using an openPMD file
 -------------------
@@ -186,7 +186,7 @@ Profile defined from an openPMD file:
     iteration = 450
     field = 'E'
 
-    FromOpenPMDProfile(path, iteration, pol, field)
+    laser_profile = FromOpenPMDProfile(path, iteration, pol, field)
 
     dimensions     = "xyt"                              # Use 3D geometry
     lo             = (-25e-6, -25e-6, -20e-15)          # Lower bounds of the simulation box
@@ -194,4 +194,4 @@ Profile defined from an openPMD file:
     num_points     = (100, 100, 100)                    # Number of points (nx,ny,nt) in each dimension
 
     laser = Laser(dimensions, lo, hi, num_points, laser_profile)
-    laser.write_to_file("openPMDlaser3D")
+    laser.write_to_file("openPMDlaser3d")

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -1,8 +1,8 @@
 Create a custom laser using lasy package
 ==================================
 
-LASY (LAser SYmple manipulator) is a Python package that can be used to define complex laser pulse profiles 
-for which either the analytical form or the experimental measurement is known. 
+LASY (LAser SYmple manipulator) is a Python package that can be used to define complex laser pulse profiles
+for which either the analytical form or the experimental measurement is known.
 Most of the contents of this user guide can be found in `lasy docs <https://lasydoc.readthedocs.io/en/latest/>`_ and one can see examples at ``Examples/Tests/laser_injection_from_file``.
 
 Install lasy package and dependencies
@@ -69,7 +69,7 @@ Now let's take a look at the laser parameters that need to be specified in the i
 
 .. code-block:: python
     #######################################################################################################################################
-    ######################################################## INPUTS FILE ################################################################## 
+    ######################################################## INPUTS FILE ##################################################################
     #######################################################################################################################################
     lasers.names        = lasy_laser
     lasy_laser.profile      = from_file                     # Specify that we want to read the lasy file instead of a handwritten laser
@@ -87,7 +87,7 @@ Now let's take a look at the laser parameters that need to be specified in the i
 or inside a PICMI script:
 
 .. code-block:: python
-    
+
 
 
 
@@ -116,7 +116,7 @@ lasy allows you to define a custom laser pulse profile using different longituna
     t_c = 20.*fs
     laser_energy = 1.0
     pol = (1, 0)
-    
+
     # Create a Laguerre Gaussian laser in RZ geometry
     profile = CombinedLongitudinalTransverseProfile(
     wavelength,pol,laser_energy,
@@ -147,7 +147,7 @@ Profile defined from a NumPy array directly (only supported for 3D arrays):
     pol = (1, 0)
 
     # Array of the electric field of the laser pulse.
-    E_field = custom_numpy_array 
+    E_field = custom_numpy_array
     # Python dictionary containing the axes vectors. Keys are ‘x’, ‘y’, ‘t’. Values are the 1D arrays of each axis. array.shape = (axes[‘x’].size, axes[‘y’].size, axes[‘t’].size)
     axes
     laser_profile = FromArrayProfile(wavelength, pol, E_field, axes, axes_order=['x', 'y', 't'])
@@ -185,4 +185,3 @@ Profile defined from an openPMD file:
 
     laser = Laser(dimensions, lo, hi, num_points, laser_profile)
     laser.write_to_file("openPMDlaser3D")
-    

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -31,6 +31,7 @@ First let's load the required functions from the library:
 Next, we define the physical parameters of the laser pulse and create the laser profile object:
 
 .. code-block:: python
+
     wavelength     = 1.e-6    # Laser wavelength in meters
     polarization   = (1,0)    # Linearly polarized in the x direction
     energy         = 1.0      # Energy of the laser pulse in joules
@@ -43,6 +44,7 @@ Next, we define the physical parameters of the laser pulse and create the laser 
 Now we create a full laser object containing the above physical parameters together with the computational settings:
 
 .. code-block:: python
+
     dimensions     = "xyt"                              # Use 3D geometry
     lo             = (-25e-6, -25e-6, -20e-15)          # Lower bounds of the simulation box
     hi             = (+25e-6, +25e-6, +20e-15)          # Upper bounds of the simulation box
@@ -54,6 +56,7 @@ Now we create a full laser object containing the above physical parameters toget
 Finally, we create a lasy file containing the laser profile, using openPMD standard:
 
 .. code-block:: python
+
     file_prefix    = 'gaussianlaser3d' # The file name will start with this prefix
     file_format    = 'h5'          # Format to be used for the output file
 
@@ -61,6 +64,7 @@ Finally, we create a lasy file containing the laser profile, using openPMD stand
 
 or simply:
 .. code-block:: python
+
     laser.write_to_file("gaussianlaser3d")  # Use h5 format by default
 
 
@@ -68,6 +72,7 @@ That's it! The laser pulse profile has been created and the complexe envelope is
 Now let's take a look at the laser parameters that need to be specified in the inputs parameters:
 
 .. code-block:: python
+
     #######################################################################################################################################
     ######################################################## INPUTS FILE ##################################################################
     #######################################################################################################################################
@@ -97,6 +102,7 @@ Customize your laser profile by using combined longitunal and transverse profile
 lasy allows you to define a custom laser pulse profile using different longitunal and transverse profiles.
 
 .. code-block:: python
+
     from lasy.laser import Laser
     from lasy.profiles import (
         CombinedLongitudinalTransverseProfile,
@@ -136,6 +142,7 @@ Customize your laser profile by using NumPy arrays
 
 Profile defined from a NumPy array directly (only supported for 3D arrays):
 .. code-block:: python
+
     from lasy.laser import Laser
     from lasy.profiles import FromArrayProfile
 
@@ -165,6 +172,7 @@ Customize your laser profile by using an openPMD file
 Profile defined from an openPMD file:
 
 .. code-block:: python
+
     from lasy.laser import Laser
     from lasy.profiles import FromOpenPMDProfile
 

--- a/Docs/source/usage/workflows/lasy_usage.rst
+++ b/Docs/source/usage/workflows/lasy_usage.rst
@@ -63,6 +63,7 @@ Finally, we create a lasy file containing the laser profile, using openPMD stand
     laser.write_to_file(file_prefix, file_format)
 
 or simply:
+
 .. code-block:: python
 
     laser.write_to_file("gaussianlaser3d")  # Use h5 format by default


### PR DESCRIPTION
Added a pretty exhaustive workflow tutorial about the usage of the lasy format to define laser profiles. It is based on the implementation in `/Examples/Tests/laser_injection_from_file` and on lasy docs `https://lasydoc.readthedocs.io/en/latest/index.html`.

- [ ]  Need to implement the external laser file injection input parameter for PICMI scripts so that it can be updated here too.
- [ ]  Some specific profiles (from a NumPy array and from an external openPMD file) need to be tested with WarpX to be sure that is compatible. I have also noticed that there is no examples in lasy docs that show how to use these profiles so it can be worth to document this.
- [ ]  Need a link that leads to this workflows (in inputs parameters for example).

