### PR TITLE
Fix preprocessor definition checks for 1D in two locations

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -154,7 +154,7 @@ struct LorentzTransformParticles
         dst.m_aos[i_dst].pos(0) = xp;
         dst.m_aos[i_dst].pos(1) = zp;
         amrex::ignore_unused(yp);
-#elif defined (WARPX_DIM_1D)
+#elif defined (WARPX_DIM_1D_Z)
         dst.m_aos[i_dst].pos(0) = zp;
         amrex::ignore_unused(xp, yp);
 #else

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1570,7 +1570,7 @@ WarpX::ReadExternalFieldFromFile (
 void
 WarpX::ReadExternalFieldFromFile (std::string , amrex::MultiFab* ,std::string, std::string)
 {
-#if defined(WARPX_DIM_1D)
+#if defined(WARPX_DIM_1D_Z)
     WARPX_ABORT_WITH_MESSAGE("Reading fields from openPMD files is not supported in 1D");
 #elif defined(WARPX_DIM_XZ)
     WARPX_ABORT_WITH_MESSAGE("Reading from openPMD for external fields is not known to work with XZ (see #3828)");


### PR DESCRIPTION
In two locations in the code, we had the line

```cpp
#ifdef WARPX_DIM_1D
    // do something
#endif
```

but the actual preprocessor variable is ```WARPX_DIM_1D_Z```. This PR fixes this issue in these two locations.