### PR TITLE
CI: Shrink NVHPC Size

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -173,10 +173,10 @@ jobs:
         # work-around for mpi4py 3.1.1 build system issue with using
         # a GNU-built Python executable with non-GNU Python modules
         #   https://github.com/mpi4py/mpi4py/issues/114
-        export CFLAGS="-noswitcherror"
+        #export CFLAGS="-noswitcherror"
 
-        python3 -m pip install --upgrade pip setuptools wheel
-        export WARPX_MPI=ON
-        export PYWARPX_LIB_DIR=$PWD/build/lib/site-packages/pywarpx/
-        python3 -m pip wheel .
-        python3 -m pip install *.whl
+        #python3 -m pip install --upgrade pip setuptools wheel
+        #export WARPX_MPI=ON
+        #export PYWARPX_LIB_DIR=$PWD/build/lib/site-packages/pywarpx/
+        #python3 -m pip wheel .
+        #python3 -m pip install *.whl

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -12,8 +12,8 @@ set -eu -o pipefail
 #   failed files the given number of times.
 echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     cmake               \
@@ -27,9 +27,12 @@ sudo apt-get install -y \
 
 echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
   sudo tee /etc/apt/sources.list.d/nvhpc.list
-sudo apt-get update -y && \
-sudo apt-get install -y --no-install-recommends nvhpc-21-11 && \
-sudo rm -rf /var/lib/apt/lists/*
+sudo apt update -y && \
+sudo apt install -y --no-install-recommends nvhpc-21-11 && \
+sudo rm -rf /var/lib/apt/lists/* && \
+  sudo rm -rf /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/examples \
+              /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/profilers \
+              /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/11.5/targets/x86_64-linux/lib/lib*_static*.a
 
 # things should reside in /opt/nvidia/hpc_sdk now
 

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -27,8 +27,9 @@ sudo apt-get install -y \
 
 echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
   sudo tee /etc/apt/sources.list.d/nvhpc.list
-sudo apt-get update -y
-sudo apt-get install -y --no-install-recommends nvhpc-21-11
+sudo apt-get update -y && \
+sudo apt-get install -y --no-install-recommends nvhpc-21-11 && \
+sudo rm -rf /var/lib/apt/lists/*
 
 # things should reside in /opt/nvidia/hpc_sdk now
 


### PR DESCRIPTION
Try to shrink the size occupied in the NVHPC CI runs. Currently running out-of-disk...

Install:
```
After this operation, 9028 MB of additional disk space will be used.
```
o.0 our limit is 10G or so on CI runners.

Also filed as suggestion to Nvidia as Bug no. 4257086.