### PR TITLE
Fix outdated element-wise comparison based assertions

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -596,7 +596,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
     for (int i = 0; i < 3; ++i)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            ng <= mf[i]->nGrowVect(),
+            ng.allLE(mf[i]->nGrowVect()),
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
@@ -653,7 +653,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
     for (int i = 0; i < 3; ++i)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            ng <= mf[i]->nGrowVect(),
+            ng.allLE(mf[i]->nGrowVect()),
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (safe_guard_cells) ? mf[i]->nGrowVect() : ng;
@@ -684,7 +684,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng <= Efield_avg_fp[lev][0]->nGrowVect(),
+                ng.allLE(Efield_avg_fp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
             ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
             ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
@@ -705,7 +705,7 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
 
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng <= Efield_avg_cp[lev][0]->nGrowVect(),
+                ng.allLE(Efield_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
             ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
             ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
@@ -737,7 +737,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng <= Bfield_fp[lev][0]->nGrowVect(),
+                ng.allLE(Bfield_fp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
             ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
             ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
@@ -757,7 +757,7 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng <= Bfield_avg_cp[lev][0]->nGrowVect(),
+                ng.allLE(Bfield_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
             ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
             ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);

--- a/Source/ablastr/coarsen/sample.cpp
+++ b/Source/ablastr/coarsen/sample.cpp
@@ -41,12 +41,12 @@ namespace ablastr::coarsen::sample
         const amrex::IntVect stag_src = mf_src.boxArray().ixType().toIntVect();
         const amrex::IntVect stag_dst = mf_dst.boxArray().ixType().toIntVect();
 
-        if ( crse_ratio > amrex::IntVect(1) ) {
+        if ( crse_ratio.allGT(amrex::IntVect(1)) ) {
             ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE( ngrowvect == amrex::IntVect(0),
                                                 "option of filling guard cells of destination MultiFab with coarsening not supported for this interpolation" );
         }
 
-        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.nGrowVect() >= stag_dst-stag_src+ngrowvect,
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE( mf_src.nGrowVect().allGE(stag_dst-stag_src+ngrowvect),
                                             "source fine MultiFab does not have enough guard cells for this interpolation" );
 
         // Auxiliary integer arrays (always 3D)

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -71,7 +71,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
     if (num_rho_deposition_guards.has_value()) {
         ng_rho = num_rho_deposition_guards.value();
     }
-    ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho <= rho->nGrowVect(),
+    ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho.allLT(rho->nGrowVect()),
                                        "num_rho_deposition_guards are larger than allocated!");
     // particle shape
     auto const[nox, noy, noz] = std::array<int, 3>{particle_shape, particle_shape, particle_shape};

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -71,7 +71,7 @@ deposit_charge (typename T_PC::ParIterType& pti,
     if (num_rho_deposition_guards.has_value()) {
         ng_rho = num_rho_deposition_guards.value();
     }
-    ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho.allLT(rho->nGrowVect()),
+    ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(ng_rho.allLE(rho->nGrowVect()),
                                        "num_rho_deposition_guards are larger than allocated!");
     // particle shape
     auto const[nox, noy, noz] = std::array<int, 3>{particle_shape, particle_shape, particle_shape};


### PR DESCRIPTION
Update comparisons of the form:
```
ng_rho <= rho->nGrowVect()
```
to
```
ng_rho.allLE(rho->nGrowVect())
```