### PR TITLE
[WIP] Enforce input for particle BC if species are included

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -407,7 +407,7 @@ Domain Boundary Conditions
     setting these variables will trigger an electrostatic solve at ``t=0``, to compute the initial
     electric field produced by the boundaries.
 
-* ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D, `absorbing` by default)
+* ``boundary.particle_lo`` and ``boundary.particle_hi`` (`2 strings` for 2D, `3 strings` for 3D)
     Options are:
 
     * ``Absorbing``: Particles leaving the boundary will be deleted.
@@ -680,6 +680,8 @@ Particle initialization
 * ``particles.species_names`` (`strings`, separated by spaces)
     The name of each species. This is then used in the rest of the input deck ;
     in this documentation we use `<species_name>` as a placeholder.
+    Note that particle boundary condition must be specified using
+    ``boundary.particle_lo`` and ``boundary.particle_hi``
 
 * ``particles.photon_species`` (`strings`, separated by spaces)
     List of species that are photon species, if any.

--- a/Examples/Physics_applications/laser_acceleration/inputs_3d
+++ b/Examples/Physics_applications/laser_acceleration/inputs_3d
@@ -17,6 +17,8 @@ amr.max_level = 0 # Maximum level in hierarchy (1 might be unstable, >1 is not s
 #################################
 boundary.field_lo = periodic periodic pec
 boundary.field_hi = periodic periodic pec
+boundary.particle_lo = periodic periodic absorbing
+boundary.particle_hi = periodic periodic absorbing
 
 #################################
 ############ NUMERICS ###########

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -415,13 +415,14 @@ void ReadBCParams ()
         ablastr::warn_manager::WMRecordWarning("Input", warnMsg);
     }
 
-    // particle boundary may not be explicitly specified for some applications
     const ParmParse pp_particles("particles");
     std::vector<std::string> species_names;
     pp_particles.queryarr("species_names",species_names);
     const ParmParse pp_boundary("boundary");
     pp_boundary.queryarr("field_lo", field_BC_lo, 0, AMREX_SPACEDIM);
     pp_boundary.queryarr("field_hi", field_BC_hi, 0, AMREX_SPACEDIM);
+
+    // If number of species is finite, then get particle boundary condition, which must be specified
     if (species_names.size() > 0) {
         pp_boundary.getarr("particle_lo", particle_BC_lo, 0, AMREX_SPACEDIM);
         pp_boundary.getarr("particle_hi", particle_BC_hi, 0, AMREX_SPACEDIM);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -416,20 +416,20 @@ void ReadBCParams ()
     }
 
     // particle boundary may not be explicitly specified for some applications
-    bool particle_boundary_specified = false;
+    const ParmParse pp_particles("particles");
+    std::vector<std::string> species_names;
+    pp_particles.queryarr("species_names",species_names);
     const ParmParse pp_boundary("boundary");
     pp_boundary.queryarr("field_lo", field_BC_lo, 0, AMREX_SPACEDIM);
     pp_boundary.queryarr("field_hi", field_BC_hi, 0, AMREX_SPACEDIM);
-    if (pp_boundary.queryarr("particle_lo", particle_BC_lo, 0, AMREX_SPACEDIM)) {
-        particle_boundary_specified = true;
-    }
-    if (pp_boundary.queryarr("particle_hi", particle_BC_hi, 0, AMREX_SPACEDIM)) {
-        particle_boundary_specified = true;
+    if (species_names.size() > 0) {
+        pp_boundary.getarr("particle_lo", particle_BC_lo, 0, AMREX_SPACEDIM);
+        pp_boundary.getarr("particle_hi", particle_BC_hi, 0, AMREX_SPACEDIM);
+        AMREX_ALWAYS_ASSERT(particle_BC_lo.size() == AMREX_SPACEDIM);
+        AMREX_ALWAYS_ASSERT(particle_BC_hi.size() == AMREX_SPACEDIM);
     }
     AMREX_ALWAYS_ASSERT(field_BC_lo.size() == AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(field_BC_hi.size() == AMREX_SPACEDIM);
-    AMREX_ALWAYS_ASSERT(particle_BC_lo.size() == AMREX_SPACEDIM);
-    AMREX_ALWAYS_ASSERT(particle_BC_hi.size() == AMREX_SPACEDIM);
 
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         // Get field boundary type
@@ -449,15 +449,11 @@ void ReadBCParams ()
                 (WarpX::field_boundary_lo[idim]  == FieldBoundaryType::Periodic) &&
                 (WarpX::field_boundary_hi[idim]  == FieldBoundaryType::Periodic),
             "field boundary must be consistenly periodic in both lo and hi");
-            if (particle_boundary_specified) {
+            if (species_names.size() > 0) {
                 WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                     (WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Periodic) &&
                     (WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Periodic),
                "field and particle boundary must be periodic in both lo and hi");
-            } else {
-                // set particle boundary to periodic
-                WarpX::particle_boundary_lo[idim] = ParticleBoundaryType::Periodic;
-                WarpX::particle_boundary_hi[idim] = ParticleBoundaryType::Periodic;
             }
         }
 


### PR DESCRIPTION
This PR will force users to include particle boundary condition in the input deck. (unlike the current behavior, where default is set to absorbing boundary condition for particles)