### PR TITLE
[WIP] Use singleton to store warpx profiler parameter "do_device_synchronize"

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -17,6 +17,7 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
+#include "WarpX.H"
 
 #include <ablastr/utils/text/StreamUtils.H>
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -22,6 +22,8 @@
 #include <AMReX_Array.H>
 #include <AMReX_REAL.H>
 
+#include <optional>
+
 /**
  * \brief This class contains the parameters needed to evaluate hybrid field
  * solutions (kinetic ions with fluid electrons).

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -9,6 +9,8 @@
 
 #include "HybridPICModel.H"
 
+#include "WarpX.H"
+
 using namespace amrex;
 
 HybridPICModel::HybridPICModel ( int nlevs_max )

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -13,6 +13,7 @@
 #include "SpectralAlgorithms/PsatdAlgorithmJLinearInTime.H"
 #include "SpectralKSpace.H"
 #include "SpectralSolver.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 

--- a/Source/Filter/Filter.cpp
+++ b/Source/Filter/Filter.cpp
@@ -9,6 +9,7 @@
 
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
+#include "WarpX.H"
 
 #include <AMReX_Array4.H>
 #include <AMReX_Box.H>

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -19,6 +19,7 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
+#include "WarpX.H"
 
 #include <ablastr/warn_manager/WarnManager.H>
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1156,7 +1156,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                 ng_rho, depos_lev, ref_ratio,
                 offset, np_to_deposit,
                 icomp, nc,
-                WarpX::do_device_synchronize
+                warpx::profiler::get_device_synchronize_flag()
         );
     }
 }

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(D IN LISTS WarpX_DIMS)
         RelativeCellPosition.cpp
         WarpXAlgorithmSelection.cpp
         WarpXMovingWindow.cpp
+        WarpXProfilerWrapper.cpp
         WarpXTagging.cpp
         WarpXUtil.cpp
         WarpXVersion.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -1,13 +1,14 @@
+CEXE_sources += Interpolate.cpp
+CEXE_sources += IntervalsParser.cpp
+CEXE_sources += ParticleUtils.cpp
+CEXE_sources += RelativeCellPosition.cpp
+CEXE_sources += SpeciesUtils.cpp
+CEXE_sources += WarpXAlgorithmSelection.cpp
 CEXE_sources += WarpXMovingWindow.cpp
+CEXE_sources += WarpXProfilerWrapper.cpp
 CEXE_sources += WarpXTagging.cpp
 CEXE_sources += WarpXUtil.cpp
 CEXE_sources += WarpXVersion.cpp
-CEXE_sources += WarpXAlgorithmSelection.cpp
-CEXE_sources += Interpolate.cpp
-CEXE_sources += IntervalsParser.cpp
-CEXE_sources += RelativeCellPosition.cpp
-CEXE_sources += ParticleUtils.cpp
-CEXE_sources += SpeciesUtils.cpp
 
 include $(WARPX_HOME)/Source/Utils/Algorithms/Make.package
 include $(WARPX_HOME)/Source/Utils/Logo/Make.package

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -8,17 +8,81 @@
 #ifndef WARPX_PROFILERWRAPPER_H_
 #define WARPX_PROFILERWRAPPER_H_
 
-#include "WarpX.H"
 #include "ablastr/profiler/ProfilerWrapper.H"
 
+namespace warpx::profiler
+{
+    /**
+    * \brief
+    * This singleton class holds the settings of the WarpX profiler
+    * (for the moment the only setting is the flag storing the value of "do_device_synchronize" parameter)
+    */
+    class ProfileSettings
+    {
+        public:
+
+        /**
+        * \brief
+        * This method returns a const references to the unique ProfileSettings instance.
+        */
+        static const ProfileSettings& GetInstance ();
+
+        /**
+        * \brief
+        * This method initialises a new instance of the ProfileSettings.
+        * The method throws an error if ProfileSettings is already initialized.
+        */
+        static void InitProfileSettings (bool device_synchronize_flag);
+
+        /** Destructor */
+        ~ProfileSettings () {delete m_instance;};
+
+        /** Copy constructor */
+        ProfileSettings ( ProfileSettings const &) = delete;
+        /** Copy operator */
+        ProfileSettings& operator= ( ProfileSettings const & ) = delete;
+        /** Move constructor */
+        ProfileSettings ( ProfileSettings && ) = default;
+        /** Move operator */
+        ProfileSettings& operator= ( ProfileSettings && ) = default;
+
+        /**
+        * \brief
+        * This function returns the value of the flag "m_device_synchronize_flag"
+        */
+        bool get_device_synchronize_flag () const
+        {
+            return m_device_synchronize_flag;
+        }
+
+        private:
+
+        /** Constructor */
+        ProfileSettings (const bool device_synchronize_flag):
+            m_device_synchronize_flag{device_synchronize_flag}
+        {}
+
+        /** Pointer to the (unique) ProfileSettings instance */
+        static ProfileSettings* m_instance;
+
+        bool m_device_synchronize_flag; /*whether to call a amrex::Gpu::synchronize() around profiling regions.*/
+
+    };
+
+    /**
+    * \brief
+    * Helper function to simplify the call to ProfileSettings::GetInstance().get_device_synchronize_flag()
+    */
+    bool get_device_synchronize_flag ();
+}
 
 // `BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__)` and `SYNC_V_##vname` used to make unique names for
 // synchronizeOnDestruct objects, like `SYNC_SCOPE_0` and `SYNC_V_pmain`
