### PR TITLE
 BoxArray in BTD has single box

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -174,8 +174,6 @@ private:
 
     /** Number of z-slices in each buffer of the snapshot */
     int m_buffer_size = 256;
-    /** max grid size used to generate BoxArray to define output MultiFabs */
-    int m_max_box_size = 256;
 
     /** Vector of lab-frame time corresponding to each snapshot */
     amrex::Vector<amrex::Real> m_t_lab;

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -259,9 +259,7 @@ BTDiagnostics::ReadParameters ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(snapshot_interval_is_specified,
         "For back-transformed diagnostics, user should specify either dz_snapshots_lab or dt_snapshots_lab");
 
-    if (utils::parser::queryWithParser(pp_diag_name, "buffer_size", m_buffer_size)) {
-        if(m_max_box_size < m_buffer_size) m_max_box_size = m_buffer_size;
-    }
+    utils::parser::queryWithParser(pp_diag_name, "buffer_size", m_buffer_size);
 #ifdef WARPX_DIM_RZ
     const amrex::Vector< std::string > BTD_varnames_supported = {"Er", "Et", "Ez",
                                                            "Br", "Bt", "Bz",
@@ -847,7 +845,7 @@ BTDiagnostics::PrepareFieldDataForOutput ()
                                              i_buffer, ZSliceInDomain,
                                              m_current_z_boost[i_buffer],
                                              m_buffer_box[i_buffer],
-                                             k_index_zlab(i_buffer, lev), m_max_box_size,
+                                             k_index_zlab(i_buffer, lev),
                                              m_snapshot_full[i_buffer] );
 
             }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -897,7 +897,6 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
     m_buffer_box[i_buffer].setSmall( m_moving_window_dir, hi_k_lab - m_buffer_size + 1);
     m_buffer_box[i_buffer].setBig( m_moving_window_dir, hi_k_lab );
     amrex::BoxArray buffer_ba( m_buffer_box[i_buffer] );
-    buffer_ba.maxSize(m_max_box_size);
     // Generate a new distribution map for the back-transformed buffer multifab
     const amrex::DistributionMapping buffer_dmap(buffer_ba);
     // Number of guard cells for the output buffer is zero.
@@ -1035,7 +1034,6 @@ BTDiagnostics::Flush (int i_buffer)
         m_buffer_box[i_buffer].setBig(m_moving_window_dir, (m_buffer_box[i_buffer].bigEnd(m_moving_window_dir) + 1) );
         const amrex::Box particle_buffer_box = m_buffer_box[i_buffer];
         amrex::BoxArray buffer_ba( particle_buffer_box );
-        buffer_ba.maxSize(m_max_box_size*2);
         m_particles_buffer[i_buffer][0]->SetParticleBoxArray(0, buffer_ba);
         for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
             // BTD output is single level. Setting particle geometry, dmap, boxarray to level0
@@ -1458,7 +1456,6 @@ BTDiagnostics::PrepareParticleDataForOutput()
                         }
                         const amrex::Box particle_buffer_box = m_buffer_box[i_buffer];
                         amrex::BoxArray buffer_ba( particle_buffer_box );
-                        buffer_ba.maxSize(m_max_box_size);
                         const amrex::DistributionMapping buffer_dmap(buffer_ba);
                         m_particles_buffer[i_buffer][i]->SetParticleBoxArray(lev, buffer_ba);
                         m_particles_buffer[i_buffer][i]->SetParticleDistributionMap(lev, buffer_dmap);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1051,7 +1051,7 @@ BTDiagnostics::Flush (int i_buffer)
             for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
                 // BTD output is single level. Setting particle geometry, dmap, boxarray to level0
                 m_particles_buffer[i_buffer][isp]->SetParGDB(vgeom[0], vdmap[0], vba.back());
-                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][i]->ParticleBoxArray(0).size() == 1,
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][isp]->ParticleBoxArray(0).size() == 1,
                     "ParticleBoxArray size must be 1 for back-transformed diagnostic particle buffer");
             }
         }
