### PR TITLE
Ensure compilation with double precision particles for DSMC collisions

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -23,7 +23,7 @@ DSMCFunc::DSMCFunc (
 {
     using namespace amrex::literals;
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( !(std::is_same<amrex::ParticleReal, float>::value),
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( (std::is_same<amrex::ParticleReal, double>::value),
     "Particle precision must be double for DSMC collisions.");
 
     const amrex::ParmParse pp_collision_name(collision_name);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -7,6 +7,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "DSMCFunc.H"
+#include "Utils/TextMsg.H"
 
 /**
  * \brief Constructor of the DSMCFunc class
@@ -21,6 +22,9 @@ DSMCFunc::DSMCFunc (
     [[maybe_unused]] const bool isSameSpecies )
 {
     using namespace amrex::literals;
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE( !(std::is_same<amrex::ParticleReal, float>::value),
+    "Particle precision must be double for DSMC collisions.");
 
     const amrex::ParmParse pp_collision_name(collision_name);
 


### PR DESCRIPTION
DSMC collisions are not properly captured with single precision for typical plasma collision cross sections. This adds an assert to ensure compilation with double precision. 

I could imagine a scenario where a user might still want to use single precision for some cross sections that would be captured, so this could we a warning too rather than an assert.