### PR TITLE
Doc: HPC Python Separate (Static/Shared AMReX)

### DIFF
--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -85,16 +85,24 @@ Finally, since Adastra does not yet provide software modules for some of our dep
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application:
 
 .. code-block:: bash
 
    cd $HOME/src/warpx
    rm -rf build_adastra
 
-   cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra -j 16
-   cmake --build build_adastra -j 16 --target pip_install
+
+and the following for the Python module:
+
+.. code-block:: bash
+
+   rm -rf build_adastra_py
+
+   cmake -S . -B build_adastra_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_adastra_py -j 16 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build_adastra/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -95,6 +95,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
    cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra -j 16
 
+The WarpX application executables are now in ``$HOME/src/warpx/build_adastra/bin/``.
 Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
@@ -104,8 +105,6 @@ Additionally, the following commands will install WarpX as a Python module:
    cmake -S . -B build_adastra_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra_py -j 16 --target pip_install
 
-**That's it!**
-The WarpX application executables are now in ``$HOME/src/warpx/build_adastra/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit Adstra compute jobs <running-cpp-adastra>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Adastra jobs (:ref:`example inputs <usage-examples>`).

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -105,7 +105,6 @@ Additionally, the following commands will install WarpX as a Python module:
    cmake -S . -B build_adastra_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra_py -j 16 --target pip_install
 
-
 Now, you can :ref:`submit Adstra compute jobs <running-cpp-adastra>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Adastra jobs (:ref:`example inputs <usage-examples>`).
 For executables, you can reference their location in your :ref:`job script <running-cpp-adastra>` .

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -85,7 +85,7 @@ Finally, since Adastra does not yet provide software modules for some of our dep
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile the application:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. code-block:: bash
 
@@ -95,7 +95,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
    cmake -S . -B build_adastra -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_adastra -j 16
 
-and the following for the Python module:
+Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
 

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -99,9 +99,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_frontier
 
-   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_frontier -j 16
-   cmake --build build_frontier -j 16 --target pip_install
+
+and the following for the Python module:
+
+.. code-block:: bash
+
+   rm -rf build_frontier_py
+
+   cmake -S . -B build_frontier_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_frontier_py -j 16 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build_frontier/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -92,7 +92,7 @@ Finally, since Frontier does not yet provide software modules for some of our de
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. code-block:: bash
 
@@ -102,7 +102,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cmake -S . -B build_frontier -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_frontier -j 16
 
-and the following for the Python module:
+The WarpX application executables are now in ``$HOME/src/warpx/build_frontier/bin/``.
+Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
 
@@ -110,9 +111,6 @@ and the following for the Python module:
 
    cmake -S . -B build_frontier_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_frontier_py -j 16 --target pip_install
-
-**That's it!**
-The WarpX application executables are now in ``$HOME/src/warpx/build_frontier/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit Frontier compute jobs <running-cpp-frontier>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Frontier jobs (:ref:`example inputs <usage-examples>`).

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -95,9 +95,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 12
-   cmake --build build -j 12 --target pip_install
+
+and the following for the Python module:
+
+.. code-block:: bash
+
+   rm -rf build_py
+
+   cmake -S . -B build_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_py -j 12 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/hpc3.rst
+++ b/Docs/source/install/hpc/hpc3.rst
@@ -88,7 +88,7 @@ Finally, since HPC3 does not yet provide software modules for some of our depend
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. code-block:: bash
 
@@ -98,7 +98,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build -j 12
 
-and the following for the Python module:
+The WarpX application executables are now in ``$HOME/src/warpx/build/bin/``.
+Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
 
@@ -106,9 +107,6 @@ and the following for the Python module:
 
    cmake -S . -B build_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_py -j 12 --target pip_install
-
-**That's it!**
-The WarpX application executables are now in ``$HOME/src/warpx/build/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit HPC3 compute jobs <running-cpp-hpc3>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit HPC3 jobs (:ref:`example inputs <usage-examples>`).

--- a/Docs/source/install/hpc/karolina.rst
+++ b/Docs/source/install/hpc/karolina.rst
@@ -107,9 +107,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_gpu
 
-         cmake -S . -B build_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_gpu -j 12
-         cmake --build build_gpu -j 12 --target pip_install
+
+      and the following for the Python module:
+
+      .. code-block:: bash
+
+         rm -rf build_gpu_py
+
+         cmake -S . -B build_gpu_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_gpu_py -j 12 --target pip_install
 
       **That's it!**
       The WarpX application executables are now in ``$HOME/src/warpx/build_gpu/bin/`` and we installed the ``pywarpx`` Python module.
@@ -121,9 +129,18 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_cpu
 
-         cmake -S . -B build_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_cpu -j 12
-         cmake --build build_cpu -j 12 --target pip_install
+
+      and the following for the Python module:
+
+      .. code-block:: bash
+
+         cd $HOME/src/warpx
+         rm -rf build_cpu_py
+
+         cmake -S . -B build_cpu_py -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_cpu_py -j 12 --target pip_install
 
       **That's it!**
       The WarpX application executables are now in ``$HOME/src/warpx/build_cpu/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/karolina.rst
+++ b/Docs/source/install/hpc/karolina.rst
@@ -96,7 +96,7 @@ On Karolina, you can run either on GPU nodes with fast A100 GPUs (recommended) o
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. tab-set::
 
@@ -110,7 +110,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cmake -S . -B build_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_gpu -j 12
 
-      and the following for the Python module:
+      The WarpX application executables are now in ``$HOME/src/warpx/build_gpu/bin/``.
+      Additionally, the following commands will install WarpX as a Python module:
 
       .. code-block:: bash
 
@@ -118,9 +119,6 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
 
          cmake -S . -B build_gpu_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_gpu_py -j 12 --target pip_install
-
-      **That's it!**
-      The WarpX application executables are now in ``$HOME/src/warpx/build_gpu/bin/`` and we installed the ``pywarpx`` Python module.
 
    .. tab-item:: CPU Nodes
 
@@ -132,7 +130,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cmake -S . -B build_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_cpu -j 12
 
-      and the following for the Python module:
+      The WarpX application executables are now in ``$HOME/src/warpx/build_cpu/bin/``.
+      Additionally, the following commands will install WarpX as a Python module:
 
       .. code-block:: bash
 
@@ -141,9 +140,6 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
 
          cmake -S . -B build_cpu_py -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_cpu_py -j 12 --target pip_install
-
-      **That's it!**
-      The WarpX application executables are now in ``$HOME/src/warpx/build_cpu/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit Karolina compute jobs <running-cpp-karolina>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Karolina jobs (:ref:`example inputs <usage-examples>`).

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -126,7 +126,7 @@ Or, if you are *developing*, do a quick PICMI install of a *single geometry* (se
 .. code-block:: bash
 
    # find dependencies & configure
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_PYTHON=ON -DWarpX_DIMS=RZ
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS=RZ
 
    # build and then call "python3 -m pip install ..."
    cmake --build build --target pip_install -j 12

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -92,7 +92,7 @@ Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` 
    # optional: for libEnsemble
    python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 
-Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile:
+Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following commands to compile the application executable:
 
 .. code-block:: bash
 

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -88,9 +88,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_lumi
 
-   cmake -S . -B build_lumi -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_lumi -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_lumi -j 16
-   cmake --build build_lumi -j 16 --target pip_install
+
+and the following for the Python module:
+
+.. code-block:: bash
+
+   rm -rf build_lumi_py
+
+   cmake -S . -B build_lumi_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_lumi_py -j 16 --target pip_install
 
 **That's it!**
 WarpX executables are now in ``build_lumi/bin/`` and :ref:`can be run <running-cpp-lumi>` with matching :ref:`example inputs files <usage-examples>`.

--- a/Docs/source/install/hpc/lumi.rst
+++ b/Docs/source/install/hpc/lumi.rst
@@ -81,7 +81,7 @@ Finally, since LUMI does not yet provide software modules for some of our depend
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. code-block:: bash
 
@@ -91,7 +91,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cmake -S . -B build_lumi -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_lumi -j 16
 
-and the following for the Python module:
+The WarpX application executables are now in ``$HOME/src/warpx/build_lumi/bin/``.
+Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
 
@@ -99,10 +100,6 @@ and the following for the Python module:
 
    cmake -S . -B build_lumi_py -DWarpX_COMPUTE=HIP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_lumi_py -j 16 --target pip_install
-
-**That's it!**
-WarpX executables are now in ``build_lumi/bin/`` and :ref:`can be run <running-cpp-lumi>` with matching :ref:`example inputs files <usage-examples>`.
-Most people execute the binary directly or copy it out to a location in ``/scratch/<project>``.
 
 
 .. _building-lumi-update:

