### PR TITLE
[WIP] Apply field boundary before sync rho

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -226,13 +226,13 @@ WarpX::AddSpaceChargeFieldLabFrame ()
         myfl->DepositCharge( lev, *rho_fp[lev] );
     }
 
-    SyncRho(rho_fp, rho_cp, charge_buf); // Apply filter, perform MPI exchange, interpolate across levels
 #ifndef WARPX_DIM_RZ
     for (int lev = 0; lev <= finestLevel(); lev++) {
         // Reflect density over PEC boundaries, if needed.
         ApplyRhofieldBoundary(lev, rho_fp[lev].get(), PatchType::fine);
     }
 #endif
+    SyncRho(rho_fp, rho_cp, charge_buf); // Apply filter, perform MPI exchange, interpolate across levels
 
     // beta is zero in lab frame
     // Todo: use simpler finite difference form with beta=0


### PR DESCRIPTION
This code change seems to fix https://github.com/ECP-WarpX/WarpX/issues/4833