### PR TITLE
ApplyPECto Rho and J if partBndry reflecting/FieldBndry PEC

### DIFF
--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -106,14 +106,14 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
                                    PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyReflectiveBoundarytoRhofield(rho, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) { PEC::ApplyReflectiveBoundarytoRhofield(rho, lev, patch_type); }
 }
 
 void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
                                  amrex::MultiFab* Jy, amrex::MultiFab* Jz,
                                  PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) { PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz, lev, patch_type); }
 }
 
 #ifdef WARPX_DIM_RZ

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -106,14 +106,14 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
                                    PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyPECtoRhofield(rho, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyReflectiveBoundarytoRhofield(rho, lev, patch_type); }
 }
 
 void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
                                  amrex::MultiFab* Jy, amrex::MultiFab* Jz,
                                  PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyPECtoJfield(Jx, Jy, Jz, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz, lev, patch_type); }
 }
 
 #ifdef WARPX_DIM_RZ

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -106,14 +106,14 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
                                    PatchType patch_type)
 {
-    if (PEC::isAnyBoundaryPEC()) { PEC::ApplyPECtoRhofield(rho, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyPECtoRhofield(rho, lev, patch_type); }
 }
 
 void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
                                  amrex::MultiFab* Jy, amrex::MultiFab* Jz,
                                  PatchType patch_type)
 {
-    if (PEC::isAnyBoundaryPEC()) { PEC::ApplyPECtoJfield(Jx, Jy, Jz, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting()) { PEC::ApplyPECtoJfield(Jx, Jy, Jz, lev, patch_type); }
 }
 
 #ifdef WARPX_DIM_RZ

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -106,14 +106,18 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
                                    PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) { PEC::ApplyReflectiveBoundarytoRhofield(rho, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) {
+        PEC::ApplyReflectiveBoundarytoRhofield(rho, lev, patch_type);
+    }
 }
 
 void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
                                  amrex::MultiFab* Jy, amrex::MultiFab* Jz,
                                  PatchType patch_type)
 {
-    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) { PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz, lev, patch_type); }
+    if (PEC::isAnyParticleBoundaryReflecting() || PEC::isAnyBoundaryPEC()) {
+        PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz, lev, patch_type);
+    }
 }
 
 #ifdef WARPX_DIM_RZ

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -479,6 +479,9 @@ using namespace amrex;
 
     /** Returns 1 if any domain boundary is set to PEC, else returns 0.*/
     bool isAnyBoundaryPEC();
+
+    /** Return true if any particle boundary is set to reflecting, else returns false*/
+    bool isAnyParticleBoundaryReflecting ();
     /**
      * \brief Sets the tangential electric field at the PEC boundary to zero.
      *        The guard cell values are set equal and opposite to the valid cell

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -355,8 +355,9 @@ using namespace amrex;
 
 
     /**
-     * \brief Sets the rho or J field value in cells close to and on reflecting particle boundary. The
-     *        charge/current density deposited in the guard cells are either reflected
+     * \brief Sets the rho or J field value in cells close to and on reflecting particle boundary
+     *        or PEC field boundary. The charge/current density deposited
+     *        in the guard cells are either reflected
      *        back into the simulation domain (if a reflecting particle
      *        boundary is used), or the opposite charge/current density is deposited
      *        back in the domain to capture the effect of an image charge.
@@ -370,7 +371,7 @@ using namespace amrex;
      * \param[in out] field    field data to be updated
      * \param[in] mirrorfac    mirror cell is given by mirrorfac - ijk_vec
      * \param[in] psign        Whether the field value should be flipped across the boundary
-     * \param[in] is_reflective      Whether the given particle boundary is reflecting
+     * \param[in] is_reflective      Whether the given particle boundary is reflecting or field boundary is pec
      * \param[in] tangent_to_bndy    Whether a given direction is perpendicular to the boundary
      * \param[in] fabbox       multifab box including ghost cells
      */

