### PR TITLE
Ensure that only necessary headers are included in FieldAccessorFunctors.H

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H
@@ -8,11 +8,9 @@
 #ifndef WARPX_FIELD_ACCESSOR_FUNCTORS_H
 #define WARPX_FIELD_ACCESSOR_FUNCTORS_H
 
-#include "WarpX.H"
-#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
-
 #include <AMReX_Array.H>
-
+#include <AMReX_Extension.H>
+#include <AMReX_Gpu.H>
 
 /**
  * \brief Functor that returns the division of the source m_field Array4 value


### PR DESCRIPTION
This PR ensures that only necessary headers are included in FieldAccessorFunctors.H