### PR TITLE
Implementation of 4th order particle shape beyond implicit solver cases

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2032,8 +2032,8 @@ Particle push, charge and current deposition, field gathering
 
      If ``algo.particle_pusher`` is not specified, ``boris`` is the default.
 
-* ``algo.particle_shape`` (`integer`; `1`, `2`, or `3`)
-    The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic.
+* ``algo.particle_shape`` (`integer`; `1`, `2`, `3`, or `4`)
+    The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic, `4` for quartic.
     Low-order shape factors result in faster simulations, but may lead to more noisy results.
     High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results. For production runs it is generally safer to use high-order shape factors, such as cubic order.
 

--- a/Examples/Tests/langmuir/analysis_2d.py
+++ b/Examples/Tests/langmuir/analysis_2d.py
@@ -38,6 +38,9 @@ current_correction = True if re.search( 'current_correction', fn ) else False
 # Parse test name and check if Vay current deposition (algo.current_deposition=vay) is used
 vay_deposition = True if re.search( 'Vay_deposition', fn ) else False
 
+# Parse test name and check if particle_shape = 4 is used
+particle_shape_4 = True if re.search('particle_shape_4', fn) else False
+
 # Parameters (these parameters must match the parameters in `inputs.multi.rt`)
 epsilon = 0.01
 n = 4.e24
@@ -114,7 +117,11 @@ ax2.set_title(r'$E_z$ (theory)')
 fig.tight_layout()
 fig.savefig('Langmuir_multi_2d_analysis.png', dpi = 200)
 
-tolerance_rel = 0.05
+if particle_shape_4:
+# lower fidelity, due to smoothing
+    tolerance_rel = 0.07
+else:
+    tolerance_rel = 0.05
 
 print("error_rel    : " + str(error_rel))
 print("tolerance_rel: " + str(tolerance_rel))

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_psatd_Vay_deposition_particle_shape_4.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_2d_psatd_Vay_deposition_particle_shape_4.json
@@ -1,0 +1,29 @@
+{
+  "electrons": {
+    "particle_momentum_x": 5.696397887862144e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 5.696397887862156e-20,
+    "particle_position_x": 0.6553600000001614,
+    "particle_position_y": 0.6553600000001614,
+    "particle_weight": 3200000000000000.5
+  },
+  "lev=0": {
+    "Ex": 3616987165668.129,
+    "Ey": 0.0,
+    "Ez": 3616987165667.9756,
+    "divE": 2.269072850514105e+18,
+    "jx": 1.0121499183289864e+16,
+    "jy": 0.0,
+    "jz": 1.0121499183289892e+16,
+    "part_per_cell": 131072.0,
+    "rho": 20090797.21028113
+  },
+  "positrons": {
+    "particle_momentum_x": 5.696397887862144e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 5.696397887862156e-20,
+    "particle_position_x": 0.6553600000001614,
+    "particle_position_y": 0.6553600000001614,
+    "particle_weight": 3200000000000000.5
+  }
+}

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -20,7 +20,7 @@ purge_output = 1
 useCmake = 1
 isSuperbuild = 1
 MAKE = make
-numMakeJobs = 16
+numMakeJobs = 8
 
 # We build by default a few tools for output comparison.
 # The build time for those can be skipped if they are not needed.

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -20,7 +20,7 @@ purge_output = 1
 useCmake = 1
 isSuperbuild = 1
 MAKE = make
-numMakeJobs = 8
+numMakeJobs = 16
 
 # We build by default a few tools for output comparison.
 # The build time for those can be skipped if they are not needed.
@@ -1419,6 +1419,25 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_2d
 runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 algo.current_deposition=vay diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475
