### PR TITLE
Fix parallel hanging in lasy reading

### DIFF
--- a/Source/Laser/LaserProfiles.H
+++ b/Source/Laser/LaserProfiles.H
@@ -328,14 +328,14 @@ private:
      */
     struct{
 
-        /** Name of the lasy file geometry ("cartesian" for 3D cartesian or "thetaMode" for RZ) */
-        std::string fileGeom;
         /** Name of the binary file containing the data */
         std::string binary_file_name;
         /** Name of the lasy file containing the data */
         std::string lasy_file_name;
         /** true if the file is in the lasy format, false if it is in the binary format */
         bool file_in_lasy_format;
+        /** lasy file geometry ("cartesian" for 3D cartesian or "thetaMode" for RZ) */
+        int file_in_cartesian_geom;
         /** Dimensions of E_binary_data or E_lasy_data. nt, nx must be >=2.
          * If DIM=3, ny must be >=2 as well.
          * If DIM=2, ny must be 1 */

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
@@ -150,7 +150,7 @@ WarpXLaserProfiles::FromFileLaserProfile::fill_amplitude (
         "Something bad has happened with the simulation time");
     }
     if (m_params.file_in_lasy_format){
-        if (m_params.fileGeom=="cartesian"){
+        if (m_params.file_in_cartesian_geom==1){
             internal_fill_amplitude_uniform_cartesian(idx_t_left, np, Xp, Yp, t, amplitude);
         } else {
             internal_fill_amplitude_uniform_cylindrical(idx_t_left, np, Xp, Yp, t, amplitude);
@@ -172,16 +172,17 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_lasy_file(std::string lasy_file_
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(E.getAttribute("dataOrder").get<std::string>() == "C",
                                          "Reading from files with non-C dataOrder is not implemented");
 
-        m_params.fileGeom = E.getAttribute("geometry").get<std::string>();
+        std::string fileGeom = E.getAttribute("geometry").get<std::string>();
         auto E_laser = E[io::RecordComponent::SCALAR];
         auto extent = E_laser.getExtent();
         // Extract grid offset and grid spacing
         std::vector<double> offset = E.gridGlobalOffset();
         std::vector<double> position = E_laser.position<double>();
         std::vector<double> spacing = E.gridSpacing<double>();
-        if (m_params.fileGeom=="thetaMode") {
+        if (fileGeom=="thetaMode") {
             //Dimensions of lasy file data: {m,t,r}
             amrex::Print() << Utils::TextMsg::Info( "Found lasy file in RZ geometry" );
+            m_params.file_in_cartesian_geom = 0;
             m_params.n_rz_azimuthal_components = extent[0];
             m_params.nt = extent[1];
             m_params.nr = extent[2];
@@ -192,9 +193,10 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_lasy_file(std::string lasy_file_
             m_params.t_max = m_params.t_min + (m_params.nt-1)*spacing[0];
             m_params.r_min = offset[1] + position[1]*spacing[1];
             m_params.r_max = m_params.r_min + (m_params.nr-1)*spacing[1];
-        } else if (m_params.fileGeom=="cartesian"){
+        } else if (fileGeom=="cartesian"){
             //Dimensions of lasy file data: {t,y,x}
             amrex::Print() << Utils::TextMsg::Info( "Found lasy file in 3D cartesian geometry");
+            m_params.file_in_cartesian_geom = 1;
             m_params.nt = extent[0];
             m_params.ny = extent[1];
             m_params.nx = extent[2];
@@ -214,6 +216,7 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_lasy_file(std::string lasy_file_
     }
 
     //Broadcast parameters
+   ParallelDescriptor::Bcast(&m_params.file_in_cartesian_geom, 1, ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&m_params.nt, 1, ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&m_params.nx, 1, ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&m_params.ny, 1, ParallelDescriptor::IOProcessorNumber());
@@ -316,7 +319,7 @@ WarpXLaserProfiles::FromFileLaserProfile::read_data_t_chunk (int t_begin, int t_
         "Reading [" + std::to_string(i_first) + ", " + std::to_string(i_last) +
             "] data chunk from " + m_params.lasy_file_name);
     int data_size;
-    if (m_params.fileGeom=="thetaMode") {
+    if (m_params.file_in_cartesian_geom==0) {
         data_size = m_params.n_rz_azimuthal_components*(i_last-i_first+1)*m_params.nr;
     } else {
         data_size = (i_last-i_first+1)*m_params.nx*m_params.ny;
@@ -329,7 +332,7 @@ WarpXLaserProfiles::FromFileLaserProfile::read_data_t_chunk (int t_begin, int t_
         auto E = i.meshes["laserEnvelope"];
         auto E_laser = E[io::RecordComponent::SCALAR];
         openPMD:: Extent full_extent = E_laser.getExtent();
-        if (m_params.fileGeom=="thetaMode") {
+        if (m_params.file_in_cartesian_geom==0) {
             const openPMD::Extent read_extent = { full_extent[0], (i_last - i_first + 1), full_extent[2]};
             auto r_data = E_laser.loadChunk< std::complex<double> >(io::Offset{ 0, i_first,  0}, read_extent);
             const int read_size = (i_last - i_first + 1)*m_params.nr;


### PR DESCRIPTION
This is done by properly broadcasting the file geometry information.

Before this, the I/O MPI rank would get `fileGeom = 'thetaMode'`, while the other ranks would get `fileGeom = ''`, which caused a number of issue, including inconsistencies when calling `Bcast`, eventually resulting in the observed hang.

Fixes #4272