### PR TITLE
Lassen (LLNL): GNU 11.2.1

### DIFF
--- a/Tools/machines/lassen-llnl/install_v100_dependencies.sh
+++ b/Tools/machines/lassen-llnl/install_v100_dependencies.sh
@@ -114,8 +114,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip cache purge
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade cython
-# see https://github.com/numpy/numpy/issues/24673
-python3 -m pip install --upgrade numpy==1.22
+python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas
 python3 -m pip install --upgrade -Ccompile-args="-j10" scipy
 python3 -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py

--- a/Tools/machines/lassen-llnl/install_v100_ml.sh
+++ b/Tools/machines/lassen-llnl/install_v100_ml.sh
@@ -37,21 +37,24 @@ then
   cd ${HOME}/src/pytorch
   git fetch
   git checkout .
-  git checkout v2.1.0-rc3
+  git checkout v2.0.1
   git submodule update --init --recursive
   cd -
 else
-  git clone -b v2.1.0-rc3 --recurse-submodules https://github.com/pytorch/pytorch.git ${HOME}/src/pytorch
+  git clone -b v2.0.1 --recurse-submodules https://github.com/pytorch/pytorch.git ${HOME}/src/pytorch
 fi
 cd ${HOME}/src/pytorch
 rm -rf build
 
-# see https://github.com/pytorch/pytorch/issues/108931
-#     https://github.com/pytorch/pytorch/pull/108932
-wget -q -O - https://github.com/pytorch/pytorch/pull/108932.patch | git apply
+# see https://github.com/pytorch/pytorch/issues/97497#issuecomment-1499069641
+#     https://github.com/pytorch/pytorch/pull/98511
+wget -q -O - https://github.com/pytorch/pytorch/pull/98511.patch | git apply
 
 python3 -m pip install -r requirements.txt
-CXX=g++ CC=gcc USE_CUDA=1 BLAS=OpenBLAS MAX_JOBS=64 ATEN_AVX512_256=OFF BUILD_TEST=0 python3 setup.py develop
+
+# see https://github.com/pytorch/pytorch/issues/108984#issuecomment-1712938737
+LDFLAGS="-L${CUDA_HOME}/nvidia/targets/ppc64le-linux/lib/" \
+USE_CUDA=1 BLAS=OpenBLAS MAX_JOBS=64 ATEN_AVX512_256=OFF BUILD_TEST=0 python3 setup.py develop
 #   (optional) If using torch.compile with inductor/triton, install the matching version of triton
 #make triton
 rm -rf build

--- a/Tools/machines/lassen-llnl/lassen_v100_warpx.profile.example
+++ b/Tools/machines/lassen-llnl/lassen_v100_warpx.profile.example
@@ -3,7 +3,7 @@
 
 # required dependencies
 module load cmake/3.23.1
-module load clang/12.0.1-gcc-8.3.1
+module load gcc/11.2.1
 module load cuda/12.0.0
 
 # optional: for QED lookup table generation support
@@ -46,8 +46,8 @@ export AMREX_CUDA_ARCH=7.0
 export CUDAARCHS=70
 
 # compiler environment hints
-export CC=$(which clang)
-export CXX=$(which clang++)
+export CC=$(which gcc)
+export CXX=$(which g++)
 export FC=$(which gfortran)
 export CUDACXX=$(which nvcc)
 export CUDAHOSTCXX=${CXX}


### PR DESCRIPTION
Switch from Clang 12 to GCC 11 on Lassen (LLNL), due to [issues seen in PyTorch](https://github.com/pytorch/pytorch/issues/108934) and a [risk of general vectorization issues in Clang/LLVM for PPC64le in LLVM](https://github.com/pytorch/pytorch/issues/108934#issuecomment-1712934724) at this point.

Follow-up to #4278

attn @bzdjordje @joshualudwig8 

Also works around linker issues installing PyTorch https://github.com/pytorch/pytorch/issues/108984