### PR TITLE
[WIP] Update install documentation for Brew

### DIFF
--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -156,7 +156,7 @@ Using the Brew Package
    python3 -m pip install --upgrade build packaging setuptools wheel
    python3 -m pip install --upgrade mpi4py
 
-WarpX can now be installed from source using CMake, outline below.
+WarpX can now be installed from source using CMake, outlined below.
 
 .. _install-cmake:
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -129,24 +129,15 @@ In the future, will publish pre-compiled binary packages on `PyPI <https://pypi.
 Using the Brew Package
 ----------------------
 
-:ref:`WarpX dependencies <install-dependencies>` can be installed using the `Brew <https://brew.sh>`__ package manager.
+A package for WarpX is available via the `Homebrew <https://brew.sh/>`_/`Linuxbrew <https://docs.brew.sh/Homebrew-on-Linux>`_ package manager.
 
 .. code-block:: bash
 
-   brew --cache
-   set +e
-   brew unlink gcc
    brew update
-   brew install --overwrite python
-   brew install fftw
-   brew install libomp
-   brew link --overwrite --force libomp
-   brew install ninja
-   brew install open-mpi
-   brew install pkg-config
-   set -e
    brew tap openpmd/openpmd
    brew install openpmd-api
+   brew tap ecp-warpx/blast
+   brew install warpx
 
    python3 -m pip install --upgrade pip
    python3 -m pip install --upgrade virtualenv
@@ -156,7 +147,6 @@ Using the Brew Package
    python3 -m pip install --upgrade build packaging setuptools wheel
    python3 -m pip install --upgrade mpi4py
 
-WarpX can now be installed from source using CMake, outlined below.
 
 .. _install-cmake:
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -129,10 +129,34 @@ In the future, will publish pre-compiled binary packages on `PyPI <https://pypi.
 Using the Brew Package
 ----------------------
 
-.. note::
+:ref:`WarpX dependencies <install-dependencies>` can be installed using the `Brew <https://brew.sh>`__ package manager.
 
-   Coming soon.
+.. code-block:: bash
 
+   brew --cache
+   set +e
+   brew unlink gcc
+   brew update 
+   brew install --overwrite python
+   brew install fftw
+   brew install libomp
+   brew link --overwrite --force libomp
+   brew install ninja
+   brew install open-mpi
+   brew install pkg-config
+   set -e
+   brew tap openpmd/openpmd
+   brew install openpmd-api
+
+   python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade virtualenv
+   python3 -m venv py-venv
+   source py-venv/bin/activate
+   python3 -m pip install --upgrade pip
+   python3 -m pip install --upgrade build packaging setuptools wheel
+   python3 -m pip install --upgrade mpi4py
+
+WarpX can now be installed from source using CMake, outline below.
 
 .. _install-cmake:
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -136,7 +136,7 @@ Using the Brew Package
    brew --cache
    set +e
    brew unlink gcc
-   brew update 
+   brew update
    brew install --overwrite python
    brew install fftw
    brew install libomp


### PR DESCRIPTION
I updated the installation documentation for `Brew`. 
It was previously "coming soon...", so I updated it to reflect the brew dependency installation as outlined in the `macos.yml` file used in github workflows.
Users are then pointed to install using `CMake`. 

Here is a preview of the docs:
![image](https://github.com/ECP-WarpX/WarpX/assets/124003120/1d5179a0-cca5-4c0a-a105-2ff14edcb6a7)
