### PR TITLE
Electrostatic sphere tests: add missing checksum analysis

### DIFF
--- a/Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
@@ -17,11 +17,15 @@ the correct speed and that the electric field is accurately modeled against a
 known analytic solution. While the radius r(t) is not analytically known, its
 inverse t(r) can be solved for exactly.
 """
+import os
 import sys
 
 import numpy as np
 from scipy.optimize import fsolve
 import yt
+
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import checksumAPI
 
 yt.funcs.mylog.setLevel(0)
 
@@ -132,3 +136,7 @@ print("L2 error along z-axis = %s" %L2_error_z)
 assert L2_error_x < 0.05
 assert L2_error_y < 0.05
 assert L2_error_z < 0.05
+
+# Checksum regression analysis
+test_name = os.path.split(os.getcwd())[1]
+checksumAPI.evaluate_checksum(test_name, filename)

--- a/Regression/Checksum/benchmarks_json/ElectrostaticSphere.json
+++ b/Regression/Checksum/benchmarks_json/ElectrostaticSphere.json
@@ -1,0 +1,17 @@
+{
+  "lev=0": {
+    "Ex": 6.504757806138167,
+    "Ey": 6.504757806138166,
+    "Ez": 6.501489620648247,
+    "rho": 2.60925680083338e-10
+  },
+  "electron": {
+    "particle_momentum_x": 1.0083594348819436e-23,
+    "particle_momentum_y": 1.0083594348819436e-23,
+    "particle_momentum_z": 1.0159789930728084e-23,
+    "particle_position_x": 518.4112403470117,
+    "particle_position_y": 518.4112403470117,
+    "particle_position_z": 520.2110302538686,
+    "particle_weight": 6212.501525878906
+  }
+}

--- a/Regression/Checksum/benchmarks_json/ElectrostaticSphereLabFrame.json
+++ b/Regression/Checksum/benchmarks_json/ElectrostaticSphereLabFrame.json
@@ -1,26 +1,17 @@
 {
-  "electron": {
-    "particle_momentum_x": 1.0475215560938395e-23,
-    "particle_momentum_y": 1.0475215560942127e-23,
-    "particle_momentum_z": 1.0475215560950524e-23,
-    "particle_position_x": 524.906527421018,
-    "particle_position_y": 524.9065274210888,
-    "particle_position_z": 524.9065274212362,
-    "particle_weight": 6212.501525878906
-  },
   "lev=0": {
-    "Ex": 6.525895284178821,
-    "Ey": 6.525895284179916,
-    "Ez": 6.5258952841836555,
+    "Ex": 6.504586436288052,
+    "Ey": 6.504586436288051,
+    "Ez": 6.501896077968277,
     "rho": 2.6092568008333797e-10
   },
-  "nbody": {
-    "particle_momentum_x": 1.0475215560938395e-23,
-    "particle_momentum_y": 1.0475215560942127e-23,
-    "particle_momentum_z": 1.0475215560950524e-23,
-    "particle_position_x": 524.906527421018,
-    "particle_position_y": 524.9065274210888,
-    "particle_position_z": 524.9065274212362,
+  "electron": {
+    "particle_momentum_x": 9.881704085619681e-24,
+    "particle_momentum_y": 9.881704085619682e-24,
+    "particle_momentum_z": 9.969862126470096e-24,
+    "particle_position_x": 513.5147715983729,
+    "particle_position_y": 513.5147715983729,
+    "particle_position_z": 515.4187595183639,
     "particle_weight": 6212.501525878906
   }
 }

--- a/Regression/Checksum/benchmarks_json/ElectrostaticSphereRZ.json
+++ b/Regression/Checksum/benchmarks_json/ElectrostaticSphereRZ.json
@@ -1,0 +1,17 @@
+{
+  "lev=0": {
+    "Er": 0.11588932103656224,
+    "Et": 0.0,
+    "Ez": 0.11483033274834441,
+    "rho": 9.716216490680392e-12
+  },
+  "electron": {
+    "particle_momentum_x": 4.54997005723341e-25,
+    "particle_momentum_y": 4.434893182689167e-25,
+    "particle_momentum_z": 6.989989085028144e-25,
+    "particle_position_x": 35.73642348640023,
+    "particle_position_y": 35.69851886414351,
+    "particle_theta": 823.0413054971611,
+    "particle_weight": 6406.017620347038
+  }
+}


### PR DESCRIPTION
Thanks to @aeriforme's PR #3982, we noticed that the checksum regression analysis was missing for three CI tests:
- `ElectrostaticSphere`
- `ElectrostaticSphereLabFrame`
- `ElectrostaticSphereRZ`

This PR adds the checksum analysis to the corresponding analysis script as well as the missing checksum JSON files.

Note that the checksum JSON file for `ElectrostaticSphereLabFrame` already existed, even though it wasn't used (which explains why it still contains the `nbody` key, which yt adds by default but is not used by us, see #2060). Therefore, the checksum benchmark values in this file were outdated.