### PR TITLE
Update `picmi.ElectrostaticSolver` child class in external Poisson solver test

### DIFF
--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -38,7 +38,7 @@ class PoissonSolver1D(picmi.ElectrostaticSolver):
             required_precision=1, **kwargs
         )
 
-    def initialize_inputs(self):
+    def solver_initialize_inputs(self):
         """Grab geometrical quantities from the grid. The boundary potentials
         are also obtained from the grid using 'warpx_potential_zmin' for the
         left_voltage and 'warpx_potential_zmax' for the right_voltage.

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -57,7 +57,7 @@ class PoissonSolver1D(picmi.ElectrostaticSolver):
         self.grid.potential_zmin = None
         self.grid.potential_zmax = None
 
-        super(PoissonSolver1D, self).initialize_inputs()
+        super(PoissonSolver1D, self).solver_initialize_inputs()
 
         self.nz = self.grid.number_of_cells[0]
         self.dz = (self.grid.upper_bound[0] - self.grid.lower_bound[0]) / self.nz
@@ -420,6 +420,10 @@ class CapacitiveDischargeExample(object):
         callbacks.installafterstep(self._get_rho_ions)
 
         self.sim.step(self.diag_steps)
+
+        if self.pythonsolver:
+            # confirm that the external solver was run
+            assert hasattr(self.solver, 'phi')
 
         if libwarpx.amr.ParallelDescriptor.MyProc() == 0:
             np.save(f'ion_density_case_{self.n+1}.npy', self.ion_density_array)

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -75,7 +75,7 @@ class PoissonSolverPseudo1D(picmi.ElectrostaticSolver):
         self.phi_wrapper = None
         self.time_sum = 0.0
 
-    def initialize_inputs(self):
+    def solver_initialize_inputs(self):
         """Grab geometrical quantities from the grid.
         """
         self.right_voltage = self.grid.potential_xmax
@@ -89,7 +89,7 @@ class PoissonSolverPseudo1D(picmi.ElectrostaticSolver):
         self.grid.potential_zmin = None
         self.grid.potential_zmax = None
 
-        super(PoissonSolverPseudo1D, self).initialize_inputs()
+        super(PoissonSolverPseudo1D, self).solver_initialize_inputs()
 
         self.nx = self.grid.number_of_cells[0]
         self.nz = self.grid.number_of_cells[1]
@@ -359,3 +359,6 @@ sim.add_diagnostic(field_diag)
 ##########################
 
 sim.step(max_steps)
+
+# confirm that the external solver was run
+assert hasattr(solver, 'phi')


### PR DESCRIPTION
This is a follow-up to #4554. The external solver tests create child classes of `picmi.ElectrostaticSolver`. The overwrite functions for `initialize_inputs` should be updated to be `solver_initialize_inputs`. This did not break those tests since without the overwrite the standard ES solver was simply used.