### PR TITLE
Update of the time saved for scraped particles on the boundaries

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1539,7 +1539,7 @@ are applied to the grid directly. In particular, these fields can be seen in the
     ``warpx.Bz_external_grid_function(x,y,z)`` to initialize the external
     magnetic field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
-    For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + *(y + z)``
+    For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + delta*(y + z)``
     then the constants `Bo` and `` required in the above equation
     can be set using ``my_constants.Bo=`` and ``my_constants.delta=`` in the
     input file. For a two-dimensional simulation, it is assumed that the first dimension

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -416,9 +416,9 @@ Domain Boundary Conditions
 
 * ``boundary.verboncoeur_axis_correction`` (`bool`) optional (default `true`)
     Whether to apply the Verboncoeur correction on the charge and current density on axis when using RZ.
-    For nodal values (rho and Jz), the cell volume for values on axis is calculated as :math:`\pi*\Delta r^2/4`.
+    For nodal values (rho and Jz), the cell volume for values on axis is calculated as :math:`\pi*\ r^2/4`.
     In :cite:t:`param-VerboncoeurJCP2001`, it is shown that using
-    :math:`\pi*\Delta r^2/3` instead will give a uniform density if the particle density is uniform.
+    :math:`\pi*\ r^2/3` instead will give a uniform density if the particle density is uniform.
 
 Additional PML parameters
 -------------------------
@@ -430,7 +430,7 @@ Additional PML parameters
     Whether or not to use an amrex::DistributionMapping for the PML grids that is `similar` to the mother grids, meaning that the
     mapping will be computed to minimize the communication costs between the PML and the mother grids.
 
-* ``warpx.pml_delta`` (`int`; default: 10)
+* ``warpx.pml_`` (`int`; default: 10)
     The characteristic depth, in number of cells, over which
     the absorption coefficients of the PML increases.
 
@@ -1453,8 +1453,8 @@ Laser initialization
 
 * ``<laser_name>.phi2`` (`float`; in seconds**2) optional (default `0.`)
     The amount of temporal chirp :math:`\phi^{(2)}` at focus (in the lab frame). Namely, a wave packet
-    centered on the frequency :math:`(\omega_0 + \delta \omega)` will reach its peak intensity
-    at :math:`z(\delta \omega) = z_0 - c \phi^{(2)} \, \delta \omega`. Thus, a positive
+    centered on the frequency :math:`(\omega_0 + \ \omega)` will reach its peak intensity
+    at :math:`z(\ \omega) = z_0 - c \phi^{(2)} \, \ \omega`. Thus, a positive
     :math:`\phi^{(2)}` corresponds to positive chirp, i.e. red part of the spectrum in the
     front of the pulse and blue part of the spectrum in the back. More specifically, the electric
     field in the focal plane is of the form:
@@ -1539,8 +1539,8 @@ are applied to the grid directly. In particular, these fields can be seen in the
     ``warpx.Bz_external_grid_function(x,y,z)`` to initialize the external
     magnetic field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
-    For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + delta*(y + z)``
-    then the constants `Bo` and `delta` required in the above equation
+    For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + *(y + z)``
+    then the constants `Bo` and `` required in the above equation
     can be set using ``my_constants.Bo=`` and ``my_constants.delta=`` in the
     input file. For a two-dimensional simulation, it is assumed that the first dimension
     is `x` and the second dimension is `z`, and the value of `y` is set to zero.
@@ -2754,7 +2754,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 
 In addition to their usual attributes, the saved particles have an integer attribute ``stepScraped``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary,
-and a real attribute ``delta``, which indicates the fraction of time between the time associated to the last step
+and a real attribute ``deltaTimeScraped``, which indicates the fraction of time between the time associated to the last step
 and the exact time when each particle hits the boundary. ``delta`` is a real between 0 and dt.
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2752,10 +2752,10 @@ The data collected at each boundary is written out to a subdirectory of the diag
 By default, all of the collected particle data is written out at the end of the simulation. Optionally, the ``<diag_name>.intervals`` parameter can be given to specify writing out the data more often.
 This can be important if a large number of particles are lost, avoiding filling up memory with the accumulated lost particle data.
 
