### PR TITLE
Docs: HPC3 (UCI) with Only `-j 12`

### DIFF
--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -96,8 +96,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    rm -rf build
 
    cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
-   cmake --build build -j 16
-   cmake --build build -j 16 --target pip_install
+   cmake --build build -j 12
+   cmake --build build -j 12 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -56,7 +56,7 @@ else
 fi
 rm -rf $HOME/src/c-blosc-pm-gpu-build
 cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 16
+cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 12
 rm -rf $HOME/src/c-blosc-pm-gpu-build
 
 # ADIOS2
@@ -71,7 +71,7 @@ else
 fi
 rm -rf $HOME/src/adios2-pm-gpu-build
 cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
-cmake --build $HOME/src/adios2-pm-gpu-build --target install -j 16
+cmake --build $HOME/src/adios2-pm-gpu-build --target install --parallel 12
 rm -rf $HOME/src/adios2-pm-gpu-build
 
 # BLAS++ (for PSATD+RZ)
@@ -87,7 +87,7 @@ else
 fi
 rm -rf $HOME/src/blaspp-pm-gpu-build
 cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
-cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 16
+cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 12
 rm -rf $HOME/src/blaspp-pm-gpu-build
 
 # LAPACK++ (for PSATD+RZ)
@@ -103,7 +103,7 @@ else
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
 CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
-cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
+cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 12
 rm -rf $HOME/src/lapackpp-pm-gpu-build
 
 


### PR DESCRIPTION
We use too many cores when we compile and thus get our compile processes killed by the system. Let's use a bit less to stay in the limits.

Fix #4181