### PR TITLE
Temporarily deactivate `Python_background_mcc_1d`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3021,25 +3021,6 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
 
-[Python_background_mcc_1d_tridiag]
-buildDir = .
-inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
-runtime_params =
-customRunCmd = python3 PICMI_inputs_1d.py --test
-dim = 1
-addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-target = pip_install
-restartTest = 0
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
-
 [Python_collisionXZ]
 buildDir = .
 inputFile = Examples/Tests/collision/PICMI_inputs_2d.py


### PR DESCRIPTION
This test mysteriously started failing about 1 week ago.

While we debug this, we should probably deactivate it, so as to avoid confusion in the CI tests of other PRs.