### PR TITLE
Use "class" on the same line as the name of the class

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -24,8 +24,7 @@
 #include <memory>
 #include <string>
 
-class
-BTDiagnostics final : public Diagnostics
+class BTDiagnostics final : public Diagnostics
 {
 public:
 

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -14,8 +14,7 @@
 
 /** collect the particles that are absorbed at the embedded boundary, throughout the simulation
  */
-class
-BoundaryScrapingDiagnostics final : public Diagnostics
+class BoundaryScrapingDiagnostics final : public Diagnostics
 {
 public:
 

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -29,8 +29,7 @@
  * lab-frame field data is then stored in mf_dst.
  */
 
-class
-BackTransformFunctor final : public ComputeDiagFunctor
+class BackTransformFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor description

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -195,8 +195,7 @@ struct LorentzTransformParticles
  * \brief BackTransform functor to select particles and Lorentz Transform them
  *  and store in particle buffers
  */
-class
-BackTransformParticleFunctor final : public ComputeParticleDiagFunctor
+class BackTransformParticleFunctor final : public ComputeParticleDiagFunctor
 {
 public:
     BackTransformParticleFunctor(WarpXParticleContainer *pc_src, std::string species_name, int num_buffers);

--- a/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.H
@@ -8,8 +8,7 @@
 /**
  * \brief Functor to cell-center MF and store result in mf_out.
  */
-class
-CellCenterFunctor final : public ComputeDiagFunctor
+class CellCenterFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -13,8 +13,7 @@
  * \brief Functor to compute a diagnostic and store the result in existing
  * MultiFab
  */
-class
-ComputeDiagFunctor
+class ComputeDiagFunctor
 {
 public:
     ComputeDiagFunctor( int ncomp, amrex::IntVect crse_ratio) :

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
@@ -15,8 +15,7 @@
 /**
  * \brief Functor to compute a diagnostic and store the result in existing ParticleContainer.
  */
-class
-ComputeParticleDiagFunctor
+class ComputeParticleDiagFunctor
 {
 public:
 

--- a/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivBFunctor.H
@@ -10,8 +10,7 @@
 /**
  * \brief Functor to compute divB into mf_out.
  */
-class
-DivBFunctor final : public ComputeDiagFunctor
+class DivBFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.H
@@ -10,8 +10,7 @@
 /**
  * \brief Functor to compute divE into mf_out.
  */
-class
-DivEFunctor final : public ComputeDiagFunctor
+class DivEFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/JFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/JFunctor.H
@@ -8,8 +8,7 @@
 /**
  * \brief Functor to cell-center MF for current density and store result in mf_out.
  */
-class
-JFunctor final : public ComputeDiagFunctor
+class JFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/PartPerCellFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/PartPerCellFunctor.H
@@ -8,8 +8,7 @@
 /**
  * \brief Functor to cell-center MF and store result in mf_out.
  */
-class
-PartPerCellFunctor final : public ComputeDiagFunctor
+class PartPerCellFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/PartPerGridFunctor.H
@@ -8,8 +8,7 @@
 /**
  * \brief Functor to cell-center MF and store result in mf_out.
  */
-class
-PartPerGridFunctor final : public ComputeDiagFunctor
+class PartPerGridFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
@@ -12,8 +12,7 @@
 /**
  * \brief Functor to calculate per-cell averages of particle properties.
  */
-class
-ParticleReductionFunctor final : public ComputeDiagFunctor
+class ParticleReductionFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.H
@@ -8,8 +8,7 @@
 /**
  * \brief Functor to compute charge density rho into mf_out
  */
-class
-RhoFunctor final : public ComputeDiagFunctor
+class RhoFunctor final : public ComputeDiagFunctor
 {
 
 public:

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -6,8 +6,7 @@
 
 #include <string>
 
-class
-FullDiagnostics final : public Diagnostics
+class FullDiagnostics final : public Diagnostics
 {
 public:
     FullDiagnostics (int i, std::string name);

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -27,8 +27,7 @@
  * \brief This class contains the macroscopic properties of the medium needed to
  * evaluate macroscopic Maxwell equation.
  */
-class
-MacroscopicProperties
+class MacroscopicProperties
 {
 public:
     MacroscopicProperties (); // constructor


### PR DESCRIPTION
Adjusts a few class definitions so that the word "class" appears on the same line as the name of the class.