### PR TITLE
ParticleHistogram2D change openPMD access type

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3104,6 +3104,9 @@ Reduced Diagnostics
             A species name must be provided,
             such that the diagnostics are done for this species.
 
+        * ``<reduced_diags_name>.file_min_digits`` (`int`) optional (default `6`)
+            The minimum number of digits used for the iteration number appended to the diagnostic file names.
+
         * ``<reduced_diags_name>.histogram_function_abs(t,x,y,z,ux,uy,uz,w)`` (`string`)
             A histogram function must be provided for the abscissa axis.
             `t` represents the physical time in seconds during the simulation.

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.H
@@ -35,6 +35,9 @@ public:
     /// File type
     std::string m_openpmd_backend {"default"};
 
+    /// minimum number of digits for file suffix (file-based only supported now for now) */
+    int m_file_min_digits = 6;
+
     /// number of bins on the abscissa and ordinate
     int m_bin_num_abs;
     int m_bin_num_ord;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -60,6 +60,7 @@ ParticleHistogram2D::ParticleHistogram2D (std::string rd_name)
     ParmParse pp_rd_name(rd_name);
 
     pp_rd_name.query("openpmd_backend", m_openpmd_backend);
+    pp_rd_name.query("file_min_digits", m_file_min_digits);
     // pick first available backend if default is chosen
     if( m_openpmd_backend == "default" ) {
         m_openpmd_backend = WarpXOpenPMDFileType();
@@ -260,10 +261,22 @@ void ParticleHistogram2D::WriteToFile (int step) const
     // only IO processor writes
     if ( !ParallelDescriptor::IOProcessor() ) { return; }
 
+    // TODO: support different filename templates
+    std::string filename = "openpmd";
+    // TODO: support also group-based encoding
+    const std::string fileSuffix = std::string("_%0") + std::to_string(m_file_min_digits) + std::string("T");
+    filename = filename.append(fileSuffix).append(".").append(m_openpmd_backend);
+
+    std::string filepath = m_path + m_rd_name + "/" + filename;
+    // transform paths for Windows
+    #ifdef _WIN32
+        filepath = openPMD::auxiliary::replace_all(filepath, "/", "\\");
+    #endif
+
     // Create the OpenPMD series
     auto series = io::Series(
-            m_path + m_rd_name + "/openpmd_%06T." + m_openpmd_backend,
-            io::Access::APPEND);
+            filepath,
+            io::Access::CREATE);
     auto i = series.iterations[step + 1];
     // record
     auto f_mesh = i.meshes["data"];


### PR DESCRIPTION
Changed openPMD access type for file creation in ParticleHistogram2D from `APPEND` to `CREATE` to avoid warnings on execution.

Additionally:
- make paths compatible with Windows
- allow to set the runtime option `file_min_digits`