### PR TITLE
Refinement patch parser

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -284,6 +284,13 @@ Setting up the field mesh
     This patch is rectangular, and thus its extent is given here by the coordinates
     of the lower corner (``warpx.fine_tag_lo``) and upper corner (``warpx.fine_tag_hi``).
 
+* ``warpx.ref_patch_function(x,y,z)`` (`string`) optional
+    A function of `x`, `y`, `z` that defines the extent of the refined patch when
+    using static mesh refinement with ``amr.max_level``>0. Note that the function can be used
+    to define distinct regions for refinement, however, the refined regions should be such that
+    the pml layer surrounding the patches should not overlap. For this reason, when defining
+    distinct patches, please ensure that they are sufficiently separated.
+
 * ``warpx.refine_plasma`` (`integer`) optional (default `0`)
     Increase the number of macro-particles that are injected "ahead" of a mesh
     refinement patch in a moving window simulation.

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -47,10 +47,10 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
                                        (k+0.5_rt)*dx[2]+problo[2])};
 #if defined (WARPX_DIM_3D)
             amrex::Real tag_val = ref_parser(pos[0], pos[1], pos[2]);
-#elif defined (WARPX_DIM_XZ)
+#elif defined (WARPX_DIM_XZ) || defined (WARPX_DIM_RZ)
             amrex::Real unused = 0.0;
             amrex::Real tag_val = ref_parser(pos[0], unused, pos[1]);
-#elif defined (WARPX_DIM_1D)
+#elif defined (WARPX_DIM_1D_Z)
             amrex::Real unused = 0.0;
             amrex::Real tag_val = ref_parser(unused, unused, pos[0]);
 #endif

--- a/Source/Utils/WarpXTagging.cpp
+++ b/Source/Utils/WarpXTagging.cpp
@@ -31,8 +31,10 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
     const auto problo = Geom(lev).ProbLoArray();
     const auto dx = Geom(lev).CellSizeArray();
 
-    amrex::ParserExecutor<3> const& ref_parser = ref_patch_parser->compile<3>();
-
+    amrex::ParserExecutor<3> ref_parser;
+    if (ref_patch_parser) ref_parser = ref_patch_parser->compile<3>();
+    const auto ftlo = fine_tag_lo;
+    const auto fthi = fine_tag_hi;
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -45,15 +47,20 @@ WarpX::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
             const RealVect pos {AMREX_D_DECL((i+0.5_rt)*dx[0]+problo[0],
                                        (j+0.5_rt)*dx[1]+problo[1],
                                        (k+0.5_rt)*dx[2]+problo[2])};
+            bool tag_val = 0;
+            if (ref_parser) {
 #if defined (WARPX_DIM_3D)
-            amrex::Real tag_val = ref_parser(pos[0], pos[1], pos[2]);
+                tag_val = (ref_parser(pos[0], pos[1], pos[2]) == 1);
 #elif defined (WARPX_DIM_XZ) || defined (WARPX_DIM_RZ)
-            amrex::Real unused = 0.0;
-            amrex::Real tag_val = ref_parser(pos[0], unused, pos[1]);
+                amrex::Real unused = 0.0;
+                tag_val = (ref_parser(pos[0], unused, pos[1]) == 1);
 #elif defined (WARPX_DIM_1D_Z)
-            amrex::Real unused = 0.0;
-            amrex::Real tag_val = ref_parser(unused, unused, pos[0]);
+                amrex::Real unused = 0.0;
+                tag_val = (ref_parser(unused, unused, pos[0]) == 1);
 #endif
+            } else {
+                tag_val = (pos > ftlo && pos < fthi);
+            }
             if ( tag_val == 1) {
                 fab(i,j,k) = TagBox::SET;
             }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1615,6 +1615,8 @@ private:
 
     amrex::RealVect fine_tag_lo;
     amrex::RealVect fine_tag_hi;
