### PR TITLE
HPC3 (UCI): Fix ADIOS2 HDF5 Build

### DIFF
--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -70,7 +70,7 @@ else
   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 rm -rf $HOME/src/adios2-pm-gpu-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_HDF5=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
 cmake --build $HOME/src/adios2-pm-gpu-build --target install --parallel 8
 rm -rf $HOME/src/adios2-pm-gpu-build
 


### PR DESCRIPTION
Disable building examples and tests for ADIOS2 for speed. Do not build HDF5 bindings of ADIOS2 due an incompatibility in this version.

cc @erny123 @floresv299 @Aquios7 @jinze-liu 