### PR TITLE
Minor fix in SLURM signal forwarding description

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -250,7 +250,7 @@ We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal
 
    .. code-block:: bash
 
-      #SBATCH --signal=B:1@360
+      #SBATCH --signal=1@360
 
       srun ...                   \
         warpx.break_signals=HUP  \


### PR DESCRIPTION
With SLURM signal forwarding if you add `B:` the signal is forwarded to only the batch shell not the job processes, so WarpX does not receive the signal.

This PR is in response to the Slack discussion: https://ecpwarpx.slack.com/archives/C043VMPR3LY/p1706308684628409