### PR TITLE
Maxlevel user option for external field initialization

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1398,10 +1398,10 @@ External fields
 Grid initialization
 ^^^^^^^^^^^^^^^^^^^
 
-* ``warpx.B_ext_grid_init_style`` (string) optional (default is "default")
+* ``warpx.B_ext_grid_init_style`` (string) optional
     This parameter determines the type of initialization for the external
-    magnetic field. The "default" style initializes the
-    external magnetic field (Bx,By,Bz) to (0.0, 0.0, 0.0).
+    magnetic field. By default, the
+    external magnetic field (Bx,By,Bz) is initialized to (0.0, 0.0, 0.0).
     The string can be set to "constant" if a constant magnetic field is
     required to be set at initialization. If set to "constant", then an
     additional parameter, namely, ``warpx.B_external_grid`` must be specified.
@@ -1429,9 +1429,9 @@ Grid initialization
     Regarding how to prepare the openPMD data file, one can refer to
     the `openPMD-example-datasets <https://github.com/openPMD/openPMD-example-datasets>`__.
 
-* ``warpx.E_ext_grid_init_style`` (string) optional (default is "default")
+* ``warpx.E_ext_grid_init_style`` (string) optional
     This parameter determines the type of initialization for the external
-    electric field. The "default" style initializes the
+    electric field. By default, the
     external electric field (Ex,Ey,Ez) to (0.0, 0.0, 0.0).
     The string can be set to "constant" if a constant electric field is
     required to be set at initialization. If set to "constant", then an
@@ -1474,12 +1474,9 @@ Grid initialization
     than periodic.
 
 * ``warpx.maxlevel_extEMfield_init`` (default is maximum number of levels in the simulation)
-    With this parameter, the externally applied electric and magnetic fields with parameters
-    ``warpx.E_ext_grid_init_style="constant"``,
-    ``warpx.B_ext_grid_init_style="constant"``,
-    ``warpx.E_ext_grid_init_style="parse_E_ext_grid_function"`` and
-    ``warpx.B_ext_grid_init_style="parse_B_ext_grid_function"`` will not be initialized with the external field
-    for levels strictly greater than ``warpx.maxlevel_extEMfield_init``. For some mesh-refinement simulations,
+    With this parameter, the externally applied electric and magnetic fields
+    will not be applied for levels greater than ``warpx.maxlevel_extEMfield_init``.
+    For some mesh-refinement simulations,
     the external fields are only applied to the parent grid and not the refined patches. In such cases,
     ``warpx.maxlevel_extEMfield_init`` can be set to 0. Note that the other levels will be initialized to
     a default value of 0.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1478,8 +1478,8 @@ Grid initialization
     will not be applied for levels greater than ``warpx.maxlevel_extEMfield_init``.
     For some mesh-refinement simulations,
     the external fields are only applied to the parent grid and not the refined patches. In such cases,
-    ``warpx.maxlevel_extEMfield_init`` can be set to 0. Note that the other levels will be initialized to
-    a default value of 0.
+    ``warpx.maxlevel_extEMfield_init`` can be set to 0.
+    In that case, the other levels have external field values of 0.
 
 Applied to Particles
 ^^^^^^^^^^^^^^^^^^^^

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1474,7 +1474,7 @@ Grid initialization
     than periodic.
 
 * ``warpx.maxlevel_extEMfield_init`` (default is maximum number of levels in the simulation)
-    With this parameter, the externally applied electric and magnetic fields with paramters
+    With this parameter, the externally applied electric and magnetic fields with parameters
     ``warpx.E_ext_grid_init_style="constant"``,
     ``warpx.B_ext_grid_init_style="constant"``,
     ``warpx.E_ext_grid_init_style="parse_E_ext_grid_function"`` and

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1473,6 +1473,17 @@ Grid initialization
     the field solver. In particular, do not use any other boundary condition
     than periodic.
 
+* ``warpx.maxlevel_extEMfield_init`` (default is maximum number of levels in the simulation)
+    With this parameter, the externally applied electric and magnetic fields with paramters
+    ``warpx.E_ext_grid_init_style="constant"``,
+    ``warpx.B_ext_grid_init_style="constant"``,
+    ``warpx.E_ext_grid_init_style="parse_E_ext_grid_function"`` and
+    ``warpx.B_ext_grid_init_style="parse_B_ext_grid_function"`` will not be initialized with the external field
+    for levels strictly greater than ``warpx.maxlevel_extEMfield_init``. For some mesh-refinement simulations,
+    the external fields are only applied to the parent grid and not the refined patches. In such cases,
+    ``warpx.maxlevel_extEMfield_init`` can be set to 0. Note that the other levels will be initialized to
+    a default value of 0.
+
 Applied to Particles
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -69,6 +69,10 @@ EmbeddedBoundary
 Applied fields
 ^^^^^^^^^^^^^^
 
