### PR TITLE
Fix redundant string init in `WarpXAlgorithmSelection.cpp`

### DIFF
--- a/Source/Utils/WarpXAlgorithmSelection.cpp
+++ b/Source/Utils/WarpXAlgorithmSelection.cpp
@@ -249,7 +249,7 @@ GetParticleBCTypeInteger( std::string BCType ){
 
 std::string
 GetFieldBCTypeString( int fb_type ) {
-    std::string boundary_name = "";
+    std::string boundary_name;
     for (const auto &valid_pair : FieldBCType_algo_to_int) {
         if ((valid_pair.second == fb_type)&&(valid_pair.first != "default")){
             boundary_name = valid_pair.first;


### PR DESCRIPTION
This PR fixes a minor issue found with `clang-tidy` that currently causes CI tests to fail.