### PR TITLE
Always write the particles' positions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2676,6 +2676,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 * ``<diag_name>.<species_name>.variables`` (list of `strings` separated by spaces, optional)
     List of particle quantities to write to output.
     Choices are ``w`` for the particle weight and ``ux`` ``uy`` ``uz`` for the particle momenta.
+    (The positions ``x``, ``y``, ``z``, as well as the particle ID are always written, and thus do not need to be specified in this list.)
     When using the lab-frame electrostatic solver, ``phi`` (electrostatic potential, on the macroparticles) is also available.
     By default, all particle quantities (except ``phi``) are written.
     If ``<diag_name>.<species_name>.variables = none``, no particle data are written, except for particle positions, which are always included.

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -50,8 +50,8 @@ ParticleDiag::ParticleDiag(
                 }
             }
             // Always write the position
-            // Note: for WARPX_DIM_RZ, no need to set the flag for x and y: they are always written
-#if defined (WARPX_DIM_2D) || defined(WARPX_DIM_3Z)
+            // Note: for WARPX_DIM_RZ, no need to set the flag y: it is always written
+#if !defined (WARPX_DIM_1D_Z)
             m_plot_flags[pc->getParticleComps().at("x")] = 1;
 #endif
 #if defined (WARPX_DIM_3D)

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -61,6 +61,13 @@ ParticleDiag::ParticleDiag(
         }
     }
 
+#ifdef WARPX_DIM_RZ
+    // Always write out theta, whether or not it's requested,
+    // to be consistent with always writing out r and z.
+    // TODO: openPMD does a reconstruction to Cartesian, so we can now skip force-writing this
+    m_plot_flags[pc->getParticleComps().at("theta")] = 1;
+#endif
+
     // build filter functors
     m_do_random_filter = utils::parser::queryWithParser(
         pp_diag_name_species_name, "random_fraction", m_random_fraction);

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -49,16 +49,17 @@ ParticleDiag::ParticleDiag(
                     m_plot_flags[existing_variable_names.at(var)] = 1;
                 }
             }
+            // Always write the position
+            // Note: for WARPX_DIM_RZ, no need to set the flag for x and y: they are always written
+#if defined (WARPX_DIM_2D) || defined(WARPX_DIM_3Z)
+            m_plot_flags[pc->getParticleComps().at("x")] = 1;
+#endif
+#if defined (WARPX_DIM_3D)
+            m_plot_flags[pc->getParticleComps().at("y")] = 1;
+#endif
+            m_plot_flags[pc->getParticleComps().at("z")] = 1;
         }
     }
-    // Always write the position
-#if !defined (WARPX_DIM_1D_Z)
-    m_plot_flags[pc->getParticleComps().at("x")] = 1;
-#endif
-#if defined (WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
-    m_plot_flags[pc->getParticleComps().at("y")] = 1;
-#endif
-    m_plot_flags[pc->getParticleComps().at("z")] = 1;
 
     // build filter functors
     m_do_random_filter = utils::parser::queryWithParser(

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -52,8 +52,12 @@ ParticleDiag::ParticleDiag(
         }
     }
     // Always write the position
+#if !defined (WARPX_DIM_1D_Z)
     m_plot_flags[pc->getParticleComps().at("x")] = 1;
+#endif
+#if defined (WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
     m_plot_flags[pc->getParticleComps().at("y")] = 1;
+#endif
     m_plot_flags[pc->getParticleComps().at("z")] = 1;
 
     // build filter functors

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -41,6 +41,7 @@ ParticleDiag::ParticleDiag(
                     // Therefore, this case needs to be treated specifically.
                     m_plot_phi = true;
                 } else {
+                    amrex::Print() << var << std::endl;
                     const auto search = existing_variable_names.find(var);
                     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         search != existing_variable_names.end(),
@@ -51,13 +52,10 @@ ParticleDiag::ParticleDiag(
             }
         }
     }
-
-#ifdef WARPX_DIM_RZ
-    // Always write out theta, whether or not it's requested,
-    // to be consistent with always writing out r and z.
-    // TODO: openPMD does a reconstruction to Cartesian, so we can now skip force-writing this
-    m_plot_flags[pc->getParticleComps().at("theta")] = 1;
-#endif
+    // Always write the position
+    m_plot_flags[pc->getParticleComps().at("x")] = 1;
+    m_plot_flags[pc->getParticleComps().at("y")] = 1;
+    m_plot_flags[pc->getParticleComps().at("z")] = 1;
 
     // build filter functors
     m_do_random_filter = utils::parser::queryWithParser(

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -41,7 +41,6 @@ ParticleDiag::ParticleDiag(
                     // Therefore, this case needs to be treated specifically.
                     m_plot_phi = true;
                 } else {
-                    amrex::Print() << var << std::endl;
                     const auto search = existing_variable_names.find(var);
                     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         search != existing_variable_names.end(),


### PR DESCRIPTION
As part of our restructuring from AoS positions to SoA (https://github.com/ECP-WarpX/WarpX/pull/4653), it seems that the particles' positions are not written out by default anymore. (But they probably should, since, in my understanding, the particles' positions and ID are [required attributes](https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#records-for-each-particle-species) in the openPMD standard.)

This PR writes out the particle positions by default.

Fixes #4841