### PR TITLE
Add Python bindings to extract the timestep dt

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -143,8 +143,7 @@ void init_WarpX (py::module& m)
             [](WarpX const & wx, int lev){ return wx.gett_new(lev); },
             py::arg("lev")
         )
-        .def("getdt",
-            [](WarpX const & wx, int lev){ return wx.getdt(lev); },
+        .def("getdt", &WarpX::getdt,
             py::arg("lev")
         )
 

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -143,6 +143,10 @@ void init_WarpX (py::module& m)
             [](WarpX const & wx, int lev){ return wx.gett_new(lev); },
             py::arg("lev")
         )
+        .def("getdt",
+            [](WarpX const & wx, int lev){ return wx.getdt(lev); },
+            py::arg("lev")
+        )
 
         .def("set_potential_on_eb",
             [](WarpX& wx, std::string potential) {

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -143,7 +143,8 @@ void init_WarpX (py::module& m)
             [](WarpX const & wx, int lev){ return wx.gett_new(lev); },
             py::arg("lev")
         )
-        .def("getdt", &WarpX::getdt,
+        .def("getdt",
+            [](WarpX const & wx, int lev){ return wx.getdt(lev); },
             py::arg("lev")
         )
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -837,7 +837,7 @@ public:
     amrex::Real gett_new (int lev) const {return t_new[lev];}
     void sett_new (int lev, amrex::Real time) {t_new[lev] = time;}
     amrex::Vector<amrex::Real> getdt () const {return dt;}
-    amrex::Real getdt (int lev) const {return dt[lev];}
+    amrex::Real getdt (int lev) const {return dt.at(lev);}
     int getdo_moving_window() const {return do_moving_window;}
     amrex::Real getmoving_window_x() const {return moving_window_x;}
     bool getis_synchronized() const {return is_synchronized;}


### PR DESCRIPTION
In many applications, it is useful to extract the timestep of the simulation in Python callbacks.