### PR TITLE
Use local deleteInvalidParticles (instead of Redistribute) in binary collisions

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -213,9 +213,8 @@ public:
                 // The fact that there are product species indicates that particles of
                 // the colliding species (`species1` and `species2`) may be removed
                 // (i.e., marked as invalid) in the process of creating new product particles.
-                // Call (local) redistribute to remove invalid particles
-                species1.Redistribute(lev, lev, 0, 1, true);
-                species2.Redistribute(lev, lev, 0, 1, true);
+                species1.deleteInvalidParticles();
+                species2.deleteInvalidParticles();
             }
         }
     }


### PR DESCRIPTION
This should be more efficient since it avoids MPI communications.