### PR TITLE
Use only 8 cores to compile on Summit

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -125,8 +125,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    rm -rf build_summit
 
    cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
-   cmake --build build_summit -j 16
-   cmake --build build_summit -j 16 --target pip_install
+   cmake --build build_summit -j 8
+   cmake --build build_summit -j 8 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build_summit/bin/`` and we installed the ``pywarpx`` Python module.


### PR DESCRIPTION
This avoids the following error, which appears when compiling with 16 cores:
```
nvcc error   : 'cicc' died due to signal 9 (Kill signal)
gmake[2]: *** [_deps/fetchedpyamrex-build/CMakeFiles/pyAMReX_2d.dir/build.make:538: _deps/fetchedpyamrex-build/CMakeFiles/pyAMReX_2d.dir/src/Particle/ParticleContainer_WarpX.cpp.o] Error 9
gmake[2]: *** Waiting for unfinished jobs....
nvcc error   : 'cicc' died due to signal 9 (Kill signal)
gmake[2]: *** [_deps/fetchedpyamrex-build/CMakeFiles/pyAMReX_3d.dir/build.make:524: _deps/fetchedpyamrex-build/CMakeFiles/pyAMReX_3d.dir/src/Particle/ParticleContainer_ImpactX.cpp.o] Error 9
gmake[1]: *** [CMakeFiles/Makefile2:2473: _deps/fetchedpyamrex-build/CMakeFiles/pyAMReX_3d.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```