### PR TITLE
ChargeDeposition: Remove Global WarpX Variable

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -16,26 +16,25 @@
 #ifdef WARPX_DIM_RZ
 #   include "Utils/WarpX_Complex.H"
 #endif
-#include "WarpX.H"
 
 #include <AMReX.H>
 
 /* \brief Perform charge deposition on a tile
- * \param GetPosition : A functor for returning the particle position.
- * \param wp           : Pointer to array of particle weights.
- * \param ion_lev      : Pointer to array of particle ionization level. This is
-                         required to have the charge of each macroparticle
-                         since q is a scalar. For non-ionizable species,
-                         ion_lev is a null pointer.
- * \param rho_fab      : FArrayBox of charge density, either full array or tile.
- * \param np_to_depose : Number of particles for which current is deposited.
- * \param dx           : 3D cell size
- * \param xyzmin       : Physical lower bounds of domain.
- * \param lo           : Index lower bounds of domain.
- * \param q            : species charge.
- * \param n_rz_azimuthal_modes: Number of azimuthal modes when using RZ geometry.
+ * \param GetPosition A functor for returning the particle position.
+ * \param wp           Pointer to array of particle weights.
+ * \param ion_lev      Pointer to array of particle ionization level. This is
+                       required to have the charge of each macroparticle
+                       since q is a scalar. For non-ionizable species,
+                       ion_lev is a null pointer.
+ * \param rho_fab      FArrayBox of charge density, either full array or tile.
+ * \param np_to_depose Number of particles for which current is deposited.
+ * \param dx           3D cell size
+ * \param xyzmin       Physical lower bounds of domain.
+ * \param lo           Index lower bounds of domain.
+ * \param q            species charge.
+ * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry.
  * \param cost: Pointer to (load balancing) cost corresponding to box where present particles deposit current.
- * \param load_balance_costs_update_algo: Selected method for updating load balance costs.
+ * \param load_balance_costs_update_algo Selected method for updating load balance costs.
  */
 template <int depos_order>
 void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
@@ -217,21 +216,27 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
 }
 
 /* \brief Perform charge deposition on a tile using shared memory
- * \param GetPosition   : A functor for returning the particle position.
- * \param wp            : Pointer to array of particle weights.
- * \param ion_lev       : Pointer to array of particle ionization level. This is
-                          required to have the charge of each macroparticle
-                          since q is a scalar. For non-ionizable species,
-                          ion_lev is a null pointer.
- * \param rho_fab       : FArrayBox of charge density, either full array or tile.
- * \param np_to_deposit : Number of particles for which charge is deposited.
- * \param dx            : 3D cell size
- * \param xyzmin        : Physical lower bounds of domain.
- * \param lo            : Index lower bounds of domain.
- * \param q             : species charge.
- * \param n_rz_azimuthal_modes: Number of azimuthal modes when using RZ geometry.
- * \param cost: Pointer to (load balancing) cost corresponding to box where present particles deposit current.
- * \param load_balance_costs_update_algo: Selected method for updating load balance costs.
+ * \param GetPosition   A functor for returning the particle position.
+ * \param wp            Pointer to array of particle weights.
+ * \param ion_lev       Pointer to array of particle ionization level. This is
+                        required to have the charge of each macroparticle
+                        since q is a scalar. For non-ionizable species,
+                        ion_lev is a null pointer.
+ * \param rho_fab       FArrayBox of charge density, either full array or tile.
+ * \param ix_type
+ * \param np_to_deposit Number of particles for which charge is deposited.
+ * \param dx            3D cell size
+ * \param xyzmin        Physical lower bounds of domain.
+ * \param lo            Index lower bounds of domain.
+ * \param q             species charge.
+ * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry.
+ * \param cost Pointer to (load balancing) cost corresponding to box where present particles deposit current.
+ * \param load_balance_costs_update_algo Selected method for updating load balance costs.
+ * \param a_bins
+ * \param box
+ * \param geom
+ * \param a_tbox_max_size
+ * \param bin_size tile size to use for shared current deposition operations
  */
 template <int depos_order>
 void doChargeDepositionSharedShapeN (const GetParticlePosition& GetPosition,
@@ -250,14 +255,16 @@ void doChargeDepositionSharedShapeN (const GetParticlePosition& GetPosition,
                                      const amrex::DenseBins<WarpXParticleContainer::ParticleType>& a_bins,
                                      const amrex::Box& box,
                                      const amrex::Geometry& geom,
-                                     const amrex::IntVect& a_tbox_max_size)
+                                     const amrex::IntVect& a_tbox_max_size,
+                                     const amrex::IntVect bin_size
+                                     )
 {
     using namespace amrex;
 
     auto permutation = a_bins.permutationPtr();
 
 #if !defined(AMREX_USE_GPU)
-    amrex::ignore_unused(ix_type, cost, load_balance_costs_update_algo, a_bins, box, geom, a_tbox_max_size);
+    amrex::ignore_unused(ix_type, cost, load_balance_costs_update_algo, a_bins, box, geom, a_tbox_max_size, bin_size);
 #endif
 
     // Whether ion_lev is a null pointer (do_ionization=0) or a real pointer
@@ -317,7 +324,6 @@ void doChargeDepositionSharedShapeN (const GetParticlePosition& GetPosition,
     const int threads_per_block = 256;
 
     std::size_t shared_mem_bytes = npts*sizeof(amrex::Real);
-    const amrex::IntVect bin_size = WarpX::shared_tilesize;
 
     const std::size_t max_shared_mem_bytes = amrex::Gpu::Device::sharedMemPerBlock();
 

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -19,6 +19,8 @@
 #   include "Utils/WarpX_Complex.H"
 #endif
 
+#include "WarpX.H" // todo: remove include and pass globals as args
+
 #include <AMReX.H>
 #include <AMReX_Arena.H>
 #include <AMReX_Array4.H>

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -879,17 +879,20 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
             doChargeDepositionSharedShapeN<1>(GetPosition, wp.dataPtr()+offset, ion_lev,
                                               rho_fab, ix_type, np_to_depose, dx, xyzmin, lo, q,
                                               WarpX::n_rz_azimuthal_modes, cost,
-                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size);
+                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
+                                              WarpX::shared_tilesize);
         } else if (WarpX::nox == 2){
             doChargeDepositionSharedShapeN<2>(GetPosition, wp.dataPtr()+offset, ion_lev,
                                               rho_fab, ix_type, np_to_depose, dx, xyzmin, lo, q,
                                               WarpX::n_rz_azimuthal_modes, cost,
-                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size);
+                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
+                                              WarpX::shared_tilesize);
         } else if (WarpX::nox == 3){
             doChargeDepositionSharedShapeN<3>(GetPosition, wp.dataPtr()+offset, ion_lev,
                                               rho_fab, ix_type, np_to_depose, dx, xyzmin, lo, q,
                                               WarpX::n_rz_azimuthal_modes, cost,
-                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size);
+                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
+                                              WarpX::shared_tilesize);
         }
 #ifndef AMREX_USE_GPU
         // CPU, tiling: atomicAdd local_rho into rho


### PR DESCRIPTION
Remove Global WarpX variable use in `ChargeDeposition`.