### PR TITLE
`isort`: First Party Modules

### DIFF
--- a/Docs/source/usage/workflows/ml_materials/run_warpx_training.py
+++ b/Docs/source/usage/workflows/ml_materials/run_warpx_training.py
@@ -2,6 +2,7 @@
 import math
 
 import numpy as np
+
 from pywarpx import picmi
 
 # Physical constants

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_1d.py
@@ -8,9 +8,10 @@ import argparse
 import sys
 
 import numpy as np
-from pywarpx import callbacks, fields, libwarpx, particle_containers, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
+
+from pywarpx import callbacks, fields, libwarpx, particle_containers, picmi
 
 constants = picmi.constants
 

--- a/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
+++ b/Examples/Physics_applications/capacitive_discharge/PICMI_inputs_2d.py
@@ -6,9 +6,10 @@
 # --- used for the field solve step.
 
 import numpy as np
-from pywarpx import callbacks, fields, picmi
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
+
+from pywarpx import callbacks, fields, picmi
 
 constants = picmi.constants
 

--- a/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
+++ b/Examples/Physics_applications/spacecraft_charging/PICMI_inputs_rz.py
@@ -15,6 +15,7 @@
 import numpy as np
 import scipy.constants as scc
 from mpi4py import MPI as mpi
+
 from pywarpx import picmi
 from pywarpx.callbacks import installafterEsolve, installafterInitEsolve
 from pywarpx.fields import ExWrapper, EzWrapper, PhiFPWrapper, RhoFPWrapper

--- a/Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
+++ b/Examples/Tests/embedded_boundary_python_api/PICMI_inputs_EB_API.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
+
 from pywarpx import fields, picmi
 
 max_steps = 1

--- a/Examples/Tests/langmuir/PICMI_inputs_rz.py
+++ b/Examples/Tests/langmuir/PICMI_inputs_rz.py
@@ -9,6 +9,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pywarpx import fields, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
+++ b/Examples/Tests/magnetostatic_eb/PICMI_inputs_3d.py
@@ -27,6 +27,7 @@ matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as con
+
 from pywarpx import fields, picmi
 
 ##########################

--- a/Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
+++ b/Examples/Tests/magnetostatic_eb/PICMI_inputs_rz.py
@@ -27,6 +27,7 @@ matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as con
+
 from pywarpx import fields, picmi
 
 ##########################

--- a/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs.py
@@ -14,6 +14,7 @@ import sys
 import dill
 import numpy as np
 from mpi4py import MPI as mpi
+
 from pywarpx import callbacks, fields, libwarpx, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs_rz.py
+++ b/Examples/Tests/ohm_solver_EM_modes/PICMI_inputs_rz.py
@@ -12,6 +12,7 @@ import sys
 import dill
 import numpy as np
 from mpi4py import MPI as mpi
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_EM_modes/analysis.py
+++ b/Examples/Tests/ohm_solver_EM_modes/analysis.py
@@ -6,6 +6,7 @@ import dill
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_EM_modes/analysis_rz.py
+++ b/Examples/Tests/ohm_solver_EM_modes/analysis_rz.py
@@ -8,9 +8,10 @@ import numpy as np
 import scipy.fft as fft
 from matplotlib import colors
 from openpmd_viewer import OpenPMDTimeSeries
-from pywarpx import picmi
 from scipy.interpolate import RegularGridInterpolator
 from scipy.special import j1, jn, jn_zeros
+
+from pywarpx import picmi
 
 constants = picmi.constants
 

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/PICMI_inputs.py
@@ -13,6 +13,7 @@ import time
 import dill
 import numpy as np
 from mpi4py import MPI as mpi
+
 from pywarpx import callbacks, fields, libwarpx, particle_containers, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/analysis.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/analysis.py
@@ -6,6 +6,7 @@ import dill
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/PICMI_inputs.py
@@ -14,6 +14,7 @@ import time
 import dill
 import numpy as np
 from mpi4py import MPI as mpi
+
 from pywarpx import callbacks, fields, libwarpx, particle_containers, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_ion_beam_instability/analysis.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/analysis.py
@@ -7,6 +7,7 @@ import h5py
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
+++ b/Examples/Tests/ohm_solver_magnetic_reconnection/PICMI_inputs.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import dill
 import numpy as np
 from mpi4py import MPI as mpi
+
 from pywarpx import callbacks, fields, libwarpx, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/particle_boundary_interaction/PICMI_inputs_rz.py
+++ b/Examples/Tests/particle_boundary_interaction/PICMI_inputs_rz.py
@@ -4,6 +4,7 @@
 # --- This input is a simple case of reflection
 # --- of one electron on the surface of a sphere.
 import numpy as np
+
 from pywarpx import callbacks, particle_containers, picmi
 
 ##########################

--- a/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
+++ b/Examples/Tests/particle_boundary_scrape/PICMI_inputs_scrape.py
@@ -4,6 +4,7 @@
 # --- to access the buffer of scraped particles.
 
 import numpy as np
+
 from pywarpx import libwarpx, particle_containers, picmi
 
 ##########################

--- a/Examples/Tests/particle_data_python/PICMI_inputs_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_2d.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 
 import numpy as np
+
 from pywarpx import callbacks, libwarpx, particle_containers, picmi
 
 # Create the parser and add the argument

--- a/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
+++ b/Examples/Tests/particle_data_python/PICMI_inputs_prev_pos_2d.py
@@ -3,6 +3,7 @@
 # --- Input file to test the saving of old particle positions
 
 import numpy as np
+
 from pywarpx import particle_containers, picmi
 
 constants = picmi.constants

--- a/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
+++ b/Examples/Tests/pass_mpi_communicator/PICMI_inputs_2d.py
@@ -6,6 +6,7 @@
 # --- if the correct amount of processors are initialized in AMReX.
 
 from mpi4py import MPI
+
 from pywarpx import picmi
 
 constants = picmi.constants

--- a/Examples/Tests/python_wrappers/PICMI_inputs_2d.py
+++ b/Examples/Tests/python_wrappers/PICMI_inputs_2d.py
@@ -3,6 +3,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
+
 from pywarpx import picmi
 
 # Number of time steps

--- a/Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
+++ b/Examples/Tests/restart/PICMI_inputs_id_cpu_read.py
@@ -6,6 +6,7 @@
 import sys
 
 import numpy as np
+
 from pywarpx import callbacks, particle_containers, picmi
 
 ##########################

--- a/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
+++ b/Examples/Tests/restart/PICMI_inputs_runtime_component_analyze.py
@@ -7,6 +7,7 @@
 import sys
 
 import numpy as np
+
 from pywarpx import callbacks, particle_containers, picmi
 
 ##########################

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import periodictable
+
 import picmistandard
 import pywarpx
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
+known_first_party = ["amrex", "picmistandard", "pywarpx", "warpx"]
 profile = "black"


### PR DESCRIPTION
Declare `amrex`, `picmistandard` and `pywarpx` our first party modules, even if they are not installed. This resolves inconsistencies when sorting imports in developer or remote runs (pre-commit.com CI).