### PR TITLE
Add callbacks after B and E field pushes

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -30,6 +30,8 @@ Functions can be called at the following times:
 * ``beforeEsolve``: before the solve for E fields
 * ``poissonsolver``: In place of the computePhi call but only in an electrostatic simulation
 * ``afterEsolve``: after the solve for E fields
+* ``afterBpush``: after the B field advance for electromagnetic solvers
+* ``afterEpush``: after the E field advance for electromagnetic solvers
 * ``beforedeposition``: before the particle deposition (for charge and/or current)
 * ``afterdeposition``: after particle deposition (for charge and/or current)
 * ``beforestep``: before the time step
@@ -276,6 +278,8 @@ callback_instances = {
     "beforeEsolve": {},
     "poissonsolver": {'singlefunconly': True}, # external Poisson solver
     "afterEsolve": {},
+    "afterBpush": {},
+    "afterEpush": {},
     "beforedeposition": {},
     "afterdeposition": {},
     "particlescraper": {},
@@ -400,6 +404,20 @@ def callfromafterEsolve(f):
     return f
 def installafterEsolve(f):
     installcallback('afterEsolve', f)
+
+# ----------------------------------------------------------------------------
+def callfromafterBpush(f):
+    installcallback('afterBpush', f)
+    return f
+def installafterBpush(f):
+    installcallback('afterBpush', f)
+
+# ----------------------------------------------------------------------------
+def callfromafterEpush(f):
+    installcallback('afterEpush', f)
+    return f
+def installafterEpush(f):
+    installcallback('afterEpush', f)
 
 # ----------------------------------------------------------------------------
 def callfrombeforedeposition(f):

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -20,6 +20,7 @@
 #       include "FieldSolver/SpectralSolver/SpectralSolver.H"
 #   endif
 #endif
+#include "Python/callbacks.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
@@ -798,6 +799,9 @@ WarpX::EvolveB (amrex::Real a_dt, DtType a_dt_type)
     for (int lev = 0; lev <= finest_level; ++lev) {
         EvolveB(lev, a_dt, a_dt_type);
     }
+
+    // Allow execution of Python callback after B-field push
+    ExecutePythonCallback("afterBpush");
 }
 
 void
@@ -848,6 +852,9 @@ WarpX::EvolveE (amrex::Real a_dt)
     {
         EvolveE(lev, a_dt);
     }
+
+    // Allow execution of Python callback after E-field push
+    ExecutePythonCallback("afterEpush");
 }
 
 void


### PR DESCRIPTION
I need to insert some logic to modify the B-field right after it is advanced (akin to applying a special boundary condition), which the `afterBpush` callback facilitates. I added the `afterEpush` callback for symmetry.