### PR TITLE
Reorder particle boundary handling and call to `Redistribute`

### DIFF
--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -65,9 +65,9 @@
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
 void
-scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb, int lev, F&& f)
+scrapeParticlesAtEB (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb, int lev, F&& f)
 {
-    scrapeParticles(pc, distance_to_eb, lev, lev, std::forward<F>(f));
+    scrapeParticlesAtEB(pc, distance_to_eb, lev, lev, std::forward<F>(f));
 }
 
 /**
@@ -108,9 +108,9 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
 void
-scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb, F&& f)
+scrapeParticlesAtEB (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb, F&& f)
 {
-    scrapeParticles(pc, distance_to_eb, 0, pc.finestLevel(), std::forward<F>(f));
+    scrapeParticlesAtEB(pc, distance_to_eb, 0, pc.finestLevel(), std::forward<F>(f));
 }
 
 /**
@@ -153,10 +153,10 @@ scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_t
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
 void
-scrapeParticles (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb,
+scrapeParticlesAtEB (PC& pc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb,
                  int lev_min, int lev_max, F&& f)
 {
-    BL_PROFILE("scrapeParticles");
+    BL_PROFILE("scrapeParticlesAtEB");
 
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -488,6 +488,9 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
 {
     mypc->ContinuousFluxInjection(cur_time, dt[0]);
 
+    mypc->ApplyBoundaryConditions();
+    m_particle_boundary_buffer->gatherParticlesFromDomainBoundaries(*mypc);
+
     // Non-Maxwell solver: particles can move by an arbitrary number of cells
     if( electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
         electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC )
@@ -514,14 +517,11 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
         }
     }
 
-    mypc->ApplyBoundaryConditions();
-
     // interact the particles with EB walls (if present)
 #ifdef AMREX_USE_EB
     mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
+    m_particle_boundary_buffer->gatherParticlesFromEmbeddedBoundaries(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
 #endif
-
-    m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
 
     mypc->deleteInvalidParticles();
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -519,11 +519,10 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
 
     // interact the particles with EB walls (if present)
 #ifdef AMREX_USE_EB
-    mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
+    mypc->ScrapeParticlesAtEB(amrex::GetVecOfConstPtrs(m_distance_to_eb));
     m_particle_boundary_buffer->gatherParticlesFromEmbeddedBoundaries(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
-#endif
-
     mypc->deleteInvalidParticles();
+#endif
 
     if (sort_intervals.contains(step+1)) {
         if (verbose) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -488,15 +488,6 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
 {
     mypc->ContinuousFluxInjection(cur_time, dt[0]);
 
-    mypc->ApplyBoundaryConditions();
-
-    // interact the particles with EB walls (if present)
-#ifdef AMREX_USE_EB
-    mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
-#endif
-
-    m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
-
     // Non-Maxwell solver: particles can move by an arbitrary number of cells
     if( electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
         electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC )
@@ -522,6 +513,17 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
             mypc->Redistribute();
         }
     }
+
+    mypc->ApplyBoundaryConditions();
+
+    // interact the particles with EB walls (if present)
+#ifdef AMREX_USE_EB
+    mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
+#endif
+
+    m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
+
+    mypc->deleteInvalidParticles();
 
     if (sort_intervals.contains(step+1)) {
         if (verbose) {

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -213,6 +213,8 @@ public:
 
     void defineAllParticleTiles ();
 
+    void deleteInvalidParticles ();
+
     void RedistributeLocal (int num_ghost);
 
     /** Apply BC. For now, just discard particles outside the domain, regardless

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -296,7 +296,7 @@ public:
 
     PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
 
-    void ScrapeParticles (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
+    void ScrapeParticlesAtEB (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
 
     std::string m_B_ext_particle_s = "none";
     std::string m_E_ext_particle_s = "none";

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -633,6 +633,14 @@ MultiParticleContainer::defineAllParticleTiles ()
 }
 
 void
+MultiParticleContainer::deleteInvalidParticles ()
+{
+    for (auto& pc : allcontainers) {
+        pc->deleteInvalidParticles();
+    }
+}
+
+void
 MultiParticleContainer::RedistributeLocal (const int num_ghost)
 {
     for (auto& pc : allcontainers) {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -953,11 +953,11 @@ void MultiParticleContainer::CheckIonizationProductSpecies()
     }
 }
 
-void MultiParticleContainer::ScrapeParticles (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb)
+void MultiParticleContainer::ScrapeParticlesAtEB (const amrex::Vector<const amrex::MultiFab*>& distance_to_eb)
 {
 #ifdef AMREX_USE_EB
     for (auto& pc : allcontainers) {
-        scrapeParticles(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
+        scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
     }
 #else
     amrex::ignore_unused(distance_to_eb);

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -39,8 +39,10 @@ public:
 
     const std::vector<std::string>& getSpeciesNames() const;
 
-    void gatherParticles (MultiParticleContainer& mypc,
-                          const amrex::Vector<const amrex::MultiFab*>& distance_to_eb);
+    void gatherParticlesFromDomainBoundaries (MultiParticleContainer& mypc);
+    void gatherParticlesFromEmbeddedBoundaries (
+        MultiParticleContainer& mypc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb
+    );
 
     void redistribute ();
     void clearParticles ();

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -354,8 +354,7 @@ void ParticleBoundaryBuffer::clearParticles (int const i) {
     }
 }
 
-void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
-                                              const amrex::Vector<const amrex::MultiFab*>& distance_to_eb)
+void ParticleBoundaryBuffer::gatherParticlesFromDomainBoundaries (MultiParticleContainer& mypc)
 {
     WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles");
 
@@ -439,9 +438,18 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
             }
         }
     }
+}
 
+void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
+    MultiParticleContainer& mypc, const amrex::Vector<const amrex::MultiFab*>& distance_to_eb)
+{
 #ifdef AMREX_USE_EB
     WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::EB");
+
+    using PIter = amrex::ParConstIterSoA<PIdx::nattribs, 0>;
+    const auto& warpx_instance = WarpX::GetInstance();
+    const amrex::Geometry& geom = warpx_instance.Geom(0);
+    auto plo = geom.ProbLoArray();
 
     auto& buffer = m_particle_containers[m_particle_containers.size()-1];
     for (int i = 0; i < numSpecies(); ++i)
@@ -526,7 +534,7 @@ void ParticleBoundaryBuffer::gatherParticles (MultiParticleContainer& mypc,
         }
     }
 #else
-    amrex::ignore_unused(distance_to_eb);
+    amrex::ignore_unused(mypc, distance_to_eb);
 #endif
 }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1476,7 +1476,7 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector const& plasma_injector, int
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
-    scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
+    scrapeParticlesAtEB( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
 #endif
 
     // The function that calls this is responsible for redistributing particles.
@@ -1973,7 +1973,7 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
-    scrapeParticles(tmp_pc, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
+    scrapeParticlesAtEB(tmp_pc, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
 #endif
 
     // Redistribute the new particles that were added to the temporary container.

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -301,7 +301,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
     auto & distance_to_eb = WarpX::GetInstance().GetDistanceToEB();
-    scrapeParticles( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
+    scrapeParticlesAtEB( *this, amrex::GetVecOfConstPtrs(distance_to_eb), ParticleBoundaryProcess::Absorb());
     deleteInvalidParticles();
 #endif
 }


### PR DESCRIPTION
Based on the bugfix from #4831, wouldn't the same risk currently exist in the `WarpX::HandleParticlesAtBoundaries()` function?
This PR reorganizes that function to first redistribute particles to their appropriate tiles before determining whether the particle is overlapping with an embedded boundary. It then uses the new `deleteInvalidParticles()` function to remove particles that were determined to be invalid during scraping.