### PR TITLE
Save the normal components in the particle buffer when there is EB

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2752,7 +2752,7 @@ The data collected at each boundary is written out to a subdirectory of the diag
 By default, all of the collected particle data is written out at the end of the simulation. Optionally, the ``<diag_name>.intervals`` parameter can be given to specify writing out the data more often.
 This can be important if a large number of particles are lost, avoiding filling up memory with the accumulated lost particle data.
 
-In addition to their usual attributes, the saved particles have 
+In addition to their usual attributes, the saved particles have
    an integer attribute ``step_scraped``, which indicates the PIC iteration at which each particle was absorbed at the boundary,
    a real attribute ``time_scraped``, which indicates the exact time calculated when each particle hit the boundary,
    3 real attributes ``nx``, ``ny``, ``nz``, which represents the three components of the normal to the EB on the point of contact of the particles (not saved if they reach grid boundaries)

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2755,7 +2755,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 In addition to their usual attributes, the saved particles have
    an integer attribute ``step_scraped``, which indicates the PIC iteration at which each particle was absorbed at the boundary,
    a real attribute ``time_scraped``, which indicates the exact time calculated when each particle hit the boundary,
-   3 real attributes ``nx``, ``ny``, ``nz``, which represents the three components of the normal to the EB on the point of contact of the particles (not saved if they reach grid boundaries)
+   3 real attributes ``nx``, ``ny``, ``nz``, which represents the three components of the normal to the boundary on the point of contact of the particles (not saved if they reach non-EB boundaries)
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2752,10 +2752,10 @@ The data collected at each boundary is written out to a subdirectory of the diag
 By default, all of the collected particle data is written out at the end of the simulation. Optionally, the ``<diag_name>.intervals`` parameter can be given to specify writing out the data more often.
 This can be important if a large number of particles are lost, avoiding filling up memory with the accumulated lost particle data.
 
-In addition to their usual attributes, the saved particles have an integer attribute ``step_scraped``, which
-indicates the PIC iteration at which each particle was absorbed at the boundary,
-and a real attribute ``time_scraped``, which indicates the exact time calculated when each
-particle hits the EB.
+In addition to their usual attributes, the saved particles have 
+   an integer attribute ``step_scraped``, which indicates the PIC iteration at which each particle was absorbed at the boundary,
+   a real attribute ``time_scraped``, which indicates the exact time calculated when each particle hit the boundary,
+   3 real attributes ``nx``, ``ny``, ``nz``, which represents the three components of the normal to the EB on the point of contact of the particles (not saved if they reach grid boundaries)
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.
 

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -49,7 +49,7 @@ print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.
 
 tolerance=0.001
 tolerance_t=0.003
-tolerance_t=0.01
+tolerance_n=0.01
 print("tolerance = "+ str(tolerance *100) + '%')
 print("tolerance for the time = "+ str(tolerance_t *100) + '%')
 print("tolerance for the normal components = "+ str(tolerance_n *100) + '%')

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -26,35 +26,45 @@ checksumAPI.evaluate_checksum(test_name, filename, output_format='openpmd')
 ts_scraping = OpenPMDTimeSeries('./diags/diag2/particles_at_eb/')
 
 it=ts_scraping.iterations
-step_scraped, time_scraped, x, y, z=ts_scraping.get_particle( ['stepScraped','timeScraped','x','y','z'], species='electron', iteration=it )
+step_scraped, time_scraped, x, y, z, nx, ny, nz=ts_scraping.get_particle( ['stepScraped','timeScraped','x','y','z', 'nx', 'ny', 'nz'], species='electron', iteration=it )
 time_scraped_reduced=time_scraped[0]*1e10
 
 # Analytical results calculated
 x_analytic=-0.1983
 y_analytic=0.02584
 z_analytic=0.0000
+nx_analytic=-0.99
+ny_analytic=0.13
+nz_analytic=0.0
 
 #result obtained by analysis of simulations
 step=3
 time_reduced=3.58
 
 print('NUMERICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],time_reduced,x[0], y[0], z[0]))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step_scraped[0],time_reduced,x[0], y[0], z[0], nx[0], ny[0], nz[0]))
 print('\n')
 print('ANALYTICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step, time_reduced, x_analytic, y_analytic, z_analytic))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step, time_reduced, x_analytic, y_analytic, z_analytic, nx_analytic, ny_analytic, nz_analytic))
 
 tolerance=0.001
 tolerance_t=0.003
+tolerance_t=0.01
 print("tolerance = "+ str(tolerance *100) + '%')
 print("tolerance for the time = "+ str(tolerance_t *100) + '%')
+print("tolerance for the normal components = "+ str(tolerance_n *100) + '%')
 
 diff_step=np.abs((step_scraped[0]-step)/step)
 diff_time=np.abs((time_scraped_reduced-time_reduced)/time_reduced)
 diff_x=np.abs((x[0]-x_analytic)/x_analytic)
 diff_y=np.abs((y[0]-y_analytic)/y_analytic)
+diff_nx=np.abs((nx[0]-nx_analytic)/nx_analytic)
+diff_ny=np.abs((ny[0]-ny_analytic)/ny_analytic)
 
 print("percentage error for x = %5.4f %%" %(diff_x *100))
 print("percentage error for y = %5.4f %%" %(diff_y *100))
+print("percentage error for nx = %5.2f %%" %(diff_nx *100))
+print("percentage error for ny = %5.2f %%" %(diff_ny *100))
+print("nz = %5.2f " %(nz[0]))
 
-assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_time < tolerance_t) , 'Test point_of_contact did not pass'
+assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_time < tolerance_t) and (diff_nx < tolerance_n) and (diff_ny < tolerance_n) and (np.abs(nz) < 1e-8) , 'Test point_of_contact did not pass'

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -774,7 +774,8 @@ class ParticleBoundaryBufferWrapper(object):
             comp_name      : str
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
-                "step_scraped","time_scraped", "nx", "ny", "nz"
+                "step_scraped","time_scraped", 
+                if boundary='eb': "nx", "ny", "nz"
 
             level          : int
                 Which AMR level to retrieve scraped particle data from.

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -774,7 +774,7 @@ class ParticleBoundaryBufferWrapper(object):
             comp_name      : str
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
-                "step_scraped","time_scraped", 
+                "step_scraped","time_scraped",
                 if boundary='eb': "nx", "ny", "nz"
 
             level          : int

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -36,7 +36,7 @@ void normalize (amrex::RealVect& a) noexcept
 
 
 
