### PR TITLE
Fix ParticleHistogram2D

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -138,6 +138,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
     Array<int,2> tlo{0,0}; // lower bounds
     Array<int,2> thi{m_bin_num_abs-1, m_bin_num_ord-1}; // inclusive upper bounds
     amrex::TableData<amrex::Real,2> d_data_2D(tlo, thi);
+    m_h_data_2D.clear();
     m_h_data_2D = amrex::TableData<amrex::Real,2> (tlo, thi, The_Pinned_Arena());
     auto const& h_table_data = m_h_data_2D.table();
 
@@ -314,6 +315,8 @@ void ParticleHistogram2D::WriteToFile (int step) const
             {static_cast<unsigned long>(m_bin_num_ord), static_cast<unsigned long>(m_bin_num_abs)});
 
     series.flush();
+    i.close();
+    series.close();
 #else
     amrex::ignore_unused(step);
     WARPX_ABORT_WITH_MESSAGE("ParticleHistogram2D: Needs openPMD-api compiled into WarpX, but was not found!");

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -138,8 +138,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
     Array<int,2> tlo{0,0}; // lower bounds
     Array<int,2> thi{m_bin_num_abs-1, m_bin_num_ord-1}; // inclusive upper bounds
     amrex::TableData<amrex::Real,2> d_data_2D(tlo, thi);
-    m_h_data_2D.clear();
-    m_h_data_2D = amrex::TableData<amrex::Real,2> (tlo, thi, The_Pinned_Arena());
+    m_h_data_2D.resize(tlo, thi, The_Pinned_Arena());
     auto const& h_table_data = m_h_data_2D.table();
 
     // Initialize data on the host


### PR DESCRIPTION
Without `m_h_data_2D.clear();` the host memory usage continues growing over the simulation until the process gets killed.
(Observed in `24.3` and `24.2`)

`i.close();` and `series.close();` were my first suspicion. It didn't help, but it is still probably a good idea to explicitly close the iteration and series. 