--- a/Source/BoundaryConditions/WarpX_PEC.H
+++ b/Source/BoundaryConditions/WarpX_PEC.H
@@ -355,12 +355,12 @@ using namespace amrex;
 
 
     /**
-     * \brief Sets the rho or J field value in cells close to and on a PEC boundary. The
+     * \brief Sets the rho or J field value in cells close to and on reflecting particle boundary. The
      *        charge/current density deposited in the guard cells are either reflected
      *        back into the simulation domain (if a reflecting particle
      *        boundary is used), or the opposite charge/current density is deposited
      *        back in the domain to capture the effect of an image charge.
-     *        The charge/current density on the PEC boundary is set to 0 while values
+     *        The charge/current density on the reflecting boundary is set to 0 while values
      *        in the guard cells are set equal (and opposite) to their mirror
      *        location inside the domain - representing image charges - in the
      *        normal (tangential) direction.
@@ -370,7 +370,7 @@ using namespace amrex;
      * \param[in out] field    field data to be updated
      * \param[in] mirrorfac    mirror cell is given by mirrorfac - ijk_vec
      * \param[in] psign        Whether the field value should be flipped across the boundary
-     * \param[in] is_pec       Whether the given boundary is PEC
+     * \param[in] is_reflective      Whether the given particle boundary is reflecting
      * \param[in] tangent_to_bndy    Whether a given direction is perpendicular to the boundary
      * \param[in] fabbox       multifab box including ghost cells
      */
@@ -380,7 +380,7 @@ using namespace amrex;
                                 amrex::Array4<amrex::Real> const& field,
                                 amrex::GpuArray<GpuArray<int, 2>, AMREX_SPACEDIM> const& mirrorfac,
                                 amrex::GpuArray<GpuArray<amrex::Real, 2>, AMREX_SPACEDIM> const& psign,
