### PR TITLE
Disambiguate the routine name initialize_inputs in picmi.py

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -219,10 +219,10 @@ class Species(picmistandard.PICMI_Species):
         self.resampling_trigger_intervals = kw.pop('warpx_resampling_trigger_intervals', None)
         self.resampling_triggering_max_avg_ppc = kw.pop('warpx_resampling_trigger_max_avg_ppc', None)
 
-    def initialize_inputs(self, layout,
-                          initialize_self_fields = False,
-                          injection_plane_position = None,
-                          injection_plane_normal_vector = None):
+    def species_initialize_inputs(self, layout,
+                                  initialize_self_fields = False,
+                                  injection_plane_position = None,
+                                  injection_plane_normal_vector = None):
         self.species_number = len(pywarpx.particles.species_names)
 
         if self.name is None:
@@ -274,7 +274,8 @@ class Species(picmistandard.PICMI_Species):
             distributions_is_list = np.iterable(self.initial_distribution)
             layout_is_list = np.iterable(layout)
             if not distributions_is_list and not layout_is_list:
-                self.initial_distribution.initialize_inputs(self.species_number, layout, self.species, self.density_scale, '')
+                self.initial_distribution.distribution_initialize_inputs(self.species_number, layout, self.species,
+                                                                         self.density_scale, '')
             elif distributions_is_list and (layout_is_list or layout is None):
                 assert layout is None or (len(self.initial_distribution) == len(layout)),\
                        Exception('The initial distribution and layout lists must have the same lenth')
@@ -282,8 +283,8 @@ class Species(picmistandard.PICMI_Species):
                 self.species.injection_sources = source_names
                 for i, dist in enumerate(self.initial_distribution):
                     layout_i = layout[i] if layout is not None else None
-                    dist.initialize_inputs(self.species_number, layout_i, self.species,
-                                           self.density_scale, source_names[i])
+                    dist.distribution_initialize_inputs(self.species_number, layout_i, self.species,
+                                                        self.density_scale, source_names[i])
             else:
                 raise Exception('The initial distribution and layout must both be scalars or both be lists')
 
@@ -298,15 +299,15 @@ class Species(picmistandard.PICMI_Species):
 
 picmistandard.PICMI_MultiSpecies.Species_class = Species
 class MultiSpecies(picmistandard.PICMI_MultiSpecies):
-    def initialize_inputs(self, layout,
-                          initialize_self_fields = False,
-                          injection_plane_position = None,
-                          injection_plane_normal_vector = None):
+    def species_initialize_inputs(self, layout,
+                                  initialize_self_fields = False,
+                                  injection_plane_position = None,
+                                  injection_plane_normal_vector = None):
         for species in self.species_instances_list:
-            species.initialize_inputs(layout,
-                                      initialize_self_fields,
-                                      injection_plane_position,
-                                      injection_plane_normal_vector)
+            species.species_initialize_inputs(layout,
+                                              initialize_self_fields,
+                                              injection_plane_position,
+                                              injection_plane_normal_vector)
 
 
 class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
@@ -314,7 +315,7 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
         self.do_symmetrize = kw.pop('warpx_do_symmetrize', None)
         self.symmetrization_order = kw.pop('warpx_symmetrization_order', None)
 
-    def initialize_inputs(self, species_number, layout, species, density_scale, source_name):
+    def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):
         species.add_new_group_attr(source_name, 'injection_style', "gaussian_beam")
         species.add_new_group_attr(source_name, 'x_m', self.centroid_position[0])
         species.add_new_group_attr(source_name, 'y_m', self.centroid_position[1])
@@ -441,7 +442,7 @@ class DensityDistributionBase(object):
 
 
 class UniformFluxDistribution(picmistandard.PICMI_UniformFluxDistribution, DensityDistributionBase):
-    def initialize_inputs(self, species_number, layout, species, density_scale, source_name):
+    def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):
 
         self.fill_in = False
         self.set_mangle_dict()
@@ -465,7 +466,7 @@ class UniformFluxDistribution(picmistandard.PICMI_UniformFluxDistribution, Densi
 
 
 class UniformDistribution(picmistandard.PICMI_UniformDistribution, DensityDistributionBase):
-    def initialize_inputs(self, species_number, layout, species, density_scale, source_name):
+    def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):
 
         self.set_mangle_dict()
         self.set_species_attributes(species, layout, source_name)
