### PR TITLE
Move FieldType enum from WarpX.H into a separate header

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -10,6 +10,7 @@
 
 #include "BoundaryConditions/PML.H"
 #include "BoundaryConditions/PMLComponent.H"
+#include "FieldSolver/Fields.H"
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
@@ -55,6 +56,7 @@
 #endif
 
 using namespace amrex;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -8,6 +8,7 @@
 #include "PML_RZ.H"
 
 #include "BoundaryConditions/PML_RZ.H"
+#include "FieldSolver/Fields.H"
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralFieldDataRZ.H"
 #endif
@@ -33,6 +34,7 @@
 #include <memory>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 PML_RZ::PML_RZ (const int lev, const amrex::BoxArray& grid_ba, const amrex::DistributionMapping& grid_dm,
                 const amrex::Geometry* geom, const int ncell, const int do_pml_in_domain)

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -15,8 +15,10 @@
 #include <algorithm>
 #include <array>
 #include <memory>
-using namespace amrex::literals;
+
 using namespace amrex;
+using namespace amrex::literals;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -14,6 +14,7 @@
 #include "Diagnostics/Diagnostics.H"
 #include "Diagnostics/FlushFormats/FlushFormat.H"
 #include "ComputeDiagFunctors/BackTransformParticleFunctor.H"
+#include "FieldSolver/Fields.H"
 #include "Utils/Algorithms/IsIn.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
@@ -46,6 +47,7 @@
 #include <vector>
 
 using namespace amrex::literals;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
@@ -6,6 +6,7 @@
 
 #include "JFunctor.H"
 
+#include "FieldSolver/Fields.H"
 #include "Particles/MultiParticleContainer.H"
 #include "WarpX.H"
 
@@ -13,6 +14,8 @@
 #include <AMReX_Extension.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_MultiFab.H>
+
+using namespace warpx::fields;
 
 JFunctor::JFunctor (const int dir, int lev,
                    amrex::IntVect crse_ratio,

--- a/Source/Diagnostics/ComputeDiagFunctors/JdispFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/JdispFunctor.cpp
@@ -6,6 +6,7 @@
 #include "JdispFunctor.H"
 
 #include "WarpX.H"
+#include "FieldSolver/Fields.H"
 #include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H"
 #include "Particles/MultiParticleContainer.H"
 
@@ -15,6 +16,7 @@
 #include <AMReX_MultiFab.H>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 JdispFunctor::JdispFunctor (int dir, int lev,
         amrex::IntVect crse_ratio, bool convertRZmodes2cartesian, int ncomp)

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -5,6 +5,7 @@
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
+#include "FieldSolver/Fields.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
@@ -19,6 +20,7 @@
 #include <AMReX_VisMF.H>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -1,16 +1,17 @@
 #include "FlushFormatPlotfile.H"
 
-#include "Particles/ParticleIO.H"
+#include "FieldSolver/Fields.H"
+#include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "Particles/Filter/FilterFunctors.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Particles/ParticleIO.H"
 #include "Particles/PinnedMemoryParticleContainer.H"
 #include "Utils/Interpolate.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
-#include "Diagnostics/MultiDiagnostics.H"
 
 #include <AMReX.H>
 #include <AMReX_Box.H>
@@ -47,6 +48,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -1,4 +1,5 @@
 #include "FullDiagnostics.H"
+
 #include "ComputeDiagFunctors/CellCenterFunctor.H"
 #include "ComputeDiagFunctors/DivBFunctor.H"
 #include "ComputeDiagFunctors/DivEFunctor.H"
@@ -10,6 +11,7 @@
 #include "ComputeDiagFunctors/RhoFunctor.H"
 #include "Diagnostics/Diagnostics.H"
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
+#include "FieldSolver/Fields.H"
 #include "FlushFormats/FlushFormat.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/Algorithms/IsIn.H"
@@ -40,6 +42,7 @@
 #include <vector>
 
 using namespace amrex::literals;
