### PR TITLE
Fix compilation issue with single-precision particles

### DIFF
--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -93,7 +93,7 @@ struct ParserFilter
      * \param time simulation time on the coarsest level
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
-        const amrex::Real a_mass, const amrex::Real time):
+        const amrex::ParticleReal a_mass, const amrex::Real time):
             m_is_active{a_is_active},
             m_function_partparser{a_filter_parser},
             m_mass{a_mass},
@@ -139,7 +139,7 @@ public:
     /** Mass of particle species */
     amrex::ParticleReal m_mass;
     /** Store physical time on the coarsest level. */
-    amrex::ParticleReal m_t;
+    amrex::Real m_t;
     /** keep track of momentum units particles will come in with **/
     InputUnits m_units;
 };


### PR DESCRIPTION
When compiling WarpX with single-precision particles (but double-precision fields) with:
```
cmake -S . -B build -DWarpX_PARTICLE_PRECISION=SINGLE
```
one gets the following error on the `development` branch:
```
In file included from /Users/rlehe/Documents/codes/warpx_directory/warpx/Source/Diagnostics/WarpXOpenPMD.cpp:12:
/Users/rlehe/Documents/codes/warpx_directory/warpx/Source/Particles/Filter/FilterFunctors.H:99:20: error: non-constant-expression cannot be narrowed from type 'amrex::Real' (aka 'double') to 'amrex::ParticleReal' (aka 'float') in initializer list [-Wc++11-narrowing]
            m_mass{a_mass},
                   ^~~~~~
/Users/rlehe/Documents/codes/warpx_directory/warpx/Source/Particles/Filter/FilterFunctors.H:99:20: note: insert an explicit cast to silence this issue
            m_mass{a_mass},
                   ^~~~~~
                   static_cast<ParticleReal>( )
/Users/rlehe/Documents/codes/warpx_directory/warpx/Source/Particles/Filter/FilterFunctors.H:100:17: error: non-constant-expression cannot be narrowed from type 'amrex::Real' (aka 'double') to 'amrex::ParticleReal' (aka 'float') in initializer list [-Wc++11-narrowing]
            m_t{time},
                ^~~~
/Users/rlehe/Documents/codes/warpx_directory/warpx/Source/Particles/Filter/FilterFunctors.H:100:17: note: insert an explicit cast to silence this issue
            m_t{time},
                ^~~~
                static_cast<ParticleReal>( )
```

This PR fixes the error by using more consistent types.