### PR TITLE
[WIP] Esirkepov: Ensure Particle Does not Run out Dt

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -359,9 +359,9 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
 
     // what is the length of the smallest cell edge?
 #if defined(WARPX_DIM_3D)
-    const Real min_dx = dx[0] < dx[1] ? dx[0] : (dx[1] < dx[2] ? dx[1] : dx[2]);
+    const Real min_dx = std::min({dx[0],dx[1],dx[2]});
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-    const Real min_dx = dx[0] < dx[2] ? dx[0] : dx[2];
+    const Real min_dx = std::min(dx[0],dx[2]);
 #else
     const Real min_dx = dx[2];
 #endif


### PR DESCRIPTION
Esirkepov: Ensure `dt` fits into cells with an assert

Re #4358
Follow-up to #4362

- [ ] Resolve comment by @roelof-groenewald in https://github.com/ECP-WarpX/WarpX/pull/4362#discussion_r1355752120

> Can this be an AMREX_ASSERT_WITH_MESSAGE instead? The actual dt*PhysConst::c < min_dx is a stronger constraint than really necessary - would only be needed for particles traveling at the speed of light. I frequently use Esirkepov deposition with the hybrid solver (since it is faster than direct current deposition - not sure why - and less noisy).
The message might also be less rigid - something like "Time step could be too large for Esirkepov..."
