### PR TITLE
Fix two minor typos in the scripts to run WarpX on Frontier

### DIFF
--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -14,7 +14,7 @@ set -eu -o pipefail
 
 # Check: ######################################################################
 #
-#   Was perlmutter_gpu_warpx.profile sourced and configured correctly?
+#   Was frontier_warpx.profile sourced and configured correctly?
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your frontier_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
 
 

--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -32,7 +32,7 @@
 export FI_MR_CACHE_MONITOR=memhooks  # alternative cache monitor
 
 # Seen since August 2023
-# OLCFDEV-1597: OFI Poll Failed UNDELIVERABLE Errors
+# OLCFDEV-1597: OFI Poll Failed UNDELIVERABLE Errors
 # https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1597-ofi-poll-failed-undeliverable-errors
 export MPICH_SMP_SINGLE_COPY_MODE=NONE
 export FI_CXI_RX_MATCH_MODE=software


### PR DESCRIPTION
This PR fix two minor typos in the scripts to run WarpX on  the Frontier supercomputer