### PR TITLE
Fix Diagnostics for Moving diag_lo and diag_hi

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -469,9 +469,12 @@ Diagnostics::InitBaseData ()
     // current moving_window location
     if (WarpX::do_moving_window) {
         const int moving_dir = WarpX::moving_window_dir;
-        const int shift_num_base = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
-        m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
-        m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+        const int shift_num_base_l = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
+        const int shift_num_base_r = static_cast<int>((warpx.getmoving_window_x() - m_hi[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
+        // Fix the wrong shift of the m_lo and m_hi
+        m_lo[moving_dir] = warpx.getmoving_window_x() - shift_num_base_l * warpx.Geom(0).CellSize(moving_dir);
+        m_hi[moving_dir] = warpx.getmoving_window_x() - shift_num_base_r * warpx.Geom(0).CellSize(moving_dir);
+
     }
     // Construct Flush class.
     if        (m_format == "plotfile"){

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -469,11 +469,10 @@ Diagnostics::InitBaseData ()
     // current moving_window location
     if (WarpX::do_moving_window) {
         const int moving_dir = WarpX::moving_window_dir;
-        const int shift_num_base_l = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
-        const int shift_num_base_r = static_cast<int>((warpx.getmoving_window_x() - m_hi[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
-        // Fix the wrong shift of the m_lo and m_hi
-        m_lo[moving_dir] = warpx.getmoving_window_x() - shift_num_base_l * warpx.Geom(0).CellSize(moving_dir);
-        m_hi[moving_dir] = warpx.getmoving_window_x() - shift_num_base_r * warpx.Geom(0).CellSize(moving_dir);
+        const int shift_num_base_lo = static_cast<int>((warpx.getmoving_window_x() - m_lo[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
+        const int shift_num_base_hi = static_cast<int>((warpx.getmoving_window_x() - m_hi[moving_dir]) / warpx.Geom(0).CellSize(moving_dir) );
+        m_lo[moving_dir] = warpx.getmoving_window_x() - shift_num_base_lo * warpx.Geom(0).CellSize(moving_dir);
+        m_hi[moving_dir] = warpx.getmoving_window_x() - shift_num_base_hi * warpx.Geom(0).CellSize(moving_dir);
 
     }
     // Construct Flush class.


### PR DESCRIPTION
This PR is to fix the question in "lower_bound" `<diag_name>.diag_lo` don't work correctly if set in the direction of the moving window #4435.

It is a separated from the fix for "Fix the bug for diag and fieldprobe #4454"