+dim = 2
+addToCompileString = USE_PSATD=TRUE
+cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
+restartTest = 0
+useMPI = 1
+numprocs = 1
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons positrons
+analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
+analysisOutputImage = langmuir_multi_2d_analysis.png
+
+[Langmuir_multi_2d_psatd_Vay_deposition_particle_shape_4]
+buildDir = .
+inputFile = Examples/Tests/langmuir/inputs_2d
+runtime_params = algo.maxwell_solver=psatd amr.max_grid_size=128 algo.current_deposition=vay diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot = Ex Ey Ez jx jy jz part_per_cell rho divE warpx.cfl = 0.7071067811865475 algo.particle_shape=4
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -1792,6 +1792,12 @@ void doGatherShapeNImplicit (
                                                       ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                                       ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                                       dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
+        } else if (nox == 4) {
+            doGatherShapeNEsirkepovStencilImplicit<4>(xp_n, yp_n, zp_n, xp_nph, yp_nph, zp_nph,
+                                                      Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                                      ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
+                                                      ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
+                                                      dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
         }
     }
     else if (depos_type==3) { // CurrentDepositionAlgo::Villasenor
@@ -1834,6 +1840,11 @@ void doGatherShapeNImplicit (
                                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
         } else if (nox == 3) {
             doGatherShapeN<3,0>(xp_nph, yp_nph, zp_nph, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
+                                ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
+                                dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
+        } else if (nox == 4) {
+            doGatherShapeN<4,0>(xp_nph, yp_nph, zp_nph, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -1689,6 +1689,11 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
+        } else if (nox == 4) {
+            doGatherShapeN<4,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
+                                ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
+                                dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
         }
     } else {
         if (nox == 1) {
@@ -1703,6 +1708,11 @@ void doGatherShapeN (const amrex::ParticleReal xp,
                                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
         } else if (nox == 3) {
             doGatherShapeN<3,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
+                                ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
+                                dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);
+        } else if (nox == 4) {
+            doGatherShapeN<4,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dx_arr, xyzmin_arr, lo, n_rz_azimuthal_modes);

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -16,7 +16,7 @@
 /**
  *  Compute shape factor and return index of leftmost cell where
  *  particle writes.
- *  Specializations are defined for orders 0 to 3 (using "if constexpr").
+ *  Specializations are defined for orders 0 to 4 (using "if constexpr").
  *  Shape factor functors may be evaluated with double arguments
  *  in current deposition to ensure that current deposited by
  *  particles that move only a small distance is still resolved.
@@ -67,13 +67,11 @@ struct Compute_shape_factor
         else if constexpr (depos_order == 4){
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint = xmid - T(j);
-            const T xint_p1 = xint + T(1.0);
-            const T xint_m1 = xint - T(1.0);
-            sx[0] = T(1.0)/T(384.0)*(T(1.0) - T(2.0)*xint)*(T(1.0) - T(2.0)*xint)*(T(1.0) - T(2.0)*xint)*(T(1.0) - T(2.0)*xint);
-            sx[1] = T(1.0)/T(96.0)*(T(55.0) + T(4.0)*xint_p1*(T(5.0) - T(2.0)*xint_p1*(T(15.0) + T(2.0)*xint_p1*(xint_p1 - T(5.0)))));
-            sx[2] = T(115.0)/T(192.0) + xint*xint*(xint*xint/T(4.0) - T(5.0)/T(8.0));
-            sx[3] = T(1.0)/T(96.0)*(T(55.0) - T(4.0)*xint_m1*(T(5.0) + T(2.0)*xint_m1*(T(15.0) - T(2.0)*xint_m1*(-xint_m1 - T(5.0)))));
-            sx[4] = T(1.0)/T(384.0)*(T(1.0) + T(2.0)*xint)*(T(1.0) + T(2.0)*xint)*(T(1.0) + T(2.0)*xint)*(T(1.0) + T(2.0)*xint);
+            sx[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
+	    sx[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+	    sx[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+	    sx[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
             // index of the leftmost cell where particle deposits
             return j-2;
         }
@@ -90,7 +88,7 @@ struct Compute_shape_factor
 /**
  *  Compute shifted shape factor and return index of leftmost cell where
  *  particle writes, for Esirkepov algorithm.
- *  Specializations are defined below for orders 1, 2 and 3 (using "if constexpr").
+ *  Specializations are defined below for orders 1, 2, 3, and 4 (using "if constexpr").
  */
 template <int depos_order>
 struct Compute_shifted_shape_factor
@@ -129,13 +127,25 @@ struct Compute_shifted_shape_factor
         else if constexpr (depos_order == 3){
             const auto i = static_cast<int>(x_old);
             const int i_shift = i - (i_new + 1);
-            const T xint = x_old - i;
+            const T xint = x_old - T(i);
             sx[1+i_shift] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
             sx[2+i_shift] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
             sx[3+i_shift] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
             sx[4+i_shift] = (T(1.0))/(T(6.0))*xint*xint*xint;
             // index of the leftmost cell where particle deposits
             return i - 1;
+        }
+        else if constexpr (depos_order == 4){
+            const auto i = static_cast<int>(x_old + T(0.5));
+            const int i_shift = i - (i_new + 2);
+            const T xint = x_old - T(i);
+            sx[1+i_shift] = (T(1.0))/(T(24.0))*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
+	    sx[2+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+	    sx[3+i_shift] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+	    sx[4+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[5+i_shift] = (T(1.0))/(T(24.0))*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
+            // index of the leftmost cell where particle deposits
+            return i - 2;
         }
         else{
             WARPX_ABORT_WITH_MESSAGE("Unknown particle shape selected in Compute_shifted_shape_factor");
@@ -209,22 +219,18 @@ struct Compute_shape_factor_pair
         else if constexpr (depos_order == 4){
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint_old = xold - T(j);
-            T xint_p1 = xint_old + T(1.0);
-            T xint_m1 = xint_old - T(1.0);
-            sx_old[0] = T(1.0)/T(384.0)*(T(1.0) - T(2.0)*xint_old)*(T(1.0) - T(2.0)*xint_old)*(T(1.0) - T(2.0)*xint_old)*(T(1.0) - T(2.0)*xint_old);
-            sx_old[1] = T(1.0)/T(96.0)*(T(55.0) + T(4.0)*xint_p1*(T(5.0) - T(2.0)*xint_p1*(T(15.0) + T(2.0)*xint_p1*(xint_p1 - T(5.0)))));
-            sx_old[2] = T(115.0)/T(192.0) + xint_old*xint_old*(xint_old*xint_old/T(4.0) - T(5.0)/T(8.0));
-            sx_old[3] = T(1.0)/T(96.0)*(T(55.0) - T(4.0)*xint_m1*(T(5.0) + T(2.0)*xint_m1*(T(15.0) - T(2.0)*xint_m1*(-xint_m1 - T(5.0)))));
-            sx_old[4] = T(1.0)/T(384.0)*(T(1.0) + T(2.0)*xint_old)*(T(1.0) + T(2.0)*xint_old)*(T(1.0) + T(2.0)*xint_old)*(T(1.0) + T(2.0)*xint_old);
+            sx_old[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint_old)*(T(0.5) - xint_old)*(T(0.5) - xint_old)*(T(0.5) - xint_old);
+	    sx_old[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) + xint_old - xint_old*xint_old));
+	    sx_old[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_old*xint_old*(xint_old*xint_old - T(2.5)));
+	    sx_old[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) - xint_old - xint_old*xint_old));
+            sx_old[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint_old)*(T(0.5) + xint_old)*(T(0.5) + xint_old)*(T(0.5)+xint_old);
             //
             const T xint_new = xnew - T(j);
-            xint_p1 = xint_new + T(1.0);
-            xint_m1 = xint_new - T(1.0);
-            sx_new[0] = T(1.0)/T(384.0)*(T(1.0) - T(2.0)*xint_new)*(T(1.0) - T(2.0)*xint_new)*(T(1.0) - T(2.0)*xint_new)*(T(1.0) - T(2.0)*xint_new);
-            sx_new[1] = T(1.0)/T(96.0)*(T(55.0) + T(4.0)*xint_p1*(T(5.0) - T(2.0)*xint_p1*(T(15.0) + T(2.0)*xint_p1*(xint_p1 - T(5.0)))));
-            sx_new[2] = T(115.0)/T(192.0) + xint_new*xint_new*(xint_new*xint_new/T(4.0) - T(5.0)/T(8.0));
-            sx_new[3] = T(1.0)/T(96.0)*(T(55.0) - T(4.0)*xint_m1*(T(5.0) + T(2.0)*xint_m1*(T(15.0) - T(2.0)*xint_m1*(-xint_m1 - T(5.0)))));
-            sx_new[4] = T(1.0)/T(384.0)*(T(1.0) + T(2.0)*xint_new)*(T(1.0) + T(2.0)*xint_new)*(T(1.0) + T(2.0)*xint_new)*(T(1.0) + T(2.0)*xint_new);
+            sx_new[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint_new)*(T(0.5) - xint_new)*(T(0.5) - xint_new)*(T(0.5) - xint_new);
+	    sx_new[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) + xint_new - xint_new*xint_new));
+	    sx_new[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_new*xint_new*(xint_new*xint_new - T(2.5)));
+	    sx_new[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) - xint_new - xint_new*xint_new));
+            sx_new[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint_new)*(T(0.5) + xint_new)*(T(0.5) + xint_new)*(T(0.5)+xint_new);
             //
             // index of the leftmost cell where particle deposits
             return j-2;

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -68,9 +68,9 @@ struct Compute_shape_factor
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint = xmid - T(j);
             sx[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
-	    sx[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
-	    sx[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
-	    sx[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+            sx[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+            sx[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
             sx[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
             // index of the leftmost cell where particle deposits
             return j-2;
@@ -140,9 +140,9 @@ struct Compute_shifted_shape_factor
             const int i_shift = i - (i_new + 2);
             const T xint = x_old - T(i);
             sx[1+i_shift] = (T(1.0))/(T(24.0))*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
-	    sx[2+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
-	    sx[3+i_shift] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
-	    sx[4+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[2+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+            sx[3+i_shift] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+            sx[4+i_shift] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
             sx[5+i_shift] = (T(1.0))/(T(24.0))*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
             // index of the leftmost cell where particle deposits
             return i - 2;
@@ -220,16 +220,16 @@ struct Compute_shape_factor_pair
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint_old = xold - T(j);
             sx_old[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint_old)*(T(0.5) - xint_old)*(T(0.5) - xint_old)*(T(0.5) - xint_old);
-	    sx_old[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) + xint_old - xint_old*xint_old));
-	    sx_old[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_old*xint_old*(xint_old*xint_old - T(2.5)));
-	    sx_old[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) - xint_old - xint_old*xint_old));
+            sx_old[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) + xint_old - xint_old*xint_old));
+            sx_old[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_old*xint_old*(xint_old*xint_old - T(2.5)));
+            sx_old[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_old + T(4.0)*xint_old*xint_old*(T(1.5) - xint_old - xint_old*xint_old));
             sx_old[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint_old)*(T(0.5) + xint_old)*(T(0.5) + xint_old)*(T(0.5)+xint_old);
             //
             const T xint_new = xnew - T(j);
             sx_new[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint_new)*(T(0.5) - xint_new)*(T(0.5) - xint_new)*(T(0.5) - xint_new);
-	    sx_new[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) + xint_new - xint_new*xint_new));
-	    sx_new[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_new*xint_new*(xint_new*xint_new - T(2.5)));
-	    sx_new[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) - xint_new - xint_new*xint_new));
+            sx_new[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) + xint_new - xint_new*xint_new));
+            sx_new[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint_new*xint_new*(xint_new*xint_new - T(2.5)));
+            sx_new[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint_new + T(4.0)*xint_new*xint_new*(T(1.5) - xint_new - xint_new*xint_new));
             sx_new[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint_new)*(T(0.5) + xint_new)*(T(0.5) + xint_new)*(T(0.5)+xint_new);
             //
             // index of the leftmost cell where particle deposits

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -547,6 +547,13 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         jx_fab, jy_fab, jz_fab, np_to_deposit, relative_time, dx,
                         xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                         WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size);
