### PR TITLE
Quartz (LLNL): New Modules, Clang

### DIFF
--- a/Docs/source/install/hpc/quartz.rst
+++ b/Docs/source/install/hpc/quartz.rst
@@ -46,15 +46,15 @@ Then, ``cd`` into the directory ``$HOME/src/warpx`` and use the following comman
 .. code-block:: bash
 
    cd $HOME/src/warpx
-   rm -rf build
+   rm -rf build_quartz
 
-   cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
-   cmake --build build -j 6
+   cmake -S . -B build_quartz -DWarpX_DIMS="1;2;3" -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON
+   cmake --build build_quartz -j 6
 
 The other :ref:`general compile-time options <building-cmake>` apply as usual.
 
 **That's it!**
-A 3D WarpX executable is now in ``build/bin/`` and :ref:`can be run <running-cpp-quartz-CPUs>` with a :ref:`3D example inputs file <usage-examples>`.
+A 3D WarpX executable is now in ``build_quartz/bin/`` and :ref:`can be run <running-cpp-quartz-CPUs>` with a :ref:`3D example inputs file <usage-examples>`.
 Most people execute the binary directly or copy it out to a location in ``/p/lustre1/$(whoami)``.
 
 

--- a/Tools/machines/quartz-llnl/quartz_warpx.profile.example
+++ b/Tools/machines/quartz-llnl/quartz_warpx.profile.example
@@ -2,25 +2,25 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cmake/3.20.2
-module load intel/2021.4
-module load mvapich2/2.3
+module load cmake/3.23.1
+module load clang/14.0.6-magic
+module load mvapich2/2.3.7
 
 # optional: for PSATD support
-module load fftw/3.3.8
+module load fftw/3.3.10
 
 # optional: for QED lookup table generation support
-module load boost/1.73.0
+module load boost/1.80.0
 
 # optional: for openPMD support
 # TODO ADIOS2
-module load hdf5-parallel/1.10.2
+module load hdf5-parallel/1.14.0
 
 # optional: for PSATD in RZ geometry support
 # TODO: blaspp lapackpp
 
 # optional: for Python bindings
-module load python/3.8.2
+module load python/3.9.12
 
 # optional: an alias to request an interactive node for two hours
 alias getNode="srun --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=18 -p pdebug --pty bash"
@@ -29,9 +29,6 @@ alias getNode="srun --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task
 shopt -s direxpand
 
 # compiler environment hints
-export CC=$(which icc)
-export CXX=$(which icpc)
-export FC=$(which ifort)
-# we need a newer libstdc++:
-export CFLAGS="-gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc ${CFLAGS}"
-export CXXFLAGS="-gxx-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++ ${CXXFLAGS}"
+export CC=$(which clang)
+export CXX=$(which clang++)
+export FC=$(which gfortran)


### PR DESCRIPTION
Module update on Quartz requires changes.
Switching to Clang 14 as the compiler.