### PR TITLE
add start/end moving step

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -584,7 +584,7 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
 
     warpx_start_moving_window_step: int, default=0
         The timestep at which the moving window starts
-        
+
     warpx_end_moving_window_step: int, default=-1
         The timestep at which the moving window ends. If -1, the moving window
     will continue until the end of the simulation.
@@ -688,7 +688,7 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
 
     warpx_start_moving_window_step: int, default=0
         The timestep at which the moving window starts
-        
+
     warpx_end_moving_window_step: int, default=-1
         The timestep at which the moving window ends. If -1, the moving window
     will continue until the end of the simulation.
@@ -789,7 +789,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
     warpx_start_moving_window_step: int, default=0
         The timestep at which the moving window starts
-        
+
     warpx_end_moving_window_step: int, default=-1
         The timestep at which the moving window ends. If -1, the moving window
     will continue until the end of the simulation.
@@ -910,7 +910,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
     warpx_start_moving_window_step: int, default=0
         The timestep at which the moving window starts
-        
+
     warpx_end_moving_window_step: int, default=-1
         The timestep at which the moving window ends. If -1, the moving window
     will continue until the end of the simulation.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -824,7 +824,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
             if self.moving_window_velocity[1] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
-            
+
             pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
             pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -583,11 +583,11 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         reflection on a boundary, or only the velocity normal to the surface
 
     warpx_start_moving_window_step: int, default=0
-        The timestep at which the moving window starts
+       The timestep at which the moving window starts
 
     warpx_end_moving_window_step: int, default=-1
-        The timestep at which the moving window ends. If -1, the moving window
-    will continue until the end of the simulation.
+       The timestep at which the moving window ends. If -1, the moving window
+       will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -687,11 +687,11 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
        Electrostatic potential on the upper longitudinal boundary
 
     warpx_start_moving_window_step: int, default=0
-        The timestep at which the moving window starts
+       The timestep at which the moving window starts
 
     warpx_end_moving_window_step: int, default=-1
-        The timestep at which the moving window ends. If -1, the moving window
-    will continue until the end of the simulation.
+       The timestep at which the moving window ends. If -1, the moving window
+       will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -788,11 +788,11 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
        Electrostatic potential on the upper z boundary
 
     warpx_start_moving_window_step: int, default=0
-        The timestep at which the moving window starts
+       The timestep at which the moving window starts
 
     warpx_end_moving_window_step: int, default=-1
-        The timestep at which the moving window ends. If -1, the moving window
-    will continue until the end of the simulation.
+       The timestep at which the moving window ends. If -1, the moving window
+       will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -909,11 +909,11 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
        Electrostatic potential on the upper z boundary
 
     warpx_start_moving_window_step: int, default=0
-        The timestep at which the moving window starts
+       The timestep at which the moving window starts
 
     warpx_end_moving_window_step: int, default=-1
-        The timestep at which the moving window ends. If -1, the moving window
-    will continue until the end of the simulation.
+       The timestep at which the moving window ends. If -1, the moving window
+       will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -598,6 +598,9 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
         self.reflect_all_velocities = kw.pop('warpx_reflect_all_velocities', None)
 
+        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
+        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+
         # Geometry
         # Set these as soon as the information is available
         # (since these are needed to determine which shared object to load)
@@ -637,6 +640,9 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
             if self.moving_window_velocity[1] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
+
+            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -686,6 +692,9 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
+        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+
         # Geometry
         # Set these as soon as the information is available
         # (since these are needed to determine which shared object to load)
@@ -714,6 +723,9 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
             if self.moving_window_velocity[0] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[0]/constants.c  # in units of the speed of light
+
+            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -776,6 +788,9 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
+        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+
         # Geometry
         # Set these as soon as the information is available
         # (since these are needed to determine which shared object to load)
@@ -809,6 +824,9 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
             if self.moving_window_velocity[1] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
+            
+            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -886,6 +904,9 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
+        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
+        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+
         # Geometry
         # Set these as soon as the information is available
         # (since these are needed to determine which shared object to load)
@@ -924,6 +945,9 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
             if self.moving_window_velocity[2] != 0.:
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[2]/constants.c  # in units of the speed of light
+
+            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -581,6 +581,13 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
     warpx_reflect_all_velocities: bool default=False
         Whether the sign of all of the particle velocities are changed upon
         reflection on a boundary, or only the velocity normal to the surface
