### PR TITLE
Fix Particle Id Overflows

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
         WARPX_CI_EB: 'TRUE'
 
   # default: 60; maximum: 360
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
 
   steps:
   # set up caches:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -115,7 +115,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach 68244ec91d118b5d4cc21f93376eaae8b56c51eb && cd -
+        cd ../amrex && git checkout --detach 99b47cb58a3c734ff9292226b952d7a79b351b72 && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 4
 
         ccache -s

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -115,7 +115,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach 99b47cb58a3c734ff9292226b952d7a79b351b72 && cd -
+        cd ../amrex && git checkout --detach 2230caa24c7d4bd07edb08b54e9368f9c73eae6e && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 4
 
         ccache -s

--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -36,17 +36,14 @@ A typical loop over particles reads:
       }
   }
 
-The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` to perform operations on all particles in a portable way. For this reasons, the particle data needs to be converted in plain-old-data structures. The innermost loop in the code snippet above could look like:
+The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` to perform operations on all particles in a portable way. The innermost loop in the code snippet above could look like:
 
 .. code-block:: cpp
 
-  // Get Array-Of-Struct particle data, also called data
-  // (x, y, z, id, cpu)
-  const auto& particles = pti.GetArrayOfStructs();
   // Get Struct-Of-Array particle data, also called attribs
-  // (ux, uy, uz, w, Exp, Ey, Ez, Bx, By, Bz)
+  // (x, y, z, ux, uy, uz, w)
   auto& attribs = pti.GetAttribs();
-  auto& Exp = attribs[PIdx::Ex];
+  auto& x = attribs[PIdx::x];
   // [...]
   // Number of particles in this box
   const long np = pti.numParticles();
@@ -66,7 +63,6 @@ On a loop over boxes in a ``MultiFab`` (``MFIter``), it can be useful to access 
   const int tile_id = mfi.LocalTileIndex();
   // Get GPU-friendly arrays of particle data
   auto& ptile = GetParticles(lev)[std::make_pair(grid_id,tile_id)];
-  ParticleType* pp = particle_tile.GetArrayOfStructs()().data();
   // Only need attribs (i.e., SoA data)
   auto& soa = ptile.GetStructOfArrays();
   // As an example, let's get the ux momentum

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 68244ec91d118b5d4cc21f93376eaae8b56c51eb
+branch = 99b47cb58a3c734ff9292226b952d7a79b351b72
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 99b47cb58a3c734ff9292226b952d7a79b351b72
+branch = 2230caa24c7d4bd07edb08b54e9368f9c73eae6e
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 68244ec91d118b5d4cc21f93376eaae8b56c51eb
+branch = 99b47cb58a3c734ff9292226b952d7a79b351b72
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 99b47cb58a3c734ff9292226b952d7a79b351b72
+branch = 2230caa24c7d4bd07edb08b54e9368f9c73eae6e
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Particles/ParticleCreation/SmartUtils.H
+++ b/Source/Particles/ParticleCreation/SmartUtils.H
@@ -49,7 +49,7 @@ SmartCopyTag getSmartCopyTag (const NameMap& src, const NameMap& dst) noexcept;
  * \param num_added the number of particles to set the ids for.
  */
 template <typename PTile>
-void setNewParticleIDs (PTile& ptile, int old_size, int num_added)
+void setNewParticleIDs (PTile& ptile, amrex::Long old_size, amrex::Long num_added)
 {
     amrex::Long pid;
 #ifdef AMREX_USE_OMP
@@ -64,8 +64,9 @@ void setNewParticleIDs (PTile& ptile, int old_size, int num_added)
     auto ptd = ptile.getParticleTileData();
     amrex::ParallelFor(num_added, [=] AMREX_GPU_DEVICE (int ip) noexcept
     {
-        auto const new_id = ip + old_size;
-        ptd.m_idcpu[new_id] = amrex::SetParticleIDandCPU(pid+ip, cpuid);
+        auto const lip = static_cast<amrex::Long>(ip);
+        auto const new_id = lip + old_size;
+        ptd.m_idcpu[new_id] = amrex::SetParticleIDandCPU(pid+lip, cpuid);
     });
 }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -51,7 +51,6 @@
 #include <AMReX_Algorithm.H>
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
-#include <AMReX_ArrayOfStructs.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -10,7 +10,6 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 
-#include <AMReX_ArrayOfStructs.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
 #include <AMReX_GpuLaunch.H>

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -273,7 +273,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "99b47cb58a3c734ff9292226b952d7a79b351b72"
+set(WarpX_amrex_branch "2230caa24c7d4bd07edb08b54e9368f9c73eae6e"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -273,7 +273,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "68244ec91d118b5d4cc21f93376eaae8b56c51eb"
+set(WarpX_amrex_branch "99b47cb58a3c734ff9292226b952d7a79b351b72"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -79,7 +79,7 @@ option(WarpX_pyamrex_internal "Download & build pyAMReX" ON)
 set(WarpX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(WarpX_pyamrex_internal)")
-set(WarpX_pyamrex_branch "5aa700de18a61f933cb435adbe2299d74d794d6b"
+set(WarpX_pyamrex_branch "0cbf4b08c9045e1845595c836b99f94bb3c1ac9f"
     CACHE STRING
     "Repository branch for WarpX_pyamrex_repo if(WarpX_pyamrex_internal)")
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -68,7 +68,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 68244ec91d118b5d4cc21f93376eaae8b56c51eb && cd -
+cd amrex && git checkout --detach 99b47cb58a3c734ff9292226b952d7a79b351b72 && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 # openPMD-example-datasets contains various required data sets

--- a/run_test.sh
+++ b/run_test.sh
@@ -68,7 +68,7 @@ python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
-cd amrex && git checkout --detach 99b47cb58a3c734ff9292226b952d7a79b351b72 && cd -
+cd amrex && git checkout --detach 2230caa24c7d4bd07edb08b54e9368f9c73eae6e && cd -
 # warpx-data contains various required data sets
 git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
 # openPMD-example-datasets contains various required data sets


### PR DESCRIPTION
- [x] add https://github.com/AMReX-Codes/amrex/pull/3772
- [x] fix other `int`/`Long` mismatches for particle ids from #4653 that lead to overflows if locally more than 2e9 particles were created over time (e.g., leading GPUs in moving window sims)

Weekly update to latest AMReX.
Weekly update to latest pyAMReX.
Weekly update to latest PICSAR (no changes).

```console
./Tools/Release/updateAMReX.py
./Tools/Release/updatepyAMReX.py
./Tools/Release/updatePICSAR.py
```