### PR TITLE
Clean up BeamRelevant with TypeMultiplier

### DIFF
--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -200,7 +200,7 @@ void BeamRelevant::ComputeDiags (int step)
         using PType = typename WarpXParticleContainer::SuperParticleType;
 
         // number of reduction operations in first concurrent batch
-        const int num_red_ops_1 = 8;
+        constexpr size_t num_red_ops_1 = 8;
         TypeMultiplier<amrex::ReduceOps, ReduceOpSum[num_red_ops_1]> reduce_ops_1;
         using ReducedDataT1 = TypeMultiplier<amrex::ReduceData, ParticleReal[num_red_ops_1]>;
 
@@ -276,7 +276,7 @@ void BeamRelevant::ComputeDiags (int step)
         }
 
         // number of reduction operations in second concurrent batch
-        const int num_red_ops_2 = 11;
+        constexpr size_t num_red_ops_2 = 11;
 
         TypeMultiplier<amrex::ReduceOps, ReduceOpSum[num_red_ops_2]> reduce_ops2;
         using ReducedDataT2 = TypeMultiplier<amrex::ReduceData, ParticleReal[num_red_ops_2]>;

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -20,6 +20,7 @@
 #include <AMReX_Particles.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Tuple.H>
+#include <AMReX_TypeList.H>
 
 #include <algorithm>
 #include <cmath>
@@ -198,14 +199,14 @@ void BeamRelevant::ComputeDiags (int step)
 
         using PType = typename WarpXParticleContainer::SuperParticleType;
 
-        amrex::ReduceOps<ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,
-        ReduceOpSum,ReduceOpSum,ReduceOpSum> reduce_ops;
-        auto r = amrex::ParticleReduce<amrex::ReduceData<ParticleReal,ParticleReal,
-        ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal>>(
+        // number of reduction operations in first concurrent batch
+        const int num_red_ops_1 = 8;
+        TypeMultiplier<amrex::ReduceOps, ReduceOpSum[num_red_ops_1]> reduce_ops_1;
+        using ReducedDataT1 = TypeMultiplier<amrex::ReduceData, ParticleReal[num_red_ops_1]>;
+
+        auto r1 = amrex::ParticleReduce<ReducedDataT1>(
             myspc,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> amrex::GpuTuple
-            <ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,
-            ParticleReal,ParticleReal,ParticleReal>
+            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> ReducedDataT1::Type
             {
                 const ParticleReal p_ux = p.rdata(PIdx::ux);
                 const ParticleReal p_uy = p.rdata(PIdx::uy);
@@ -242,18 +243,17 @@ void BeamRelevant::ComputeDiags (int step)
                         p_ux_mean, p_uy_mean, p_uz_mean,
                         p_gm_mean};
             },
-            reduce_ops);
+            reduce_ops_1);
 
-        std::vector<ParticleReal> values_per_rank_1st = {
-            amrex::get<0>(r), // w
-            amrex::get<1>(r), // x_mean
-            amrex::get<2>(r), // y_mean
-            amrex::get<3>(r), // z_mean
-            amrex::get<4>(r), // ux_mean
-            amrex::get<5>(r), // uy_mean
-            amrex::get<6>(r), // uz_mean
-            amrex::get<7>(r), // gm_mean
-        };
+        std::vector<ParticleReal> values_per_rank_1st(num_red_ops_1);
+
+        /* contains in this order:
+         * w, x_mean, y_mean, z_mean
+         * ux_mean, uy_mean, uz_mean, gm_mean
+         */
+        amrex::constexpr_for<0, num_red_ops_1> ([&](auto i) {
+            values_per_rank_1st[i] = amrex::get<i>(r1);
+        });
 
         // reduced sum over mpi ranks (allreduce)
         amrex::ParallelAllReduce::Sum
@@ -275,16 +275,15 @@ void BeamRelevant::ComputeDiags (int step)
             return;
         }
 
-        amrex::ReduceOps<ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,
-        ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum> reduce_ops2;
+        // number of reduction operations in second concurrent batch
+        const int num_red_ops_2 = 11;
 
-        auto r2 = amrex::ParticleReduce<amrex::ReduceData<ParticleReal,ParticleReal,
-        ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,
-        ParticleReal,ParticleReal,ParticleReal>>(
+        TypeMultiplier<amrex::ReduceOps, ReduceOpSum[num_red_ops_2]> reduce_ops2;
+        using ReducedDataT2 = TypeMultiplier<amrex::ReduceData, ParticleReal[num_red_ops_2]>;
+
+        auto r2 = amrex::ParticleReduce<ReducedDataT2>(
             myspc,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> amrex::GpuTuple
-            <ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal,
-            ParticleReal,ParticleReal,ParticleReal,ParticleReal,ParticleReal>
+            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> ReducedDataT2::Type
             {
                 const ParticleReal p_ux = p.rdata(PIdx::ux);
                 const ParticleReal p_uy = p.rdata(PIdx::uy);
@@ -336,19 +335,18 @@ void BeamRelevant::ComputeDiags (int step)
             },
             reduce_ops2);
 
-        std::vector<ParticleReal> values_per_rank_2nd = {
-            amrex::get<0>(r2), // x_ms
-            amrex::get<1>(r2), // y_ms
-            amrex::get<2>(r2), // z_ms
-            amrex::get<3>(r2), // ux_ms
-            amrex::get<4>(r2), // uy_ms
-            amrex::get<5>(r2), // uz_ms
-            amrex::get<6>(r2), // gm_ms
-            amrex::get<7>(r2), // xux
-            amrex::get<8>(r2), // yuy
-            amrex::get<9>(r2), // zuz
-            amrex::get<10>(r2) // charge
-        };
+        std::vector<ParticleReal> values_per_rank_2nd(num_red_ops_2);
+
+        /* contains in this order:
+         * x_ms, y_ms, z_ms
+         * ux_ms, uy_ms, uz_ms,
+         * gm_ms
+         * xux, yuy, zuz,
+         * charge
+         */
+        amrex::constexpr_for<0, num_red_ops_2> ([&](auto i) {
+            values_per_rank_2nd[i] = amrex::get<i>(r2);
+        });
 
         // reduced sum over mpi ranks (reduce to IO rank)
         ParallelDescriptor::ReduceRealSum


### PR DESCRIPTION
The `BeamRelevant` reduced diagnostics had a lot of code where `amrex::ReduceOps` were constructed from lists of types. This PR cleans it up with the `TypeMultiplier` utility that makes it more legible.

Credit goes to @AlexanderSinn's work in https://github.com/Hi-PACE/hipace/pull/1052 and https://github.com/AMReX-Codes/amrex/pull/3718.