### PR TITLE
Add updated instructions for WarpX on Karolina

### DIFF
--- a/Tools/machines/karolina-it4i/install_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_dependencies.sh
@@ -26,12 +26,24 @@ if [ ! -d "$WORK/spack" ]
 then
     git clone -c feature.manyFiles=true -b v0.21.0 https://github.com/spack/spack.git $WORK/spack
     source $WORK/spack/share/spack/setup-env.sh
+else
+    # If the directory exists, checkout v0.21.0 branch
+    cd $WORK/spack
+    git checkout v0.21.0
+    git pull origin v0.21.0
+    source $WORK/spack/share/spack/setup-env.sh
 
-    # create and activate the spack environment
-    spack env create warpx-karolina-cuda $WORK/src/warpx/Tools/machines/karolina-it4i/spack-karolina-cuda.yaml
-    spack env activate warpx-karolina-cuda
-    spack install
+    # Delete spack env if present
+    if spack env list | grep -q warpx-karolina-cuda; then
+        spack env deactivate
+        spack env rm -y warpx-karolina-cuda
+    fi
 fi
+
+# create and activate the spack environment
+spack env create warpx-karolina-cuda $WORK/src/warpx/Tools/machines/karolina-it4i/spack-karolina-cuda.yaml
+spack env activate warpx-karolina-cuda
+spack install
 
 # Python ##########################################################
 #

--- a/Tools/machines/karolina-it4i/install_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_dependencies.sh
@@ -34,10 +34,10 @@ else
     source $WORK/spack/share/spack/setup-env.sh
 
     # Delete spack env if present
-    if spack env list | grep -q warpx-karolina-cuda; then
-        spack env deactivate
-        spack env rm -y warpx-karolina-cuda
-    fi
+    spack env deactivate || true
+    spack env rm -y warpx-karolina-cuda || true
+
+    cd -
 fi
 
 # create and activate the spack environment

--- a/Tools/machines/karolina-it4i/karolina_gpu.sbatch
+++ b/Tools/machines/karolina-it4i/karolina_gpu.sbatch
@@ -27,6 +27,7 @@
 
 # OpenMP threads per MPI rank
 export OMP_NUM_THREADS=16
+export SRUN_CPUS_PER_TASK=16
 
 # set user rights to u=rwx;g=r-x;o=---
 umask 0027

--- a/Tools/machines/karolina-it4i/karolina_warpx.profile.example
+++ b/Tools/machines/karolina-it4i/karolina_warpx.profile.example
@@ -26,15 +26,11 @@ fi
 module purge
 module load OpenMPI/4.1.4-GCC-11.3.0-CUDA-11.7.0
 
-# download and activate spack
-if [ ! -d "$WORK/spack" ]
-then
-    echo "WARNING: Spack installation not detected, please run install_dependencies.sh"
-else
-    # activate the spack environment
-    source $WORK/spack/share/spack/setup-env.sh
-    spack env activate warpx-karolina-cuda
-fi
+source $WORK/spack/share/spack/setup-env.sh && spack env activate warpx-karolina-cuda && {
+    echo "Spack environment 'warpx-karolina-cuda' activated successfully."
+} || {
+    echo "Failed to activate Spack environment 'warpx-karolina-cuda'. Please run install_dependencies.sh."
+}
 
 # Text Editor for Tools ########################## (edit this line)
 # examples: "nano", "vim", "emacs -nw" or without terminal: "gedit"


### PR DESCRIPTION
Use spack for installing all dependencies, and the new slurm scheduler.

As suggested in https://github.com/ECP-WarpX/WarpX/pull/4477#discussion_r1425742388, I
added an else branch that checks out the v0.21.0 branch if the directory exists, removes the warpx-karolina-cuda environment, if it exists, and does the same install.

Also added the SRUN_CPUS_PER_TASK var in the slurm script, according to https://slurm.schedmd.com/sbatch.html#OPT_cpus-per-task

Finally, the profile file was somewhat simplified.


