### PR TITLE
Add custom input parameter t_lab for externally loaded species in the boosted frame

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -718,7 +718,7 @@ Particle initialization
       ``<species_name>.mass`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.z_shift`` (`double`) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
       ``<species_name>.t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
-      ``<species_name>.t_lab`` (`double`) optional (default is 0) which allows to set a custom t_lab for the Lorentz Transform. This option overrides ``t_lab_from_file`` if the latter is defined.
+      ``<species_name>.t_lab`` (`double`) optional, which allows to set a custom t_lab for the Lorentz Transform. This option overrides ``t_lab_from_file`` if the latter is defined.
       Warning: ``q_tot!=0`` is not supported with the ``external_file`` injection style. If a value is provided, it is ignored and no re-scaling is done.
       The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
       If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see ``<species_name>.mass``, ``<species_name>.charge`` or ``<species_name>.species_type``).

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -718,7 +718,7 @@ Particle initialization
       ``<species_name>.mass`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.z_shift`` (`double`) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
       ``<species_name>.t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
-      One can use instead ``<species_name>.t_lab`` (`double`) optional (default is 0) which allows to set a custom t_lab for the Lorentz Transform.
+      ``<species_name>.t_lab`` (`double`) optional (default is 0) which allows to set a custom t_lab for the Lorentz Transform. This option overrides ``t_lab_from_file`` if the latter is defined.
       Warning: ``q_tot!=0`` is not supported with the ``external_file`` injection style. If a value is provided, it is ignored and no re-scaling is done.
       The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
       If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see ``<species_name>.mass``, ``<species_name>.charge`` or ``<species_name>.species_type``).

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -717,7 +717,8 @@ Particle initialization
       ``<species_name>.charge`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.mass`` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
       ``<species_name>.z_shift`` (`double`) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
-      ``<species_name>.impose_t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
+      ``<species_name>.t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
+      One can use instead ``<species_name>.t_lab`` (`double`) optional (default is 0) which allows to set a custom t_lab for the Lorentz Transform.
       Warning: ``q_tot!=0`` is not supported with the ``external_file`` injection style. If a value is provided, it is ignored and no re-scaling is done.
       The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
       If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see ``<species_name>.mass``, ``<species_name>.charge`` or ``<species_name>.species_type``).

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -360,7 +360,7 @@ protected:
     bool m_rz_random_theta = true;
 
     // Impose t_lab from the openPMD file for externally loaded species
-    bool impose_t_lab_from_file = false;
+    bool t_lab_from_file = false;
 
     Resampling m_resampler;
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -593,11 +593,21 @@ PhysicalParticleContainer::AddPlasmaFromFile(ParticleReal q_tot,
         // assumption asserts: see PlasmaInjector
         openPMD::Iteration it = series->iterations.begin()->second;
         const ParmParse pp_species_name(species_name);
-        pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
         double t_lab = 0._prt;
-        if (impose_t_lab_from_file) {
+        pp_species_name.query("t_lab_from_file", t_lab_from_file);
+        if (t_lab_from_file) {
             // Impose t_lab as being the time stored in the openPMD file
             t_lab = it.time<double>() * it.timeUnitSI();
+        }
+        const bool t_lab_from_input =
+            utils::parser::queryWithParser(pp_species_name, "t_lab", t_lab);
+        if ( t_lab_from_input && t_lab_from_file ){
+            std::stringstream warnMsg;
+                warnMsg << "Both '" + species_name +  ".t_lab' and '" +
+                    species_name + ".t_lab_from_file = 1' are specified.\n '" +
+                    species_name + ".t_lab = " << std::scientific << std::setprecision(3) << t_lab << "' will take precedence.\n" ;
+            ablastr::warn_manager::WMRecordWarning("AddPlasmaFromFile",
+                warnMsg.str());
         }
         std::string const ps_name = it.particles.begin()->first;
         openPMD::ParticleSpecies ps = it.particles.begin()->second;


### PR DESCRIPTION
This PR adds the possibility to parse a custom real parameter `t_lab` instead of imposing it from file (`t_lab_from_file`) for externally loaded species in the boosted frame.