@@ -1073,7 +1073,7 @@ BTDiagnostics::Flush (int i_buffer)
             for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
                 // BTD output is single level. Setting particle geometry, dmap, boxarray to level0
                 m_particles_buffer[i_buffer][isp]->SetParGDB(vgeom[0], vdmap[0], vba.back());
-                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][i]->ParticleBoxArray(0).size() == 1,
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][isp]->ParticleBoxArray(0).size() == 1,
                     "ParticleBoxArray size must be 1 for back-transformed diagnostic particle buffer");
             }
         }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -940,6 +940,8 @@ BTDiagnostics::DefineFieldBufferMultiFab (const int i_buffer, const int lev)
                                                       WarpX::RefRatio(lev-1) );
     }
     m_field_buffer_multifab_defined[i_buffer] = 1;
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_mf_output[i_buffer][lev].boxArray().size() == 1,
+        "BoxArray size must be 1 for back-transformed diagnostics multifab that stores buffers");
 }
 
 
@@ -1049,6 +1051,8 @@ BTDiagnostics::Flush (int i_buffer)
             for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
                 // BTD output is single level. Setting particle geometry, dmap, boxarray to level0
                 m_particles_buffer[i_buffer][isp]->SetParGDB(vgeom[0], vdmap[0], vba.back());
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][i]->ParticleBoxArray(0).size() == 1,
+                    "ParticleBoxArray size must be 1 for back-transformed diagnostic particle buffer");
             }
         }
     }
@@ -1060,7 +1064,7 @@ BTDiagnostics::Flush (int i_buffer)
         m_max_buffer_multifabs[i_buffer], m_geom_snapshot[i_buffer][0], isLastBTDFlush,
         m_totalParticles_flushed_already[i_buffer]);
 
-    // Note : test if this is needed before or after WriteToFile. This is because, for plotfiles, when writing particles, amrex checks if the particles are within the bounds defined by the box. However, in BTD, particles can be (at max) 1 cell outside the bounds of the geometry. Hence rescaling the box after WriteToFile
+    // Rescaling the box for plotfile after WriteToFile. This is because, for plotfiles, when writing particles, amrex checks if the particles are within the bounds defined by the box. However, in BTD, particles can be (at max) 1 cell outside the bounds of the geometry. So we keep a one-cell bigger box for plotfile when writing out the particle data and rescale after.
     if (m_format == "plotfile") {
         if (m_particles_buffer.at(i_buffer).size() > 0 ) {
             m_buffer_box[i_buffer].setSmall(m_moving_window_dir, (m_buffer_box[i_buffer].smallEnd(m_moving_window_dir) + 1) );
@@ -1069,6 +1073,8 @@ BTDiagnostics::Flush (int i_buffer)
             for (int isp = 0; isp < m_particles_buffer.at(i_buffer).size(); ++isp) {
                 // BTD output is single level. Setting particle geometry, dmap, boxarray to level0
                 m_particles_buffer[i_buffer][isp]->SetParGDB(vgeom[0], vdmap[0], vba.back());
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][i]->ParticleBoxArray(0).size() == 1,
+                    "ParticleBoxArray size must be 1 for back-transformed diagnostic particle buffer");
             }
         }
     }
@@ -1458,6 +1464,8 @@ BTDiagnostics::PrepareParticleDataForOutput()
                         m_particles_buffer[i_buffer][i]->SetParticleBoxArray(lev, buffer_ba);
                         m_particles_buffer[i_buffer][i]->SetParticleDistributionMap(lev, buffer_dmap);
                         m_particles_buffer[i_buffer][i]->SetParticleGeometry(lev, m_geom_snapshot[i_buffer][lev]);
