### PR TITLE
Add function to set value of `do_not_push`

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -426,6 +426,8 @@ public:
     virtual QuantumSynchrotronEngine* get_quantum_sync_engine_ptr () const {return nullptr;}
 #endif
 
+    void setDoNotPush (bool flag) { do_not_push = flag; }
+
 protected:
     int species_id;
 
@@ -442,7 +444,7 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
-    int do_not_push = 0;
+    bool do_not_push = 0;
     int do_not_gather = 0;
 
     // Whether to allow particles outside of the simulation domain to be

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -444,7 +444,7 @@ protected:
     //! instead of gathering fields from the finest patch level, gather from the coarsest
     bool m_gather_from_main_grid = false;
 
-    bool do_not_push = 0;
+    bool do_not_push = false;
     int do_not_gather = 0;
 
     // Whether to allow particles outside of the simulation domain to be

--- a/Source/Python/Particles/WarpXParticleContainer.cpp
+++ b/Source/Python/Particles/WarpXParticleContainer.cpp
@@ -137,5 +137,9 @@ void init_WarpXParticleContainer (py::module& m)
             },
             py::arg("lev"), py::arg("local")
         )
+        .def("set_do_not_push",
+            [](WarpXParticleContainer& pc, bool flag) { pc.setDoNotPush(flag); },
+            py::arg("flag")
+        )
     ;
 }


### PR DESCRIPTION
I have a use case where I want to not evolve a certain species for a specific amount of time. This PR allows me to turn on the evolution of that species at a desired time.

This functionality (with Python callbacks) can also be used to achieve the desired effect from #4853 (might need to add a similar function for `do_not_deposit`).