### PR TITLE
Make the static variable "authors" of the WarpX class a private member of the WarpX class 

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -106,7 +106,8 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
     encoding, openpmd_backend,
     operator_type, operator_parameters,
     engine_type, engine_parameters,
-    warpx.getPMLdirections()
+    warpx.getPMLdirections(),
+    warpx.GetAuthors()
   );
 }
 

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -88,6 +88,7 @@ public:
    * @param engine_type ADIOS engine for output
    * @param engine_parameters map of parameters for the engine
    * @param fieldPMLdirections PML field solver, @see WarpX::getPMLdirections()
+   * @param authors a string specifying the authors of the simulation (can be empty)
    */
   WarpXOpenPMDPlot (openPMD::IterationEncoding ie,
                     std::string filetype,

--- a/Source/Diagnostics/WarpXOpenPMD.H
+++ b/Source/Diagnostics/WarpXOpenPMD.H
@@ -95,7 +95,8 @@ public:
                     std::map< std::string, std::string > operator_parameters,
                     std::string engine_type,
                     std::map< std::string, std::string > engine_parameters,
-                    std::vector<bool> fieldPMLdirections);
+                    std::vector<bool> fieldPMLdirections,
+                    const std::string& authors);
 
   ~WarpXOpenPMDPlot ();
 
@@ -339,6 +340,9 @@ private:
 
   // meta data
   std::vector< bool > m_fieldPMLdirections; //! @see WarpX::getPMLdirections()
+
+  // The authors' string
+  std::string m_authors;
 };
 #endif // WARPX_USE_OPENPMD
 

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -376,13 +376,15 @@ WarpXOpenPMDPlot::WarpXOpenPMDPlot (
     std::map< std::string, std::string > operator_parameters,
     std::string engine_type,
     std::map< std::string, std::string > engine_parameters,
-    std::vector<bool> fieldPMLdirections)
+    std::vector<bool> fieldPMLdirections,
+    const std::string& authors)
   :m_Series(nullptr),
    m_MPIRank{amrex::ParallelDescriptor::MyProc()},
    m_MPISize{amrex::ParallelDescriptor::NProcs()},
    m_Encoding(ie),
    m_OpenPMDFileType(std::move(openPMDFileType)),
-   m_fieldPMLdirections(std::move(fieldPMLdirections))
+   m_fieldPMLdirections(std::move(fieldPMLdirections)),
+   m_authors{authors}
 {
     m_OpenPMDoptions = detail::getSeriesOptions(operator_type, operator_parameters,
                                                 engine_type, engine_parameters);
@@ -502,8 +504,8 @@ WarpXOpenPMDPlot::Init (openPMD::Access access, bool isBTD)
     m_Series->setIterationEncoding( m_Encoding );
 
     // input file / simulation setup author
-    if( !WarpX::authors.empty())
-        m_Series->setAuthor( WarpX::authors );
+    if( !m_authors.empty())
+        m_Series->setAuthor( m_authors );
     // more natural naming for PIC
     m_Series->setMeshesPath( "fields" );
     // conform to ED-PIC extension of openPMD

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -131,8 +131,12 @@ public:
                          amrex::Real external_field=0.0, bool useparser = false,
                          amrex::ParserExecutor<3> const& field_parser={});
 
-    //! Author of an input file / simulation setup
-    static std::string authors;
+    /**
+     * \brief
+     * If an authors' string is specified in the inputfile, this method returns that string.
+     * Otherwise, it returns an empty string.
+     */
+    std::string GetAuthors () const { return m_authors; }
 
     //! Initial electric field on the grid
     static amrex::Vector<amrex::Real> E_external_grid;
@@ -1404,6 +1408,9 @@ private:
                                    bool pml_flag=false);
 #   endif
 #endif
+
+    //! Author of an input file / simulation setup
+    std::string m_authors;
 
     amrex::Vector<int> istep;      // which step?
     amrex::Vector<int> nsubsteps;  // how many substeps on each level?

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -88,7 +88,6 @@ using namespace amrex;
 Vector<Real> WarpX::E_external_grid(3, 0.0);
 Vector<Real> WarpX::B_external_grid(3, 0.0);
 
-std::string WarpX::authors;
 std::string WarpX::B_ext_grid_s = "default";
 std::string WarpX::E_ext_grid_s = "default";
 bool WarpX::add_external_E_field = false;
@@ -518,7 +517,7 @@ WarpX::ReadParameters ()
         const ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.
         utils::parser::queryWithParser(pp, "max_step", max_step);
         utils::parser::queryWithParser(pp, "stop_time", stop_time);
-        pp.query("authors", authors);
+        pp.query("authors", m_authors);
     }
 
     {


### PR DESCRIPTION
This PR is part of the effort to reduce the use of static functions and variables in WarpX.