### PR TITLE
Use function to remove invalid particles without MPI exchange

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -322,6 +322,13 @@ public:
                         int nattr_int, amrex::Vector<amrex::Vector<int>> const & attr_int,
                         int uniqueparticles, amrex::Long id=-1);
 
+    /** Remove particles with invalid ID
+    *
+    * This is a local operation (no MPI communication) and is thus preferable over `ReDistribute`
+    * (which also removes invalid particles, but involves MPI communications at the same time)
+    */
+    void deleteInvalidParticles ();
+
     virtual void ReadHeader (std::istream& is) = 0;
 
     virtual void WriteHeader (std::ostream& os) const = 0;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -302,7 +302,11 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
-    // Remove particles with invalid ids
+    deleteInvalidParticles();
+}
+
+void
+WarpXParticleContainer::deleteInvalidParticles () {
     const int nLevels = finestLevel();
     for (int lev = 0; lev <= nLevels; ++lev) {
 #ifdef AMREX_USE_OMP

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -309,7 +309,8 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 #pragma omp parallel
 #endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti) {
-            removeInvalidParticles( pti );
+            ParticleTileType& ptile = ParticlesAt(lev, pti);
+            removeInvalidParticles( ptile );
         }
     }
 #endif

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -303,6 +303,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
     deleteInvalidParticles();
+#endif
 }
 
 void
@@ -317,7 +318,6 @@ WarpXParticleContainer::deleteInvalidParticles () {
             removeInvalidParticles( ptile );
         }
     }
-#endif
 }
 
 /* \brief Current Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -302,8 +302,16 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
     scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
-    // Call (local) redistribute again to remove particles with invalid ids
-    Redistribute(0, -1, 0, 1, true);
+    // Remove particles with invalid ids
+    const int nLevels = finestLevel();
+    for (int lev = 0; lev <= nLevels; ++lev) {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti) {
+            removeInvalidParticles( pti );
+        }
+    }
 #endif
 }
 


### PR DESCRIPTION
The new function (introduced by @AlexanderSinn in `amrex`) is a local operation (no MPI communication) and is thus preferable over `ReDistribute` (which also removes invalid particles, but involves MPI communications at the same time).