### PR TITLE
ParticleBoundaryBuffer: move function from .H file to .cpp file

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -23,16 +23,7 @@ public:
 
     int numSpecies() const { return getSpeciesNames().size(); }
 
-    const std::vector<std::string>& getSpeciesNames() const {
-        static bool initialized = false;
-        if (!initialized)
-        {
-            const amrex::ParmParse pp_particles("particles");
-            pp_particles.queryarr("species_names", m_species_names);
-            initialized = true;
-        }
-        return m_species_names;
-    }
+    const std::vector<std::string>& getSpeciesNames() const;
 
     void gatherParticles (MultiParticleContainer& mypc,
                           const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -186,6 +186,18 @@ void ParticleBoundaryBuffer::redistribute () {
     }
 }
 
+const std::vector<std::string>& ParticleBoundaryBuffer::getSpeciesNames() const
+{
+    static bool initialized = false;
+    if (!initialized)
+    {
+        const amrex::ParmParse pp_particles("particles");
+        pp_particles.queryarr("species_names", m_species_names);
+        initialized = true;
+    }
+    return m_species_names;
+}
+
 void ParticleBoundaryBuffer::clearParticles () {
     for (int i = 0; i < numBoundaries(); ++i)
     {


### PR DESCRIPTION
This PR moves a function from a header file to the corresponding cpp file.