+AnalyticInitialField
+""""""""""""""""""""
+.. autoclass:: pywarpx.picmi.AnalyticInitialField
+
 ConstantAppliedField
 """"""""""""""""""""
 .. autoclass:: pywarpx.picmi.ConstantAppliedField

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1233,9 +1233,11 @@ class LoadInitialField(picmistandard.PICMI_LoadGriddedField):
 class AnalyticInitialField(picmistandard.PICMI_AnalyticAppliedField):
     def init(self, kw):
         self.mangle_dict = None
+        self.maxlevel_extEMfield_init = kw.pop('warpx_maxlevel_extEMfield_init', None);
 
     def initialize_inputs(self):
         # Note that lower and upper_bound are not used by WarpX
+        pywarpx.warpx.maxlevel_extEMfield_init = self.maxlevel_extEMfield_init;
 
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this distribution

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -767,7 +767,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
         if ( ( B_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
-            || B_ext_grid_s == "default")
         {
            Bfield_fp[lev][i]->setVal(B_external_grid[i]);
            if (fft_do_time_averaging) {
@@ -785,7 +784,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
         if ( ( E_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
-            || E_ext_grid_s == "default")
         {
            Efield_fp[lev][i]->setVal(E_external_grid[i]);
            if (fft_do_time_averaging) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -747,25 +747,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                    E_ext_grid_s.begin(),
                    ::tolower);
 
-    // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
-    // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-    // Note that if the external fields are not provided, the fields, E and B, on all levels
-    // will still be initialized with the default value of 0.
-    if ( (B_ext_grid_s == "constant") || (B_ext_grid_s == "parse_b_ext_grid_function")) {
-        if (lev > maxlevel_extEMfield_init) {
-            Bfield_fp[lev][0]->setVal(0.);
-            Bfield_fp[lev][1]->setVal(0.);
-            Bfield_fp[lev][2]->setVal(0.);
-        }
-    }
-    if ( (E_ext_grid_s == "constant") || (E_ext_grid_s == "parse_e_ext_grid_function")) {
-        if (lev > maxlevel_extEMfield_init) {
-            Efield_fp[lev][0]->setVal(0.);
-            Efield_fp[lev][1]->setVal(0.);
-            Efield_fp[lev][2]->setVal(0.);
-        }
-    }
-
     // if the input string is "constant", the values for the
     // external grid must be provided in the input.
     if (B_ext_grid_s == "constant")

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -747,6 +747,17 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                    E_ext_grid_s.begin(),
                    ::tolower);
 
+    // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
+    // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
+    // Note that if the external fields are not provided, the fields, E and B, on all levels
+    // will still be initialized with the default value of 0.
+    if ( (B_ext_grid_s == "constant") || (B_ext_grid_s == "parse_b_ext_grid_function")) {
+        if (lev > maxlevel_extEMfield_init) continue;
+    }
+    if ( (E_ext_grid_s == "constant") || (E_ext_grid_s == "parse_e_ext_grid_function")) {
+        if (lev > maxlevel_extEMfield_init) continue;
+    }
+
     // if the input string is "constant", the values for the
     // external grid must be provided in the input.
     if (B_ext_grid_s == "constant")

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -766,7 +766,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-        if ( ( B_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
+        if ( ( B_ext_grid_s == "constant") && (lev <= maxlevel_extEMfield_init) )
         {
            Bfield_fp[lev][i]->setVal(B_external_grid[i]);
            if (fft_do_time_averaging) {
@@ -783,7 +783,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         }
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-        if ( ( E_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
+        if ( ( E_ext_grid_s == "constant") && (lev <= maxlevel_extEMfield_init) )
         {
            Efield_fp[lev][i]->setVal(E_external_grid[i]);
            if (fft_do_time_averaging) {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -756,7 +756,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             Bfield_fp[lev][0]->setVal(0.);
             Bfield_fp[lev][1]->setVal(0.);
             Bfield_fp[lev][2]->setVal(0.);
-            return;
         }
     }
     if ( (E_ext_grid_s == "constant") || (E_ext_grid_s == "parse_e_ext_grid_function")) {
@@ -764,7 +763,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             Efield_fp[lev][0]->setVal(0.);
             Efield_fp[lev][1]->setVal(0.);
             Efield_fp[lev][2]->setVal(0.);
-            return;
         }
     }
 
@@ -785,7 +783,11 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
     for (int i = 0; i < 3; ++i) {
 
-        if (B_ext_grid_s == "constant" || B_ext_grid_s == "default") {
+        // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
+        // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
+        if ( ( B_ext_grid_s == "constant" && (lev > maxlevel_extEMfield_init) )
+            || B_ext_grid_s == "default")
+        {
            Bfield_fp[lev][i]->setVal(B_external_grid[i]);
            if (fft_do_time_averaging) {
                 Bfield_avg_fp[lev][i]->setVal(B_external_grid[i]);
@@ -799,7 +801,11 @@ WarpX::InitLevelData (int lev, Real /*time*/)
               }
            }
         }
-        if (E_ext_grid_s == "constant" || E_ext_grid_s == "default") {
+        // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
+        // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
+        if ( ( E_ext_grid_s == "constant" && (lev > maxlevel_extEMfield_init) )
+            || E_ext_grid_s == "default")
+        {
            Efield_fp[lev][i]->setVal(E_external_grid[i]);
            if (fft_do_time_averaging) {
                Efield_avg_fp[lev][i]->setVal(E_external_grid[i]);
@@ -822,7 +828,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // if the input string for the B-field is "parse_b_ext_grid_function",
     // then the analytical expression or function must be
     // provided in the input file.
-    if (B_ext_grid_s == "parse_b_ext_grid_function") {
+    // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
+    // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
+    if (B_ext_grid_s == "parse_b_ext_grid_function" && (lev > maxlevel_extEMfield_init)) {
 
         //! Strings storing parser function to initialize the components of the magnetic field on the grid
         std::string str_Bx_ext_grid_function;
@@ -893,7 +901,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // if the input string for the E-field is "parse_e_ext_grid_function",
     // then the analytical expression or function must be
     // provided in the input file.
-    if (E_ext_grid_s == "parse_e_ext_grid_function") {
+    // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
+    // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
+    if (E_ext_grid_s == "parse_e_ext_grid_function" && (lev > maxlevel_extEMfield_init)) {
 
 #ifdef WARPX_DIM_RZ
         WARPX_ABORT_WITH_MESSAGE(

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -785,7 +785,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-        if ( ( B_ext_grid_s == "constant" && (lev > maxlevel_extEMfield_init) )
+        if ( ( B_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
             || B_ext_grid_s == "default")
         {
            Bfield_fp[lev][i]->setVal(B_external_grid[i]);
@@ -803,7 +803,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         }
         // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
         // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-        if ( ( E_ext_grid_s == "constant" && (lev > maxlevel_extEMfield_init) )
+        if ( ( E_ext_grid_s == "constant" && (lev <= maxlevel_extEMfield_init) )
             || E_ext_grid_s == "default")
         {
            Efield_fp[lev][i]->setVal(E_external_grid[i]);
@@ -830,7 +830,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // provided in the input file.
     // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
     // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-    if (B_ext_grid_s == "parse_b_ext_grid_function" && (lev > maxlevel_extEMfield_init)) {
+    if (B_ext_grid_s == "parse_b_ext_grid_function" && (lev <= maxlevel_extEMfield_init)) {
 
         //! Strings storing parser function to initialize the components of the magnetic field on the grid
         std::string str_Bx_ext_grid_function;
@@ -903,7 +903,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // provided in the input file.
     // Externally imposed fields are only initialized until the user-defined maxlevel_extEMfield_init.
     // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
-    if (E_ext_grid_s == "parse_e_ext_grid_function" && (lev > maxlevel_extEMfield_init)) {
+    if (E_ext_grid_s == "parse_e_ext_grid_function" && (lev <= maxlevel_extEMfield_init)) {
 
 #ifdef WARPX_DIM_RZ
         WARPX_ABORT_WITH_MESSAGE(

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -752,10 +752,20 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // Note that if the external fields are not provided, the fields, E and B, on all levels
     // will still be initialized with the default value of 0.
     if ( (B_ext_grid_s == "constant") || (B_ext_grid_s == "parse_b_ext_grid_function")) {
-        if (lev > maxlevel_extEMfield_init) continue;
+        if (lev > maxlevel_extEMfield_init) {
+            Bfield_fp[lev][0]->setVal(0.);
+            Bfield_fp[lev][1]->setVal(0.);
+            Bfield_fp[lev][2]->setVal(0.);
+            return;
+        }
     }
     if ( (E_ext_grid_s == "constant") || (E_ext_grid_s == "parse_e_ext_grid_function")) {
-        if (lev > maxlevel_extEMfield_init) continue;
+        if (lev > maxlevel_extEMfield_init) {
+            Efield_fp[lev][0]->setVal(0.);
+            Efield_fp[lev][1]->setVal(0.);
+            Efield_fp[lev][2]->setVal(0.);
+            return;
+        }
     }
 
     // if the input string is "constant", the values for the

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -167,6 +167,12 @@ public:
     //! User-defined parser to initialize z-component of the electric field on the grid
     std::unique_ptr<amrex::Parser> Ezfield_parser;
 
+    /** Maximum level upto which the externally defined electric and magnetic fields are initialized.
+     *  The default value is set to the max levels in the simulation.
+     *  if lev > maxlevel_extEMfield_init, the fields on those levels will have a default value of 0
+     */
+    int maxlevel_extEMfield_init;
+
     // Algorithms
     //! Integer that corresponds to the current deposition algorithm (Esirkepov, direct, Vay)
     static short current_deposition_algo;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -167,7 +167,7 @@ public:
     //! User-defined parser to initialize z-component of the electric field on the grid
     std::unique_ptr<amrex::Parser> Ezfield_parser;
 
-    /** Maximum level upto which the externally defined electric and magnetic fields are initialized.
+    /** Maximum level up to which the externally defined electric and magnetic fields are initialized.
      *  The default value is set to the max levels in the simulation.
      *  if lev > maxlevel_extEMfield_init, the fields on those levels will have a default value of 0
      */

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -88,8 +88,9 @@ using namespace amrex;
 Vector<Real> WarpX::E_external_grid(3, 0.0);
 Vector<Real> WarpX::B_external_grid(3, 0.0);
 
-std::string WarpX::B_ext_grid_s = "default";
-std::string WarpX::E_ext_grid_s = "default";
+std::string WarpX::authors;
+std::string WarpX::B_ext_grid_s;
+std::string WarpX::E_ext_grid_s;
 bool WarpX::add_external_E_field = false;
 bool WarpX::add_external_B_field = false;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -88,7 +88,6 @@ using namespace amrex;
 Vector<Real> WarpX::E_external_grid(3, 0.0);
 Vector<Real> WarpX::B_external_grid(3, 0.0);
 
-std::string WarpX::authors;
 std::string WarpX::B_ext_grid_s;
 std::string WarpX::E_ext_grid_s;
 bool WarpX::add_external_E_field = false;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2210,13 +2210,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     //
     const std::array<Real,3> dx = CellSize(lev);
 
-    AllocInitMultiFab(Bfield_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[x]");
-    AllocInitMultiFab(Bfield_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[y]");
-    AllocInitMultiFab(Bfield_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[z]");
+    AllocInitMultiFab(Bfield_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[x]", 0.0_rt);
+    AllocInitMultiFab(Bfield_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[y]", 0.0_rt);
+    AllocInitMultiFab(Bfield_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp[z]", 0.0_rt);
 
-    AllocInitMultiFab(Efield_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[x]");
-    AllocInitMultiFab(Efield_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[y]");
-    AllocInitMultiFab(Efield_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[z]");
+    AllocInitMultiFab(Efield_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[x]", 0.0_rt);
+    AllocInitMultiFab(Efield_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[y]", 0.0_rt);
+    AllocInitMultiFab(Efield_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp[z]", 0.0_rt);
 
     AllocInitMultiFab(current_fp[lev][0], amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, lev, "current_fp[x]", 0.0_rt);
     AllocInitMultiFab(current_fp[lev][1], amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, lev, "current_fp[y]", 0.0_rt);
@@ -2224,14 +2224,14 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     // Match external field MultiFabs to fine patch
     if (add_external_B_field) {
-        AllocInitMultiFab(Bfield_fp_external[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[x]");
-        AllocInitMultiFab(Bfield_fp_external[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[y]");
-        AllocInitMultiFab(Bfield_fp_external[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[z]");
+        AllocInitMultiFab(Bfield_fp_external[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[x]", 0.0_rt);
+        AllocInitMultiFab(Bfield_fp_external[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[y]", 0.0_rt);
+        AllocInitMultiFab(Bfield_fp_external[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_fp_external[z]", 0.0_rt);
     }
     if (add_external_E_field) {
-        AllocInitMultiFab(Efield_fp_external[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[x]");
-        AllocInitMultiFab(Efield_fp_external[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[y]");
-        AllocInitMultiFab(Efield_fp_external[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[z]");
+        AllocInitMultiFab(Efield_fp_external[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[x]", 0.0_rt);
+        AllocInitMultiFab(Efield_fp_external[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[y]", 0.0_rt);
+        AllocInitMultiFab(Efield_fp_external[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_fp_external[z]", 0.0_rt);
     }
 
     if (do_current_centering)
@@ -2292,13 +2292,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     if (fft_do_time_averaging)
     {
-        AllocInitMultiFab(Bfield_avg_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[x]");
-        AllocInitMultiFab(Bfield_avg_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[y]");
-        AllocInitMultiFab(Bfield_avg_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[z]");
+        AllocInitMultiFab(Bfield_avg_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[x]", 0.0_rt);
+        AllocInitMultiFab(Bfield_avg_fp[lev][1], amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[y]", 0.0_rt);
+        AllocInitMultiFab(Bfield_avg_fp[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[z]", 0.0_rt);
 
-        AllocInitMultiFab(Efield_avg_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[x]");
-        AllocInitMultiFab(Efield_avg_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[y]");
-        AllocInitMultiFab(Efield_avg_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[z]");
+        AllocInitMultiFab(Efield_avg_fp[lev][0], amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[x]", 0.0_rt);
+        AllocInitMultiFab(Efield_avg_fp[lev][1], amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[y]", 0.0_rt);
+        AllocInitMultiFab(Efield_avg_fp[lev][2], amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_fp[z]", 0.0_rt);
     }
 
 #ifdef AMREX_USE_EB
@@ -2503,24 +2503,24 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         const std::array<Real,3> cdx = CellSize(lev-1);
 
         // Create the MultiFabs for B
-        AllocInitMultiFab(Bfield_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[x]");
-        AllocInitMultiFab(Bfield_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[y]");
-        AllocInitMultiFab(Bfield_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[z]");
+        AllocInitMultiFab(Bfield_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[x]", 0.0_rt);
+        AllocInitMultiFab(Bfield_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[y]", 0.0_rt);
+        AllocInitMultiFab(Bfield_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_cp[z]", 0.0_rt);
 
         // Create the MultiFabs for E
-        AllocInitMultiFab(Efield_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[x]");
-        AllocInitMultiFab(Efield_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[y]");
-        AllocInitMultiFab(Efield_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[z]");
+        AllocInitMultiFab(Efield_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[x]", 0.0_rt);
+        AllocInitMultiFab(Efield_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[y]", 0.0_rt);
+        AllocInitMultiFab(Efield_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_cp[z]", 0.0_rt);
 
         if (fft_do_time_averaging)
         {
-            AllocInitMultiFab(Bfield_avg_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[x]");
-            AllocInitMultiFab(Bfield_avg_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[y]");
-            AllocInitMultiFab(Bfield_avg_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[z]");
+            AllocInitMultiFab(Bfield_avg_cp[lev][0], amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[x]", 0.0_rt);
+            AllocInitMultiFab(Bfield_avg_cp[lev][1], amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[y]", 0.0_rt);
+            AllocInitMultiFab(Bfield_avg_cp[lev][2], amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_cp[z]", 0.0_rt);
 
-            AllocInitMultiFab(Efield_avg_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[x]");
-            AllocInitMultiFab(Efield_avg_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[y]");
-            AllocInitMultiFab(Efield_avg_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[z]");
+            AllocInitMultiFab(Efield_avg_cp[lev][0], amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[x]", 0.0_rt);
+            AllocInitMultiFab(Efield_avg_cp[lev][1], amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[y]", 0.0_rt);
+            AllocInitMultiFab(Efield_avg_cp[lev][2], amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, lev, "Efield_avg_cp[z]", 0.0_rt);
         }
 
         // Create the MultiFabs for the current

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -740,6 +740,9 @@ WarpX::ReadParameters ()
             add_external_E_field = true;
         }
 
+        maxlevel_extEMfield_init = maxLevel();
+        pp_warpx.query("maxlevel_extEMfield_init", maxlevel_extEMfield_init);
+
         electrostatic_solver_id = GetAlgorithmInteger(pp_warpx, "do_electrostatic");
         // if an electrostatic solver is used, set the Maxwell solver to None
         if (electrostatic_solver_id != ElectrostaticSolverAlgo::None) {


### PR DESCRIPTION
For some mesh-refinement simulations, it is useful to only initiaize the external electric and magnetic fields only on the parent grid. This PR adds an option for maximum levels upto which the fields are initialized with the external field options.

A suggested change was to remove default option for external field initialization, and instead use `AllocInitMultiFab` to initialize fields to 0.0 
This simplified a lot of the code in the InitLevelData function
