### PR TITLE
t_lab optionally imposed for externally loaded species in the boosted frame

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -717,6 +717,7 @@ Particle initialization
       ``<species_name>.charge`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.mass`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.z_shift`` (`double`) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
+      ``<species_name>.impose_t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
       Warning: ``q_tot!=0`` is not supported with the ``external_file`` injection style. If a value is provided, it is ignored and no re-scaling is done.
       The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
       If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see ``<species_name>.mass``, ``<species_name>.charge`` or ``<species_name>.species_type``).

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -359,9 +359,6 @@ protected:
     bool do_backward_propagation = false;
     bool m_rz_random_theta = true;
 
-    // By default, t_lab for the Lorentz Transform is set to 0
-    amrex::Real t_lab = 0._prt;
-
     // Impose t_lab from the openPMD file for externally loaded species
     bool impose_t_lab_from_file = false;
 

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -359,6 +359,12 @@ protected:
     bool do_backward_propagation = false;
     bool m_rz_random_theta = true;
 
+    // By default, t_lab for the Lorentz Transform is set to 0
+    amrex::Real t_lab = 0._prt;
+
+    // Impose t_lab from the openPMD file for externally loaded species
+    bool impose_t_lab_from_file = false;
+
     Resampling m_resampler;
 
     // Inject particles during the whole simulation

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -200,7 +200,7 @@ public:
 
     void MapParticletoBoostedFrame (amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
                                     amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
-                                    amrex::ParticleReal t_lab = 0._prt);
+                                    amrex::Real t_lab = 0._prt);
 
     void AddGaussianBeam (
         const amrex::Real x_m, const amrex::Real y_m, const amrex::Real z_m,
@@ -226,7 +226,7 @@ public:
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uy,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_uz,
         amrex::Gpu::HostVector<amrex::ParticleReal>& particle_w,
-        amrex::ParticleReal t_lab= 0._prt);
+        amrex::Real t_lab= 0._prt);
 
     /**
      * \brief Default initialize runtime attributes in a tile. This routine does not initialize the

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -407,8 +407,6 @@ void PhysicalParticleContainer::MapParticletoBoostedFrame (
     // tpr is the particle's time in the boosted frame
     const ParticleReal tpr = WarpX::gamma_boost*t_lab - uz_boost*z/(PhysConst::c*PhysConst::c);
 
-    // For all species: impose t_lab if the real input parameter 'species.t_lab' is given
-
     // The particle's transformed location in the boosted frame
     const ParticleReal xpr = x;
     const ParticleReal ypr = y;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -407,6 +407,8 @@ void PhysicalParticleContainer::MapParticletoBoostedFrame (
     // tpr is the particle's time in the boosted frame
     const ParticleReal tpr = WarpX::gamma_boost*t_lab - uz_boost*z/(PhysConst::c*PhysConst::c);
 
+    // For all species: impose t_lab if the real input parameter 'species.t_lab' is given
+
     // The particle's transformed location in the boosted frame
     const ParticleReal xpr = x;
     const ParticleReal ypr = y;
@@ -580,6 +582,7 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         auto series = std::move(plasma_injector->m_openpmd_input_series);
 
         // assumption asserts: see PlasmaInjector
+        // Optionnaly impose t_lab as the time in the species openPMD external file (create bool or 0/1 input parameter called 'impose_t_lab_from_file')
         openPMD::Iteration it = series->iterations.begin()->second;
         double const t_lab = it.time<double>() * it.timeUnitSI();
         std::string const ps_name = it.particles.begin()->first;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -585,7 +585,7 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         openPMD::Iteration it = series->iterations.begin()->second;
         const ParmParse pp_species_name(species_name);
         pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
-        
+
         if (WarpX::gamma_boost > 1. && impose_t_lab_from_file) {
             // Impose t_lab as being the time stored in the openPMD file
             t_lab = it.time<double>() * it.timeUnitSI();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -393,7 +393,7 @@ void PhysicalParticleContainer::InitData ()
 }
 
 void PhysicalParticleContainer::MapParticletoBoostedFrame (
-    ParticleReal& x, ParticleReal& y, ParticleReal& z, ParticleReal& ux, ParticleReal& uy, ParticleReal& uz, ParticleReal t_lab)
+    ParticleReal& x, ParticleReal& y, ParticleReal& z, ParticleReal& ux, ParticleReal& uy, ParticleReal& uz, Real t_lab)
 {
     // Map the particles from the lab frame to the boosted frame.
     // This boosts the particle to the lab frame and calculates
@@ -583,7 +583,8 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         openPMD::Iteration it = series->iterations.begin()->second;
         const ParmParse pp_species_name(species_name);
         pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
-        if (WarpX::gamma_boost > 1. && impose_t_lab_from_file) {
+        double t_lab = 0._prt;
+        if (impose_t_lab_from_file) {
             // Impose t_lab as being the time stored in the openPMD file
             t_lab = it.time<double>() * it.timeUnitSI();
         }
@@ -801,7 +802,7 @@ PhysicalParticleContainer::CheckAndAddParticle (
     Gpu::HostVector<ParticleReal>& particle_uy,
     Gpu::HostVector<ParticleReal>& particle_uz,
     Gpu::HostVector<ParticleReal>& particle_w,
-    ParticleReal t_lab)
+    Real t_lab)
 {
     if (WarpX::gamma_boost > 1.) {
         MapParticletoBoostedFrame(x, y, z, ux, uy, uz, t_lab);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -583,7 +583,6 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         openPMD::Iteration it = series->iterations.begin()->second;
         const ParmParse pp_species_name(species_name);
         pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
-
         if (WarpX::gamma_boost > 1. && impose_t_lab_from_file) {
             // Impose t_lab as being the time stored in the openPMD file
             t_lab = it.time<double>() * it.timeUnitSI();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -582,9 +582,14 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         auto series = std::move(plasma_injector->m_openpmd_input_series);
 
         // assumption asserts: see PlasmaInjector
-        // Optionnaly impose t_lab as the time in the species openPMD external file (create bool or 0/1 input parameter called 'impose_t_lab_from_file')
         openPMD::Iteration it = series->iterations.begin()->second;
-        double const t_lab = it.time<double>() * it.timeUnitSI();
+        const ParmParse pp_species_name(species_name);
+        pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
+        
+        if (WarpX::gamma_boost > 1. && impose_t_lab_from_file) {
+            // Impose t_lab as being the time stored in the openPMD file
+            t_lab = it.time<double>() * it.timeUnitSI();
+        }
         std::string const ps_name = it.particles.begin()->first;
         openPMD::ParticleSpecies ps = it.particles.begin()->second;
 


### PR DESCRIPTION
Mainly motivated for simulations that don't start at t=0.
`t_lab` is already imposed in the Lorentz Transformation when we read the species from an openPMD file: https://github.com/ECP-WarpX/WarpX/pull/3996.
We would want to make this feature optional and to make it possible to impose `t_lab` from an input real value given in the inputs file for handwritten species.

Update: After some discussion with @RemiLehe we ended up thinking that imposing t_lab for species which we provide the density function is not clear as we assume that it does not depend on time. This PR now only focuses on making https://github.com/ECP-WarpX/WarpX/pull/3996 optional.

New input parameter: parse `species.impose_t_lab_from_file`(bool, false by default) in the inputs file for species loaded from an openPMD file will impose the value of `t_lab` from the file, otherwise `t_lab=0`.

- [x] Update the docs