### PR TITLE
Replace links to learn git

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,10 +10,7 @@ Git workflow
 ------------
 
 The WarpX project uses `git <https://git-scm.com>`_ for version control.
-If you are new to git, you can follow one of these tutorials:
-
-- `Learn git with bitbucket <https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud>`_
-- `git - the simple guide <http://rogerdudler.github.io/git-guide/>`_
+If you are new to git, you can follow `this tutorial <https://swcarpentry.github.io/git-novice/>`_.
 
 Configure your GitHub Account & Development Machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Git workflow
 ------------
 
 The WarpX project uses `git <https://git-scm.com>`_ for version control.
-If you are new to git, you can follow `this tutorial <https://swcarpentry.github.io/git-novice/>`_.
+If you are new to git, you can follow `this tutorial <https://swcarpentry.github.io/git-novice/>`__.
 
 Configure your GitHub Account & Development Machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The links that we had for `git` where not ideal:
- One of them was using Bitbucket, which is not what we use in practice
- The other one is more of a cheatsheet, rather than something that introduce `git` to someone that does not know it.

This PR replaces these links with the Software Carpentry tutorial (which does use Github)