### PR TITLE
Make geometry.dims abort message more user-friendly

### DIFF
--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -289,11 +289,17 @@ void CheckDims ()
 #endif
     const ParmParse pp_geometry("geometry");
     std::string dims;
-    pp_geometry.get("dims", dims);
     std::string dims_error = "The selected WarpX executable was built as '";
     dims_error.append(dims_compiled).append("'-dimensional, but the ");
-    dims_error.append("inputs file declares 'geometry.dims = ").append(dims).append("'.\n");
-    dims_error.append("Please re-compile with a different WarpX_DIMS option or select the right executable name.");
+    if (pp_geometry.contains("dims")) {
+        pp_geometry.get("dims", dims);
+        dims_error.append("inputs file declares 'geometry.dims = ").append(dims).append("'.\n");
+        dims_error.append("Please re-compile with a different WarpX_DIMS option or select the right executable name.");
+    } else {
+        dims = "Not specified";
+        dims_error.append("inputs file does not declare 'geometry.dims'. Please add 'geometry.dims = ");
+        dims_error.append(dims_compiled).append("' to inputs file.");
+    }
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(dims == dims_compiled, dims_error);
 }
 


### PR DESCRIPTION
## Summary

This PR modifies the abort message to handle the case where "geometry.dims" is not specified in the inputs file with a more user-friendly way error message.

## Additional information

I made this PR in response to attempting to test the macroscopic solver using the input file 
[inputs_sigma1000.txt](https://github.com/ECP-WarpX/WarpX/files/13518723/inputs_sigma1000.txt).

This is the output I get with the current version of development: 
[inputs_sigma1000_output_dev.txt](https://github.com/ECP-WarpX/WarpX/files/13518726/inputs_sigma1000_output_dev.txt)

Compare that to the output from this PR: 
[inputs_sigma1000_output_PR.txt](https://github.com/ECP-WarpX/WarpX/files/13518730/inputs_sigma1000_output_PR.txt)

The difference is because pp_geometry.get("dims") throws an error via AMReX in the case where "geometry.dims" isn't specified, and the error becomes much harder to track down compared to a WarpX assert with message.