### PR TITLE
Remove some unnecessary static variables from WarpX.H

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -807,6 +807,12 @@ WarpX::InitLevelData (int lev, Real /*time*/)
        WARPX_ABORT_WITH_MESSAGE(
            "E and B parser for external fields does not work with RZ -- TO DO");
 #endif
+
+       //! Strings storing parser function to initialize the components of the magnetic field on the grid
+       std::string str_Bx_ext_grid_function;
+       std::string str_By_ext_grid_function;
+       std::string str_Bz_ext_grid_function;
+
        utils::parser::Store_parserString(pp_warpx, "Bx_external_grid_function(x,y,z)",
           str_Bx_ext_grid_function);
        utils::parser::Store_parserString(pp_warpx, "By_external_grid_function(x,y,z)",
@@ -865,6 +871,12 @@ WarpX::InitLevelData (int lev, Real /*time*/)
        WARPX_ABORT_WITH_MESSAGE(
            "E and B parser for external fields does not work with RZ -- TO DO");
 #endif
+
+       //! Strings storing parser function to initialize the components of the electric field on the grid
+       std::string str_Ex_ext_grid_function;
+       std::string str_Ey_ext_grid_function;
+       std::string str_Ez_ext_grid_function;
+
        utils::parser::Store_parserString(pp_warpx, "Ex_external_grid_function(x,y,z)",
            str_Ex_ext_grid_function);
        utils::parser::Store_parserString(pp_warpx, "Ey_external_grid_function(x,y,z)",

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -146,19 +146,6 @@ public:
     //! Whether to apply the effect of an externally-defined magnetic field
     static bool add_external_B_field;
 
-    //! String storing parser function to initialize x-component of the magnetic field on the grid
-    static std::string str_Bx_ext_grid_function;
-    //! String storing parser function to initialize y-component of the magnetic field on the grid
-    static std::string str_By_ext_grid_function;
-    //! String storing parser function to initialize z-component of the magnetic field on the grid
-    static std::string str_Bz_ext_grid_function;
-    //! String storing parser function to initialize x-component of the electric field on the grid
-    static std::string str_Ex_ext_grid_function;
-    //! String storing parser function to initialize y-component of the electric field on the grid
-    static std::string str_Ey_ext_grid_function;
-    //! String storing parser function to initialize z-component of the electric field on the grid
-    static std::string str_Ez_ext_grid_function;
-
     //! User-defined parser to initialize x-component of the magnetic field on the grid
     std::unique_ptr<amrex::Parser> Bxfield_parser;
     //! User-defined parser to initialize y-component of the magnetic field on the grid

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -92,15 +92,6 @@ std::string WarpX::E_ext_grid_s = "default";
 bool WarpX::add_external_E_field = false;
 bool WarpX::add_external_B_field = false;
 
-// Parser for B_external on the grid
-std::string WarpX::str_Bx_ext_grid_function;
-std::string WarpX::str_By_ext_grid_function;
-std::string WarpX::str_Bz_ext_grid_function;
-// Parser for E_external on the grid
-std::string WarpX::str_Ex_ext_grid_function;
-std::string WarpX::str_Ey_ext_grid_function;
-std::string WarpX::str_Ez_ext_grid_function;
-
 int WarpX::do_moving_window = 0;
 int WarpX::start_moving_window_step = 0;
 int WarpX::end_moving_window_step = -1;


### PR DESCRIPTION
The static variables 
```
std::string WarpX::str_Ex_ext_grid_function;
std::string WarpX::str_Ey_ext_grid_function;
std::string WarpX::str_Ez_ext_grid_function;
std::string WarpX::str_Bx_ext_grid_function;
std::string WarpX::str_By_ext_grid_function;
std::string WarpX::str_Bz_ext_grid_function;
```
are actually used only once to parse the field functions from the inputfile. For this reason, I don't think that they need to be static variables of the WarpX class.
