### PR TITLE
Use input parameter parser for lattice elements

### DIFF
--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.cpp
@@ -5,6 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "HardEdgedPlasmaLens.H"
+#include "Utils/Parser/ParserUtils.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
@@ -25,8 +26,8 @@ HardEdgedPlasmaLens::AddElement (amrex::ParmParse & pp_element, amrex::ParticleR
 
     amrex::ParticleReal dEdx = 0._prt;
     amrex::ParticleReal dBdx = 0._prt;
-    pp_element.query("dEdx", dEdx);
-    pp_element.query("dBdx", dBdx);
+    utils::parser::queryWithParser(pp_element, "dEdx", dEdx);
+    utils::parser::queryWithParser(pp_element, "dBdx", dBdx);
 
     h_dEdx.push_back(dEdx);
     h_dBdx.push_back(dBdx);

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.cpp
@@ -5,6 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "HardEdgedQuadrupole.H"
+#include "Utils/Parser/ParserUtils.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
@@ -25,8 +26,8 @@ HardEdgedQuadrupole::AddElement (amrex::ParmParse & pp_element, amrex::ParticleR
 
     amrex::ParticleReal dEdx = 0._prt;
     amrex::ParticleReal dBdx = 0._prt;
-    pp_element.query("dEdx", dEdx);
-    pp_element.query("dBdx", dBdx);
+    utils::parser::queryWithParser(pp_element, "dEdx", dEdx);
+    utils::parser::queryWithParser(pp_element, "dBdx", dBdx);
 
     h_dEdx.push_back(dEdx);
     h_dBdx.push_back(dBdx);

--- a/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.cpp
+++ b/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.cpp
@@ -5,6 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "LatticeElementBase.H"
+#include "Utils/Parser/ParserUtils.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
@@ -21,7 +22,7 @@ LatticeElementBase::AddElementBase (amrex::ParmParse & pp_element, amrex::Partic
 {
     // Read in the length of the element and save the start and end, and update z_location
     amrex::ParticleReal ds;
-    pp_element.get("ds", ds);
+    utils::parser::getWithParser(pp_element, "ds", ds);
 
     h_zs.push_back(z_location);
     z_location += ds;


### PR DESCRIPTION
As the title says, for the accelerator lattice elements, this changes the reading of the input parameters to use the parser instead of direct query or get.