### PR TITLE
Fix neutral particle got pushed

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2859,7 +2859,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
             doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                       Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                      ion_lev ? ion_lev[ip] : 0, ion_lev,
+                                      ion_lev ? ion_lev[ip] : 1,
                                       m, q, pusher_algo, do_crr,
 #ifdef WARPX_QED
                                       t_chi_max,
@@ -2879,7 +2879,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
                 doParticleMomentumPush<1>(ux[ip], uy[ip], uz[ip],
                                           Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                          ion_lev ? ion_lev[ip] : 0, ion_lev,
+                                          ion_lev ? ion_lev[ip] : 1,
                                           m, q, pusher_algo, do_crr,
                                           t_chi_max,
                                           dt);
@@ -3119,7 +3119,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter& pti,
         {
             doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                       Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                      ion_lev ? ion_lev[ip] : 0, ion_lev,
+                                      ion_lev ? ion_lev[ip] : 1,
                                       m, q, pusher_algo, do_crr,
 #ifdef WARPX_QED
                                       t_chi_max,
@@ -3131,7 +3131,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter& pti,
             if constexpr (qed_control == has_qed) {
                 doParticleMomentumPush<1>(ux[ip], uy[ip], uz[ip],
                                           Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                          ion_lev ? ion_lev[ip] : 0, ion_lev,
+                                          ion_lev ? ion_lev[ip] : 1,
                                           m, q, pusher_algo, do_crr,
                                           t_chi_max,
                                           dt);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2859,7 +2859,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
             doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                       Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                      ion_lev ? ion_lev[ip] : 0,
+                                      ion_lev ? ion_lev[ip] : 0, ion_lev,
                                       m, q, pusher_algo, do_crr,
 #ifdef WARPX_QED
                                       t_chi_max,
@@ -2879,7 +2879,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
                 doParticleMomentumPush<1>(ux[ip], uy[ip], uz[ip],
                                           Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                          ion_lev ? ion_lev[ip] : 0,
+                                          ion_lev ? ion_lev[ip] : 0, ion_lev,
                                           m, q, pusher_algo, do_crr,
                                           t_chi_max,
                                           dt);
@@ -3119,7 +3119,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter& pti,
         {
             doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                       Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                      ion_lev ? ion_lev[ip] : 0,
+                                      ion_lev ? ion_lev[ip] : 0, ion_lev,
                                       m, q, pusher_algo, do_crr,
 #ifdef WARPX_QED
                                       t_chi_max,
@@ -3131,7 +3131,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter& pti,
             if constexpr (qed_control == has_qed) {
                 doParticleMomentumPush<1>(ux[ip], uy[ip], uz[ip],
                                           Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                                          ion_lev ? ion_lev[ip] : 0,
+                                          ion_lev ? ion_lev[ip] : 0, ion_lev,
                                           m, q, pusher_algo, do_crr,
                                           t_chi_max,
                                           dt);

--- a/Source/Particles/Pusher/PushSelector.H
+++ b/Source/Particles/Pusher/PushSelector.H
@@ -47,7 +47,6 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
                             const amrex::ParticleReal By,
                             const amrex::ParticleReal Bz,
                             const int ion_lev,
-                            const int *arr_ion_lev,
                             const amrex::ParticleReal m,
                             const amrex::ParticleReal a_q,
                             const int pusher_algo,
@@ -58,7 +57,7 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
                             const amrex::Real dt)
 {
     amrex::ParticleReal qp = a_q;
-    if (arr_ion_lev) { qp *= ion_lev; }
+    qp *= ion_lev;
 
     if (do_crr) {
 #ifdef WARPX_QED

--- a/Source/Particles/Pusher/PushSelector.H
+++ b/Source/Particles/Pusher/PushSelector.H
@@ -47,6 +47,7 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
                             const amrex::ParticleReal By,
                             const amrex::ParticleReal Bz,
                             const int ion_lev,
+                            const int *arr_ion_lev,
                             const amrex::ParticleReal m,
                             const amrex::ParticleReal a_q,
                             const int pusher_algo,
@@ -57,7 +58,7 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
                             const amrex::Real dt)
 {
     amrex::ParticleReal qp = a_q;
-    if (ion_lev) { qp *= ion_lev; }
+    if (arr_ion_lev) { qp *= ion_lev; }
 
     if (do_crr) {
 #ifdef WARPX_QED


### PR DESCRIPTION
As discussed in [#4592](https://github.com/ECP-WarpX/WarpX/issues/4592), the pointer of ionization level arrays is passed to the function which updates momentum. It used the pointer to determine whether to adjust particle's charge or not.

I tested the modified code and this branch can be successfully compiled and worked fine.