### PR TITLE
Update spacecraft charging test

### DIFF
--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -25,7 +25,8 @@ from pywarpx.particle_containers import ParticleBoundaryBufferWrapper
 class SpaceChargeFieldCorrector(object):
     """
     Class used by the callback functions to calculate the
-    correct charge on the spacecraft at each initialisation.
+    correct field around the spacecraft, at each timestep
+    (taking into account the charge that has been collected on the spacecraft)
     """
     def __init__(self):
         self.saved_first_iteration_fields = False
@@ -46,11 +47,11 @@ class SpaceChargeFieldCorrector(object):
             q = compute_actual_charge_on_spacecraft()
 
         # Correct fields so as to recover the actual charge
-        Er = ExWrapper(include_ghosts=True)[:,:]
+        Er = ExWrapper(include_ghosts=True)
         Er[...] = Er[...]+(q - q_v)*self.normalized_Er[...]
-        Ez = EzWrapper(include_ghosts=True)[:,:]
+        Ez = EzWrapper(include_ghosts=True)
         Ez[...]  += (q - q_v)*self.normalized_Ez[...]
-        phi = PhiFPWrapper(include_ghosts=True)[:,:]
+        phi = PhiFPWrapper(include_ghosts=True)
         phi[...]  += (q - q_v)*self.normalized_phi[...]
         self.spacecraft_potential += (q - q_v)*self.spacecraft_capacitance
         sim.extension.warpx.set_potential_on_eb( "%f" %self.spacecraft_potential )

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -48,11 +48,11 @@ class SpaceChargeFieldCorrector(object):
 
         # Correct fields so as to recover the actual charge
         Er = ExWrapper(include_ghosts=True)
-        Er[...] += (q - q_v)*self.normalized_Er[...]
+        Er[...] += (q - q_v)*self.normalized_Er
         Ez = EzWrapper(include_ghosts=True)
-        Ez[...]  += (q - q_v)*self.normalized_Ez[...]
+        Ez[...]  += (q - q_v)*self.normalized_Ez
         phi = PhiFPWrapper(include_ghosts=True)
-        phi[...]  += (q - q_v)*self.normalized_phi[...]
+        phi[...]  += (q - q_v)*self.normalized_phi
         self.spacecraft_potential += (q - q_v)*self.spacecraft_capacitance
         sim.extension.warpx.set_potential_on_eb( "%f" %self.spacecraft_potential )
         print('Setting potential to %f' %self.spacecraft_potential)

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -112,7 +112,7 @@ def compute_virtual_charge_on_spacecraft():
 
     # Compute integral of rho over volume of the domain
     # (i.e. total charge of the plasma particles)
-    rho_integral = (rho[1:nr-1,1:nz-1] * r[1:nr-1,np.new_axis]).sum()*dr*dz
+    rho_integral = (rho[1:nr-1,1:nz-1] * r[1:nr-1,np.newaxis]).sum()*dr*dz
 
     # Due to an oddity in WarpX (which will probably be solved later)
     # we need to multiply `rho` by `-epsilon_0` to get the correct charge

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -48,7 +48,7 @@ class SpaceChargeFieldCorrector(object):
 
         # Correct fields so as to recover the actual charge
         Er = ExWrapper(include_ghosts=True)
-        Er[...] = Er[...]+(q - q_v)*self.normalized_Er[...]
+        Er[...] += (q - q_v)*self.normalized_Er[...]
         Ez = EzWrapper(include_ghosts=True)
         Ez[...]  += (q - q_v)*self.normalized_Ez[...]
         phi = PhiFPWrapper(include_ghosts=True)

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -112,10 +112,7 @@ def compute_virtual_charge_on_spacecraft():
 
     # Compute integral of rho over volume of the domain
     # (i.e. total charge of the plasma particles)
-    rho_integral = 0.0
-    for k in range(1, nz-1):
-        for i in range(1, nr-1):
-            rho_integral += rho[i,k] * r[i] * dr * dz
+    rho_integral = (rho[1:nr-1,1:nz-1] * r[1:nr-1,np.new_axis]).sum()*dr*dz    
 
     # Due to an oddity in WarpX (which will probably be solved later)
     # we need to multiply `rho` by `-epsilon_0` to get the correct charge

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -112,7 +112,7 @@ def compute_virtual_charge_on_spacecraft():
 
     # Compute integral of rho over volume of the domain
     # (i.e. total charge of the plasma particles)