+    //! User-defined parser to define refinement patches
+    std::unique_ptr<amrex::Parser> ref_patch_parser;
 
     bool is_synchronized = true;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1016,8 +1016,8 @@ WarpX::ReadParameters ()
 
             if ( (fine_tag_lo_specified && fine_tag_hi_specified) && parser_specified) {
                ablastr::warn_manager::WMRecordWarning("Refined patch", "Both fine_tag_lo,fine_tag_hi\
-                   and ref_patch_function(x,y,z) are provided. Note that the ref_patch_function will\
-                   override the fine_tag_lo/fine_tag_hi definition for the refined patches");
+                   and ref_patch_function(x,y,z) are provided. Note that fine_tag_lo/fine_tag_hi will\
+                   override the ref_patch_function(x,y,z) for defining the refinement patches");
             }
             if (fine_tag_lo_specified && fine_tag_hi_specified) {
                 fine_tag_lo = RealVect{lo};

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1008,12 +1008,17 @@ WarpX::ReadParameters ()
             bool fine_tag_hi_specified = utils::parser::queryArrWithParser(pp_warpx, "fine_tag_hi", hi);
             std::string ref_patch_function;
             bool parser_specified = pp_warpx.query("ref_patch_function(x,y,z)",ref_patch_function);
-            const std::string error_string = std::string( "For max_level > 0, you need to either set\
-                                             warpx.fine_tag_lo and warpx.fine_tag_hi\
-                                             or warpx.ref_patch_function(x,y,z)");
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ((fine_tag_lo_specified && fine_tag_hi_specified) ||
                                                 parser_specified ),
-                                                error_string);
+                                                "For max_level > 0, you need to either set\
+                                                warpx.fine_tag_lo and warpx.fine_tag_hi\
+                                                or warpx.ref_patch_function(x,y,z)");
+
+            if ( (fine_tag_lo_specified && fine_tag_hi_specified) && parser_specified) {
+               ablastr::warn_manager::WMRecordWarning("Refined patch", "Both fine_tag_lo,fine_tag_hi\
+                   and ref_patch_function(x,y,z) are provided. Note that the ref_patch_function will\
+                   override the fine_tag_lo/fine_tag_hi definition for the refined patches");
+            }
             if (fine_tag_lo_specified && fine_tag_hi_specified) {
                 fine_tag_lo = RealVect{lo};
                 fine_tag_hi = RealVect{hi};

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1017,34 +1017,11 @@ WarpX::ReadParameters ()
             if (fine_tag_lo_specified && fine_tag_hi_specified) {
                 fine_tag_lo = RealVect{lo};
                 fine_tag_hi = RealVect{hi};
-#if defined (WARPX_DIM_3D)
-                ref_patch_function =   " ( x > " + std::to_string(fine_tag_lo[0]) + " ) "
-                                   + " * ( x < " + std::to_string(fine_tag_hi[0]) + " )"
-                                   + " * ( y > " + std::to_string(fine_tag_lo[1]) + " )"
-                                   + " * ( y < " + std::to_string(fine_tag_hi[1]) + " )"
-                                   + " * ( z > " + std::to_string(fine_tag_lo[2]) + " )"
-                                   + " * ( z < " + std::to_string(fine_tag_hi[2]) + " )";
-#elif defined (WARPX_DIM_RZ)
-                ref_patch_function =   " ( x > " + std::to_string(fine_tag_lo[0]) + " ) "
-                                   + " * ( x < " + std::to_string(fine_tag_hi[0]) + " )"
-                                   + " * ( z > " + std::to_string(fine_tag_lo[1]) + " )"
-                                   + " * ( z < " + std::to_string(fine_tag_hi[1]) + " )";
-#elif defined (WARPX_DIM_XZ)
-                ref_patch_function =   " ( x > " + std::to_string(fine_tag_lo[0]) + " ) "
-                                   + " * ( x < " + std::to_string(fine_tag_hi[0]) + " )"
-                                   + " * ( z > " + std::to_string(fine_tag_lo[1]) + " )"
-                                   + " * ( z < " + std::to_string(fine_tag_hi[1]) + " )";
-#elif defined (WARPX_DIM_1D_Z)
-                ref_patch_function =   " ( z > " + std::to_string(fine_tag_lo[0]) + " ) "
-                                   + " * ( z < " + std::to_string(fine_tag_hi[0]) + " )";
-#endif
-                amrex::Print() << " ref patch func " << ref_patch_function << "\n";
             } else {
-                utils::parser::Store_parserString(pp_warpx, "ref_patch_function(x,y,z)",
-                    ref_patch_function);
+                utils::parser::Store_parserString(pp_warpx, "ref_patch_function(x,y,z)", ref_patch_function);
+                ref_patch_parser = std::make_unique<amrex::Parser>(
+                    utils::parser::makeParser(ref_patch_function,{"x","y","z"}));
             }
-            ref_patch_parser = std::make_unique<amrex::Parser>(
-                utils::parser::makeParser(ref_patch_function,{"x","y","z"}));
         }
 
         pp_warpx.query("do_dynamic_scheduling", do_dynamic_scheduling);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1034,7 +1034,7 @@ WarpX::ReadParameters ()
                                    + " * ( x < " + std::to_string(fine_tag_hi[0]) + " )"
                                    + " * ( z > " + std::to_string(fine_tag_lo[1]) + " )"
                                    + " * ( z < " + std::to_string(fine_tag_hi[1]) + " )";
-#elif defined (WARPX_DIM_1D)
+#elif defined (WARPX_DIM_1D_Z)
                 ref_patch_function =   " ( z > " + std::to_string(fine_tag_lo[0]) + " ) "
                                    + " * ( z < " + std::to_string(fine_tag_hi[0]) + " )";
 #endif


### PR DESCRIPTION
This PR adds a parser to define refinement patches. 
Thanks to @WeiqunZhang for the offline discussions

Input using `fine_tag_lo` and `fine_tag_hi` : 
[inputs_3d_mr.txt](https://github.com/ECP-WarpX/WarpX/files/12600471/inputs_3d_mr.txt)

results in : 
![using_finetaglo_tag_hi](https://github.com/ECP-WarpX/WarpX/assets/41089244/22230038-0348-43e6-95b3-94d9a927752c)

The same result can be obtained when using 
`warpx.ref_patch_function(x,y,z) = (x >-9.e-6) * (x < 9.e-6) * (y > -9.e-6) * (y < 9.e-6) * (z > -9.e-6) * (z < 9.e-6)`

![using_function](https://github.com/ECP-WarpX/WarpX/assets/41089244/d5f68703-f1ba-4592-95c1-7c873fb399fc)

Additionally, the parser can be used to define distinct patches : 
input : 
[inputs_3d_mr.txt](https://github.com/ECP-WarpX/WarpX/files/12600506/inputs_3d_mr.txt)


![using_function_distinct_patches](https://github.com/ECP-WarpX/WarpX/assets/41089244/e9ca69a5-baa0-454c-b7b3-d2624f81b80f)
