### PR TITLE
macOS CI: export CCACHE_DEPEND=1

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,6 +55,7 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=100M
+        export CCACHE_DEPEND=1
         ccache -z
 
         source py-venv/bin/activate


### PR DESCRIPTION
Without it, the hit rate of ccache is very low.