### PR TITLE
Assert moving window is off when EB is enabled.

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -693,7 +693,7 @@ WarpX::ReadParameters ()
 #if defined(AMREX_USE_EB)
         AMREX_ALWAYS_ASSERT_WTH_MESSAGE(do_moving_window == 0,
             "The moving window is currently not supported when embedded boundaries are enabled.");
-#endi
+#endif
         if (do_moving_window)
         {
             utils::parser::queryWithParser(

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -690,6 +690,10 @@ WarpX::ReadParameters ()
             compute_max_step_from_btd);
 
         pp_warpx.query("do_moving_window", do_moving_window);
+#if defined(AMREX_USE_EB)
+        AMREX_ALWAYS_ASSERT_WTH_MESSAGE(do_moving_window == 0,
+            "The moving window is currently not supported when embedded boundaries are enabled.");
+#endi
         if (do_moving_window)
         {
             utils::parser::queryWithParser(

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -691,7 +691,7 @@ WarpX::ReadParameters ()
 
         pp_warpx.query("do_moving_window", do_moving_window);
 #if defined(AMREX_USE_EB)
-        AMREX_ALWAYS_ASSERT_WTH_MESSAGE(do_moving_window == 0,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_moving_window == 0,
             "The moving window is currently not supported when embedded boundaries are enabled.");
 #endif
         if (do_moving_window)


### PR DESCRIPTION
This is currently not implemented and requires some thought - add an assertion to fail early for now.