### PR TITLE
Change default behavior of picmi.FieldDiagnostic and picmi.ParticleDiagnostic & fix CI tests

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -11,7 +11,7 @@ docutils>=0.17.1
 
 # PICMI API docs
 # note: keep in sync with version in ../requirements.txt
-picmistandard==0.26.0
+picmistandard==0.28.0
 # for development against an unreleased PICMI version, use:
 # picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -324,6 +324,12 @@ class CapacitiveDischargeExample(object):
         else:
             file_prefix = 'Python_background_mcc_1d_tridiag_plt'
 
+        particle_diag = picmi.ParticleDiagnostic(
+            name='diag1',
+            period=0,
+            write_dir='.',
+            warpx_file_prefix=file_prefix
+        )
         field_diag = picmi.FieldDiagnostic(
             name='diag1',
             grid=self.grid,
@@ -332,6 +338,7 @@ class CapacitiveDischargeExample(object):
             write_dir='.',
             warpx_file_prefix=file_prefix
         )
+        self.sim.add_diagnostic(particle_diag)
         self.sim.add_diagnostic(field_diag)
 
     def _get_rho_ions(self):

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -312,6 +312,12 @@ solver = PoissonSolverPseudo1D(grid=grid)
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = diagnostic_intervals,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_background_mcc_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -345,6 +351,7 @@ sim.add_species(
     )
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_1d.py
@@ -79,6 +79,11 @@ solver = picmi.ElectromagneticSolver(
 
 # Diagnostics
 diag_field_list = ['B', 'E', 'J', 'rho']
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 100,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_LaserAcceleration_1d_plt')
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -108,6 +113,7 @@ sim.add_laser(
     injection_method = laser_antenna)
 
 # Add diagnostics
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 # Write input file that can be used to run with the compiled version

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_2d.py
@@ -112,6 +112,11 @@ solver = picmi.ElectromagneticSolver(
 
 # Diagnostics
 diag_field_list = ['B', 'E', 'J', 'rho']
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 200,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_LaserAccelerationMR_plt')
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -145,6 +150,7 @@ sim.add_laser(
     injection_method = laser_antenna)
 
 # Add diagnostics
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 # Write input file that can be used to run with the compiled version

--- a/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
+++ b/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
@@ -110,6 +110,11 @@ solver = picmi.ElectromagneticSolver(
 
 # Diagnostics
 diag_field_list = ['B', 'E', 'J', 'rho']
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 100,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_LaserAcceleration_plt')
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -144,6 +149,7 @@ sim.add_laser(
     injection_method = laser_antenna)
 
 # Add diagnostics
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 # Write input file that can be used to run with the compiled version

--- a/Examples/Tests/LoadExternalField/PICMI_inputs_3d.py
+++ b/Examples/Tests/LoadExternalField/PICMI_inputs_3d.py
@@ -90,6 +90,8 @@ solver = picmi.ElectrostaticSolver(grid=grid)
 particle_diag = picmi.ParticleDiagnostic(
         name='diag1',
         period=300,
+        species=[ions],
+        data_list = ['ux', 'uy', 'uz', 'x', 'y', 'z', 'weighting'],
         write_dir='.',
         warpx_file_prefix='Python_LoadExternalField3D_plt'
         )
@@ -97,6 +99,7 @@ field_diag = picmi.FieldDiagnostic(
         name='diag1',
         grid=grid,
         period=300,
+        data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
         write_dir='.',
         warpx_file_prefix='Python_LoadExternalField3D_plt'
         )
@@ -126,8 +129,8 @@ sim.add_species(
             )
         )
 
-sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
+sim.add_diagnostic(particle_diag)
 
 #################################
 ##### SIMULATION EXECUTION ######

--- a/Examples/Tests/LoadExternalField/PICMI_inputs_3d.py
+++ b/Examples/Tests/LoadExternalField/PICMI_inputs_3d.py
@@ -87,6 +87,12 @@ solver = picmi.ElectrostaticSolver(grid=grid)
 ######### DIAGNOSTICS ###########
 #################################
 
+particle_diag = picmi.ParticleDiagnostic(
+        name='diag1',
+        period=300,
+        write_dir='.',
+        warpx_file_prefix='Python_LoadExternalField3D_plt'
+        )
 field_diag = picmi.FieldDiagnostic(
         name='diag1',
         grid=grid,
@@ -120,6 +126,7 @@ sim.add_species(
             )
         )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 #################################

--- a/Examples/Tests/collision/PICMI_inputs_2d.py
+++ b/Examples/Tests/collision/PICMI_inputs_2d.py
@@ -106,6 +106,12 @@ solver = picmi.ElectromagneticSolver(grid=grid, cfl=cfl)
 ######### DIAGNOSTICS ###########
 #################################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name='diag1',
+    period=10,
+    write_dir='.',
+    warpx_file_prefix='Python_collisionXZ_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name='diag1',
     grid=grid,
@@ -140,6 +146,7 @@ sim.add_species(
     )
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 #################################

--- a/Examples/Tests/electrostatic_dirichlet_bc/PICMI_inputs_2d.py
+++ b/Examples/Tests/electrostatic_dirichlet_bc/PICMI_inputs_2d.py
@@ -58,6 +58,12 @@ solver = picmi.ElectrostaticSolver(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 4,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_dirichletbc_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -79,6 +85,7 @@ sim = picmi.Simulation(
     verbose = 0
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Tests/electrostatic_sphere_eb/PICMI_inputs_3d.py
+++ b/Examples/Tests/electrostatic_sphere_eb/PICMI_inputs_3d.py
@@ -70,6 +70,12 @@ embedded_boundary = picmi.EmbeddedBoundary(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 1,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_ElectrostaticSphereEB_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -102,6 +108,7 @@ sim = picmi.Simulation(
     warpx_field_gathering_algo='momentum-conserving'
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 sim.add_diagnostic(reduced_diag)
 sim.add_diagnostic(reduced_diag_one_eighth)

--- a/Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
+++ b/Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
@@ -58,6 +58,12 @@ embedded_boundary = picmi.EmbeddedBoundary(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 1,
+    write_dir = '.',
+    warpx_file_prefix = "embedded_boundary_python_API_plt"
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -78,6 +84,7 @@ sim = picmi.Simulation(
     verbose = 1
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 sim.initialize_inputs()

--- a/Examples/Tests/ionization/PICMI_inputs_2d.py
+++ b/Examples/Tests/ionization/PICMI_inputs_2d.py
@@ -87,12 +87,15 @@ solver = picmi.ElectromagneticSolver(
 particle_diag = picmi.ParticleDiagnostic(
     name = 'diag1',
     period = 10000,
+    species = [electrons, ions],
+    data_list = ['ux', 'uy', 'uz', 'x', 'y', 'weighting'],
     write_dir = '.',
     warpx_file_prefix = 'Python_ionization_plt')
-diag = picmi.FieldDiagnostic(
+field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
     period = 10000,
+    data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
     write_dir = '.',
     warpx_file_prefix = 'Python_ionization_plt')
 
@@ -121,7 +124,7 @@ sim.add_laser(
 
 # Add diagnostics
 sim.add_diagnostic(particle_diag)
-sim.add_diagnostic(diag)
+sim.add_diagnostic(field_diag)
 
 # Write input file that can be used to run with the compiled version
 sim.write_input_file(file_name = 'inputs_2d_picmi')

--- a/Examples/Tests/ionization/PICMI_inputs_2d.py
+++ b/Examples/Tests/ionization/PICMI_inputs_2d.py
@@ -84,6 +84,11 @@ solver = picmi.ElectromagneticSolver(
     cfl = 0.999)
 
 # Diagnostics
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 10000,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_ionization_plt')
 diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -115,6 +120,7 @@ sim.add_laser(
     injection_method = laser_antenna)
 
 # Add diagnostics
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(diag)
 
 # Write input file that can be used to run with the compiled version

--- a/Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
+++ b/Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
@@ -113,6 +113,12 @@ beam_layout = picmi.GriddedLayout(n_macroparticle_per_cell=[2,2,2], grid=grid)
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 1,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_magnetostatic_eb_3d_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -140,6 +146,7 @@ sim = picmi.Simulation(
 
 sim.add_species(beam, layout=beam_layout, initialize_self_field=True)
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
+++ b/Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
@@ -110,6 +110,12 @@ beam_layout = picmi.GriddedLayout(n_macroparticle_per_cell=[2,2,2], grid=grid)
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 1,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_magnetostatic_eb_rz_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -137,6 +143,7 @@ sim = picmi.Simulation(
 
 sim.add_species(beam, layout=beam_layout, initialize_self_field=True)
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
@@ -256,6 +256,15 @@ class EMModes(object):
             self.output_file_name = 'perp_field_data.txt'
 
         if self.test:
+            particle_diag = picmi.ParticleDiagnostic(
+                name='field_diag',
+                period=self.total_steps,
+                write_dir='.',
+                warpx_file_prefix='Python_ohms_law_solver_EM_modes_1d_plt',
+                # warpx_format = 'openpmd',
+                # warpx_openpmd_backend = 'h5'
+            )
+            simulation.add_diagnostic(particle_diag)
             field_diag = picmi.FieldDiagnostic(
                 name='field_diag',
                 grid=self.grid,

--- a/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
@@ -21,7 +21,10 @@ constants = picmi.constants
 
 comm = mpi.COMM_WORLD
 
-simulation = picmi.Simulation(verbose=0)
+simulation = picmi.Simulation(
+    warpx_serialize_initial_conditions=True,
+    verbose=0
+)
 # make a shorthand for simulation.extension since we use it a lot
 sim_ext = simulation.extension
 

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
@@ -216,6 +216,13 @@ class IonLandauDamping(object):
         callbacks.installafterstep(self.text_diag)
 
         if self.test:
+            particle_diag = picmi.ParticleDiagnostic(
+                name='field_diag',
+                period=100,
+                write_dir='.',
+                warpx_file_prefix=f'Python_ohms_law_solver_landau_damping_{self.dim}d_plt',
+            )
+            simulation.add_diagnostic(particle_diag)
             field_diag = picmi.FieldDiagnostic(
                 name='field_diag',
                 grid=self.grid,

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
@@ -20,7 +20,9 @@ constants = picmi.constants
 
 comm = mpi.COMM_WORLD
 
-simulation = picmi.Simulation(verbose=0)
+simulation = picmi.Simulation(
+    warpx_serialize_initial_conditions=True,
+    verbose=0)
 # make a shorthand for simulation.extension since we use it a lot
 sim_ext = simulation.extension
 
@@ -217,17 +219,20 @@ class IonLandauDamping(object):
 
         if self.test:
             particle_diag = picmi.ParticleDiagnostic(
-                name='field_diag',
+                name='diag1',
                 period=100,
                 write_dir='.',
+                species=[self.ions],
+                data_list = ['ux', 'uy', 'uz', 'x', 'y', 'weighting'],
                 warpx_file_prefix=f'Python_ohms_law_solver_landau_damping_{self.dim}d_plt',
             )
             simulation.add_diagnostic(particle_diag)
             field_diag = picmi.FieldDiagnostic(
-                name='field_diag',
+                name='diag1',
                 grid=self.grid,
                 period=100,
                 write_dir='.',
+                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
                 warpx_file_prefix=f'Python_ohms_law_solver_landau_damping_{self.dim}d_plt',
             )
             simulation.add_diagnostic(field_diag)

--- a/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
@@ -257,16 +257,19 @@ class HybridPICBeamInstability(object):
 
         if self.test:
             part_diag = picmi.ParticleDiagnostic(
-                name='field_diag',
+                name='diag1',
                 period=1250,
+                species=[self.ions, self.beam_ions],
+                data_list = ['ux', 'uy', 'uz', 'x', 'weighting'],
                 write_dir='.',
                 warpx_file_prefix='Python_ohms_law_solver_ion_beam_1d_plt',
             )
             simulation.add_diagnostic(part_diag)
             field_diag = picmi.FieldDiagnostic(
-                name='field_diag',
+                name='diag1',
                 grid=self.grid,
                 period=1250,
+                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'jx', 'jy', 'jz'],
                 write_dir='.',
                 warpx_file_prefix='Python_ohms_law_solver_ion_beam_1d_plt',
             )

--- a/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
@@ -256,6 +256,13 @@ class HybridPICBeamInstability(object):
         callbacks.installafterstep(self.text_diag)
 
         if self.test:
+            part_diag = picmi.ParticleDiagnostic(
+                name='field_diag',
+                period=1250,
+                write_dir='.',
+                warpx_file_prefix='Python_ohms_law_solver_ion_beam_1d_plt',
+            )
+            simulation.add_diagnostic(part_diag)
             field_diag = picmi.FieldDiagnostic(
                 name='field_diag',
                 grid=self.grid,

--- a/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
@@ -21,7 +21,9 @@ constants = picmi.constants
 
 comm = mpi.COMM_WORLD
 
-simulation = picmi.Simulation(verbose=0)
+simulation = picmi.Simulation(
+    warpx_serialize_initial_conditions=True,
+    verbose=0)
 # make a shorthand for simulation.extension since we use it a lot
 sim_ext = simulation.extension
 
@@ -269,7 +271,7 @@ class HybridPICBeamInstability(object):
                 name='diag1',
                 grid=self.grid,
                 period=1250,
-                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez'],
+                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
                 write_dir='.',
                 warpx_file_prefix='Python_ohms_law_solver_ion_beam_1d_plt',
             )

--- a/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
@@ -269,7 +269,7 @@ class HybridPICBeamInstability(object):
                 name='diag1',
                 grid=self.grid,
                 period=1250,
-                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'jx', 'jy', 'jz'],
+                data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez'],
                 write_dir='.',
                 warpx_file_prefix='Python_ohms_law_solver_ion_beam_1d_plt',
             )

--- a/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
@@ -22,7 +22,9 @@ constants = picmi.constants
 
 comm = mpi.COMM_WORLD
 
-simulation = picmi.Simulation(verbose=0)
+simulation = picmi.Simulation(
+    warpx_serialize_initial_conditions=True,
+    verbose=0)
 # make a shorthand for simulation.extension since we use it a lot
 sim_ext = simulation.extension
 
@@ -250,27 +252,28 @@ class ForceFreeSheetReconnection(object):
 
         if self.test:
             particle_diag = picmi.ParticleDiagnostic(
-                name='field_diag',
+                name='diag1',
                 period=self.total_steps,
                 write_dir='.',
+                species=[self.ions],
+                data_list=['ux', 'uy', 'uz', 'x', 'y', 'weighting'],
                 warpx_file_prefix='Python_ohms_law_solver_magnetic_reconnection_2d_plt',
                 # warpx_format='openpmd',
                 # warpx_openpmd_backend='h5',
-                warpx_write_species=True
             )
             simulation.add_diagnostic(particle_diag)
             field_diag = picmi.FieldDiagnostic(
-                name='field_diag',
+                name='diag1',
                 grid=self.grid,
                 period=self.total_steps,
-                data_list=['B', 'E', 'j'],
+                data_list=['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez'],
                 write_dir='.',
                 warpx_file_prefix='Python_ohms_law_solver_magnetic_reconnection_2d_plt',
                 # warpx_format='openpmd',
                 # warpx_openpmd_backend='h5',
-                warpx_write_species=True
             )
             simulation.add_diagnostic(field_diag)
+
 
         # reduced diagnostics for reconnection rate calculation
         # create a 2 l_i box around the X-point on which to measure

--- a/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
@@ -249,6 +249,16 @@ class ForceFreeSheetReconnection(object):
         callbacks.installafterEsolve(self.check_fields)
 
         if self.test:
+            particle_diag = picmi.ParticleDiagnostic(
+                name='field_diag',
+                period=self.total_steps,
+                write_dir='.',
+                warpx_file_prefix='Python_ohms_law_solver_magnetic_reconnection_2d_plt',
+                # warpx_format='openpmd',
+                # warpx_openpmd_backend='h5',
+                warpx_write_species=True
+            )
+            simulation.add_diagnostic(particle_diag)
             field_diag = picmi.FieldDiagnostic(
                 name='field_diag',
                 grid=self.grid,

--- a/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
+++ b/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
@@ -74,6 +74,13 @@ electrons = picmi.Species(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 10,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_particle_reflection_plt',
+    warpx_write_species=False
+)
 field_diag = picmi.FieldDiagnostic(
     grid=grid,
     name = 'diag1',
@@ -102,6 +109,7 @@ sim.add_species(
         n_macroparticle_per_cell=[5, 2], grid=grid
     )
 )
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
+++ b/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
@@ -78,8 +78,7 @@ particle_diag = picmi.ParticleDiagnostic(
     name = 'diag1',
     period = 10,
     write_dir = '.',
-    warpx_file_prefix = 'Python_particle_reflection_plt',
-    warpx_write_species=False
+    warpx_file_prefix = 'Python_particle_reflection_plt'
 )
 field_diag = picmi.FieldDiagnostic(
     grid=grid,
@@ -87,8 +86,7 @@ field_diag = picmi.FieldDiagnostic(
     data_list=['E'],
     period = 10,
     write_dir = '.',
-    warpx_file_prefix = 'Python_particle_reflection_plt',
-    warpx_write_species=False
+    warpx_file_prefix = 'Python_particle_reflection_plt'
 )
 
 ##########################

--- a/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
+++ b/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
@@ -73,6 +73,12 @@ embedded_boundary = picmi.EmbeddedBoundary(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = diagnostic_intervals,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_particle_scrape_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -102,6 +108,7 @@ sim.add_species(
     )
 )
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 ##########################

--- a/Examples/Tests/particle_data_python/PICMI_inputs_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_2d.py
@@ -70,6 +70,12 @@ electrons = picmi.Species(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 10,
+    write_dir = '.',
+    warpx_file_prefix = f"Python_particle_attr_access_{'unique_' if args.unique else ''}plt"
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -96,6 +102,7 @@ sim.add_species(
         n_macroparticle_per_cell=[0, 0], grid=grid
     )
 )
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 sim.initialize_inputs()

--- a/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
@@ -73,13 +73,20 @@ electrons = picmi.Species(
 
 part_diag = picmi.ParticleDiagnostic(
     name = 'diag1',
-    data_list=['previous_positions'],
+    data_list=['ux', 'uy', 'uz', 'x', 'y', 'prev_x', 'prev_z', 'weighting'],
     period = 10,
     species=[electrons],
     write_dir = '.',
     warpx_file_prefix = 'Python_prev_positions_plt'
 )
-
+field_diag = picmi.FieldDiagnostic(
+    name = 'diag1',
+    data_list=['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
+    period = 10,
+    grid=grid,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_prev_positions_plt'
+)
 ##########################
 # simulation setup
 ##########################
@@ -98,7 +105,7 @@ sim.add_species(
     )
 )
 sim.add_diagnostic(part_diag)
-
+sim.add_diagnostic(field_diag)
 ##########################
 # simulation run
 ##########################

--- a/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
@@ -71,11 +71,11 @@ electrons = picmi.Species(
 # diagnostics
 ##########################
 
-field_diag = picmi.ParticleDiagnostic(
-    species=electrons,
+part_diag = picmi.ParticleDiagnostic(
     name = 'diag1',
     data_list=['previous_positions'],
     period = 10,
+    species=[electrons],
     write_dir = '.',
     warpx_file_prefix = 'Python_prev_positions_plt'
 )
@@ -97,7 +97,7 @@ sim.add_species(
         n_macroparticle_per_cell=[1, 1], grid=grid
     )
 )
-sim.add_diagnostic(field_diag)
+sim.add_diagnostic(part_diag)
 
 ##########################
 # simulation run

--- a/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
@@ -73,7 +73,6 @@ electrons = picmi.Species(
 
 part_diag = picmi.ParticleDiagnostic(
     name = 'diag1',
-    data_list=['ux', 'uy', 'uz', 'x', 'y', 'prev_x', 'prev_z', 'weighting'],
     period = 10,
     species=[electrons],
     write_dir = '.',

--- a/Examples/Tests/plasma_lens/PICMI_inputs_3d.py
+++ b/Examples/Tests/plasma_lens/PICMI_inputs_3d.py
@@ -61,10 +61,16 @@ solver = picmi.ElectromagneticSolver(grid = grid,
 part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
                                       period = max_steps,
                                       species = [electrons],
-                                      data_list = ['ux', 'uy', 'uz'],
+                                      data_list = ['ux', 'uy', 'uz', 'x', 'y', 'z'],
                                       write_dir = '.',
                                       warpx_file_prefix = 'Python_plasma_lens_plt')
 
+field_diag1 = picmi.FieldDiagnostic(name = 'diag1',
+                                   grid = grid,
+                                   period = max_steps,
+                                   data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
+                                   write_dir = '.',
+                                   warpx_file_prefix = 'Python_plasma_lens_plt')
 # Set up simulation
 sim = picmi.Simulation(solver = solver,
                        max_steps = max_steps,
@@ -81,6 +87,7 @@ sim.add_applied_field(plasma_lenses)
 
 # Add diagnostics
 sim.add_diagnostic(part_diag1)
+sim.add_diagnostic(field_diag1)
 
 # Write input file that can be used to run with the compiled version
 #sim.write_input_file(file_name = 'inputs_3d_picmi')

--- a/Examples/Tests/python_wrappers/PICMI_inputs_2d.py
+++ b/Examples/Tests/python_wrappers/PICMI_inputs_2d.py
@@ -62,6 +62,11 @@ solver = picmi.ElectromagneticSolver(grid=grid, cfl=0.95, method='PSATD',
 
 # Initialize diagnostics
 diag_field_list = ["E", "B"]
+particle_diag = picmi.ParticleDiagnostic(name = 'diag1',
+                                   period = 10,
+                                   write_dir = '.',
+                                   warpx_file_prefix = 'Python_wrappers_plt',
+                                   data_list = diag_field_list)
 field_diag = picmi.FieldDiagnostic(name = 'diag1',
                                    grid = grid,
                                    period = 10,
@@ -80,6 +85,7 @@ sim = picmi.Simulation(solver = solver,
                        warpx_use_filter = 1)
 
 # Add diagnostics to simulation
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 
 # Write input file to run with compiled version

--- a/Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
+++ b/Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
@@ -79,13 +79,18 @@ reduced_diags.append(picmi.ReducedDiagnostic(
 
 # Diagnostic
 particle_diag = picmi.ParticleDiagnostic(
+    name='diag1',
     period=3,
+    species=[electrons],
+    data_list = ['ux', 'uy', 'uz', 'x', 'y', 'z', 'weighting'],
     write_dir='.',
     warpx_file_prefix='Python_reduced_diags_loadbalancecosts_timers_plt'
 )
-diag = picmi.FieldDiagnostic(
+field_diag = picmi.FieldDiagnostic(
+    name='diag1',
     grid=grid,
     period=3,
+    data_list = ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Jx', 'Jy', 'Jz'],
     write_dir='.',
     warpx_file_prefix='Python_reduced_diags_loadbalancecosts_timers_plt'
 )
@@ -110,7 +115,7 @@ for reduced_diag in reduced_diags:
 
 # Add diagnostics
 sim.add_diagnostic(particle_diag)
-sim.add_diagnostic(diag)
+sim.add_diagnostic(field_diag)
 
 # Advance simulation until last time step
 # sim.write_input_file("test_input")

--- a/Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
+++ b/Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
@@ -78,6 +78,11 @@ reduced_diags.append(picmi.ReducedDiagnostic(
 ))
 
 # Diagnostic
+particle_diag = picmi.ParticleDiagnostic(
+    period=3,
+    write_dir='.',
+    warpx_file_prefix='Python_reduced_diags_loadbalancecosts_timers_plt'
+)
 diag = picmi.FieldDiagnostic(
     grid=grid,
     period=3,
@@ -104,6 +109,7 @@ for reduced_diag in reduced_diags:
     sim.add_diagnostic(reduced_diag)
 
 # Add diagnostics
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(diag)
 
 # Advance simulation until last time step

--- a/Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
+++ b/Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
@@ -62,6 +62,12 @@ electrons = picmi.Species(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 10,
+    write_dir = '.',
+    warpx_file_prefix = f'Python_restart_runtime_components_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -103,6 +109,7 @@ for arg in sys.argv:
         sim.amr_restart = restart_file_name
         sys.argv.remove(arg)
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 sim.add_diagnostic(checkpoint)
 sim.initialize_inputs()

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -63,6 +63,12 @@ electrons = picmi.Species(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = 10,
+    write_dir = '.',
+    warpx_file_prefix = f'Python_restart_runtime_components_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -104,6 +110,7 @@ for arg in sys.argv:
         sim.amr_restart = restart_file_name
         sys.argv.remove(arg)
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 sim.add_diagnostic(checkpoint)
 sim.initialize_inputs()

--- a/Examples/Tests/restart_eb/PICMI_inputs_restart_eb.py
+++ b/Examples/Tests/restart_eb/PICMI_inputs_restart_eb.py
@@ -73,6 +73,12 @@ embedded_boundary = picmi.EmbeddedBoundary(
 # diagnostics
 ##########################
 
+particle_diag = picmi.ParticleDiagnostic(
+    name = 'diag1',
+    period = diagnostic_intervals,
+    write_dir = '.',
+    warpx_file_prefix = 'Python_restart_eb_plt'
+)
 field_diag = picmi.FieldDiagnostic(
     name = 'diag1',
     grid = grid,
@@ -116,6 +122,7 @@ for arg in sys.argv:
         sim.amr_restart = restart_file_name
         sys.argv.remove(arg)
 
+sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
 sim.add_diagnostic(checkpoint)
 sim.initialize_inputs()

--- a/Python/pywarpx/Diagnostics.py
+++ b/Python/pywarpx/Diagnostics.py
@@ -26,3 +26,12 @@ class Diagnostic(Bucket):
 
     def __setattr__(self, name, value):
         self.add_new_attr_with_check(name, value)
+
+    def set_or_replace_attr(self, name, value):
+        """
+        Explicitly set or replace an existing attribute
+        (since __setattr__ cannot be used for replacing
+        as it would raise an Exception)
+        """
+        assert not name.startswith('_')
+        self.argvattrs[name] = value

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -59,7 +59,7 @@ setup(name = 'pywarpx',
       package_dir = {'pywarpx': 'pywarpx'},
       description = """Wrapper of WarpX""",
       package_data = package_data,
-      install_requires = ['numpy', 'picmistandard==0.26.0', 'periodictable'],
+      install_requires = ['numpy', 'picmistandard==0.28.0', 'periodictable'],
       python_requires = '>=3.8',
       zip_safe=False
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ periodictable~=1.5
 
 # PICMI
 # note: don't forget to update the version in Docs/requirements.txt, too
-picmistandard==0.26.0
+picmistandard==0.28.0
 #   for development against an unreleased PICMI version, use:
 #picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 


### PR DESCRIPTION
This PR fixes couples of Python CI tests in PR #3745. Close #3745

Description of the initial PR #3745 by @RemiLehe: 

Right now, with picmi.FieldDiagnostic and picmi.LabFrameFieldDiagnostic, the default is to write all particle species (along with the fields). This is probably not what the user expects (note that there is a separate class -- picmi.ParticleDiagnostic -- to be used when writing particles). In addition, this default behavior could be computationally costly, if there is a large number of particles in the simulation.

Similar, with picmi.ParticleDiagnostic, the default is to write all fields, which is again probably not what the user expects.

This PR changes the default behavior, so that species are not written by default for picmi.FieldDiagnostic, and fields are not written by default for picmi.ParticleDiagnostic. It also removes the parameter warpx_write_species, since the user can use picmi.ParticleDiagnostic instead.

- [ ] update affected tests