+            } else if (WarpX::nox == 4){
+                doDepositionSharedShapeN<4>(
+                        GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
+                        uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        jx_fab, jy_fab, jz_fab, np_to_deposit, relative_time, dx,
+                        xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size);
             }
             WARPX_PROFILE_VAR_STOP(direct_current_dep_kernel);
         }
@@ -571,6 +578,13 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         WarpX::load_balance_costs_update_algo);
                 } else if (WarpX::nox == 3){
                     doEsirkepovDepositionShapeN<3>(
+                        GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
+                        uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        jx_arr, jy_arr, jz_arr, np_to_deposit, dt, relative_time, dx, xyzmin, lo, q,
+                        WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo);
+                } else if (WarpX::nox == 4){
+                    doEsirkepovDepositionShapeN<4>(
                         GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                         uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
                         jx_arr, jy_arr, jz_arr, np_to_deposit, dt, relative_time, dx, xyzmin, lo, q,
@@ -615,6 +629,15 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         WarpX::load_balance_costs_update_algo);
                 } else if (WarpX::nox == 3){
                     doChargeConservingDepositionShapeNImplicit<3>(
+                        xp_n_data, yp_n_data, zp_n_data,
+                        GetPosition, wp.dataPtr() + offset,
+                        uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                        uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        jx_arr, jy_arr, jz_arr, np_to_deposit, dt, dx, xyzmin, lo, q,
+                        WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo);
+                } else if (WarpX::nox == 4){
+                    doChargeConservingDepositionShapeNImplicit<4>(
                         xp_n_data, yp_n_data, zp_n_data,
                         GetPosition, wp.dataPtr() + offset,
                         uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
@@ -709,6 +732,13 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         jx_fab, jy_fab, jz_fab, np_to_deposit, dt, relative_time, dx, xyzmin, lo, q,
                         WarpX::n_rz_azimuthal_modes, cost,
                         WarpX::load_balance_costs_update_algo);
+            } else if (WarpX::nox == 4){
+                doVayDepositionShapeN<4>(
+                        GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
+                    uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        jx_fab, jy_fab, jz_fab, np_to_deposit, dt, relative_time, dx, xyzmin, lo, q,
+                        WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo);
             }
         } else { // Direct deposition
             if (push_type == PushType::Explicit) {
@@ -728,6 +758,13 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         WarpX::load_balance_costs_update_algo);
                 } else if (WarpX::nox == 3){
                     doDepositionShapeN<3>(
+                        GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
+                        uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        jx_fab, jy_fab, jz_fab, np_to_deposit, relative_time, dx,
+                        xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo);
+                } else if (WarpX::nox == 4){
+                    doDepositionShapeN<4>(
                         GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
                         uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
                         jx_fab, jy_fab, jz_fab, np_to_deposit, relative_time, dx,
@@ -758,6 +795,15 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                         WarpX::load_balance_costs_update_algo);
                 } else if (WarpX::nox == 3){
                     doDepositionShapeNImplicit<3>(
+                        GetPosition, wp.dataPtr() + offset,
+                        uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                        uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
+                        ion_lev,
+                        jx_fab, jy_fab, jz_fab, np_to_deposit, dx,
+                        xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
+                        WarpX::load_balance_costs_update_algo);
+                } else if (WarpX::nox == 4){
+                    doDepositionShapeNImplicit<4>(
                         GetPosition, wp.dataPtr() + offset,
                         uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
                         uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
@@ -1061,6 +1107,12 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
         } else if (WarpX::nox == 3){
             doChargeDepositionSharedShapeN<3>(GetPosition, wp.dataPtr()+offset, ion_lev,
                                               rho_fab, ix_type, np_to_deposit, dx, xyzmin, lo, q,
+                                              WarpX::n_rz_azimuthal_modes, cost,
+                                              WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
+                                              WarpX::shared_tilesize);
+        } else if (WarpX::nox == 4){
+            doChargeDepositionSharedShapeN<4>(GetPosition, wp.dataPtr()+offset, ion_lev,
+                                              rho_fab, ix_type, np_to_depose, dx, xyzmin, lo, q,
                                               WarpX::n_rz_azimuthal_modes, cost,
                                               WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
                                               WarpX::shared_tilesize);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -735,7 +735,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
             } else if (WarpX::nox == 4){
                 doVayDepositionShapeN<4>(
                         GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
-                    uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
+                        uyp.dataPtr() + offset, uzp.dataPtr() + offset, ion_lev,
                         jx_fab, jy_fab, jz_fab, np_to_deposit, dt, relative_time, dx, xyzmin, lo, q,
                         WarpX::n_rz_azimuthal_modes, cost,
                         WarpX::load_balance_costs_update_algo);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1112,7 +1112,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                                               WarpX::shared_tilesize);
         } else if (WarpX::nox == 4){
             doChargeDepositionSharedShapeN<4>(GetPosition, wp.dataPtr()+offset, ion_lev,
-                                              rho_fab, ix_type, np_to_depose, dx, xyzmin, lo, q,
+                                              rho_fab, ix_type, np_to_deposit, dx, xyzmin, lo, q,
                                               WarpX::n_rz_azimuthal_modes, cost,
                                               WarpX::load_balance_costs_update_algo, bins, box, geom, max_tbox_size,
                                               WarpX::shared_tilesize);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -440,6 +440,11 @@ WarpX::WarpX ()
                     costs_heuristic_cells_wt = 0.250_rt;
                     costs_heuristic_particles_wt = 0.750_rt;
                     break;
+                case 4:
+		    // temporary
+                    costs_heuristic_cells_wt = 0.200_rt;
+                    costs_heuristic_particles_wt = 0.800_rt;
+                    break;
             }
         } else { // FDTD
             switch (WarpX::nox)
@@ -455,6 +460,11 @@ WarpX::WarpX ()
                 case 3:
                     costs_heuristic_cells_wt = 0.145_rt;
                     costs_heuristic_particles_wt = 0.855_rt;
+                    break;
+                case 4:
+		    // temporary
+                    costs_heuristic_cells_wt = 0.100_rt;
+                    costs_heuristic_particles_wt = 0.900_rt;
                     break;
             }
         }