-In addition to their usual attributes, the saved particles have an integer attribute ``step_scraped``, which
+In addition to their usual attributes, the saved particles have an integer attribute ``stepScraped``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary,
-and a real attribute ``time_scraped``, which indicates the exact time calculated when each
-particle hits the EB.
+and a real attribute ``delta``, which indicates the fraction of time between the time associated to the last step 
+and the exact time when each particle hits the boundary. ``delta`` is a real between 0 and dt.
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1454,7 +1454,7 @@ Laser initialization
 * ``<laser_name>.phi2`` (`float`; in seconds**2) optional (default `0.`)
     The amount of temporal chirp :math:`\phi^{(2)}` at focus (in the lab frame). Namely, a wave packet
     centered on the frequency :math:`(\omega_0 + \delta \omega)` will reach its peak intensity
-    at :math:`z(\ \omega) = z_0 - c \phi^{(2)} \, \ \omega`. Thus, a positive
+    at :math:`z(\delta \omega) = z_0 - c \phi^{(2)} \, \delta \omega`. Thus, a positive
     :math:`\phi^{(2)}` corresponds to positive chirp, i.e. red part of the spectrum in the
     front of the pulse and blue part of the spectrum in the back. More specifically, the electric
     field in the focal plane is of the form:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -416,9 +416,9 @@ Domain Boundary Conditions
 
 * ``boundary.verboncoeur_axis_correction`` (`bool`) optional (default `true`)
     Whether to apply the Verboncoeur correction on the charge and current density on axis when using RZ.
-    For nodal values (rho and Jz), the cell volume for values on axis is calculated as :math:`\pi*\ r^2/4`.
+    For nodal values (rho and Jz), the cell volume for values on axis is calculated as :math:`\pi*\Delta r^2/4`.
     In :cite:t:`param-VerboncoeurJCP2001`, it is shown that using
-    :math:`\pi*\ r^2/3` instead will give a uniform density if the particle density is uniform.
+    :math:`\pi*\Delta r^2/3` instead will give a uniform density if the particle density is uniform.
 
 Additional PML parameters
 -------------------------

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2754,7 +2754,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 
 In addition to their usual attributes, the saved particles have an integer attribute ``stepScraped``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary,
-and a real attribute ``delta``, which indicates the fraction of time between the time associated to the last step 
+and a real attribute ``delta``, which indicates the fraction of time between the time associated to the last step
 and the exact time when each particle hits the boundary. ``delta`` is a real between 0 and dt.
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1453,7 +1453,7 @@ Laser initialization
 
 * ``<laser_name>.phi2`` (`float`; in seconds**2) optional (default `0.`)
     The amount of temporal chirp :math:`\phi^{(2)}` at focus (in the lab frame). Namely, a wave packet
-    centered on the frequency :math:`(\omega_0 + \ \omega)` will reach its peak intensity
+    centered on the frequency :math:`(\omega_0 + \delta \omega)` will reach its peak intensity
     at :math:`z(\ \omega) = z_0 - c \phi^{(2)} \, \ \omega`. Thus, a positive
     :math:`\phi^{(2)}` corresponds to positive chirp, i.e. red part of the spectrum in the
     front of the pulse and blue part of the spectrum in the back. More specifically, the electric

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -430,7 +430,7 @@ Additional PML parameters
     Whether or not to use an amrex::DistributionMapping for the PML grids that is `similar` to the mother grids, meaning that the
     mapping will be computed to minimize the communication costs between the PML and the mother grids.
 
-* ``warpx.pml_`` (`int`; default: 10)
+* ``warpx.pml_delta`` (`int`; default: 10)
     The characteristic depth, in number of cells, over which
     the absorption coefficients of the PML increases.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1540,7 +1540,7 @@ are applied to the grid directly. In particular, these fields can be seen in the
     magnetic field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
     For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + delta*(y + z)``
