### PR TITLE
Fix: Remove Overly Exported Classes

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolver.H
@@ -7,8 +7,6 @@
 #ifndef ELECTROSTATICSOLVER_H_
 #define ELECTROSTATICSOLVER_H_
 
-#include "Utils/export.H"
-
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
@@ -40,7 +38,7 @@ namespace ElectrostaticSolver {
         }
     };
 
-    class WARPX_EXPORT PoissonBoundaryHandler {
+    class PoissonBoundaryHandler {
     public:
 
         amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM> lobc, hibc;

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -13,7 +13,6 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpXAlgorithmSelection.H"
-#include "Utils/WarpXProfilerWrapper.H"
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"
 #endif

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -16,6 +16,7 @@
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"
 #endif
+#include "WarpX.H"
 
 #include <AMReX.H>
 

--- a/Source/Particles/Deposition/SharedDepositionUtils.H
+++ b/Source/Particles/Deposition/SharedDepositionUtils.H
@@ -10,7 +10,6 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpXAlgorithmSelection.H"
-#include "Utils/WarpXProfilerWrapper.H"
 #include "Utils/WarpXConst.H"
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"

--- a/Source/Particles/NamedComponentParticleContainer.H
+++ b/Source/Particles/NamedComponentParticleContainer.H
@@ -7,7 +7,6 @@
 #ifndef NamedComponentParticleContainer_H_
 #define NamedComponentParticleContainer_H_
 
-#include "Utils/export.H"
 #include "Utils/TextMsg.H"
 
 #include <AMReX.H>
@@ -45,7 +44,7 @@ struct PIdx
  * arena, pinned memory arena, etc.) the particle data will be stored
  */
 template <template<class> class T_Allocator=amrex::DefaultAllocator>
-class WARPX_EXPORT NamedComponentParticleContainer :
+class NamedComponentParticleContainer :
 public amrex::ParticleContainer<0,0,PIdx::nattribs,0,T_Allocator>
 {
 public:

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -23,7 +23,6 @@
 #endif
 #include "MultiParticleContainer_fwd.H"
 #include "NamedComponentParticleContainer.H"
-#include "Utils/export.H"
 
 #include <AMReX_Array.H>
 #include <AMReX_FArrayBox.H>
@@ -50,7 +49,7 @@
 
 using namespace amrex::literals;
 
-class WARPX_EXPORT WarpXParIter
+class WarpXParIter
     : public amrex::ParIter<0,0,PIdx::nattribs>
 {
 public:
@@ -102,7 +101,7 @@ public:
  * Note: many functions are pure virtual (meaning they MUST be defined in
  * derived classes, e.g., Evolve) or actual functions (e.g. CurrentDeposition).
  */
-class WARPX_EXPORT WarpXParticleContainer
+class WarpXParticleContainer
     : public NamedComponentParticleContainer<amrex::DefaultAllocator>
 {
 public:


### PR DESCRIPTION
Luckily, many of them should not contain global state.

Avoids that we need to include the WarpX "lib" export header downstream in ImpactX, which only needs ABLASTR. ABLASTR currently still side-includes some WarpX headers.

Follow-up to #3474 