### PR TITLE
Scale fields by a dimensionless number between 0 and 1

### DIFF
--- a/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
+++ b/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
@@ -1,40 +1,5 @@
 {
   "lev=0": {
-<<<<<<< Updated upstream
-    "Bx": 4818955.485214876,
-    "By": 1752.8017794063862,
-    "Bz": 14516.212849468406,
-    "Ex": 2366115511749.6064,
-    "Ey": 1446112026972328.0,
-    "Ez": 21864189477873.78,
-    "jx": 1996366361598696.5,
-    "jy": 5.312583836700398e+16,
-    "jz": 2.0491352591140016e+16,
-    "rho": 68443961.6079968
-  },
-  "electrons": {
-    "particle_momentum_x": 2.2135944672847805e-23,
-    "particle_momentum_y": 2.82245592458273e-22,
-    "particle_momentum_z": 5.260626007649988e-22,
-    "particle_position_x": 0.010800577787630073,
-    "particle_position_y": 0.21115060628317733,
-    "particle_weight": 4.121554826246186e+16
-  },
-  "ions": {
-    "particle_momentum_x": 6.24847236820344e-23,
-    "particle_momentum_y": 4.449097670697282e-22,
-    "particle_momentum_z": 5.768168724446374e-22,
-    "particle_position_x": 0.010800001678510515,
-    "particle_position_y": 0.21114947608115428,
-    "particle_weight": 4.121554826246186e+16
-  },
-  "beam": {
-    "particle_momentum_x": 3.5357352601344873e-19,
-    "particle_momentum_y": 4.363147101327531e-19,
-    "particle_momentum_z": 5.658494028187168e-17,
-    "particle_position_x": 0.008314957057032625,
-    "particle_position_y": 1.1704335719922687,
-=======
     "Bx": 4818955.480792835,
     "By": 1752.8025402207227,
     "Bz": 14516.21278267981,
@@ -68,7 +33,6 @@
     "particle_momentum_z": 5.658606416951657e-17,
     "particle_position_x": 0.008314723025211447,
     "particle_position_y": 1.1704335743854242,
->>>>>>> Stashed changes
     "particle_weight": 62415090744.60765
   }
 }

--- a/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
+++ b/Regression/Checksum/benchmarks_json/LaserAccelerationBoost.json
@@ -1,5 +1,6 @@
 {
   "lev=0": {
+<<<<<<< Updated upstream
     "Bx": 4818955.485214876,
     "By": 1752.8017794063862,
     "Bz": 14516.212849468406,
@@ -33,6 +34,41 @@
     "particle_momentum_z": 5.658494028187168e-17,
     "particle_position_x": 0.008314957057032625,
     "particle_position_y": 1.1704335719922687,
+=======
+    "Bx": 4818955.480792835,
+    "By": 1752.8025402207227,
+    "Bz": 14516.21278267981,
+    "Ex": 2366115496505.249,
+    "Ey": 1446112025634143.0,
+    "Ez": 21864189507353.19,
+    "jx": 1996366349839211.5,
+    "jy": 5.312583827165288e+16,
+    "jz": 2.049135262445976e+16,
+    "rho": 68443961.71835628
+  },
+  "electrons": {
+    "particle_momentum_x": 2.2135945391227107e-23,
+    "particle_momentum_y": 2.8224559499572622e-22,
+    "particle_momentum_z": 5.260626010211241e-22,
+    "particle_position_x": 0.010800577787628053,
+    "particle_position_y": 0.2111506062831815,
+    "particle_weight": 4.121554826246186e+16
+  },
+  "ions": {
+    "particle_momentum_x": 6.248472277235318e-23,
+    "particle_momentum_y": 4.449097689427615e-22,
+    "particle_momentum_z": 5.768168724780326e-22,
+    "particle_position_x": 0.010800001678510512,
+    "particle_position_y": 0.21114947608115425,
+    "particle_weight": 4.121554826246186e+16
+  },
+  "beam": {
+    "particle_momentum_x": 3.535745635169933e-19,
+    "particle_momentum_y": 4.363391839372122e-19,
+    "particle_momentum_z": 5.658606416951657e-17,
+    "particle_position_x": 0.008314723025211447,
+    "particle_position_y": 1.1704335743854242,
+>>>>>>> Stashed changes
     "particle_weight": 62415090744.60765
   }
 }