@@ -1327,19 +1337,10 @@ WarpX::ReadParameters ()
         int particle_shape;
         if (!species_names.empty() || !lasers_names.empty()) {
             if (utils::parser::queryWithParser(pp_algo, "particle_shape", particle_shape)){
-
-                if(current_deposition_algo == CurrentDepositionAlgo::Villasenor) {
-                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                        (particle_shape >= 1) && (particle_shape <=4),
-                        "algo.particle_shape can be only 1, 2, 3, or 4 with villasenor deposition"
-                    );
-                }
-                else {
-                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                        (particle_shape >= 1) && (particle_shape <=3),
-                        "algo.particle_shape can be only 1, 2, or 3"
-                    );
-                }
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    (particle_shape >= 1) && (particle_shape <=4),
+                    "algo.particle_shape can be only 1, 2, 3, or 4"
+                );
 
                 nox = particle_shape;
                 noy = particle_shape;
@@ -1348,8 +1349,7 @@ WarpX::ReadParameters ()
             else{
                 WARPX_ABORT_WITH_MESSAGE(
                     "algo.particle_shape must be set in the input file:"
-                    " please set algo.particle_shape to 1, 2, or 3."
-                    " if using the villasenor deposition, can use 4 also.");
+                    " please set algo.particle_shape to 1, 2, 3, or 4");
             }
 
             if ((maxLevel() > 0) && (particle_shape > 1) && (do_pml_j_damping == 1))

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -441,7 +441,7 @@ WarpX::WarpX ()
                     costs_heuristic_particles_wt = 0.750_rt;
                     break;
                 case 4:
