### PR TITLE
[WIP] Refine particles in add plasma

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -978,7 +978,7 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector const& plasma_injector, int
         rrfac = m_gdb->refRatio(0);
         fine_injection_box.coarsen(rrfac);
     }
-    static bool refineplasma = false;
+    bool refineplasma = false;
     amrex::ParticleLocator<amrex::DenseBins<amrex::Box> > refinepatch_locator;
     if (WarpX::refineAddplasma)
     {
@@ -993,8 +993,6 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector const& plasma_injector, int
     }
     refinepatch_locator.setGeometry(Geom(0));
     auto assignpartgrid = refinepatch_locator.getGridAssignor();
-        // if assign_grid(ijk_vec) > 0, then we are in refinement patch. therefore refine plasma particles
-        // else, usual num_part
 
     InjectorPosition* inj_pos = plasma_injector.getInjectorPosition();
     InjectorDensity*  inj_rho = plasma_injector.getInjectorDensity();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -335,6 +335,7 @@ public:
 
     static bool do_dynamic_scheduling;
     static bool refine_plasma;
+    static bool refineAddplasma;
 
     static utils::parser::IntervalsParser sort_intervals;
     static amrex::IntVect sort_bin_size;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -173,6 +173,7 @@ bool WarpX::use_filter_compensation = false;
 
 bool WarpX::serialize_initial_conditions = false;
 bool WarpX::refine_plasma     = false;
+bool WarpX::refineAddplasma   = false;
 
 int WarpX::num_mirrors = 0;
 
@@ -882,6 +883,7 @@ WarpX::ReadParameters ()
 
         pp_warpx.query("serialize_initial_conditions", serialize_initial_conditions);
         pp_warpx.query("refine_plasma", refine_plasma);
+        pp_warpx.query("refineAddplasma", refineAddplasma);
         pp_warpx.query("do_dive_cleaning", do_dive_cleaning);
         pp_warpx.query("do_divb_cleaning", do_divb_cleaning);
         utils::parser::queryWithParser(


### PR DESCRIPTION
The current option of initializing particles with 'NUniformPerCell', injects N particles per cell in the parent grid. However, the number of particles may not be sufficient for the fine cell resolution, if MR is on. With this PR, an option is included to refine plasma when initializing particles in the parent grid, such that, in the region that overlaps with MR patch, the number of particles is increased by (refinement ratio)^DIMS .

Below is an example, where 1 particles per cell is used with refineplasma option, and thus there is one particle per refined cell in the fine patch.

to do : 
1. check in about input API 
2. CI coverage
3. generalize to include refineplasma option with continuous injection

<img width="637" alt="Screenshot 2024-03-30 at 8 54 35 PM" src="https://github.com/ECP-WarpX/WarpX/assets/41089244/9c81017f-0872-4d03-a0d0-40e88baae055">

