### PR TITLE
[WIP] Fix bug in clang-tidy configuration file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,10 @@
 Checks: '-*,
-    bugprone-*
+    bugprone-*,
         -bugprone-easily-swappable-parameters,
         -bugprone-implicit-widening-of-multiplication-result,
         -bugprone-misplaced-widening-cast,
         -bugprone-unchecked-optional-access,
-    cert-*
+    cert-*,
         -cert-err58-cpp,
     cppcoreguidelines-avoid-goto,
     cppcoreguidelines-interfaces-global-init,

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -110,7 +110,7 @@ struct LatticeElementFinder
             [=] AMREX_GPU_DEVICE (int iz) {
 
                 // Get the location of the grid node
-                amrex::Real z_node = zmin + iz*dz;
+                amrex::Real z_node = zmin + static_cast<amrex::Real>(iz)*dz;
 
                 if (gamma_boost > 1._prt) {
                     // Transform to lab frame

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -877,8 +877,9 @@ PML::MakeBoxArray_single (const amrex::Box& regular_domain, const amrex::BoxArra
                           const amrex::IntVect& do_pml_Hi)
 {
     BoxList bl;
-    for (int i = 0, N = grid_ba.size(); i < N; ++i) {
-        Box const& b = grid_ba[i];
+    const auto grid_ba_size = static_cast<int>(grid_ba.size());
+    for (int i = 0; i < grid_ba_size; ++i) {
+        const auto& b = grid_ba[i];
         for (OrientationIter oit; oit.isValid(); ++oit) {
             // In 3d, a Box has 6 faces.  This iterates over the 6 faces.
             // 3 of them are on the lower side and the others are on the
@@ -926,9 +927,10 @@ PML::MakeBoxArray_multiple (const amrex::Geometry& geom, const amrex::BoxArray& 
         }
     }
     BoxList bl;
-    for (int i = 0, N = grid_ba.size(); i < N; ++i)
+    const auto grid_ba_size = static_cast<int>(grid_ba.size());
+    for (int i = 0; i < grid_ba_size; ++i)
     {
-        const Box& grid_bx = grid_ba[i];
+        const auto& grid_bx = grid_ba[i];
         const IntVect& grid_bx_sz = grid_bx.size();
 
         if (do_pml_in_domain == 0) {

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -96,7 +96,7 @@ PML_RZ::ApplyDamping (amrex::MultiFab* Et_fp, amrex::MultiFab* Ez_fp,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int icomp)
             {
                 const amrex::Real rr = static_cast<amrex::Real>(i - nr_damp_min);
-                const amrex::Real wr = rr/nr_damp;
+                const amrex::Real wr = rr/ static_cast<amrex::Real>(nr_damp);
                 const amrex::Real damp_factor = std::exp( -4._rt * cdt_over_dr * wr*wr );
 
                 // Substract the theta PML fields from the regular theta fields

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -163,7 +163,7 @@ void BTDiagnostics::DerivedInitData ()
     // j >= i / gamma / (1+beta) * dt_snapshot / dt_boosted_frame
     const int final_snapshot_starting_step = static_cast<int>(std::ceil(final_snapshot_iteration / WarpX::gamma_boost / (1._rt+WarpX::beta_boost) * m_dt_snapshots_lab / dt_boosted_frame));
     const int final_snapshot_fill_iteration = final_snapshot_starting_step + num_buffers * m_buffer_size - 1;
-    const amrex::Real final_snapshot_fill_time = final_snapshot_fill_iteration * dt_boosted_frame;
+    const amrex::Real final_snapshot_fill_time = static_cast<amrex::Real>(final_snapshot_fill_iteration) * dt_boosted_frame;
     if (WarpX::compute_max_step_from_btd) {
         if (final_snapshot_fill_iteration > warpx.maxStep()) {
             warpx.updateMaxStep(final_snapshot_fill_iteration);
@@ -392,9 +392,9 @@ BTDiagnostics::InitializeBufferData ( int i_buffer , int lev, bool restart)
     // from the coarsenable, cell-centered BoxArray, ba.
     for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
-            diag_ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
+            static_cast<amrex::Real>(diag_ba.getCellCenteredBox(0).smallEnd(idim)) * warpx.Geom(lev).CellSize(idim));
         diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-            (diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+            static_cast<amrex::Real>(diag_ba.getCellCenteredBox( diag_ba.size()-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
     }
 
     // Define buffer_domain in lab-frame for the i^th snapshot.

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -105,7 +105,7 @@ BoundaryScrapingDiagnostics::InitializeParticleBuffer ()
     // Initialize total number of particles flushed
     m_totalParticles_flushed_already.resize(m_num_buffers);
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
-        int const n_species = m_output_species_names.size();
+        int const n_species = static_cast<int>(m_output_species_names.size());
         m_totalParticles_flushed_already[i_buffer].resize(n_species);
         for (int i_species=0; i_species<n_species; i_species++) {
             m_totalParticles_flushed_already[i_buffer][i_species] = 0;

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -465,8 +465,9 @@ Diagnostics::InitBaseData ()
     if (WarpX::do_moving_window) {
         const int moving_dir = WarpX::moving_window_dir;
         const int shift_num_base = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
-        m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
-        m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+        const auto shift = static_cast<amrex::Real>(shift_num_base)*warpx.Geom(0).CellSize(moving_dir);
+        m_lo[moving_dir] += shift;
+        m_hi[moving_dir] += shift;
     }
     // Construct Flush class.
     if        (m_format == "plotfile"){

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -782,8 +782,8 @@ FullDiagnostics::MovingWindowAndGalileanDomainShift (int step)
             new_lo[idim] = cur_lo[idim];
             new_hi[idim] = cur_hi[idim];
         }
-        new_lo[moving_dir] = cur_lo[moving_dir] + num_shift_base*geom_dx[moving_dir];
-        new_hi[moving_dir] = cur_hi[moving_dir] + num_shift_base*geom_dx[moving_dir];
+        new_lo[moving_dir] = cur_lo[moving_dir] + static_cast<amrex::Real>(num_shift_base)*geom_dx[moving_dir];
+        new_hi[moving_dir] = cur_hi[moving_dir] + static_cast<amrex::Real>(num_shift_base)*geom_dx[moving_dir];
         // Update RealBox of geometry with shifted domain geometry for moving-window
         for (int lev = 0; lev < nmax_lev; ++lev) {
             // Note that Full diagnostics has only one snapshot, m_num_buffers = 1

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -541,9 +541,9 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
         // from the coarsenable, cell-centered BoxArray, ba.
         for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
-                ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
+                static_cast<amrex::Real>(ba.getCellCenteredBox(0).smallEnd(idim)) * warpx.Geom(lev).CellSize(idim));
             diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-                (ba.getCellCenteredBox( static_cast<int>(ba.size())-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+                static_cast<amrex::Real>(ba.getCellCenteredBox( static_cast<int>(ba.size())-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
         }
     }
 

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -95,11 +95,10 @@ RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
     PhysicalParticleContainer::WriteHeader( os );
 
     // Write quantities that are specific to the rigid-injected species
-    const int nlevs = zinject_plane_levels.size();
-    os << nlevs << "\n";
-    for (int i = 0; i < nlevs; ++i)
+    os << zinject_plane_levels.size() << "\n";
+    for (const auto& el : zinject_plane_levels)
     {
-        os << zinject_plane_levels[i] << "\n";
+        os << el << "\n";
     }
     os << vzbeam_ave_boosted << "\n";
 }

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -634,7 +634,7 @@ void FieldProbe::WriteToFile (int step) const
     long int first_id = static_cast<long int>(m_data_out[0]);
     for (long int i = 0; i < m_valid_particles; i++)
     {
-        if (m_data_out[i*noutputs] < first_id)
+        if (static_cast<long int>(m_data_out[i*noutputs]) < first_id)
             first_id = static_cast<long int>(m_data_out[i*noutputs]);
     }
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -252,9 +252,9 @@ void FieldProbe::InitData ()
 
             // Final - initial / steps. Array contains dx, dy, dz
             const amrex::Real DetLineStepSize[3]{
-                    (x1_probe - x_probe) / (m_resolution - 1),
-                    (y1_probe - y_probe) / (m_resolution - 1),
-                    (z1_probe - z_probe) / (m_resolution - 1)};
+                    (x1_probe - x_probe) / static_cast<amrex::Real>(m_resolution - 1),
+                    (y1_probe - y_probe) / static_cast<amrex::Real>(m_resolution - 1),
+                    (z1_probe - z_probe) / static_cast<amrex::Real>(m_resolution - 1)};
             for ( int step = 0; step < m_resolution; step++)
             {
                 xpos.push_back(x_probe + (DetLineStepSize[0] * step));
@@ -300,13 +300,13 @@ void FieldProbe::InitData ()
 
             // create array containing point-to-point step size
             const amrex::Real SideStepSize[3]{
-                (loweropposite[0] - lowercorner[0]) / (m_resolution - 1),
-                (loweropposite[1] - lowercorner[1]) / (m_resolution - 1),
-                (loweropposite[2] - lowercorner[2]) / (m_resolution - 1)};
+                (loweropposite[0] - lowercorner[0]) / static_cast<amrex::Real>(m_resolution - 1),
+                (loweropposite[1] - lowercorner[1]) / static_cast<amrex::Real>(m_resolution - 1),
+                (loweropposite[2] - lowercorner[2]) / static_cast<amrex::Real>(m_resolution - 1)};
             const amrex::Real UpStepSize[3]{
-                (uppercorner[0] - lowercorner[0]) / (m_resolution - 1),
-                (uppercorner[1] - lowercorner[1]) / (m_resolution - 1),
-                (uppercorner[2] - lowercorner[2]) / (m_resolution - 1)};
+                (uppercorner[0] - lowercorner[0]) / static_cast<amrex::Real>(m_resolution - 1),
+                (uppercorner[1] - lowercorner[1]) / static_cast<amrex::Real>(m_resolution - 1),
+                (uppercorner[2] - lowercorner[2]) / static_cast<amrex::Real>(m_resolution - 1)};
 
             amrex::Real temp_pos[3]{};
             // Starting at the lowercorner point, step sideways and up to form
@@ -556,7 +556,7 @@ void FieldProbe::ComputeDiags (int step)
                         amrex::ParticleReal xp, yp, zp;
                         getPosition(ip, xp, yp, zp);
                         long idx = ip*noutputs;
-                        dvp[idx++] = m_structs[ip].id();
+                        dvp[idx++] = static_cast<amrex::Real>(m_structs[ip].id());
                         dvp[idx++] = xp;
                         dvp[idx++] = yp;
                         dvp[idx++] = zp;

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -174,15 +174,15 @@ public:
 #if defined(WARPX_DIM_1D_Z)
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
-                const amrex::Real z = (k + 0.5_rt)*dx[0] + real_box.lo(0);
+                const amrex::Real z = (static_cast<amrex::Real>(k) + 0.5_rt)*dx[0] + real_box.lo(0);
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const amrex::Real x = (i + 0.5_rt)*dx[0] + real_box.lo(0);
+                const amrex::Real x = (static_cast<amrex::Real>(i) + 0.5_rt)*dx[0] + real_box.lo(0);
                 const amrex::Real y = 0._rt;
-                const amrex::Real z = (j + 0.5_rt)*dx[1] + real_box.lo(1);
+                const amrex::Real z = (static_cast<amrex::Real>(j) + 0.5_rt)*dx[1] + real_box.lo(1);
 #else
-                const amrex::Real x = (i + 0.5_rt)*dx[0] + real_box.lo(0);
-                const amrex::Real y = (j + 0.5_rt)*dx[1] + real_box.lo(1);
-                const amrex::Real z = (k + 0.5_rt)*dx[2] + real_box.lo(2);
+                const amrex::Real x = (static_cast<amrex::Real>(i) + 0.5_rt)*dx[0] + real_box.lo(0);
+                const amrex::Real y = (static_cast<amrex::Real>(j) + 0.5_rt)*dx[1] + real_box.lo(1);
+                const amrex::Real z = (static_cast<amrex::Real>(k) + 0.5_rt)*dx[2] + real_box.lo(2);
 #endif
                 const amrex::Real Ex_interp = ablastr::coarsen::sample::Interp(arrEx, Extype, cellCenteredtype,
                                                                                reduction_coarsening_ratio, i, j, k, reduction_comp);

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -132,7 +132,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
             const Box& tbx = mfi.tilebox();
             m_data[shift_m_data + mfi.index()*m_nDataFields + 0] = (*costs[lev])[mfi.index()];
             m_data[shift_m_data + mfi.index()*m_nDataFields + 1] = dm[mfi.index()];
-            m_data[shift_m_data + mfi.index()*m_nDataFields + 2] = lev;
+            m_data[shift_m_data + mfi.index()*m_nDataFields + 2] = static_cast<amrex::Real>(lev);
             m_data[shift_m_data + mfi.index()*m_nDataFields + 3] = tbx.loVect()[0];
 #if (AMREX_SPACEDIM >= 2)
             m_data[shift_m_data + mfi.index()*m_nDataFields + 4] = tbx.loVect()[1];
@@ -367,7 +367,11 @@ void LoadBalanceCosts::WriteToFile (int step) const
         ofstmp.close();
 
         // remove the original, rename tmp file
-        std::remove(fileDataName.c_str());
-        std::rename(fileTmpName.c_str(), fileDataName.c_str());
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            std::remove(fileDataName.c_str()) == EXIT_SUCCESS,
+            "Failed to remove " + fileDataName);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            std::rename(fileTmpName.c_str(), fileDataName.c_str()) == EXIT_SUCCESS,
+            "Failed to rename " + fileTmpName + " to " + fileDataName);
     }
 }

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -145,7 +145,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
             m_data[shift_m_data + mfi.index()*m_nDataFields + 5] = 0.;
 #endif
             m_data[shift_m_data + mfi.index()*m_nDataFields + 6] = tbx.d_numPts(); // note: difference to volume
-            m_data[shift_m_data + mfi.index()*m_nDataFields + 7] = countBoxMacroParticles(mfi, lev);
+            m_data[shift_m_data + mfi.index()*m_nDataFields + 7] = static_cast<amrex::Real>(countBoxMacroParticles(mfi, lev));
 #ifdef AMREX_USE_GPU
             m_data[shift_m_data + mfi.index()*m_nDataFields + 8] = amrex::Gpu::Device::deviceId();
 #endif
@@ -158,7 +158,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
 
     // parallel reduce to IO proc and get data over all procs
     ParallelDescriptor::ReduceRealSum(m_data.data(),
-                                      m_data.size(),
+                                      static_cast<int>(m_data.size()),
                                       ParallelDescriptor::IOProcessorNumber());
 
 #ifdef AMREX_USE_MPI

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -219,7 +219,7 @@ void ParticleHistogram::ComputeDiags (int step)
 
                     // don't count a particle if it is filtered out
                     if (do_parser_filter)
-                        if (!fun_filterparser(t, x, y, z, ux, uy, uz))
+                        if (fun_filterparser(t, x, y, z, ux, uy, uz) <= 0.0)
                             return;
                     // continue function if particle is not filtered out
                     auto const f = fun_partparser(t, x, y, z, ux, uy, uz);

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -133,7 +133,7 @@ void RhoMaximum::ComputeDiags (int step)
     // get number of levels
     const auto nLevel = warpx.finestLevel() + 1;
 
-    const int n_charged_species = m_rho_functors[0].size() - 1;
+    const int n_charged_species = static_cast<int>(m_rho_functors[0].size() - 1);
     // Min and max of total rho + max of |rho| for each species
     const int noutputs_per_level = 2+n_charged_species;
 

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -376,7 +376,7 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
                 // If modified index.hi is > baselinebox.hi, move the point  //
                 // to the previous coarsenable point                         //
                 const auto small_number = 0.01;
-                if ( (hi_new * dom_geom[0].CellSize(idim))
+                if ( (static_cast<amrex::Real>(hi_new) * dom_geom[0].CellSize(idim))
                       > real_box.hi(idim) - real_box.lo(idim) + dom_geom[0].CellSize(idim)*small_number)
                 {
                    hi_new = index_hi - mod_hi;
@@ -401,9 +401,9 @@ CheckSliceInput( const RealBox real_box, RealBox &slice_cc_nd_box,
                 slice_lo[idim] = index_lo;
                 slice_hi[idim] = index_hi - 1; // since default is cell-centered
             }
-            slice_realbox.setLo( idim, index_lo * dom_geom[0].CellSize(idim)
+            slice_realbox.setLo( idim, static_cast<amrex::Real>(index_lo) * dom_geom[0].CellSize(idim)
                                  + real_box.lo(idim) );
-            slice_realbox.setHi( idim, index_hi * dom_geom[0].CellSize(idim)
+            slice_realbox.setHi( idim, static_cast<amrex::Real>(index_hi) * dom_geom[0].CellSize(idim)
                                  + real_box.lo(idim) );
             slice_cc_nd_box.setLo( idim, slice_realbox.lo(idim) + Real(fac) );
             slice_cc_nd_box.setHi( idim, slice_realbox.hi(idim) - Real(fac) );
@@ -449,8 +449,8 @@ InterpolateLo(const Box& bx, FArrayBox &fabox, IntVect slice_lo,
     const auto hi = amrex::ubound(bx);
     const double fac = ( 1.0-IndType[idir] )*geom[0].CellSize(idir) * 0.5;
     const int imin = slice_lo[idir];
-    const double minpos = imin*geom[0].CellSize(idir) + fac + real_box.lo(idir);
-    const double maxpos = (imin+1)*geom[0].CellSize(idir) + fac + real_box.lo(idir);
+    const double minpos = static_cast<amrex::Real>(imin)*geom[0].CellSize(idir) + fac + real_box.lo(idir);
+    const double maxpos = static_cast<amrex::Real>(imin+1)*geom[0].CellSize(idir) + fac + real_box.lo(idir);
     const double slice_minpos = slice_realbox.lo(idir) ;
 
     switch (idir) {

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -69,7 +69,7 @@ namespace detail
     snakeToCamel (const std::string& snake_string)
     {
         std::string camelString = snake_string;
-        const int n = camelString.length();
+        const auto n = static_cast<int>(camelString.length());
         for (int x = 0; x < n; x++)
         {
             if (x == 0)
@@ -783,7 +783,9 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
                         [](uint64_t const *p) { delete[] p; }
                 );
                 for (auto i = 0; i < numParticleOnTile; i++) {
-                    ids.get()[i] = ablastr::particles::localIDtoGlobal(aos[i].id(), aos[i].cpu());
+                    ids.get()[i] = ablastr::particles::localIDtoGlobal(
+                        static_cast<int>(aos[i].id()),
+                        static_cast<int>(aos[i].cpu()));
                 }
                 auto const scalar = openPMD::RecordComponent::SCALAR;
                 currSpecies["id"][scalar].storeChunk(ids, {offset}, {numParticleOnTile64});
@@ -1148,11 +1150,11 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
       fieldBoundary.resize(AMREX_SPACEDIM * 2);
       particleBoundary.resize(AMREX_SPACEDIM * 2);
 
-      for (auto i = 0u; i < fieldBoundary.size() / 2u; ++i)
+      for (int i = 0; i < static_cast<int>(fieldBoundary.size()) / 2; ++i)
           if (m_fieldPMLdirections.at(i))
               fieldBoundary.at(i) = "open";
 
-      for (auto i = 0u; i < fieldBoundary.size() / 2u; ++i)
+      for (int i = 0; i < static_cast<int>(fieldBoundary.size()) / 2; ++i)
           if (period.isPeriodic(i)) {
               fieldBoundary.at(2u * i) = "periodic";
               fieldBoundary.at(2u * i + 1u) = "periodic";

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1540,7 +1540,7 @@ WarpXParticleCounter::GetParticleOffsetOfProcessor (
     amrex::ParallelGather::Gather (numParticles, result.data(), -1, amrex::ParallelDescriptor::Communicator());
 
     sum = 0;
-    int const num_results = result.size();
+    int const num_results = static_cast<int>(result.size());
     for (int i=0; i<num_results; i++) {
         sum += result[i];
         if (i<m_MPIRank)

--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -373,14 +373,14 @@ ComputeNBorrowEightFacesExtension(const amrex::Dim3 cell, const amrex::Real S_ex
         }
     }
 
-    amrex::Real denom = local_avail(0, 1) * GetNeigh(S, i, j, k, -1, 0, idim) +
-                        local_avail(2, 1) * GetNeigh(S, i, j, k, 1, 0, idim) +
-                        local_avail(1, 0) * GetNeigh(S, i, j, k, 0, -1, idim) +
-                        local_avail(1, 2) * GetNeigh(S, i, j, k, 0, 1, idim) +
-                        local_avail(0, 0) * GetNeigh(S, i, j, k, -1, -1, idim) +
-                        local_avail(2, 0) * GetNeigh(S, i, j, k, 1, -1, idim) +
-                        local_avail(0, 2) * GetNeigh(S, i, j, k, -1, 1, idim) +
-                        local_avail(2, 2) * GetNeigh(S, i, j, k, 1, 1, idim);
+    amrex::Real denom = static_cast<amrex::Real>(local_avail(0, 1)) * GetNeigh(S, i, j, k, -1, 0, idim) +
+                        static_cast<amrex::Real>(local_avail(2, 1)) * GetNeigh(S, i, j, k, 1, 0, idim) +
+                        static_cast<amrex::Real>(local_avail(1, 0)) * GetNeigh(S, i, j, k, 0, -1, idim) +
+                        static_cast<amrex::Real>(local_avail(1, 2)) * GetNeigh(S, i, j, k, 0, 1, idim) +
+                        static_cast<amrex::Real>(local_avail(0, 0)) * GetNeigh(S, i, j, k, -1, -1, idim) +
+                        static_cast<amrex::Real>(local_avail(2, 0)) * GetNeigh(S, i, j, k, 1, -1, idim) +
+                        static_cast<amrex::Real>(local_avail(0, 2)) * GetNeigh(S, i, j, k, -1, 1, idim) +
+                        static_cast<amrex::Real>(local_avail(2, 2)) * GetNeigh(S, i, j, k, 1, 1, idim);
 
     bool neg_face = true;
 
@@ -398,14 +398,14 @@ ComputeNBorrowEightFacesExtension(const amrex::Dim3 cell, const amrex::Real S_ex
             }
         }
 
-        denom = local_avail(0, 1) * GetNeigh(S, i, j, k, -1, 0, idim) +
-                local_avail(2, 1) * GetNeigh(S, i, j, k, 1, 0, idim) +
-                local_avail(1, 0) * GetNeigh(S, i, j, k, 0, -1, idim) +
-                local_avail(1, 2) * GetNeigh(S, i, j, k, 0, 1, idim) +
-                local_avail(0, 0) * GetNeigh(S, i, j, k, -1, -1, idim) +
-                local_avail(2, 0) * GetNeigh(S, i, j, k, 1, -1, idim) +
-                local_avail(0, 2) * GetNeigh(S, i, j, k, -1, 1, idim) +
-                local_avail(2, 2) * GetNeigh(S, i, j, k, 1, 1, idim);
+        denom = static_cast<amrex::Real>(local_avail(0, 1)) * GetNeigh(S, i, j, k, -1, 0, idim) +
+                static_cast<amrex::Real>(local_avail(2, 1)) * GetNeigh(S, i, j, k, 1, 0, idim) +
+                static_cast<amrex::Real>(local_avail(1, 0)) * GetNeigh(S, i, j, k, 0, -1, idim) +
+                static_cast<amrex::Real>(local_avail(1, 2)) * GetNeigh(S, i, j, k, 0, 1, idim) +
+                static_cast<amrex::Real>(local_avail(0, 0)) * GetNeigh(S, i, j, k, -1, -1, idim) +
+                static_cast<amrex::Real>(local_avail(2, 0)) * GetNeigh(S, i, j, k, 1, -1, idim) +
+                static_cast<amrex::Real>(local_avail(0, 2)) * GetNeigh(S, i, j, k, -1, 1, idim) +
+                static_cast<amrex::Real>(local_avail(2, 2)) * GetNeigh(S, i, j, k, 1, 1, idim);
     }
 
     // We count the number of entries in local_avail which are still True, this is the number of

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -156,7 +156,7 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
         amrex::ParallelFor(tdive,
 
             [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
-                Real const r = rmin + i*dr; // r on a nodal grid (F is nodal in r)
+                Real const r = rmin + static_cast<Real>(i)*dr; // r on a nodal grid (F is nodal in r)
                 if (r != 0) { // Off-axis, regular equations
                     divE(i, j, 0, 0) =
                           T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 0)

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -94,11 +94,11 @@ void FiniteDifferenceSolver::ComputeDivECartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tdive = mfi.tilebox(divEfield.ixType().toIntVect());
@@ -140,9 +140,9 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = m_stencil_coefs_r.size();
+        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract cylindrical specific parameters
         Real const dr = m_dr;

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -120,7 +120,7 @@ void FiniteDifferenceSolver::EvolveBCartesian (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Bx = Bfield[0]->array(mfi);
@@ -132,11 +132,11 @@ void FiniteDifferenceSolver::EvolveBCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tbx  = mfi.tilebox(Bfield[0]->ixType().toIntVect());
@@ -233,7 +233,7 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             // Extract field data for this grid/tile
@@ -385,7 +385,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Br = Bfield[0]->array(mfi);
@@ -397,9 +397,9 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = m_stencil_coefs_r.size();
+        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract cylindrical specific parameters
         Real const dr = m_dr;

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -195,7 +195,7 @@ void FiniteDifferenceSolver::EvolveBCartesian (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -356,7 +356,7 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -477,7 +477,7 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveBPML.cpp
@@ -98,11 +98,11 @@ void FiniteDifferenceSolver::EvolveBPMLCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tbx  = mfi.tilebox(Bfield[0]->ixType().ixType());

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -117,7 +117,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Ex = Efield[0]->array(mfi);
@@ -138,11 +138,11 @@ void FiniteDifferenceSolver::EvolveECartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
@@ -249,7 +249,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Er = Efield[0]->array(mfi);
@@ -264,9 +264,9 @@ void FiniteDifferenceSolver::EvolveECylindrical (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = m_stencil_coefs_r.size();
+        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract cylindrical specific parameters
         Real const dr = m_dr;

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -221,7 +221,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -423,7 +423,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     } // end of loop over grid/tiles

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
@@ -149,7 +149,7 @@ void FiniteDifferenceSolver::EvolveRhoCartesianECT (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
 #ifdef WARPX_DIM_XZ

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveECTRho.cpp
@@ -88,7 +88,7 @@ void FiniteDifferenceSolver::EvolveRhoCartesianECT (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers) {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto amrex::Real wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         amrex::Array4<amrex::Real> const &Ex = Efield[0]->array(mfi);

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -117,11 +117,11 @@ void FiniteDifferenceSolver::EvolveEPMLCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().ixType());

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -182,7 +182,7 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
         amrex::ParallelFor(tf,
 
             [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
-                Real const r = rmin + i*dr; // r on a nodal grid (F is nodal in r)
+                Real const r = rmin + static_cast<Real>(i)*dr; // r on a nodal grid (F is nodal in r)
                 if (r != 0) { // Off-axis, regular equations
                     F(i, j, 0, 0) += dt * (
                         - rho(i, j, 0, rho_shift) * inv_epsilon0

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -103,11 +103,11 @@ void FiniteDifferenceSolver::EvolveFCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tf  = mfi.tilebox(Ffield->ixType().toIntVect());
@@ -156,9 +156,9 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = m_stencil_coefs_r.size();
+        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract cylindrical specific parameters
         Real const dr = m_dr;

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveFPML.cpp
@@ -92,11 +92,11 @@ void FiniteDifferenceSolver::EvolveFPMLCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tf  = mfi.tilebox(Ffield->ixType().ixType());

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -176,7 +176,7 @@ struct ElectronPressure {
                                      amrex::Real const T0,
                                      amrex::Real const gamma,
                                      amrex::Real const rho) {
-        return n0 * T0 * pow((rho/PhysConst::q_e)/n0, gamma);
+        return n0 * T0 * std::pow((rho/PhysConst::q_e)/n0, gamma);
     }
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -179,7 +179,7 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCartesian (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -365,7 +365,7 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -497,7 +497,7 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -98,7 +98,7 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCartesian (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Jx = Jfield[0]->array(mfi);
@@ -116,11 +116,11 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tjx  = mfi.tilebox(Jfield[0]->ixType().toIntVect());
@@ -316,7 +316,7 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         Array4<Real> const& enE_nodal = enE_nodal_mf.array(mfi);
         Array4<Real const> const& Jx = Jfield[0]->const_array(mfi);
@@ -380,7 +380,7 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
         Array4<Real> const& Ex = Efield[0]->array(mfi);
@@ -401,11 +401,11 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
         Box const& tey  = mfi.tilebox(Efield[1]->ixType().toIntVect());

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -152,11 +152,11 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        int const n_coefs_x = m_stencil_coefs_x.size();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        int const n_coefs_y = m_stencil_coefs_y.size();
+        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        int const n_coefs_z = m_stencil_coefs_z.size();
+        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // This functor computes Hx = Bx/mu
         // Note that mu is cell-centered here and will be interpolated/averaged

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -416,7 +416,7 @@ SpectralFieldData::BackwardTransform (const int lev,
             const amrex::Array4<amrex::Real> mf_arr = mf[mfi].array();
             const amrex::Array4<const amrex::Real> tmp_arr = tmpRealField[mfi].array();
 
-            const amrex::Real inv_N = 1._rt / tmpRealField[mfi].box().numPts();
+            const amrex::Real inv_N = 1._rt / static_cast<amrex::Real>(tmpRealField[mfi].box().numPts());
 
             // Total number of cells, including ghost cells (nj represents ny in 3D and nz in 2D)
             const int ni = mf_box.length(0);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -193,7 +193,7 @@ SpectralFieldData::SpectralFieldData( const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -309,7 +309,7 @@ SpectralFieldData::ForwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -470,7 +470,7 @@ SpectralFieldData::BackwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldData.cpp
@@ -173,7 +173,7 @@ SpectralFieldData::SpectralFieldData( const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Note: the size of the real-space box and spectral-space box
         // differ when using real-to-complex FFT. When initializing
@@ -242,7 +242,7 @@ SpectralFieldData::ForwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Copy the real-space field `mf` to the temporary field `tmpRealField`
         // This ensures that all fields have the same number of points
@@ -367,7 +367,7 @@ SpectralFieldData::BackwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Copy the spectral-space field `tmpSpectralField` to the appropriate
         // field (specified by the input argument field_index)

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -470,7 +470,7 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto amrex::Real wt = static_cast<amrex::Real>(amrex::second());
 
         // Perform the Hankel transform first.
         // tempHTransformedSplit includes the imaginary component of mode 0.
@@ -527,7 +527,7 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         amrex::Box const& realspace_bx = tempHTransformed[mfi].box();
 
@@ -589,7 +589,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         amrex::Box realspace_bx = tempHTransformed[mfi].box();
 
@@ -674,7 +674,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         amrex::Box realspace_bx = tempHTransformed[mfi].box();
 
@@ -773,7 +773,7 @@ SpectralFieldDataRZ::ApplyFilter (const int lev, int const field_index)
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         auto const & filter_r = binomialfilter[mfi].getFilterArrayR();
         auto const & filter_z = binomialfilter[mfi].getFilterArrayZ();
@@ -818,7 +818,7 @@ SpectralFieldDataRZ::ApplyFilter (const int lev, int const field_index1,
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         auto const & filter_r = binomialfilter[mfi].getFilterArrayR();
         auto const & filter_z = binomialfilter[mfi].getFilterArrayZ();

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -490,7 +490,7 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -556,7 +556,7 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -640,7 +640,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -736,7 +736,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -798,7 +798,7 @@ SpectralFieldDataRZ::ApplyFilter (const int lev, int const field_index)
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -847,7 +847,7 @@ SpectralFieldDataRZ::ApplyFilter (const int lev, int const field_index1,
         if (do_costs)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -239,10 +239,10 @@ SpectralKSpace::getModifiedKComponent( const DistributionMapping& dm,
                 for (int n=0; n<nstencil; n++){
                     if (grid_type == GridType::Collocated){
                         p_modified_k[i] += p_stencil_coef[n]*
-                            std::sin( p_k[i]*(n+1)*delta_x )/( (n+1)*delta_x );
+                            std::sin( p_k[i]*static_cast<Real>(n+1)*delta_x )/( static_cast<Real>(n+1)*delta_x );
                     } else {
                         p_modified_k[i] += p_stencil_coef[n]* \
-                            std::sin( p_k[i]*(n+0.5)*delta_x )/( (n+0.5)*delta_x );
+                            std::sin( p_k[i]*(static_cast<Real>(n)+0.5_rt)*delta_x )/( static_cast<Real>(static_cast<Real>(n)+0.5_rt)*delta_x );
                     }
                 }
 

--- a/Source/FieldSolver/WarpX_FDTD.H
+++ b/Source/FieldSolver/WarpX_FDTD.H
@@ -24,6 +24,9 @@ void warpx_computedivb(int i, int j, int k, int dcomp,
 #endif
                        )
 {
+
+    using namespace amrex;
+
 #if defined WARPX_DIM_3D
     divB(i,j,k,dcomp) = (Bx(i+1,j  ,k  ) - Bx(i,j,k))*dxinv
                +        (By(i  ,j+1,k  ) - By(i,j,k))*dyinv
@@ -37,8 +40,8 @@ void warpx_computedivb(int i, int j, int k, int dcomp,
     amrex::ignore_unused(j, Bx, dxinv);
     amrex::ignore_unused(k, By, dyinv);
 #elif defined WARPX_DIM_RZ
-    const amrex::Real ru = 1. + 0.5/(rmin*dxinv + i + 0.5);
-    const amrex::Real rd = 1. - 0.5/(rmin*dxinv + i + 0.5);
+    const amrex::Real ru = 1._rt + 0.5_rt/(rmin*dxinv + i + 0.5_rt);
+    const amrex::Real rd = 1._rt - 0.5_rt/(rmin*dxinv + i + 0.5_rt);
     divB(i,j,0,dcomp) = (ru*Bx(i+1,j,0) - rd*Bx(i,j,0))*dxinv
                        + (Bz(i,j+1,0) - Bz(i,j,0))*dzinv;
     amrex::ignore_unused(k, By, dyinv);

--- a/Source/FieldSolver/WarpX_FDTD.H
+++ b/Source/FieldSolver/WarpX_FDTD.H
@@ -40,8 +40,9 @@ void warpx_computedivb(int i, int j, int k, int dcomp,
     amrex::ignore_unused(j, Bx, dxinv);
     amrex::ignore_unused(k, By, dyinv);
 #elif defined WARPX_DIM_RZ
-    const amrex::Real ru = 1._rt + 0.5_rt/(rmin*dxinv + i + 0.5_rt);
-    const amrex::Real rd = 1._rt - 0.5_rt/(rmin*dxinv + i + 0.5_rt);
+    const auto rcc = 0.5_rt/(rmin*dxinv + static_cast<amrex::Real>(i) + 0.5_rt);
+    const amrex::Real ru = 1._rt + rcc;
+    const amrex::Real rd = 1._rt - rcc;
     divB(i,j,0,dcomp) = (ru*Bx(i+1,j,0) - rd*Bx(i,j,0))*dxinv
                        + (Bz(i,j+1,0) - Bz(i,j,0))*dzinv;
     amrex::ignore_unused(k, By, dyinv);

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -59,7 +59,7 @@ Filter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, const int lev, int
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -236,7 +236,7 @@ Filter::ApplyStencil (amrex::MultiFab& dstmf, const amrex::MultiFab& srcmf, cons
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
             }
         }

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -47,7 +47,7 @@ Filter::ApplyStencil (MultiFab& dstmf, const MultiFab& srcmf, const int lev, int
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         const auto& src = srcmf.array(mfi);
         const auto& dst = dstmf.array(mfi);
@@ -218,7 +218,7 @@ Filter::ApplyStencil (amrex::MultiFab& dstmf, const amrex::MultiFab& srcmf, cons
             {
                 amrex::Gpu::synchronize();
             }
-            amrex::Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             const auto& srcfab = srcmf[mfi];
             auto& dstfab = dstmf[mfi];

--- a/Source/Initialization/GetVelocity.H
+++ b/Source/Initialization/GetVelocity.H
@@ -57,11 +57,11 @@ struct GetVelocity
         {
             case (VelConstantValue):
             {
-                return m_sign_dir * m_velocity;
+                return static_cast<amrex::Real>(m_sign_dir) * m_velocity;
             }
             case (VelParserFunction):
             {
-                return m_sign_dir * m_velocity_parser(x,y,z);
+                return static_cast<amrex::Real>(m_sign_dir) * m_velocity_parser(x,y,z);
             }
             default:
             {

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -231,12 +231,14 @@ struct InjectorMomentumUniform
         : m_ux_min(a_ux_min), m_uy_min(a_uy_min), m_uz_min(a_uz_min),
           m_ux_max(a_ux_max), m_uy_max(a_uy_max), m_uz_max(a_uz_max)
         {
+            using namespace amrex;
+
             m_Dux = m_ux_max - m_ux_min;
             m_Duy = m_uy_max - m_uy_min;
             m_Duz = m_uz_max - m_uz_min;
-            m_ux_h = 0.5 * (m_ux_max + m_ux_min);
-            m_uy_h = 0.5 * (m_uy_max + m_uy_min);
-            m_uz_h = 0.5 * (m_uz_max + m_uz_min);
+            m_ux_h = 0.5_prt * (m_ux_max + m_ux_min);
+            m_uy_h = 0.5_prt * (m_uy_max + m_uy_min);
+            m_uz_h = 0.5_prt * (m_uz_max + m_uz_min);
         }
 
     AMREX_GPU_HOST_DEVICE

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1044,6 +1044,19 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
        amrex::ignore_unused(edge_lengths, face_areas, field);
 #endif
 
+
+#if defined(WARPX_DIM_1D_Z)
+        const auto fac_z = (x_nodal_flag[0] == 1) ? 0.0_rt : dx_lev[0] * 0.5_rt;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        const auto fac_x = (x_nodal_flag[0] == 1) ? 0.0_rt : dx_lev[0] * 0.5_rt;
+        const auto fac_z = (x_nodal_flag[1] == 1) ? 0.0_rt : dx_lev[1] * 0.5_rt;
+#else
+        const auto fac_x = (x_nodal_flag[0] == 1) ? 0.0_rt : dx_lev[0] * 0.5_rt;
+        const auto fac_y = (x_nodal_flag[1] == 1) ? 0.0_rt : dx_lev[1] * 0.5_rt;
+        const auto fac_z = (x_nodal_flag[2] == 1) ? 0.0_rt : dx_lev[1] * 0.5_rt;
+#endif
+
+
         amrex::ParallelFor (tbx, tby, tbz,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
@@ -1059,21 +1072,15 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
 #if defined(WARPX_DIM_1D_Z)
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = static_cast<amrex::Real>(j)*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real x = static_cast<amrex::Real>(i)*dx_lev[0] + real_box.lo(0) + fac_x;
                 const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
+                const amrex::Real z = static_cast<amrex::Real>(j)*dx_lev[1] + real_box.lo(1) + fac_z;
 #else
-                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real fac_y = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
-                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
+                const amrex::Real x = static_cast<amrex::Real>(i)*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real y = static_cast<amrex::Real>(j)*dx_lev[1] + real_box.lo(1) + fac_y;
+                const amrex::Real z = static_cast<amrex::Real>(k)*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the x-component of the field.
                 mfxfab(i,j,k) = xfield_parser(x,y,z);

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -58,11 +58,14 @@ void warpx_interp (int j, int k, int l,
     for         (int jj = 0; jj < nj; jj++) {
         for     (int kk = 0; kk < nk; kk++) {
             for (int ll = 0; ll < nl; ll++) {
-                const amrex::Real wj = static_cast<amrex::Real>(rj - std::abs(j + hj - (jc + jj + hj) * rj))
+                const amrex::Real wj = static_cast<amrex::Real>(
+                    rj - amrex::Math::abs(j + hj - (jc + jj + hj) * rj))
                     / static_cast<amrex::Real>(rj);
-                const amrex::Real wk = static_cast<amrex::Real>(rk - std::abs(k + hk - (kc + kk + hk) * rk))
+                const amrex::Real wk = static_cast<amrex::Real>(
+                    rk - amrex::Math::abs(k + hk - (kc + kk + hk) * rk))
                     / static_cast<amrex::Real>(rk);
-                const amrex::Real wl = static_cast<amrex::Real>(rl - std::abs(l + hl - (lc + ll + hl) * rl))
+                const amrex::Real wl = static_cast<amrex::Real>(
+                    rl - amrex::Math::abs(l + hl - (lc + ll + hl) * rl))
                     / static_cast<amrex::Real>(rl);
                 res += wj * wk * wl * arr_coarse_zeropad(jc+jj,kc+kk,lc+ll);
             }

--- a/Source/Parallelization/WarpXComm_K.H
+++ b/Source/Parallelization/WarpXComm_K.H
@@ -58,9 +58,12 @@ void warpx_interp (int j, int k, int l,
     for         (int jj = 0; jj < nj; jj++) {
         for     (int kk = 0; kk < nk; kk++) {
             for (int ll = 0; ll < nl; ll++) {
-                const amrex::Real wj = (rj - amrex::Math::abs(j + hj - (jc + jj + hj) * rj)) / static_cast<amrex::Real>(rj);
-                const amrex::Real wk = (rk - amrex::Math::abs(k + hk - (kc + kk + hk) * rk)) / static_cast<amrex::Real>(rk);
-                const amrex::Real wl = (rl - amrex::Math::abs(l + hl - (lc + ll + hl) * rl)) / static_cast<amrex::Real>(rl);
+                const amrex::Real wj = static_cast<amrex::Real>(rj - std::abs(j + hj - (jc + jj + hj) * rj))
+                    / static_cast<amrex::Real>(rj);
+                const amrex::Real wk = static_cast<amrex::Real>(rk - std::abs(k + hk - (kc + kk + hk) * rk))
+                    / static_cast<amrex::Real>(rk);
+                const amrex::Real wl = static_cast<amrex::Real>(rl - std::abs(l + hl - (lc + ll + hl) * rl))
+                    / static_cast<amrex::Real>(rl);
                 res += wj * wk * wl * arr_coarse_zeropad(jc+jj,kc+kk,lc+ll);
             }
         }

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -285,7 +285,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, amrex::Real dt, Mult
             {
                 amrex::Gpu::synchronize();
             }
-            amrex::Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             doBackgroundCollisionsWithinTile(pti, cur_time);
 
@@ -484,7 +484,7 @@ void BackgroundMCCCollision::doBackgroundIonization
         {
             amrex::Gpu::synchronize();
         }
-        amrex::Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         auto& elec_tile = species1.ParticlesAt(lev, pti);
         auto& ion_tile = species2.ParticlesAt(lev, pti);

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -292,7 +292,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, amrex::Real dt, Mult
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
             }
         }
@@ -508,7 +508,7 @@ void BackgroundMCCCollision::doBackgroundIonization
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
         }
     }

--- a/Source/Particles/Collision/BackgroundMCC/ImpactIonization.H
+++ b/Source/Particles/Collision/BackgroundMCC/ImpactIonization.H
@@ -177,7 +177,7 @@ public:
         // get references to the particle to get its position
         const auto& p = src.getSuperParticle(i_src);
         ParticleReal x, y, z;
-        double E_coll;
+        amrex::ParticleReal E_coll;
         get_particle_position(p, x, y, z);
 
         // calculate standard deviation in neutral velocity distribution using

--- a/Source/Particles/Collision/BackgroundMCC/MCCProcess.H
+++ b/Source/Particles/Collision/BackgroundMCC/MCCProcess.H
@@ -89,7 +89,7 @@ public:
                 const int idx_2 = static_cast<int>(ceil(temp));
 
                 // linearly interpolate to the given energy value
-                temp -= idx_1;
+                temp -= static_cast<amrex::ParticleReal>(idx_1);
                 return m_sigmas_data[idx_1] + (m_sigmas_data[idx_2] - m_sigmas_data[idx_1]) * temp;
             }
         }

--- a/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
+++ b/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
@@ -115,7 +115,7 @@ BackgroundStopping::doCollisions (amrex::Real cur_time, amrex::Real dt, MultiPar
             {
                 amrex::Gpu::synchronize();
             }
-            amrex::Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             if (background_type == BackgroundStoppingType::ELECTRONS) {
                 doBackgroundStoppingOnElectronsWithinTile(pti, dt, cur_time, species_mass, species_charge);

--- a/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
+++ b/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
@@ -126,7 +126,7 @@ BackgroundStopping::doCollisions (amrex::Real cur_time, amrex::Real dt, MultiPar
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add(&(*cost)[pti.index()], wt);
             }
         }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -182,7 +182,7 @@ public:
                 if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
                 {
                     amrex::Gpu::synchronize();
-                    wt = amrex::second() - wt;
+                    wt = static_cast<amrex::Real>(amrex::second()) - wt;
                     amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
                 }
             }
@@ -243,7 +243,7 @@ public:
             // Loop over cells, and collide the particles in each cell
 
             // Extract low-level data
-            int const n_cells = bins_1.numBins();
+            int const n_cells = static_cast<int>(bins_1.numBins());
             // - Species 1
             const auto soa_1 = ptile_1.getParticleTileData();
             index_type* AMREX_RESTRICT indices_1 = bins_1.permutationPtr();
@@ -383,7 +383,7 @@ public:
             // Loop over cells, and collide the particles in each cell
 
             // Extract low-level data
-            int const n_cells = bins_1.numBins();
+            int const n_cells = static_cast<int>(bins_1.numBins());
             // - Species 1
             const auto soa_1 = ptile_1.getParticleTileData();
             index_type* AMREX_RESTRICT indices_1 = bins_1.permutationPtr();

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -174,7 +174,7 @@ public:
                 {
                     amrex::Gpu::synchronize();
                 }
-                amrex::Real wt = amrex::second();
+                auto wt = static_cast<amrex::Real>(amrex::second());
 
                 doCollisionsWithinTile( dt, lev, mfi, species1, species2, product_species_vector,
                                          copy_species1_data, copy_species2_data);

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -110,7 +110,7 @@ namespace {
         // Factor 0.5 is here because each alpha only gets half of the decay energy
         constexpr amrex::ParticleReal gamma_Bestar = (1._prt + 0.5_prt*E_decay/(m_alpha*c_sq));
         constexpr amrex::ParticleReal gamma_Bestar_sq_minus_one = gamma_Bestar*gamma_Bestar - 1._prt;
-        const amrex::ParticleReal p_Bestar = m_alpha*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
+        const amrex::ParticleReal p_Bestar = static_cast<amrex::ParticleReal>(m_alpha)*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
 
         // Compute momentum of second alpha in Beryllium rest frame, assuming isotropic distribution
         amrex::ParticleReal px_Bestar, py_Bestar, pz_Bestar;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -97,20 +97,20 @@ namespace {
             soa_2.m_rdata[PIdx::ux][idx_2],
             soa_2.m_rdata[PIdx::uy][idx_2],
             soa_2.m_rdata[PIdx::uz][idx_2], m2,
-            ux_alpha1, uy_alpha1, uz_alpha1, m_alpha,
-            ux_Be, uy_Be, uz_Be, m_beryllium,
+            ux_alpha1, uy_alpha1, uz_alpha1, static_cast<amrex::ParticleReal>(m_alpha),
+            ux_Be, uy_Be, uz_Be, static_cast<amrex::ParticleReal>(m_beryllium),
             E_fusion, engine);
 
         // Compute momentum of beryllium in lab frame
-        const amrex::ParticleReal px_Be = m_beryllium * ux_Be;
-        const amrex::ParticleReal py_Be = m_beryllium * uy_Be;
-        const amrex::ParticleReal pz_Be = m_beryllium * uz_Be;
+        const amrex::ParticleReal px_Be = static_cast<amrex::ParticleReal>(m_beryllium) * ux_Be;
+        const amrex::ParticleReal py_Be = static_cast<amrex::ParticleReal>(m_beryllium) * uy_Be;
+        const amrex::ParticleReal pz_Be = static_cast<amrex::ParticleReal>(m_beryllium) * uz_Be;
 
         // Compute momentum norm of second and third alphas in Beryllium rest frame
         // Factor 0.5 is here because each alpha only gets half of the decay energy
-        constexpr amrex::ParticleReal gamma_Bestar = (1._prt + 0.5_prt*E_decay/(m_alpha*c_sq));
+        constexpr amrex::ParticleReal gamma_Bestar = (1._prt + 0.5_prt*E_decay/(static_cast<amrex::ParticleReal>(m_alpha)*c_sq));
         constexpr amrex::ParticleReal gamma_Bestar_sq_minus_one = gamma_Bestar*gamma_Bestar - 1._prt;
-        const amrex::ParticleReal p_Bestar = m_alpha*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
+        const amrex::ParticleReal p_Bestar = static_cast<amrex::ParticleReal>(m_alpha)*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
 
         // Compute momentum of second alpha in Beryllium rest frame, assuming isotropic distribution
         amrex::ParticleReal px_Bestar, py_Bestar, pz_Bestar;
@@ -120,8 +120,8 @@ namespace {
         amrex::ParticleReal px_alpha2, py_alpha2, pz_alpha2;
         // Preliminary calculation: compute Beryllium velocity v_Be
         const amrex::ParticleReal p_Be_sq   = px_Be*px_Be + py_Be*py_Be + pz_Be*pz_Be;
-        const amrex::ParticleReal g_Be      = std::sqrt(1._prt + p_Be_sq / (mBe_sq*c_sq));
-        const amrex::ParticleReal mg_Be     = m_beryllium*g_Be;
+        const amrex::ParticleReal g_Be      = std::sqrt(1._prt + p_Be_sq / (static_cast<amrex::ParticleReal>(mBe_sq)*c_sq));
+        const amrex::ParticleReal mg_Be     = static_cast<amrex::ParticleReal>(m_beryllium)*g_Be;
         const amrex::ParticleReal v_Bex     = px_Be / mg_Be;
         const amrex::ParticleReal v_Bey     = py_Be / mg_Be;
         const amrex::ParticleReal v_Bez     = pz_Be / mg_Be;
@@ -133,7 +133,7 @@ namespace {
         {
             const amrex::ParticleReal vcDps = v_Bex*px_Bestar + v_Bey*py_Bestar + v_Bez*pz_Bestar;
             const amrex::ParticleReal factor0 = (g_Be-1._prt)/v_Be_sq;
-            const amrex::ParticleReal factor = factor0*vcDps + m_alpha*gamma_Bestar*g_Be;
+            const amrex::ParticleReal factor = factor0*vcDps + static_cast<amrex::ParticleReal>(m_alpha)*gamma_Bestar*g_Be;
             px_alpha2 = px_Bestar + v_Bex * factor;
             py_alpha2 = py_Bestar + v_Bey * factor;
             pz_alpha2 = pz_Bestar + v_Bez * factor;
@@ -159,18 +159,18 @@ namespace {
         soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 1] = ux_alpha1;
         soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 1] = uy_alpha1;
         soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 1] = uz_alpha1;
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 2] = px_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 2] = py_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 2] = pz_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 3] = px_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 3] = py_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 3] = pz_alpha2/m_alpha;
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 4] = px_alpha3/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 4] = py_alpha3/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 4] = pz_alpha3/m_alpha;
-        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 5] = px_alpha3/m_alpha;
-        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 5] = py_alpha3/m_alpha;
-        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 5] = pz_alpha3/m_alpha;
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 2] = px_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 2] = py_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 2] = pz_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 3] = px_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 3] = py_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 3] = pz_alpha2/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 4] = px_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 4] = py_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 4] = pz_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::ux][idx_alpha_start + 5] = px_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uy][idx_alpha_start + 5] = py_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
+        soa_alpha.m_rdata[PIdx::uz][idx_alpha_start + 5] = pz_alpha3/static_cast<amrex::ParticleReal>(m_alpha);
     }
 
 }

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -110,7 +110,7 @@ namespace {
         // Factor 0.5 is here because each alpha only gets half of the decay energy
         constexpr amrex::ParticleReal gamma_Bestar = (1._prt + 0.5_prt*E_decay/(m_alpha*c_sq));
         constexpr amrex::ParticleReal gamma_Bestar_sq_minus_one = gamma_Bestar*gamma_Bestar - 1._prt;
-        const amrex::ParticleReal p_Bestar = static_cast<amrex::ParticleReal>(m_alpha)*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
+        const amrex::ParticleReal p_Bestar = m_alpha*PhysConst::c*std::sqrt(gamma_Bestar_sq_minus_one);
 
         // Compute momentum of second alpha in Beryllium rest frame, assuming isotropic distribution
         amrex::ParticleReal px_Bestar, py_Bestar, pz_Bestar;

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -130,7 +130,7 @@ public:
             // one electron, we create two electrons, one at the position of each particle that
             // collided. This allows for exact charge conservation.
             const index_type num_added = total * m_num_products_host[i] * 2;
-            num_added_vec[i] = num_added;
+            num_added_vec[i] = static_cast<int>(num_added);
             tile_products[i]->resize(products_np[i] + num_added);
         }
 
@@ -185,10 +185,10 @@ public:
                                                    2*(p_offsets[i]*p_num_products_device[j] + k);
                         // Create product particle at position of particle 1
                         copy_species1[j](soa_products_data[j], soa_1, p_pair_indices_1[i],
-                                      product_index, engine);
+                                      static_cast<int>(product_index), engine);
                         // Create another product particle at position of particle 2
                         copy_species2[j](soa_products_data[j], soa_2, p_pair_indices_2[i],
-                                      product_index + 1, engine);
+                                      static_cast<int>(product_index + 1), engine);
 
                         // Set the weight of the new particles to p_pair_reaction_weight[i]/2
                         soa_products_data[j].m_rdata[PIdx::w][product_index] =

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -159,7 +159,8 @@ struct GetExternalEBField
                 // find which is the next lens
                 int i_lens = static_cast<int>(std::floor(zl/m_repeated_plasma_lens_period));
                 if (i_lens < m_n_lenses) {
-                    amrex::ParticleReal const lens_start = m_repeated_plasma_lens_starts[i_lens] + i_lens*m_repeated_plasma_lens_period;
+                    amrex::ParticleReal const lens_start = m_repeated_plasma_lens_starts[i_lens] +
+                        static_cast<amrex::ParticleReal>(i_lens)*m_repeated_plasma_lens_period;
                     amrex::ParticleReal const lens_end = lens_start + m_repeated_plasma_lens_lengths[i_lens];
 
                     // Calculate the residence correction

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -234,9 +234,9 @@ public:
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);
     void SetParticleDistributionMap (int lev, amrex::DistributionMapping& new_dm);
 
-    int nSpecies () const {return species_names.size();}
-    int nLasers () const {return lasers_names.size();}
-    int nContainers () const {return allcontainers.size();}
+    int nSpecies () const {return static_cast<int>(species_names.size());}
+    int nLasers () const {return static_cast<int>(lasers_names.size());}
+    int nContainers () const {return static_cast<int>(allcontainers.size());}
 
     /** Whether back-transformed diagnostics need to be performed for any plasma species.
      *
@@ -253,13 +253,13 @@ public:
     int nSpeciesDepositOnMainGrid () const {
         bool const onMainGrid = true;
         auto const & v = m_deposit_on_main_grid;
-        return std::count( v.begin(), v.end(), onMainGrid );
+        return static_cast<int>(std::count( v.begin(), v.end(), onMainGrid ));
     }
 
     int nSpeciesGatherFromMainGrid() const {
         bool const fromMainGrid = true;
         auto const & v = m_gather_from_main_grid;
-        return std::count( v.begin(), v.end(), fromMainGrid );
+        return static_cast<int>(std::count( v.begin(), v.end(), fromMainGrid ));
     }
 
     // Inject particles during the simulation (for particles entering the

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -910,7 +910,7 @@ MultiParticleContainer::doFieldIonization (int lev,
             {
                 amrex::Gpu::synchronize();
             }
-            Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             auto& src_tile = pc_source ->ParticlesAt(lev, pti);
             auto& dst_tile = pc_product->ParticlesAt(lev, pti);
@@ -1542,7 +1542,7 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
             {
                 amrex::Gpu::synchronize();
             }
-            Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             auto Transform = PairGenerationTransformFunc(pair_gen_functor,
                                                          pti, lev, Ex.nGrowVect(),
@@ -1617,7 +1617,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
             {
                 amrex::Gpu::synchronize();
             }
-            Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             auto Transform = PhotonEmissionTransformFunc(
                   m_shr_p_qs_engine->build_optical_depth_functor(),

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -928,7 +928,7 @@ MultiParticleContainer::doFieldIonization (int lev,
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
             }
         }
@@ -1566,7 +1566,7 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
             }
         }
@@ -1645,7 +1645,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
             }
         }

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -35,7 +35,7 @@ public:
     /** Move operator for NamedComponentParticleContainer */
     ParticleBoundaryBuffer& operator= ( ParticleBoundaryBuffer && ) = default;
 
-    int numSpecies() const { return getSpeciesNames().size(); }
+    int numSpecies() const { return static_cast<int>(getSpeciesNames().size()); }
 
     const std::vector<std::string>& getSpeciesNames() const;
 

--- a/Source/Particles/ParticleCreation/SmartUtils.H
+++ b/Source/Particles/ParticleCreation/SmartUtils.H
@@ -31,7 +31,7 @@ struct SmartCopyTag
     amrex::Gpu::DeviceVector<int> src_comps;
     amrex::Gpu::DeviceVector<int> dst_comps;
 
-    int size () const noexcept { return common_names.size(); }
+    int size () const noexcept { return static_cast<int>(common_names.size()); }
 };
 
 PolicyVec getPolicies (const NameMap& names) noexcept;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -159,22 +159,22 @@ namespace
     {
         XDim3 pos;
 #if defined(WARPX_DIM_3D)
-        pos.x = lo_corner[0] + (iv[0]+r.x)*dx[0];
-        pos.y = lo_corner[1] + (iv[1]+r.y)*dx[1];
-        pos.z = lo_corner[2] + (iv[2]+r.z)*dx[2];
+        pos.x = lo_corner[0] + static_cast<Real>(iv[0]+r.x)*dx[0];
+        pos.y = lo_corner[1] + static_cast<Real>(iv[1]+r.y)*dx[1];
+        pos.z = lo_corner[2] + static_cast<Real>(iv[2]+r.z)*dx[2];
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        pos.x = lo_corner[0] + (iv[0]+r.x)*dx[0];
+        pos.x = lo_corner[0] + static_cast<Real>(iv[0]+r.x)*dx[0];
         pos.y = 0.0_rt;
 #if   defined WARPX_DIM_XZ
-        pos.z = lo_corner[1] + (iv[1]+r.y)*dx[1];
+        pos.z = lo_corner[1] + static_cast<Real>(iv[1]+r.y)*dx[1];
 #elif defined WARPX_DIM_RZ
         // Note that for RZ, r.y will be theta
-        pos.z = lo_corner[1] + (iv[1]+r.z)*dx[1];
+        pos.z = lo_corner[1] + static_cast<Real>(iv[1]+r.z)*dx[1];
 #endif
 #else
         pos.x = 0.0_rt;
         pos.y = 0.0_rt;
-        pos.z = lo_corner[0] + (iv[0]+r.x)*dx[0];
+        pos.z = lo_corner[0] + static_cast<Real>(iv[0]+r.x)*dx[0];
 #endif
         return pos;
     }
@@ -319,7 +319,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     // User-defined real attributes
     pp_species_name.queryarr("addRealAttributes", m_user_real_attribs);
-    const int n_user_real_attribs = m_user_real_attribs.size();
+    const auto n_user_real_attribs = static_cast<int>(m_user_real_attribs.size());
     std::vector< std::string > str_real_attrib_function;
     str_real_attrib_function.resize(n_user_real_attribs);
     m_user_real_attrib_parser.resize(n_user_real_attribs);
@@ -711,8 +711,8 @@ PhysicalParticleContainer::DefaultInitializeRuntimeAttributes (
         const int np = pinned_tile.numParticles();
 
         // Preparing data needed for user defined attributes
-        const int n_user_real_attribs = m_user_real_attribs.size();
-        const int n_user_int_attribs = m_user_int_attribs.size();
+        const auto n_user_real_attribs = static_cast<int>(m_user_real_attribs.size());
+        const auto n_user_int_attribs = static_cast<int>(m_user_int_attribs.size());
         const auto get_position = GetParticlePosition(pinned_tile);
         const auto soa = pinned_tile.getParticleTileData();
         const amrex::ParticleReal* AMREX_RESTRICT ux = soa.m_rdata[PIdx::ux];
@@ -984,7 +984,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         const Box& tile_box = mfi.tilebox();
         const RealBox tile_realbox = WarpX::getRealBox(tile_box, lev);
@@ -1120,8 +1120,8 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
             pa[ia] = soa.GetRealData(ia).data() + old_size;
         }
         // user-defined integer and real attributes
-        const int n_user_int_attribs = m_user_int_attribs.size();
-        const int n_user_real_attribs = m_user_real_attribs.size();
+        const auto n_user_int_attribs = static_cast<int>(m_user_int_attribs.size());
+        const auto n_user_real_attribs = static_cast<int>(m_user_real_attribs.size());
         amrex::Gpu::PinnedVector<int*> pa_user_int_pinned(n_user_int_attribs);
         amrex::Gpu::PinnedVector<ParticleReal*> pa_user_real_pinned(n_user_real_attribs);
         amrex::Gpu::PinnedVector< amrex::ParserExecutor<7> > user_int_attrib_parserexec_pinned(n_user_int_attribs);
@@ -1525,7 +1525,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
         {
             amrex::Gpu::synchronize();
         }
-        Real wt = amrex::second();
+        auto wt = static_cast<amrex::Real>(amrex::second());
 
         const Box& tile_box = mfi.tilebox();
         const RealBox tile_realbox = WarpX::getRealBox(tile_box, 0);
@@ -1670,8 +1670,8 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
         }
 
         // user-defined integer and real attributes
-        const int n_user_int_attribs = m_user_int_attribs.size();
-        const int n_user_real_attribs = m_user_real_attribs.size();
+        const auto n_user_int_attribs = static_cast<int>(m_user_int_attribs.size());
+        const auto n_user_real_attribs = static_cast<int>(m_user_real_attribs.size());
         amrex::Gpu::PinnedVector<int*> pa_user_int_pinned(n_user_int_attribs);
         amrex::Gpu::PinnedVector<ParticleReal*> pa_user_real_pinned(n_user_real_attribs);
         amrex::Gpu::PinnedVector< amrex::ParserExecutor<7> > user_int_attrib_parserexec_pinned(n_user_int_attribs);
@@ -2011,7 +2011,7 @@ PhysicalParticleContainer::Evolve (int lev,
             {
                 amrex::Gpu::synchronize();
             }
-            Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             const Box& box = pti.validbox();
 
@@ -2310,9 +2310,9 @@ PhysicalParticleContainer::SplitParticles (int lev)
             // offset for split particles is computed as a function of cell size
             // and number of particles per cell, so that a uniform distribution
             // before splitting results in a uniform distribution after splitting
-            split_offset[0] /= ppc_nd[0];
-            split_offset[1] /= ppc_nd[1];
-            split_offset[2] /= ppc_nd[2];
+            split_offset[0] /= static_cast<amrex::Real>(ppc_nd[0]);
+            split_offset[1] /= static_cast<amrex::Real>(ppc_nd[1]);
+            split_offset[2] /= static_cast<amrex::Real>(ppc_nd[2]);
         }
         // particle Array Of Structs data
         auto& particles = pti.GetArrayOfStructs();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1432,7 +1432,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -1923,7 +1923,7 @@ PhysicalParticleContainer::AddPlasmaFlux (amrex::Real dt)
 
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }
@@ -2180,7 +2180,7 @@ PhysicalParticleContainer::Evolve (int lev,
 
             if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*cost)[pti.index()], wt);
             }
         }

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -88,7 +88,7 @@ struct GetParticlePosition
      *         located at index `i + a_offset` and store them in the variables
      *         `x`, `y`, `z` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (const int i, RType& x, RType& y, RType& z) const noexcept
+    void operator() (const long i, RType& x, RType& y, RType& z) const noexcept
     {
         const PType& p = m_structs[i];
 #ifdef WARPX_DIM_RZ
@@ -117,7 +117,7 @@ struct GetParticlePosition
      *         This is only different for RZ since this returns (r, theta, z)
      *         in that case. */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void AsStored (const int i, RType& x, RType& y, RType& z) const noexcept
+    void AsStored (const long i, RType& x, RType& y, RType& z) const noexcept
     {
         const PType& p = m_structs[i];
 #ifdef WARPX_DIM_RZ
@@ -199,7 +199,7 @@ struct SetParticlePosition
      *         This is only different for RZ since the input should
      *         be (r, theta, z) in that case. */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void AsStored (const int i, RType x, RType y, RType z) const noexcept
+    void AsStored (const long i, RType x, RType y, RType z) const noexcept
     {
 #if defined(WARPX_DIM_XZ)
         amrex::ignore_unused(y);

--- a/Source/Particles/Resampling/LevelingThinning.cpp
+++ b/Source/Particles/Resampling/LevelingThinning.cpp
@@ -70,7 +70,7 @@ void LevelingThinning::operator() (WarpXParIter& pti, const int lev,
     // algorithm.
     auto bins = ParticleUtils::findParticlesInEachCell(lev, pti, ptile);
 
-    const int n_cells = bins.numBins();
+    const auto n_cells = static_cast<int>(bins.numBins());
     const auto indices = bins.permutationPtr();
     const auto cell_offsets = bins.offsetsPtr();
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1189,9 +1189,9 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
 
     std::array<amrex::ParticleReal, 3> mean_v;
     if (np_total > 0) {
-        mean_v[0] = vx_total / np_total;
-        mean_v[1] = vy_total / np_total;
-        mean_v[2] = vz_total / np_total;
+        mean_v[0] = vx_total / static_cast<amrex::ParticleReal>(np_total);
+        mean_v[1] = vy_total / static_cast<amrex::ParticleReal>(np_total);
+        mean_v[2] = vz_total / static_cast<amrex::ParticleReal>(np_total);
     }
 
     return mean_v;
@@ -1280,7 +1280,7 @@ WarpXParticleContainer::PushX (int lev, amrex::Real dt)
             if (costs && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
             {
                 amrex::Gpu::synchronize();
-                wt = amrex::second() - wt;
+                wt = static_cast<amrex::Real>(amrex::second()) - wt;
                 amrex::HostDevice::Atomic::Add( &(*costs)[pti.index()], wt);
             }
         }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1252,7 +1252,7 @@ WarpXParticleContainer::PushX (int lev, amrex::Real dt)
             {
                 amrex::Gpu::synchronize();
             }
-            Real wt = amrex::second();
+            auto wt = static_cast<amrex::Real>(amrex::second());
 
             //
             // Particle Push

--- a/Source/Utils/Parser/IntervalsParser.cpp
+++ b/Source/Utils/Parser/IntervalsParser.cpp
@@ -256,19 +256,19 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
 
 int utils::parser::BTDIntervalsParser::NumSnapshots () const
 {
-    return m_btd_iterations.size();
+    return static_cast<int>(m_btd_iterations.size());
 }
 
 
 int utils::parser::BTDIntervalsParser::GetBTDIteration (int i_buffer) const
 {
-    return m_btd_iterations[i_buffer];
+    return static_cast<int>(m_btd_iterations[i_buffer]);
 }
 
 
 int utils::parser::BTDIntervalsParser::GetFinalIteration () const
 {
-    return m_btd_iterations.back();
+    return static_cast<int>(m_btd_iterations.back());
 }
 
 

--- a/Source/Utils/Parser/ParserUtils.H
+++ b/Source/Utils/Parser/ParserUtils.H
@@ -130,7 +130,7 @@ namespace utils::parser
 
             if (std::is_same<T, int>::value) {
 
-                val = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+                val = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
             }
             else {
                 val = static_cast<T>(parser.compileHost<0>()());
@@ -155,7 +155,7 @@ namespace utils::parser
             for (int i=0 ; i < n ; i++) {
                 auto parser = makeParser(tmp_str_arr[i], {});
                 if (std::is_same<T, int>::value) {
-                    val[i] = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+                    val[i] = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
                 }
                 else {
                     val[i] = static_cast<T>(parser.compileHost<0>()());
@@ -197,7 +197,7 @@ namespace utils::parser
             for (int i=0 ; i < n ; i++) {
                 auto parser = makeParser(tmp_str_arr[i], {});
                 if (std::is_same<T, int>::value) {
-                    val[i] = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+                    val[i] = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
                 }
                 else {
                     val[i] = static_cast<T>(parser.compileHost<0>()());
@@ -229,7 +229,7 @@ namespace utils::parser
 
         auto parser = makeParser(str_val, {});
         if (std::is_same<T, int>::value) {
-            val = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+            val = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
         }
         else {
             val = static_cast<T>(parser.compileHost<0>()());
@@ -248,7 +248,7 @@ namespace utils::parser
         for (int i=0 ; i < n ; i++) {
             auto parser = makeParser(tmp_str_arr[i], {});
             if (std::is_same<T, int>::value) {
-                val[i] = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+                val[i] = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
             }
             else {
                 val[i] = static_cast<T>(parser.compileHost<0>()());
@@ -285,7 +285,7 @@ namespace utils::parser
         for (int i=0 ; i < n ; i++) {
             auto parser = makeParser(tmp_str_arr[i], {});
             if (std::is_same<T, int>::value) {
-                val[i] = safeCastToInt(std::round(parser.compileHost<0>()()), str);
+                val[i] = safeCastToInt(static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
             }
             else {
                 val[i] = static_cast<T>(parser.compileHost<0>()());

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -99,8 +99,8 @@ namespace ParticleUtils {
         // precompute repeatedly used quantities
         constexpr auto c2 = PhysConst::c * PhysConst::c;
         const auto V2 = (Vx*Vx + Vy*Vy + Vz*Vz);
-        const auto gamma_V = 1.0_prt / sqrt(1.0_prt - V2 / c2);
-        const auto gamma_u = sqrt(1.0_prt + (ux*ux + uy*uy + uz*uz) / c2);
+        const auto gamma_V = 1.0_prt / std::sqrt(1.0_prt - V2 / c2);
+        const auto gamma_u = std::sqrt(1.0_prt + (ux*ux + uy*uy + uz*uz) / c2);
 
         // copy velocity vector values
         const auto vx = ux;

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -508,14 +508,14 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
                 }
 
 #if defined(WARPX_DIM_1D_Z)
-                const auto fac_z = static_cast<amrex::Real>(1 - mf_type[0]) * dx[0]*0.5_rt;
+                const auto fac_z = (mf_type[0] == 1) ? 0.0_rt : dx[0]*0.5_rt;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const auto fac_x = static_cast<amrex::Real>(1 - mf_type[0]) * dx[0]*0.5_rt;
-                const auto fac_z = static_cast<amrex::Real>(1 - mf_type[1]) * dx[1]*0.5_rt;
+                const auto fac_x = (mf_type[0] == 1) ? 0.0_rt : dx[0]*0.5_rt;
+                const auto fac_z = (mf_type[1] == 1) ? 0.0_rt : dx[1]*0.5_rt;
 #else
-                const auto fac_x = static_cast<amrex::Real>(1 - mf_type[0]) * dx[0]*0.5_rt;
-                const auto fac_y = static_cast<amrex::Real>(1 - mf_type[1]) * dx[1]*0.5_rt;
-                const auto fac_z = static_cast<amrex::Real>(1 - mf_type[2]) * dx[2]*0.5_rt;
+                const auto fac_x = (mf_type[0] == 1) ? 0.0_rt : dx[0]*0.5_rt;
+                const auto fac_y = (mf_type[1] == 1) ? 0.0_rt : dx[1]*0.5_rt;
+                const auto fac_z = (mf_type[2] == 1) ? 0.0_rt : dx[2]*0.5_rt;
 #endif
 
                 amrex::ParallelFor (outbox, nc,

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -556,7 +556,7 @@ WarpX::shiftMF (amrex::MultiFab& mf, const amrex::Geometry& geom,
             WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
-            wt = amrex::second() - wt;
+            wt = static_cast<amrex::Real>(amrex::second()) - wt;
             amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
         }
     }

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -92,14 +92,14 @@ void getCellCoordinates (int i, int j, int k,
                          amrex::Real &x, amrex::Real &y, amrex::Real &z)
 {
     using namespace amrex::literals;
-    x = domain_lo[0] + static_cast<amrex::Real>(i)*dx[0] + (1._rt - mf_type[0]) * dx[0]*0.5_rt;
+    x = domain_lo[0] + static_cast<amrex::Real>(i)*dx[0] + static_cast<amrex::Real>(1 - mf_type[0]) * dx[0]*0.5_rt;
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     amrex::ignore_unused(j);
     y = 0._rt;
-    z = domain_lo[1] + static_cast<amrex::Real>(k)*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
+    z = domain_lo[1] + static_cast<amrex::Real>(k)*dx[1] + static_cast<amrex::Real>(1 - mf_type[1]) * dx[1]*0.5_rt;
 #else
-    y = domain_lo[1] + static_cast<amrex::Real>(j)*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
-    z = domain_lo[2] + static_cast<amrex::Real>(k)*dx[2] + (1._rt - mf_type[2]) * dx[2]*0.5_rt;
+    y = domain_lo[1] + static_cast<amrex::Real>(j)*dx[1] + static_cast<amrex::Real>(1 - mf_type[1]) * dx[1]*0.5_rt;
+    z = domain_lo[2] + static_cast<amrex::Real>(k)*dx[2] + static_cast<amrex::Real>(1 - mf_type[2]) * dx[2]*0.5_rt;
 #endif
 }
 

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -92,14 +92,14 @@ void getCellCoordinates (int i, int j, int k,
                          amrex::Real &x, amrex::Real &y, amrex::Real &z)
 {
     using namespace amrex::literals;
-    x = domain_lo[0] + i*dx[0] + (1._rt - mf_type[0]) * dx[0]*0.5_rt;
+    x = domain_lo[0] + static_cast<amrex::Real>(i)*dx[0] + (1._rt - mf_type[0]) * dx[0]*0.5_rt;
 #if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     amrex::ignore_unused(j);
     y = 0._rt;
-    z = domain_lo[1] + k*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
+    z = domain_lo[1] + static_cast<amrex::Real>(k)*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
 #else
-    y = domain_lo[1] + j*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
-    z = domain_lo[2] + k*dx[2] + (1._rt - mf_type[2]) * dx[2]*0.5_rt;
+    y = domain_lo[1] + static_cast<amrex::Real>(j)*dx[1] + (1._rt - mf_type[1]) * dx[1]*0.5_rt;
+    z = domain_lo[2] + static_cast<amrex::Real>(k)*dx[2] + (1._rt - mf_type[2]) * dx[2]*0.5_rt;
 #endif
 }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -522,7 +522,7 @@ WarpX::ReadParameters ()
 
     {
         const ParmParse pp_algo("algo");
-        electromagnetic_solver_id = GetAlgorithmInteger(pp_algo, "maxwell_solver");
+        electromagnetic_solver_id = static_cast<short>(GetAlgorithmInteger(pp_algo, "maxwell_solver"));
     }
 
     {
@@ -1007,7 +1007,7 @@ WarpX::ReadParameters ()
 
         // Integer that corresponds to the type of grid used in the simulation
         // (collocated, staggered, hybrid)
-        grid_type = GetAlgorithmInteger(pp_warpx, "grid_type");
+        grid_type =static_cast<short>(GetAlgorithmInteger(pp_warpx, "grid_type"));
 
         // Use same shape factors in all directions, for gathering
         if (grid_type == GridType::Collocated) galerkin_interpolation = false;
@@ -1106,9 +1106,9 @@ WarpX::ReadParameters ()
 
         // note: current_deposition must be set after maxwell_solver is already determined,
         //       because its default depends on the solver selection
-        current_deposition_algo = GetAlgorithmInteger(pp_algo, "current_deposition");
-        charge_deposition_algo = GetAlgorithmInteger(pp_algo, "charge_deposition");
-        particle_pusher_algo = GetAlgorithmInteger(pp_algo, "particle_pusher");
+        current_deposition_algo = static_cast<short>(GetAlgorithmInteger(pp_algo, "current_deposition"));
+        charge_deposition_algo = static_cast<short>(GetAlgorithmInteger(pp_algo, "charge_deposition"));
+        particle_pusher_algo = static_cast<short>(GetAlgorithmInteger(pp_algo, "particle_pusher"));
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             current_deposition_algo != CurrentDepositionAlgo::Esirkepov ||
@@ -3004,11 +3004,11 @@ amrex::Vector<amrex::Real> WarpX::getFornbergStencilCoefficients(const int n_ord
     if (a_grid_type == GridType::Collocated)
     {
        // First coefficient
-       coeffs.at(0) = m * 2. / (m+1);
+       coeffs.at(0) = m * 2._rt / (m+1);
        // Other coefficients by recurrence
        for (int n = 1; n < m; n++)
        {
-           coeffs.at(n) = - (m-n) * 1. / (m+n+1) * coeffs.at(n-1);
+           coeffs.at(n) = - (m-n) * 1._rt / (m+n+1) * coeffs.at(n-1);
        }
     }
     // Coefficients for staggered finite-difference approximation
@@ -3017,10 +3017,10 @@ amrex::Vector<amrex::Real> WarpX::getFornbergStencilCoefficients(const int n_ord
        Real prod = 1.;
        for (int k = 1; k < m+1; k++)
        {
-           prod *= (m + k) / (4. * k);
+           prod *= (m + k) / (4._rt * k);
        }
        // First coefficient
-       coeffs.at(0) = 4 * m * prod * prod;
+       coeffs.at(0) = 4_rt * m * prod * prod;
        // Other coefficients by recurrence
        for (int n = 1; n < m; n++)
        {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1140,7 +1140,7 @@ WarpX::ReadParameters ()
 
         // Query algo.field_gathering from input, set field_gathering_algo to
         // "default" if not found (default defined in Utils/WarpXAlgorithmSelection.cpp)
-        field_gathering_algo = GetAlgorithmInteger(pp_algo, "field_gathering");
+        field_gathering_algo = static_cast<short>(GetAlgorithmInteger(pp_algo, "field_gathering"));
 
         // Set default field gathering algorithm for hybrid grids (momentum-conserving)
         std::string tmp_algo;
@@ -1188,7 +1188,7 @@ WarpX::ReadParameters ()
             pp_algo.query("load_balance_knapsack_factor", load_balance_knapsack_factor);
         utils::parser::queryWithParser(pp_algo, "load_balance_efficiency_ratio_threshold",
                         load_balance_efficiency_ratio_threshold);
-        load_balance_costs_update_algo = GetAlgorithmInteger(pp_algo, "load_balance_costs_update");
+        load_balance_costs_update_algo = static_cast<short>(GetAlgorithmInteger(pp_algo, "load_balance_costs_update"));
         if (WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic) {
             utils::parser::queryWithParser(
                 pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
@@ -1368,12 +1368,12 @@ WarpX::ReadParameters ()
         // Integer that corresponds to the order of the PSATD solution
         // (whether the PSATD equations are derived from first-order or
         // second-order solution)
-        psatd_solution_type = GetAlgorithmInteger(pp_psatd, "solution_type");
+        psatd_solution_type = static_cast<short>(GetAlgorithmInteger(pp_psatd, "solution_type"));
 
         // Integers that correspond to the time dependency of J (constant, linear)
         // and rho (linear, quadratic) for the PSATD algorithm
-        J_in_time = GetAlgorithmInteger(pp_psatd, "J_in_time");
-        rho_in_time = GetAlgorithmInteger(pp_psatd, "rho_in_time");
+        J_in_time = static_cast<short>(GetAlgorithmInteger(pp_psatd, "J_in_time"));
+        rho_in_time = static_cast<short>(GetAlgorithmInteger(pp_psatd, "rho_in_time"));
 
         if (psatd_solution_type != PSATDSolutionType::FirstOrder || !do_multi_J)
         {
@@ -3004,11 +3004,11 @@ amrex::Vector<amrex::Real> WarpX::getFornbergStencilCoefficients(const int n_ord
     if (a_grid_type == GridType::Collocated)
     {
        // First coefficient
-       coeffs.at(0) = m * 2._rt / (m+1);
+       coeffs.at(0) = static_cast<amrex::Real>(m * 2) / static_cast<amrex::Real>(m+1);
        // Other coefficients by recurrence
        for (int n = 1; n < m; n++)
        {
-           coeffs.at(n) = - (m-n) * 1._rt / (m+n+1) * coeffs.at(n-1);
+           coeffs.at(n) = - static_cast<amrex::Real>(m-n) / static_cast<amrex::Real>(m+n+1) * coeffs.at(n-1);
        }
     }
     // Coefficients for staggered finite-difference approximation
@@ -3017,14 +3017,14 @@ amrex::Vector<amrex::Real> WarpX::getFornbergStencilCoefficients(const int n_ord
        Real prod = 1.;
        for (int k = 1; k < m+1; k++)
        {
-           prod *= (m + k) / (4._rt * k);
+           prod *= static_cast<amrex::Real>(m + k) / static_cast<amrex::Real>(4 * k);
        }
        // First coefficient
-       coeffs.at(0) = 4_rt * m * prod * prod;
+       coeffs.at(0) = 4_rt * static_cast<amrex::Real>(m) * prod * prod;
        // Other coefficients by recurrence
        for (int n = 1; n < m; n++)
        {
-           coeffs.at(n) = - ((2*n-1) * (m-n)) * 1. / ((2*n+1) * (m+n)) * coeffs.at(n-1);
+           coeffs.at(n) = - static_cast<amrex::Real>((2*n-1) * (m-n))  / static_cast<amrex::Real>((2*n+1) * (m+n)) * coeffs.at(n-1);
        }
     }
 

--- a/Source/ablastr/coarsen/average.H
+++ b/Source/ablastr/coarsen/average.H
@@ -111,6 +111,24 @@ namespace ablastr::coarsen::average
             return arr_src.contains(ix, iy, iz) ? arr_src(ix, iy, iz, n) : 0.0_rt;
         };
 
+        // if cell-centered
+        const auto if_cc_wx = static_cast<amrex::Real>((1 - sfx) * (1 - scx));
+        const auto if_cc_wy = static_cast<amrex::Real>((1 - sfy) * (1 - scy));
+        const auto if_cc_wz = static_cast<amrex::Real>((1 - sfz) * (1 - scz));
+
+        // if nodal
+        const auto if_nd_wx = static_cast<amrex::Real>(sfx * scx);
+        const auto if_nd_wy = static_cast<amrex::Real>(sfy * scy);
+        const auto if_nd_wz = static_cast<amrex::Real>(sfz * scz);
+
+        // Auxiliary real variables
+        const auto crx2 = static_cast<amrex::Real>(crx * crx);
+        const auto cry2 = static_cast<amrex::Real>(cry * cry);
+        const auto crz2 = static_cast<amrex::Real>(crz * crz);
+        const auto one_over_numx = (1.0_rt / static_cast<amrex::Real>(numx));
+        const auto one_over_numy = (1.0_rt / static_cast<amrex::Real>(numy));
+        const auto one_over_numz = (1.0_rt / static_cast<amrex::Real>(numz));
+
         // Interpolate over points computed above. Weights are computed in order
         // to guarantee total charge conservation for both cell-centered data
         // (equal weights) and nodal data (weights depend on distance between
@@ -126,15 +144,18 @@ namespace ablastr::coarsen::average
                     const int ii = imin + iref;
                     const int jj = jmin + jref;
                     const int kk = kmin + kref;
-                    const amrex::Real wx = (1.0_rt / static_cast<amrex::Real>(numx)) * (1 - sfx) * (1 - scx) // if cell-centered
-                         + ((amrex::Math::abs(crx - amrex::Math::abs(ii - i * crx))) /
-                            static_cast<amrex::Real>(crx * crx)) * sfx * scx; // if nodal
-                    const amrex::Real wy = (1.0_rt / static_cast<amrex::Real>(numy)) * (1 - sfy) * (1 - scy) // if cell-centered
-                         + ((amrex::Math::abs(cry - amrex::Math::abs(jj - j * cry))) /
-                            static_cast<amrex::Real>(cry * cry)) * sfy * scy; // if nodal
-                    const amrex::Real wz = (1.0_rt / static_cast<amrex::Real>(numz)) * (1 - sfz) * (1 - scz) // if cell-centered
-                         + ((amrex::Math::abs(crz - amrex::Math::abs(kk - k * crz))) /
-                            static_cast<amrex::Real>(crz * crz)) * sfz * scz; // if nodal
+
+                    const auto c_nd_x = (static_cast<amrex::Real>(
+                        (amrex::Math::abs(crx - amrex::Math::abs(ii - i * crx)))) / crx2);
+                    const auto c_nd_y = (static_cast<amrex::Real>(
+                        (amrex::Math::abs(cry - amrex::Math::abs(jj - j * cry)))) / cry2);
+                    const auto c_nd_z = (static_cast<amrex::Real>(
+                        (amrex::Math::abs(crz - amrex::Math::abs(kk - k * crz)))) / crz2);
+
+                    const amrex::Real wx = one_over_numx * if_cc_wx + c_nd_x * if_nd_wx;
+                    const amrex::Real wy = one_over_numy * if_cc_wy + c_nd_y * if_nd_wy;
+                    const amrex::Real wz = one_over_numz * if_cc_wz + c_nd_z * if_nd_wz;
+
                     c += wx * wy * wz * arr_src_safe(ii, jj, kk, comp);
                 }
             }

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -115,7 +115,7 @@ computeVectorPotential   (  amrex::Vector<amrex::Array<amrex::MultiFab*, 3> > co
         rel_ref_ratio = amrex::Vector<amrex::IntVect>{{amrex::IntVect(AMREX_D_DECL(1, 1, 1))}};
     }
 
-    int const finest_level = curr.size() - 1u;
+    int const finest_level = curr.size() - 1;
 
     // scale J appropriately; also determine if current is zero everywhere
     amrex::Real max_comp_J = 0.0;

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -47,9 +47,9 @@ void compute_weights_nodal (const amrex::ParticleReal xp,
     j = static_cast<int>(amrex::Math::floor(y));
     k = static_cast<int>(amrex::Math::floor(z));
 
-    W[0][1] = x - i;
-    W[1][1] = y - j;
-    W[2][1] = z - k;
+    W[0][1] = x - static_cast<amrex::Real>(i);
+    W[1][1] = y - static_cast<amrex::Real>(j);
+    W[2][1] = z - static_cast<amrex::Real>(k);
 
     W[0][0] = 1.0_rt - W[0][1];
     W[1][0] = 1.0_rt - W[1][1];

--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -90,7 +90,7 @@ SignalHandling::parseSignalNameToNumber (const std::string &str)
         std::string name_upper = sp.abbrev;
         std::string name_lower = name_upper;
         for (char &c : name_lower) {
-            c = std::tolower(c);
+            c =  static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         }
 
         signals_parser.setConstant(name_upper, sp.value);

--- a/Source/ablastr/utils/timer/Timer.H
+++ b/Source/ablastr/utils/timer/Timer.H
@@ -8,8 +8,6 @@
 #ifndef ABLASTR_TIMER_H_
 #define ABLASTR_TIMER_H_
 
-#include <AMReX_REAL.H>
-
 namespace ablastr::utils::timer
 {
 
@@ -46,7 +44,7 @@ namespace ablastr::utils::timer
         *
         * @return the duration
         */
-        amrex::Real get_duration () noexcept;
+        double get_duration () noexcept;
 
 
         /**
@@ -55,12 +53,12 @@ namespace ablastr::utils::timer
         *
         * @return the maximum duration across all the MPI ranks
         */
-        amrex::Real get_global_duration ();
+        double get_global_duration ();
 
         private:
 
-        amrex::Real m_start_time /*! The start time*/;
-        amrex::Real m_stop_time /*! The stop time*/;
+        double m_start_time /*! The start time*/;
+        double m_stop_time /*! The stop time*/;
     };
 
 }

--- a/Source/ablastr/utils/timer/Timer.cpp
+++ b/Source/ablastr/utils/timer/Timer.cpp
@@ -25,13 +25,13 @@ Timer::record_stop_time() noexcept
     m_stop_time = amrex::ParallelDescriptor::second();
 }
 
-amrex::Real
+double
 Timer::get_duration () noexcept
 {
     return m_stop_time - m_start_time;
 }
 
-amrex::Real
+double
 Timer::get_global_duration ()
 {
     auto duration = this->get_duration();


### PR DESCRIPTION
This PR fixes a bug in the clang-tidy configuration file.

As a result of this bug, some checks were not performed. This PR also addresses the issues found after the bugfix.