@@ -492,7 +493,7 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution, DensityDist
     def init(self, kw):
         self.momentum_spread_expressions = kw.pop('warpx_momentum_spread_expressions', [None, None, None])
 
-    def initialize_inputs(self, species_number, layout, species, density_scale, source_name):
+    def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):
 
         self.set_mangle_dict()
         self.set_species_attributes(species, layout, source_name)
@@ -509,7 +510,7 @@ class ParticleListDistribution(picmistandard.PICMI_ParticleListDistribution):
     def init(self, kw):
         pass
 
-    def initialize_inputs(self, species_number, layout, species, density_scale, source_name):
+    def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):
 
         species.add_new_group_attr(source_name, 'injection_style', "multipleparticles")
         species.add_new_group_attr(source_name, 'multiple_particles_pos_x', self.x)
@@ -539,7 +540,7 @@ class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
 
 class BinomialSmoother(picmistandard.PICMI_BinomialSmoother):
 
-    def initialize_inputs(self, solver):
+    def smoother_initialize_inputs(self, solver):
         pywarpx.warpx.use_filter = 1
         pywarpx.warpx.use_filter_compensation = bool(np.all(self.compensation))
         if self.n_pass is None:
@@ -629,7 +630,7 @@ class CylindricalGrid(picmistandard.PICMI_CylindricalGrid):
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
 
-    def initialize_inputs(self):
+    def grid_initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
         # Maximum allowable size of each subdomain in the problem domain;
@@ -730,7 +731,7 @@ class Cartesian1DGrid(picmistandard.PICMI_Cartesian1DGrid):
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
 
-    def initialize_inputs(self):
+    def grid_initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
         # Maximum allowable size of each subdomain in the problem domain;
@@ -833,7 +834,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
 
-    def initialize_inputs(self):
+    def grid_initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
         # Maximum allowable size of each subdomain in the problem domain;
@@ -956,7 +957,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         pywarpx.geometry.prob_lo = self.lower_bound  # physical domain
         pywarpx.geometry.prob_hi = self.upper_bound
 
-    def initialize_inputs(self):
+    def grid_initialize_inputs(self):
         pywarpx.amr.n_cell = self.number_of_cells
 
         # Maximum allowable size of each subdomain in the problem domain;
@@ -1061,9 +1062,9 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
         self.pml_has_particles = kw.pop('warpx_pml_has_particles', None)
         self.do_pml_j_damping = kw.pop('warpx_do_pml_j_damping', None)
 
-    def initialize_inputs(self):
+    def solver_initialize_inputs(self):
 
-        self.grid.initialize_inputs()
+        self.grid.grid_initialize_inputs()
 
         pywarpx.warpx.pml_ncell = self.pml_ncell
 
@@ -1099,7 +1100,7 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
             pywarpx.warpx.cfl = self.cfl
 
         if self.source_smoother is not None:
-            self.source_smoother.initialize_inputs(self)
+            self.source_smoother.smoother_initialize_inputs(self)
 
         pywarpx.warpx.do_dive_cleaning = self.divE_cleaning
         pywarpx.warpx.do_divb_cleaning = self.divB_cleaning
@@ -1167,14 +1168,14 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self):
+    def solver_initialize_inputs(self):
 
         # Add the user defined keywords to my_constants
         # The keywords are mangled if there is a conflicting variable already
         # defined in my_constants with the same name but different value.
         self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
 
-        self.grid.initialize_inputs()
+        self.grid.grid_initialize_inputs()
 
         pywarpx.algo.maxwell_solver = self.method
 
@@ -1222,9 +1223,9 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
         self.self_fields_verbosity = kw.pop('warpx_self_fields_verbosity', None)
         self.magnetostatic = kw.pop('warpx_magnetostatic', False)
 
-    def initialize_inputs(self):
+    def solver_initialize_inputs(self):
 
-        self.grid.initialize_inputs()
+        self.grid.grid_initialize_inputs()
 
         if self.relativistic:
             pywarpx.warpx.do_electrostatic = 'relativistic'
