### PR TITLE
CI: Unbreak macOS (libomp)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
         brew install ccache
         brew install fftw
         brew install libomp
-        brew link --force libomp
+        brew link --overwrite --force libomp
         brew install ninja
         brew install open-mpi
         brew install pkg-config


### PR DESCRIPTION
Something changed in the base image again.

```
==> Fetching libomp
==> Downloading https://ghcr.io/v2/homebrew/core/libomp/blobs/sha256:1a274d0205407af0f98b9808fb940ea063af41ef1913139e069f1607c1e60562
==> Pouring libomp--17.0.2.monterey.bottle.tar.gz
==> Caveats
Warning: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK is set: not checking for outdated
libomp is keg-only, which means it was not symlinked into /usr/local,
dependents or dependents with broken linkage!
because it can override GCC headers and result in broken builds.

For compilers to find libomp you may need to set:
  export LDFLAGS="-L/usr/local/opt/libomp/lib"
  export CPPFLAGS="-I/usr/local/opt/libomp/include"
==> Summary
🍺  /usr/local/Cellar/libomp/17.0.2: 7 files, 1.7MB
Error: Could not symlink lib/libomp.a
Linking /usr/local/Cellar/libomp/17.0.2... 
Target /usr/local/lib/libomp.a
is a symlink belonging to libomp. You can unlink it:
  brew unlink libomp

To force the link and overwrite all conflicting files:
  brew link --overwrite libomp

To list all files that would be deleted:
  brew link --overwrite --dry-run libomp
```