### PR TITLE
Reactivate CI test (`Python_background_mcc_1d_tridiag`)

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3021,24 +3021,24 @@ doVis = 0
 compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
 
-# [Python_background_mcc_1d_tridiag]
-# buildDir = .
-# inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
-# runtime_params =
-# customRunCmd = python3 PICMI_inputs_1d.py --test
-# dim = 1
-# addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
-# cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
-# target = pip_install
-# restartTest = 0
-# useMPI = 1
-# numprocs = 2
-# useOMP = 1
-# numthreads = 1
-# compileTest = 0
-# doVis = 0
-# compareParticles = 0
-# analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
+[Python_background_mcc_1d_tridiag]
+buildDir = .
+inputFile = Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+runtime_params =
+customRunCmd = python3 PICMI_inputs_1d.py --test
+dim = 1
+addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE
+cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_APP=OFF -DWarpX_PYTHON=ON -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
+target = pip_install
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
 
 [Python_collisionXZ]
 buildDir = .


### PR DESCRIPTION
Checking if the previously disabled CI test can now be activated again after merging #4646.

Fixes #4629.