@@ -1246,7 +1247,7 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
 
 
 class GaussianLaser(picmistandard.PICMI_GaussianLaser):
-    def initialize_inputs(self):
+    def laser_initialize_inputs(self):
         self.laser_number = len(pywarpx.lasers.names) + 1
         if self.name is None:
             self.name = 'laser{}'.format(self.laser_number)
@@ -1271,7 +1272,7 @@ class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
     def init(self, kw):
         self.mangle_dict = None
 
-    def initialize_inputs(self):
+    def laser_initialize_inputs(self):
         self.laser_number = len(pywarpx.lasers.names) + 1
         if self.name is None:
             self.name = 'laser{}'.format(self.laser_number)
@@ -1294,7 +1295,7 @@ class AnalyticLaser(picmistandard.PICMI_AnalyticLaser):
 
 
 class LaserAntenna(picmistandard.PICMI_LaserAntenna):
-    def initialize_inputs(self, laser):
+    def laser_antenna_initialize_inputs(self, laser):
         laser.laser.position = self.position  # This point is on the laser plane
         if (
             self.normal_vector is not None
@@ -1321,7 +1322,7 @@ class LaserAntenna(picmistandard.PICMI_LaserAntenna):
 
 
 class LoadInitialField(picmistandard.PICMI_LoadGriddedField):
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
         pywarpx.warpx.read_fields_from_path = self.read_fields_from_path
         if self.load_E:
             pywarpx.warpx.E_ext_grid_init_style = 'read_from_file'
@@ -1334,7 +1335,7 @@ class AnalyticInitialField(picmistandard.PICMI_AnalyticAppliedField):
         self.mangle_dict = None
         self.maxlevel_extEMfield_init = kw.pop('warpx_maxlevel_extEMfield_init', None);
 
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
         # Note that lower and upper_bound are not used by WarpX
         pywarpx.warpx.maxlevel_extEMfield_init = self.maxlevel_extEMfield_init;
 
@@ -1361,7 +1362,7 @@ class AnalyticInitialField(picmistandard.PICMI_AnalyticAppliedField):
 
 
 class ConstantAppliedField(picmistandard.PICMI_ConstantAppliedField):
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
         # Note that lower and upper_bound are not used by WarpX
 
         if (self.Ex is not None or
@@ -1381,7 +1382,7 @@ class AnalyticAppliedField(picmistandard.PICMI_AnalyticAppliedField):
     def init(self, kw):
         self.mangle_dict = None
 
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
         # Note that lower and upper_bound are not used by WarpX
 
         if self.mangle_dict is None:
@@ -1407,7 +1408,7 @@ class AnalyticAppliedField(picmistandard.PICMI_AnalyticAppliedField):
 
 
 class Mirror(picmistandard.PICMI_Mirror):
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
         try:
             pywarpx.warpx.num_mirrors
         except AttributeError:
@@ -1426,7 +1427,7 @@ class FieldIonization(picmistandard.PICMI_FieldIonization):
     """
     WarpX only has ADK ionization model implemented.
     """
-    def initialize_inputs(self):
+    def interaction_initialize_inputs(self):
         assert self.model == 'ADK', 'WarpX only has ADK ionization model implemented'
         self.ionized_species.species.do_field_ionization = 1
         self.ionized_species.species.physical_element = self.ionized_species.particle_type
@@ -1464,7 +1465,7 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self):
+    def collision_initialize_inputs(self):
         collision = pywarpx.Collisions.newcollision(self.name)
         collision.type = 'pairwisecoulomb'
         collision.species = [species.name for species in self.species]
@@ -1521,7 +1522,7 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self):
+    def collision_initialize_inputs(self):
         collision = pywarpx.Collisions.newcollision(self.name)
         collision.type = 'background_mcc'
         collision.species = self.species.name
@@ -1613,7 +1614,7 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self, solver):
+    def embedded_boundary_initialize_inputs(self, solver):
 
         # Add the user defined keywords to my_constants
         # The keywords are mangled if there is a conflicting variable already