+using namespace warpx::fields;
 
 FullDiagnostics::FullDiagnostics (int i, const std::string& name):
     Diagnostics{i, name},

--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -7,6 +7,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
+#include "FieldSolver/Fields.H"
 #include "Particles/ParticleIO.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/PhysicalParticleContainer.H"
@@ -41,6 +42,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 void
 LaserParticleContainer::ReadHeader (std::istream& is)

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -8,6 +8,7 @@
 #include "ChargeOnEB.H"
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
+#include "FieldSolver/Fields.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/Parser/ParserUtils.H"
@@ -26,6 +27,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 // constructor
 ChargeOnEB::ChargeOnEB (const std::string& rd_name)

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -8,6 +8,7 @@
 #include "ColliderRelevant.H"
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
+#include "FieldSolver/Fields.H"
 #if (defined WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif
@@ -58,6 +59,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 ColliderRelevant::ColliderRelevant (const std::string& rd_name)
 : ReducedDiags{rd_name}

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -7,6 +7,7 @@
 
 #include "FieldEnergy.H"
 
+#include "FieldSolver/Fields.H"
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
@@ -28,6 +29,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 // constructor
 FieldEnergy::FieldEnergy (const std::string& rd_name)

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -7,6 +7,7 @@
 
 #include "FieldMaximum.H"
 
+#include "FieldSolver/Fields.H"
 #include "Utils/TextMsg.H"
 #include "WarpX.H"
 
@@ -38,6 +39,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 // constructor
 FieldMaximum::FieldMaximum (const std::string& rd_name)

--- a/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
@@ -7,6 +7,7 @@
 
 #include "FieldMomentum.H"
 
+#include "FieldSolver/Fields.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
@@ -37,6 +38,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 FieldMomentum::FieldMomentum (const std::string& rd_name)
     : ReducedDiags{rd_name}

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -7,6 +7,7 @@
 
 #include "FieldProbe.H"
 #include "FieldProbeParticleContainer.H"
+#include "FieldSolver/Fields.H"
 #include "Particles/Gather/FieldGather.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Pusher/UpdatePosition.H"
@@ -44,6 +45,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 // constructor
 

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -9,6 +9,7 @@
 #define WARPX_DIAGNOSTICS_REDUCEDDIAGS_FIELDREDUCTION_H_
 
 #include "ReducedDiags.H"
+#include "FieldSolver/Fields.H"
 #include "WarpX.H"
 
 #include <ablastr/coarsen/sample.H>
