### PR TITLE
Contributing style and conventions additions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -230,24 +230,16 @@ Style and conventions
          Print() << "Like this!";
      }
 
-  or
-
-  .. code-block:: cpp
-
-     for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
+     for (int n = 0; n < 10; ++n) { Print() << "Or like this!"; }
 
   but not
 
   .. code-block:: cpp
 
-     for (int n = 0; n < 10; ++n) Print() << "Not like this.";
-
-  or
-
-  .. code-block:: cpp
-
      for (int n = 0; n < 10; ++n)
          Print() << "Not like this.";
+
+     for (int n = 0; n < 10; ++n) Print() << "Nor like this.";
 
 - It is recommended that style changes are not included in the PR where new code is added.
   This is to avoid any errors that may be introduced in a PR just to do style change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -230,7 +230,7 @@ Style and conventions
        Print() << "Like this!";
    }
 
-  or
+or
 
 .. code-block:: cpp
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -212,12 +212,36 @@ Style and conventions
 
 - Space before and after assignment operator (``=``)
 
-- To define a function , for e.g., ``myfunction()`` use a space between the name of the function and the paranthesis - ``myfunction ()``.
-  To call the function, the space is not required, i.e., just use ``myfunction()``.
+- To define a function, use a space between the name of the function and the paranthesis, e.g., ``myfunction ()``.
+  When calling a function, no space should be used, i.e., just use ``myfunction()``.
+  The reason this is beneficial is that when we do a ``git grep`` to search for ``myfunction ()``, we can clearly see the locations where ``myfunction ()`` is defined and where ``myfunction()`` is called.
+  Also, using ``git grep "myfunction ()"`` searches for files only in the git repo, which is more efficient compared to the ``grep "myfunction ()"`` command that searches through all the files in a directory, including plotfiles for example.
 
-- The reason this is beneficial is that when we do a ``git grep`` to search for ``myfunction ()``, we can clearly see the locations where ``myfunction ()`` is defined and where ``myfunction()`` is called.
+- To define a class, use ``class`` on the same line as the name of the class, e.g., ``class MyClass``.
+  The reason this is beneficial is that when we do a ``git grep`` to search for ``class MyClass``, we can clearly see the locations where ``class MyClass`` is defined and where ``MyClass`` is called.
 
