### PR TITLE
Fix: Fails in Python Callbacks Abort

### DIFF
--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -12,6 +12,7 @@
 #include "Utils/export.H"
 #include "Utils/WarpXProfilerWrapper.H"
 
+#include <functional>
 #include <map>
 #include <string>
 

--- a/Source/Python/WarpX_py.cpp
+++ b/Source/Python/WarpX_py.cpp
@@ -8,6 +8,7 @@
  */
 #include "WarpX_py.H"
 
+#include <cstdlib>
 #include <exception>
 
 

--- a/Source/Python/WarpX_py.cpp
+++ b/Source/Python/WarpX_py.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include <exception>
+#include <iostream>
 
 
 std::map< std::string, std::function<void()> > warpx_callback_py_map;


### PR DESCRIPTION
Make sure that errors in Python callbacks abort the simulation. Before, MPI-parallel simulations would hang.
Fix #4375

Tested with this input file: [PICMI_inputs_3d.py.txt](https://github.com/ECP-WarpX/WarpX/files/12923292/PICMI_inputs_3d.py.txt)
```console
mpirun -n 4 Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
```
```
STEP 1 starts ...
Python callback 'beforestep' failed!
AttributeError: module 'mpi4py.MPI' has no attribute 'oopsi'

At:
  /home/axel/src/warpx/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py(169): mycallback
  /home/axel/micromamba/envs/warpx-openmp-dev/lib/python3.11/site-packages/pywarpx/callbacks.py(247): callfuncsinlist
  /home/axel/micromamba/envs/warpx-openmp-dev/lib/python3.11/site-packages/pywarpx/callbacks.py(98): __call__
  /home/axel/micromamba/envs/warpx-openmp-dev/lib/python3.11/site-packages/pywarpx/WarpX.py(101): evolve
  /home/axel/micromamba/envs/warpx-openmp-dev/lib/python3.11/site-packages/pywarpx/picmi.py(1930): step
  /home/axel/src/warpx/Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py(175): <module>
```
```
# simulation returns
```