### PR TITLE
GetAndSetPosition: General Particle PIdx

### DIFF
--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -167,7 +167,7 @@ struct LatticeElementFinderDevice
     amrex::ParticleReal m_uz_boost;
     amrex::Real m_time;
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     const amrex::ParticleReal* AMREX_RESTRICT m_ux = nullptr;
     const amrex::ParticleReal* AMREX_RESTRICT m_uy = nullptr;
     const amrex::ParticleReal* AMREX_RESTRICT m_uz = nullptr;

--- a/Source/AcceleratorLattice/LatticeElementFinder.cpp
+++ b/Source/AcceleratorLattice/LatticeElementFinder.cpp
@@ -96,7 +96,7 @@ LatticeElementFinderDevice::InitLatticeElementFinderDevice (WarpXParIter const& 
 
     int const lev = a_pti.GetLevel();
 
-    m_get_position = GetParticlePosition(a_pti, a_offset);
+    m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
     auto& attribs = a_pti.GetAttribs();
     m_ux = attribs[PIdx::ux].dataPtr() + a_offset;
     m_uy = attribs[PIdx::uy].dataPtr() + a_offset;

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -62,7 +62,7 @@ struct SelectParticles
     }
 
     /** Object to extract the positions of the macroparticles inside a ParallelFor kernel */
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     /** Z coordinate in boosted frame that corresponds to a give snapshot*/
     amrex::Real m_current_z_boost;
     /** Previous Z coordinate in boosted frame that corresponds to a give snapshot*/