-- Also, using ``git grep "myfunction ()"`` searches for files only in the git repo, which is more efficient compared to the ``grep "myfunction ()"`` command that searches through all the files in a directory, including plotfiles for example.
+- When defining a function or class, make sure the starting ``{`` token to appears on a new line.
+
+- Use curly braces for single statement blocks. For example:
+```cpp
+       for (int n = 0; n < 10; ++n) {
+           Print() << "Like this!";
+       }
+```
+  or
+```cpp
+       for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
+```
+  but not
+```cpp
+
+       for (int n = 0; n < 10; ++n) Print() << "Not like this.";
+```
+  or
+```cpp
+       for (int n = 0; n < 10; ++n)
+          Print() << "Not like this.";
+```
 
 - It is recommended that style changes are not included in the PR where new code is added.
   This is to avoid any errors that may be introduced in a PR just to do style change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -214,9 +214,7 @@ Style and conventions
 
 - To define a function, use a space between the name of the function and the paranthesis, e.g., ``myfunction ()``.
   When calling a function, no space should be used, i.e., just use ``myfunction()``.
-
   The reason this is beneficial is that when we do a ``git grep`` to search for ``myfunction ()``, we can clearly see the locations where ``myfunction ()`` is defined and where ``myfunction()`` is called.
-
   Also, using ``git grep "myfunction ()"`` searches for files only in the git repo, which is more efficient compared to the ``grep "myfunction ()"`` command that searches through all the files in a directory, including plotfiles for example.
 
 - To define a class, use ``class`` on the same line as the name of the class, e.g., ``class MyClass``.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -224,30 +224,30 @@ Style and conventions
 
 - Use curly braces for single statement blocks. For example:
 
-.. code-block:: cpp
+  .. code-block:: cpp
 
-   for (int n = 0; n < 10; ++n) {
-       Print() << "Like this!";
-   }
+     for (int n = 0; n < 10; ++n) {
+         Print() << "Like this!";
+     }
 
-or
+  or
 
-.. code-block:: cpp
+  .. code-block:: cpp
 
-   for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
+     for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
 
-but not
+  but not
 
-.. code-block:: cpp
+  .. code-block:: cpp
 
-   for (int n = 0; n < 10; ++n) Print() << "Not like this.";
+     for (int n = 0; n < 10; ++n) Print() << "Not like this.";
 
-or
+  or
 
-.. code-block:: cpp
+  .. code-block:: cpp
 
-   for (int n = 0; n < 10; ++n)
-       Print() << "Not like this.";
+     for (int n = 0; n < 10; ++n)
+         Print() << "Not like this.";
 
 - It is recommended that style changes are not included in the PR where new code is added.
   This is to avoid any errors that may be introduced in a PR just to do style change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -223,25 +223,31 @@ Style and conventions
 - When defining a function or class, make sure the starting ``{`` token to appears on a new line.
 
 - Use curly braces for single statement blocks. For example:
-```cpp
-       for (int n = 0; n < 10; ++n) {
-           Print() << "Like this!";
-       }
-```
-  or
-```cpp
-       for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
-```
-  but not
-```cpp
 
-       for (int n = 0; n < 10; ++n) Print() << "Not like this.";
-```
+.. code-block:: cpp
+
+   for (int n = 0; n < 10; ++n) {
+       Print() << "Like this!";
+   }
+
   or
-```cpp
-       for (int n = 0; n < 10; ++n)
-          Print() << "Not like this.";
-```
+
+.. code-block:: cpp
+
+   for (int n = 0; n < 10; ++n) { Print() << "Like this!"; }
+
+but not
+
+.. code-block:: cpp
+
+   for (int n = 0; n < 10; ++n) Print() << "Not like this.";
+
+or
+
+.. code-block:: cpp
+
+   for (int n = 0; n < 10; ++n)
+       Print() << "Not like this.";
 
 - It is recommended that style changes are not included in the PR where new code is added.
   This is to avoid any errors that may be introduced in a PR just to do style change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,19 +227,19 @@ Style and conventions
   .. code-block:: cpp
 
      for (int n = 0; n < 10; ++n) {
-         Print() << "Like this!";
+         amrex::Print() << "Like this!";
      }
 
-     for (int n = 0; n < 10; ++n) { Print() << "Or like this!"; }
+     for (int n = 0; n < 10; ++n) { amrex::Print() << "Or like this!"; }
 
   but not
 
   .. code-block:: cpp
 
      for (int n = 0; n < 10; ++n)
-         Print() << "Not like this.";
+         amrex::Print() << "Not like this.";
 
-     for (int n = 0; n < 10; ++n) Print() << "Nor like this.";
+     for (int n = 0; n < 10; ++n) amrex::Print() << "Nor like this.";
 
 - It is recommended that style changes are not included in the PR where new code is added.
   This is to avoid any errors that may be introduced in a PR just to do style change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -214,13 +214,15 @@ Style and conventions
 
 - To define a function, use a space between the name of the function and the paranthesis, e.g., ``myfunction ()``.
   When calling a function, no space should be used, i.e., just use ``myfunction()``.
+
   The reason this is beneficial is that when we do a ``git grep`` to search for ``myfunction ()``, we can clearly see the locations where ``myfunction ()`` is defined and where ``myfunction()`` is called.
+
   Also, using ``git grep "myfunction ()"`` searches for files only in the git repo, which is more efficient compared to the ``grep "myfunction ()"`` command that searches through all the files in a directory, including plotfiles for example.
 
 - To define a class, use ``class`` on the same line as the name of the class, e.g., ``class MyClass``.
   The reason this is beneficial is that when we do a ``git grep`` to search for ``class MyClass``, we can clearly see the locations where ``class MyClass`` is defined and where ``MyClass`` is called.
 
-- When defining a function or class, make sure the starting ``{`` token to appears on a new line.
+- When defining a function or class, make sure the starting ``{`` token appears on a new line.
 
 - Use curly braces for single statement blocks. For example:
 

--- a/Docs/source/developers/documentation.rst
+++ b/Docs/source/developers/documentation.rst
@@ -11,21 +11,21 @@ Whenever you create a new class, please document it where it is declared (typica
 
 .. code-block:: cpp
 
-   /** A brief title
+   /** \brief A brief title
     *
-    * few-line description explaining the purpose of my_class.
+    * few-line description explaining the purpose of MyClass.
     *
-    * If you are kind enough, also quickly explain how things in my_class work.
+    * If you are kind enough, also quickly explain how things in MyClass work.
     * (typically a few more lines)
     */
-   class my_class
+   class MyClass
    { ... }
 
 Doxygen reads this docstring, so please be accurate with the syntax! See `Doxygen manual <http://www.doxygen.nl/manual/docblocks.html>`__ for more information. Similarly, please document functions when you declare them (typically in a header file) like:
 
 .. code-block:: cpp
 
-  /** A brief title
+  /** \brief A brief title
    *
    * few-line description explaining the purpose of my_function.
    *
@@ -33,7 +33,7 @@ Doxygen reads this docstring, so please be accurate with the syntax! See `Doxyge
    *                       my_function will operate.
    * \return what is the meaning and value range of the returned value
    */
-  int my_class::my_function(int* my_int);
+  int MyClass::my_function (int* my_int);
 
 An online version of this documentation is :ref:`linked here <development-doxygen>`.
 


### PR DESCRIPTION
This PR modifies contributing.rst in the following ways:
- New convention about class definitions: use “class” on same line as class name, e.g., “class MyClass”.
- New convention to always use curly brackets for single statement blocks.
- Reword function definition convention to be more concise and only use one bullet point.

Additionally, documentation.rst is changed to conform to class snake-case naming convention.
