### PR TITLE
Remove unnecessary include of WarpX.H in "ParticleCreationFunc.H"

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -15,7 +15,6 @@
 #include "Particles/ParticleCreation/SmartCopy.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
-#include "WarpX.H"
 
 #include <AMReX_DenseBins.H>
 #include <AMReX_GpuAtomic.H>


### PR DESCRIPTION
This PR removes an unnecessary include.