### PR TITLE
Fix CI for ROCm 6.0

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -41,7 +41,8 @@ sudo apt-get install -y --no-install-recommends \
     rocm-dev        \
     rocfft-dev      \
     rocprim-dev     \
-    rocrand-dev
+    rocrand-dev     \
+    hiprand-dev
 
 # ccache
 $(dirname "$0")/ccache.sh


### PR DESCRIPTION
Need to explicitly install hiprand package in CI because it's now a standalone project, not a submodule for rocRand according to the release notes.