### PR TITLE
Printing out the time dependencies of the charge and current densitie…

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -300,6 +300,18 @@ WarpX::PrintMainPICparameters ()
       amrex::Print() << "                      | - multi-J deposition is ON \n";
       amrex::Print() << "                      |   - do_multi_J_n_depositions = "
                                         << WarpX::do_multi_J_n_depositions << "\n";
+      if (J_in_time == JInTime::Linear){
+        amrex::Print() << "                      |   - J_in_time = linear \n";
+      }
+      if (J_in_time == JInTime::Constant){
+        amrex::Print() << "                      |   - J_in_time = constant \n";
+      }
+      if (rho_in_time == RhoInTime::Linear){
+        amrex::Print() << "                      |   - rho_in_time = linear \n";
+      }
+      if (rho_in_time == RhoInTime::Constant){
+        amrex::Print() << "                      |   - rho_in_time = constant \n";
+      }
     }
     if (fft_do_time_averaging == 1){
       amrex::Print()<<"                      | - time-averaged is ON \n";


### PR DESCRIPTION
This PR prints out the information about the time dependencies of the charge and current densities over one time step when used with multi-J PSATD: `warpx.do_multi_J = 1`. It's especially will be useful once [PR 4263](https://github.com/ECP-WarpX/WarpX/pull/4263) is merged, where we have arbitrary time dependencies for J and rho (up to the second order).