+                        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_particles_buffer[i_buffer][i]->ParticleBoxArray(lev).size() == 1,
+                            "ParticleBoxArray size must be 1 for back-transformed diagnostic particle buffer");
                     }
                 }
                 m_all_particle_functors[i]->PrepareFunctorData (

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -76,7 +76,6 @@ public:
      * \param[in] buffer_box        Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab      k-index in the lab-frame corresponding to the
      *            current z co-ordinate in the lab-frame for the ith buffer.
-     * \param[in] max_box_size      maximum box size for the multifab to generate box arrays
      * \param[in] snapshot_full     if the current snapshot, with index, i_buffer, is full (1)
                   or not (0). If it is full, then Lorentz-transform is not performed
                   by setting m_perform_backtransform to 0.
@@ -84,7 +83,7 @@ public:
     void PrepareFunctorData ( int i_buffer, bool z_slice_in_domain,
                               amrex::Real current_z_boost,
                               amrex::Box buffer_box, const int k_index_zlab,
-                              const int max_box_size, const int snapshot_full ) override;
+                              const int snapshot_full ) override;
     /** Allocate and initialize member variables and arrays required to back-transform
      *  field-data from boosted-frame to lab-frame.
      */
@@ -123,8 +122,6 @@ private:
     /** Vector of user-defined field names without modifications for rz modes */
     amrex::Vector< std::string > m_varnames_fields;
 
-    /** max grid size used to generate BoxArray to define output MultiFabs */
-    int m_max_box_size = 256;
     /** Indices that map user-defined fields to plot to the fields
      *  stored in the cell-centered MultiFab, m_mf_src.
      *  The cell-centered MultiFab stores Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, and rho.

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -82,7 +82,6 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
 
         // Make it a BoxArray
         amrex::BoxArray slice_ba(slice_box);
-        slice_ba.maxSize( m_max_box_size );
         // Define MultiFab with the distribution map of the destination multifab and
         // containing all ten components that were in the slice generated from m_mf_src.
         std::unique_ptr< amrex::MultiFab > tmp_slice_ptr = nullptr;

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -156,14 +156,13 @@ void
 BackTransformFunctor::PrepareFunctorData (int i_buffer,
                           bool z_slice_in_domain, amrex::Real current_z_boost,
                           amrex::Box buffer_box, const int k_index_zlab,
-                          const int max_box_size, const int snapshot_full)
+                          const int snapshot_full)
 {
     m_buffer_box[i_buffer] = buffer_box;
     m_current_z_boost[i_buffer] = current_z_boost;
     m_k_index_zlab[i_buffer] = k_index_zlab;
     m_perform_backtransform[i_buffer] = 0;
     if (z_slice_in_domain && (snapshot_full == 0)) m_perform_backtransform[i_buffer] = 1;
-    m_max_box_size = max_box_size;
 }
 
 void

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -45,7 +45,6 @@ public:
      * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
      *                           current z co-ordinate in the lab-frame for the ith buffer.
-     * \param[in] max_box_size   maximum box size for the multifab to generate box arrays
      * \param[in] snapshot_full   if the current snapshot, with index, i_buffer, is full (1)
                                  or not (0). If it is full, then Lorentz-transform
                                  is not performed by setting m_perform_backtransform to 0;
@@ -53,11 +52,11 @@ public:
     virtual void PrepareFunctorData ( int i_buffer, bool z_slice_in_domain,
                                       amrex::Real current_z_boost,
                                       amrex::Box buffer_box, const int k_index_zlab,
-                                      const int max_box_size, const int snapshot_full) {
+                                      const int snapshot_full) {
                                           amrex::ignore_unused(i_buffer,
                                           z_slice_in_domain,
                                           current_z_boost, buffer_box,
-                                          k_index_zlab, max_box_size, snapshot_full);
+                                          k_index_zlab, snapshot_full);
                                       }
     virtual void InitData() {}
 


### PR DESCRIPTION
The BoxArray max size in BTD was set equal to buffer-size -- i.e., number of cells in the z-direction. 
However, if number of cells in x and y > z, then the box array will have more than one box. 
BTD is designed to have only one box -- since we write one buffer at a time 

This is fixed in this PR

