### PR TITLE
Add ohms law hybrid multifab redistribution

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1297,12 +1297,6 @@ void WarpX::CheckKnownIssues()
                 ablastr::warn_manager::WarnPriority::low);
         }
 
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            !load_balance_intervals.isActivated(),
-            "The hybrid-PIC algorithm involves multifabs that are not yet "
-            "properly redistributed during load balancing events."
-        );
-
         const bool external_particle_field_used = (
             mypc->m_B_ext_particle_s != "none" || mypc->m_E_ext_particle_s != "none"
         );

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -235,7 +235,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         RemakeMultiFab(phi_fp[lev], dm, true ,lev);
 
         if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC) {
-            RemakeMultiFab(m_hybrid_pic_model->rho_fp_temp[lev], dm, false, lev);
+            RemakeMultiFab(m_hybrid_pic_model->rho_fp_temp[lev], dm, true, lev);
             RemakeMultiFab(m_hybrid_pic_model->electron_pressure_fp[lev], dm, false, lev);
         }
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -11,6 +11,7 @@
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 #include "EmbeddedBoundary/WarpXFaceInfoBox.H"
+#include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H"
 #include "Initialization/ExternalField.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
@@ -206,6 +207,11 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 RemakeMultiFab(Efield_avg_fp[lev][idim], dm, true ,lev);
                 RemakeMultiFab(Bfield_avg_fp[lev][idim], dm, true ,lev);
             }
+            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC) {
+                RemakeMultiFab(m_hybrid_pic_model->current_fp_temp[lev][idim], dm, false, lev);
+                RemakeMultiFab(m_hybrid_pic_model->current_fp_ampere[lev][idim], dm, false, lev);
+                RemakeMultiFab(m_hybrid_pic_model->current_fp_external[lev][idim], dm, true, lev);
+            }
 #ifdef AMREX_USE_EB
             if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
                 RemakeMultiFab(m_edge_lengths[lev][idim], dm, false ,lev);
@@ -227,6 +233,11 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         // phi_fp should be redistributed since we use the solution from
         // the last step as the initial guess for the next solve
         RemakeMultiFab(phi_fp[lev], dm, true ,lev);
+
+        if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC) {
+            RemakeMultiFab(m_hybrid_pic_model->rho_fp_temp[lev], dm, false, lev);
+            RemakeMultiFab(m_hybrid_pic_model->electron_pressure_fp[lev], dm, false, lev);
+        }
 
 #ifdef AMREX_USE_EB
         RemakeMultiFab(m_distance_to_eb[lev], dm, false ,lev);

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -208,7 +208,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 RemakeMultiFab(Bfield_avg_fp[lev][idim], dm, true ,lev);
             }
             if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC) {
-                RemakeMultiFab(m_hybrid_pic_model->current_fp_temp[lev][idim], dm, false, lev);
+                RemakeMultiFab(m_hybrid_pic_model->current_fp_temp[lev][idim], dm, true, lev);
                 RemakeMultiFab(m_hybrid_pic_model->current_fp_ampere[lev][idim], dm, false, lev);
                 RemakeMultiFab(m_hybrid_pic_model->current_fp_external[lev][idim], dm, true, lev);
             }


### PR DESCRIPTION
This PR adds redistribution of Ohm's Law Hybrid solver multifabs to allow for load balancing when not using explicit processor decomposition.