@@ -35,7 +36,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
 
 /**
  * This class contains a function that computes an arbitrary reduction of the fields. The function
@@ -99,15 +99,15 @@ public:
         const auto dx = geom.CellSizeArray();
 
         // get MultiFab data
-        const amrex::MultiFab & Ex = warpx.getField(FieldType::Efield_aux, lev,0);
-        const amrex::MultiFab & Ey = warpx.getField(FieldType::Efield_aux, lev,1);
-        const amrex::MultiFab & Ez = warpx.getField(FieldType::Efield_aux, lev,2);
-        const amrex::MultiFab & Bx = warpx.getField(FieldType::Bfield_aux, lev,0);
-        const amrex::MultiFab & By = warpx.getField(FieldType::Bfield_aux, lev,1);
-        const amrex::MultiFab & Bz = warpx.getField(FieldType::Bfield_aux, lev,2);
-        const amrex::MultiFab & jx = warpx.getField(FieldType::current_fp, lev,0);
-        const amrex::MultiFab & jy = warpx.getField(FieldType::current_fp, lev,1);
-        const amrex::MultiFab & jz = warpx.getField(FieldType::current_fp, lev,2);
+        const amrex::MultiFab & Ex = warpx.getField(warpx::fields::FieldType::Efield_aux, lev,0);
+        const amrex::MultiFab & Ey = warpx.getField(warpx::fields::FieldType::Efield_aux, lev,1);
+        const amrex::MultiFab & Ez = warpx.getField(warpx::fields::FieldType::Efield_aux, lev,2);
+        const amrex::MultiFab & Bx = warpx.getField(warpx::fields::FieldType::Bfield_aux, lev,0);
+        const amrex::MultiFab & By = warpx.getField(warpx::fields::FieldType::Bfield_aux, lev,1);
+        const amrex::MultiFab & Bz = warpx.getField(warpx::fields::FieldType::Bfield_aux, lev,2);
+        const amrex::MultiFab & jx = warpx.getField(warpx::fields::FieldType::current_fp, lev,0);
+        const amrex::MultiFab & jy = warpx.getField(warpx::fields::FieldType::current_fp, lev,1);
+        const amrex::MultiFab & jz = warpx.getField(warpx::fields::FieldType::current_fp, lev,2);
 
 
         // General preparation of interpolation and reduction operations

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -7,6 +7,7 @@
 #include "LoadBalanceCosts.H"
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
+#include "FieldSolver/Fields.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -35,6 +36,7 @@
 #include <utility>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -11,6 +11,7 @@
 #if (defined WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif
+#include "FieldSolver/Fields.H"
 #include "Particles/Gather/FieldGather.H"
 #include "Particles/Gather/GetExternalFields.H"
 #include "Particles/MultiParticleContainer.H"
@@ -51,6 +52,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 // constructor
 ParticleExtrema::ParticleExtrema (const std::string& rd_name)

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -7,8 +7,9 @@
  */
 #include "SliceDiagnostic.H"
 
-#include "WarpX.H"
+#include "FieldSolver/Fields.H"
 #include "Utils/TextMsg.H"
+#include "WarpX.H"
 
 #include <ablastr/utils/Communication.H>
 #include <ablastr/warn_manager/WarnManager.H>
@@ -40,7 +41,7 @@
 #include <sstream>
 
 using namespace amrex;
-
+using namespace warpx::fields;
 
 /* \brief
  *  The functions creates the slice for diagnostics based on the user-input.

--- a/Source/FieldSolver/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver.cpp
@@ -55,6 +55,7 @@
 #include <string>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 void
 WarpX::ComputeSpaceChargeField (bool const reset_fields)

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -1,0 +1,40 @@
+/* Copyright 2024 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_FIELDS_H_
+#define WARPX_FIELDS_H_
+
+namespace warpx::fields
+{
+    enum struct FieldType : int
+    {
+        Efield_aux,
+        Bfield_aux,
+        Efield_fp,
+        Bfield_fp,
+        current_fp,
+        current_fp_nodal,
+        rho_fp,
+        F_fp,
+        G_fp,
+        phi_fp,
+        vector_potential_fp,
+        Efield_cp,
+        Bfield_cp,
+        current_cp,
+        rho_cp,
+        F_cp,
+        G_cp,
+        edge_lengths,
+        face_areas,
+        Efield_avg_fp,
+        Bfield_avg_fp,
+        Efield_avg_cp,
+        Bfield_avg_cp
+    };
+}
+
+#endif //WARPX_FIELDS_H_

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -9,7 +9,10 @@
 
 #include "HybridPICModel.H"
 
+#include "FieldSolver/Fields.H"
+
 using namespace amrex;
+using namespace warpx::fields;
 
 HybridPICModel::HybridPICModel ( int nlevs_max )
 {

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -1,5 +1,6 @@
 #include "MacroscopicProperties.H"
 
+#include "FieldSolver/Fields.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
 #include "WarpX.H"
@@ -26,6 +27,7 @@
 #include <sstream>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 MacroscopicProperties::MacroscopicProperties ()
 {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -10,6 +10,8 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "MultiParticleContainer.H"
+
+#include "FieldSolver/Fields.H"
 #include "Particles/ElementaryProcess/Ionization.H"
 #ifdef WARPX_QED
 #   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
@@ -80,6 +82,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 namespace
 {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -38,6 +38,7 @@
 #include "AcceleratorLattice/AcceleratorLattice.H"
 #include "Evolve/WarpXDtType.H"
 #include "Evolve/WarpXPushType.H"
+#include "FieldSolver/Fields.H"
 #include "FieldSolver/ElectrostaticSolver.H"
 #include "FieldSolver/MagnetostaticSolver/MagnetostaticSolver.H"
 #include "Filter/BilinearFilter.H"
@@ -74,33 +75,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-enum struct FieldType : int
-{
-    Efield_aux,
-    Bfield_aux,
-    Efield_fp,
-    Bfield_fp,
-    current_fp,
-    current_fp_nodal,
-    rho_fp,
-    F_fp,
-    G_fp,
-    phi_fp,
-    vector_potential_fp,
-    Efield_cp,
-    Bfield_cp,
-    current_cp,
-    rho_cp,
-    F_cp,
-    G_cp,
-    edge_lengths,
-    face_areas,
-    Efield_avg_fp,
-    Bfield_avg_fp,
-    Efield_avg_cp,
-    Bfield_avg_cp
-};
 
 class WARPX_EXPORT WarpX
     : public amrex::AmrCore
@@ -494,7 +468,7 @@ public:
      * \return true if the field is initialized, false otherwise
      */
     [[nodiscard]] bool
