### PR TITLE
Remove legacy references to EvolveEM which had been renamed Evolve

### DIFF
--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -40,7 +40,7 @@ By default, the ``MultiFab`` are set to ``0`` at initialization. They can be ass
 Field solver
 ------------
 
-The field solver is performed in ``WarpX::EvolveE`` for the electric field and ``WarpX::EvolveB`` for the magnetic field, called from ``WarpX::OneStep_nosub`` in ``WarpX::EvolveEM``. This section describes the FDTD field push. It is implemented in ``Source/FieldSolver/FiniteDifferenceSolver/``.
+The field solver is performed in ``WarpX::EvolveE`` for the electric field and ``WarpX::EvolveB`` for the magnetic field, called from ``WarpX::OneStep_nosub`` in ``WarpX::Evolve``. This section describes the FDTD field push. It is implemented in ``Source/FieldSolver/FiniteDifferenceSolver/``.
 
 As all cell-wise operation, the field push is done as follows (this is split in multiple functions in the actual implementation to avoid code duplication)
 :

--- a/Docs/source/developers/repo_organization.rst
+++ b/Docs/source/developers/repo_organization.rst
@@ -8,7 +8,7 @@ Repo Organization
 
 All the WarpX source code is located in ``Source/``.
 All sub-directories have a pretty straightforward name.
-The PIC loop is part of the WarpX class, in function ``WarpX::EvolveEM`` implemented in ``Source/WarpXEvolveEM.cpp``.
+The PIC loop is part of the WarpX class, in function ``WarpX::Evolve`` implemented in ``Source/WarpXEvolve.cpp``.
 The core of the PIC loop (i.e., without diagnostics etc.) is in ``WarpX::OneStep_nosub`` (when subcycling is OFF) or ``WarpX::OneStep_sub1`` (when subcycling is ON, with method 1).
 Here is a `visual representation <https://mango-dune-07a8b7110.1.azurestaticapps.net/?repo=ECP-WarpX%2FWarpX>`__ of the repository structure.
 

--- a/Docs/source/glossary.rst
+++ b/Docs/source/glossary.rst
@@ -69,7 +69,7 @@ Terms
 * **Ascent:** `many-core capable flyweight in situ visualization and analysis infrastructure <https://alpine-dav.github.io/ascent/>`__, a visualization backend usable with WarpX data
 * **boosted frame:** a :ref:`Lorentz-boosted frame of reference <theory-boostedframe>` for a simulation
 * **evolve:** this is a generic term to advance a quantity (same nomenclature in AMReX).
-              For instance, ``WarpX::EvolveE(dt)`` advances the electric field for duration ``dt``, ``PhysicalParticleContainer::Evolve(...)`` does field gather + particle push + current deposition for all particles in ``PhysicalParticleContainer``, and ``WarpX::EvolveEM`` is the central ``WarpX`` function that performs 1 PIC iteration.
+              For instance, ``WarpX::EvolveE(dt)`` advances the electric field for duration ``dt``, ``PhysicalParticleContainer::Evolve(...)`` does field gather + particle push + current deposition for all particles in ``PhysicalParticleContainer``, and ``WarpX::Evolve`` is the central ``WarpX`` function that performs 1 PIC iteration.
 * **Frontier:** an `Exascale supercomputer at OLCF <https://www.olcf.ornl.gov/frontier/>`__
 * **hybrid-PIC:** a plasma simulation scheme that combines fluid and kinetic approaches, with (usually) the electrons treated as a fluid and the ions as kinetic particles (see :ref:`theory-kinetic-fluid-hybrid-model`)
 * **laser:** most of the time, we mean a `laser pulse <https://en.wikipedia.org/wiki/Ultrashort_pulse>`__

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1220,11 +1220,6 @@ private:
     //! Complete the asynchronous broadcast of signal flags, and initiate a checkpoint if requested
     void HandleSignals ();
 
-    ///
-    /// Advance the simulation by numsteps steps, electromagnetic case.
-    ///
-    void EvolveEM(int numsteps);
-
     void FillBoundaryB (int lev, PatchType patch_type, amrex::IntVect ng, std::optional<bool> nodal_sync = std::nullopt);
     void FillBoundaryE (int lev, PatchType patch_type, amrex::IntVect ng, std::optional<bool> nodal_sync = std::nullopt);
     void FillBoundaryF (int lev, PatchType patch_type, amrex::IntVect ng, std::optional<bool> nodal_sync = std::nullopt);

