### PR TITLE
Adding normal components to regular boundary buffer

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -167,6 +167,7 @@ struct CopyAndTimestamp {
     int m_delta_index;
     int m_normal_index;
     int m_step;
+    const amrex::Real m_dt;
     int m_idim;
     int m_iside;
 
@@ -421,6 +422,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                         {
                           WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::filterAndTransform");
                           auto& warpx = WarpX::GetInstance();
+                          const auto dt = warpx.getdt(pti.GetLevel());
                           auto string_to_index_intcomp = buffer[i].getParticleRuntimeiComps();
                           const int step_scraped_index = string_to_index_intcomp.at("stepScraped");
                           auto string_to_index_realcomp = buffer[i].getParticleRuntimeComps();
@@ -429,7 +431,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                           const int step = warpx_instance.getistep(0);
                           amrex::filterAndTransformParticles(ptile_buffer, ptile,
                                                              predicate,
-                                                             CopyAndTimestamp{step_scraped_index, delta_index, normal_index, step, idim, iside},
+                                                             CopyAndTimestamp{step_scraped_index, delta_index, normal_index, step, dt, idim, iside},
                                                              0, dst_index);
                         }
                     }

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -169,7 +169,7 @@ struct CopyAndTimestamp {
     int m_step;
     int m_idim;
     int m_iside;
-    
+
 
     template <typename DstData, typename SrcData>
     AMREX_GPU_HOST_DEVICE
@@ -188,10 +188,10 @@ struct CopyAndTimestamp {
         }
 
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_rdata[m_delta_index][dst_i] = 0._rt; 
+        dst.m_runtime_rdata[m_delta_index][dst_i] = 0._rt;
 
         //calculation of the normal to the boundary
-        std::array<double, 3> n = {0.0, 0.0, 0.0}; 
+        std::array<double, 3> n = {0.0, 0.0, 0.0};
         n[m_idim]=1-2*m_iside;
         dst.m_runtime_rdata[m_normal_index][dst_i]= n[0];
         dst.m_runtime_rdata[m_normal_index+1][dst_i]= n[1];
@@ -401,7 +401,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
                         if (np == 0) { continue; }
 
                         auto predicate = IsOutsideDomainBoundary{plo, phi, idim, iside};
-				
+
                         const auto ptile_data = ptile.getConstParticleTileData();
 
                         amrex::ReduceOps<amrex::ReduceOpSum> reduce_op;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -189,7 +189,7 @@ struct CopyAndTimestamp {
         }
 
         dst.m_runtime_idata[m_step_index][dst_i] = m_step;
-        dst.m_runtime_rdata[m_delta_index][dst_i] = 0._rt;
+        dst.m_runtime_rdata[m_delta_index][dst_i] = 0._rt; //delta_fraction is initialized to zero
 
         //calculation of the normal to the boundary
         std::array<double, 3> n = {0.0, 0.0, 0.0};


### PR DESCRIPTION
The boundary buffers of the regular boundaries (non-EB) didn't have the normal components to the boundary where the particle hits. This PR adds it.
The modification of the position and the `detaTimeScraped` still needed (see  #4748)