### PR TITLE
Fix printing of warning messages at the end of the simulation

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -39,7 +39,8 @@ int main(int argc, char* argv[])
         warpx.Evolve();
 
         //Print warning messages at the end of the simulation
-        ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("THE END");
+        amrex::Print() <<
+            ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("THE END");
 
         timer.record_stop_time();
         if (warpx.Verbose()) {


### PR DESCRIPTION
Warning messages were not printed at the end of the simulation. This PR fixes this bug.