### PR TITLE
Docs: update hybrid-pic description and parameters

### DIFF
--- a/Docs/source/theory/kinetic_fluid_hybrid_model.rst
+++ b/Docs/source/theory/kinetic_fluid_hybrid_model.rst
@@ -73,13 +73,13 @@ If we now further assume electrons are inertialess (i.e. :math:`m=0`), the above
         en_e\vec{E} = -\vec{J}_e\times\vec{B}-\nabla\cdot{\overleftrightarrow P}_e+\vec{R}_e.
 
 Making the further simplifying assumptions that the electron pressure is isotropic and that
-the electron drag term can be written as a simple resistance
-i.e. :math:`\vec{R}_e = en_e\vec{\eta}\cdot\vec{J}`, brings us to the implemented form of
+the electron drag term can be written using a simple resistivity (:math:`\eta`) and hyper-resistivity (:math:`\eta_h`)
+i.e. :math:`\vec{R}_e = en_e(\eta-\eta_h \nabla^2)\vec{J}`, brings us to the implemented form of
 Ohm's law:
 
     .. math::
 
-        \vec{E} = -\frac{1}{en_e}\left( \vec{J}_e\times\vec{B} + \nabla P_e \right)+\vec{\eta}\cdot\vec{J}.
+        \vec{E} = -\frac{1}{en_e}\left( \vec{J}_e\times\vec{B} + \nabla P_e \right)+\eta\vec{J}-\eta_h \nabla^2\vec{J}.
 
 Lastly, if an electron temperature is given from which the electron pressure can
 be calculated, the model is fully constrained and can be evolved given initial
@@ -92,10 +92,6 @@ Implementation details
 
     Various verification tests of the hybrid model implementation can be found in
     the :ref:`examples section <examples-hybrid-model>`.
-
-.. note::
-    WarpX's displacement current diagnostic is equivalent to electron current in
-    the kinetic-fluid hybrid model.
 
 The kinetic-fluid hybrid extension mostly uses the same routines as the standard electromagnetic
 PIC algorithm with the only exception that the E-field is calculated from the
@@ -170,6 +166,14 @@ input parameters, :math:`T_{e0}`, :math:`n_0` and :math:`\gamma` using
 
 The isothermal limit is given by :math:`\gamma = 1` while :math:`\gamma = 5/3`
 (default) produces the adiabatic limit.
+
+Electron current
+^^^^^^^^^^^^^^^^
+
+WarpX's displacement current diagnostic can be used to output the electron current in
+the kinetic-fluid hybrid model since in the absence of kinetic electrons, and under
+the assumption of zero displacement current, that diagnostic simply calculates the
+hybrid model's electron current.
 
 .. bibliography::
     :keyprefix: kfhm-

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2263,6 +2263,9 @@ Maxwell solver: kinetic-fluid hybrid
 * ``hybrid_pic_model.plasma_resistivity(rho,J)`` (`float` or `str`) optional (default ``0``)
     If ``algo.maxwell_solver`` is set to ``hybrid``, this sets the plasma resistivity in :math:`\Omega m`.
 
+* ``hybrid_pic_model.plasma_hyper_resistivity`` (`float` or `str`) optional (default ``0``)
+    If ``algo.maxwell_solver`` is set to ``hybrid``, this sets the plasma hyper-resistivity in :math:`\Omega m^3`.
+
 * ``hybrid_pic_model.J[x/y/z]_external_grid_function(x, y, z, t)`` (`float` or `str`) optional (default ``0``)
     If ``algo.maxwell_solver`` is set to ``hybrid``, this sets the external current (on the grid) in :math:`A/m^2`.
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1134,6 +1134,9 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
     plasma_resistivity: float or str
         Value or expression to use for the plasma resistivity.
 
+    plasma_hyper_resistivity: float or str
+        Value or expression to use for the plasma hyper-resistivity.
+
     substeps: int, default=100
         Number of substeps to take when updating the B-field.
 


### PR DESCRIPTION
Just a quick update to the docs to include the recent addition of hyper-resistivity in the hybrid-PIC description.