### PR TITLE
Update dsmc and fusion binary collisions

### DIFF
--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -187,6 +187,9 @@ class CapacitiveDischargeExample(object):
         else:
             self.mcc_subcycling_steps = None
 
+        if self.dsmc:
+            self.rng = np.random.default_rng(23094290)
+
         self.ion_density_array = np.zeros(self.nz + 1)
 
         self.setup_run()
@@ -397,9 +400,9 @@ class CapacitiveDischargeExample(object):
         vel_std = np.sqrt(constants.kb * self.gas_temp / self.m_ion)
         for ii in range(len(ux_arrays)):
             nps = len(ux_arrays[ii])
-            ux_arrays[ii][:] = vel_std * np.random.normal(size=nps)
-            uy_arrays[ii][:] = vel_std * np.random.normal(size=nps)
-            uz_arrays[ii][:] = vel_std * np.random.normal(size=nps)
+            ux_arrays[ii][:] = vel_std * self.rng.normal(size=nps)
+            uy_arrays[ii][:] = vel_std * self.rng.normal(size=nps)
+            uz_arrays[ii][:] = vel_std * self.rng.normal(size=nps)
 
     def _get_rho_ions(self):
         # deposit the ion density in rho_fp

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -77,18 +77,8 @@ void CollisionPairFilter (const amrex::ParticleReal& u1x, const amrex::ParticleR
     // In principle this is obtained by computing 1 - exp(-probability_estimate)
     // However, the computation of this quantity can fail numerically when probability_estimate is
     // too small (e.g. exp(-probability_estimate) returns 1 and the computation returns 0).
-    // In this case, we simply use "probability_estimate" instead of 1 - exp(-probability_estimate)
-    // The threshold exp_threshold at which we switch between the two formulas is determined by the
-    // fact that computing the exponential is only useful if it can resolve the x^2/2 term of its
-    // Taylor expansion, i.e. the square of probability_estimate should be greater than the
-    // machine epsilon.
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-    constexpr auto exp_threshold = amrex::ParticleReal(1.e-3);
-#else
-    constexpr auto exp_threshold = amrex::ParticleReal(5.e-8);
-#endif
-    const amrex::ParticleReal probability = (exponent < exp_threshold) ?
-                                exponent: 1._prt - std::exp(-exponent);
+    // std::expm1 is used since it maintains correctness for small exponent.
+    const amrex::ParticleReal probability = -std::expm1(-exponent);
 
     // Now we determine if a collision should occur
     if (amrex::Random(engine) < probability)

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
@@ -113,18 +113,8 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
     // In principle this is obtained by computing 1 - exp(-probability_estimate)
     // However, the computation of this quantity can fail numerically when probability_estimate is
     // too small (e.g. exp(-probability_estimate) returns 1 and the computation returns 0).
-    // In this case, we simply use "probability_estimate" instead of 1 - exp(-probability_estimate)
-    // The threshold exp_threshold at which we switch between the two formulas is determined by the
-    // fact that computing the exponential is only useful if it can resolve the x^2/2 term of its
-    // Taylor expansion, i.e. the square of probability_estimate should be greater than the
-    // machine epsilon.
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-    constexpr auto exp_threshold = amrex::ParticleReal(1.e-3);
-#else
-    constexpr auto exp_threshold = amrex::ParticleReal(5.e-8);
-#endif
-    const amrex::ParticleReal probability = (probability_estimate < exp_threshold) ?
-                                    probability_estimate: 1._prt - std::exp(-probability_estimate);
+    // std::expm1 is used since it maintains correctness for small exponent.
+    const amrex::ParticleReal probability = -std::expm1(-probability_estimate);
 
     // Get a random number
     const amrex::ParticleReal random_number = amrex::Random(engine);


### PR DESCRIPTION
This PR makes two updates:

For the DSMC test cast Python_dsmc_1d, this now sets the numpy random number seed, to ensure consistent results.

For DSMC and fusion, when calculating the probability, the code now uses `std::expm1`, which ensures accurate results even for small exponents. This is a simplification of the code.