### PR TITLE
RZ m=0 mode support for particle field diagnostics 

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -78,7 +78,7 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
                 const amrex::ParticleReal x = p.pos(0);
                 const amrex::Real lx = (x - plo[0]) * dxi[0];
                 ii = static_cast<int>(amrex::Math::floor(lx));
-#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_3D)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
                 const amrex::ParticleReal y = p.pos(1);
                 const amrex::Real ly = (y - plo[1]) * dxi[1];
                 jj = static_cast<int>(amrex::Math::floor(ly));

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -122,7 +122,7 @@ Diagnostics::BaseReadParameters ()
             "Diagnostics",
             "Particle field diagnostics will output the 0th mode only.",
             ablastr::warn_manager::WarnPriority::low
-        )
+        );
     }
 #endif
 

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -117,8 +117,8 @@ Diagnostics::BaseReadParameters ()
     }
 #ifdef WARPX_DIM_RZ
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        m_pfield_varnames.empty(),
-        "Input error: cannot use particle_fields_to_plot with RZ"
+        (WarpX::ncomps == 1),
+        "particle_fields_to_plot only work for m=0 RZ modes."
     );
 #endif
 
@@ -127,6 +127,9 @@ Diagnostics::BaseReadParameters ()
     std::string filter_parser_str;
     const amrex::ParmParse pp_diag_pfield(m_diag_name + ".particle_fields");
     for (const auto& var : m_pfield_varnames) {
+
+        amrex::Print() << var << std::endl;
+
         bool do_average = true;
         pp_diag_pfield.query((var + ".do_average").c_str(), do_average);
         m_pfield_do_average.push_back(do_average);
@@ -164,6 +167,9 @@ Diagnostics::BaseReadParameters ()
         // Loop over all species
         for (int i = 0, n = int(m_all_species_names.size()); i < n; i++) {
             if (species == m_all_species_names[i]) {
+
+                amrex::Print() << i << std::endl;
+
                 // Store species index: will be used in ParticleReductionFunctor to calculate
                 // averages for this species
                 m_pfield_species_index.push_back(i);
@@ -186,6 +192,9 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
+
+            amrex::Print() << fname << sname << std::endl;
+
             auto varname = fname;
             varname.append("_").append(sname);
             m_varnames.push_back(varname);
@@ -246,6 +255,10 @@ Diagnostics::BaseReadParameters ()
     const bool species_specified =
         pp_diag_name.queryarr("species", m_output_species_names);
 
+    amrex::Print() << "printing out all vars" << std::endl;
+    for (const auto& var : m_varnames) {
+        amrex::Print() << var << " ";
+    }
 
     // Loop over all fields stored in m_varnames
     for (const auto& var : m_varnames) {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -115,11 +115,15 @@ Diagnostics::BaseReadParameters ()
     if (!pfield_varnames_specified){
         m_pfield_varnames = {};
     }
+
 #ifdef WARPX_DIM_RZ
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        (WarpX::ncomps == 1),
-        "particle_fields_to_plot only work for m=0 RZ modes."
-    );
+    if (pfield_varnames_specified){
+        ablastr::warn_manager::WMRecordWarning(
+            "Diagnostics",
+            "Particle field diagnostics will output the 0th mode only.",
+            ablastr::warn_manager::WarnPriority::low
+        )
+    }
 #endif
 
     // Get parser strings for particle fields and generate map of parsers

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -128,8 +128,6 @@ Diagnostics::BaseReadParameters ()
     const amrex::ParmParse pp_diag_pfield(m_diag_name + ".particle_fields");
     for (const auto& var : m_pfield_varnames) {
 
-        amrex::Print() << var << std::endl;
-
         bool do_average = true;
         pp_diag_pfield.query((var + ".do_average").c_str(), do_average);
         m_pfield_do_average.push_back(do_average);
@@ -167,9 +165,6 @@ Diagnostics::BaseReadParameters ()
         // Loop over all species
         for (int i = 0, n = int(m_all_species_names.size()); i < n; i++) {
             if (species == m_all_species_names[i]) {
-
-                amrex::Print() << i << std::endl;
-
                 // Store species index: will be used in ParticleReductionFunctor to calculate
                 // averages for this species
                 m_pfield_species_index.push_back(i);
@@ -192,9 +187,6 @@ Diagnostics::BaseReadParameters ()
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {
-
-            amrex::Print() << fname << sname << std::endl;
-
             auto varname = fname;
             varname.append("_").append(sname);
             m_varnames.push_back(varname);
@@ -255,10 +247,6 @@ Diagnostics::BaseReadParameters ()
     const bool species_specified =
         pp_diag_name.queryarr("species", m_output_species_names);
 
-    amrex::Print() << "printing out all vars" << std::endl;
-    for (const auto& var : m_varnames) {
-        amrex::Print() << var << " ";
-    }
 
     // Loop over all fields stored in m_varnames
     for (const auto& var : m_varnames) {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -187,9 +187,6 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     const int ncomp = ncomp_multimodefab;
     // This function is called multiple times, for different values of `lev`
     // but the `varnames` need only be updated once.
-    for (const auto& var : m_varnames) {
-        amrex::Print() << var << " ";
-    }
 
     const bool update_varnames = (lev==0);
     if (update_varnames) {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -329,6 +329,8 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
         }
     }
 
+    // Generate field functors for every particle field diagnostic for every species in m_pfield_species.
+    // The names of the diagnostics are output in the `[varname]_[species]` format.
     for (int pcomp=0; pcomp<int(m_pfield_varnames.size()); pcomp++) {
         for (int ispec=0; ispec<int(m_pfield_species.size()); ispec++) {
             m_all_field_functors[lev][nvar + pcomp * nspec + ispec] = std::make_unique<ParticleReductionFunctor>(nullptr,

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -187,7 +187,6 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     const int ncomp = ncomp_multimodefab;
     // This function is called multiple times, for different values of `lev`
     // but the `varnames` need only be updated once.
-    amrex::Print() << "printing out all vars Full Diagnostic" << std::endl;
     for (const auto& var : m_varnames) {
         amrex::Print() << var << " ";
     }
@@ -339,10 +338,7 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
                     lev, m_crse_ratio, m_pfield_strings[pcomp], m_pfield_species_index[ispec], m_pfield_do_average[pcomp],
                     m_pfield_dofilter[pcomp], m_pfield_filter_strings[pcomp]);
             if (update_varnames) {
-                AddRZModesToOutputNames(std::string(m_pfield_varnames[pcomp]) + std::to_string(m_pfield_species_index[ispec]), ncomp);
-                // amrex::Print() << "varname " << m_pfield_varnames[pcomp] << std::endl;
-                // amrex::Print() << "string " << m_pfield_strings[pcomp] << std::endl;
-                // amrex::Print() << "m_varnames.size() " << m_varnames.size() << std::endl;
+                AddRZModesToOutputNames(std::string(m_pfield_varnames[pcomp]) + "_" + std::string(m_pfield_species[ispec]), ncomp);
             }
         }
     }
@@ -354,8 +350,6 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     for (int jj=0; jj<m_all_field_functors[0].size(); jj++){
         ncomp_from_src += m_all_field_functors[lev][jj]->nComp();
     }
-    // amrex::Print() << std::endl << "ncomp_from_src " << ncomp_from_src << std::endl;
-    // amrex::Print() << "m_varnames.size() " << m_varnames.size() << std::endl;
 
     AMREX_ALWAYS_ASSERT( ncomp_from_src == m_varnames.size() );
 #else

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -187,6 +187,11 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     const int ncomp = ncomp_multimodefab;
     // This function is called multiple times, for different values of `lev`
     // but the `varnames` need only be updated once.
+    amrex::Print() << "printing out all vars Full Diagnostic" << std::endl;
+    for (const auto& var : m_varnames) {
+        amrex::Print() << var << " ";
+    }
+
     const bool update_varnames = (lev==0);
     if (update_varnames) {
         m_varnames.clear();
@@ -194,9 +199,14 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
         m_varnames.reserve(n_rz);
     }
 
-    // Reser field functors
+    // Add functors for average particle data for each species
+    const auto nvar = static_cast<int>(m_varnames_fields.size());
+    const auto nspec = static_cast<int>(m_pfield_species.size());
+    const auto ntot = static_cast<int>(nvar + m_pfield_varnames.size() * nspec);
+
+    // Reset field functors
     m_all_field_functors[lev].clear();
-    m_all_field_functors[lev].resize(m_varnames_fields.size());
+    m_all_field_functors[lev].resize(ntot);
 
     // Boolean flag for whether the current density should be deposited before
     // diagnostic output
@@ -322,6 +332,21 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
                 "Error: " + m_varnames_fields[comp] + " is not a known field output type in RZ geometry");
         }
     }
+
+    for (int pcomp=0; pcomp<int(m_pfield_varnames.size()); pcomp++) {
+        for (int ispec=0; ispec<int(m_pfield_species.size()); ispec++) {
+            m_all_field_functors[lev][nvar + pcomp * nspec + ispec] = std::make_unique<ParticleReductionFunctor>(nullptr,
+                    lev, m_crse_ratio, m_pfield_strings[pcomp], m_pfield_species_index[ispec], m_pfield_do_average[pcomp],
+                    m_pfield_dofilter[pcomp], m_pfield_filter_strings[pcomp]);
+            if (update_varnames) {
+                AddRZModesToOutputNames(std::string(m_pfield_varnames[pcomp]) + std::to_string(m_pfield_species_index[ispec]), ncomp);
+                // amrex::Print() << "varname " << m_pfield_varnames[pcomp] << std::endl;
+                // amrex::Print() << "string " << m_pfield_strings[pcomp] << std::endl;
+                // amrex::Print() << "m_varnames.size() " << m_varnames.size() << std::endl;
+            }
+        }
+    }
+
     // Sum the number of components in input vector m_all_field_functors
     // and check that it corresponds to the number of components in m_varnames
     // and m_mf_output
@@ -329,6 +354,9 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     for (int jj=0; jj<m_all_field_functors[0].size(); jj++){
         ncomp_from_src += m_all_field_functors[lev][jj]->nComp();
     }
+    // amrex::Print() << std::endl << "ncomp_from_src " << ncomp_from_src << std::endl;
+    // amrex::Print() << "m_varnames.size() " << m_varnames.size() << std::endl;
+
     AMREX_ALWAYS_ASSERT( ncomp_from_src == m_varnames.size() );
 #else
     amrex::ignore_unused(lev);


### PR DESCRIPTION
Hi all,

This PR adds support for particle field diagnostics for m=0 RZ simulations. 

I intended for the names of the diagnostics to match with what openPMD-viewer expects so that different direction components (r, theta, and z) custom field diagnostics can be specified and OpenPMD-viewer would automatically treat it them as a components of a single vector field.