### PR TITLE
Adding hyper-resistivity to generalized ohms law hybrid solver.

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1142,7 +1142,8 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
         Function of space and time specifying external (non-plasma) currents.
     """
     def __init__(self, grid, Te=None, n0=None, gamma=None,
-                 n_floor=None, plasma_resistivity=None, substeps=None,
+                 n_floor=None, plasma_resistivity=None, 
+                 plasma_hyper_resistivity=None, substeps=None,
                  Jx_external_function=None, Jy_external_function=None,
                  Jz_external_function=None, **kw):
         self.grid = grid
@@ -1153,6 +1154,7 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
         self.gamma = gamma
         self.n_floor = n_floor
         self.plasma_resistivity = plasma_resistivity
+        self.plasma_hyper_resistivity = plasma_hyper_resistivity
 
         self.substeps = substeps
 
@@ -1187,6 +1189,7 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
             'plasma_resistivity(rho,J)',
             pywarpx.my_constants.mangle_expression(self.plasma_resistivity, self.mangle_dict)
         )
+        pywarpx.hybridpicmodel.plasma_hyper_resistivity = self.plasma_hyper_resistivity
         pywarpx.hybridpicmodel.substeps = self.substeps
         pywarpx.hybridpicmodel.__setattr__(
             'Jx_external_grid_function(x,y,z,t)',

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1142,7 +1142,7 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
         Function of space and time specifying external (non-plasma) currents.
     """
     def __init__(self, grid, Te=None, n0=None, gamma=None,
-                 n_floor=None, plasma_resistivity=None, 
+                 n_floor=None, plasma_resistivity=None,
                  plasma_hyper_resistivity=None, substeps=None,
                  Jx_external_function=None, Jy_external_function=None,
                  Jz_external_function=None, **kw):

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -101,6 +101,25 @@ struct CartesianYeeAlgorithm {
     }
 
     /**
+     * Perform second derivative along x on a cell-centered grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Dxx (
+        T_Field const& F,
+        amrex::Real const * const coefs_x, int const /*n_coefs_x*/,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+#if (defined WARPX_DIM_1D_Z)
+        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+        return 0._rt; // 1D Cartesian: derivative along x is 0
+#else
+        amrex::Real const inv_dx2 = coefs_x[0]*coefs_x[0];
+        return inv_dx2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
+#endif
+    }
+
+    /**
      * Perform derivative along y on a cell-centered grid, from a nodal field `F`*/
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDy (
@@ -148,6 +167,30 @@ struct CartesianYeeAlgorithm {
     }
 
     /**
+     * Perform derivative along y on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Dyy (
+        T_Field const& F,
+        amrex::Real const * const coefs_y, int const n_coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+#if defined WARPX_DIM_3D
+        Real const inv_dy2 = coefs_y[0]*coefs_y[0];
+        amrex::ignore_unused(n_coefs_y);
+        return inv_dy2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
+#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+            i, j, k, ncomp);
+        return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
+#else
+        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+            i, j, k, ncomp);
+#endif
+    }
+
+    /**
      * Perform derivative along z on a cell-centered grid, from a nodal field `F`*/
    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDz (
@@ -183,6 +226,26 @@ struct CartesianYeeAlgorithm {
         return inv_dz*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
 #elif (defined WARPX_DIM_1D_Z)
         return inv_dz*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
+#endif
+    }
+
+    /**
+     * Perform second derivative along z on a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Dzz (
+        T_Field const& F,
+        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+        Real const inv_dz2 = coefs_z[0]*coefs_z[0];
+#if defined WARPX_DIM_3D
+        return inv_dz2*( F(i,j,k-1,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j,k+1,ncomp) );
+#elif (defined WARPX_DIM_XZ)
+        return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
+#elif (defined WARPX_DIM_1D_Z)
+        return inv_dz2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
 #endif
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -172,21 +172,16 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real Dyy (
         T_Field const& F,
-        amrex::Real const * const coefs_y, int const n_coefs_y,
+        amrex::Real const * const coefs_y, int const /*n_coefs_y*/,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
 #if defined WARPX_DIM_3D
         Real const inv_dy2 = coefs_y[0]*coefs_y[0];
-        amrex::ignore_unused(n_coefs_y);
         return inv_dy2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
 #elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
+        amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
-#else
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
 #endif
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -149,7 +149,7 @@ struct CylindricalYeeAlgorithm {
         ignore_unused(n_coefs_r);
 
         Real const inv_dr2 = coefs_r[0]*coefs_r[0];
-        return 1._rt/r * inv_dr2*( (r+0.5_rt*dr)*(F(i+1,j,k,comp) - F(i,j,k,comp)) 
+        return 1._rt/r * inv_dr2*( (r+0.5_rt*dr)*(F(i+1,j,k,comp) - F(i,j,k,comp))
                                  - (r-0.5_rt*dr)*(F(i,j,k,comp) - F(i-1,j,k,comp)) );
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -142,11 +142,10 @@ struct CylindricalYeeAlgorithm {
     static amrex::Real Dr_rDr_over_r (
         T_Field const& F,
         amrex::Real const r, amrex::Real const dr,
-        amrex::Real const * const coefs_r, int const n_coefs_r,
+        amrex::Real const * const coefs_r, int const /*n_coefs_r*/,
         int const i, int const j, int const k, int const comp ) {
 
         using namespace amrex;
-        ignore_unused(n_coefs_r);
 
         Real const inv_dr2 = coefs_r[0]*coefs_r[0];
         return 1._rt/r * inv_dr2*( (r+0.5_rt*dr)*(F(i+1,j,k,comp) - F(i,j,k,comp))

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -134,6 +134,25 @@ struct CylindricalYeeAlgorithm {
         return inv_dr*( F(i,j,k,comp) - F(i-1,j,k,comp) );
     }
 
+    /** Applies the differential operator `1/r * d(r * dF/dr)/dr`,
+     * where `F` is on a *cell-centered* or a nodal grid in `r`
+     * The input parameter `r` is given at the cell-centered position */
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Dr_rDr_over_r (
+        T_Field const& F,
+        amrex::Real const r, amrex::Real const dr,
+        amrex::Real const * const coefs_r, int const n_coefs_r,
+        int const i, int const j, int const k, int const comp ) {
+
+        using namespace amrex;
+        ignore_unused(n_coefs_r);
+
+        Real const inv_dr2 = coefs_r[0]*coefs_r[0];
+        return 1._rt/r * inv_dr2*( (r+0.5_rt*dr)*(F(i+1,j,k,comp) - F(i,j,k,comp)) 
+                                 - (r-0.5_rt*dr)*(F(i,j,k,comp) - F(i-1,j,k,comp)) );
+    }
+
     /**
      * Perform derivative along z on a cell-centered grid, from a nodal field `F` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -160,6 +179,21 @@ struct CylindricalYeeAlgorithm {
 
         amrex::Real const inv_dz = coefs_z[0];
         return inv_dz*( F(i,j,k,comp) - F(i,j-1,k,comp) );
+    }
+
+    /**
+     * Perform second derivative along z on a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Dzz (
+        T_Field const& F,
+        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+        Real const inv_dz2 = coefs_z[0]*coefs_z[0];
+
+        return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -147,7 +147,6 @@ class FiniteDifferenceSolver
           * \param[in] lev  level number for the calculation
           * \param[in] hybrid_model instance of the hybrid-PIC model
           * \param[in] include_resistivity_term boolean flag for whether to include resistivity
-          * \param[in] include_hyper_resistivity_term boolean flag for whether to include hyper-resistivity
           */
         void HybridPICSolveE ( std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3>& Jfield,
@@ -158,8 +157,7 @@ class FiniteDifferenceSolver
                       std::unique_ptr<amrex::MultiFab> const& Pefield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
                       int lev, HybridPICModel const* hybrid_model,
-                      bool include_resistivity_term,
-                      bool include_hyper_resistivity_term );
+                      bool include_resistivity_term );
 
         /**
           * \brief Calculation of total current using Ampere's law (without
@@ -244,8 +242,7 @@ class FiniteDifferenceSolver
             std::unique_ptr<amrex::MultiFab> const& Pefield,
             std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
             int lev, HybridPICModel const* hybrid_model,
-            bool include_resistivity_term,
-            bool include_hyper_resisitivity_term );
+            bool include_resistivity_term );
 
         template<typename T_Algo>
         void CalculateCurrentAmpereCylindrical (
@@ -350,8 +347,7 @@ class FiniteDifferenceSolver
             std::unique_ptr<amrex::MultiFab> const& Pefield,
             std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
             int lev, HybridPICModel const* hybrid_model,
-            bool include_resistivity_term,
-            bool include_hyper_resistivity_term );
+            bool include_resistivity_term );
 
         template<typename T_Algo>
         void CalculateCurrentAmpereCartesian (

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -147,6 +147,7 @@ class FiniteDifferenceSolver
           * \param[in] lev  level number for the calculation
           * \param[in] hybrid_model instance of the hybrid-PIC model
           * \param[in] include_resistivity_term boolean flag for whether to include resistivity
+          * \param[in] include_hyper_resistivity_term boolean flag for whether to include hyper-resistivity
           */
         void HybridPICSolveE ( std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3>& Jfield,
@@ -157,7 +158,8 @@ class FiniteDifferenceSolver
                       std::unique_ptr<amrex::MultiFab> const& Pefield,
                       std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
                       int lev, HybridPICModel const* hybrid_model,
-                      bool include_resistivity_term );
+                      bool include_resistivity_term,
+                      bool include_hyper_resistivity_term );
 
         /**
           * \brief Calculation of total current using Ampere's law (without
@@ -242,7 +244,8 @@ class FiniteDifferenceSolver
             std::unique_ptr<amrex::MultiFab> const& Pefield,
             std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
             int lev, HybridPICModel const* hybrid_model,
-            bool include_resistivity_term );
+            bool include_resistivity_term,
+            bool include_hyper_resisitivity_term );
 
         template<typename T_Algo>
         void CalculateCurrentAmpereCylindrical (
@@ -347,7 +350,8 @@ class FiniteDifferenceSolver
             std::unique_ptr<amrex::MultiFab> const& Pefield,
             std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
             int lev, HybridPICModel const* hybrid_model,
-            bool include_resistivity_term );
+            bool include_resistivity_term,
+            bool include_hyper_resistivity_term );
 
         template<typename T_Algo>
         void CalculateCurrentAmpereCartesian (

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -89,7 +89,7 @@ public:
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& Bfield,
         amrex::Vector<std::unique_ptr<amrex::MultiFab>> const& rhofield,
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& edge_lengths,
-        bool include_resistivity_term);
+        bool include_resistivity_term, bool include_hyper_resistivity_term);
 
     void HybridPICSolveE (
         std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
@@ -97,7 +97,7 @@ public:
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
         std::unique_ptr<amrex::MultiFab> const& rhofield,
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-        int lev, bool include_resistivity_term);
+        int lev, bool include_resistivity_term, bool include_hyper_resistivity_term);
 
     void HybridPICSolveE (
         std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
@@ -105,7 +105,8 @@ public:
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
         std::unique_ptr<amrex::MultiFab> const& rhofield,
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-        int lev, PatchType patch_type, bool include_resistivity_term);
+        int lev, PatchType patch_type, bool include_resistivity_term,
+        bool include_hyper_resistivity_term);
 
     void BfieldEvolveRK (
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>>& Bfield,
@@ -174,6 +175,9 @@ public:
     std::unique_ptr<amrex::Parser> m_resistivity_parser;
     amrex::ParserExecutor<2> m_eta;
     bool m_resistivity_has_J_dependence = false;
+
+    /** Plasma hyper-resisitivity */
+    amrex::Real m_eta_h = 0.0;
 
     /** External current */
     std::string m_Jx_ext_grid_function = "0.0";

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -89,7 +89,7 @@ public:
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& Bfield,
         amrex::Vector<std::unique_ptr<amrex::MultiFab>> const& rhofield,
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& edge_lengths,
-        bool include_resistivity_term, bool include_hyper_resistivity_term);
+        bool include_resistivity_term);
 
     void HybridPICSolveE (
         std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
@@ -97,7 +97,7 @@ public:
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
         std::unique_ptr<amrex::MultiFab> const& rhofield,
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-        int lev, bool include_resistivity_term, bool include_hyper_resistivity_term);
+        int lev, bool include_resistivity_term);
 
     void HybridPICSolveE (
         std::array< std::unique_ptr<amrex::MultiFab>, 3>& Efield,
@@ -105,8 +105,7 @@ public:
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
         std::unique_ptr<amrex::MultiFab> const& rhofield,
         std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-        int lev, PatchType patch_type, bool include_resistivity_term,
-        bool include_hyper_resistivity_term);
+        int lev, PatchType patch_type, bool include_resistivity_term);
 
     void BfieldEvolveRK (
         amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>>& Bfield,

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -427,16 +427,14 @@ void HybridPICModel::HybridPICSolveE (
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& Bfield,
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> const& rhofield,
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& edge_lengths,
-    const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term)
+    const bool include_resistivity_term)
 {
     auto& warpx = WarpX::GetInstance();
     for (int lev = 0; lev <= warpx.finestLevel(); ++lev)
     {
         HybridPICSolveE(
             Efield[lev], Jfield[lev], Bfield[lev], rhofield[lev],
-            edge_lengths[lev], lev, include_resistivity_term,
-            include_hyper_resistivity_term
+            edge_lengths[lev], lev, include_resistivity_term
         );
     }
 }
@@ -447,15 +445,13 @@ void HybridPICModel::HybridPICSolveE (
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
     std::unique_ptr<amrex::MultiFab> const& rhofield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-    const int lev, const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term)
+    const int lev, const bool include_resistivity_term)
 {
     WARPX_PROFILE("WarpX::HybridPICSolveE()");
 
     HybridPICSolveE(
         Efield, Jfield, Bfield, rhofield, edge_lengths, lev,
-        PatchType::fine, include_resistivity_term,
-        include_hyper_resistivity_term
+        PatchType::fine, include_resistivity_term
     );
     if (lev > 0)
     {
@@ -471,8 +467,7 @@ void HybridPICModel::HybridPICSolveE (
     std::unique_ptr<amrex::MultiFab> const& rhofield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
     const int lev, PatchType patch_type,
-    const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term)
+    const bool include_resistivity_term)
 {
     auto& warpx = WarpX::GetInstance();
 
@@ -481,8 +476,7 @@ void HybridPICModel::HybridPICSolveE (
         Efield, current_fp_ampere[lev], Jfield, current_fp_external[lev],
         Bfield, rhofield,
         electron_pressure_fp[lev],
-        edge_lengths, lev, this, include_resistivity_term,
-        include_hyper_resistivity_term
+        edge_lengths, lev, this, include_resistivity_term
     );
     warpx.ApplyEfieldBoundary(lev, patch_type);
 }
@@ -688,12 +682,10 @@ void HybridPICModel::FieldPush (
 {
     auto& warpx = WarpX::GetInstance();
 
-    bool do_hyper_resisitivity = (m_eta_h > 0.0);
-
     // Calculate J = curl x B / mu0
     CalculateCurrentAmpere(Bfield, edge_lengths);
     // Calculate the E-field from Ohm's law
-    HybridPICSolveE(Efield, Jfield, Bfield, rhofield, edge_lengths, true, do_hyper_resisitivity);
+    HybridPICSolveE(Efield, Jfield, Bfield, rhofield, edge_lengths, true);
     warpx.FillBoundaryE(ng, nodal_sync);
     // Push forward the B-field using Faraday's law
     warpx.EvolveB(dt, dt_type);

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -40,6 +40,8 @@ void HybridPICModel::ReadParameters ()
     pp_hybrid.query("plasma_resistivity(rho,J)", m_eta_expression);
     utils::parser::queryWithParser(pp_hybrid, "n_floor", m_n_floor);
 
+    utils::parser::queryWithParser(pp_hybrid, "plasma_hyper_resistivity", m_eta_h);
+
     // convert electron temperature from eV to J
     m_elec_temp *= PhysConst::q_e;
 
@@ -425,14 +427,16 @@ void HybridPICModel::HybridPICSolveE (
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& Bfield,
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> const& rhofield,
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3>> const& edge_lengths,
-    const bool include_resistivity_term)
+    const bool include_resistivity_term,
+    const bool include_hyper_resistivity_term)
 {
     auto& warpx = WarpX::GetInstance();
     for (int lev = 0; lev <= warpx.finestLevel(); ++lev)
     {
         HybridPICSolveE(
             Efield[lev], Jfield[lev], Bfield[lev], rhofield[lev],
-            edge_lengths[lev], lev, include_resistivity_term
+            edge_lengths[lev], lev, include_resistivity_term,
+            include_hyper_resistivity_term
         );
     }
 }
@@ -443,13 +447,15 @@ void HybridPICModel::HybridPICSolveE (
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& Bfield,
     std::unique_ptr<amrex::MultiFab> const& rhofield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
-    const int lev, const bool include_resistivity_term)
+    const int lev, const bool include_resistivity_term,
+    const bool include_hyper_resistivity_term)
 {
     WARPX_PROFILE("WarpX::HybridPICSolveE()");
 
     HybridPICSolveE(
         Efield, Jfield, Bfield, rhofield, edge_lengths, lev,
-        PatchType::fine, include_resistivity_term
+        PatchType::fine, include_resistivity_term,
+        include_hyper_resistivity_term
     );
     if (lev > 0)
     {
@@ -465,7 +471,8 @@ void HybridPICModel::HybridPICSolveE (
     std::unique_ptr<amrex::MultiFab> const& rhofield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3> const& edge_lengths,
     const int lev, PatchType patch_type,
-    const bool include_resistivity_term)
+    const bool include_resistivity_term,
+    const bool include_hyper_resistivity_term)
 {
     auto& warpx = WarpX::GetInstance();
 
@@ -474,7 +481,8 @@ void HybridPICModel::HybridPICSolveE (
         Efield, current_fp_ampere[lev], Jfield, current_fp_external[lev],
         Bfield, rhofield,
         electron_pressure_fp[lev],
-        edge_lengths, lev, this, include_resistivity_term
+        edge_lengths, lev, this, include_resistivity_term,
+        include_hyper_resistivity_term
     );
     warpx.ApplyEfieldBoundary(lev, patch_type);
 }
@@ -680,10 +688,12 @@ void HybridPICModel::FieldPush (
 {
     auto& warpx = WarpX::GetInstance();
 
+    bool do_hyper_resisitivity = (m_eta_h > 0.0);
+
     // Calculate J = curl x B / mu0
     CalculateCurrentAmpere(Bfield, edge_lengths);
     // Calculate the E-field from Ohm's law
-    HybridPICSolveE(Efield, Jfield, Bfield, rhofield, edge_lengths, true);
+    HybridPICSolveE(Efield, Jfield, Bfield, rhofield, edge_lengths, true, do_hyper_resisitivity);
     warpx.FillBoundaryE(ng, nodal_sync);
     // Push forward the B-field using Faraday's law
     warpx.EvolveB(dt, dt_type);

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -375,8 +375,7 @@ void FiniteDifferenceSolver::HybridPICSolveE (
     std::unique_ptr<amrex::MultiFab> const& Pefield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
     int lev, HybridPICModel const* hybrid_model,
-    const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term)
+    const bool include_resistivity_term)
 {
     // Select algorithm (The choice of algorithm is a runtime option,
     // but we compile code for each algorithm, using templates)
@@ -385,16 +384,14 @@ void FiniteDifferenceSolver::HybridPICSolveE (
 
         HybridPICSolveECylindrical <CylindricalYeeAlgorithm> (
             Efield, Jfield, Jifield, Jextfield, Bfield, rhofield, Pefield,
-            edge_lengths, lev, hybrid_model, include_resistivity_term,
-            include_hyper_resistivity_term
+            edge_lengths, lev, hybrid_model, include_resistivity_term
         );
 
 #else
 
         HybridPICSolveECartesian <CartesianYeeAlgorithm> (
             Efield, Jfield, Jifield, Jextfield, Bfield, rhofield, Pefield,
-            edge_lengths, lev, hybrid_model, include_resistivity_term,
-            include_hyper_resistivity_term
+            edge_lengths, lev, hybrid_model, include_resistivity_term
         );
 
 #endif
@@ -416,8 +413,7 @@ void FiniteDifferenceSolver::HybridPICSolveECylindrical (
     std::unique_ptr<amrex::MultiFab> const& Pefield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
     int lev, HybridPICModel const* hybrid_model,
-    const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term )
+    const bool include_resistivity_term )
 {
 #ifndef AMREX_USE_EB
     amrex::ignore_unused(edge_lengths);
@@ -439,6 +435,8 @@ void FiniteDifferenceSolver::HybridPICSolveECylindrical (
     const auto eta_h = hybrid_model->m_eta_h;
     const auto rho_floor = hybrid_model->m_n_floor * PhysConst::q_e;
     const auto resistivity_has_J_dependence = hybrid_model->m_resistivity_has_J_dependence;
+
+    const bool include_hyper_resistivity_term = (eta_h > 0.0) && include_resistivity_term;
 
     // Index type required for interpolating fields from their respective
     // staggering to the Ex, Ey, Ez locations
@@ -733,8 +731,7 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
     std::unique_ptr<amrex::MultiFab> const& Pefield,
     std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& edge_lengths,
     int lev, HybridPICModel const* hybrid_model,
-    const bool include_resistivity_term,
-    const bool include_hyper_resistivity_term )
+    const bool include_resistivity_term )
 {
 #ifndef AMREX_USE_EB
     amrex::ignore_unused(edge_lengths);
@@ -750,6 +747,8 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
     const auto eta_h = hybrid_model->m_eta_h;
     const auto rho_floor = hybrid_model->m_n_floor * PhysConst::q_e;
     const auto resistivity_has_J_dependence = hybrid_model->m_resistivity_has_J_dependence;
+
+    const bool include_hyper_resistivity_term = (eta_h > 0.) && include_resistivity_term;
 
     // Index type required for interpolating fields from their respective
     // staggering to the Ex, Ey, Ez locations

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -155,7 +155,7 @@ void WarpX::HybridPICEvolveFields ()
     m_hybrid_pic_model->CalculateCurrentAmpere(Bfield_fp, m_edge_lengths);
     m_hybrid_pic_model->HybridPICSolveE(
         Efield_fp, current_fp_temp, Bfield_fp, rho_fp, m_edge_lengths,
-        false
+        false, false
     );
     FillBoundaryE(guard_cells.ng_FieldSolver, WarpX::sync_nodal_points);
 

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -154,8 +154,7 @@ void WarpX::HybridPICEvolveFields ()
     // Update the E field to t=n+1 using the extrapolated J_i^n+1 value
     m_hybrid_pic_model->CalculateCurrentAmpere(Bfield_fp, m_edge_lengths);
     m_hybrid_pic_model->HybridPICSolveE(
-        Efield_fp, current_fp_temp, Bfield_fp, rho_fp, m_edge_lengths,
-        false, false
+        Efield_fp, current_fp_temp, Bfield_fp, rho_fp, m_edge_lengths, false
     );
     FillBoundaryE(guard_cells.ng_FieldSolver, WarpX::sync_nodal_points);
 


### PR DESCRIPTION
Hyper resistivity is added to the generalized Ohm's law solver to suppress spurious whistler noise in low density regions.  This required addition of Laplacian operators to evaluate the extra term in the Ohm's law.  (\nabla^2 J)