-    then the constants `Bo` and `` required in the above equation
+    then the constants `Bo` and `delta` required in the above equation
     can be set using ``my_constants.Bo=`` and ``my_constants.delta=`` in the
     input file. For a two-dimensional simulation, it is assumed that the first dimension
     is `x` and the second dimension is `z`, and the value of `y` is set to zero.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2755,7 +2755,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 In addition to their usual attributes, the saved particles have an integer attribute ``stepScraped``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary,
 and a real attribute ``deltaTimeScraped``, which indicates the fraction of time between the time associated to the last step
-and the exact time when each particle hits the boundary. ``delta`` is a real between 0 and dt.
+and the exact time when each particle hits the boundary. ``deltaTimeScraped`` is a real between 0 and dt.
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2755,7 +2755,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 In addition to their usual attributes, the saved particles have an integer attribute ``stepScraped``, which
 indicates the PIC iteration at which each particle was absorbed at the boundary,
 and a real attribute ``deltaTimeScraped``, which indicates the fraction of time between the time associated to the last step
-and the exact time when each particle hits the boundary. ``deltaTimeScraped`` is a real between 0 and dt.
+and the exact time when each particle hits the boundary. ``deltaTimeScraped`` is a real between ``0`` and ``dt``.
 
 ``BoundaryScrapingDiagnostics`` can be used with ``<diag_name>.<species>.random_fraction``, ``<diag_name>.<species>.uniform_stride``, and ``<diag_name>.<species>.plot_filter_function``, which have the same behavior as for ``FullDiagnostics``. For ``BoundaryScrapingDiagnostics``, these filters are applied at the time the data is written to file. An implication of this is that more particles may initially be accumulated in memory than are ultimately written. ``t`` in ``plot_filter_function`` refers to the time the diagnostic is written rather than the time the particle crossed the boundary.
 

--- a/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
+++ b/Examples/Tests/particle_boundary_process/PICMI_inputs_reflection.py
@@ -131,12 +131,12 @@ n = buffer.get_particle_boundary_buffer_size("electrons", 'z_lo')
 print("Number of electrons in lower buffer:", n)
 assert n == 67
 
-scraped_steps = buffer.get_particle_boundary_buffer("electrons", 'z_hi', 'step_scraped', 0)
+scraped_steps = buffer.get_particle_boundary_buffer("electrons", 'z_hi', 'stepScraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 4)
 
-scraped_steps = buffer.get_particle_boundary_buffer("electrons", 'z_lo', 'step_scraped', 0)
+scraped_steps = buffer.get_particle_boundary_buffer("electrons", 'z_lo', 'stepScraped', 0)
 for arr in scraped_steps:
     # print(arr)
     assert all(arr == 8)

--- a/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
+++ b/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
@@ -133,7 +133,7 @@ n = particle_buffer.get_particle_boundary_buffer_size("electrons", 'eb')
 print(f"Number of electrons in buffer (proc #{my_id}): {n}")
 assert n == 612
 
-scraped_steps = particle_buffer.get_particle_boundary_buffer("electrons", 'eb', 'step_scraped', 0)
+scraped_steps = particle_buffer.get_particle_boundary_buffer("electrons", 'eb', 'stepScraped', 0)
 for arr in scraped_steps:
     assert all(np.array(arr, copy=False) > 40)
 

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -27,7 +27,7 @@ ts_scraping = OpenPMDTimeSeries('./diags/diag2/particles_at_eb/')
 
 it=ts_scraping.iterations
 step_scraped, delta, x, y, z=ts_scraping.get_particle( ['stepScraped','delta','x','y','z'], species='electron', iteration=it )
-delta_reduced=time_scraped[0]*1e10
+delta_reduced=delta[0]*1e10
 
 # Analytical results calculated
 x_analytic=-0.1983

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -26,8 +26,8 @@ checksumAPI.evaluate_checksum(test_name, filename, output_format='openpmd')
 ts_scraping = OpenPMDTimeSeries('./diags/diag2/particles_at_eb/')
 
 it=ts_scraping.iterations
-step_scraped, time_scraped, x, y, z, nx, ny, nz=ts_scraping.get_particle( ['stepScraped','timeScraped','x','y','z', 'nx', 'ny', 'nz'], species='electron', iteration=it )
-time_scraped_reduced=time_scraped[0]*1e10
+step_scraped, delta, x, y, z, nx, ny, nz=ts_scraping.get_particle( ['stepScraped','deltaTimeScraped','x','y','z', 'nx', 'ny', 'nz'], species='electron', iteration=it )
+delta_reduced=delta[0]*1e10
 
 # Analytical results calculated
 x_analytic=-0.1983

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -67,4 +67,4 @@ print("percentage error for nx = %5.2f %%" %(diff_nx *100))
 print("percentage error for ny = %5.2f %%" %(diff_ny *100))
 print("nz = %5.2f " %(nz[0]))
 
-assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_time < tolerance_t) and (diff_nx < tolerance_n) and (diff_ny < tolerance_n) and (np.abs(nz) < 1e-8) , 'Test point_of_contact did not pass'
+assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_delta < tolerance_t) and (diff_nx < tolerance_n) and (diff_ny < tolerance_n) and (np.abs(nz) < 1e-8) , 'Test point_of_contact did not pass'

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -26,7 +26,7 @@ checksumAPI.evaluate_checksum(test_name, filename, output_format='openpmd')
 ts_scraping = OpenPMDTimeSeries('./diags/diag2/particles_at_eb/')
 
 it=ts_scraping.iterations
