### PR TITLE
`ElectrostaticSphereLabFrame_MR_emass_10`: +Positions

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -468,7 +468,7 @@ analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sph
 [ElectrostaticSphereLabFrame_MR_emass_10]
 buildDir = .
 inputFile = Examples/Tests/electrostatic_sphere/inputs_3d
-runtime_params = warpx.do_electrostatic=labframe diag2.electron.variables=ux uy uz w warpx.abort_on_warning_threshold=medium electron.mass = 10 amr.max_level = 1 amr.ref_ratio_vect = 2 2 2 warpx.fine_tag_lo = -0.5 -0.5 -0.5 warpx.fine_tag_hi =  0.5  0.5  0.5 max_step = 2
+runtime_params = warpx.do_electrostatic=labframe diag2.electron.variables=x y z ux uy uz w warpx.abort_on_warning_threshold=medium electron.mass = 10 amr.max_level = 1 amr.ref_ratio_vect = 2 2 2 warpx.fine_tag_lo = -0.5 -0.5 -0.5 warpx.fine_tag_hi =  0.5  0.5  0.5 max_step = 2
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3


### PR DESCRIPTION
Follow-up to #4914 + #4916, which ran independently (success) but have colliding changes (new test + change in output checks).