### PR TITLE
clean up `ablastr/fields`

### DIFF
--- a/Source/ablastr/fields/Interpolate.H
+++ b/Source/ablastr/fields/Interpolate.H
@@ -1,0 +1,58 @@
+/* Copyright 2019-2022 Axel Huebl, Remi Lehe
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef ABLASTR_INTERPOLATE_H
+#define ABLASTR_INTERPOLATE_H
+
+#include <AMReX_Array4.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MFInterp_C.H>
+
+#include <ablastr/fields/Interpolate.H>
+
+#include <array>
+#include <optional>
+
+
+namespace ablastr::fields {
+
+namespace details
+{
+    /** Local interpolation from phi_cp to phi[lev+1]
+     *
+     * This is needed to work-around an NVCC limitation in downstream code (ImpactX),
+     * when nesting lambdas. Otherwise this could be written directly into the
+     * ParallelFor.
+     *
+     * @param[out] phi_fp_arr phi on the fine level
+     * @param[in] phi_cp_arr phi on the coarse level
+     * @param[in] refratio refinement ration
+     */
+    struct PoissonInterpCPtoFP
+    {
+        PoissonInterpCPtoFP(
+                amrex::Array4<amrex::Real> const phi_fp_arr,
+                amrex::Array4<amrex::Real const> const phi_cp_arr,
+                amrex::IntVect const refratio)
+        : m_phi_fp_arr(phi_fp_arr), m_phi_cp_arr(phi_cp_arr), m_refratio(refratio)
+        {}
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        void
+        operator() (int i, int j, int k) const noexcept
+        {
+            amrex::mf_nodebilin_interp(i, j, k, 0, m_phi_fp_arr, 0, m_phi_cp_arr,
+                                       0, m_refratio);
+        }
+
+        amrex::Array4<amrex::Real> const m_phi_fp_arr;
+        amrex::Array4<amrex::Real const> const m_phi_cp_arr;
+        amrex::IntVect const m_refratio;
+    };
+}
+} // namespace ablastr::fields
+
+#endif // ABLASTR_INTERPOLATE_H

--- a/Source/ablastr/fields/Interpolate.H
+++ b/Source/ablastr/fields/Interpolate.H
@@ -17,10 +17,8 @@
 #include <optional>
 
 
-namespace ablastr::fields {
+namespace ablastr::fields::details {
 
-namespace details
-{
     /** Local interpolation from phi_cp to phi[lev+1]
      *
      * This is needed to work-around an NVCC limitation in downstream code (ImpactX),
@@ -52,7 +50,6 @@ namespace details
         amrex::Array4<amrex::Real const> const m_phi_cp_arr;
         amrex::IntVect const m_refratio;
     };
-}
-} // namespace ablastr::fields
+} // namespace ablastr::fields::details
 
 #endif // ABLASTR_INTERPOLATE_H

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -11,6 +11,7 @@
 #include <ablastr/utils/Communication.H>
 #include <ablastr/utils/TextMsg.H>
 #include <ablastr/warn_manager/WarnManager.H>
+#include <ablastr/fields/Interpolate.H>
 
 
 #include <AMReX_Array.H>
@@ -51,41 +52,6 @@
 
 
 namespace ablastr::fields {
-
-namespace details
-{
-    /** Local interpolation from phi_cp to phi[lev+1]
-     *
-     * This is needed to work-around an NVCC limitation in downstream code (ImpactX),
-     * when nesting lambdas. Otherwise this could be written directly into the
-     * ParallelFor.
-     *
-     * @param[out] phi_fp_arr phi on the fine level
-     * @param[in] phi_cp_arr phi on the coarse level
-     * @param[in] refratio refinement ration
-     */
-    struct PoissonInterpCPtoFP
-    {
-        PoissonInterpCPtoFP(
-                amrex::Array4<amrex::Real> const phi_fp_arr,
-                amrex::Array4<amrex::Real const> const phi_cp_arr,
-                amrex::IntVect const refratio)
-        : m_phi_fp_arr(phi_fp_arr), m_phi_cp_arr(phi_cp_arr), m_refratio(refratio)
-        {}
-
-        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-        void
-        operator() (int i, int j, int k) const noexcept
-        {
-            amrex::mf_nodebilin_interp(i, j, k, 0, m_phi_fp_arr, 0, m_phi_cp_arr,
-                                       0, m_refratio);
-        }
-
-        amrex::Array4<amrex::Real> const m_phi_fp_arr;
-        amrex::Array4<amrex::Real const> const m_phi_cp_arr;
-        amrex::IntVect const m_refratio;
-    };
-}
 
 /** Compute the potential `phi` by solving the Poisson equation
  *

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -8,7 +8,7 @@
 #define ABLASTR_VECTOR_POISSON_SOLVER_H
 
 #include <ablastr/constant.H>
-#include <ablastr/fields/PoissonSolver.H>
+#include <ablastr/fields/Interpolate.H>
 #include <ablastr/utils/Communication.H>
 #include <ablastr/utils/TextMsg.H>
 #include <ablastr/warn_manager/WarnManager.H>


### PR DESCRIPTION
Move `PoissonInterpCPtoFP` to a new file `Interpolate.H` and removed import of `PoissonSolver.H` in `VectorPoissonSolver.H`.




