### PR TITLE
DepositCharge: Component 1 Allocated?

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2227,10 +2227,9 @@ PhysicalParticleContainer::Evolve (int lev,
             if (rho && ! skip_deposition && ! do_not_deposit) {
                 // Deposit charge after particle push, in component 1 of MultiFab rho.
                 // (Skipped for electrostatic solver, as this may lead to out-of-bounds)
-                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(rho->nComp() >= 2,
-                    "Cannot deposit charge in rho component 1: only component 0 is allocated!");
-
                 if (WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
+                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(rho->nComp() >= 2,
+                        "Cannot deposit charge in rho component 1: only component 0 is allocated!");
 
                     const int* const AMREX_RESTRICT ion_lev = (do_field_ionization)?
                         pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr():nullptr;

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2227,6 +2227,9 @@ PhysicalParticleContainer::Evolve (int lev,
             if (rho && ! skip_deposition && ! do_not_deposit) {
                 // Deposit charge after particle push, in component 1 of MultiFab rho.
                 // (Skipped for electrostatic solver, as this may lead to out-of-bounds)
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(rho->nComp() >= 2,
+                    "Cannot deposit charge in rho component 1: only component 0 is allocated!");
+
                 if (WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
 
                     const int* const AMREX_RESTRICT ion_lev = (do_field_ionization)?

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -883,6 +883,12 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                                        const long offset, const long np_to_deposit,
                                        const int thread_num, const int lev, const int depos_lev)
 {
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        rho->nComp() >= icomp - 1,
+        "Cannot deposit charge in rho component icomp=" + std::to_string(icomp) +
+        ": not enough components allocated (" + std::to_string(rho->nComp()) + "!"
+    );
+
     if (WarpX::do_shared_mem_charge_deposition)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE((depos_lev==(lev-1)) ||
@@ -1208,6 +1214,12 @@ WarpXParticleContainer::DepositCharge (std::unique_ptr<amrex::MultiFab>& rho,
                                        const bool apply_boundary_and_scale_volume,
                                        const int icomp)
 {
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        rho->nComp() >= icomp - 1,
+        "Cannot deposit charge in rho component icomp=" + std::to_string(icomp) +
+        ": not enough components allocated (" + std::to_string(rho->nComp()) + "!"
+    );
+
     // Reset the rho array if reset is True
     int const nc = WarpX::ncomps;
     if (reset) { rho->setVal(0., icomp*nc, nc, rho->nGrowVect()); }


### PR DESCRIPTION
It looks like in the EM solver, with `rho` field diagnostics enabled, we try to write into component 1 of rho even if it is not allocated.

Spotted by @sevicky 

- [x] add asserts
- [ ] add a test if needed
- [ ] fix bug