### PR TITLE
Bugfix in `fields.py` `mesh()` with ghost cells included

### DIFF
--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -160,8 +160,8 @@ class _MultiFABWrapper(object):
         if self.include_ghosts:
             # The ghost cells are added to the upper and lower end of the global domain.
             nghosts = self.mf.n_grow_vect()
-            ilo = list(ilo)
-            ihi = list(ihi)
+            ilo = [ilo] if self.dim == 1 else list(ilo)
+            ihi = [ihi] if self.dim == 1 else list(ihi)
             min_box = self.mf.box_array().minimal_box()
             imax = min_box.big_end
             for i in range(self.dim):
@@ -169,6 +169,12 @@ class _MultiFABWrapper(object):
                     ilo[i] -= nghosts[i]
                 if ihi[i] == imax[i]:
                     ihi[i] += nghosts[i]
+
+            # Switch ilo and ihi back to integers if 1d since in that case
+            # `ProbLo(idir)` is a float (not a list)
+            if self.dim == 1:
+                ilo = ilo[0]
+                ihi = ihi[0]
 
         # Cell size in the direction
         warpx = libwarpx.libwarpx_so.get_instance()

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -160,21 +160,8 @@ class _MultiFABWrapper(object):
         if self.include_ghosts:
             # The ghost cells are added to the upper and lower end of the global domain.
             nghosts = self.mf.n_grow_vect()
-            ilo = [ilo] if self.dim == 1 else list(ilo)
-            ihi = [ihi] if self.dim == 1 else list(ihi)
-            min_box = self.mf.box_array().minimal_box()
-            imax = min_box.big_end
-            for i in range(self.dim):
-                if ilo[i] == 0:
-                    ilo[i] -= nghosts[i]
-                if ihi[i] == imax[i]:
-                    ihi[i] += nghosts[i]
-
-            # Switch ilo and ihi back to integers if 1d since in that case
-            # `ProbLo(idir)` is a float (not a list)
-            if self.dim == 1:
-                ilo = ilo[0]
-                ihi = ihi[0]
+            ilo -= nghosts[idir]
+            ihi += nghosts[idir]
 
         # Cell size in the direction
         warpx = libwarpx.libwarpx_so.get_instance()


### PR DESCRIPTION
There is an issue in `fields.py`'s `mesh()` function in 1d when ghost cells are included due to the fact that 
```
        ilo = min_box.small_end[idir]
        ihi = min_box.big_end[idir]
```
returns `int`s not lists.
Firstly, the call `ilo = list(ilo)` fails with `TypeError: 'int' object is not iterable`.
Secondly (after fixing the first point), the `lo + np.arange(ilo,ihi+1)*dd + shift` fails due to the fact that `lo` is a float: `TypeError: can only concatenate list (not "int") to list`.