### PR TITLE
In .github/workflows/macos.yml, clean up pip packages

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,6 +61,8 @@ jobs:
     - name: build WarpX
       run: |
         python3 -m pip install --upgrade pip
+        # Start with a clean pip
+        pip freeze | xargs pip uninstall -y
         python3 -m pip install --upgrade build packaging setuptools wheel
 
         cmake -S . -B build_dp         \


### PR DESCRIPTION
This is a bit of a hack but it does seem to fix the failing CI tests for MacOS. The errors that were appearing seem to be related to doing pip installs of packages that are already installed. The fix proposed here is to do a uninstall of all of the pip packages first before doing the later installs. Yes, this is an ugly brute force approach, but at least it seems to work.