--- a/Tools/PerformanceTests/functions_perftest.py
+++ b/Tools/PerformanceTests/functions_perftest.py
@@ -154,7 +154,7 @@ def read_run_perf(filename, n_steps):
                     '\nPPC::FieldGather.*',\
                     '\nPPC::ParticlePush.*',\
                     '\nPPC::Evolve::Copy.*',\
-                    '\nWarpX::EvolveEM().*',\
+                    '\nWarpX::Evolve().*',\
                     'Checkpoint().*',\
                     'WriteParticles().*',\
                     '\nVisMF::Write(FabArray).*',\

--- a/Tools/PerformanceTests/performance_log.txt
+++ b/Tools/PerformanceTests/performance_log.txt
@@ -1,4 +1,4 @@
-## year month day run_name compiler architecture n_node n_mpi n_omp time_initialization time_one_iteration Redistribute FillBoundary ParallelCopy CurrentDeposition FieldGather ParthiclePush Copy EvolveEM Checkpoint WriteParticles Write_FabArray WriteMultiLevelPlotfile(unit: second) RedistributeMPI
+## year month day run_name compiler architecture n_node n_mpi n_omp time_initialization time_one_iteration Redistribute FillBoundary ParallelCopy CurrentDeposition FieldGather ParthiclePush Copy Evolve Checkpoint WriteParticles Write_FabArray WriteMultiLevelPlotfile(unit: second) RedistributeMPI
 2018 01 31 automated_test_1_uniform_rest_32ppc intel knl 1 16 8 3.14 0.3986 0.1713 0.01719 0.01615 0.06987 0.03636 0.01901 0.01999 0.003602 0 0 0 0 0.007262
 2018 01 31 automated_test_1_uniform_rest_32ppc intel knl 1 16 8 3.39 0.4009 0.1712 0.01676 0.01583 0.07061 0.03684 0.01926 0.02011 0.003687 0 0 0 0 0.007841
 2018 01 31 automated_test_1_uniform_rest_32ppc intel knl 1 16 8 2.91 0.4024 0.1716 0.01826 0.01918 0.0703 0.0363 0.01912 0.01989 0.003017 0 0 0 0 0.007256

--- a/Tools/PerformanceTests/run_alltests.py
+++ b/Tools/PerformanceTests/run_alltests.py
@@ -259,7 +259,7 @@ if args.mode == 'read':
         log_line = '## year month day run_name compiler architecture n_node n_mpi ' +\
                    'n_omp time_initialization time_one_iteration Redistribute '+\
                    'FillBoundary ParallelCopy CurrentDeposition FieldGather '+\
-                   'ParthiclePush Copy EvolveEM Checkpoint '+\
+                   'ParthiclePush Copy Evolve Checkpoint '+\
                    'WriteParticles Write_FabArray '+\
                    'WriteMultiLevelPlotfile '+\
                    'RedistributeMPI(unit: second)\n'

--- a/Tools/PerformanceTests/run_alltests_1node.py
+++ b/Tools/PerformanceTests/run_alltests_1node.py
@@ -228,7 +228,7 @@ if args.mode == 'read':
         log_line = '## year month day input_file compiler architecture n_node n_mpi ' +\
                    'n_omp time_initialization time_one_iteration Redistribute '+\
                    'FillBoundary ParallelCopy CurrentDeposition FieldGather '+\
-                   'ParthiclePush Copy EvolveEM Checkpoint '+\
+                   'ParthiclePush Copy Evolve Checkpoint '+\
                    'WriteParticles Write_FabArray '+\
                    'WriteMultiLevelPlotfile(unit: second) '+\
                    'RedistributeMPI\n'
@@ -318,7 +318,7 @@ if args.mode == 'read':
     nrepeat = 4
     legends = [ 'n_node', 'n_mpi', 'n_omp', 'time_initialization', 'time_one_iteration', \
                 'Redistribute', 'FillBoundary', 'ParallelCopy', 'CurrentDeposition', \
-                'FieldGather', 'ParthiclePush', 'Copy', 'EvolveEM', 'Checkpoint', \
+                'FieldGather', 'ParthiclePush', 'Copy', 'Evolve', 'Checkpoint', \
                 'WriteParticles', 'Write_FabArray', 'WriteMultiLevelPlotfile', \
                 'RedistributeMPI']
     date = np.loadtxt( filename, usecols = np.arange(0, 3 ))


### PR DESCRIPTION
I happened to notice this old name being used in a number of places and was still being declared in WarpX.H

Is there a clang-tidy check for routines declared in the header but not defined?