### PR TITLE
Enable `divE` field diagnostic with Ohm's law solver

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1991,7 +1991,7 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
                     fields_to_plot.add(dataname)
                 elif dataname in A_fields_list:
                     fields_to_plot.add(dataname)
-                elif dataname in ['rho', 'phi', 'F', 'proc_number', 'part_per_cell']:
+                elif dataname in ['rho', 'phi', 'F', 'divE', 'divB', 'proc_number', 'part_per_cell']:
                     fields_to_plot.add(dataname)
                 elif dataname in J_fields_list:
                     fields_to_plot.add(dataname.lower())

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -46,7 +46,8 @@ void FiniteDifferenceSolver::ComputeDivE (
    // Select algorithm (The choice of algorithm is a runtime option,
    // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
-    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
+    if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee ||
+        m_fdtd_algo == ElectromagneticSolverAlgo::HybridPIC){
 
         ComputeDivECylindrical <CylindricalYeeAlgorithm> ( Efield, divEfield );
 
@@ -55,7 +56,8 @@ void FiniteDifferenceSolver::ComputeDivE (
 
         ComputeDivECartesian <CartesianNodalAlgorithm> ( Efield, divEfield );
 
-    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee) {
+    } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee ||
+               m_fdtd_algo == ElectromagneticSolverAlgo::HybridPIC) {
 
         ComputeDivECartesian <CartesianYeeAlgorithm> ( Efield, divEfield );
 


### PR DESCRIPTION
When using the Ohm's law solver (hybridPIC) the divergence of E should be calculated the same as with the `Yee` finite difference algorithm.