### PR TITLE
Remove WarpX:: from `ablastr/fields/VectorPoissonSolver.H`

### DIFF
--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -185,11 +185,10 @@ computeVectorPotential   (  amrex::Vector<amrex::Array<amrex::MultiFab*, 3> > co
                         relative_tolerance, absolute_tolerance );
 
             // Synchronize the ghost cells, do halo exchange
-            ablastr::utils::communication::FillBoundary(*A[lev][adim],
-                                                        A[lev][adim]->nGrowVect(),
-                                                        WarpX::do_single_precision_comms,
-                                                        geom[lev].periodicity(),
-                                                        false);
+            ablastr::utils::communication::FillBoundary(
+                *A[lev][adim], A[lev][adim]->nGrowVect(),
+                do_single_precision_comms,
+                geom[lev].periodicity(), false);
 
             // needed for solving the levels by levels:
             // - coarser level is initial guess for finer level


### PR DESCRIPTION
In `ablastr/fields/VectorPoissonSolver.H` we were using `WarpX::do_single_precision_comms` by mistake, since `do_single_precision_comms` is already passed as an argument. This PR fixes the issue.