-// This function calculates the normal vector using the nodes and cell-centered nodes
+// This function calculates the normal vector using the nodal and cell-centered data.
 // i,j,k are the index of the nearest node to the left of the point at which we interpolate.
 // W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
 // ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -34,7 +34,7 @@ void normalize (amrex::RealVect& a) noexcept
                  a[2] *= inv_norm);
 }
 
- 
+
 
 // This function calculates the normal vector using the nodes and cell-centered nodes
 // i,j,k are the index of the nearest node to the left of the point at which we interpolate.

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -102,10 +102,6 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 int wccomp = static_cast<int>(iic%2);
                 int w1comp = static_cast<int>(jj%2);
                 normal[0] += sign * phi(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp];
-                std::cout << phi(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp] << std::endl;
-                std::cout << "i=" << i << ", j=" << j << ", k=" << k << std::endl;
-                std::cout << "normal[0]" << sign << "=phi(ic+" << iic + ii << ", j+" << jj << ", k) * dxi[0] * Wc[0][" << wccomp << "] * W[1][" <<  w1comp << "]; \n" << std::endl;
-
             }
         }
     }
@@ -117,9 +113,6 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 int wccomp = static_cast<int>(iic%2);
                 int w1comp = static_cast<int>(ii%2);
                 normal[1] += sign * phi(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp];
-                std::cout << phi(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp] << std::endl;
-                std::cout << "i=" << i << ", j=" << j << ", k=" << k << std::endl;
-                std::cout << "normal[1]" << sign << "=phi(i+" << ii << ",jc+" << iic + jj << ", k) * dxi[1] * W[0][" << w1comp << "] * Wc[1][" <<  wccomp << "]; \n" << std::endl;
             }
         }
     }

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -34,18 +34,19 @@ void normalize (amrex::RealVect& a) noexcept
                  a[2] *= inv_norm);
 }
 
