### PR TITLE
Update Python installation instructions on HPC

### DIFF
--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -315,21 +315,16 @@ So another sophisticated example might be: use Clang as the compiler, build with
 Here we wrote this all in one line, but one can also set all environment variables in a development environment and keep the pip call nice and short as in the beginning.
 Note that you need to use absolute paths for external source trees, because pip builds in a temporary directory, e.g. ``export WARPX_AMREX_SRC=$HOME/src/amrex``.
 
-The Python library ``pywarpx`` can also be created by pre-building WarpX into one or more shared libraries externally.
-For example, a package manager might split WarpX into a C++ package and a Python package.
-If the C++ libraries are already pre-compiled, we can pick them up in the Python build step instead of compiling them again:
+All of this can also be run from CMake.
+This is the workflow most developers will prefer as it allows rapid re-compiles:
 
 .. code-block:: bash
 
    # build WarpX executables and libraries
    cmake -S . -B build -DWarpX_DIMS="1;2;RZ;3" -DWarpX_PYTHON=ON
-   cmake --build build -j 4
 
-   # Python package
-   PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
-
-   # install
-   python3 -m pip install pywarpx-*whl
+   # build & install Python only
+   cmake --build build -j 4 --target pip_install
 
 
 WarpX release managers might also want to generate a self-contained source package that can be distributed to exotic architectures:

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -92,7 +92,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_adastra
 
-   cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra -j 16
    cmake --build build_adastra -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -99,7 +99,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_frontier
 
-   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_frontier -j 16
    cmake --build build_frontier -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -95,7 +95,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 12
    cmake --build build -j 12 --target pip_install
 

--- a/Docs/source/install/hpc/karolina.rst
+++ b/Docs/source/install/hpc/karolina.rst
@@ -107,7 +107,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_gpu
 
-         cmake -S . -B build_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_gpu -j 12
          cmake --build build_gpu -j 12 --target pip_install
 
@@ -121,7 +121,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_cpu
 
-         cmake -S . -B build_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_cpu -j 12
          cmake --build build_cpu -j 12 --target pip_install
 

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -126,7 +126,7 @@ Or, if you are *developing*, do a quick PICMI install of a *single geometry* (se
 .. code-block:: bash
 
    # find dependencies & configure
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_LIB=ON -DWarpX_DIMS=RZ
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_PYTHON=ON -DWarpX_DIMS=RZ
 
    # build and then call "python3 -m pip install ..."
    cmake --build build --target pip_install -j 12

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -88,7 +88,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_lumi
 
-   cmake -S . -B build_lumi -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_lumi -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_lumi -j 16
    cmake --build build_lumi -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -150,11 +150,11 @@ Now, ensure Python tooling is up-to-date:
    python3 -m pip install -U pip setuptools wheel
    python3 -m pip install -U cmake
 
-Then we compile WarpX as in the previous section (with or without CUDA) adding ``-DWarpX_LIB=ON`` and then we install it into our Python:
+Then we compile WarpX as in the previous section (with or without CUDA) adding ``-DWarpX_PYTHON=ON`` and then we install it into our Python:
 
 .. code-block:: bash
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_LIB=ON
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_PYTHON=ON
    cmake --build build --target pip_install -j 6
 
 This builds WarpX for 3D geometry.

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -153,7 +153,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_gpu
 
-         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_gpu -j 16
          cmake --build build_pm_gpu -j 16 --target pip_install
 
@@ -167,7 +167,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_cpu
 
-         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_cpu -j 16
          cmake --build build_pm_cpu -j 16 --target pip_install
 

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -124,7 +124,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_summit
 
-   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_summit -j 16
    cmake --build build_summit -j 16 --target pip_install
 


### PR DESCRIPTION
We should use the new flag `WarpX_PYTHON`

Follow-up to #3474 