### PR TITLE
Use cupy when available with the particle container wrapper

### DIFF
--- a/Python/pywarpx/LoadThirdParty.py
+++ b/Python/pywarpx/LoadThirdParty.py
@@ -1,0 +1,35 @@
+# This file is part of WarpX.
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+
+from ._libwarpx import libwarpx
+
+
+def load_cupy():
+    """
+    This is a helper for
+    https://docs.cupy.dev/en/stable/user_guide/basic.html
+    """
+    amr = libwarpx.amr
+    status = None
+
+    if amr.Config.have_gpu:
+        try:
+            import cupy as cp
+            xp = cp
+            # Note: found and will use cupy
+        except ImportError:
+            status = "Warning: GPU found but cupy not available! Trying managed memory in numpy..."
+            import numpy as np
+            xp = np
+        if amr.Config.gpu_backend == "SYCL":
+            status = "Warning: SYCL GPU backend not yet implemented for Python"
+            import numpy as np
+            xp = np
+
+    else:
+        import numpy as np
+        xp = np
+        # Note: found and will use numpy
+    return xp, status

--- a/Python/pywarpx/__init__.py
+++ b/Python/pywarpx/__init__.py
@@ -34,6 +34,7 @@ from .Geometry import geometry
 from .HybridPICModel import hybridpicmodel
 from .Interpolation import interpolation
 from .Lasers import lasers
+from .LoadThirdParty import load_cupy
 from .PSATD import psatd
 from .Particles import newspecies, particles
 from .WarpX import warpx

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -203,11 +203,11 @@ class ParticleContainerWrapper(object):
         ----------
 
         level        : int
-            The refinement level to reference
+            The refinement level to reference (default=0)
 
         copy_to_host : bool
             For GPU-enabled runs, one can either return the GPU
-            arrays or force a device-to-host copy.
+            arrays (the default) or force a device-to-host copy.
 
         Returns
         -------
@@ -252,11 +252,11 @@ class ParticleContainerWrapper(object):
             The component of the array data that will be returned
 
         level          : int
-            The refinement level to reference
+            The refinement level to reference (default=0)
 
         copy_to_host   : bool
             For GPU-enabled runs, one can either return the GPU
-            arrays or force a device-to-host copy.
+            arrays (the default) or force a device-to-host copy.
 
         Returns
         -------
