### PR TITLE
Fix undefined behavior in meanParticleVelocity

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1287,7 +1287,7 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
         ParallelDescriptor::ReduceLongSum(np_total);
     }
 
-    std::array<amrex::ParticleReal, 3> mean_v;
+    std::array<amrex::ParticleReal, 3> mean_v = {0,0,0};
     if (np_total > 0) {
         mean_v[0] = vx_total / np_total;
         mean_v[1] = vy_total / np_total;


### PR DESCRIPTION
Since the variable `mean_v` was not initialized, the code resulted in undefined behavior in the case `ntot = 0`.

This PR fixes the issue.