### PR TITLE
Bugfix: sum guard cell values in current density diagnostic

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
@@ -52,6 +52,12 @@ JFunctor::operator() (amrex::MultiFab& mf_dst, int dcomp, const int /*i_buffer*/
 
         auto& mypc = warpx.GetPartContainer();
         mypc.DepositCurrent(current_fp_temp, warpx.getdt(m_lev), 0.0);
+
+        // sum values in guard cells - note that this does not filter the
+        // current density.
+        for (int idim = 0; idim < 3; ++idim) {
+            current_fp_temp[0][idim]->FillBoundary(warpx.Geom(m_lev).periodicity());
+        }
     }
 
     InterpolateMFForDiag(mf_dst, *m_mf_src, dcomp, warpx.DistributionMap(m_lev),


### PR DESCRIPTION
Fixes #4562.

`WarpX::SumBoundaryJ` which would also apply appropriate filtering to the current density values is private to `WarpX`, so this PR introduces an intermediate quick-fix that simply sums the guard cell values in the newly deposited current density multifab. Note that this bug only affects the current density diagnostic for electrostatic simulations (or simulations with no field solver).