### PR TITLE
Clang-tidy: enable no-malloc check in clang-tidy CI test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: '
         -cppcoreguidelines-avoid-non-const-global-variables,
         -cppcoreguidelines-init-variables,
         -cppcoreguidelines-macro-usage,
-        -cppcoreguidelines-no-malloc,
         -cppcoreguidelines-narrowing-conversions,
         -cppcoreguidelines-non-private-member-variables-in-classes,
         -cppcoreguidelines-owning-memory,


### PR DESCRIPTION
This PR enforces the 
- [cppcoreguidelines-no-malloc](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-no-malloc.html)

check in `clang-tidy` CI test