### PR TITLE
Fix clang-tidy error [readability-simplify-boolean-expr]

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1031,7 +1031,7 @@ WarpX::ReadParameters ()
             const ParmParse pp_fluids("fluids");
             std::vector<std::string> fluid_species_names = {};
             pp_fluids.queryarr("species_names", fluid_species_names);
-            if ( fluid_species_names.empty() == false ) do_fluid_species = 1;
+            if (!fluid_species_names.empty()) do_fluid_species = 1;
             if (do_fluid_species) {
                 WARPX_ALWAYS_ASSERT_WITH_MESSAGE(max_level <= 1,
                     "Fluid species cannot currently be used with mesh refinement.");


### PR DESCRIPTION
Fix clang-tidy error that showed up after commit 9bf35a1416f5425da3c98107359f193f62c82c8d (merge of #3991):
```
/home/runner/work/WarpX/WarpX/Source/WarpX.cpp:1034:49: warning: redundant boolean literal supplied to boolean operator [readability-simplify-boolean-expr]
            if ( fluid_species_names.empty() == false ) do_fluid_species = 1;
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
                 !fluid_species_names.empty()
```

Full error displayed here: https://github.com/ECP-WarpX/WarpX/actions/runs/6346205384/job/17239391090