--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -154,7 +154,7 @@ Then we compile WarpX as in the previous section (with or without CUDA) adding `
 
 .. code-block:: bash
 
-   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_PYTHON=ON
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_DIMS="1;2;RZ;3" -DWarpX_APP=OFF -DWarpX_PYTHON=ON
    cmake --build build --target pip_install -j 6
 
 This builds WarpX for 3D geometry.

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -142,7 +142,7 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. tab-set::
 
@@ -156,7 +156,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_gpu -j 16
 
-      and the following for the Python module:
+      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_gpu/bin/``.
+      Additionally, the following commands will install WarpX as a Python module:
 
       .. code-block:: bash
 
@@ -165,9 +166,6 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
 
          cmake -S . -B build_pm_gpu_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_gpu_py -j 16 --target pip_install
-
-      **That's it!**
-      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_gpu/bin/`` and we installed the ``pywarpx`` Python module.
 
    .. tab-item:: CPU Nodes
 
@@ -179,7 +177,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_cpu -j 16
 
-      and the following for the Python module:
+      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_cpu/bin/``.
+      Additionally, the following commands will install WarpX as a Python module:
 
       .. code-block:: bash
 
@@ -187,9 +186,6 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
 
          cmake -S . -B build_pm_cpu_py -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_cpu_py -j 16 --target pip_install
-
-      **That's it!**
-      The WarpX application executables are now in ``$HOME/src/warpx/build_pm_cpu/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit Perlmutter compute jobs <running-cpp-perlmutter>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Perlmutter jobs (:ref:`example inputs <usage-examples>`).

--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -153,9 +153,18 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_gpu
 
-         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_gpu -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_gpu -j 16
-         cmake --build build_pm_gpu -j 16 --target pip_install
+
+      and the following for the Python module:
+
+      .. code-block:: bash
+
+         cd $HOME/src/warpx
+         rm -rf build_pm_gpu_py
+
+         cmake -S . -B build_pm_gpu_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_pm_gpu_py -j 16 --target pip_install
 
       **That's it!**
       The WarpX application executables are now in ``$HOME/src/warpx/build_pm_gpu/bin/`` and we installed the ``pywarpx`` Python module.
@@ -167,9 +176,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
          cd $HOME/src/warpx
          rm -rf build_pm_cpu
 
-         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_cpu -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
          cmake --build build_pm_cpu -j 16
-         cmake --build build_pm_cpu -j 16 --target pip_install
+
+      and the following for the Python module:
+
+      .. code-block:: bash
+
+         rm -rf build_pm_cpu_py
+
+         cmake -S . -B build_pm_cpu_py -DWarpX_COMPUTE=OMP -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+         cmake --build build_pm_cpu_py -j 16 --target pip_install
 
       **That's it!**
       The WarpX application executables are now in ``$HOME/src/warpx/build_pm_cpu/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -124,9 +124,17 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cd $HOME/src/warpx
    rm -rf build_summit
 
-   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_summit -j 8
-   cmake --build build_summit -j 8 --target pip_install
+
+and the following for the Python module:
+
+.. code-block:: bash
+
+   rm -rf build_summit_py
+
+   cmake -S . -B build_summit_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
+   cmake --build build_summit_py -j 8 --target pip_install
 
 **That's it!**
 The WarpX application executables are now in ``$HOME/src/warpx/build_summit/bin/`` and we installed the ``pywarpx`` Python module.

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -117,7 +117,7 @@ Finally, since Summit does not yet provide software modules for some of our depe
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
 
 .. code-block:: bash
 
@@ -127,7 +127,8 @@ Use the following :ref:`cmake commands <building-cmake>` to compile:
    cmake -S . -B build_summit -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_summit -j 8
 
-and the following for the Python module:
+The WarpX application executables are now in ``$HOME/src/warpx/build_summit/bin/``.
+Additionally, the following commands will install WarpX as a Python module:
 
 .. code-block:: bash
 
@@ -135,9 +136,6 @@ and the following for the Python module:
 
    cmake -S . -B build_summit_py -DWarpX_COMPUTE=CUDA -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_DIMS="1;2;RZ;3"
    cmake --build build_summit_py -j 8 --target pip_install
-
-**That's it!**
-The WarpX application executables are now in ``$HOME/src/warpx/build_summit/bin/`` and we installed the ``pywarpx`` Python module.
 
 Now, you can :ref:`submit Summit compute jobs <running-cpp-summit>` for WarpX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).
 Or, you can use the WarpX executables to submit Summit jobs (:ref:`example inputs <usage-examples>`).

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -37,7 +37,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -53,7 +53,7 @@ rm -rf $HOME/src/blaspp-adastra-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -48,7 +48,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -64,7 +64,7 @@ rm -rf $HOME/src/blaspp-frontier-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -48,7 +48,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/c-blosc ]
 then
   cd $HOME/src/c-blosc
-  git fetch
+  git fetch --prune
   git checkout v1.21.1
   cd -
 else
@@ -63,7 +63,7 @@ rm -rf $HOME/src/c-blosc-pm-gpu-build
 if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
-  git fetch
+  git fetch --prune
   git checkout v2.8.3
   cd -
 else
@@ -78,7 +78,7 @@ rm -rf $HOME/src/adios2-pm-gpu-build
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -94,7 +94,7 @@ rm -rf $HOME/src/blaspp-pm-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/karolina-it4i/install_cpu_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_cpu_dependencies.sh
@@ -37,7 +37,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/c-blosc ]
 then
   cd $HOME/src/c-blosc
-  git fetch
+  git fetch --prune
   git checkout v1.21.1
   cd -
 else
@@ -52,7 +52,7 @@ rm -rf $HOME/src/c-blosc-cpu-build
 if [ -d $HOME/src/hdf5 ]
 then
   cd $HOME/src/hdf5
-  git fetch
+  git fetch --prune
   git checkout hdf5-1_14_1-2
   cd -
 else
@@ -67,7 +67,7 @@ rm -rf $HOME/src/hdf5-build
 if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
-  git fetch
+  git fetch --prune
   git checkout v2.8.3
   cd -
 else
@@ -82,7 +82,7 @@ rm -rf $HOME/src/adios2-cpu-build
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -98,7 +98,7 @@ rm -rf $HOME/src/blaspp-cpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/karolina-it4i/install_gpu_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_gpu_dependencies.sh
@@ -37,7 +37,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/c-blosc ]
 then
   cd $HOME/src/c-blosc
-  git fetch
+  git fetch --prune
   git checkout v1.21.1
   cd -
 else
@@ -52,7 +52,7 @@ rm -rf $HOME/src/c-blosc-gpu-build
 if [ -d $HOME/src/hdf5 ]
 then
   cd $HOME/src/hdf5
-  git fetch
+  git fetch --prune
   git checkout hdf5-1_14_1-2
   cd -
 else
@@ -67,7 +67,7 @@ rm -rf $HOME/src/hdf5-build
 if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
-  git fetch
+  git fetch --prune
   git checkout v2.8.3
   cd -
 else
@@ -82,7 +82,7 @@ rm -rf $HOME/src/adios2-gpu-build
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -98,7 +98,7 @@ rm -rf $HOME/src/blaspp-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -37,7 +37,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -53,7 +53,7 @@ rm -rf $HOME/src/blaspp-lumi-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -48,7 +48,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/c-blosc ]
 then
   cd $HOME/src/c-blosc
-  git fetch
+  git fetch --prune
   git checkout v1.21.1
   cd -
 else
@@ -63,7 +63,7 @@ rm -rf $HOME/src/c-blosc-pm-cpu-build
 if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
-  git fetch
+  git fetch --prune
   git checkout v2.8.3
   cd -
 else
@@ -78,7 +78,7 @@ rm -rf $HOME/src/adios2-pm-cpu-build
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -94,7 +94,7 @@ rm -rf $HOME/src/blaspp-pm-cpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -48,7 +48,7 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 if [ -d $HOME/src/c-blosc ]
 then
   cd $HOME/src/c-blosc
-  git fetch
+  git fetch --prune
   git checkout v1.21.1
   cd -
 else
@@ -63,7 +63,7 @@ rm -rf $HOME/src/c-blosc-pm-gpu-build
 if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
-  git fetch
+  git fetch --prune
   git checkout v2.8.3
   cd -
 else
@@ -78,7 +78,7 @@ rm -rf $HOME/src/adios2-pm-gpu-build
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -94,7 +94,7 @@ rm -rf $HOME/src/blaspp-pm-gpu-build
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -

--- a/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+++ b/Tools/machines/summit-olcf/install_gpu_dependencies.sh
@@ -62,7 +62,7 @@ build_dir=$(mktemp -d)
 if [ -d $HOME/src/blaspp ]
 then
   cd $HOME/src/blaspp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -
@@ -76,7 +76,7 @@ cmake --build ${build_dir}/blaspp-summit-build --target install --parallel 10
 if [ -d $HOME/src/lapackpp ]
 then
   cd $HOME/src/lapackpp
-  git fetch
+  git fetch --prune
   git checkout master
   git pull
   cd -


### PR DESCRIPTION
Currently, due to global variables used in AMReX to store implicit state instead of using handlers, we cannot build shared libraries for Python (pyAMReX + pyWarpX + pyImpactX) with a *static* `libamrex_Nd.a`. Thus, we automatically build a shared AMReX library in our superbuild the moment that we need Python bindings.

That can confuse people that just use the C++ application with AMReX inputs files, which then also depends on this shared AMReX library (which also needs to be copied around, for instance).

This update the HPC docs to just build App and bindings twice (twice the time spent), to work around this current imitation of AMReX by linking the app statically and the Python bindings shared.

Also, for dependency install fetch via `git fetch --prune`.
Fixes an issue first seen in blaspp/lapackpp where fetch failed because an unused remote branch was gone.