### PR TITLE
openPMD: Fix Particle Weight Dims in 1D/2D

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -319,9 +319,9 @@ namespace detail
             return {{openPMD::UnitDimension::M, 1.}};
         } else if( record_name == "weighting" ) {
 #if defined(WARPX_DIM_1D_Z)
-            return {{openPMD::UnitDimension::L,  -2.}};
+            return {{openPMD::UnitDimension::L, -2.}};
 #elif defined(WARPX_DIM_XZ)
-            return {{openPMD::UnitDimension::L,  -1.}};
+            return {{openPMD::UnitDimension::L, -1.}};
 #else  // 3D and RZ
             return {};
 #endif

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -316,7 +316,17 @@ namespace detail
             return {{openPMD::UnitDimension::T,  1.},
                     {openPMD::UnitDimension::I,  1.}};
         } else if( record_name == "mass" ) {
-            return {{openPMD::UnitDimension::M,  1.}};
+            return {{openPMD::UnitDimension::M, 1.}};
+        } else if( record_name == "weighting" ) {
+#if defined(WARPX_DIM_1D_Z)
+            return {{openPMD::UnitDimension::L,  -2.}};
+#elif defined(WARPX_DIM_XZ)
+            return {{openPMD::UnitDimension::L,  -1.}};
+#elif defined(WARPX_DIM_RZ)
+            return {};
+#else
+            return {};
+#endif
         } else if( record_name == "E" ) {
             return {{openPMD::UnitDimension::L,  1.},
                     {openPMD::UnitDimension::M,  1.},

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -322,9 +322,7 @@ namespace detail
             return {{openPMD::UnitDimension::L,  -2.}};
 #elif defined(WARPX_DIM_XZ)
             return {{openPMD::UnitDimension::L,  -1.}};
-#elif defined(WARPX_DIM_RZ)
-            return {};
-#else
+#else  // 3D and RZ
             return {};
 #endif
         } else if( record_name == "E" ) {


### PR DESCRIPTION
Weighting of a macro particle is a count in 3D and RZ sims, but a count per line in 2D and a count per surface in 1D.

This reflects this now in the `weighting` attribute `unitDimensions`.