### PR TITLE
CMake: Fix logic that triggers shared AMReX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 # shared WarpX library or a third party, like ImpactX, uses ablastr in a
 # shared library (e.g., for Python bindings), then we need relocatable code.
 option(ABLASTR_POSITION_INDEPENDENT_CODE
-    "Build ABLASTR with position independent code" ${WarpX_LIB})
+       "Build ABLASTR with position independent code" ON)
 mark_as_advanced(ABLASTR_POSITION_INDEPENDENT_CODE)
 
 # this defined the variable BUILD_TESTING which is ON by default
@@ -233,7 +233,7 @@ foreach(D IN LISTS WarpX_DIMS)
         list(APPEND _ALL_TARGETS app_${SD})
     endif()
 
-    if(WarpX_PYTHON OR WarpX_LIB)
+    if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
         set(ABLASTR_POSITION_INDEPENDENT_CODE ON CACHE BOOL
             "Build ABLASTR with position independent code" FORCE)
     endif()

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -87,9 +87,13 @@ macro(find_amrex)
         endif()
 
         # shared libs, i.e. for Python bindings, need relocatable code
-        #   openPMD: currently triggers shared libs (TODO)
-        if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS) OR ABLASTR_POSITION_INDEPENDENT_CODE OR WarpX_OPENPMD)
-            set(AMReX_PIC ON CACHE INTERNAL "")
+        if(WarpX_PYTHON OR
+           ABLASTR_POSITION_INDEPENDENT_CODE OR
+           (WarpX_LIB AND BUILD_SHARED_LIBS))
+            set(AMReX_PIC ON CACHE INTERNAL "" FORCE)
+        endif()
+        if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
+            set(AMReX_PIC ON CACHE INTERNAL "" FORCE)
 
             # WE NEED AMReX AS SHARED LIB, OTHERWISE WE CANNOT SHARE ITS GLOBALS
             # BETWEEN MULTIPLE PYTHON MODULES


### PR DESCRIPTION
Accidentally always built AMReX as a shared library, which is only needed if we build with Python (aka: only needed if we share the AMReX library and its global variables over multiple libs).

Follow-up to #3474 