### PR TITLE
Perlmutter (NERSC): January 2024 Update

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
@@ -7,14 +7,14 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # required dependencies
 module load cpu
-module load cmake/3.22.0
-module load cray-fftw/3.3.10.3
+module load cmake/3.24.3
+module load cray-fftw/3.3.10.6
 
 # optional: for QED support with detailed tables
 export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/boost-1.82.0-ow5r5qrgslcwu33grygouajmuluzuzv3
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.7
+module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master:$CMAKE_PREFIX_PATH
@@ -28,10 +28,10 @@ export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master/
 export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
+export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load cray-python/3.11.5
 
 if [ -d "${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/warpx" ]
 then

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -12,13 +12,13 @@ module load craype
 module load craype-x86-milan
 module load craype-accel-nvidia80
 module load cudatoolkit
-module load cmake/3.22.0
+module load cmake/3.24.3
 
 # optional: for QED support with detailed tables
 export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/boost-1.82.0-ow5r5qrgslcwu33grygouajmuluzuzv3
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.7
+module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master:$CMAKE_PREFIX_PATH
@@ -32,10 +32,10 @@ export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-mast
 export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
+export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load cray-python/3.11.5
 
 if [ -d "${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx" ]
 then


### PR DESCRIPTION
Update modules of Perlmutter after the system upgrade.

Since the default compilers changed, please run the install of dependencies scripts again and rebuild your WarpX executables, too. Essentially, the order documented here from the top: https://warpx.readthedocs.io/en/latest/install/hpc/perlmutter.html

GPU update example:
```bash
source $HOME/perlmutter_gpu_warpx.profile  # updates in this PR!!

bash $HOME/src/warpx/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/warpx/bin/activate

cd ~/src/warpx
rm -rf build
...
```

Close #4606

## Details

- System default C/CXX compiler is now GNU 12.3.0
- System default CUDA compiler is now NVCC 12.2.91 (from NVHPC 23.9)
- Both appear to be [compatible](https://gist.github.com/ax3l/9489132).

## Check List

- [x] GPU compiles
- [x] GPU runs
- [x] CPU compiles
- [x] CPU runs