### PR TITLE
Fix Python test due to recent openPMD-viewer update

### DIFF
--- a/Examples/Tests/scraping/analysis_rz.py
+++ b/Examples/Tests/scraping/analysis_rz.py
@@ -53,7 +53,7 @@ def n_remaining_particles( iteration ):
     w, = ts_full.get_particle(['w'], iteration=iteration)
     return len(w)
 def n_scraped_particles( iteration ):
-    timestamp = ts_scraping.get_particle( ['timestamp'] )
+    timestamp = ts_scraping.get_particle( ['timestamp'], iteration=ts_scraping.iterations[0] )
     return (timestamp <= iteration).sum()
 n_remaining = np.array([ n_remaining_particles(iteration) for iteration in ts_full.iterations ])
 n_scraped = np.array([ n_scraped_particles(iteration) for iteration in ts_full.iterations ])


### PR DESCRIPTION
This fixes the error in the analysis script:
```
openpmd_viewer.openpmd_timeseries.main.OpenPMDException: Please pass either a time (`t`) or an iteration (`iteration`)
```