-'''
-    i,j,k are the index of the nearest node to the left of the point at which we interpolate.
-    W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
-    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
-    Wc are the corresponding interpolation weights.
-'''
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SPACEDIM][2],
                                int ic, int jc, int kc, const amrex::Real Wc[AMREX_SPACEDIM][2],
                                amrex::Array4<const amrex::Real> const& phi,
                                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
 {
+'''
+    This function calculate the normal vector using the nodes and cell-centered nodes
+    i,j,k are the index of the nearest node to the left of the point at which we interpolate.
+    W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
+    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
+    Wc are the corresponding interpolation weights.
+'''
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
 

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -36,53 +36,90 @@ void normalize (amrex::RealVect& a) noexcept
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SPACEDIM][2],
+                               int ic, int jc, int kc, const amrex::Real Wc[AMREX_SPACEDIM][2],
                                amrex::Array4<const amrex::Real> const& phi,
                                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
 {
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
 
-    normal[0] -= phi(i,   j  , k  ) * dxi[0] * W[1][0] * W[2][0];
-    normal[0] += phi(i+1, j  , k  ) * dxi[0] * W[1][0] * W[2][0];
-    normal[0] -= phi(i,   j+1, k  ) * dxi[0] * W[1][1] * W[2][0];
-    normal[0] += phi(i+1, j+1, k  ) * dxi[0] * W[1][1] * W[2][0];
-    normal[0] -= phi(i,   j  , k+1) * dxi[0] * W[1][0] * W[2][1];
-    normal[0] += phi(i+1, j  , k+1) * dxi[0] * W[1][0] * W[2][1];
-    normal[0] -= phi(i  , j+1, k+1) * dxi[0] * W[1][1] * W[2][1];
-    normal[0] += phi(i+1, j+1, k+1) * dxi[0] * W[1][1] * W[2][1];
+    normal[0] -= phi(ic,   j  , k  ) * dxi[0] * Wc[0][0] * W[1][0] * W[2][0];
+    normal[0] += phi(ic+1, j  , k  ) * dxi[0] * Wc[0][0] * W[1][0] * W[2][0];
+    normal[0] -= phi(ic,   j+1, k  ) * dxi[0] * Wc[0][0] * W[1][1] * W[2][0];
+    normal[0] += phi(ic+1, j+1, k  ) * dxi[0] * Wc[0][0] * W[1][1] * W[2][0];
+    normal[0] -= phi(ic,   j  , k+1) * dxi[0] * Wc[0][0] * W[1][0] * W[2][1];
+    normal[0] += phi(ic+1, j  , k+1) * dxi[0] * Wc[0][0] * W[1][0] * W[2][1];
+    normal[0] -= phi(ic,   j+1, k+1) * dxi[0] * Wc[0][0] * W[1][1] * W[2][1];
+    normal[0] += phi(ic+1, j+1, k+1) * dxi[0] * Wc[0][0] * W[1][1] * W[2][1];
+    normal[0] -= phi(ic+1, j  , k  ) * dxi[0] * Wc[0][1] * W[1][0] * W[2][0];
+    normal[0] += phi(ic+2, j  , k  ) * dxi[0] * Wc[0][1] * W[1][0] * W[2][0];
+    normal[0] -= phi(ic+1, j+1, k  ) * dxi[0] * Wc[0][1] * W[1][1] * W[2][0];
+    normal[0] += phi(ic+2, j+1, k  ) * dxi[0] * Wc[0][1] * W[1][1] * W[2][0];
+    normal[0] -= phi(ic+1, j  , k+1) * dxi[0] * Wc[0][1] * W[1][0] * W[2][1];
+    normal[0] += phi(ic+2, j  , k+1) * dxi[0] * Wc[0][1] * W[1][0] * W[2][1];
+    normal[0] -= phi(ic+1, j+1, k+1) * dxi[0] * Wc[0][1] * W[1][1] * W[2][1];
+    normal[0] += phi(ic+2, j+1, k+1) * dxi[0] * Wc[0][1] * W[1][1] * W[2][1];
 
-    normal[1] -= phi(i,   j  , k  ) * dxi[1] * W[0][0] * W[2][0];
-    normal[1] += phi(i  , j+1, k  ) * dxi[1] * W[0][0] * W[2][0];
-    normal[1] -= phi(i+1, j  , k  ) * dxi[1] * W[0][1] * W[2][0];
-    normal[1] += phi(i+1, j+1, k  ) * dxi[1] * W[0][1] * W[2][0];
-    normal[1] -= phi(i,   j  , k+1) * dxi[1] * W[0][0] * W[2][1];
-    normal[1] += phi(i  , j+1, k+1) * dxi[1] * W[0][0] * W[2][1];
-    normal[1] -= phi(i+1, j  , k+1) * dxi[1] * W[0][1] * W[2][1];
-    normal[1] += phi(i+1, j+1, k+1) * dxi[1] * W[0][1] * W[2][1];
+    normal[1] -= phi(i,   jc  , k  ) * dxi[1] * W[0][0] * Wc[1][0] * W[2][0];
+    normal[1] += phi(i  , jc+1, k  ) * dxi[1] * W[0][0] * Wc[1][0] * W[2][0];
+    normal[1] -= phi(i+1, jc  , k  ) * dxi[1] * W[0][1] * Wc[1][0] * W[2][0];
+    normal[1] += phi(i+1, jc+1, k  ) * dxi[1] * W[0][1] * Wc[1][0] * W[2][0];
+    normal[1] -= phi(i,   jc  , k+1) * dxi[1] * W[0][0] * Wc[1][0] * W[2][1];
+    normal[1] += phi(i  , jc+1, k+1) * dxi[1] * W[0][0] * Wc[1][0] * W[2][1];
+    normal[1] -= phi(i+1, jc  , k+1) * dxi[1] * W[0][1] * Wc[1][0] * W[2][1];
+    normal[1] += phi(i+1, jc+1, k+1) * dxi[1] * W[0][1] * Wc[1][0] * W[2][1];
+    normal[1] -= phi(i,   jc+1, k  ) * dxi[1] * W[0][0] * Wc[1][1] * W[2][0];
+    normal[1] += phi(i  , jc+2, k  ) * dxi[1] * W[0][0] * Wc[1][1] * W[2][0];
+    normal[1] -= phi(i+1, jc+1, k  ) * dxi[1] * W[0][1] * Wc[1][1] * W[2][0];
+    normal[1] += phi(i+1, jc+2, k  ) * dxi[1] * W[0][1] * Wc[1][1] * W[2][0];
+    normal[1] -= phi(i,   jc+1, k+1) * dxi[1] * W[0][0] * Wc[1][1] * W[2][1];
+    normal[1] += phi(i  , jc+2, k+1) * dxi[1] * W[0][0] * Wc[1][1] * W[2][1];
+    normal[1] -= phi(i+1, jc+1, k+1) * dxi[1] * W[0][1] * Wc[1][1] * W[2][1];
+    normal[1] += phi(i+1, jc+2, k+1) * dxi[1] * W[0][1] * Wc[1][1] * W[2][1];
 
-    normal[2] -= phi(i  , j  , k  ) * dxi[2] * W[0][0] * W[1][0];
-    normal[2] += phi(i  , j  , k+1) * dxi[2] * W[0][0] * W[1][0];
-    normal[2] -= phi(i+1, j  , k  ) * dxi[2] * W[0][1] * W[1][0];
-    normal[2] += phi(i+1, j  , k+1) * dxi[2] * W[0][1] * W[1][0];
-    normal[2] -= phi(i,   j+1, k  ) * dxi[2] * W[0][0] * W[1][1];
-    normal[2] += phi(i  , j+1, k+1) * dxi[2] * W[0][0] * W[1][1];
-    normal[2] -= phi(i+1, j+1, k  ) * dxi[2] * W[0][1] * W[1][1];
-    normal[2] += phi(i+1, j+1, k+1) * dxi[2] * W[0][1] * W[1][1];
+    normal[2] -= phi(i  , j  , kc  ) * dxi[2] * W[0][0] * W[1][0] * Wc[2][0];
+    normal[2] += phi(i  , j  , kc+1) * dxi[2] * W[0][0] * W[1][0] * Wc[2][0];
+    normal[2] -= phi(i+1, j  , kc  ) * dxi[2] * W[0][1] * W[1][0] * Wc[2][0];
+    normal[2] += phi(i+1, j  , kc+1) * dxi[2] * W[0][1] * W[1][0] * Wc[2][0];
+    normal[2] -= phi(i,   j+1, kc  ) * dxi[2] * W[0][0] * W[1][1] * Wc[2][0];
+    normal[2] += phi(i  , j+1, kc+1) * dxi[2] * W[0][0] * W[1][1] * Wc[2][0];
+    normal[2] -= phi(i+1, j+1, kc  ) * dxi[2] * W[0][1] * W[1][1] * Wc[2][0];
+    normal[2] += phi(i+1, j+1, kc+1) * dxi[2] * W[0][1] * W[1][1] * Wc[2][0];
+    normal[2] -= phi(i  , j  , kc+1) * dxi[2] * W[0][0] * W[1][0] * Wc[2][1];
+    normal[2] += phi(i  , j  , kc+2) * dxi[2] * W[0][0] * W[1][0] * Wc[2][1];
+    normal[2] -= phi(i+1, j  , kc+1) * dxi[2] * W[0][1] * W[1][0] * Wc[2][1];
+    normal[2] += phi(i+1, j  , kc+2) * dxi[2] * W[0][1] * W[1][0] * Wc[2][1];
+    normal[2] -= phi(i,   j+1, kc+1) * dxi[2] * W[0][0] * W[1][1] * Wc[2][1];
+    normal[2] += phi(i  , j+1, kc+2) * dxi[2] * W[0][0] * W[1][1] * Wc[2][1];
+    normal[2] -= phi(i+1, j+1, kc+1) * dxi[2] * W[0][1] * W[1][1] * Wc[2][1];
+    normal[2] += phi(i+1, j+1, kc+2) * dxi[2] * W[0][1] * W[1][1] * Wc[2][1];
+
+
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     amrex::RealVect normal{0.0, 0.0};
 
-    normal[0] -= phi(i,   j  , k) * dxi[0] * W[1][0];
-    normal[0] += phi(i+1, j  , k) * dxi[0] * W[1][0];
-    normal[0] -= phi(i,   j+1, k) * dxi[0] * W[1][1];
-    normal[0] += phi(i+1, j+1, k) * dxi[0] * W[1][1];
+    normal[0] -= phi(ic,   j  , k) * dxi[0] * Wc[0][0] * W[1][0];
+    normal[0] += phi(ic+1, j  , k) * dxi[0] * Wc[0][0] * W[1][0];
+    normal[0] -= phi(ic,   j+1, k) * dxi[0] * Wc[0][0] * W[1][1];
+    normal[0] += phi(ic+1, j+1, k) * dxi[0] * Wc[0][0] * W[1][1];
+    normal[0] -= phi(ic+1, j  , k) * dxi[0] * Wc[0][1] * W[1][0];
+    normal[0] += phi(ic+2, j  , k) * dxi[0] * Wc[0][1] * W[1][0];
+    normal[0] -= phi(ic+1, j+1, k) * dxi[0] * Wc[0][1] * W[1][1];
+    normal[0] += phi(ic+2, j+1, k) * dxi[0] * Wc[0][1] * W[1][1];
 
-    normal[1] -= phi(i,   j  , k) * dxi[1] * W[0][0];
-    normal[1] += phi(i  , j+1, k) * dxi[1] * W[0][0];
-    normal[1] -= phi(i+1, j  , k) * dxi[1] * W[0][1];
-    normal[1] += phi(i+1, j+1, k) * dxi[1] * W[0][1];
+    normal[1] -= phi(i,   jc  , k) * dxi[1] * W[0][0] * Wc[1][0];
+    normal[1] += phi(i  , jc+1, k) * dxi[1] * W[0][0] * Wc[1][0];
+    normal[1] -= phi(i+1, jc  , k) * dxi[1] * W[0][1] * Wc[1][0];
+    normal[1] += phi(i+1, jc+1, k) * dxi[1] * W[0][1] * Wc[1][0];
+    normal[1] -= phi(i,   jc+1, k) * dxi[1] * W[0][0] * Wc[1][1];
+    normal[1] += phi(i  , jc+2, k) * dxi[1] * W[0][0] * Wc[1][1];
+    normal[1] -= phi(i+1, jc+1, k) * dxi[1] * W[0][1] * Wc[1][1];
+    normal[1] += phi(i+1, jc+2, k) * dxi[1] * W[0][1] * Wc[1][1];
+
+    amrex::ignore_unused(kc);
 #else
     amrex::RealVect normal{0.0, 0.0};
-    amrex::ignore_unused(i, j, k, W, phi, dxi);
+    amrex::ignore_unused(i, j, k, ic, jc, kc, W, Wc, phi, dxi);
     WARPX_ABORT_WITH_MESSAGE("Error: interp_distance not yet implemented in 1D");
 #endif
     return normal;

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -34,6 +34,12 @@ void normalize (amrex::RealVect& a) noexcept
                  a[2] *= inv_norm);
 }
 
