### PR TITLE
Remove unnecessary include "WarpX.H" from FlushFormat.H

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -5,7 +5,6 @@
 
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
 #include "Particles/MultiParticleContainer.H"
-#include "WarpX.H"
 
 class FlushFormat
 {


### PR DESCRIPTION
This PR removes an unnecessary `include "WarpX.H"` from `FlushFormat.H`