-                                amrex::GpuArray<GpuArray<bool, 2>, AMREX_SPACEDIM> const& is_pec,
+                                amrex::GpuArray<GpuArray<bool, 2>, AMREX_SPACEDIM> const& is_reflective,
                                 amrex::GpuArray<bool, AMREX_SPACEDIM> const& tangent_to_bndy,
                                 amrex::Box const& fabbox)
     {
@@ -391,7 +391,7 @@ using namespace amrex;
         {
             for (int iside = 0; iside < 2; ++iside)
             {
-                if (!is_pec[idim][iside]) { continue; }
+                if (!is_reflective[idim][iside]) { continue; }
 
                 // Get the mirror guard cell index
                 amrex::IntVect iv_mirror = ijk_vec;
@@ -412,7 +412,7 @@ using namespace amrex;
         {
             for (int iside = 0; iside < 2; ++iside)
             {
-                if (!is_pec[idim][iside]) { continue; }
+                if (!is_reflective[idim][iside]) { continue; }
 
                 amrex::IntVect iv_mirror = ijk_vec;
                 iv_mirror[idim] = mirrorfac[idim][iside] - ijk_vec[idim];
@@ -516,7 +516,7 @@ using namespace amrex;
      * \param[in]     lev        level of the Multifab
      * \param[in]     patch_type coarse or fine
      */
-    void ApplyPECtoRhofield(amrex::MultiFab* rho, int lev,
+    void ApplyReflectiveBoundarytoRhofield(amrex::MultiFab* rho, int lev,
                             PatchType patch_type);
 
     /**
@@ -527,7 +527,7 @@ using namespace amrex;
      * \param[in]     lev        level of the Multifab
      * \param[in]     patch_type coarse or fine
      */
-    void ApplyPECtoJfield(amrex::MultiFab* Jx, amrex::MultiFab* Jy,
+    void ApplyReflectiveBoundarytoJfield(amrex::MultiFab* Jx, amrex::MultiFab* Jy,
                           amrex::MultiFab* Jz, int lev,
                           PatchType patch_type);
 

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -24,6 +24,15 @@ PEC::isAnyBoundaryPEC() {
     return false;
 }
 
+bool
+PEC::isAnyParticleBoundaryReflecting () {
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        if (WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting) {return true;}
+        if (WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting) {return true;}
+    }
+    return false;
+}
+
 void
 PEC::ApplyPECtoEfield (std::array<amrex::MultiFab*, 3> Efield, const int lev,
                        PatchType patch_type, const bool split_pml_field)
@@ -248,8 +257,10 @@ PEC::ApplyPECtoRhofield (amrex::MultiFab* rho, const int lev, PatchType patch_ty
     amrex::GpuArray<GpuArray<amrex::Real,2>, AMREX_SPACEDIM> psign;
     amrex::GpuArray<GpuArray<int,2>, AMREX_SPACEDIM> mirrorfac;
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
-        is_pec[idim][0] = WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC;
-        is_pec[idim][1] = WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC;
+        is_pec[idim][0] = (  WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC
+                          || WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
+        is_pec[idim][1] = (  WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC
+                          || WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
         if (!is_pec[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_pec[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 
@@ -340,8 +351,10 @@ PEC::ApplyPECtoJfield(amrex::MultiFab* Jx, amrex::MultiFab* Jy,
     amrex::GpuArray<GpuArray<GpuArray<amrex::Real, 2>, AMREX_SPACEDIM>, 3> psign;
     amrex::GpuArray<GpuArray<GpuArray<int, 2>, AMREX_SPACEDIM>, 3> mirrorfac;
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
-        is_pec[idim][0] = WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC;
-        is_pec[idim][1] = WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC;
+        is_pec[idim][0] = (  WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC
+                          || WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
+        is_pec[idim][1] = (  WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC
+                          || WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting);
         if (!is_pec[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_pec[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -260,7 +260,7 @@ PEC::ApplyReflectiveBoundarytoRhofield (amrex::MultiFab* rho, const int lev, Pat
         is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting)
                               || ( WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC);
         is_reflective[idim][1] = ( WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
-                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC)
+                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC);
         if (!is_reflective[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_reflective[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -354,7 +354,7 @@ PEC::ApplyReflectiveBoundarytoJfield(amrex::MultiFab* Jx, amrex::MultiFab* Jy,
         is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting)
                               || ( WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC);
         is_reflective[idim][1] = ( WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
-                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC)
+                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC);
         if (!is_reflective[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_reflective[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -257,8 +257,10 @@ PEC::ApplyReflectiveBoundarytoRhofield (amrex::MultiFab* rho, const int lev, Pat
     amrex::GpuArray<GpuArray<amrex::Real,2>, AMREX_SPACEDIM> psign;
     amrex::GpuArray<GpuArray<int,2>, AMREX_SPACEDIM> mirrorfac;
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
-        is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
-        is_reflective[idim][1] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
+        is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting)
+                              || ( WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC);
+        is_reflective[idim][1] = ( WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
+                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC)
         if (!is_reflective[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_reflective[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 
@@ -349,8 +351,10 @@ PEC::ApplyReflectiveBoundarytoJfield(amrex::MultiFab* Jx, amrex::MultiFab* Jy,
     amrex::GpuArray<GpuArray<GpuArray<amrex::Real, 2>, AMREX_SPACEDIM>, 3> psign;
     amrex::GpuArray<GpuArray<GpuArray<int, 2>, AMREX_SPACEDIM>, 3> mirrorfac;
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
-        is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting);
-        is_reflective[idim][1] = ( WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting);
+        is_reflective[idim][0] = ( WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting)
+                              || ( WarpX::field_boundary_lo[idim] == FieldBoundaryType::PEC);
+        is_reflective[idim][1] = ( WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
+                              || ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PEC)
         if (!is_reflective[idim][0]) { grown_domain_box.growLo(idim, ng_fieldgather[idim]); }
         if (!is_reflective[idim][1]) { grown_domain_box.growHi(idim, ng_fieldgather[idim]); }
 


### PR DESCRIPTION
In this PR, instead of calling `ApplyPECtoRhoField` or `ApplyPECtoJField` ONLY when field boundary is PEC, we call the functions when the particle boundary is set to reflecting or field BC is PEC 
This ensures that the current behavior is supported, but also adds flexibility for delineating field and particle BCs
