### PR TITLE
Enable `WarpX::ComputeEdgeLengths` in RZ

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -114,16 +114,15 @@ WarpX::InitEB ()
 void
 WarpX::ComputeEdgeLengths (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& edge_lengths,
                            const amrex::EBFArrayBoxFactory& eb_fact) {
-#ifndef WARPX_DIM_RZ
     BL_PROFILE("ComputeEdgeLengths");
 
     auto const &flags = eb_fact.getMultiEBCellFlagFab();
     auto const &edge_centroid = eb_fact.getEdgeCent();
-#ifdef WARPX_DIM_XZ
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     edge_lengths[1]->setVal(0.);
 #endif
     for (amrex::MFIter mfi(flags); mfi.isValid(); ++mfi){
-#ifdef WARPX_DIM_XZ
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         for (int idim = 0; idim < 3; ++idim){
             if(idim == 1) continue;
 #elif defined(WARPX_DIM_3D)
@@ -148,7 +147,7 @@ WarpX::ComputeEdgeLengths (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& ed
                     edge_lengths_dim(i, j, k) = 0.;
                 });
             } else {
-#ifdef WARPX_DIM_XZ
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 int idim_amrex = idim;
                 if(idim == 2) idim_amrex = 1;
                 auto const &edge_cent = edge_centroid[idim_amrex]->const_array(mfi);
@@ -175,7 +174,6 @@ WarpX::ComputeEdgeLengths (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& ed
             }
         }
     }
-#endif
 }
 
 
@@ -246,11 +244,10 @@ WarpX::ComputeFaceAreas (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& face
 void
 WarpX::ScaleEdges (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& edge_lengths,
                    const std::array<amrex::Real,3>& cell_size) {
-#ifndef WARPX_DIM_RZ
     BL_PROFILE("ScaleEdges");
 
     for (amrex::MFIter mfi(*edge_lengths[0]); mfi.isValid(); ++mfi) {
-#ifdef WARPX_DIM_XZ
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         for (int idim = 0; idim < 3; ++idim){
             if(idim == 1) continue;
 #elif defined(WARPX_DIM_3D)
@@ -267,7 +264,6 @@ WarpX::ScaleEdges (std::array< std::unique_ptr<amrex::MultiFab>, 3 >& edge_lengt
             });
         }
     }
-#endif
 }
 
 void

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -754,7 +754,7 @@ WarpX::ReadParameters ()
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         electromagnetic_solver_id==ElectromagneticSolverAlgo::None
         || electromagnetic_solver_id==ElectromagneticSolverAlgo::HybridPIC,
-        "Currently, the embedded boundary in RZ only works for electrostatic solvers (or no solver).");
+        "Currently, the embedded boundary in RZ only works for electrostatic solvers, the Ohm's law solver or with no solver installed.");
 #endif
 
         if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrame ||

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -752,7 +752,8 @@ WarpX::ReadParameters ()
 
 #if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        electromagnetic_solver_id==ElectromagneticSolverAlgo::None,
+        electromagnetic_solver_id==ElectromagneticSolverAlgo::None
+        || electromagnetic_solver_id==ElectromagneticSolverAlgo::HybridPIC,
         "Currently, the embedded boundary in RZ only works for electrostatic solvers (or no solver).");
 #endif
 


### PR DESCRIPTION
As far as I can tell, `WarpX::ComputeEdgeLengths` was excluded in RZ simulations out of an abundance of caution. But initial testing doesn't show any problems with handling RZ the same as 2D. I'm specifically interested in using this with the hybrid-PIC solver so I haven't done any testing with the regular electromagnetic solvers (which is why I only request to allow the hybrid-solver to use this for now).

As a simple sanity check of whether this works as intended, I ran a modified case of the normal modes in a cylinder test by covering the domain at r > R_max/2 with an embedded boundary. The plot below shows the normal modes dispersion relations for a cylinder with radius equal to R_max in white and with radius equal to R_max/2 in blue. The simulation with embedded boundary over r > R_max/2 is seen to follow the blue dispersion and therefore passes the simple check.

![image](https://github.com/ECP-WarpX/WarpX/assets/40245517/a6cddb8a-1eaa-401d-8ba6-ba6dd5f9662c)
