### PR TITLE
fix undefined behavior in btd intervals

### DIFF
--- a/Source/Utils/Parser/IntervalsParser.cpp
+++ b/Source/Utils/Parser/IntervalsParser.cpp
@@ -193,12 +193,12 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
         const int start = temp_slice.getStart();
         const int period = temp_slice.getPeriod();
         int btd_iter_ind;
-        // for Slice temp_slice in m_slices,
-        // determine the index in m_btd_iterations where temp_slice's starting value goes
-        //
         // Implementation note:
-        // assuming the user mostly lists slices in ascending order,
         // start at the end of m_btd_iterations and search backward
+        // with the thinking that the user mostly lists slices in ascending order
+        //
+        // for Slice temp_slice in m_slices,
+        // determine the largest index in m_btd_iterations smaller than start
         if (m_btd_iterations.size() == 0)
         {
             btd_iter_ind = 0;
@@ -206,7 +206,7 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
         else
         {
             btd_iter_ind = m_btd_iterations.size() - 1;
-            while (start < m_btd_iterations[btd_iter_ind] and btd_iter_ind>0)
+            while (start < m_btd_iterations.at(btd_iter_ind) and btd_iter_ind>0)
             {
                 btd_iter_ind--;
             }
@@ -214,26 +214,42 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
         // insert each iteration contained in temp_slice into m_btd_iterations
         // adding them in increasing sorted order and not adding any iterations
         // already contained in m_btd_iterations
-        for (int ii = start; ii <= temp_slice.getStop(); ii += period)
+        for (int slice_iter = start; slice_iter <= temp_slice.getStop(); slice_iter += period)
         {
-            if (m_btd_iterations.size() > 0)
+            // number of iterations currently in this slice
+            auto const num_btd_iterations = static_cast<int>(m_btd_iterations.size());
+
+            if (num_btd_iterations > 0)
             {
-                // find where iteration ii should go in m_btd_iterations
-                while (ii > m_btd_iterations[btd_iter_ind] && btd_iter_ind < static_cast<int>(m_btd_iterations.size()))
+                // increment btd_iter_ind for each existing iteration,
+                // if slice_iter is larger than an existing one
+                while (btd_iter_ind < num_btd_iterations &&
+                       slice_iter > m_btd_iterations.at(btd_iter_ind))
                 {
                     btd_iter_ind++;
                 }
-                if (ii != m_btd_iterations[btd_iter_ind])
+                // this is the place to insert slice_iter if it is not in m_btd_iterations
+                // if slice_iter > all entries in m_btd_iterations, append slice_iter
+                if (btd_iter_ind == num_btd_iterations)
                 {
-                    m_btd_iterations.insert(m_btd_iterations.begin() + btd_iter_ind, ii);
+                    m_btd_iterations.insert(m_btd_iterations.begin() + btd_iter_ind, slice_iter);
+                } else
+                {
+                    if (slice_iter != m_btd_iterations.at(btd_iter_ind))
+                    {
+                        m_btd_iterations.insert(m_btd_iterations.begin() + btd_iter_ind, slice_iter);
+                    }
                 }
             } else
             {
-                m_btd_iterations.push_back(ii);
+                m_btd_iterations.push_back(slice_iter);
             }
         }
-        if ((temp_slice.getPeriod() > 0) &&
-               (temp_slice.getStop() >= start)) m_activated = true;
+        if (temp_slice.getPeriod() > 0 &&
+            temp_slice.getStop() >= start)
+        {
+            m_activated = true;
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug added in PR #3367, which provides interval parsing for the back-transformed diagnostic.  This bug caused unsafe memory access and had indeterminate behavior that likely resulted in a non-deterministic failure to add certain BTD snapshots, or worse to perhaps not register all snapshots on all ranks.