### PR TITLE
Clang-tidy: enable readability-duplicate-include check in clang-tidy CI test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,7 +39,6 @@ Checks: '
     readability-*,
         -readability-braces-around-statements,
         -readability-convert-member-functions-to-static,
-        -readability-duplicate-include,
         -readability-else-after-return,
         -readability-function-cognitive-complexity,
         -readability-identifier-length,

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -12,21 +12,6 @@
 #include <ablastr/utils/TextMsg.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
-#include <AMReX_MultiFab.H>
-#include <AMReX_REAL.H>
-#include <AMReX_MLLinOp.H>
-#include <AMReX_Vector.H>
-#include <AMReX_Array.H>
-#include <AMReX_MLNodeTensorLaplacian.H>
-#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
-#   include <AMReX_MLEBNodeFDLaplacian.H>
-#endif
-#ifdef AMREX_USE_EB
-#   include <AMReX_EBFabFactory.H>
-#endif
-#include <AMReX_Parser.H>
-#include <AMReX_REAL.H>
-#include <AMReX_MFInterp_C.H>
 
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
@@ -45,12 +30,21 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_LO_BCTYPES.H>
 #include <AMReX_MFIter.H>
+#include <AMReX_MFInterp_C.H>
 #include <AMReX_MLMG.H>
+#include <AMReX_MLLinOp.H>
+#include <AMReX_MLNodeTensorLaplacian.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_Parser.H>
 #include <AMReX_REAL.H>
 #include <AMReX_SPACE.H>
 #include <AMReX_Vector.H>
-#include <AMReX_MFInterp_C.H>
+#if defined(AMREX_USE_EB) || defined(WARPX_DIM_RZ)
+#   include <AMReX_MLEBNodeFDLaplacian.H>
+#endif
+#ifdef AMREX_USE_EB
+#   include <AMReX_EBFabFactory.H>
+#endif
 
 #include <array>
 #include <optional>

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -13,19 +13,6 @@
 #include <ablastr/utils/TextMsg.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
-#include <AMReX_MultiFab.H>
-#include <AMReX_REAL.H>
-#include <AMReX_MLLinOp.H>
-#include <AMReX_Vector.H>
-#include <AMReX_Array.H>
-#include <AMReX_MLEBNodeFDLaplacian.H>
-#ifdef AMREX_USE_EB
-#   include <AMReX_EBFabFactory.H>
-#endif
-#include <AMReX_Parser.H>
-#include <AMReX_REAL.H>
-#include <AMReX_MFInterp_C.H>
-
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
 #include <AMReX_BLassert.H>
@@ -43,12 +30,18 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_LO_BCTYPES.H>
 #include <AMReX_MFIter.H>
+#include <AMReX_MFInterp_C.H>
+#include <AMReX_MLEBNodeFDLaplacian.H>
+#include <AMReX_MLLinOp.H>
 #include <AMReX_MLMG.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_Parser.H>
 #include <AMReX_REAL.H>
 #include <AMReX_SPACE.H>
 #include <AMReX_Vector.H>
-#include <AMReX_MFInterp_C.H>
+#ifdef AMREX_USE_EB
+#   include <AMReX_EBFabFactory.H>
+#endif
 
 #include <array>
 #include <optional>


### PR DESCRIPTION
This PR eliminates duplicated includes and enforces the 
- [readability-duplicate-include](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-duplicate-include.html) 

check in clang-tidy CI test.