### PR TITLE
Add lower and upper bound params to regular diags in PICMI

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1951,6 +1951,8 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
         self.file_prefix = kw.pop('warpx_file_prefix', None)
         self.file_min_digits = kw.pop('warpx_file_min_digits', None)
         self.dump_rz_modes = kw.pop('warpx_dump_rz_modes', None)
+        self.lower_bound = kw.pop('warpx_lower_bound', None)
+        self.upper_bound = kw.pop('warpx_upper_bound', None)
 
     def initialize_inputs(self):
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1938,6 +1938,14 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
     warpx_dump_rz_modes: bool, optional
         Flag whether to dump the data for all RZ modes
+
+    warpx_lower_bound: vector of floats, optional
+        Lower corner of output fields
+        that is passed to <diagnostic name>.lower_bound
+
+    warpx_upper_bound: vector of floats, optional
+        Upper corner of output fields
+        that is passed to <diagnostic name>.upper_bound
     """
     def init(self, kw):
 


### PR DESCRIPTION
The parameters `warpx_lower_bound` and `warpx_upper_bound` can now be used in the definition of a `FieldDiagnostic` in PICMI.