### PR TITLE
CI: Sphinx <7.2 for now

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -17,7 +17,9 @@ picmistandard==0.26.0
 
 pygments
 recommonmark
-sphinx>=5.3
+# Sphinx<7.2 because we are waiting for
+#   https://github.com/breathe-doc/breathe/issues/943
+sphinx>=5.3,<7.2
 sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=1.1.1


### PR DESCRIPTION
Because breathe is not yet ready.

https://github.com/breathe-doc/breathe/issues/943