### PR TITLE
Particle fields diagnostic support for PICMI

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2067,6 +2067,8 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
         particle_fields_to_plot = list()
         if self.particle_fields_to_plot is not None:
             for pfd in self.particle_fields_to_plot:
+                if pfd.name in particle_fields_to_plot:
+                    raise Exception('A particle fields data name can not be repeated.')
                 particle_fields_to_plot.append(pfd.name)
                 self.diagnostic.__setattr__(
                     f'particle_fields.{pfd.name}(x,y,z,ux,uy,uz)', pfd.func

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -8,9 +8,9 @@
 
 """Classes following the PICMI standard
 """
+from dataclasses import dataclass
 import os
 import re
-from dataclasses import dataclass
 
 import numpy as np
 import periodictable

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1910,6 +1910,7 @@ class WarpXDiagnosticBase(object):
 
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class ParticleFieldDiagnostic(object):
     """

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2051,14 +2051,20 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
                     self.diagnostic.__setattr__(
                         f'particle_fields.{dataname}(x,y,z,ux,uy,uz)', params['func']
                     )
+                    params.pop('func', None)
                 if "do_average" in params:
                     self.diagnostic.__setattr__(
                         f'particle_fields.{dataname}.do_average', params['do_average']
                     )
+                    params.pop('do_average', None)
                 if "filter" in params:
                     self.diagnostic.__setattr__(
                         f'particle_fields.{dataname}.filter(x,y,z,ux,uy,uz)', params['filter']
                     )
+                    params.pop('filter', None)
+                # catches unexpected keywords
+                if params:
+                    raise TypeError(f"Unexpected keyword argument for particle field {dataname} - {list(params)}")
 
             # --- Convert the set to a sorted list so that the order
             # --- is the same on all processors.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1938,6 +1938,17 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
     warpx_dump_rz_modes: bool, optional
         Flag whether to dump the data for all RZ modes
+
+    warpx_particle_fields_to_plot: dict, optional
+        Keys: particle field diagnostic name (string)
+        Values: Dictionaries with key/value pairs of corresponding parser function
+        and parameters. The keys must be "func" (parser string, mandatory),
+        "do_average" (0 or 1, optional, default 1), and "filter" (parser string, optional).
+
+    warpx_particle_fields_species: list of strings, optional
+        Species for which to calcualte particle_fields_to_plot functions. Fields will
+        be calculated separately for each specified species. If not passed, default is
+        all of the available particle species.
     """
     def init(self, kw):
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2043,10 +2043,7 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
         particle_fields_to_plot = list()
         for dataname, params in self.particle_fields_to_plot.items():
-            if dataname in particle_fields_to_plot:
-                raise Exception('A particle fields data name can not be repeated!')
-            else:
-                particle_fields_to_plot.add(dataname)
+            particle_fields_to_plot.append(dataname)
             try:
                 self.diagnostic.__setattr__(
                     f'particle_fields.{dataname}(x,y,z,ux,uy,uz)', params.pop('func')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2075,6 +2075,7 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
         self.set_write_dir()
 
+
 ElectrostaticFieldDiagnostic = FieldDiagnostic
 
 


### PR DESCRIPTION
This PR adds support for particle field functions in the `FieldDiagnostic` class in PICMI.

The user specifies the field names and their corresponding field functions and parameters in a dictionary of dictionaries, as described by the doc string. Happy to make improvements or provide an example of the format in the doc string if necessary!