### PR TITLE
Open Governance Model

### DIFF
--- a/Docs/source/governance.rst
+++ b/Docs/source/governance.rst
@@ -1,0 +1,1 @@
+../../GOVERNANCE.rst

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -150,4 +150,5 @@ Epilogue
    :hidden:
 
    glossary
+   governance
    acknowledgements

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -25,6 +25,7 @@ Members of the steering committee (SC) can change organizational settings, do ad
 SC members can call votes for decisions (technical or governance).
 
 The SC can veto decisions of the technical committee (TC) by voting in the SC.
+The TC can overwrite a veto with a 2/3rd majority vote in the TC.
 
 The SC can change the governance structure, but only in a unanimous vote.
 

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -53,7 +53,7 @@ Current Roster
 ^^^^^^^^^^^^^^
 
 - Luca Fedeli
-- Roelof Groenwald
+- Roelof Groenewald
 - David Grote
 - Axel Huebl
 - Revathi Jambunathan

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -62,6 +62,7 @@ Current Roster
 - Remi Lehe
 - Andrew Myers
 - Maxence Thévenet
+- Jean-Luc Vay
 - Weiqun Zhang
 - Edoardo Zoni
 

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -1,0 +1,138 @@
+.. _governance:
+
+WarpX Governance
+================
+
+WarpX is led in an open governance model, described in this file.
+
+
+Steering Committee
+------------------
+
+Current Roster
+^^^^^^^^^^^^^^
+
+- Jean-Luc Vay (chair)
+- Remi Lehe
+- Axel Huebl
+
+See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-admins>`__
+
+Role
+^^^^
+
+The steering committee (SC) can change repo requirements, can do administrative operations such as rename/move/archive projects, etc.
+SC members call votes for decisions.
+
+The SC can veto decisions of the technical committee (TC) by voting in the SC.
+
+The SC can change the governance structure, but only in an unanimous vote.
+
+Decision Process
+^^^^^^^^^^^^^^^^
+
+Decision are made in a public, majority vote of SC members.
+In tie situations, the chair of the SC acts as the tie breaker.
+
+Appointment Process
+^^^^^^^^^^^^^^^^^^^
+
+Appointed by current SC members in an unanimous vote.
+
+SC members can resign or be removed by majority vote, e.g., due to inactivity, bad acting or other reason.
+
+
+Technical Committee
+-------------------
+
+Current Roster
+^^^^^^^^^^^^^^
+
+- Luca Fedeli
+- Roelof Groenwald
+- David Grote
+- Axel Huebl
+- Revathi Jambunathan
+- Remi Lehe
+- Andrew Myers
+- Maxence Thévenet
+- Weiqun Zhang
+- Edoardo Zoni
+
+See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-push-merge-write>`__
+
+Role
+^^^^
+
+The technical committee (TC) is the core governance body, where under normal operations most ideas are discussed and decisions are made.
+Individual TC members can approve and merge code changes.
+Usually, they seek approval by another maintainer for their own changes, too.
+TC members lead and weight in on technical discussions and can call a vote between TC members, if needed for a technical decision.
+TC members merge/close PRs and issues, and moderate (including block/mute) bad actors.
+The TC can propose governance changes to the SC.
+
+
+Decision Process
+^^^^^^^^^^^^^^^^
+
+Discussion on a topic in the weekly developer meetings.
+
+If someone calls for a vote to make a decision: majority based on the passed votes; we need 50% of the committee participating to vote. In the absence of a quorum, the SC will decide.
+
+Decision are made in a public, majority vote of TC members.
+
+In the absence of a quorum (>50%) in the TC, the SC decides according to its voting rules.
+
+TC members can individually highlight  new contributors, unless a vote is called on an individual.
+
+Appointment Process
+^^^^^^^^^^^^^^^^^^^
+
+TC members are the maintainers of WarpX.
+As a TC member, regularly attending and contributing to the weekly developer meetings is expected.
+
+One is appointed to the TC by the steering committee, in an unanimous vote.
+Steering committee members can also be TC members.
+
+TC members can resign or be removed by majority vote by either TC or SC, e.g., due to inactivity, bad acting or other reason.
+
+
+Contributors
+------------
+
+Current Roster
+^^^^^^^^^^^^^^
+
+See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-contributors>`__
+
+Role
+^^^^
+
+Contributors are valuable, vetted developers to WarpX.
+Contributions can be in many forms and not all need to be code contributions.
+Examples include code pull requests, support in issues & user discussions, writing and updating documentation, R&D on novel numerics, testing and benchmarking, etc.
+Contributors can participate in developer meetings and weight in on discussions.
+Contributors can "triage" (add labels) to pull requests, issues, and GitHub discussion pages.
+Contributors can comment and review PRs (but not merge).
+
+Decision Process
+^^^^^^^^^^^^^^^^
+
+Contributors can individually decide on classification (triage) of pull requests, issues, and GitHub discussion pages.
+
+Appointment Process
+^^^^^^^^^^^^^^^^^^^
+
+Appointed after contributing to WarpX (see above) by any member of the TC.
+
+The role can be lost by resigning or majority vote by TC or SC due to inactivity, bad acting or other.
+
+
+Former Members
+--------------
+
+"Former members" are the giants on whose shoulders we stand.
+But, for the purpose of WarpX governance, they are *not* tracked as a governance role in WarpX.
+Instead, former (e.g., inactive) contributors are acknowledged separately in GitHub contributor tracking, the WarpX documentation, references, citable Zenodo archives of releases, etc. as appropriate.
+
+Former members of SC, TC and Contributors are not kept in the roster, since committee role rosters shall reflect currently active members and responsible governance body.

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -21,7 +21,7 @@ See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-admins>`__
 Role
 ^^^^
 