+
+    warpx_start_moving_window_step: int, default=0
+        The timestep at which the moving window starts
+        
+    warpx_end_moving_window_step: int, default=-1
+        The timestep at which the moving window ends. If -1, the moving window
+    will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -598,8 +605,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
         self.reflect_all_velocities = kw.pop('warpx_reflect_all_velocities', None)
 
-        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
-        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+        self.start_moving_window_step = kw.pop('warpx_start_moving_window_step', None)
+        self.end_moving_window_step = kw.pop('warpx_end_moving_window_step', None)
 
         # Geometry
         # Set these as soon as the information is available
@@ -641,8 +648,8 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
 
-            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
-            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
+            pywarpx.warpx.start_moving_window_step = self.start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -678,6 +685,13 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
 
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper longitudinal boundary
+
+    warpx_start_moving_window_step: int, default=0
+        The timestep at which the moving window starts
+        
+    warpx_end_moving_window_step: int, default=-1
+        The timestep at which the moving window ends. If -1, the moving window
+    will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -692,8 +706,8 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
-        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
-        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+        self.start_moving_window_step = kw.pop('warpx_start_moving_window_step', None)
+        self.end_moving_window_step = kw.pop('warpx_end_moving_window_step', None)
 
         # Geometry
         # Set these as soon as the information is available
@@ -724,8 +738,8 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[0]/constants.c  # in units of the speed of light
 
-            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
-            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
+            pywarpx.warpx.start_moving_window_step = self.start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -772,6 +786,13 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
+
+    warpx_start_moving_window_step: int, default=0
+        The timestep at which the moving window starts
+        
+    warpx_end_moving_window_step: int, default=-1
+        The timestep at which the moving window ends. If -1, the moving window
+    will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -788,8 +809,8 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
-        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
-        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+        self.start_moving_window_step = kw.pop('warpx_start_moving_window_step', None)
+        self.end_moving_window_step = kw.pop('warpx_end_moving_window_step', None)
 
         # Geometry
         # Set these as soon as the information is available
@@ -825,8 +846,8 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[1]/constants.c  # in units of the speed of light
 
-            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
-            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
+            pywarpx.warpx.start_moving_window_step = self.start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')
@@ -886,6 +907,13 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
+
+    warpx_start_moving_window_step: int, default=0
+        The timestep at which the moving window starts
+        
+    warpx_end_moving_window_step: int, default=-1
+        The timestep at which the moving window ends. If -1, the moving window
+    will continue until the end of the simulation.
     """
     def init(self, kw):
         self.max_grid_size = kw.pop('warpx_max_grid_size', 32)
@@ -904,8 +932,8 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.potential_zmin = kw.pop('warpx_potential_lo_z', None)
         self.potential_zmax = kw.pop('warpx_potential_hi_z', None)
 
-        self.warpx_start_moving_window_step = kw.pop('warpx_start_moving_window_step', 0)
-        self.warpx_end_moving_window_step = kw.pop('warpx_end_moving_window_step', -1)
+        self.start_moving_window_step = kw.pop('warpx_start_moving_window_step', None)
+        self.end_moving_window_step = kw.pop('warpx_end_moving_window_step', None)
 
         # Geometry
         # Set these as soon as the information is available
@@ -946,8 +974,8 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
                 pywarpx.warpx.moving_window_dir = 'z'
                 pywarpx.warpx.moving_window_v = self.moving_window_velocity[2]/constants.c  # in units of the speed of light
 
-            pywarpx.warpx.start_moving_window_step = self.warpx_start_moving_window_step
-            pywarpx.warpx.end_moving_window_step = self.warpx_end_moving_window_step
+            pywarpx.warpx.start_moving_window_step = self.start_moving_window_step
+            pywarpx.warpx.end_moving_window_step = self.end_moving_window_step
 
         if self.refined_regions:
             assert len(self.refined_regions) == 1, Exception('WarpX only supports one refined region.')


### PR DESCRIPTION
Add 'warpx_start_moving_window_step' and 'warpx_end_moving_window_step' for class CylindricalGrid/Cartesian1DGrid to make python interface could stop the moving window

