### PR TITLE
Docs fix: extra whitespace in perlmutter gpu batch script 

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
@@ -15,7 +15,7 @@
 # A100 40GB (most nodes)
 #SBATCH -C gpu
 # A100 80GB (256 nodes)
-#S BATCH -C gpu&hbm80g
+#SBATCH -C gpu&hbm80g
 #SBATCH --exclusive
 #SBATCH --gpu-bind=none
 #SBATCH --gpus-per-node=4


### PR DESCRIPTION
Removes an extra whitespace from perlmutter batch script 
in `Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch`.

