### PR TITLE
Update `CuPy` version in Perlmutter dependencies

### DIFF
--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -130,9 +130,9 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update WarpX dependencies such as picmistandard
 python3 -m pip install --upgrade -r $HOME/src/warpx/requirements.txt
-python3 -m pip install cupy-cuda11x  # CUDA 11.7 compatible wheel
+python3 -m pip install cupy-cuda12x  # CUDA 12 compatible wheel
 # optional: for libEnsemble
 python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
-python3 -m pip install --upgrade torch  # CUDA 11.7 compatible wheel
+python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel
 python3 -m pip install -r $HOME/src/warpx/Tools/optimas/requirements.txt


### PR DESCRIPTION
Follow-up to #4620, updating the `CuPy` version.

With old cupy version I got:
```
RuntimeError: CuPy failed to load libnvrtc.so.11.2: OSError: libnvrtc.so.11.2: cannot open shared object file: No such file or directory

At:
  cupy_backends/cuda/_softlink.pyx(32): cupy_backends.cuda._softlink.SoftLink.__init__
```