### PR TITLE
Fix rigid injection in the boosted frame

### DIFF
--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -74,7 +74,7 @@ void RigidInjectedParticleContainer::InitData()
     // Perform Lorentz transform of `z_inject_plane`
     const amrex::Real t_boost = WarpX::GetInstance().gett_new(0);
     amrex::Real zinject_plane_boost = zinject_plane/WarpX::gamma_boost
-                                    - WarpX::beta_boost*t_boost;
+                                    - WarpX::beta_boost*PhysConst::c*t_boost;
     zinject_plane_levels.resize(finestLevel()+1, zinject_plane_boost);
 
     AddParticles(0); // Note - add on level 0


### PR DESCRIPTION
This PR adds a missing term in the computation of the plane of injection in the boosted frame.