--- a/Regression/Checksum/benchmarks_json/comoving_2d_psatd_hybrid.json
+++ b/Regression/Checksum/benchmarks_json/comoving_2d_psatd_hybrid.json
@@ -1,40 +1,5 @@
 {
   "lev=0": {
-<<<<<<< Updated upstream
-    "Bx": 1118808.3734374465,
-    "By": 3248957.1122179274,
-    "Bz": 280612.78289064515,
-    "Ex": 975532732112639.6,
-    "Ey": 402861836732114.4,
-    "Ez": 159049610399317.66,
-    "jx": 2.9997053130250828e+16,
-    "jy": 8.866654890775573e+16,
-    "jz": 3.163974708948631e+17,
-    "rho": 1059977729.0184418
-  },
-  "ions": {
-    "particle_momentum_x": 1.6150569180478943e-18,
-    "particle_momentum_y": 2.2334266828401142e-18,
-    "particle_momentum_z": 4.2792495306800117e-13,
-    "particle_position_x": 1.4883816864865955,
-    "particle_position_y": 16.45238650413084,
-    "particle_weight": 1.234867369440658e+18
-  },
-  "electrons": {
-    "particle_momentum_x": 7.05821754019506e-19,
-    "particle_momentum_y": 2.2042393263043917e-18,
-    "particle_momentum_z": 2.5305214316289944e-16,
-    "particle_position_x": 1.5006580331362074,
-    "particle_position_y": 16.45438830674347,
-    "particle_weight": 1.234867020725368e+18
-  },
-  "beam": {
-    "particle_momentum_x": 6.874634694077579e-19,
-    "particle_momentum_y": 4.374677735660533e-19,
-    "particle_momentum_z": 6.432600800266472e-18,
-    "particle_position_x": 0.0012933700124436584,
-    "particle_position_y": 0.358720803656086,
-=======
     "Bx": 1118808.3686978193,
     "By": 3248970.5506422943,
     "Bz": 280612.7921641442,
@@ -68,7 +33,6 @@
     "particle_momentum_z": 6.4523206583503136e-18,
     "particle_position_x": 0.001290816359726098,
     "particle_position_y": 0.3586691102823157,
->>>>>>> Stashed changes
     "particle_weight": 3120754537230.3823
   }
 }

--- a/Regression/Checksum/benchmarks_json/comoving_2d_psatd_hybrid.json
+++ b/Regression/Checksum/benchmarks_json/comoving_2d_psatd_hybrid.json
@@ -1,5 +1,6 @@
 {
   "lev=0": {
+<<<<<<< Updated upstream
     "Bx": 1118808.3734374465,
     "By": 3248957.1122179274,
     "Bz": 280612.78289064515,
@@ -33,6 +34,41 @@
     "particle_momentum_z": 6.432600800266472e-18,
     "particle_position_x": 0.0012933700124436584,
     "particle_position_y": 0.358720803656086,
+=======
+    "Bx": 1118808.3686978193,
+    "By": 3248970.5506422943,
+    "Bz": 280612.7921641442,
+    "Ex": 975536649649286.1,
+    "Ey": 402861835403418.1,
+    "Ez": 159049265640492.28,
+    "jx": 2.9996888133195436e+16,
+    "jy": 8.866654944519546e+16,
+    "jz": 3.164008885453435e+17,
+    "rho": 1059988299.6088305
+  },
+  "ions": {
+    "particle_momentum_x": 1.6150513873065298e-18,
+    "particle_momentum_y": 2.233426695677123e-18,
+    "particle_momentum_z": 4.279249529993671e-13,
+    "particle_position_x": 1.4883816864183497,
+    "particle_position_y": 16.452386504127254,
+    "particle_weight": 1.234867369440658e+18
+  },
+  "electrons": {
+    "particle_momentum_x": 7.058167362825288e-19,
+    "particle_momentum_y": 2.204239326446281e-18,
+    "particle_momentum_z": 2.530521998715408e-16,
+    "particle_position_x": 1.5006581263609764,
+    "particle_position_y": 16.454388313398017,
+    "particle_weight": 1.234867020725368e+18
+  },
+  "beam": {
+    "particle_momentum_x": 6.869222298759882e-19,
+    "particle_momentum_y": 4.374719809060106e-19,
+    "particle_momentum_z": 6.4523206583503136e-18,
+    "particle_position_x": 0.001290816359726098,
+    "particle_position_y": 0.3586691102823157,
+>>>>>>> Stashed changes
     "particle_weight": 3120754537230.3823
   }
 }

