### PR TITLE
Fix time update in the boosted frame for externally loaded fields

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -576,7 +576,7 @@ LaserParticleContainer::Evolve (int lev,
     }
 
     // Update laser profile
-    m_up_laser_profile->update(t);
+    m_up_laser_profile->update(t_lab);
 
     BL_ASSERT(OnSameGrids(lev,jx));
 


### PR DESCRIPTION
This fixes the time update when we load fields from an external file (`lasy` or binary format) and map them to boosted frame.