-step_scraped, delta, x, y, z=ts_scraping.get_particle( ['stepScraped','delta','x','y','z'], species='electron', iteration=it )
+step_scraped, delta, x, y, z=ts_scraping.get_particle( ['stepScraped','deltaTimeScraped','x','y','z'], species='electron', iteration=it )
 delta_reduced=delta[0]*1e10
 
 # Analytical results calculated

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -36,7 +36,7 @@ z_analytic=0.0000
 
 #result obtained by analysis of simulations
 step_ref=3
-delta_reduced_ref=0.58
+delta_reduced_ref=0.59
 
 print('NUMERICAL coordinates of the point of contact:')
 print('step_scraped=%d, delta=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0]))

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -42,13 +42,13 @@ step_ref=3
 delta_reduced_ref=0.59
 
 print('NUMERICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step_scraped[0],time_reduced,x[0], y[0], z[0], nx[0], ny[0], nz[0]))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0], nx[0], ny[0], nz[0]))
 print('\n')
 print('ANALYTICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step, time_reduced, x_analytic, y_analytic, z_analytic, nx_analytic, ny_analytic, nz_analytic))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step, delta_reduced_ref, x_analytic, y_analytic, z_analytic, nx_analytic, ny_analytic, nz_analytic))
 
 tolerance=0.001
-tolerance_t=0.003
+tolerance_t=0.01
 tolerance_n=0.01
 print("tolerance = "+ str(tolerance *100) + '%')
 print("tolerance for the time = "+ str(tolerance_t *100) + '%')

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -45,7 +45,7 @@ print('NUMERICAL coordinates of the point of contact:')
 print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0], nx[0], ny[0], nz[0]))
 print('\n')
 print('ANALYTICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step, delta_reduced_ref, x_analytic, y_analytic, z_analytic, nx_analytic, ny_analytic, nz_analytic))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f, nx=%5.4f, ny=%5.4f, nz=%5.4f' % (step_ref, delta_reduced_ref, x_analytic, y_analytic, z_analytic, nx_analytic, ny_analytic, nz_analytic))
 
 tolerance=0.001
 tolerance_t=0.01

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -39,13 +39,13 @@ step_ref=3
 delta_reduced_ref=0.58
 
 print('NUMERICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0]))
+print('step_scraped=%d, delta=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0]))
 print('\n')
 print('ANALYTICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_ref, delta_reduced_ref, x_analytic, y_analytic, z_analytic))
+print('step_scraped=%d, delta=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_ref, delta_reduced_ref, x_analytic, y_analytic, z_analytic))
 
 tolerance=0.001
-tolerance_t=0.003
+tolerance_t=0.01
 print("tolerance = "+ str(tolerance *100) + '%')
 print("tolerance for the time = "+ str(tolerance_t *100) + '%')
 

--- a/Examples/Tests/point_of_contact_EB/analysis.py
+++ b/Examples/Tests/point_of_contact_EB/analysis.py
@@ -26,8 +26,8 @@ checksumAPI.evaluate_checksum(test_name, filename, output_format='openpmd')
 ts_scraping = OpenPMDTimeSeries('./diags/diag2/particles_at_eb/')
 
 it=ts_scraping.iterations
-step_scraped, time_scraped, x, y, z=ts_scraping.get_particle( ['stepScraped','timeScraped','x','y','z'], species='electron', iteration=it )
-time_scraped_reduced=time_scraped[0]*1e10
+step_scraped, delta, x, y, z=ts_scraping.get_particle( ['stepScraped','delta','x','y','z'], species='electron', iteration=it )
+delta_reduced=time_scraped[0]*1e10
 
 # Analytical results calculated
 x_analytic=-0.1983
@@ -35,26 +35,26 @@ y_analytic=0.02584
 z_analytic=0.0000
 
 #result obtained by analysis of simulations
-step=3
-time_reduced=3.58
+step_ref=3
+delta_reduced_ref=0.58
 
 print('NUMERICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],time_reduced,x[0], y[0], z[0]))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_scraped[0],delta_reduced,x[0], y[0], z[0]))
 print('\n')
 print('ANALYTICAL coordinates of the point of contact:')
-print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step, time_reduced, x_analytic, y_analytic, z_analytic))
+print('step_scraped=%d, time_stamp=%5.4f e-10, x=%5.4f, y=%5.4f, z=%5.4f' % (step_ref, delta_reduced_ref, x_analytic, y_analytic, z_analytic))
 
 tolerance=0.001
 tolerance_t=0.003
 print("tolerance = "+ str(tolerance *100) + '%')
 print("tolerance for the time = "+ str(tolerance_t *100) + '%')
 
-diff_step=np.abs((step_scraped[0]-step)/step)
-diff_time=np.abs((time_scraped_reduced-time_reduced)/time_reduced)
+diff_step=np.abs((step_scraped[0]-step_ref)/step_ref)
+diff_delta=np.abs((delta_reduced-delta_reduced_ref)/delta_reduced_ref)
 diff_x=np.abs((x[0]-x_analytic)/x_analytic)
 diff_y=np.abs((y[0]-y_analytic)/y_analytic)
 
 print("percentage error for x = %5.4f %%" %(diff_x *100))
 print("percentage error for y = %5.4f %%" %(diff_y *100))
 
-assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_time < tolerance_t) , 'Test point_of_contact did not pass'
+assert (diff_x < tolerance) and (diff_y < tolerance) and (np.abs(z[0]) < 1e-8) and (diff_step < 1e-8) and (diff_delta < tolerance_t) , 'Test point_of_contact did not pass'

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -774,7 +774,7 @@ class ParticleBoundaryBufferWrapper(object):
             comp_name      : str
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
-                "step_scraped","time_scraped", "nx", "ny", "nz"
+                "stepScraped","delta", "nx", "ny", "nz"
 
             level          : int
                 Which AMR level to retrieve scraped particle data from.

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -774,7 +774,6 @@ class ParticleBoundaryBufferWrapper(object):
             comp_name      : str
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
-
                 "stepScraped","deltaTimeScraped",
                 if boundary='eb': "nx", "ny", "nz"
 

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -775,7 +775,7 @@ class ParticleBoundaryBufferWrapper(object):
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
 
-                "stepScraped","timeScraped",
+                "stepScraped","deltaTimeScraped",
                 if boundary='eb': "nx", "ny", "nz"
 
             level          : int

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -774,7 +774,7 @@ class ParticleBoundaryBufferWrapper(object):
             comp_name      : str
                 The component of the array data that will be returned.
                 "x", "y", "z", "ux", "uy", "uz", "w"
-                "stepScraped","delta", "nx", "ny", "nz"
+                "stepScraped","deltaTimeScraped", "nx", "ny", "nz"
 
             level          : int
                 Which AMR level to retrieve scraped particle data from.

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -133,7 +133,7 @@ struct CopyAndTimestamp {
     int m_step_index;
     int m_delta_index;
     int m_step;
-    int m_dt;
+    const amrex::Real m_dt;
 
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -397,7 +397,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
         {
             buffer[i] = pc.make_alike<amrex::PinnedArenaAllocator>();
             buffer[i].AddIntComp("stepScraped", false);
-            buffer[i].AddRealComp("delta", false);
+            buffer[i].AddRealComp("deltaTimeScraped", false);
         }
         auto& species_buffer = buffer[i];
         for (int lev = 0; lev < pc.numLevels(); ++lev)
@@ -453,7 +453,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                 auto string_to_index_intcomp = buffer[i].getParticleRuntimeiComps();
                 const int step_scraped_index = string_to_index_intcomp.at("stepScraped");
                 auto string_to_index_realcomp = buffer[i].getParticleRuntimeComps();
-                const int delta_index = string_to_index_realcomp.at("delta");
+                const int delta_index = string_to_index_realcomp.at("deltaTimeScraped");
                 const int step = warpx_instance.getistep(0);
 
                 {

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -151,7 +151,7 @@ struct CopyAndTimestamp {
             dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][src_i];
         }
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_idata[m_delta_index][dst_i] = 0*m_dt; //delta_fraction is putted as zero, we need to calculate it  
+        dst.m_runtime_idata[m_delta_index][dst_i] = 0*m_dt; //delta_fraction is putted as zero, we need to calculate it
         \\\\\\\\\\\\\\\\\\\TO DO\\\\\\\\\\\\\\\\\\\\\\\\\\
     }
 };

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -151,7 +151,7 @@ struct CopyAndTimestamp {
             dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][src_i];
         }
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_idata[m_delta_index][dst_i] = 0*m_dt; //delta_fraction is putted as zero, we need to calculate it
+        dst.m_runtime_idata[m_delta_index][dst_i] = 0._rt; //delta_fraction is initialized to zero
     }
 };
 

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -101,7 +101,7 @@ struct FindEmbeddedBoundaryIntersection {
 
         // Also record the real time on the destination
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_rdata[m_time_index][dst_i] = (1- dt_fraction)*m_dt;
+        dst.m_runtime_rdata[m_delta_index][dst_i] = (1- dt_fraction)*m_dt;
 
         // Now that dt_fraction has be obtained (with bisect)
         // Save the corresponding position of the particle at the boundary

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -22,6 +22,7 @@
 #include <AMReX_Tuple.H>
 #include <AMReX.H>
 #include <AMReX_Algorithm.H>
+using namespace amrex::literals;
 
 struct IsOutsideDomainBoundary {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> m_plo;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -152,7 +152,7 @@ struct CopyAndTimestamp {
             dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][src_i];
         }
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_idata[m_delta_index][dst_i] = 0._rt; //delta_fraction is initialized to zero
+        dst.m_runtime_rdata[m_delta_index][dst_i] = 0._rt; //delta_fraction is initialized to zero
     }
 };
 

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -152,7 +152,6 @@ struct CopyAndTimestamp {
         }
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
         dst.m_runtime_idata[m_delta_index][dst_i] = 0*m_dt; //delta_fraction is putted as zero, we need to calculate it
-        \\\\\\\\\\\\\\\\\\\TO DO\\\\\\\\\\\\\\\\\\\\\\\\\\
     }
 };
 

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -101,7 +101,7 @@ struct FindEmbeddedBoundaryIntersection {
 
         // Also record the real time on the destination
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_rdata[m_delta_index][dst_i] = (1- dt_fraction)*m_dt;
+        dst.m_runtime_rdata[m_delta_index][dst_i] = (1._rt- dt_fraction)*m_dt;
 
         // Now that dt_fraction has be obtained (with bisect)
         // Save the corresponding position of the particle at the boundary


### PR DESCRIPTION
Update of the PR #4695
From the buffer of scraped particles, we can have access now to:
-the integer "stepScraped" which corresponds to the PIC iterations just before each particle hits boundaries (EB + regular boundaries)
-The real "deltaTimeScraped" which corresponds to the fraction of time between the time associated with the last step and the exact time when each particle hits an EB (for the regular boundaries, it is equal to 0 --> we still need to calculate it). This real is between 0 and dt.