@@ -1685,7 +1686,7 @@ class PlasmaLens(picmistandard.base._ClassWithInit):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self):
+    def applied_field_initialize_inputs(self):
 
         pywarpx.particles.E_ext_particle_init_style = 'repeated_plasma_lens'
         pywarpx.particles.B_ext_particle_init_style = 'repeated_plasma_lens'
@@ -1973,7 +1974,7 @@ class Simulation(picmistandard.PICMI_Simulation):
                 interpolation_order = particle_shape
             pywarpx.algo.particle_shape = interpolation_order
 
-        self.solver.initialize_inputs()
+        self.solver.solver_initialize_inputs()
 
         # Initialize warpx.field_centering_no<x,y,z> and warpx.current_centering_no<x,y,z>
         # if set by the user in the input (need to access grid info from solver attribute)
@@ -1991,33 +1992,33 @@ class Simulation(picmistandard.PICMI_Simulation):
             pywarpx.warpx.current_centering_noz = self.current_centering_order[-1]
 
         for i in range(len(self.species)):
-            self.species[i].initialize_inputs(self.layouts[i],
-                                              self.initialize_self_fields[i],
-                                              self.injection_plane_positions[i],
-                                              self.injection_plane_normal_vectors[i])
+            self.species[i].species_initialize_inputs(self.layouts[i],
+                                                      self.initialize_self_fields[i],
+                                                      self.injection_plane_positions[i],
+                                                      self.injection_plane_normal_vectors[i])
 
         for interaction in self.interactions:
             assert(isinstance(interaction, FieldIonization))
-            interaction.initialize_inputs()
+            interaction.interaction_initialize_inputs()
 
         if self.collisions is not None:
             pywarpx.collisions.collision_names = []
             for collision in self.collisions:
                 pywarpx.collisions.collision_names.append(collision.name)
-                collision.initialize_inputs()
+                collision.collision_initialize_inputs()
 
         if self.embedded_boundary is not None:
-            self.embedded_boundary.initialize_inputs(self.solver)
+            self.embedded_boundary.embedded_boundary_initialize_inputs(self.solver)
 
         for i in range(len(self.lasers)):
-            self.lasers[i].initialize_inputs()
-            self.laser_injection_methods[i].initialize_inputs(self.lasers[i])
+            self.lasers[i].laser_initialize_inputs()
+            self.laser_injection_methods[i].laser_antenna_initialize_inputs(self.lasers[i])
 
         for applied_field in self.applied_fields:
-            applied_field.initialize_inputs()
+            applied_field.applied_field_initialize_inputs()
 
         for diagnostic in self.diagnostics:
-            diagnostic.initialize_inputs()
+            diagnostic.diagnostic_initialize_inputs()
 
         if self.amr_restart:
             pywarpx.amr.restart = self.amr_restart
@@ -2175,7 +2176,7 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
         self.particle_fields_to_plot = kw.pop('warpx_particle_fields_to_plot', [])
         self.particle_fields_species = kw.pop('warpx_particle_fields_species', None)
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 
@@ -2313,7 +2314,7 @@ class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
 
         self.handle_init(kw)
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 
@@ -2373,7 +2374,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
 
         self.mangle_dict = None
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 
@@ -2488,7 +2489,7 @@ class LabFrameFieldDiagnostic(picmistandard.PICMI_LabFrameFieldDiagnostic,
         self.lower_bound = kw.pop('warpx_lower_bound', None)
         self.upper_bound = kw.pop('warpx_upper_bound', None)
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 
@@ -2587,7 +2588,7 @@ class LabFrameParticleDiagnostic(picmistandard.PICMI_LabFrameParticleDiagnostic,
         self.file_min_digits = kw.pop('warpx_file_min_digits', None)
         self.buffer_size = kw.pop('warpx_buffer_size', None)
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 
@@ -2879,7 +2880,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
 
         return kw
 
-    def initialize_inputs(self):
+    def diagnostic_initialize_inputs(self):
 
         self.add_diagnostic()
 


### PR DESCRIPTION
This PR improves code readability in the picmi interface. Previously, each class had a  method called `initialize_inputs`, but with all classes having a routine of the same name, it made it hard to find specific versions of the method. This PR adds prefixes to the name, based on the input type of the class. For instance, in the diagnostic classes, the routine is called `diagnostic_initialize_inputs`.