### PR TITLE
Fix distribution map initialization for particle buffers in BTD

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1450,8 +1450,9 @@ BTDiagnostics::PrepareParticleDataForOutput()
             {
                 // Check if the zslice is in domain
                 const bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
-                if (ZSliceInDomain) {
-                    if ( m_totalParticles_in_buffer[i_buffer][i] == 0) {
+                const bool kindexInSnapshotBox = GetKIndexInSnapshotBoxFlag (i_buffer, lev);
+                if (kindexInSnapshotBox) {
+                    if ( buffer_empty(i_buffer) ) {
                         if (!m_do_back_transformed_fields || m_varnames_fields.empty()) {
                             if ( m_buffer_flush_counter[i_buffer] == 0) {
                                 DefineSnapshotGeometry(i_buffer, lev);


### PR DESCRIPTION
 Particle buffers are now initialized when the buffer is empty and when the k-index of the buffer is within the snapshot box, similar to the times when the field buffer is initialized.

In the current dev branch, the particle buffers are initialized everytime the number of particles in the buffer is 0. And this could lead to performance decrease as observed in the BTD simulations, where, the number of calls to the distribution mapping constructor was very high. 