### PR TITLE
Remove AddToMultiFabMap functions from WarpX class

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -452,26 +452,6 @@ public:
     static std::map<std::string, amrex::MultiFab *> multifab_map;
     static std::map<std::string, amrex::iMultiFab *> imultifab_map;
 
-    /**
-     * \brief
-     * Add the MultiFab to the map of MultiFabs
-     * \param name The name of the MultiFab use to reference the MultiFab
-     * \param mf The MultiFab to be added to the map (via a pointer to it)
-     */
-    static void AddToMultiFabMap(const std::string& name, const std::unique_ptr<amrex::MultiFab>& mf) {
-        multifab_map[name] = mf.get();
-    }
-
-    /**
-     * \brief
-     * Add the iMultiFab to the map of MultiFabs
-     * \param name The name of the iMultiFab use to reference the iMultiFab
-     * \param mf The iMultiFab to be added to the map (via a pointer to it)
-     */
-    static void AddToMultiFabMap(const std::string& name, const std::unique_ptr<amrex::iMultiFab>& mf) {
-        imultifab_map[name] = mf.get();
-    }
-
     std::array<const amrex::MultiFab* const, 3>
     get_array_Bfield_aux  (const int lev) const {
         return {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3175,7 +3175,7 @@ WarpX::AllocInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    multifab_map[name] = mf.get();
+    multifab_map[name_with_suffix] = mf.get();
 }
 
 void
@@ -3195,7 +3195,7 @@ WarpX::AllocInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    imultifab_map[name] = mf.get();
+    imultifab_map[name_with_suffix] = mf.get();
 }
 
 void
@@ -3213,5 +3213,5 @@ WarpX::AliasInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    multifab_map[name] = mf.get();
+    multifab_map[name_with_suffix] = mf.get();
 }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3175,7 +3175,7 @@ WarpX::AllocInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    WarpX::AddToMultiFabMap(name_with_suffix, mf);
+    multifab_map[name] = mf.get();
 }
 
 void
@@ -3195,7 +3195,7 @@ WarpX::AllocInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    WarpX::AddToMultiFabMap(name_with_suffix, mf);
+    imultifab_map[name] = mf.get();
 }
 
 void
@@ -3213,5 +3213,5 @@ WarpX::AliasInitMultiFab (
     if (initial_value) {
         mf->setVal(*initial_value);
     }
-    WarpX::AddToMultiFabMap(name_with_suffix, mf);
+    multifab_map[name] = mf.get();
 }


### PR DESCRIPTION
As part of the ongoing effort to clean the WarpX class, this PR removes the static `AddToMultiFabMap` functions from it.
These functions actually contained just the instruction `multifab_map[name] = mf.get();` (or `imultifab_map[name] = mf.get();`). These instructions are now used directly in the code.