### PR TITLE
Set alpha mass directly from NIST data

### DIFF
--- a/Source/Particles/SpeciesPhysicalProperties.cpp
+++ b/Source/Particles/SpeciesPhysicalProperties.cpp
@@ -126,8 +126,10 @@ namespace {
 
     constexpr auto quiet_NaN = std::numeric_limits<amrex::Real>::quiet_NaN();
 
-    // The atomic mass data below is from this NIST page
+    // The atomic mass data below is from these NIST pages
     // https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=&ascii=ascii2&isotype=some
+    // https://physics.nist.gov/cgi-bin/cuu/Value?malu
+
     const
     std::map<PhysicalSpecies,Properties> species_to_properties
     {
@@ -177,7 +179,7 @@ namespace {
              amrex::Real(4.00260325413) * PhysConst::m_u,
              amrex::Real(2) * PhysConst::q_e}},
         {PhysicalSpecies::alpha, Properties{
-             amrex::Real(4.00260325413) * PhysConst::m_u - amrex::Real(2) * PhysConst::m_e,
+             amrex::Real(4.001506179127) * PhysConst::m_u,
              amrex::Real(2) * PhysConst::q_e}},
         {PhysicalSpecies::lithium, Properties{
              amrex::Real(6.967) * PhysConst::m_u,

--- a/Source/Particles/SpeciesPhysicalProperties.cpp
+++ b/Source/Particles/SpeciesPhysicalProperties.cpp
@@ -129,7 +129,6 @@ namespace {
     // The atomic mass data below is from these NIST pages
     // https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=&ascii=ascii2&isotype=some
     // https://physics.nist.gov/cgi-bin/cuu/Value?malu
-
     const
     std::map<PhysicalSpecies,Properties> species_to_properties
     {


### PR DESCRIPTION
NIST data provides the mass of the alpha particle directly with a high degree of certainty. We might as well use that instead of approximating it by subtracting the mass of two electrons from the mass of helium4.