### PR TITLE
Add Low-noise Mode GPU-to-CPU mapping for Frontier

### DIFF
--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -5,11 +5,12 @@
 #SBATCH -o %x-%j.out
 #SBATCH -t 00:10:00
 #SBATCH -p batch
-# Currently not configured on Frontier:
-#S BATCH --ntasks-per-node=8
-#S BATCH --cpus-per-task=8
-#S BATCH --gpus-per-task=1
-#S BATCH --gpu-bind=closest
+#SBATCH --ntasks-per-node=8
+# Due to Frontier's Low-Noise Mode Layout only 7 instead of 8 cores are available per process
+# https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#low-noise-mode-layout
+#SBATCH --cpus-per-task=7
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
 #SBATCH -N 20
 
 # load cray libs and ROCm libs


### PR DESCRIPTION
Frontier uses a Low-noise Mode Layout for its nodes which pins system processes via the default core specification `-S 8` to the first core every L3 region.