### PR TITLE
Bugfix in `fields.py` for GPU run without `cupy`

### DIFF
--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -47,6 +47,7 @@ try:
     import cupy as cp
 except ImportError:
     cp = None
+from .LoadThirdParty import load_cupy
 
 try:
     from mpi4py import MPI as mpi
@@ -525,8 +526,11 @@ class _MultiFABWrapper(object):
                 if isinstance(value, np.ndarray):
                     slice_value = value3d[global_slices]
                     if libwarpx.libwarpx_so.Config.have_gpu:
+                        xp, cupy_status = load_cupy()
                         # Copy data from host to device
-                        slice_value = cp.asarray(slice_value)
+                        slice_value = xp.asarray(slice_value)
+                        if cupy_status is not None:
+                            libwarpx.amr.Print(cupy_status)
                     mf_arr[block_slices] = slice_value
                 else:
                     mf_arr[block_slices] = value

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -517,6 +517,12 @@ class _MultiFABWrapper(object):
             if not isinstance(ic   , slice) or len(global_shape) < 4: global_shape[3:3] = [1]
             value3d.shape = global_shape
 
+            if libwarpx.libwarpx_so.Config.have_gpu:
+                # check if cupy is available for use
+                xp, cupy_status = load_cupy()
+                if cupy_status is not None:
+                    libwarpx.amr.Print(cupy_status)
+
         starts = [ixstart, iystart, izstart]
         stops = [ixstop, iystop, izstop]
         for mfi in self.mf:
@@ -526,11 +532,8 @@ class _MultiFABWrapper(object):
                 if isinstance(value, np.ndarray):
                     slice_value = value3d[global_slices]
                     if libwarpx.libwarpx_so.Config.have_gpu:
-                        xp, cupy_status = load_cupy()
                         # Copy data from host to device
                         slice_value = xp.asarray(slice_value)
-                        if cupy_status is not None:
-                            libwarpx.amr.Print(cupy_status)
                     mf_arr[block_slices] = slice_value
                 else:
                     mf_arr[block_slices] = value


### PR DESCRIPTION
Currently if `libwarpx.libwarpx_so.Config.have_gpu == True` but `cupy` is not installed (i.e. `cp == None`) an error occurs if a user tries to set field values:
```
AttributeError: 'NoneType' object has no attribute 'asarray'
```

This PR avoids that failure and allows for the possibility that managed memory is turned on. If managed memory is not turned on an error will still occur but before the error a message will be printed based on `cupy_status`, which for CUDA builds without cupy will read:
```
"Warning: GPU found but cupy not available! Trying managed memory in numpy..."
```