### PR TITLE
WarpXAMReXInit: move include directive from header to cpp file

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.H
+++ b/Source/Initialization/WarpXAMReXInit.H
@@ -7,8 +7,6 @@
 #ifndef WARPX_AMREX_INIT_H_
 #define WARPX_AMREX_INIT_H_
 
-#include <AMReX_ccse-mpi.H>
-
 #include <AMReX_BaseFwd.H>
 
 namespace warpx::initialization

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -8,6 +8,7 @@
 #include "Initialization/WarpXAMReXInit.H"
 
 #include <AMReX.H>
+#include <AMReX_ccse-mpi.H>
 #include <AMReX_ParmParse.H>
 
 #include <memory>


### PR DESCRIPTION
This mini-PR moves an include directive from `WarpXAMReXInit.H` to `WarpXAMReXInit.cpp` . 