-The steering committee (SC) can change organizational settings, do administrative operations such as rename/move/archive repositories, change branch protection rules, etc.
+Members of the steering committee (SC) can change organizational settings, do administrative operations such as rename/move/archive repositories, change branch protection rules, etc.
 SC members can call votes for decisions (technical or governance).
 
 The SC can veto decisions of the technical committee (TC) by voting in the SC.

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -21,25 +21,29 @@ See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-admins>`__
 Role
 ^^^^
 
-The steering committee (SC) can change repo requirements, can do administrative operations such as rename/move/archive projects, etc.
-SC members call votes for decisions.
+The steering committee (SC) can change organizational settings, do administrative operations such as rename/move/archive repositories, change branch protection rules, etc.
+SC members can call votes for decisions (technical or governance).
 
 The SC can veto decisions of the technical committee (TC) by voting in the SC.
 
-The SC can change the governance structure, but only in an unanimous vote.
+The SC can change the governance structure, but only in a unanimous vote.
 
 Decision Process
 ^^^^^^^^^^^^^^^^
 
-Decision are made in a public, majority vote of SC members.
+Decision of the SC usually happen in the weekly developer meetings, via e-mail or public chat.
+
+Decisions are made in a non-confidential manner, by majority on the cast votes of SC members.
+Votes can be cast in asynchronous manner, e.g., over the time of 1-2 weeks.
 In tie situations, the chair of the SC acts as the tie breaker.
 
 Appointment Process
 ^^^^^^^^^^^^^^^^^^^
 
 Appointed by current SC members in an unanimous vote.
+As a SC member, regularly attending and contributing to the weekly developer meetings is expected.
 
-SC members can resign or be removed by majority vote, e.g., due to inactivity, bad acting or other reason.
+SC members can resign or be removed by majority vote, e.g., due to inactivity, bad acting or other reasons.
 
 
 Technical Committee
@@ -67,7 +71,7 @@ Role
 The technical committee (TC) is the core governance body, where under normal operations most ideas are discussed and decisions are made.
 Individual TC members can approve and merge code changes.
 Usually, they seek approval by another maintainer for their own changes, too.
-TC members lead and weight in on technical discussions and can call a vote between TC members, if needed for a technical decision.
+TC members lead - and weigh in on - technical discussions and, if needed, can call for a vote between TC members for a technical decision.
 TC members merge/close PRs and issues, and moderate (including block/mute) bad actors.
 The TC can propose governance changes to the SC.
 
@@ -75,15 +79,13 @@ The TC can propose governance changes to the SC.
 Decision Process
 ^^^^^^^^^^^^^^^^
 
-Discussion on a topic in the weekly developer meetings.
+Discussion in the TC usually happens in the weekly developer meetings.
 
-If someone calls for a vote to make a decision: majority based on the passed votes; we need 50% of the committee participating to vote. In the absence of a quorum, the SC will decide.
+If someone calls for a vote to make a decision: majority based on the cast votes; we need 50% of the committee participating to vote. In the absence of a quorum, the SC will decide according to its voting rules.
 
-Decision are made in a public, majority vote of TC members.
+Votes are cast in a non-confidential manner.
 
-In the absence of a quorum (>50%) in the TC, the SC decides according to its voting rules.
-
-TC members can individually highlight  new contributors, unless a vote is called on an individual.
+TC members can individually appoint new contributors, unless a vote is called on an individual.
 
 Appointment Process
 ^^^^^^^^^^^^^^^^^^^
@@ -91,10 +93,10 @@ Appointment Process
 TC members are the maintainers of WarpX.
 As a TC member, regularly attending and contributing to the weekly developer meetings is expected.
 
-One is appointed to the TC by the steering committee, in an unanimous vote.
+One is appointed to the TC by the steering committee, in a unanimous vote, or by majority vote of the TC. The SC can veto appointments.
 Steering committee members can also be TC members.
 
-TC members can resign or be removed by majority vote by either TC or SC, e.g., due to inactivity, bad acting or other reason.
+TC members can resign or be removed by majority vote by either TC or SC, e.g., due to inactivity, bad acting or other reasons.
 
 
 Contributors
@@ -108,10 +110,10 @@ See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-contributors>`_
 Role
 ^^^^
 
