### PR TITLE
sqrt -> std::sqrt

### DIFF
--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -341,7 +341,7 @@ struct InjectorMomentumBoltzmann
         for (auto& el : u) el = 0.0_rt;
         const amrex::Real beta = velocity(x,y,z);
         int const dir = velocity.direction();
-        const auto gamma = static_cast<amrex::Real>(1._rt/sqrt(1._rt-beta*beta));
+        const auto gamma = 1._rt/std::sqrt(1._rt-beta*beta);
         u[dir] = gamma*beta;
         return amrex::XDim3 {u[0],u[1],u[2]};
     }
@@ -444,7 +444,7 @@ struct InjectorMomentumJuttner
         for (auto& el : u) el = 0.0_rt;
         amrex::Real const beta = velocity(x,y,z);
         int const dir = velocity.direction();
-        auto const gamma = static_cast<amrex::Real>(1._rt/sqrt(1._rt-beta*beta));
+        auto const gamma = 1._rt/std::sqrt(1._rt-beta*beta);
         u[dir] = gamma*beta;
         return amrex::XDim3 {u[0],u[1],u[2]};
     }


### PR DESCRIPTION
Unlike std::sqrt that has overloads for double and float, sqrt is a C function that takes a double. If the argument is a float, it will have to be promoted to double first.