-    isFieldInitialized (FieldType field_type, int lev, int direction = 0) const;
+    isFieldInitialized (warpx::fields::FieldType field_type, int lev, int direction = 0) const;
 
     /**
      * \brief
@@ -507,7 +481,7 @@ public:
      * \return the pointer to an amrex::MultiFab containing the field data
      */
     [[nodiscard]] amrex::MultiFab*
-    getFieldPointer (FieldType field_type, int lev, int direction = 0) const;
+    getFieldPointer (warpx::fields::FieldType field_type, int lev, int direction = 0) const;
 
     /**
      * \brief
@@ -519,7 +493,7 @@ public:
      * \return an array of three pointers amrex::MultiFab* containing the field data
      */
     [[nodiscard]] std::array<const amrex::MultiFab* const, 3>
-    getFieldPointerArray (FieldType field_type, int lev) const;
+    getFieldPointerArray (warpx::fields::FieldType field_type, int lev) const;
 
     /**
      * \brief
@@ -532,7 +506,7 @@ public:
      * \return a constant refernce to an amrex::MultiFab containing the field data
      */
     [[nodiscard]] const amrex::MultiFab&
-    getField(FieldType field_type, int lev, int direction = 0) const;
+    getField(warpx::fields::FieldType field_type, int lev, int direction = 0) const;
 
     [[nodiscard]] bool DoPML () const {return do_pml;}
     [[nodiscard]] bool DoFluidSpecies () const {return do_fluid_species;}
@@ -1603,7 +1577,7 @@ private:
      * \return the pointer to an amrex::MultiFab containing the field data
      */
     [[nodiscard]] amrex::MultiFab*
-    getFieldPointerUnchecked (FieldType field_type, int lev, int direction = 0) const;
+    getFieldPointerUnchecked (warpx::fields::FieldType field_type, int lev, int direction = 0) const;
 
     // PML
     int do_pml = 0;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -85,6 +85,7 @@
 #include <utility>
 
 using namespace amrex;
+using namespace warpx::fields;
 
 int WarpX::do_moving_window = 0;
 int WarpX::start_moving_window_step = 0;


### PR DESCRIPTION
This PR moves the `FieldType` enum struct from `WarpX.H` to `FieldSolver/Fields.H`, inside a newly created `warpx::fields` namespace. All the other changes (inclusion of the new header, `using namespace warpx::fields` ...) are a consequence of this change.

The immediate advantage of this PR is a slight simplification of the `WarpX.H` header field. However, the main interest of this PR is that it can be considered as a first step towards a more modular approach for fields, similarly to what is done for particles. The final goal (to be discussed) could be to have a sort of MultiFieldContainer member of the WarpX class.