@@ -286,30 +286,72 @@ class ParticleContainerWrapper(object):
 
     def get_particle_id(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'id'
         numbers on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle ids
         '''
         structs = self.get_particle_structs(level, copy_to_host)
         return [libwarpx.amr.unpack_ids(struct['cpuid']) for struct in structs]
 
     def get_particle_cpu(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'cpu'
         numbers on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle cpus
         '''
         structs = self.get_particle_structs(level, copy_to_host)
         return [libwarpx.amr.unpack_cpus(struct['cpuid']) for struct in structs]
 
     def get_particle_x(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'x'
         positions on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle x position
         '''
         xp, cupy_status = load_cupy()
 
@@ -324,10 +366,24 @@ class ParticleContainerWrapper(object):
 
     def get_particle_y(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'y'
         positions on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle y position
         '''
         xp, cupy_status = load_cupy()
 
@@ -342,10 +398,24 @@ class ParticleContainerWrapper(object):
 
     def get_particle_r(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'r'
         positions on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle r position
         '''
         xp, cupy_status = load_cupy()
 
@@ -360,10 +430,24 @@ class ParticleContainerWrapper(object):
 
     def get_particle_theta(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle
         theta on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle theta position
         '''
         xp, cupy_status = load_cupy()
 
@@ -378,10 +462,24 @@ class ParticleContainerWrapper(object):
 
     def get_particle_z(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle 'z'
         positions on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle z position
         '''
         structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d':
@@ -394,40 +492,96 @@ class ParticleContainerWrapper(object):
 
     def get_particle_weight(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle
         weight on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle weight
         '''
         return self.get_particle_arrays('w', level, copy_to_host=copy_to_host)
     wp = property(get_particle_weight)
 
     def get_particle_ux(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle
         x momentum on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle x momentum
         '''
         return self.get_particle_arrays('ux', level, copy_to_host=copy_to_host)
     uxp = property(get_particle_ux)
 
     def get_particle_uy(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle
         y momentum on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle y momentum
         '''
         return self.get_particle_arrays('uy', level, copy_to_host=copy_to_host)
     uyp = property(get_particle_uy)
 
     def get_particle_uz(self, level=0, copy_to_host=False):
         '''
-
         Return a list of numpy or cupy arrays containing the particle
         z momentum on each tile.
 
+        Parameters
+        ----------
+
+        level        : int
+            The refinement level to reference (default=0)
+
+        copy_to_host : bool
+            For GPU-enabled runs, one can either return the GPU
+            arrays (the default) or force a device-to-host copy.
+
+        Returns
+        -------
+
+        List of arrays
+            The requested particle z momentum
         '''
 
         return self.get_particle_arrays('uz', level, copy_to_host=copy_to_host)

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -195,7 +195,7 @@ class ParticleContainerWrapper(object):
         arrays are fully writeable.
 
         Note that cupy does not support structs:
-        ...
+        https://github.com/cupy/cupy/issues/2031
         and will return arrays of binary blobs for the AoS (DP: "|V24"). If copied
         to host via copy_to_host, we correct for the right numpy AoS type.
 

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -353,13 +353,18 @@ class ParticleContainerWrapper(object):
         List of arrays
             The requested particle x position
         '''
-        xp, cupy_status = load_cupy()
+        if copy_to_host:
+            # Use the numpy version of cosine
+            xp = np
+        else:
+            xp, cupy_status = load_cupy()
 
         structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d' or libwarpx.geometry_dim == '2d':
             return [struct['x'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
-            return [struct['x']*xp.cos(theta) for struct, theta in zip(structs, self.get_particle_theta())]
+            theta = self.get_particle_theta(level, copy_to_host)
+            return [struct['x']*xp.cos(theta) for struct, theta in zip(structs, theta)]
         elif libwarpx.geometry_dim == '1d':
             raise Exception('get_particle_x: There is no x coordinate with 1D Cartesian')
     xp = property(get_particle_x)
@@ -385,13 +390,18 @@ class ParticleContainerWrapper(object):
         List of arrays
             The requested particle y position
         '''
-        xp, cupy_status = load_cupy()
+        if copy_to_host:
+            # Use the numpy version of sine
+            xp = np
+        else:
+            xp, cupy_status = load_cupy()
 
         structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d':
             return [struct['y'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
-            return [struct['x']*xp.sin(theta) for struct, theta in zip(structs, self.get_particle_theta())]
+            theta = self.get_particle_theta(level, copy_to_host)
+            return [struct['x']*xp.sin(theta) for struct, theta in zip(structs, theta)]
         elif libwarpx.geometry_dim == '1d' or libwarpx.geometry_dim == '2d':
             raise Exception('get_particle_y: There is no y coordinate with 1D or 2D Cartesian')
     yp = property(get_particle_y)

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -425,7 +425,7 @@ class ParticleContainerWrapper(object):
         return self.get_particle_arrays('uz', level, copy_to_host=copy_to_host)
     uzp = property(get_particle_uz)
 
-    def get_species_charge_sum(self, local=False, copy_to_host=copy_to_host):
+    def get_species_charge_sum(self, local=False):
         '''
         Returns the total charge in the simulation due to the given species.
 

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -284,27 +284,27 @@ class ParticleContainerWrapper(object):
 
         return data_array
 
-    def get_particle_id(self, level=0):
+    def get_particle_id(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'id'
         numbers on each tile.
 
         '''
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         return [libwarpx.amr.unpack_ids(struct['cpuid']) for struct in structs]
 
-    def get_particle_cpu(self, level=0):
+    def get_particle_cpu(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'cpu'
         numbers on each tile.
 
         '''
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         return [libwarpx.amr.unpack_cpus(struct['cpuid']) for struct in structs]
 
-    def get_particle_x(self, level=0):
+    def get_particle_x(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'x'
@@ -313,7 +313,7 @@ class ParticleContainerWrapper(object):
         '''
         xp, cupy_status = load_cupy()
 
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d' or libwarpx.geometry_dim == '2d':
             return [struct['x'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
@@ -322,7 +322,7 @@ class ParticleContainerWrapper(object):
             raise Exception('get_particle_x: There is no x coordinate with 1D Cartesian')
     xp = property(get_particle_x)
 
-    def get_particle_y(self, level=0):
+    def get_particle_y(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'y'
@@ -331,7 +331,7 @@ class ParticleContainerWrapper(object):
         '''
         xp, cupy_status = load_cupy()
 
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d':
             return [struct['y'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
@@ -340,7 +340,7 @@ class ParticleContainerWrapper(object):
             raise Exception('get_particle_y: There is no y coordinate with 1D or 2D Cartesian')
     yp = property(get_particle_y)
 
-    def get_particle_r(self, level=0):
+    def get_particle_r(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'r'
@@ -349,7 +349,7 @@ class ParticleContainerWrapper(object):
         '''
         xp, cupy_status = load_cupy()
 
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == 'rz':
             return [struct['x'] for struct in structs]
         elif libwarpx.geometry_dim == '3d':
@@ -358,7 +358,7 @@ class ParticleContainerWrapper(object):
             raise Exception('get_particle_r: There is no r coordinate with 1D or 2D Cartesian')
     rp = property(get_particle_r)
 
-    def get_particle_theta(self, level=0):
+    def get_particle_theta(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle
@@ -368,22 +368,22 @@ class ParticleContainerWrapper(object):
         xp, cupy_status = load_cupy()
 
         if libwarpx.geometry_dim == 'rz':
-            return self.get_particle_arrays('theta', level)
+            return self.get_particle_arrays('theta', level, copy_to_host)
         elif libwarpx.geometry_dim == '3d':
-            structs = self.get_particle_structs(level)
+            structs = self.get_particle_structs(level, copy_to_host)
             return [xp.arctan2(struct['y'], struct['x']) for struct in structs]
         elif libwarpx.geometry_dim == '2d' or libwarpx.geometry_dim == '1d':
             raise Exception('get_particle_theta: There is no theta coordinate with 1D or 2D Cartesian')
     thetap = property(get_particle_theta)
 
-    def get_particle_z(self, level=0):
+    def get_particle_z(self, level=0, copy_to_host=False):
         '''
 
         Return a list of numpy or cupy arrays containing the particle 'z'
         positions on each tile.
 
         '''
-        structs = self.get_particle_structs(level)
+        structs = self.get_particle_structs(level, copy_to_host)
         if libwarpx.geometry_dim == '3d':
             return [struct['z'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz' or libwarpx.geometry_dim == '2d':

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -311,11 +311,13 @@ class ParticleContainerWrapper(object):
         positions on each tile.
 
         '''
+        xp, cupy_status = load_cupy()
+
         structs = self.get_particle_structs(level)
         if libwarpx.geometry_dim == '3d' or libwarpx.geometry_dim == '2d':
             return [struct['x'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
-            return [struct['x']*cnp.cos(theta) for struct, theta in zip(structs, self.get_particle_theta())]
+            return [struct['x']*xp.cos(theta) for struct, theta in zip(structs, self.get_particle_theta())]
         elif libwarpx.geometry_dim == '1d':
             raise Exception('get_particle_x: There is no x coordinate with 1D Cartesian')
     xp = property(get_particle_x)
@@ -327,11 +329,13 @@ class ParticleContainerWrapper(object):
         positions on each tile.
 
         '''
+        xp, cupy_status = load_cupy()
+
         structs = self.get_particle_structs(level)
         if libwarpx.geometry_dim == '3d':
             return [struct['y'] for struct in structs]
         elif libwarpx.geometry_dim == 'rz':
-            return [struct['x']*cnp.sin(theta) for struct, theta in zip(structs, self.get_particle_theta())]
+            return [struct['x']*xp.sin(theta) for struct, theta in zip(structs, self.get_particle_theta())]
         elif libwarpx.geometry_dim == '1d' or libwarpx.geometry_dim == '2d':
             raise Exception('get_particle_y: There is no y coordinate with 1D or 2D Cartesian')
     yp = property(get_particle_y)
@@ -343,11 +347,13 @@ class ParticleContainerWrapper(object):
         positions on each tile.
 
         '''
+        xp, cupy_status = load_cupy()
+
         structs = self.get_particle_structs(level)
         if libwarpx.geometry_dim == 'rz':
             return [struct['x'] for struct in structs]
         elif libwarpx.geometry_dim == '3d':
-            return [cnp.sqrt(struct['x']**2 + struct['y']**2) for struct in structs]
+            return [xp.sqrt(struct['x']**2 + struct['y']**2) for struct in structs]
         elif libwarpx.geometry_dim == '2d' or libwarpx.geometry_dim == '1d':
             raise Exception('get_particle_r: There is no r coordinate with 1D or 2D Cartesian')
     rp = property(get_particle_r)
@@ -359,11 +365,13 @@ class ParticleContainerWrapper(object):
         theta on each tile.
 
         '''
+        xp, cupy_status = load_cupy()
+
         if libwarpx.geometry_dim == 'rz':
             return self.get_particle_arrays('theta', level)
         elif libwarpx.geometry_dim == '3d':
             structs = self.get_particle_structs(level)
-            return [cnp.arctan2(struct['y'], struct['x']) for struct in structs]
+            return [xp.arctan2(struct['y'], struct['x']) for struct in structs]
         elif libwarpx.geometry_dim == '2d' or libwarpx.geometry_dim == '1d':
             raise Exception('get_particle_theta: There is no theta coordinate with 1D or 2D Cartesian')
     thetap = property(get_particle_theta)
@@ -567,6 +575,8 @@ class ParticleBoundaryBufferWrapper(object):
             level          : int
                 Which AMR level to retrieve scraped particle data from.
         '''
+        xp, cupy_status = load_cupy()
+
         part_container = self.particle_buffer.get_particle_container(
             species_name, self._get_boundary_number(boundary)
         )
@@ -576,14 +586,14 @@ class ParticleBoundaryBufferWrapper(object):
             comp_idx = part_container.num_int_comps() - 1
             for ii, pti in enumerate(libwarpx.libwarpx_so.BoundaryBufferParIter(part_container, level)):
                 soa = pti.soa()
-                data_array.append(cnp.array(soa.GetIntData(comp_idx), copy=False))
+                data_array.append(xp.array(soa.GetIntData(comp_idx), copy=False))
         else:
             mypc = libwarpx.warpx.multi_particle_container()
             sim_part_container_wrapper = mypc.get_particle_container_from_name(species_name)
             comp_idx = sim_part_container_wrapper.get_comp_index(comp_name)
             for ii, pti in enumerate(libwarpx.libwarpx_so.BoundaryBufferParIter(part_container, level)):
                 soa = pti.soa()
-                data_array.append(cnp.array(soa.GetRealData(comp_idx), copy=False))
+                data_array.append(xp.array(soa.GetRealData(comp_idx), copy=False))
 
         return data_array
 


### PR DESCRIPTION
This avoid relying on managed memory by explicitly using `cupy` when it is available.

- [x] we might be able to replace this mostly with https://github.com/AMReX-Codes/pyamrex/pull/88