-    rho_integral = (rho[1:nr-1,1:nz-1] * r[1:nr-1,np.new_axis]).sum()*dr*dz    
+    rho_integral = (rho[1:nr-1,1:nz-1] * r[1:nr-1,np.new_axis]).sum()*dr*dz
 
     # Due to an oddity in WarpX (which will probably be solved later)
     # we need to multiply `rho` by `-epsilon_0` to get the correct charge

--- a/Examples/Physics_applications/spacecraft_charging/analysis.py
+++ b/Examples/Physics_applications/spacecraft_charging/analysis.py
@@ -61,8 +61,8 @@ print('fit parameters between the min(phi) curve over the time and the function 
 print('v0=%5.3f, tau=%5.9f' % (popt[0], popt[1]))
 
 
-tolerance_v0=0.01
-tolerance_tau=0.01
+tolerance_v0=0.04
+tolerance_tau=0.04
 print("tolerance for v0 = "+ str(tolerance_v0 *100) + '%')
 print("tolerance for tau = "+ str(tolerance_tau*100) + '%')
 

--- a/Regression/Checksum/benchmarks_json/spacecraft_charging.json
+++ b/Regression/Checksum/benchmarks_json/spacecraft_charging.json
@@ -1,30 +1,28 @@
 {
   "lev=0": {
-    "Er": 75713.05000099652,
-    "Ez": 75260.78239853957,
-    "phi": 55650.30604185804,
-    "rho": 1.4793075271598396e-06,
-    "rho_electrons": 6.506538129003745e-06,
-    "rho_protons": 6.98347902659172e-06
+  "Er": 72926.92774219153,
+  "Ez": 71877.43945667242,
+  "phi": 58270.32861572235,
+  "rho": 1.460951374255109e-06,
+  "rho_electrons": 6.501141119196457e-06,
+  "rho_protons": 6.992817056027598e-06
   },
   "electrons": {
-    "particle_position_x": 38158.7364935527,
-    "particle_position_y": 37779.25499255196,
-    "particle_position_z": 45010.371467374425,
-    "particle_momentum_x": 8.27307207197173e-20,
-    "particle_momentum_y": 8.264475255806164e-20,
-    "particle_momentum_z": 8.271327169054914e-20,
-    "particle_weight": 1140673608016.2212
+  "particle_position_x": 38094.07563382932,
+  "particle_position_y": 37781.48683071032,
+  "particle_position_z": 44952.3745721341,
+  "particle_momentum_x": 8.278426203619687e-20,
+  "particle_momentum_y": 8.272126720129096e-20,
+  "particle_momentum_z": 8.268559239607837e-20,
+  "particle_weight": 1140843527312.664
   },
   "protons": {
-    "particle_position_x": 751407.372588289,
-    "particle_position_y": 751687.788498272,
-    "particle_position_z": 644420.0485148785,
-    "particle_momentum_x": 1.468116154656724e-17,
-    "particle_momentum_y": 1.4650318746367807e-17,
-    "particle_momentum_z": 1.1638654342620123e-17,
-    "particle_weight": 1175692137613.312
+  "particle_position_x": 751412.1033107714,
+  "particle_position_y": 751687.9554423956,
+  "particle_position_z": 644516.6066265699,
+  "particle_momentum_x": 1.4698270572291615e-17,
+  "particle_momentum_y": 1.466699162579312e-17,
+  "particle_momentum_z": 1.162881798230096e-17,
+  "particle_weight": 1176011216106.0706
   }
 }
-
-


### PR DESCRIPTION
The spacecraft charging test was not properly correctly the electric field in the simulation with callback functions.

The purpose of the callback functions here is to correct the electric field, so that the charge on the spacecraft computed using Gauss law (from the electric field) matches the actual charge (calculated from collecting particles on the embedded boundary).

However, the current script corrects a **copy** of the electric field. The actual electric field in the simulation was not corrected. This can be seen from the `print` statements when the code is running. (The `print` statements print the charge from Gauss law and the actual charge, and they did not match with the current version of the script.)