### PR TITLE
pyWarpX.H: Add Include Guard

### DIFF
--- a/Source/Python/pyWarpX.H
+++ b/Source/Python/pyWarpX.H
@@ -6,6 +6,9 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#ifndef WARPX_PYWARPX_H_
+#define WARPX_PYWARPX_H_
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
@@ -18,3 +21,5 @@ namespace py = pybind11;
 //using namespace warpx;
 
 // PYBIND11_MAKE_OPAQUE(std::list<...>)
+
+#endif  // WARPX_PYWARPX_H_


### PR DESCRIPTION
Add an include guard to this header file.

Follow-up to #3474 