### PR TITLE
added a workaround for issue 4604

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -709,6 +709,7 @@ WarpXOpenPMDPlot::DumpToFile (ParticleContainer* pc,
     }
 
     if (is_last_flush_to_step) {
+        SetupPos(currSpecies, NewParticleVectorSize, isBTD); // workaround for issue 4604
         SetConstParticleRecordsEDPIC(currSpecies, NewParticleVectorSize, charge, mass);
     }
 


### PR DESCRIPTION
Guard against BTD case:
 - 0  particles are written at the last flush step  (due to fraction = 0)
 - offset > 0 (particles do exist although not selected)

See issue #4604 