### PR TITLE
Fix macOS CI failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,9 +36,6 @@ jobs:
         brew tap openpmd/openpmd
         brew install openpmd-api
 
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade virtualenv
-
         python3 -m venv py-venv
         source py-venv/bin/activate
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
Just a quick experiment to see if this fixes the maxOS build failure.

Basically the error seen appears to say that `pip install ...` cannot be called from outside a virtual environment on macOS anymore.