@@ -166,7 +166,7 @@ struct LorentzTransformParticles
         dst.m_rdata[PIdx::uz][i_dst] = uzp;
     }
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
 
     amrex::ParticleReal* AMREX_RESTRICT m_xpold = nullptr;
     amrex::ParticleReal* AMREX_RESTRICT m_ypold = nullptr;

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
@@ -20,7 +20,7 @@ SelectParticles::SelectParticles (const WarpXParIter& a_pti, TmpParticles& tmp_p
                                   int a_offset)
     : m_current_z_boost(current_z_boost), m_old_z_boost(old_z_boost)
 {
-    m_get_position = GetParticlePosition(a_pti, a_offset);
+    m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
 
     const auto lev = a_pti.GetLevel();
     const auto index = a_pti.GetPairIndex();
@@ -38,7 +38,7 @@ LorentzTransformParticles::LorentzTransformParticles ( const WarpXParIter& a_pti
     using namespace amrex::literals;
 
     if (tmp_particle_data.empty()) return;
-    m_get_position = GetParticlePosition(a_pti, a_offset);
+    m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
 
     auto& attribs = a_pti.GetAttribs();
     m_wpnew = attribs[PIdx::w].dataPtr();

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -456,7 +456,7 @@ void ColliderRelevant::ComputeDiags (int step)
             // Loop over boxes
             for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
             {
-                const auto GetPosition = GetParticlePosition(pti);
+                const auto GetPosition = GetParticlePosition<PIdx>(pti);
                 // get particle arrays
                 amrex::ParticleReal* const AMREX_RESTRICT ux = pti.GetAttribs()[PIdx::ux].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT uy = pti.GetAttribs()[PIdx::uy].dataPtr();

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -429,8 +429,8 @@ void FieldProbe::ComputeDiags (int step)
 
         for (MyParIter pti(m_probe, lev); pti.isValid(); ++pti)
         {
-            const auto getPosition = GetParticlePosition(pti);
-            auto setPosition = SetParticlePosition(pti);
+            const auto getPosition = GetParticlePosition<FieldProbePIdx>(pti);
+            auto setPosition = SetParticlePosition<FieldProbePIdx>(pti);
             const auto& aos = pti.GetArrayOfStructs();
             const auto* AMREX_RESTRICT m_structs = aos().dataPtr();
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.H
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.H
@@ -19,21 +19,17 @@
  * This enumerated struct is used to index the field probe particle
  * values that are being stored as SoA data. Nattribs
  * is enumerated to give the number of attributes stored.
- * The strange insertion of `theta` below is due to the use of
- * GetParticlePosition for the field probe locations, which reads the probe
- * theta value from PIdx::theta = 4.
  */
 struct FieldProbePIdx
 {
     enum
     {
         Ex = 0, Ey, Ez,
-        Bx,
+        Bx, By, Bz,
+        S, //!< the Poynting vector
 #ifdef WARPX_DIM_RZ
         theta,      ///< RZ needs all three position components
 #endif
-        By, Bz,
-        S, //!< the Poynting vector
         nattribs
     };
 };

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -388,7 +388,7 @@ void ParticleExtrema::ComputeDiags (int step)
                 // Loop over boxes
                 for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
                 {
-                    const auto GetPosition = GetParticlePosition(pti);
+                    const auto GetPosition = GetParticlePosition<PIdx>(pti);
                     // get particle arrays
                     amrex::ParticleReal* const AMREX_RESTRICT ux = pti.GetAttribs()[PIdx::ux].dataPtr();
                     amrex::ParticleReal* const AMREX_RESTRICT uy = pti.GetAttribs()[PIdx::uy].dataPtr();

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -196,7 +196,7 @@ void ParticleHistogram::ComputeDiags (int step)
         {
             for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
             {
-                auto const GetPosition = GetParticlePosition(pti);
+                auto const GetPosition = GetParticlePosition<PIdx>(pti);
 
                 auto & attribs = pti.GetAttribs();
                 ParticleReal* const AMREX_RESTRICT d_w = attribs[PIdx::w].dataPtr();

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -193,7 +193,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
         {
             for (WarpXParIter pti(myspc, lev); pti.isValid(); ++pti)
             {
-                auto const GetPosition = GetParticlePosition(pti);
+                auto const GetPosition = GetParticlePosition<PIdx>(pti);
 
                 auto & attribs = pti.GetAttribs();
                 ParticleReal* const AMREX_RESTRICT d_w = attribs[PIdx::w].dataPtr();

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -163,7 +163,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
         const auto dxi = pc.Geom(lev).InvCellSizeArray();
         for(WarpXParIter pti(pc, lev); pti.isValid(); ++pti)
         {
-            const auto getPosition = GetParticlePosition(pti);
+            const auto getPosition = GetParticlePosition<PIdx>(pti);
             auto& tile = pti.GetParticleTile();
             auto ptd = tile.getParticleTileData();
             const auto np = tile.numParticles();

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -340,7 +340,7 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
 
     // we need particle positions in order to calculate the local density
     // and temperature
-    auto GetPosition = GetParticlePosition(pti);
+    auto GetPosition = GetParticlePosition<PIdx>(pti);
 
     // get Struct-Of-Array particle data, also called attribs
     auto& attribs = pti.GetAttribs();

--- a/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
+++ b/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
@@ -159,7 +159,7 @@ void BackgroundStopping::doBackgroundStoppingOnElectronsWithinTile (WarpXParIter
     amrex::ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
 
     // May be needed to evaluate the density and/or temperature functions
-    auto const GetPosition = GetParticlePosition(pti);
+    auto const GetPosition = GetParticlePosition<PIdx>(pti);
 
     amrex::ParallelFor(np,
         [=] AMREX_GPU_HOST_DEVICE (long ip)
@@ -234,7 +234,7 @@ void BackgroundStopping::doBackgroundStoppingOnIonsWithinTile (WarpXParIter& pti
     amrex::ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
 
     // May be needed to evaluate the density function
-    auto const GetPosition = GetParticlePosition(pti);
+    auto const GetPosition = GetParticlePosition<PIdx>(pti);
 
     amrex::ParallelFor(np,
         [=] AMREX_GPU_HOST_DEVICE (long ip)

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -221,7 +221,7 @@ public:
         // Store product species data in vectors
         const int n_product_species = m_product_species.size();
         amrex::Vector<ParticleTileType*> tile_products;
-        amrex::Vector<GetParticlePosition> get_position_products;
+        amrex::Vector<GetParticlePosition<PIdx>> get_position_products;
         amrex::Vector<index_type> products_np;
         amrex::Vector<amrex::ParticleReal> products_mass;
         constexpr int getpos_offset = 0;
@@ -229,7 +229,7 @@ public:
         {
             ParticleTileType& ptile_product = product_species_vector[i]->ParticlesAt(lev, mfi);
             tile_products.push_back(&ptile_product);
-            get_position_products.push_back(GetParticlePosition(ptile_product,
+            get_position_products.push_back(GetParticlePosition<PIdx>(ptile_product,
                                                                       getpos_offset));
             products_np.push_back(ptile_product.numParticles());
             products_mass.push_back(product_species_vector[i]->getMass());
@@ -254,7 +254,7 @@ public:
             index_type const* AMREX_RESTRICT cell_offsets_1 = bins_1.offsetsPtr();
             const amrex::ParticleReal q1 = species_1.getCharge();
             const amrex::ParticleReal m1 = species_1.getMass();
-            auto get_position_1  = GetParticlePosition(ptile_1, getpos_offset);
+            auto get_position_1  = GetParticlePosition<PIdx>(ptile_1, getpos_offset);
             // Needed to access the particle id
             ParticleType * AMREX_RESTRICT
                                  particle_ptr_1 = ptile_1.GetArrayOfStructs()().data();
@@ -394,7 +394,7 @@ public:
             index_type const* AMREX_RESTRICT cell_offsets_1 = bins_1.offsetsPtr();
             const amrex::ParticleReal q1 = species_1.getCharge();
             const amrex::ParticleReal m1 = species_1.getMass();
-            auto get_position_1  = GetParticlePosition(ptile_1, getpos_offset);
+            auto get_position_1  = GetParticlePosition<PIdx>(ptile_1, getpos_offset);
             // Needed to access the particle id
             ParticleType * AMREX_RESTRICT
                                  particle_ptr_1 = ptile_1.GetArrayOfStructs()().data();
@@ -404,7 +404,7 @@ public:
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
             const amrex::ParticleReal q2 = species_2.getCharge();
             const amrex::ParticleReal m2 = species_2.getMass();
-            auto get_position_2  = GetParticlePosition(ptile_2, getpos_offset);
+            auto get_position_2  = GetParticlePosition<PIdx>(ptile_2, getpos_offset);
             // Needed to access the particle id
             ParticleType * AMREX_RESTRICT
                                  particle_ptr_2 = ptile_2.GetArrayOfStructs()().data();

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
@@ -77,7 +77,7 @@ public:
         index_type const* AMREX_RESTRICT I1,
         index_type const* AMREX_RESTRICT I2,
         SoaData_type soa_1, SoaData_type soa_2,
-        GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
+        GetParticlePosition<PIdx> /*get_position_1*/, GetParticlePosition<PIdx> /*get_position_2*/,
         amrex::ParticleReal const  q1, amrex::ParticleReal const  q2,
         amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
         amrex::Real const  dt, amrex::Real const dV,

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -123,7 +123,7 @@ public:
         index_type const* AMREX_RESTRICT I1,
         index_type const* AMREX_RESTRICT I2,
         SoaData_type soa_1, SoaData_type soa_2,
-        GetParticlePosition /*get_position_1*/, GetParticlePosition /*get_position_2*/,
+        GetParticlePosition<PIdx> /*get_position_1*/, GetParticlePosition<PIdx> /*get_position_2*/,
         amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
         amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
         amrex::Real const  dt, amrex::Real const dV,

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -37,7 +37,7 @@
  * \param load_balance_costs_update_algo Selected method for updating load balance costs.
  */
 template <int depos_order>
-void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
+void doChargeDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                                const amrex::ParticleReal * const wp,
                                const int* ion_lev,
                                amrex::FArrayBox& rho_fab,
@@ -239,7 +239,7 @@ void doChargeDepositionShapeN (const GetParticlePosition& GetPosition,
  * \param bin_size tile size to use for shared current deposition operations
  */
 template <int depos_order>
-void doChargeDepositionSharedShapeN (const GetParticlePosition& GetPosition,
+void doChargeDepositionSharedShapeN (const GetParticlePosition<PIdx>& GetPosition,
                                      const amrex::ParticleReal * const wp,
                                      const int* ion_lev,
                                      amrex::FArrayBox& rho_fab,

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -51,7 +51,7 @@
  * \param load_balance_costs_update_algo Selected method for updating load balance costs.
  */
 template <int depos_order>
-void doDepositionShapeN (const GetParticlePosition& GetPosition,
+void doDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                          const amrex::ParticleReal * const wp,
                          const amrex::ParticleReal * const uxp,
                          const amrex::ParticleReal * const uyp,
@@ -365,7 +365,7 @@ void doDepositionShapeN (const GetParticlePosition& GetPosition,
  * \param load_balance_costs_update_algo Selected method for updating load balance costs.
  */
 template <int depos_order>
-void doDepositionSharedShapeN (const GetParticlePosition& GetPosition,
+void doDepositionSharedShapeN (const GetParticlePosition<PIdx>& GetPosition,
                                const amrex::ParticleReal * const wp,
                                const amrex::ParticleReal * const uxp,
                                const amrex::ParticleReal * const uyp,
@@ -577,7 +577,7 @@ void doDepositionSharedShapeN (const GetParticlePosition& GetPosition,
  * \param load_balance_costs_update_algo Selected method for updating load balance costs.
  */
 template <int depos_order>
-void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
+void doEsirkepovDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                                   const amrex::ParticleReal * const wp,
                                   const amrex::ParticleReal * const uxp,
                                   const amrex::ParticleReal * const uyp,
@@ -957,7 +957,7 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
  * \param[in] load_balance_costs_update_algo Selected method for updating load balance costs
  */
 template <int depos_order>
-void doVayDepositionShapeN (const GetParticlePosition& GetPosition,
+void doVayDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                             const amrex::ParticleReal* const wp,
                             const amrex::ParticleReal* const uxp,
                             const amrex::ParticleReal* const uyp,

--- a/Source/Particles/Deposition/SharedDepositionUtils.H
+++ b/Source/Particles/Deposition/SharedDepositionUtils.H
@@ -65,7 +65,7 @@ void addLocalToGlobal (const amrex::Box& bx,
 #if defined(AMREX_USE_HIP) || defined(AMREX_USE_CUDA)
 template <int depos_order>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void depositComponent (const GetParticlePosition& GetPosition,
+void depositComponent (const GetParticlePosition<PIdx>& GetPosition,
                        const amrex::ParticleReal * const wp,
                        const amrex::ParticleReal * const uxp,
                        const amrex::ParticleReal * const uyp,

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -37,7 +37,7 @@ struct IonizationFilterFunc
     int comp;
     int m_atomic_number;
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     GetExternalEBField m_get_externalEB;
 
     amrex::Array4<const amrex::Real> m_ex_arr;

--- a/Source/Particles/ElementaryProcess/Ionization.cpp
+++ b/Source/Particles/ElementaryProcess/Ionization.cpp
@@ -42,7 +42,7 @@ IonizationFilterFunc::IonizationFilterFunc (const WarpXParIter& a_pti, int lev, 
     comp = a_comp;
     m_atomic_number = a_atomic_number;
 
-    m_get_position  = GetParticlePosition(a_pti, a_offset);
+    m_get_position  = GetParticlePosition<PIdx>(a_pti, a_offset);
     m_get_externalEB = GetExternalEBField(a_pti, a_offset);
 
     m_ex_arr = exfab.array();

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -168,7 +168,7 @@ private:
     const BreitWheelerGeneratePairs
     m_generate_functor; /*!< A copy of the functor to generate pairs. It contains only pointers to the lookup tables.*/
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     GetExternalEBField m_get_externalEB;
 
     amrex::Array4<const amrex::Real> m_ex_arr;

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
@@ -32,7 +32,7 @@ PairGenerationTransformFunc (BreitWheelerGeneratePairs const generate_functor,
 
     using namespace amrex::literals;
 
-    m_get_position  = GetParticlePosition(a_pti, a_offset);
+    m_get_position  = GetParticlePosition<PIdx>(a_pti, a_offset);
     m_get_externalEB = GetExternalEBField(a_pti, a_offset);
 
     m_ex_arr = exfab.array();

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -178,7 +178,7 @@ private:
     const QuantumSynchrotronPhotonEmission
         m_emission_functor;  /*!< A copy of the functor to generate photons. It contains only pointers to the lookup tables.*/
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     GetExternalEBField m_get_externalEB;
 
     amrex::Array4<const amrex::Real> m_ex_arr;

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.cpp
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.cpp
@@ -35,7 +35,7 @@ PhotonEmissionTransformFunc (QuantumSynchrotronGetOpticalDepth opt_depth_functor
 
     using namespace amrex::literals;
 
-    m_get_position  = GetParticlePosition(a_pti, a_offset);
+    m_get_position  = GetParticlePosition<PIdx>(a_pti, a_offset);
     m_get_externalEB = GetExternalEBField(a_pti, a_offset);
 
     m_ex_arr = exfab.array();

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -432,7 +432,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
  * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry
  */
 template <int depos_order, int lower_in_v>
-void doGatherShapeN(const GetParticlePosition& getPosition,
+void doGatherShapeN(const GetParticlePosition<PIdx>& getPosition,
                     const GetExternalEBField& getExternalEB,
                     amrex::ParticleReal * const Exp, amrex::ParticleReal * const Eyp,
                     amrex::ParticleReal * const Ezp, amrex::ParticleReal * const Bxp,

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -45,7 +45,7 @@ struct GetExternalEBField
     amrex::ParserExecutor<4> m_Byfield_partparser;
     amrex::ParserExecutor<4> m_Bzfield_partparser;
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
     amrex::Real m_time;
 
     amrex::ParticleReal m_repeated_plasma_lens_period;

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -56,7 +56,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
         mypc.m_B_ext_particle_s == "repeated_plasma_lens")
     {
         m_time = warpx.gett_new(a_pti.GetLevel());
-        m_get_position = GetParticlePosition(a_pti, a_offset);
+        m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
     }
 
     if (mypc.m_E_ext_particle_s == "parse_e_ext_particle_function")

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -790,7 +790,7 @@ LaserParticleContainer::calculate_laser_plane_coordinates (const WarpXParIter& p
                                                            Real * AMREX_RESTRICT const pplane_Xp,
                                                            Real * AMREX_RESTRICT const pplane_Yp)
 {
-    const auto GetPosition = GetParticlePosition(pti);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti);
 
 #if (AMREX_SPACEDIM >= 2)
     const Real tmp_u_X_0 = m_u_X[0];
@@ -852,8 +852,8 @@ LaserParticleContainer::update_laser_particle (WarpXParIter& pti,
                                                Real const * AMREX_RESTRICT const amplitude,
                                                const Real dt)
 {
-    const auto GetPosition = GetParticlePosition(pti);
-    auto       SetPosition = SetParticlePosition(pti);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti);
+    auto       SetPosition = SetParticlePosition<PIdx>(pti);
 
     const Real tmp_p_X_0 = m_p_X[0];
     const Real tmp_p_X_1 = m_p_X[1];

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -313,7 +313,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                 auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
                 if(plevel.find(index) == plevel.end()) continue;
 
-                const auto getPosition = GetParticlePosition(pti);
+                const auto getPosition = GetParticlePosition<PIdx>(pti);
                 auto& ptile_buffer = species_buffer.DefineAndReturnParticleTile(lev, pti.index(),
                                                                                 pti.LocalTileIndex());
                 const auto& ptile = plevel.at(index);

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -129,8 +129,8 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     auto copyAttribs = CopyParticleAttribs(pti, tmp_particle_data, offset);
     const int do_copy = (m_do_back_transformed_particles && (a_dt_type!=DtType::SecondHalf) );
 
-    const auto GetPosition = GetParticlePosition(pti, offset);
-    auto SetPosition = SetParticlePosition(pti, offset);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
+    auto SetPosition = SetParticlePosition<PIdx>(pti, offset);
 
     const auto getExternalEB = GetExternalEBField(pti, offset);
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -712,7 +712,7 @@ PhysicalParticleContainer::DefaultInitializeRuntimeAttributes (
         // Preparing data needed for user defined attributes
         const auto n_user_real_attribs = static_cast<int>(m_user_real_attribs.size());
         const auto n_user_int_attribs = static_cast<int>(m_user_int_attribs.size());
-        const auto get_position = GetParticlePosition(pinned_tile);
+        const auto get_position = GetParticlePosition<PIdx>(pinned_tile);
         const auto soa = pinned_tile.getParticleTileData();
         const amrex::ParticleReal* AMREX_RESTRICT ux = soa.m_rdata[PIdx::ux];
         const amrex::ParticleReal* AMREX_RESTRICT uy = soa.m_rdata[PIdx::uy];
@@ -2298,7 +2298,7 @@ PhysicalParticleContainer::SplitParticles (int lev)
     // Loop over particle interator
     for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
     {
-        const auto GetPosition = GetParticlePosition(pti);
+        const auto GetPosition = GetParticlePosition<PIdx>(pti);
 
         const amrex::Vector<int> ppc_nd = plasma_injector->num_particles_per_cell_each_dim;
         const std::array<Real,3>& dx = WarpX::CellSize(lev);
@@ -2494,7 +2494,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             const FArrayBox& byfab = By[pti];
             const FArrayBox& bzfab = Bz[pti];
 
-            const auto getPosition = GetParticlePosition(pti);
+            const auto getPosition = GetParticlePosition<PIdx>(pti);
 
             const auto getExternalEB = GetExternalEBField(pti);
 
@@ -2670,8 +2670,8 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     // Add guard cells to the box.
     box.grow(ngEB);
 
-    const auto getPosition = GetParticlePosition(pti, offset);
-          auto setPosition = SetParticlePosition(pti, offset);
+    const auto getPosition = GetParticlePosition<PIdx>(pti, offset);
+          auto setPosition = SetParticlePosition<PIdx>(pti, offset);
 
     const auto getExternalEB = GetExternalEBField(pti, offset);
 

--- a/Source/Particles/Pusher/CopyParticleAttribs.H
+++ b/Source/Particles/Pusher/CopyParticleAttribs.H
@@ -22,7 +22,7 @@ struct CopyParticleAttribs
 {
     using TmpParticles = WarpXParticleContainer::TmpParticles;
 
-    GetParticlePosition m_get_position;
+    GetParticlePosition<PIdx> m_get_position;
 
     const amrex::ParticleReal* AMREX_RESTRICT uxp = nullptr;
     const amrex::ParticleReal* AMREX_RESTRICT uyp = nullptr;
@@ -66,7 +66,7 @@ struct CopyParticleAttribs
         uypold = tmp_particle_data[lev].at(index)[TmpIdx::uyold].dataPtr() + a_offset;
         uzpold = tmp_particle_data[lev].at(index)[TmpIdx::uzold].dataPtr() + a_offset;
 
-        m_get_position = GetParticlePosition(a_pti, a_offset);
+        m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
     }
 
     /** \brief copy the position and momentum of particle i to the

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -9,6 +9,7 @@
 #define WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 
 #include "Particles/WarpXParticleContainer.H"
+#include "Particles/NamedComponentParticleContainer.H"
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>
@@ -18,7 +19,11 @@
 
 /** \brief Extract the cartesian position coordinates of the particle
  *         p and store them in the variables `x`, `y`, `z`
- *         This version operates on a SuperParticle */
+ *         This version operates on a SuperParticle
+ *
+ * \tparam T_PIdx particle index enumerator
+ */
+template<typename T_PIdx = PIdx>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
                             amrex::ParticleReal& x,
@@ -26,7 +31,7 @@ void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
                             amrex::ParticleReal& z) noexcept
 {
 #ifdef WARPX_DIM_RZ
-    const amrex::ParticleReal theta = p.rdata(PIdx::theta);
+    const amrex::ParticleReal theta = p.rdata(T_PIdx::theta);
     const amrex::ParticleReal r = p.pos(0);
     x = r*std::cos(theta);
     y = r*std::sin(theta);
@@ -48,7 +53,10 @@ void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
 
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel
+ *
+ * \tparam T_PIdx particle index enumerator
 */
+template<typename T_PIdx = PIdx>
 struct GetParticlePosition
 {
     using PType = WarpXParticleContainer::ParticleType;
@@ -80,7 +88,7 @@ struct GetParticlePosition
         m_structs = aos().dataPtr() + a_offset;
 #if defined(WARPX_DIM_RZ)
         const auto& soa = a_pti.GetStructOfArrays();
-        m_theta = soa.GetRealData(PIdx::theta).dataPtr() + a_offset;
+        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
 #endif
     }
 
@@ -143,9 +151,11 @@ struct GetParticlePosition
 /** \brief Functor that can be used to modify the positions of the macroparticles,
  *         inside a ParallelFor kernel.
  *
+ * \tparam T_PIdx particle index enumerator
  * \param a_pti iterator to the tile being modified
  * \param a_offset offset to apply to the particle indices
 */
+template<typename T_PIdx = PIdx>
 struct SetParticlePosition
 {
     using PType = WarpXParticleContainer::ParticleType;
@@ -163,7 +173,7 @@ struct SetParticlePosition
         m_structs = aos().dataPtr() + a_offset;
 #if defined(WARPX_DIM_RZ)
         auto& soa = a_pti.GetStructOfArrays();
-        m_theta = soa.GetRealData(PIdx::theta).dataPtr() + a_offset;
+        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
 #endif
     }
 

--- a/Source/Particles/Pusher/PushSelector.H
+++ b/Source/Particles/Pusher/PushSelector.H
@@ -43,8 +43,8 @@
 
 template <int do_sync>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void doParticlePush(const GetParticlePosition& GetPosition,
-                    const SetParticlePosition& SetPosition,
+void doParticlePush(const GetParticlePosition<PIdx>& GetPosition,
+                    const SetParticlePosition<PIdx>& SetPosition,
                     const CopyParticleAttribs& copyAttribs,
                     const long i,
                     amrex::ParticleReal& ux,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -121,8 +121,8 @@ RigidInjectedParticleContainer::RemapParticles()
                     const auto uyp = attribs[PIdx::uy].dataPtr();
                     const auto uzp = attribs[PIdx::uz].dataPtr();
 
-                    const auto GetPosition = GetParticlePosition(pti);
-                          auto SetPosition = SetParticlePosition(pti);
+                    const auto GetPosition = GetParticlePosition<PIdx>(pti);
+                          auto SetPosition = SetParticlePosition<PIdx>(pti);
 
                     // Loop over particles
                     const long np = pti.numParticles();
@@ -181,8 +181,8 @@ RigidInjectedParticleContainer::PushPX (WarpXParIter& pti,
     amrex::Gpu::DeviceVector<ParticleReal> optical_depth_save;
 #endif
 
-    const auto GetPosition = GetParticlePosition(pti, offset);
-          auto SetPosition = SetParticlePosition(pti, offset);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
+          auto SetPosition = SetParticlePosition<PIdx>(pti, offset);
 
     amrex::ParticleReal* const AMREX_RESTRICT ux = uxp.dataPtr() + offset;
     amrex::ParticleReal* const AMREX_RESTRICT uy = uyp.dataPtr() + offset;
@@ -357,7 +357,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
             const FArrayBox& byfab = By[pti];
             const FArrayBox& bzfab = Bz[pti];
 
-            const auto getPosition = GetParticlePosition(pti);
+            const auto getPosition = GetParticlePosition<PIdx>(pti);
 
             const auto getExternalEB = GetExternalEBField(pti);
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -424,7 +424,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     Array4<Real> const& jz_arr = local_jz[thread_num].array();
 #endif
 
-    const auto GetPosition = GetParticlePosition(pti, offset);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
 
     // Lower corner of tile box physical domain
     // Note that this includes guard cells since it is after tilebox.ngrow
@@ -870,7 +870,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
         amrex::LayoutData<amrex::Real>* costs = WarpX::getCosts(lev);
         amrex::Real* cost = costs ? &((*costs)[pti.index()]) : nullptr;
 
-        const auto GetPosition = GetParticlePosition(pti, offset);
+        const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
         const Geometry& geom = Geom(lev);
         Box box = pti.validbox();
         box.grow(ng_rho);
@@ -1258,8 +1258,8 @@ WarpXParticleContainer::PushX (int lev, amrex::Real dt)
             // Particle Push
             //
 
-            const auto GetPosition = GetParticlePosition(pti);
-                  auto SetPosition = SetParticlePosition(pti);
+            const auto GetPosition = GetParticlePosition<PIdx>(pti);
+                  auto SetPosition = SetParticlePosition<PIdx>(pti);
 
             // - momenta are stored as a struct of array, in `attribs`
             auto& attribs = pti.GetAttribs();
@@ -1345,8 +1345,8 @@ WarpXParticleContainer::ApplyBoundaryConditions (){
 #endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
-            auto GetPosition = GetParticlePosition(pti);
-            auto SetPosition = SetParticlePosition(pti);
+            auto GetPosition = GetParticlePosition<PIdx>(pti);
+            auto SetPosition = SetParticlePosition<PIdx>(pti);
 #ifndef WARPX_DIM_1D_Z
             const Real xmin = Geom(lev).ProbLo(0);
             const Real xmax = Geom(lev).ProbHi(0);

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -170,7 +170,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
     auto & rho_fab = local_rho;
 #endif
 
-    const auto GetPosition = GetParticlePosition(pti, offset);
+    const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
 
     // Indices of the lower bound
     const amrex::Dim3 lo = lbound(tilebox);


### PR DESCRIPTION
Generalize the `SetParticlePosition` & `GetParticlePosition` classes to work with arbitrary particle index enumerators. That way, we can reuse them between different particle containers.

Follow-up to #4057 making the `FieldProbe` implementation way more robust to changes.
https://www.youtube.com/watch?v=QRVExJZKIT8