### PR TITLE
Machines: HDF5 & ADIOS2 Tools in PATH

### DIFF
--- a/Tools/machines/adastra-cines/adastra_warpx.profile.example
+++ b/Tools/machines/adastra-cines/adastra_warpx.profile.example
@@ -21,6 +21,8 @@ module load cray-hdf5-parallel
 export CMAKE_PREFIX_PATH=${HOME}/sw/adastra/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${HOME}/sw/adastra/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 
+export PATH=${HOME}/sw/adastra/gpu/adios2-2.8.3/bin:${PATH}
+
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.9.13.1
 

--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -27,6 +27,7 @@ export LD_LIBRARY_PATH=${HOME}/sw/hpc3/gpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${HOME}/sw/hpc3/gpu/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${HOME}/sw/hpc3/gpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=${HOME}/sw/hpc3/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: CCache
 #module load ccache  # missing

--- a/Tools/machines/karolina-it4i/karolina_cpu_warpx.profile.example
+++ b/Tools/machines/karolina-it4i/karolina_cpu_warpx.profile.example
@@ -27,6 +27,9 @@ export LD_LIBRARY_PATH=${HOME}/sw/karolina/cpu/adios2-2.8.3/lib64:$LD_LIBRARY_PA
 export LD_LIBRARY_PATH=${HOME}/sw/karolina/cpu/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${HOME}/sw/karolina/cpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=${HOME}/sw/karolina/cpu/hdf5-1.14.1.2/bin:${PATH}
+export PATH=${HOME}/sw/karolina/cpu/adios2-2.8.3/bin:${PATH}
+
 # optional: CCache (not found)
 #module load ccache
 

--- a/Tools/machines/karolina-it4i/karolina_gpu_warpx.profile.example
+++ b/Tools/machines/karolina-it4i/karolina_gpu_warpx.profile.example
@@ -29,6 +29,9 @@ export LD_LIBRARY_PATH=${HOME}/sw/karolina/gpu/adios2-2.8.3/lib64:$LD_LIBRARY_PA
 export LD_LIBRARY_PATH=${HOME}/sw/karolina/gpu/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${HOME}/sw/karolina/gpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=${HOME}/sw/karolina/gpu/hdf5-1.14.1.2/bin:${PATH}
+export PATH=${HOME}/sw/karolina/gpu/adios2-2.8.3/bin:${PATH}
+
 # optional: CCache (not found)
 #ml ccache
 

--- a/Tools/machines/lassen-llnl/lassen_v100_warpx.profile.example
+++ b/Tools/machines/lassen-llnl/lassen_v100_warpx.profile.example
@@ -18,6 +18,8 @@ export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/hdf5-1.14.1.2/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
+export PATH=${SW_DIR}/hdf5-1.14.1.2/bin:${PATH}
+export PATH=${SW_DIR}/adios2-2.8.3/bin:$PATH
 
 # optional: for PSATD in RZ geometry support
 export CMAKE_PREFIX_PATH=${SW_DIR}/blaspp-master:$CMAKE_PREFIX_PATH

--- a/Tools/machines/lassen-llnl/lassen_v100_warpx_toss3.profile.example
+++ b/Tools/machines/lassen-llnl/lassen_v100_warpx_toss3.profile.example
@@ -18,6 +18,8 @@ export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/hdf5-1.14.1.2/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
+export PATH=${SW_DIR}/hdf5-1.14.1.2/bin:${PATH}
+export PATH=${SW_DIR}/adios2-2.8.3/bin:${PATH}
 
 # optional: for PSATD in RZ geometry support
 export CMAKE_PREFIX_PATH=${SW_DIR}/blaspp-master:$CMAKE_PREFIX_PATH

--- a/Tools/machines/lawrencium-lbnl/lawrencium_warpx.profile.example
+++ b/Tools/machines/lawrencium-lbnl/lawrencium_warpx.profile.example
@@ -21,6 +21,8 @@ export CMAKE_PREFIX_PATH=$HOME/sw/v100/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$HOME/sw/v100/blaspp-master:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$HOME/sw/v100/lapackpp-master:$CMAKE_PREFIX_PATH
 
+export PATH=$HOME/sw/v100/adios2-2.8.3/bin:$PATH
+
 # optional: CCache
 #module load ccache  # missing
 

--- a/Tools/machines/leonardo-cineca/leonardo_gpu_warpx.profile.example
+++ b/Tools/machines/leonardo-cineca/leonardo_gpu_warpx.profile.example
@@ -24,6 +24,8 @@ export LD_LIBRARY_PATH=$HOME/sw/adios2-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$HOME/sw/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$HOME/sw/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=$HOME/sw/adios2-master/bin:$PATH
+
 # optional: for Python bindings or libEnsemble
 module load python/3.10.8--gcc--11.3.0
 

--- a/Tools/machines/lumi-csc/lumi_warpx.profile.example
+++ b/Tools/machines/lumi-csc/lumi_warpx.profile.example
@@ -22,6 +22,7 @@ module load Boost/1.81.0-cpeCray-23.03
 module load cray-hdf5/1.12.2.3
 export CMAKE_PREFIX_PATH=${HOME}/sw/lumi/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${HOME}/sw/lumi/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
+export PATH=${HOME}/sw/lumi/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.9.13.1

--- a/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
@@ -25,6 +25,8 @@ export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/lib
 export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/bin:${PATH}
+
 # optional: CCache
 export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
 

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -23,6 +23,8 @@ export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/
 export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
 
+export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/bin:${PATH}
+
 # optional: CCache
 export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
 

--- a/Tools/machines/quartz-llnl/quartz_warpx.profile.example
+++ b/Tools/machines/quartz-llnl/quartz_warpx.profile.example
@@ -18,6 +18,7 @@ module load hdf5-parallel/1.14.0
 SW_DIR="/usr/workspace/${USER}/quartz"
 export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.8.3:$CMAKE_PREFIX_PATH
+export PATH=${SW_DIR}/adios2-2.8.3/bin:${PATH}
 
 # optional: for PSATD in RZ geometry support
 export CMAKE_PREFIX_PATH=${SW_DIR}/blaspp-master:$CMAKE_PREFIX_PATH


### PR DESCRIPTION
Ensure tools such as `bpls`, `bpdump` and `h5ls` are available to users if we self-compile them.