--- a/Regression/Checksum/benchmarks_json/galilean_2d_psatd_hybrid.json
+++ b/Regression/Checksum/benchmarks_json/galilean_2d_psatd_hybrid.json
@@ -1,38 +1,38 @@
 {
   "lev=0": {
-    "Bx": 1086729.9983020213,
-    "By": 2886537.292820136,
-    "Bz": 264259.5410465989,
-    "Ex": 867382749986595.4,
-    "Ey": 392666737316432.8,
-    "Ez": 146897959667920.22,
-    "jx": 2.7028854305928356e+16,
-    "jy": 8.615938520657634e+16,
-    "jz": 2.7328721771319978e+17,
-    "rho": 915931445.5917195
-  },
-  "electrons": {
-    "particle_momentum_x": 6.2409905560361695e-19,
-    "particle_momentum_y": 1.5790611507526441e-18,
-    "particle_momentum_z": 2.506435264953701e-16,
-    "particle_position_x": 1.5014136629221837,
-    "particle_position_y": 16.52378170697116,
-    "particle_weight": 1.2372401466086835e+18
+    "Bx": 1086729.9718613266,
+    "By": 2886554.482275311,
+    "Bz": 264259.55093734514,
+    "Ex": 867387781289915.2,
+    "Ey": 392666724461952.5,
+    "Ez": 146897592531660.03,
+    "jx": 2.702866174672266e+16,
+    "jy": 8.615938361747776e+16,
+    "jz": 2.7329155817806224e+17,
+    "rho": 915945723.7934376
   },
   "ions": {
-    "particle_momentum_x": 1.4394967936107095e-18,
-    "particle_momentum_y": 1.5967629122067375e-18,
-    "particle_momentum_z": 4.287340658682592e-13,
-    "particle_position_x": 1.4911814217840271,
-    "particle_position_y": 16.521964978774346,
+    "particle_momentum_x": 1.4394902513923003e-18,
+    "particle_momentum_y": 1.5967629157922875e-18,
+    "particle_momentum_z": 4.287340658051679e-13,
+    "particle_position_x": 1.4911814217142487,
+    "particle_position_y": 16.521964978771,
     "particle_weight": 1.2372405194129536e+18
   },
+  "electrons": {
+    "particle_momentum_x": 6.240933687389075e-19,
+    "particle_momentum_y": 1.5790611427694247e-18,
+    "particle_momentum_z": 2.5064357834741096e-16,
+    "particle_position_x": 1.501413766926399,
+    "particle_position_y": 16.523781713952324,
+    "particle_weight": 1.2372401466086835e+18
+  },
   "beam": {
-    "particle_momentum_x": 7.0050974522936195e-19,
-    "particle_momentum_y": 4.374915691594075e-19,
-    "particle_momentum_z": 6.1754662837862646e-18,
-    "particle_position_x": 0.0016025830388130494,
-    "particle_position_y": 0.35897909980539305,
+    "particle_momentum_x": 7.000932845220306e-19,
+    "particle_momentum_y": 4.374936866729326e-19,
+    "particle_momentum_z": 6.194468548032543e-18,
+    "particle_position_x": 0.0016030835496557787,
+    "particle_position_y": 0.3589262705964349,
     "particle_weight": 3120754537230.3823
   }
 }

--- a/Source/Particles/Gather/ScaleFields.H
+++ b/Source/Particles/Gather/ScaleFields.H
@@ -47,7 +47,7 @@ struct ScaleFields
         // This only approximates what should be happening. The particles
         // should by advanced a fraction of a time step instead.
         // Scaling the fields is much easier and may be good enough.
-        const amrex::Real dtscale = 1 - (m_z_plane_previous - zp)/(m_vz_ave_boosted + m_v_boost)/m_dt;
+        const amrex::Real dtscale = 1._rt - (m_z_plane_previous - zp)/(m_vz_ave_boosted + m_v_boost)/m_dt;
         if (0._rt < dtscale && dtscale < 1._rt)
         {
             Exp *= dtscale;

--- a/Source/Particles/Gather/ScaleFields.H
+++ b/Source/Particles/Gather/ScaleFields.H
@@ -47,8 +47,8 @@ struct ScaleFields
         // This only approximates what should be happening. The particles
         // should by advanced a fraction of a time step instead.
         // Scaling the fields is much easier and may be good enough.
-        const amrex::Real dtscale = m_dt - (m_z_plane_previous - zp)/(m_vz_ave_boosted + m_v_boost);
-        if (0._rt < dtscale && dtscale < m_dt)
+        const amrex::Real dtscale = 1 - (m_z_plane_previous - zp)/(m_vz_ave_boosted + m_v_boost)/m_dt;
+        if (0._rt < dtscale && dtscale < 1._rt)
         {
             Exp *= dtscale;
             Eyp *= dtscale;


### PR DESCRIPTION
It seems that, for rigidly injected particles, fields are being scaled by a time (in SI units, i.e. seconds), instead of a ratio of times (i.e. the ratio of the time spent to the right of the injecting plane, divided by the timestep).

This PR fixes this issue.