### PR TITLE
macOS CI: Fix brew installation by explicitly specifing Python version

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
         set +e
         brew unlink gcc
         brew update
-        brew install --overwrite python
+        brew install --overwrite --force python@3.12
         brew install ccache
         brew install fftw
         brew install libomp


### PR DESCRIPTION
Force install python 3.12. This is likely to be faster than `brew upgrade` in #4493.