### PR TITLE
Work-Around: Segfault in MPI_Init with HIP

### DIFF
--- a/Source/ablastr/parallelization/MPIInitHelpers.cpp
+++ b/Source/ablastr/parallelization/MPIInitHelpers.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#include <stdexcept>
 #include <sstream>
 
 
@@ -53,7 +54,7 @@ namespace ablastr::parallelization
         hipError_t hip_ok = hipInit(0);
         if (hip_ok != hipSuccess) {
             std::cerr << "hipInit failed with error code " << hip_ok << "! Aborting now.\n";
-            return 1;
+            throw std::runtime_error("hipInit failed. Did not proceeding with MPI_Init_thread.");
         }
 #endif
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -18,8 +18,27 @@
 
 #include <AMReX_Print.H>
 
+// OLCFDEV-1655: Segfault during MPI_Init & in PMI_Allgather
+// https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init
+#if defined(AMREX_USE_HIP)
+#include <hip/hip_runtime.h>
+#endif
+
+#include <iostream>
+
+
 int main(int argc, char* argv[])
 {
+// OLCFDEV-1655: Segfault during MPI_Init & in PMI_Allgather
+// https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init
+#if defined(AMREX_USE_HIP) && defined(AMREX_USE_MPI)
+    hipError_t hip_ok = hipInit(0);
+    if (hip_ok != hipSuccess) {
+        std::cerr << "hipInit failed with error code " << hip_ok << "! Aborting now.\n";
+        return 1;
+    }
+#endif
+
     ablastr::parallelization::mpi_init(argc, argv);
 
     warpx::initialization::amrex_init(argc, argv);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -18,27 +18,9 @@
 
 #include <AMReX_Print.H>
 
-// OLCFDEV-1655: Segfault during MPI_Init & in PMI_Allgather
-// https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init
-#if defined(AMREX_USE_HIP)
-#include <hip/hip_runtime.h>
-#endif
-
-#include <iostream>
-
 
 int main(int argc, char* argv[])
 {
-// OLCFDEV-1655: Segfault during MPI_Init & in PMI_Allgather
-// https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init
-#if defined(AMREX_USE_HIP) && defined(AMREX_USE_MPI)
-    hipError_t hip_ok = hipInit(0);
-    if (hip_ok != hipSuccess) {
-        std::cerr << "hipInit failed with error code " << hip_ok << "! Aborting now.\n";
-        return 1;
-    }
-#endif
-
     ablastr::parallelization::mpi_init(argc, argv);
 
     warpx::initialization::amrex_init(argc, argv);


### PR DESCRIPTION
See:
  https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init

Proposed work-around for @tmsclark in #4236.

I think this might be a general defect of GPU-aware MPI implementations from HPE/Cray at this point, explicit device context init before MPI init can help establishing GPU-aware MPI init assumptions at this point.
Clarifying with AMD if we can have a check for an already existing HIP/ROCm initialized runtime, in case we want to move this safety net to AMReX at some point, too. (Also, not clear if `hipInit` is idempotent.)

- [x] make part of `ablastr::parallelization::mpi_init`?
- [x] test on AMD GPUs, i.e. Frontier, LUMI