### PR TITLE
Remove brew cache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,22 +18,8 @@ jobs:
       #CMAKE_GENERATOR: Ninja
     steps:
     - uses: actions/checkout@v3
-    - name: Brew Cache
-      uses: actions/cache@v3
-      # - once stored under a key, they become immutable (even if local cache path content changes)
-      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
-      with:
-        path: |
-          /usr/local/bin
-          /usr/local/lib
-          /usr/local/share
-          /Users/runner/Library/Caches/Homebrew
-        key: brew-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}
-        restore-keys: |
-          brew-macos-appleclang-
     - name: install dependencies
       run: |
-        brew --cache
         set +e
         brew unlink gcc
         brew update


### PR DESCRIPTION
The size of the brew cache is huge. It can be as big as more than 6 GB. Since we only have 10 GB GitHub cache space, the brew cache is disabled in the macOS CI. It should not increase the time for the macOS CI too much. Without any cache, it usually takes less than 10 minutes to install all the brew packages.