### PR TITLE
Remove unused function declaration in WarpX.H

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1361,12 +1361,6 @@ private:
     void InitNCICorrector ();
 
     /**
-     * \brief Check that the number of guard cells is smaller than the number of valid cells,
-     * for all available MultiFabs, and abort otherwise.
-     */
-    void CheckGuardCells();
-
-    /**
      * \brief Checks for known numerical issues involving different WarpX modules
      */
     void CheckKnownIssues();


### PR DESCRIPTION
`CheckGuardCells();` is used only in `WarpXInitData.cpp`, where it is defined as a pure function inside an anonymous namespace.