### PR TITLE
Replace static function WarpX::CheckSignals() with direct call to SignalHandling::CheckSignals()

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -79,7 +79,8 @@ WarpX::Evolve (int numsteps)
         WARPX_PROFILE("WarpX::Evolve::step");
         const Real evolve_time_beg_step = amrex::second();
 
-        CheckSignals();
+        //Check and clear signal flags and asynchronously broadcast them from process 0
+        SignalHandling::CheckSignals();
 
         multi_diags->NewIteration();
 
@@ -1106,12 +1107,6 @@ WarpX::applyMirrors(Real time)
             }
         }
     }
-}
-
-void
-WarpX::CheckSignals()
-{
-    SignalHandling::CheckSignals();
 }
 
 void

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1158,8 +1158,6 @@ private:
     // Singleton is used when the code is run from python
     static WarpX* m_instance;
 
-    //! Check and clear signal flags and asynchronously broadcast them from process 0
-    static void CheckSignals ();
     //! Complete the asynchronous broadcast of signal flags, and initiate a checkpoint if requested
     void HandleSignals ();
 


### PR DESCRIPTION
This PR is part of an ongoing effort to simplify the WarpX class.