### PR TITLE
Fix out of bounds access to `distance_to_eb`

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -302,10 +302,9 @@ WarpXParticleContainer::AddNParticles (int lev, long n,
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
-#endif
-
     // Call (local) redistribute again to remove particles with invalid ids
     Redistribute(lev, lev, 0, 1, true);
+#endif
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -305,7 +305,7 @@ WarpXParticleContainer::AddNParticles (int lev, long n,
 #endif
 
     // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(lev, lev, 1, true, true);
+    Redistribute(lev, lev, 0, 0, true);
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -158,7 +158,7 @@ WarpXParticleContainer::AllocData ()
 }
 
 void
-WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
+WarpXParticleContainer::AddNParticles (int lev, long n,
                                        amrex::Vector<amrex::ParticleReal> const & x,
                                        amrex::Vector<amrex::ParticleReal> const & y,
                                        amrex::Vector<amrex::ParticleReal> const & z,
@@ -305,7 +305,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 #endif
 
     // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(0, -1, 0, true, true);
+    Redistribute(lev, lev, 1, true, true);
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -295,13 +295,17 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
         );
     }
 
+    // Move particles to their appropriate tiles
+    Redistribute();
+
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
 #endif
 
-    Redistribute();
+    // Call (local) redistribute again to remove particles with invalid ids
+    Redistribute(0, -1, 0, 1, 1);
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -305,7 +305,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 #endif
 
     // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(0, -1, 0, 1, 1);
+    Redistribute(0, -1, 0, true, true);
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -158,7 +158,7 @@ WarpXParticleContainer::AllocData ()
 }
 
 void
-WarpXParticleContainer::AddNParticles (int lev, long n,
+WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
                                        amrex::Vector<amrex::ParticleReal> const & x,
                                        amrex::Vector<amrex::ParticleReal> const & y,
                                        amrex::Vector<amrex::ParticleReal> const & z,
@@ -303,7 +303,7 @@ WarpXParticleContainer::AddNParticles (int lev, long n,
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
     // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(lev, lev, 0, 1, true);
+    Redistribute(0, -1, 0, 1, true);
 #endif
 }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -305,7 +305,7 @@ WarpXParticleContainer::AddNParticles (int lev, long n,
 #endif
 
     // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(lev, lev, 0, 0, true);
+    Redistribute(lev, lev, 0, 1, true);
 }
 
 /* \brief Current Deposition for thread thread_num


### PR DESCRIPTION
While running in debug mode I found that there are out of bounds accesses to the `distance_to_eb` multifab. Tracing these I discovered that they come from `AddNParticles()` due to the fact that particles are scraped before they are redistributed. This PR fixes the issue.