-Contributors are valuable, vetted developers to WarpX.
+Contributors are valuable, vetted developers of WarpX.
 Contributions can be in many forms and not all need to be code contributions.
-Examples include code pull requests, support in issues & user discussions, writing and updating documentation, R&D on novel numerics, testing and benchmarking, etc.
-Contributors can participate in developer meetings and weight in on discussions.
+Examples include code pull requests, support in issues & user discussions, writing and updating documentation, writing tutorials, visualizations, R&D on algorithms, testing and benchmarking, etc.
+Contributors can participate in developer meetings and weigh in on discussions.
 Contributors can "triage" (add labels) to pull requests, issues, and GitHub discussion pages.
 Contributors can comment and review PRs (but not merge).
 
@@ -125,7 +127,7 @@ Appointment Process
 
 Appointed after contributing to WarpX (see above) by any member of the TC.
 
-The role can be lost by resigning or majority vote by TC or SC due to inactivity, bad acting or other.
+The role can be lost by resigning or by decision of an individual TC or SC member, e.g., due to inactivity, bad acting or other.
 
 
 Former Members
@@ -135,4 +137,4 @@ Former Members
 But, for the purpose of WarpX governance, they are *not* tracked as a governance role in WarpX.
 Instead, former (e.g., inactive) contributors are acknowledged separately in GitHub contributor tracking, the WarpX documentation, references, citable Zenodo archives of releases, etc. as appropriate.
 
-Former members of SC, TC and Contributors are not kept in the roster, since committee role rosters shall reflect currently active members and responsible governance body.
+Former members of SC, TC and Contributors are not kept in the roster, since committee role rosters shall reflect currently active members and the responsible governance body.

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -26,6 +26,7 @@ SC members can call votes for decisions (technical or governance).
 
 The SC can veto decisions of the technical committee (TC) by voting in the SC.
 The TC can overwrite a veto with a 2/3rd majority vote in the TC.
+Decisions are documented in the `weekly developer meeting notes <https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit>`__ and/or on the GitHub repository.
 
 The SC can change the governance structure, but only in a unanimous vote.
 
@@ -85,6 +86,7 @@ Discussion in the TC usually happens in the weekly developer meetings.
 If someone calls for a vote to make a decision: majority based on the cast votes; we need 50% of the committee participating to vote. In the absence of a quorum, the SC will decide according to its voting rules.
 
 Votes are cast in a non-confidential manner.
+Decisions are documented in the `weekly developer meeting notes <https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit>`__ and/or on the GitHub repository.
 
 TC members can individually appoint new contributors, unless a vote is called on an individual.
 


### PR DESCRIPTION
This is a first draft of the open governance model for WarpX, developed after discussion with the current leadership team.

The goal of the governance model is to:
- document and make transparent our decision structure,
- structure and openly credit sensible roles,
- clarify appointment and off-boarding,
- encourage participation, engagement and growth.

Thoughts that guided the initial document include:
- accurately reflecting our successful project workflows,
- evolving it for shared responsibility and co-ownership,
- avoiding unnecessary overheads and deadlocks,
- be flexible enough to enable later introduction of sub-roles and further formalization, depending on community growth.

Once reviewed and accepted, this implements and closes #4683

## Next Steps

- [x] discussion and revision of the draft between @ECP-WarpX/warpx-admins, March 13th, 2024
- [x] presentation at the weekly developer meeting,  March 26th, 2024
- [x] discussion, revision and ratification at the weekly developer meeting, April 23rd, 2024