### PR TITLE
Do not call pre-processing routine in Python initialization

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -169,10 +169,6 @@ class LibWarpX():
         if argv is None:
             argv = sys.argv
         self.amrex_init(argv, mpi_comm)
-        self.libwarpx_so.convert_lab_params_to_boost()
-        self.libwarpx_so.read_BC_params()
-        if self.geometry_dim == 'rz':
-            self.libwarpx_so.check_gridding_for_RZ_spectral()
         self.warpx = self.libwarpx_so.get_instance()
         self.warpx.initialize_data()
         self.libwarpx_so.execute_python_callback("afterinit")

--- a/Source/Python/pyWarpX.cpp
+++ b/Source/Python/pyWarpX.cpp
@@ -120,12 +120,6 @@ PYBIND11_MODULE(PYWARPX_MODULE_NAME, m) {
         "Initialize AMReX library");
     m.def("amrex_finalize", [] () { amrex::Finalize(); },
         "Close out the amrex related data");
-    m.def("convert_lab_params_to_boost",  &ConvertLabParamsToBoost,
-        "Convert input parameters from the lab frame to the boosted frame");
-    m.def("read_BC_params", &ReadBCParams,
-        "Read the boundary condition parametes and check for consistency");
-    m.def("check_gridding_for_RZ_spectral", &CheckGriddingForRZSpectral,
-        "Ensure that the grid is setup appropriately with using the RZ spectral solver");
 
     // Expose functions to get the processor number
     m.def("getNProcs", [](){return amrex::ParallelDescriptor::NProcs();} );


### PR DESCRIPTION
We used to call the following pre-processing routines in `main.cpp` (which is used when building the C++ executable):
- `ParseGeometryInput`
- `ConvertLabParamsToBoost`
- `ReadBCParams`

As a consequence, these routines are also directly called in `_libwarpx.py` (which is used when WarpX is run as a Python module).

However, in https://github.com/ECP-WarpX/WarpX/pull/4104, these calls were moved from `main.cpp` to inside the function `MakeWarpX` (which is called by `GetInstance`). Since `_libwarpx.py` itself does call `GetInstance`, does not need to call the pre-processing routines anymore (otherwise these routines are called twice, which is erroneous - esp. in the case of boosted-frame simulations)