### PR TITLE
Off schedule update of AMReX

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -108,7 +108,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach d36463103daed09a40cdea235041a6ab79ff280c && cd -
+        cd ../amrex && git checkout --detach 15a0bb9a8c1b34136632b16c5511375e9d56b184 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-11-nvcc:

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = d36463103daed09a40cdea235041a6ab79ff280c
+branch = 15a0bb9a8c1b34136632b16c5511375e9d56b184
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = d36463103daed09a40cdea235041a6ab79ff280c
+branch = 15a0bb9a8c1b34136632b16c5511375e9d56b184
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -269,7 +269,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "d36463103daed09a40cdea235041a6ab79ff280c"
+set(WarpX_amrex_branch "15a0bb9a8c1b34136632b16c5511375e9d56b184"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -68,7 +68,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach d36463103daed09a40cdea235041a6ab79ff280c && cd -
+cd amrex && git checkout --detach 15a0bb9a8c1b34136632b16c5511375e9d56b184 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 # openPMD-example-datasets contains various required data sets


### PR DESCRIPTION
This update includes the latest change in AMReX that is needed to avoid an issue with deprecated code in SYCL. See the PR in AMReX https://github.com/AMReX-Codes/amrex/pull/3630. This change is required to fix errors that occur during CI testing.