### PR TITLE
Properly flush metadata of incomplete BTD, at the end of simulation

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -47,7 +47,7 @@ private:
      * can be defined and implemented in Diagnostics.H, such that,
      * the function call to flush out buffer data for
      * FullDiagnostics and BTDiagnostics is the same */
-    void Flush (int i_buffer) override;
+    void Flush (int i_buffer, bool force_flush) override;
     /** whether to write output files at this time step
      *  The data is flushed when the buffer is full and/or
      *  when the simulation ends or when forced.

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -994,7 +994,7 @@ BTDiagnostics::GetKIndexInSnapshotBoxFlag (const int i_buffer, const int lev)
 }
 
 void
-BTDiagnostics::Flush (int i_buffer)
+BTDiagnostics::Flush (int i_buffer, bool force_flush)
 {
     auto & warpx = WarpX::GetInstance();
     std::string file_name = m_file_prefix;
@@ -1003,7 +1003,7 @@ BTDiagnostics::Flush (int i_buffer)
         file_name = file_name+"/buffer";
     }
     SetSnapshotFullStatus(i_buffer);
-    const bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 );
+    const bool isLastBTDFlush = ( m_snapshot_full[i_buffer] == 1 ) || force_flush;
     bool const use_pinned_pc = true;
     bool const isBTD = true;
     double const labtime = m_t_lab[i_buffer];

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -34,7 +34,7 @@ private:
     utils::parser::IntervalsParser m_intervals;
 
     /** \brief Flush data to file. */
-    void Flush (int i_buffer) override;
+    void Flush (int i_buffer, bool /* force_flush */) override;
     /** \brief Return whether to dump data to file at this time step.
      * (i.e. whether to call Flush)
      *

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -130,7 +130,7 @@ BoundaryScrapingDiagnostics::DoDump (int step, int /*i_buffer*/, bool force_flus
 }
 
 void
-BoundaryScrapingDiagnostics::Flush (int i_buffer)
+BoundaryScrapingDiagnostics::Flush (int i_buffer, bool /* force_flush */)
 {
     auto & warpx = WarpX::GetInstance();
     ParticleBoundaryBuffer& particle_buffer = warpx.GetParticleBoundaryBuffer();

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -58,8 +58,10 @@ public:
      *   multiple times yet.
      *  When these are fixed, the implementation of Flush should be in Diagnostics.cpp
      * \param[in] i_buffer index of the buffer data to be flushed.
+     * \param[in] force_flush only used for BTD, whether to do a complete flush of the data
+     * (including metadata listing the total number of particles) even if the snapshot is incomplete
      */
-    virtual void Flush (int i_buffer) = 0;
+    virtual void Flush (int i_buffer, bool force_flush) = 0;
     /** Initialize pointers to main fields and allocate output multifab m_mf_output. */
     void InitData ();
     void InitDataBeforeRestart ();

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -575,7 +575,7 @@ Diagnostics::FilterComputePackFlush (int step, bool force_flush)
 
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         if ( !DoDump (step, i_buffer, force_flush) ) continue;
-        Flush(i_buffer);
+        Flush(i_buffer, force_flush);
     }
 
 

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -27,7 +27,7 @@ private:
      */
     bool m_solver_deposits_current = true;
     /** Flush m_mf_output and particles to file for the i^th buffer */
-    void Flush (int i_buffer) override;
+    void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */
     void FlushRaw ();
     /** whether to compute and pack cell-centered data in m_mf_output

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -128,7 +128,7 @@ FullDiagnostics::BackwardCompatibility ()
 }
 
 void
-FullDiagnostics::Flush ( int i_buffer )
+FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
 {
     // This function should be moved to Diagnostics when plotfiles/openpmd format
     // is supported for BackTransformed Diagnostics, in BTDiagnostics class.


### PR DESCRIPTION
This PR makes sure that we write openPMD metadata (esp. constant record) for all files at the end of the simulation. In particular, BTD snapshots that are incomplete (i.e. do not have all slices written yet) also have their metadata written.