-		    // temporary
+                    // this is only a guess
                     costs_heuristic_cells_wt = 0.200_rt;
                     costs_heuristic_particles_wt = 0.800_rt;
                     break;
@@ -462,7 +462,7 @@ WarpX::WarpX ()
                     costs_heuristic_particles_wt = 0.855_rt;
                     break;
                 case 4:
-		    // temporary
+                    // this is only a guess
                     costs_heuristic_cells_wt = 0.100_rt;
                     costs_heuristic_particles_wt = 0.900_rt;
                     break;

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -200,6 +200,11 @@ deposit_charge (typename T_PC::ParIterType& pti,
                                     rho_fab, np_to_deposit.value(), dx, xyzmin, lo, charge,
                                     n_rz_azimuthal_modes, cost,
                                     load_balance_costs_update_algo);
+    } else if (nox == 4){
+        doChargeDepositionShapeN<4>(GetPosition, wp.dataPtr()+offset, ion_lev,
+                                    rho_fab, np_to_depose.value(), dx, xyzmin, lo, charge,
+                                    n_rz_azimuthal_modes, cost,
+                                    load_balance_costs_update_algo);
     }
     ABLASTR_PROFILE_VAR_STOP(blp_ppc_chd, do_device_synchronize);
 

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -200,11 +200,6 @@ deposit_charge (typename T_PC::ParIterType& pti,
                                     rho_fab, np_to_deposit.value(), dx, xyzmin, lo, charge,
                                     n_rz_azimuthal_modes, cost,
                                     load_balance_costs_update_algo);