-#define WARPX_PROFILE(fname) ABLASTR_PROFILE(fname, WarpX::do_device_synchronize)
-#define WARPX_PROFILE_VAR(fname, vname) ABLASTR_PROFILE_VAR(fname, vname, WarpX::do_device_synchronize)
-#define WARPX_PROFILE_VAR_NS(fname, vname) ABLASTR_PROFILE_VAR_NS(fname, vname, WarpX::do_device_synchronize)
-#define WARPX_PROFILE_VAR_START(vname) ABLASTR_PROFILE_VAR_START(vname, WarpX::do_device_synchronize)
-#define WARPX_PROFILE_VAR_STOP(vname) ABLASTR_PROFILE_VAR_STOP(vname, WarpX::do_device_synchronize)
-#define WARPX_PROFILE_REGION(rname) ABLASTR_PROFILE_REGION(rname, WarpX::do_device_synchronize)
+#define WARPX_PROFILE(fname) ABLASTR_PROFILE(fname, warpx::profiler::get_device_synchronize_flag())
+#define WARPX_PROFILE_VAR(fname, vname) ABLASTR_PROFILE_VAR(fname, vname, warpx::profiler::get_device_synchronize_flag())
+#define WARPX_PROFILE_VAR_NS(fname, vname) ABLASTR_PROFILE_VAR_NS(fname, vname, warpx::profiler::get_device_synchronize_flag())
+#define WARPX_PROFILE_VAR_START(vname) ABLASTR_PROFILE_VAR_START(vname, warpx::profiler::get_device_synchronize_flag())
+#define WARPX_PROFILE_VAR_STOP(vname) ABLASTR_PROFILE_VAR_STOP(vname, warpx::profiler::get_device_synchronize_flag())
+#define WARPX_PROFILE_REGION(rname) ABLASTR_PROFILE_REGION(rname, warpx::profiler::get_device_synchronize_flag())
 
 #endif // WARPX_PROFILERWRAPPER_H_

--- a/Source/Utils/WarpXProfilerWrapper.H
+++ b/Source/Utils/WarpXProfilerWrapper.H
@@ -35,7 +35,7 @@ namespace warpx::profiler
         static void InitProfileSettings (bool device_synchronize_flag);
 
         /** Destructor */
-        ~ProfileSettings () {delete m_instance;};
+        ~ProfileSettings () {delete m_instance;}
 
         /** Copy constructor */
         ProfileSettings ( ProfileSettings const &) = delete;

--- a/Source/Utils/WarpXProfilerWrapper.cpp
+++ b/Source/Utils/WarpXProfilerWrapper.cpp
@@ -1,0 +1,37 @@
+/* Copyright 2020-2024 Axel Huebl, Maxence Thevenet, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "WarpXProfilerWrapper.H"
+
+#include "Utils/TextMsg.H"
+
+#include "AMReX_Extension.H"
+
+using namespace warpx::profiler;
+
+ProfileSettings* ProfileSettings::m_instance = nullptr;
+
+const ProfileSettings& ProfileSettings::GetInstance ()
+{
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_instance != nullptr,
+        "warpx::profiler::ProfileSettings is not initialized.");
+    AMREX_ASSUME(m_instance != nullptr);
+    return *m_instance;
+}
+
+
+void ProfileSettings::InitProfileSettings (const bool device_synchronize_flag)
+{
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_instance == nullptr,
+        "warpx::profiler::ProfileSettings is already initialized.");
+    m_instance = new ProfileSettings{device_synchronize_flag};
+}
+
+bool warpx::profiler::get_device_synchronize_flag()
+{
+    return ProfileSettings::GetInstance().get_device_synchronize_flag();
+}

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -369,7 +369,6 @@ public:
     static bool do_multi_J;
     static int do_multi_J_n_depositions;
 
-    static bool do_device_synchronize;
     static bool safe_guard_cells;
 
     //! With mesh refinement, particles located inside a refinement patch, but within

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -214,12 +214,6 @@ amrex::IntVect m_rho_nodal_flag;
 
 int WarpX::do_similar_dm_pml = 1;
 
-#ifdef AMREX_USE_GPU
-bool WarpX::do_device_synchronize = true;
-#else
-bool WarpX::do_device_synchronize = false;
-#endif
-
 WarpX* WarpX::m_instance = nullptr;
 
 void WarpX::MakeWarpX ()
@@ -686,7 +680,13 @@ WarpX::ReadParameters ()
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
 
+#ifdef AMREX_USE_GPU
+        bool do_device_synchronize = true;
+#else
+        bool do_device_synchronize = false;
+#endif
         pp_warpx.query("do_device_synchronize", do_device_synchronize);
+        warpx::profiler::ProfileSettings::InitProfileSettings(do_device_synchronize);
 
         // queryWithParser returns 1 if argument zmax_plasma_to_compute_max_step is
         // specified by the user, 0 otherwise.


### PR DESCRIPTION
Right now `Source/Utils/WarpXProfilerWrapper.H` includes the huge header `WarpX.H`, just because we need to pass `WarpX::do_device_synchronize` to `ABLASTR_PROFILE`.

This PR avoids this issue by introducing a new singleton class `warpx::profiler::ProfileSettings` (singletons make sense for loggers and profilers in my opinion) that stores this parameter (it might store additional parameters in the future). So, during the initialization, the WarpX class simply calls the function `warpx::profiler::ProfileSettings::InitProfileSettings(do_device_synchronize);` , and the parameter `do_device_synchronize` is stored inside `ProfileSettings`. This allows us to avoid the transitive inclusion of `WarpX.H` every time the profiler is used. 
In some cases, including `WarpX.H` (or other headers included by `WarpX.H`) is now required because `Utils/WarpXProfilerWrapper.H"` no longer includes such libraries.