+'''
+    i,j,k are the index of the nearest node to the left of the point at which we interpolate. 
+    W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
+    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate. 
+    Wc are the corresponding interpolation weights.
+'''
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SPACEDIM][2],
                                int ic, int jc, int kc, const amrex::Real Wc[AMREX_SPACEDIM][2],

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -35,9 +35,9 @@ void normalize (amrex::RealVect& a) noexcept
 }
 
 '''
-    i,j,k are the index of the nearest node to the left of the point at which we interpolate. 
+    i,j,k are the index of the nearest node to the left of the point at which we interpolate.
     W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
-    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate. 
+    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
     Wc are the corresponding interpolation weights.
 '''
 AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -41,93 +41,96 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
 {
 '''
-    This function calculate the normal vector using the nodes and cell-centered nodes
+    This function calculates the normal vector using the nodes and cell-centered nodes
     i,j,k are the index of the nearest node to the left of the point at which we interpolate.
     W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
     ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
     Wc are the corresponding interpolation weights.
-'''
+'''  
+
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
-
-    normal[0] -= phi(ic,   j  , k  ) * dxi[0] * Wc[0][0] * W[1][0] * W[2][0];
-    normal[0] += phi(ic+1, j  , k  ) * dxi[0] * Wc[0][0] * W[1][0] * W[2][0];
-    normal[0] -= phi(ic,   j+1, k  ) * dxi[0] * Wc[0][0] * W[1][1] * W[2][0];
-    normal[0] += phi(ic+1, j+1, k  ) * dxi[0] * Wc[0][0] * W[1][1] * W[2][0];
-    normal[0] -= phi(ic,   j  , k+1) * dxi[0] * Wc[0][0] * W[1][0] * W[2][1];
-    normal[0] += phi(ic+1, j  , k+1) * dxi[0] * Wc[0][0] * W[1][0] * W[2][1];
-    normal[0] -= phi(ic,   j+1, k+1) * dxi[0] * Wc[0][0] * W[1][1] * W[2][1];
-    normal[0] += phi(ic+1, j+1, k+1) * dxi[0] * Wc[0][0] * W[1][1] * W[2][1];
-    normal[0] -= phi(ic+1, j  , k  ) * dxi[0] * Wc[0][1] * W[1][0] * W[2][0];
-    normal[0] += phi(ic+2, j  , k  ) * dxi[0] * Wc[0][1] * W[1][0] * W[2][0];
-    normal[0] -= phi(ic+1, j+1, k  ) * dxi[0] * Wc[0][1] * W[1][1] * W[2][0];
-    normal[0] += phi(ic+2, j+1, k  ) * dxi[0] * Wc[0][1] * W[1][1] * W[2][0];
-    normal[0] -= phi(ic+1, j  , k+1) * dxi[0] * Wc[0][1] * W[1][0] * W[2][1];
-    normal[0] += phi(ic+2, j  , k+1) * dxi[0] * Wc[0][1] * W[1][0] * W[2][1];
-    normal[0] -= phi(ic+1, j+1, k+1) * dxi[0] * Wc[0][1] * W[1][1] * W[2][1];
-    normal[0] += phi(ic+2, j+1, k+1) * dxi[0] * Wc[0][1] * W[1][1] * W[2][1];
-
-    normal[1] -= phi(i,   jc  , k  ) * dxi[1] * W[0][0] * Wc[1][0] * W[2][0];
-    normal[1] += phi(i  , jc+1, k  ) * dxi[1] * W[0][0] * Wc[1][0] * W[2][0];
-    normal[1] -= phi(i+1, jc  , k  ) * dxi[1] * W[0][1] * Wc[1][0] * W[2][0];
-    normal[1] += phi(i+1, jc+1, k  ) * dxi[1] * W[0][1] * Wc[1][0] * W[2][0];
-    normal[1] -= phi(i,   jc  , k+1) * dxi[1] * W[0][0] * Wc[1][0] * W[2][1];
-    normal[1] += phi(i  , jc+1, k+1) * dxi[1] * W[0][0] * Wc[1][0] * W[2][1];
-    normal[1] -= phi(i+1, jc  , k+1) * dxi[1] * W[0][1] * Wc[1][0] * W[2][1];
-    normal[1] += phi(i+1, jc+1, k+1) * dxi[1] * W[0][1] * Wc[1][0] * W[2][1];
-    normal[1] -= phi(i,   jc+1, k  ) * dxi[1] * W[0][0] * Wc[1][1] * W[2][0];
-    normal[1] += phi(i  , jc+2, k  ) * dxi[1] * W[0][0] * Wc[1][1] * W[2][0];
-    normal[1] -= phi(i+1, jc+1, k  ) * dxi[1] * W[0][1] * Wc[1][1] * W[2][0];
-    normal[1] += phi(i+1, jc+2, k  ) * dxi[1] * W[0][1] * Wc[1][1] * W[2][0];
-    normal[1] -= phi(i,   jc+1, k+1) * dxi[1] * W[0][0] * Wc[1][1] * W[2][1];
-    normal[1] += phi(i  , jc+2, k+1) * dxi[1] * W[0][0] * Wc[1][1] * W[2][1];
-    normal[1] -= phi(i+1, jc+1, k+1) * dxi[1] * W[0][1] * Wc[1][1] * W[2][1];
-    normal[1] += phi(i+1, jc+2, k+1) * dxi[1] * W[0][1] * Wc[1][1] * W[2][1];
-
-    normal[2] -= phi(i  , j  , kc  ) * dxi[2] * W[0][0] * W[1][0] * Wc[2][0];
-    normal[2] += phi(i  , j  , kc+1) * dxi[2] * W[0][0] * W[1][0] * Wc[2][0];
-    normal[2] -= phi(i+1, j  , kc  ) * dxi[2] * W[0][1] * W[1][0] * Wc[2][0];
-    normal[2] += phi(i+1, j  , kc+1) * dxi[2] * W[0][1] * W[1][0] * Wc[2][0];
-    normal[2] -= phi(i,   j+1, kc  ) * dxi[2] * W[0][0] * W[1][1] * Wc[2][0];
-    normal[2] += phi(i  , j+1, kc+1) * dxi[2] * W[0][0] * W[1][1] * Wc[2][0];
-    normal[2] -= phi(i+1, j+1, kc  ) * dxi[2] * W[0][1] * W[1][1] * Wc[2][0];
-    normal[2] += phi(i+1, j+1, kc+1) * dxi[2] * W[0][1] * W[1][1] * Wc[2][0];
-    normal[2] -= phi(i  , j  , kc+1) * dxi[2] * W[0][0] * W[1][0] * Wc[2][1];
-    normal[2] += phi(i  , j  , kc+2) * dxi[2] * W[0][0] * W[1][0] * Wc[2][1];
-    normal[2] -= phi(i+1, j  , kc+1) * dxi[2] * W[0][1] * W[1][0] * Wc[2][1];
-    normal[2] += phi(i+1, j  , kc+2) * dxi[2] * W[0][1] * W[1][0] * Wc[2][1];
-    normal[2] -= phi(i,   j+1, kc+1) * dxi[2] * W[0][0] * W[1][1] * Wc[2][1];
-    normal[2] += phi(i  , j+1, kc+2) * dxi[2] * W[0][0] * W[1][1] * Wc[2][1];
-    normal[2] -= phi(i+1, j+1, kc+1) * dxi[2] * W[0][1] * W[1][1] * Wc[2][1];
-    normal[2] += phi(i+1, j+1, kc+2) * dxi[2] * W[0][1] * W[1][1] * Wc[2][1];
-
+    for (int iic = 0; iic < 2; ++iic) {
+        for (int kk = 0; kk < 2; ++kk) {
+            for (int jj=0; jj< 2; ++jj) {
+                for (int ii = 0; ii < 2; ++ii) {
+                    int icstart = ic + iic;
+                    amrex::Real sign = (ii%2)*2. - 1.;
+                    int wccomp = static_cast<int>(iic%2);
+                    int w1comp = static_cast<int>(jj%2);
+                    int w2comp = static_cast<int>(kk%2);
+                    normal[0] += sign * phi(icstart + ii, j + jj, k + kk) * dxi[0] * Wc[0][wccomp] * W[1][w1comp] * W[2][w2comp];
+                }
+            }
+        }
+    }
+    for (int iic = 0; iic < 2; ++iic) {
+        for (int kk = 0; kk < 2; ++kk) {
+            for (int ii=0; ii< 2; ++ii) {
+                for (int jj = 0; jj < 2; ++jj) {
+                    int jcstart = jc + iic;
+                    amrex::Real sign = (jj%2)*2. - 1.;
+                    int wccomp = static_cast<int>(iic%2);
+                    int w1comp = static_cast<int>(ii%2);
+                    int w2comp = static_cast<int>(kk%2);
+                    normal[1] += sign * phi(i + ii, jcstart + jj, k + kk) * dxi[1] * W[0][w1comp] * Wc[1][wccomp] * W[2][w2comp];
+                }
+            }
+        }
+    }    
+    for (int iic = 0; iic < 2; ++iic) {
+        for (int jj = 0; jj < 2; ++jj) {
+            for (int ii=0; ii< 2; ++ii) {
+                for (int kk = 0; kk < 2; ++kk) {
+                    int kcstart = kc + iic;
+                    amrex::Real sign = (kk%2)*2. - 1.;
+                    int wccomp = static_cast<int>(iic%2);
+                    int w1comp = static_cast<int>(ii%2);
+                    int w2comp = static_cast<int>(jj%2);
+                    normal[2] += sign * phi(i + ii, j + jj, kcstart + kk) * dxi[2] * W[0][w1comp] * W[1][w2comp] * Wc[2][wccomp];
+                }
+            }
+        }
+    }     
 
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     amrex::RealVect normal{0.0, 0.0};
+    for (int iic = 0; iic < 2; ++iic) {
+        for (int jj=0; jj< 2; ++jj) {
+            for (int ii = 0; ii < 2; ++ii) {
+                int icstart = ic + iic;
+                amrex::Real sign = (ii%2)*2. - 1.;
+                int wccomp = static_cast<int>(iic%2);
+                int w1comp = static_cast<int>(jj%2);
+                normal[0] += sign * phi(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp];
+                std::cout << phi(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp] << std::endl;
+                std::cout << "i=" << i << ", j=" << j << ", k=" << k << std::endl;
+                std::cout << "normal[0]" << sign << "=phi(ic+" << iic + ii << ", j+" << jj << ", k) * dxi[0] * Wc[0][" << wccomp << "] * W[1][" <<  w1comp << "]; \n" << std::endl;
 
-    normal[0] -= phi(ic,   j  , k) * dxi[0] * Wc[0][0] * W[1][0];
-    normal[0] += phi(ic+1, j  , k) * dxi[0] * Wc[0][0] * W[1][0];
-    normal[0] -= phi(ic,   j+1, k) * dxi[0] * Wc[0][0] * W[1][1];
-    normal[0] += phi(ic+1, j+1, k) * dxi[0] * Wc[0][0] * W[1][1];
-    normal[0] -= phi(ic+1, j  , k) * dxi[0] * Wc[0][1] * W[1][0];
-    normal[0] += phi(ic+2, j  , k) * dxi[0] * Wc[0][1] * W[1][0];
-    normal[0] -= phi(ic+1, j+1, k) * dxi[0] * Wc[0][1] * W[1][1];
-    normal[0] += phi(ic+2, j+1, k) * dxi[0] * Wc[0][1] * W[1][1];
-
-    normal[1] -= phi(i,   jc  , k) * dxi[1] * W[0][0] * Wc[1][0];
-    normal[1] += phi(i  , jc+1, k) * dxi[1] * W[0][0] * Wc[1][0];
-    normal[1] -= phi(i+1, jc  , k) * dxi[1] * W[0][1] * Wc[1][0];
-    normal[1] += phi(i+1, jc+1, k) * dxi[1] * W[0][1] * Wc[1][0];
-    normal[1] -= phi(i,   jc+1, k) * dxi[1] * W[0][0] * Wc[1][1];
-    normal[1] += phi(i  , jc+2, k) * dxi[1] * W[0][0] * Wc[1][1];
-    normal[1] -= phi(i+1, jc+1, k) * dxi[1] * W[0][1] * Wc[1][1];
-    normal[1] += phi(i+1, jc+2, k) * dxi[1] * W[0][1] * Wc[1][1];
-
+            }
+        }
+    }
+    for (int iic = 0; iic < 2; ++iic) {
+        for (int ii=0; ii< 2; ++ii) {
+            for (int jj = 0; jj < 2; ++jj) {
+                int jcstart = jc + iic;
+                amrex::Real sign = (jj%2)*2. - 1.;
+                int wccomp = static_cast<int>(iic%2);
+                int w1comp = static_cast<int>(ii%2);
+                normal[1] += sign * phi(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp];
+                std::cout << phi(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp] << std::endl;
+                std::cout << "i=" << i << ", j=" << j << ", k=" << k << std::endl;
+                std::cout << "normal[1]" << sign << "=phi(i+" << ii << ",jc+" << iic + jj << ", k) * dxi[1] * W[0][" << w1comp << "] * Wc[1][" <<  wccomp << "]; \n" << std::endl;
+            }
+        }
+    }
     amrex::ignore_unused(kc);
+
 #else
-    amrex::RealVect normal{0.0, 0.0};
     amrex::ignore_unused(i, j, k, ic, jc, kc, W, Wc, phi, dxi);
+    amrex::RealVect normal{0.0, 0.0};
     WARPX_ABORT_WITH_MESSAGE("Error: interp_distance not yet implemented in 1D");
+
 #endif
     return normal;
 }

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -46,7 +46,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
     W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
     ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
     Wc are the corresponding interpolation weights.
-'''  
+'''
 
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
@@ -77,7 +77,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 }
             }
         }
-    }    
+    }
     for (int iic = 0; iic < 2; ++iic) {
         for (int jj = 0; jj < 2; ++jj) {
             for (int ii=0; ii< 2; ++ii) {
@@ -91,7 +91,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 }
             }
         }
-    }     
+    }
 
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     amrex::RealVect normal{0.0, 0.0};

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -34,19 +34,18 @@ void normalize (amrex::RealVect& a) noexcept
                  a[2] *= inv_norm);
 }
 
+ 
+
+// This function calculates the normal vector using the nodes and cell-centered nodes
+// i,j,k are the index of the nearest node to the left of the point at which we interpolate.
+// W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
+// ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SPACEDIM][2],
                                int ic, int jc, int kc, const amrex::Real Wc[AMREX_SPACEDIM][2],
                                amrex::Array4<const amrex::Real> const& phi,
                                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
 {
-'''
-    This function calculates the normal vector using the nodes and cell-centered nodes
-    i,j,k are the index of the nearest node to the left of the point at which we interpolate.
-    W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
-    ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
-    Wc are the corresponding interpolation weights.
-'''
 
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -208,7 +208,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
 #elif (defined WARPX_DIM_1D_Z)
                     pos[0] = zp;
 #endif
-                f(ptd, ip, pos, normal, engine);
+                    f(ptd, ip, pos, normal, engine);
 
                 }
             });

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -184,12 +184,6 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
                 int i, j, k;
                 amrex::Real W[AMREX_SPACEDIM][2];
                 ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, i, j, k, W);
-                int ic, jc, kc; // Cell-centered indices
-                amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weights
-                int nodal;
-                ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, ic, jc, kc, Wc, nodal=0);
-                amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);
-                DistanceToEB::normalize(normal);
                 amrex::Real phi_value  = ablastr::particles::interp_field_nodal(i, j, k, W, phi);
 
                 if (phi_value < 0.0)

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -10,6 +10,7 @@
 #include "EmbeddedBoundary/DistanceToEB.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 
+
 #include <ablastr/particles/NodalFieldGather.H>
 
 #include <AMReX.H>
@@ -182,16 +183,17 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
 
                 int i, j, k;
                 amrex::Real W[AMREX_SPACEDIM][2];
-                ablastr::particles::compute_weights_nodal(xp, yp, zp, plo, dxi, i, j, k, W);
-
+                ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, i, j, k, W);
+                int ic, jc, kc; // Cell-centered indices
+                amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weights
+                int nodal;
+                ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, ic, jc, kc, Wc, nodal=0);
+                amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);
+                DistanceToEB::normalize(normal);
                 amrex::Real phi_value  = ablastr::particles::interp_field_nodal(i, j, k, W, phi);
 
                 if (phi_value < 0.0)
                 {
-
-                    amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, phi, dxi);
-                    DistanceToEB::normalize(normal);
-
                     amrex::RealVect pos;
 #if (defined WARPX_DIM_3D)
                     pos[0] = xp;
@@ -206,7 +208,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
 #elif (defined WARPX_DIM_1D_Z)
                     pos[0] = zp;
 #endif
-                    f(ptd, ip, pos, normal, engine);
+                f(ptd, ip, pos, normal, engine);
 
                 }
             });

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -188,6 +188,11 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
 
                 if (phi_value < 0.0)
                 {
+                    int ic, jc, kc; // Cell-centered indices
+                    amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weights
+                    ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, ic, jc, kc, Wc, nodal=0);
+                    amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);
+                    DistanceToEB::normalize(normal);
                     amrex::RealVect pos;
 #if (defined WARPX_DIM_3D)
                     pos[0] = xp;

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -189,6 +189,7 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
                 if (phi_value < 0.0)
                 {
                     int ic, jc, kc; // Cell-centered indices
+                    int nodal;
                     amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weights
                     ablastr::particles::compute_weights(xp, yp, zp, plo, dxi, ic, jc, kc, Wc, nodal=0);
                     amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -108,7 +108,7 @@ struct FindEmbeddedBoundaryIntersection {
         // Save the corresponding position of the particle at the boundary
         amrex::ParticleReal x_temp=xp, y_temp=yp, z_temp=zp;
         UpdatePosition(x_temp, y_temp, z_temp, ux, uy, uz, -dt_fraction*m_dt);
-        
+
         // record the components of the normal on the destination
         int i, j, k;
         amrex::Real W[AMREX_SPACEDIM][2];

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -44,6 +44,7 @@ struct IsOutsideDomainBoundary {
     }
 };
 
+#ifdef AMREX_USE_EB
 struct FindEmbeddedBoundaryIntersection {
     const int m_step_index;
     const int m_time_index;
@@ -157,6 +158,7 @@ struct FindEmbeddedBoundaryIntersection {
 #endif
     }
 };
+#endif
 
 struct CopyAndTimestamp {
     int m_step_index;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -117,7 +117,7 @@ struct FindEmbeddedBoundaryIntersection {
         int ic, jc, kc; // Cell-centered indices
         amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weight
         int nodal;
-        ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, ic, jc, kc, Wc, nodal=0); // nodal=0 to calculate the weights in respect to the cell-centered nodes
+        ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, ic, jc, kc, Wc, nodal=0); // nodal=0 to calculate the weights with respect to the cell-centered nodes
         amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phiarr, dxi);
         DistanceToEB::normalize(normal);
 

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -116,7 +116,6 @@ struct FindEmbeddedBoundaryIntersection {
         ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, i, j, k, W);
         int ic, jc, kc; // Cell-centered indices
         amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weight
-        int nodal;
         ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, ic, jc, kc, Wc, nodal=0); // nodal=0 to calculate the weights with respect to the cell-centered nodes
         amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phiarr, dxi);
         DistanceToEB::normalize(normal);

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -95,7 +95,7 @@ struct FindEmbeddedBoundaryIntersection {
                 amrex::Real W[AMREX_SPACEDIM][2];
                 amrex::ParticleReal x_temp=xp, y_temp=yp, z_temp=zp;
                 UpdatePosition(x_temp, y_temp, z_temp, ux, uy, uz, -dt_frac*dt);
-                ablastr::particles::compute_weights_nodal(x_temp, y_temp, z_temp, plo, dxi, i, j, k, W);
+                ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, i, j, k, W);
                 amrex::Real phi_value  = ablastr::particles::interp_field_nodal(i, j, k, W, phiarr);
                 return phi_value;
             } );

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -115,6 +115,7 @@ struct FindEmbeddedBoundaryIntersection {
         amrex::Real W[AMREX_SPACEDIM][2];
         ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, i, j, k, W);
         int ic, jc, kc; // Cell-centered indices
+        int nodal;
         amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weight
         ablastr::particles::compute_weights(x_temp, y_temp, z_temp, plo, dxi, ic, jc, kc, Wc, nodal=0); // nodal=0 to calculate the weights with respect to the cell-centered nodes
         amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phiarr, dxi);

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -45,9 +45,9 @@ void compute_weights (const amrex::ParticleReal xp,
 #endif
 
 #if (defined WARPX_DIM_3D)
-    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
-    const amrex::Real y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
-    const amrex::Real z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
+    const amrex::ParticleReal x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
+    const amrex::ParticleReal y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
+    const amrex::ParticleReal z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
 
     i = static_cast<int>(amrex::Math::floor(x));
     j = static_cast<int>(amrex::Math::floor(y));

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -64,7 +64,7 @@ void compute_weights (const amrex::ParticleReal xp,
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
 
 #   if (defined WARPX_DIM_XZ)
-    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
     amrex::ignore_unused(yp);
     i = static_cast<int>(amrex::Math::floor(x));
     W[0][1] = x - i;

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -26,7 +26,7 @@ namespace ablastr::particles
  * \param xp,yp,zp Particle position coordinates
  * \param plo      Index lower bounds of domain.
  * \param dxi      inverse 3D cell spacing
- * \param i,j,k    Variables to store indices of position on grid
+ * \param i,j,k    Variables to store indices of position on grid (nodal or cell-centered, depending of the value of `nodal`)
  * \param W        2D array of weights to store each neighbouring node (or cell-centered node)
  * \param nodal    Int that tells if the weights are calculated in respect to the nodes (nodal=1) of the cell-centered nodes (nodal=0)
  */

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -45,9 +45,9 @@ void compute_weights (const amrex::ParticleReal xp,
 #endif
 
 #if (defined WARPX_DIM_3D)
-    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
-    const amrex::Real y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
-    const amrex::Real z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real y = (yp - plo[1]) * dxi[1] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real z = (zp - plo[2]) * dxi[2] + static_cast<amrex::Real>((nodal-1)*0.5);
 
     i = static_cast<int>(amrex::Math::floor(x));
     j = static_cast<int>(amrex::Math::floor(y));
@@ -64,17 +64,17 @@ void compute_weights (const amrex::ParticleReal xp,
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
 
 #   if (defined WARPX_DIM_XZ)
-    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
     amrex::ignore_unused(yp);
     i = static_cast<int>(amrex::Math::floor(x));
     W[0][1] = x - i;
 #   elif (defined WARPX_DIM_RZ)
-    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0] + (nodal-1)*0.5;
+    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
     i = static_cast<int>(amrex::Math::floor(r));
     W[0][1] = r - i;
 #   endif
 
-    const amrex::Real z = (zp - plo[1]) * dxi[1] + (nodal-1)*0.5;
+    const amrex::Real z = (zp - plo[1]) * dxi[1] + static_cast<amrex::Real>((nodal-1)*0.5);
     j = static_cast<int>(amrex::Math::floor(z));
     W[1][1] = z - j;
 

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -45,9 +45,9 @@ void compute_weights (const amrex::ParticleReal xp,
 #endif
 
 #if (defined WARPX_DIM_3D)
-    const amrex::ParticleReal x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
-    const amrex::ParticleReal y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
-    const amrex::ParticleReal z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
+    const amrex::Real y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
+    const amrex::Real z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
 
     i = static_cast<int>(amrex::Math::floor(x));
     j = static_cast<int>(amrex::Math::floor(y));

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -69,7 +69,7 @@ void compute_weights (const amrex::ParticleReal xp,
     i = static_cast<int>(amrex::Math::floor(x));
     W[0][1] = x - i;
 #   elif (defined WARPX_DIM_RZ)
-    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
     i = static_cast<int>(amrex::Math::floor(r));
     W[0][1] = r - i;
 #   endif

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -45,9 +45,9 @@ void compute_weights (const amrex::ParticleReal xp,
 #endif
 
 #if (defined WARPX_DIM_3D)
-    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>((nodal-1)*0.5);
-    const amrex::Real y = (yp - plo[1]) * dxi[1] + static_cast<amrex::Real>((nodal-1)*0.5);
-    const amrex::Real z = (zp - plo[2]) * dxi[2] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
+    const amrex::Real y = (yp - plo[1]) * dxi[1] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
+    const amrex::Real z = (zp - plo[2]) * dxi[2] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
 
     i = static_cast<int>(amrex::Math::floor(x));
     j = static_cast<int>(amrex::Math::floor(y));

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -74,7 +74,7 @@ void compute_weights (const amrex::ParticleReal xp,
     W[0][1] = r - i;
 #   endif
 
-    const amrex::Real z = (zp - plo[1]) * dxi[1] + static_cast<amrex::Real>((nodal-1)*0.5);
+    const amrex::Real z = (zp - plo[1]) * dxi[1] + static_cast<amrex::Real>(nodal-1)*0.5_rt;
     j = static_cast<int>(amrex::Math::floor(z));
     W[1][1] = z - j;
 

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -18,8 +18,8 @@
 namespace ablastr::particles
 {
 /**
- * \brief Compute weight of each surrounding node in interpolating a nodal field
- *        to the given coordinates.
+ * \brief Compute weight of each surrounding node (or cell-centered nodes) in interpolating a nodal ((or a cell-centered node) field
+ *        to the given coordinates. If nodal=1, then the calculations will be done with respect to the nodes (default). If nodal=0, then the calculations will be done with respect to the cell-centered nodal)
  *
  * This currently only does linear order.
  *
@@ -27,21 +27,27 @@ namespace ablastr::particles
  * \param plo      Index lower bounds of domain.
  * \param dxi      inverse 3D cell spacing
  * \param i,j,k    Variables to store indices of position on grid
- * \param W        2D array of weights to store each neighbouring node
+ * \param W        2D array of weights to store each neighbouring node (or cell-centered node)
+ * \param nodal    Int that tells if the weights are calculated in respect to the nodes (nodal=1) of the cell-centered nodes (nodal=0)
  */
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void compute_weights_nodal (const amrex::ParticleReal xp,
+void compute_weights (const amrex::ParticleReal xp,
                             const amrex::ParticleReal yp,
                             const amrex::ParticleReal zp,
                             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& plo,
                             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& dxi,
-                            int& i, int& j, int& k, amrex::Real W[AMREX_SPACEDIM][2]) noexcept
+                            int& i, int& j, int& k, amrex::Real W[AMREX_SPACEDIM][2], int nodal=1) noexcept
 {
     using namespace amrex::literals;
+
+#if !((nodal==0)||(nodal==1))
+    ABLASTR_ABORT_WITH_MESSAGE("Error: 'nodal' has to be equal to 0 or 1");
+#endif
+
 #if (defined WARPX_DIM_3D)
-    const amrex::Real x = (xp - plo[0]) * dxi[0];
-    const amrex::Real y = (yp - plo[1]) * dxi[1];
-    const amrex::Real z = (zp - plo[2]) * dxi[2];
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
+    const amrex::Real y = (yp - plo[1]) * dxi[1] + (nodal-1)*0.5;
+    const amrex::Real z = (zp - plo[2]) * dxi[2] + (nodal-1)*0.5;
 
     i = static_cast<int>(amrex::Math::floor(x));
     j = static_cast<int>(amrex::Math::floor(y));
@@ -58,17 +64,17 @@ void compute_weights_nodal (const amrex::ParticleReal xp,
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
 
 #   if (defined WARPX_DIM_XZ)
-    const amrex::Real x = (xp - plo[0]) * dxi[0];
+    const amrex::Real x = (xp - plo[0]) * dxi[0] + (nodal-1)*0.5;
     amrex::ignore_unused(yp);
     i = static_cast<int>(amrex::Math::floor(x));
     W[0][1] = x - i;
 #   elif (defined WARPX_DIM_RZ)
-    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0];
+    const amrex::Real r = (std::sqrt(xp*xp+yp*yp) - plo[0]) * dxi[0] + (nodal-1)*0.5;
     i = static_cast<int>(amrex::Math::floor(r));
     W[0][1] = r - i;
 #   endif
 
-    const amrex::Real z = (zp - plo[1]) * dxi[1];
+    const amrex::Real z = (zp - plo[1]) * dxi[1] + (nodal-1)*0.5;
     j = static_cast<int>(amrex::Math::floor(z));
     W[1][1] = z - j;
 
@@ -77,7 +83,7 @@ void compute_weights_nodal (const amrex::ParticleReal xp,
 
     k = 0;
 #else
-    amrex::ignore_unused(xp, yp, zp, plo, dxi, i, j, k, W);
+    amrex::ignore_unused(xp, yp, zp, plo, dxi, i, j, k, W, nodal);
     ABLASTR_ABORT_WITH_MESSAGE("Error: compute_weights not yet implemented in 1D");
 #endif
 }
@@ -138,7 +144,7 @@ amrex::Real doGatherScalarFieldNodal (const amrex::ParticleReal xp,
     // first find the weight of surrounding nodes to use during interpolation
     int ii, jj, kk;
     amrex::Real W[AMREX_SPACEDIM][2];
-    compute_weights_nodal(xp, yp, zp, lo, dxi, ii, jj, kk, W);
+    compute_weights(xp, yp, zp, lo, dxi, ii, jj, kk, W);
 
     return interp_field_nodal(ii, jj, kk, W, scalar_field);
 }
@@ -166,7 +172,7 @@ doGatherVectorFieldNodal (const amrex::ParticleReal xp,
     // first find the weight of surrounding nodes to use during interpolation
     int ii, jj, kk;
     amrex::Real W[AMREX_SPACEDIM][2];
-    compute_weights_nodal(xp, yp, zp, lo, dxi, ii, jj, kk, W);
+    compute_weights(xp, yp, zp, lo, dxi, ii, jj, kk, W);
 
     amrex::GpuArray<amrex::Real, 3> const field_interp = {
         interp_field_nodal(ii, jj, kk, W, vector_field_x),


### PR DESCRIPTION
This PR completes the PR #4695. It saves in the particle buffer the normal components when there are embedded boundaries. The calculation of the normal components were also modified: we take now in account the weights of the cell-centered nodes.

Note: new option for the function compute_weights() --> nodal=0 or 1 (1 by default)
nodal=0: we calculate the cell-centered indices
nodal=1: we calculate the nodes indices