### PR TITLE
Enable different types of diagnostics for ParticleDiagnostic() in Python

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2404,7 +2404,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
     def init(self, kw):
 
         self.format = kw.pop('warpx_format', 'plotfile')
-        self.type = kw.pop('warpx_diag_type', None)
+        self.type = kw.pop('warpx_diag_type', 'Full')
         self.openpmd_backend = kw.pop('warpx_openpmd_backend', None)
         self.file_prefix = kw.pop('warpx_file_prefix', None)
         self.file_min_digits = kw.pop('warpx_file_min_digits', None)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2383,6 +2383,9 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
     warpx_format: {plotfile, checkpoint, openpmd, ascent, sensei}, optional
         Diagnostic file format
 
+    warpx_diag_type: {Full, BoundaryScraping, BackTransformed}, 'Full' by default, optional
+        Diagnostic type
+
     warpx_openpmd_backend: {bp, h5, json}, optional
         Openpmd backend file format
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2404,6 +2404,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
     def init(self, kw):
 
         self.format = kw.pop('warpx_format', 'plotfile')
+        self.type = kw.pop('warpx_diag_type', None)
         self.openpmd_backend = kw.pop('warpx_openpmd_backend', None)
         self.file_prefix = kw.pop('warpx_file_prefix', None)
         self.file_min_digits = kw.pop('warpx_file_min_digits', None)
@@ -2426,7 +2427,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
 
         self.add_diagnostic()
 
-        self.diagnostic.diag_type = 'Full'
+        self.diagnostic.diag_type = self.type
         self.diagnostic.format = self.format
         self.diagnostic.openpmd_backend = self.openpmd_backend
         self.diagnostic.file_min_digits = self.file_min_digits


### PR DESCRIPTION
This PR enables to have the file of ``ParticleDiagnostic`` with different type ("Full", "BoundaryScraping" or "BackTransformed").
This is possible in adding the option `warpx_diag_type` in ``picmi.ParticleDiagnostic()``
The option warpx_diag_type='Full' is set by default.