### PR TITLE
New Cache Strategy

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -20,9 +20,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/ccache
-        key: ccache-clang-tidy-${{ github.job }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-clang-tidy-${{ github.job }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX & run clang-tidy
       run: |
         export CCACHE_COMPRESS=1
@@ -56,3 +56,18 @@ jobs:
 
         ccache -s
         du -hs ~/.cache/ccache
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -1,0 +1,40 @@
+name: CleanUpCachePostPR
+
+on:
+  workflow_run:
+    workflows: [PostPR]
+    types:
+      - completed
+
+jobs:
+  CleanUpCcacheCachePostPR:
+    name: Clean Up Ccache Cache Post PR
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean up ccache
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          gh run download ${{ github.event.workflow_run.id }} -n pr_number
+          pr_number=`cat pr_number.txt`
+          BRANCH=refs/pull/${pr_number}/merge
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH | cut -f 1)
+          # $keys might contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
+          for k in $keys
+          do
+            gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+          done
+          unset IFS

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,63 @@
+name: CleanUpCache
+
+on:
+  workflow_run:
+    workflows: [🧹 clang-tidy, 🔍 CodeQL, 🐧 CUDA, 🐧 HIP, 🐧 Intel, 🍏 macOS, 🐧 OpenMP]
+    types:
+      - completed
+
+jobs:
+  CleanUpCcacheCache:
+    name: Clean Up Ccache Cache for ${{ github.event.workflow_run.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean up ccache
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          # push or pull_request or schedule or ...
+          EVENT=${{ github.event.workflow_run.event }}
+
+          # Triggering workflow run name (e.g., LinuxClang)
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+
+          if [[ $EVENT == "pull_request" ]]; then
+            gh run download ${{ github.event.workflow_run.id }} -n pr_number
+            pr_number=`cat pr_number.txt`
+            BRANCH=refs/pull/${pr_number}/merge
+          else
+            BRANCH=refs/heads/${{ github.event.workflow_run.head_branch }}
+          fi
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          # In our cache keys, substring after `-git-` is git hash, substring
+          # before that is a unique id for jobs (e.g., `ccache-LinuxClang-configure-2d`).
+          # The goal is to keep the last used key of each job and delete all others.
+
+          # something like ccache-LinuxClang-
+          keyprefix="ccache-${WORKFLOW_NAME}-"
+
+          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "$keyprefix" | awk -F '-git-' '{print $1}' | sort | uniq)
+
+          # cached_jobs is something like "ccache-LinuxClang-configure-1d ccache-LinuxClang-configure-2d".
+          # It might also contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
+          for j in $cached_jobs
+          do
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-git-" --sort last-used | cut -f 1 | tail -n +2)
+            for k in $old_keys
+            do
+              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+            done
+          done
+          unset IFS

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,21 @@ jobs:
         if: ${{ matrix.language == 'cpp' }}
         run: |
           sudo apt-get update
-          sudo apt-get install --yes cmake openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libadios-openmpi-dev
+          sudo apt-get install --yes cmake openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libadios-openmpi-dev ccache
 
           python -m pip install --upgrade pip
           python -m pip install --upgrade wheel
           python -m pip install --upgrade cmake
           export CMAKE="$HOME/.local/bin/cmake" && echo "CMAKE=$CMAKE" >> $GITHUB_ENV
+
+      - name: Set Up Cache
+        if: ${{ matrix.language == 'cpp' }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+          restore-keys: |
+               ccache-${{ github.workflow }}-${{ github.job }}-git-
 
       - name: Configure (C++)
         if: ${{ matrix.language == 'cpp' }}
@@ -61,6 +70,19 @@ jobs:
       - name: Build (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
+          export CCACHE_COMPRESS=1
+          export CCACHE_COMPRESSLEVEL=10
+          export CCACHE_MAXSIZE=100M
+          ccache -z
+
+          $CMAKE --build build -j 2
+
+          ccache -s
+          du -hs ~/.cache/ccache
+
+          # Make sure CodeQL has something to do
+          touch Source/Utils/WarpXVersion.cpp
+          export CCACHE_DISABLE=1
           $CMAKE --build build -j 2
 
       - name: Perform CodeQL Analysis
@@ -88,3 +110,18 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -29,18 +29,18 @@ jobs:
         .github/workflows/dependencies/nvcc11-3.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-nvcc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: install openPMD-api
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=600M
+        ccache -z
+
         export CEI_SUDO="sudo"
         export CEI_TMP="/tmp/cei"
         cmake-easyinstall --prefix=/usr/local \
@@ -53,6 +53,10 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=600M
+
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
         which nvcc || echo "nvcc not in PATH!"
@@ -78,6 +82,9 @@ jobs:
         python3 -m pip wheel .
         python3 -m pip install *.whl
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
   # make sure legacy build system continues to build, i.e., that we don't forget
   # to add new .cpp files
   build_nvcc_gnumake:
@@ -91,18 +98,18 @@ jobs:
         .github/workflows/dependencies/nvcc11-8.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-cuda-gnumake-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-gnumake-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=600M
+        ccache -z
+
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
         which nvcc || echo "nvcc not in PATH!"
@@ -110,6 +117,9 @@ jobs:
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
         cd ../amrex && git checkout --detach 9b733ec45cd93a80234a7c98248b6eb4816589d5 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
   build_nvhpc21-11-nvcc:
     name: NVHPC@21.11 NVCC/NVC++ Release [tests]
@@ -124,18 +134,18 @@ jobs:
       run: .github/workflows/dependencies/nvhpc.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-cuda-nvhpc-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-nvhpc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=600M
+        ccache -z
+
         source /etc/profile.d/modules.sh
         module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.11
         which nvcc || echo "nvcc not in PATH!"
@@ -174,3 +184,21 @@ jobs:
         #export PYWARPX_LIB_DIR=$PWD/build/lib/site-packages/pywarpx/
         #python3 -m pip wheel .
         #python3 -m pip install *.whl
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/dependencies/ccache.sh
+++ b/.github/workflows/dependencies/ccache.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [[ $# -eq 2 ]]; then
+  CVER=$1
+else
+  CVER=4.8.3
+fi
+
+wget https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64.tar.xz
+tar xvf ccache-${CVER}-linux-x86_64.tar.xz
+sudo cp -f ccache-${CVER}-linux-x86_64/ccache /usr/local/bin/

--- a/.github/workflows/dependencies/clang14.sh
+++ b/.github/workflows/dependencies/clang14.sh
@@ -15,7 +15,6 @@ echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 sudo apt-get -qqq update
 sudo apt-get install -y \
     cmake               \
-    ccache              \
     clang-14            \
     clang-tidy-14       \
     libblas-dev         \
@@ -28,6 +27,9 @@ sudo apt-get install -y \
     libopenmpi-dev      \
     libomp-dev          \
     ninja-build
+
+# ccache
+$(dirname "$0")/ccache.sh
 
 # cmake-easyinstall
 #

--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -34,7 +34,6 @@ for itry in {1..5}
 do
     sudo apt-get install -y --no-install-recommends \
         build-essential \
-        ccache          \
         cmake           \
         intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel \
         g++ gfortran    \
@@ -58,3 +57,6 @@ sudo rm -rf /opt/intel/oneapi/mkl/latest/lib/intel64/*.a           \
 du -sh /opt/intel/oneapi/
 du -sh /opt/intel/oneapi/*/*
 df -h
+
+# ccache
+$(dirname "$0")/ccache.sh

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -16,9 +16,11 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
-    ccache              \
     cmake               \
     gnupg               \
     ninja-build         \
     pkg-config          \
     wget
+
+# ccache
+$(dirname "$0")/ccache.sh

--- a/.github/workflows/dependencies/gcc12.sh
+++ b/.github/workflows/dependencies/gcc12.sh
@@ -16,7 +16,6 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
-    ccache              \
     cmake               \
     g++-12              \
     gnupg               \
@@ -28,3 +27,6 @@ sudo apt-get install -y \
     ninja-build         \
     pkg-config          \
     wget
+
+# ccache
+$(dirname "$0")/ccache.sh

--- a/.github/workflows/dependencies/gcc12_blaspp_lapackpp.sh
+++ b/.github/workflows/dependencies/gcc12_blaspp_lapackpp.sh
@@ -16,7 +16,6 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
-    ccache              \
     cmake               \
     g++-12              \
     gnupg               \
@@ -29,6 +28,9 @@ sudo apt-get install -y \
     ninja-build         \
     pkg-config          \
     wget
+
+# ccache
+$(dirname "$0")/ccache.sh
 
 # cmake-easyinstall
 #

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -43,6 +43,9 @@ sudo apt-get install -y --no-install-recommends \
     rocprim-dev     \
     rocrand-dev
 
+# ccache
+$(dirname "$0")/ccache.sh
+
 # activate
 #
 source /etc/profile.d/rocm.sh
@@ -56,12 +59,3 @@ sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.c
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
 export CEI_TMP="/tmp/cei"
-
-# ccache 4.2+
-#
-CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
-    git+https://github.com/ccache/ccache.git@v4.6 \
-    -DCMAKE_BUILD_TYPE=Release        \
-    -DENABLE_DOCUMENTATION=OFF        \
-    -DENABLE_TESTING=OFF              \
-    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/icc.sh
+++ b/.github/workflows/dependencies/icc.sh
@@ -17,11 +17,13 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
   build-essential \
   ca-certificates \
-  ccache          \
   cmake           \
   gnupg           \
   pkg-config      \
   wget
+
+# ccache
+$(dirname "$0")/ccache.sh
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB

--- a/.github/workflows/dependencies/nvcc11-3.sh
+++ b/.github/workflows/dependencies/nvcc11-3.sh
@@ -26,6 +26,9 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
+# ccache
+$(dirname "$0")/ccache.sh
+
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 
@@ -55,12 +58,3 @@ sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.c
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
 export CEI_TMP="/tmp/cei"
-
-# ccache 4.2+
-#
-CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
-    git+https://github.com/ccache/ccache.git@v4.6 \
-    -DCMAKE_BUILD_TYPE=Release        \
-    -DENABLE_DOCUMENTATION=OFF        \
-    -DENABLE_TESTING=OFF              \
-    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/nvcc11-8.sh
+++ b/.github/workflows/dependencies/nvcc11-8.sh
@@ -26,6 +26,9 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
+# ccache
+$(dirname "$0")/ccache.sh
+
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 
@@ -55,12 +58,3 @@ sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.c
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
 export CEI_TMP="/tmp/cei"
-
-# ccache 4.2+
-#
-CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
-    git+https://github.com/ccache/ccache.git@v4.6 \
-    -DCMAKE_BUILD_TYPE=Release        \
-    -DENABLE_DOCUMENTATION=OFF        \
-    -DENABLE_TESTING=OFF              \
-    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -25,6 +25,9 @@ sudo apt install -y     \
     pkg-config          \
     wget
 
+# ccache
+$(dirname "$0")/ccache.sh
+
 echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
   sudo tee /etc/apt/sources.list.d/nvhpc.list
 sudo apt update -y && \
@@ -46,12 +49,3 @@ sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.c
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
 export CEI_TMP="/tmp/cei"
-
-# ccache 4.2+
-#
-CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
-    git+https://github.com/ccache/ccache.git@v4.6 \
-    -DCMAKE_BUILD_TYPE=Release        \
-    -DENABLE_DOCUMENTATION=OFF        \
-    -DENABLE_TESTING=OFF              \
-    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/pyfull.sh
+++ b/.github/workflows/dependencies/pyfull.sh
@@ -16,7 +16,6 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
-    ccache              \
     clang               \
     cmake               \
     gnupg               \
@@ -34,6 +33,9 @@ sudo apt-get install -y \
     python3-pip         \
     python3-setuptools  \
     wget
+
+# ccache
+$(dirname "$0")/ccache.sh
 
 # cmake-easyinstall
 #

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -21,19 +21,19 @@ jobs:
       run: .github/workflows/dependencies/hip.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-hip-3dsp-${{ hashFiles('.github/workflows/hip.yml') }}-
-          ccache-hip-3dsp-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       shell: bash
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         source /etc/profile.d/rocm.sh
         hipcc --version
         which clang
@@ -63,6 +63,9 @@ jobs:
         python3 -m pip wheel .
         python3 -m pip install *.whl
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
   build_hip_2d_dp:
     name: HIP 2D DP
     runs-on: ubuntu-20.04
@@ -77,19 +80,19 @@ jobs:
       run: .github/workflows/dependencies/hip.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-hip-2ddp-${{ hashFiles('.github/workflows/hip.yml') }}-
-          ccache-hip-2ddp-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       shell: bash
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         source /etc/profile.d/rocm.sh
         hipcc --version
         which clang
@@ -119,3 +122,21 @@ jobs:
         export PYWARPX_LIB_DIR=$PWD/build_2d/lib/site-packages/pywarpx/
         python3 -m pip wheel .
         python3 -m pip install *.whl
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -23,18 +23,19 @@ jobs:
         .github/workflows/dependencies/icc.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-intel-icc-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-icc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=200M
+        export CCACHE_DEPEND=1
+        ccache -z
+
         set +eu
         source /opt/intel/oneapi/setvars.sh
         set -eu
@@ -66,6 +67,9 @@ jobs:
         cmake --build build_sp -j 2
         cmake --build build_sp --target pip_install
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
   build_icpx:
     name: oneAPI ICX SP
     runs-on: ubuntu-20.04
@@ -85,19 +89,20 @@ jobs:
         .github/workflows/dependencies/dpcpp.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-intel-icpx-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-icpx-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       shell: bash
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_DEPEND=1
+        ccache -z
+
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
@@ -117,6 +122,9 @@ jobs:
           -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
         cmake --build build_sp --target pip_install
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: run pywarpx
       run: |
@@ -145,19 +153,20 @@ jobs:
         .github/workflows/dependencies/dpcpp.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-intel-dpcc-${{ hashFiles('.github/workflows/intel.yml') }}-
-          ccache-intel-dpcc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       shell: bash
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_DEPEND=1
+        ccache -z
+
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
@@ -177,8 +186,26 @@ jobs:
           -DWarpX_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
      # Skip this as it will copy the binary artifacts and we are tight on disk space
      #   python3 -m pip install --upgrade pip
      #   python3 -m pip install --upgrade build packaging setuptools wheel
      #   PYWARPX_LIB_DIR=$PWD/build_sp/lib/site-packages/pywarpx/ python3 -m pip wheel .
      #   python3 -m pip install *.whl
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,16 +59,18 @@ jobs:
         python3 -m pip install --upgrade mpi4py
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
         path: /Users/runner/Library/Caches/ccache
-        key: ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-
-          ccache-macos-appleclang-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         source py-venv/bin/activate
 
         cmake -S . -B build_dp         \
@@ -89,9 +91,26 @@ jobs:
         cmake --build build_sp -j 3
         cmake --build build_sp --target pip_install
 
+        ccache -s
+
     - name: run pywarpx
       run: |
         source py-venv/bin/activate
         export OMP_NUM_THREADS=1
 
         mpirun -n 2 Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -1,0 +1,20 @@
+name: PostPR
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,18 +20,18 @@ jobs:
         .github/workflows/dependencies/gcc.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-cxxminimal-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_DIMS="RZ;3"          \
@@ -41,6 +41,9 @@ jobs:
         cmake --build build -j 2
         ./build/bin/warpx.3d Examples/Physics_applications/laser_acceleration/inputs_3d
         ./build/bin/warpx.rz Examples/Physics_applications/laser_acceleration/inputs_rz
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
   build_1D_2D:
     name: GCC 1D & 2D w/ MPI
@@ -57,18 +60,18 @@ jobs:
         .github/workflows/dependencies/gcc12.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-openmp-1D-2D-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-1D-2D-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-1D-2D-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         cmake -S . -B build            \
           -GNinja                      \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
@@ -79,6 +82,9 @@ jobs:
         cmake --build build -j 2
         ./build/bin/warpx.1d Examples/Physics_applications/laser_acceleration/inputs_1d
         ./build/bin/warpx.2d Examples/Physics_applications/laser_acceleration/inputs_2d
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
   build_3D_sp:
     name: GCC 3D & RZ w/ MPI, single precision
@@ -94,18 +100,17 @@ jobs:
         .github/workflows/dependencies/gcc12_blaspp_lapackpp.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-openmp-3D-RZ-SP-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-3D-RZ-SP-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-3D-RZ-SP-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=200M
+        ccache -z
 
         # we need to define this *after* having installed the dependencies,
         # because the compilation of blaspp raises warnings.
@@ -125,6 +130,9 @@ jobs:
         ./build/bin/warpx.3d Examples/Physics_applications/laser_acceleration/inputs_3d
         ./build/bin/warpx.rz Examples/Physics_applications/laser_acceleration/inputs_rz
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
   build_gcc_ablastr:
     name: GCC ABLASTR w/o MPI
     runs-on: ubuntu-20.04
@@ -140,23 +148,26 @@ jobs:
         sudo apt-get install -y libopenmpi-dev openmpi-bin
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-gccablastr-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-gccablastr-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_APP=OFF              \
           -DWarpX_LIB=OFF
         cmake --build build -j 2
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
   build_pyfull:
     name: Clang pywarpx
@@ -174,18 +185,18 @@ jobs:
         .github/workflows/dependencies/pyfull.sh
     - name: CCache Cache
       uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
-        path: |
-          ~/.ccache
-          ~/.cache/ccache
-        key: ccache-openmp-pyfull-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/AMReX.cmake') }}
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-pyfull-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-pyfull-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade build packaging setuptools wheel
 
@@ -199,7 +210,25 @@ jobs:
           -DWarpX_QED_TABLE_GEN=ON
         cmake --build build -j 2 --target pip_install
 
+        ccache -s
+        du -hs ~/.cache/ccache
+
     - name: run pywarpx
       run: |
         export OMP_NUM_THREADS=1
         mpirun -n 2 Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1


### PR DESCRIPTION
If a cache is updated during a job, GitHub does not store the new cache unless it's not found with the primary key. To work around that, we use the git hash in the cache name. When the cache action tries to load the cache using the primary key, it's always a miss. It will then try to load a cache using the restore-keys. If the cache is updated during CI, the new version will be stored under the primary key's name.

In this new strategy, a new PR will use the cache associated with the latest development branch. The updated cache will be stored and become private to that PR. Any updates to the PR will also create new updated caches. But we don't need to keep all the copies.  We only need to keep the latest version of the cache associated with the PR. So we use a workflow (clean-cache.yml) to clean up the old caches.

After a PR is closed, we use clean-cache-postpr.yml to clean up all the caches associated with the PR. There is no easy way to get the PR number of the PR that triggers the cleanup workflow. Thus, we store the PR number as an artifact for the cleanup workflow.

It turns out ccache encounters internal errors in some CIs on Ubuntu 20.04. Switching to the latest ccache solves the issues.

CIs on Windows are not updated, because ccache does not work there.