### PR TITLE
Fix undefined behavior issue in WarpX initialization

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -288,26 +288,28 @@ WarpX::WarpX ()
     t_old.resize(nlevs_max, std::numeric_limits<Real>::lowest());
     dt.resize(nlevs_max, std::numeric_limits<Real>::max());
 
-    // Loop over species (particles and lasers)
-    // and set current injection position per species
-    mypc = std::make_unique<MultiParticleContainer>(this);
-    const int n_containers = mypc->nContainers();
-    for (int i=0; i<n_containers; i++)
-    {
-        WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
+    if (do_moving_window){
+        // Loop over species (particles and lasers)
+        // and set current injection position per species
+        mypc = std::make_unique<MultiParticleContainer>(this);
+        const int n_containers = mypc->nContainers();
+        for (int i=0; i<n_containers; i++)
+        {
+            WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
 
-        // Storing injection position for all species, regardless of whether
-        // they are continuously injected, since it makes looping over the
-        // elements of current_injection_position easier elsewhere in the code.
-        if (moving_window_v > 0._rt)
-        {
-            // Inject particles continuously from the right end of the box
-            pc.m_current_injection_position = geom[0].ProbHi(moving_window_dir);
-        }
-        else if (moving_window_v < 0._rt)
-        {
-            // Inject particles continuously from the left end of the box
-            pc.m_current_injection_position = geom[0].ProbLo(moving_window_dir);
+            // Storing injection position for all species, regardless of whether
+            // they are continuously injected, since it makes looping over the
+            // elements of current_injection_position easier elsewhere in the code.
+            if (moving_window_v > 0._rt)
+            {
+                // Inject particles continuously from the right end of the box
+                pc.m_current_injection_position = geom[0].ProbHi(moving_window_dir);
+            }
+            else if (moving_window_v < 0._rt)
+            {
+                // Inject particles continuously from the left end of the box
+                pc.m_current_injection_position = geom[0].ProbLo(moving_window_dir);
+            }
         }
     }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -288,10 +288,11 @@ WarpX::WarpX ()
     t_old.resize(nlevs_max, std::numeric_limits<Real>::lowest());
     dt.resize(nlevs_max, std::numeric_limits<Real>::max());
 
-    if (do_moving_window){
-        // Loop over species (particles and lasers)
-        // and set current injection position per species
-        mypc = std::make_unique<MultiParticleContainer>(this);
+    mypc = std::make_unique<MultiParticleContainer>(this);
+
+    // Loop over species (particles and lasers)
+    // and set current injection position per species
+     if (do_moving_window){
         const int n_containers = mypc->nContainers();
         for (int i=0; i<n_containers; i++)
         {


### PR DESCRIPTION
This PR fixes an "out of bound" access issue found with UBSAN. 
If the moving window is not initialized, `moving_window_dir` is `-1`, which resulted in the call of
`pc.m_current_injection_position = geom[0].ProbHi(-1);` or `pc.m_current_injection_position = geom[0].ProbLo(-1);`. These are "out of bound" memory accesses.