### PR TITLE
Add function to set domain boundary potentials from Python

### DIFF
--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -90,6 +90,12 @@ This object is the Python equivalent to the C++ ``WarpX`` simulation class.
 
    .. py:method:: get_particle_boundary_buffer
 
+   .. py:method:: set_potential_on_domain_boundary(potential_[lo/hi]_[x/y/z]: str)
+
+      The potential on the domain boundaries can be modified when using the electrostatic solver.
+      This function updates the strings and function parsers which set the domain
+      boundary potentials during the Poisson solve.
+
    .. py:method:: set_potential_on_eb(potential: str)
 
       The embedded boundary (EB) conditions can be modified when using the electrostatic solver.

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -170,6 +170,34 @@ The physical fields in WarpX have the following naming:
             "Get the current physical time step size on mesh-refinement level ``lev``."
         )
 
+        .def("set_potential_on_domain_boundary",
+            [](WarpX& wx,
+               std::string potential_xlo, std::string potential_xhi,
+               std::string potential_ylo, std::string potential_yhi,
+               std::string potential_zlo, std::string potential_zhi)
+            {
+                if (potential_xlo != "")
+                    wx.m_poisson_boundary_handler.potential_xlo_str = potential_xlo;
+                if (potential_xhi != "")
+                    wx.m_poisson_boundary_handler.potential_xhi_str = potential_xhi;
+                if (potential_ylo != "")
+                    wx.m_poisson_boundary_handler.potential_ylo_str = potential_ylo;
+                if (potential_yhi != "")
+                    wx.m_poisson_boundary_handler.potential_yhi_str = potential_yhi;
+                if (potential_zlo != "")
+                    wx.m_poisson_boundary_handler.potential_zlo_str = potential_zlo;
+                if (potential_zhi != "")
+                    wx.m_poisson_boundary_handler.potential_zhi_str = potential_zhi;
+                wx.m_poisson_boundary_handler.buildParsers();
+            },
+            py::arg("potential_xlo") = "",
+            py::arg("potential_xhi") = "",
+            py::arg("potential_ylo") = "",
+            py::arg("potential_yhi") = "",
+            py::arg("potential_zlo") = "",
+            py::arg("potential_zhi") = "",
+            "Sets the domain boundary potential string(s) and updates the function parser."
+        )
         .def("set_potential_on_eb",
             [](WarpX& wx, std::string potential) {
                 wx.m_poisson_boundary_handler.setPotentialEB(potential);

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -172,30 +172,24 @@ The physical fields in WarpX have the following naming:
 
         .def("set_potential_on_domain_boundary",
             [](WarpX& wx,
-               std::string potential_xlo, std::string potential_xhi,
-               std::string potential_ylo, std::string potential_yhi,
-               std::string potential_zlo, std::string potential_zhi)
+               std::string potential_lo_x, std::string potential_hi_x,
+               std::string potential_lo_y, std::string potential_hi_y,
+               std::string potential_lo_z, std::string potential_hi_z)
             {
-                if (potential_xlo != "")
-                    wx.m_poisson_boundary_handler.potential_xlo_str = potential_xlo;
-                if (potential_xhi != "")
-                    wx.m_poisson_boundary_handler.potential_xhi_str = potential_xhi;
-                if (potential_ylo != "")
-                    wx.m_poisson_boundary_handler.potential_ylo_str = potential_ylo;
-                if (potential_yhi != "")
-                    wx.m_poisson_boundary_handler.potential_yhi_str = potential_yhi;
-                if (potential_zlo != "")
-                    wx.m_poisson_boundary_handler.potential_zlo_str = potential_zlo;
-                if (potential_zhi != "")
-                    wx.m_poisson_boundary_handler.potential_zhi_str = potential_zhi;
+                if (potential_lo_x != "") wx.m_poisson_boundary_handler.potential_xlo_str = potential_lo_x;
+                if (potential_hi_x != "") wx.m_poisson_boundary_handler.potential_xhi_str = potential_hi_x;
+                if (potential_lo_y != "") wx.m_poisson_boundary_handler.potential_ylo_str = potential_lo_y;
+                if (potential_hi_y != "") wx.m_poisson_boundary_handler.potential_yhi_str = potential_hi_y;
+                if (potential_lo_z != "") wx.m_poisson_boundary_handler.potential_zlo_str = potential_lo_z;
+                if (potential_hi_z != "") wx.m_poisson_boundary_handler.potential_zhi_str = potential_hi_z;
                 wx.m_poisson_boundary_handler.buildParsers();
             },
-            py::arg("potential_xlo") = "",
-            py::arg("potential_xhi") = "",
-            py::arg("potential_ylo") = "",
-            py::arg("potential_yhi") = "",
-            py::arg("potential_zlo") = "",
-            py::arg("potential_zhi") = "",
+            py::arg("potential_lo_x") = "",
+            py::arg("potential_hi_x") = "",
+            py::arg("potential_lo_y") = "",
+            py::arg("potential_hi_y") = "",
+            py::arg("potential_lo_z") = "",
+            py::arg("potential_hi_z") = "",
             "Sets the domain boundary potential string(s) and updates the function parser."
         )
         .def("set_potential_on_eb",


### PR DESCRIPTION
Fixes #4715.

Functionality is added to allow a python user to update the potentials on the domain boundaries, similar to how one can already update the potential on an embedded boundary.