-    } else if (nox == 4){
-        doChargeDepositionShapeN<4>(GetPosition, wp.dataPtr()+offset, ion_lev,
-                                    rho_fab, np_to_depose.value(), dx, xyzmin, lo, charge,
-                                    n_rz_azimuthal_modes, cost,
-                                    load_balance_costs_update_algo);
     }
     ABLASTR_PROFILE_VAR_STOP(blp_ppc_chd, do_device_synchronize);
 


### PR DESCRIPTION
Extension of 4th order particle shape to (hopefully all) other gather and deposition schemes

Motivation:

4th order particle shape improves energy conservation. This can be needed for laser-solid interaction problems if one does not use current filtering, especially if strong magnetic fields are present.

Overview of changes:

1. Added the 4th order case for Compute_shifted_shape_factor and the gather/deposition routines which were previously missing
2. Rewrote the 4th order shape factor to have fewer divisions/operations and be stylistically closer to the other cases. The new version is mathematically equivalent to the earlier version written by Justin Angus. The new version comes more-or-less directly from the pic code epoch
3. Added a test that includes 4th order particle shape to the regression testing suite

Benchmarking done:

1. Verified that this branch produces identical results as development for the regression test ImplicitPicard_VandB_2d, when particle_shape=4 is used
2.  Verified that warpx produces the same energy conservation/growth rates as epoch for a few different stable and unstable test cases (epoch corresponds to energy-conserving gather with galerkin_scheme=0 and esirkepov deposition)

Notes:

1. The choice of test problem was somewhat arbitrary, motivated by 1) including a check on charge conservation, and 2) trying to keep the the test cheap
2. Disclaimer: although I checked that this branch works with a variety of gather/deposition scenarios (including the default energy-conserving case), it's possible I may have missed some
