### PR TITLE
Picmi: allow different `random_fraction` for different species

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2605,24 +2605,21 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         else:
             species_names = [self.species.name]
 
-        # check if random fraction is specified and whether a value is given for each species
+        # check if random fraction is specified and whether a value is given per species
         random_fraction = {}
-        for species_name in species_names:
-            if isinstance(self.random_fraction, dict):
-                random_fraction[species_name] = self.random_fraction.get(species_name, 1)
-            else:
-                # use the same random fraction for all species
-                random_fraction[species_name] = self.random_fraction
+        random_fraction_default = self.random_fraction
+        if isinstance(self.random_fraction, dict):
+            random_fraction_default = 1.0
+            for key, val in self.random_fraction.items():
+                random_fraction[key.name] = val
 
-        # check if uniform stride is specified and whether a value is given for each species
+        # check if uniform stride is specified and whether a value is given per species
         uniform_stride = {}
-        for species_name in species_names:
-            if isinstance(self.uniform_stride, dict):
-                uniform_stride[species_name] = self.uniform_stride.get(species_name, 1)
-            else:
-                # use the same stride for all species
-                uniform_stride[species_name] = self.uniform_stride
-
+        uniform_stride_default = self.uniform_stride
+        if isinstance(self.uniform_stride, dict):
+            uniform_stride_default = 1
+            for key, val in self.uniform_stride.items():
+                uniform_stride[key.name] = val
 
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this distribution
@@ -2632,8 +2629,8 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         for name in species_names:
             diag = pywarpx.Bucket.Bucket(self.name + '.' + name,
                                          variables = variables,
-                                         random_fraction = random_fraction[name],
-                                         uniform_stride = uniform_stride[name])
+                                         random_fraction = random_fraction.get(name, random_fraction_default),
+                                         uniform_stride = uniform_stride.get(name, uniform_stride_default))
             expression = pywarpx.my_constants.mangle_expression(self.plot_filter_function, self.mangle_dict)
             diag.__setattr__('plot_filter_function(t,x,y,z,ux,uy,uz)', expression)
             self.diagnostic._species_dict[name] = diag

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2609,7 +2609,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         random_fraction = {}
         for species_name in species_names:
             if isinstance(self.random_fraction, dict):
-                random_fraction[species_name] = self.random_fraction.get(species_name)
+                random_fraction[species_name] = self.random_fraction.get(species_name, 1)
             else:
                 # use the same random fraction for all species
                 random_fraction[species_name] = self.random_fraction
@@ -2618,7 +2618,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         uniform_stride = {}
         for species_name in species_names:
             if isinstance(self.uniform_stride, dict):
-                uniform_stride[species_name] = self.uniform_stride.get(species_name)
+                uniform_stride[species_name] = self.uniform_stride.get(species_name, 1)
             else:
                 # use the same stride for all species
                 uniform_stride[species_name] = self.uniform_stride

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2500,13 +2500,13 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
     warpx_random_fraction: float or dict, optional
         Random fraction of particles to include in the diagnostic. If a float
         is given the same fraction will be used for all species, if a dictionary
-        is given the keys should be species names with the value specifying
-        the random fraction for that species.
+        is given the keys should be species with the value specifying the random
+        fraction for that species.
 
     warpx_uniform_stride: integer or dict, optional
         Stride to down select to the particles to include in the diagnostic.
         If an integer is given the same stride will be used for all species, if
-        a dictionary is given the keys should be species names with the value
+        a dictionary is given the keys should be species with the value
         specifying the stride for that species.
 
     warpx_plot_filter_function: string, optional

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2606,7 +2606,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
                     "Species list and random fraction list do not have equal length"
                 )
         else:
-            random_fraction = [self.random_fraction] * len(species_names)
+            self.random_fraction = [self.random_fraction] * len(species_names)
 
         # check if a different stride is given for each species
         if np.iterable(self.uniform_stride):
@@ -2615,7 +2615,7 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
                     "Species list and stride list do not have equal length"
                 )
         else:
-            uniform_stride = [self.uniform_stride] * len(species_names)
+            self.uniform_stride = [self.uniform_stride] * len(species_names)
 
 
         if self.mangle_dict is None:
@@ -2626,8 +2626,8 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         for ii, name in enumerate(species_names):
             diag = pywarpx.Bucket.Bucket(self.name + '.' + name,
                                          variables = variables,
-                                         random_fraction = random_fraction[ii],
-                                         uniform_stride = uniform_stride[ii])
+                                         random_fraction = self.random_fraction[ii],
+                                         uniform_stride = self.uniform_stride[ii])
             expression = pywarpx.my_constants.mangle_expression(self.plot_filter_function, self.mangle_dict)
             diag.__setattr__('plot_filter_function(t,x,y,z,ux,uy,uz)', expression)
             self.diagnostic._species_dict[name] = diag

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2599,16 +2599,35 @@ class ParticleDiagnostic(picmistandard.PICMI_ParticleDiagnostic, WarpXDiagnostic
         else:
             species_names = [self.species.name]
 
+        # check if a different random fraction is given for each species
+        if np.iterable(self.random_fraction):
+            if len(self.random_fraction) != len(species_names):
+                raise AttributeError(
+                    "Species list and random fraction list do not have equal length"
+                )
+        else:
+            random_fraction = [self.random_fraction] * len(species_names)
+
+        # check if a different stride is given for each species
+        if np.iterable(self.uniform_stride):
+            if len(self.uniform_stride) != len(species_names):
+                raise AttributeError(
+                    "Species list and stride list do not have equal length"
+                )
+        else:
+            uniform_stride = [self.uniform_stride] * len(species_names)
+
+
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this distribution
             # is used multiple times
             self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
 
-        for name in species_names:
+        for ii, name in enumerate(species_names):
             diag = pywarpx.Bucket.Bucket(self.name + '.' + name,
                                          variables = variables,
-                                         random_fraction = self.random_fraction,
-                                         uniform_stride = self.uniform_stride)
+                                         random_fraction = random_fraction[ii],
+                                         uniform_stride = uniform_stride[ii])
             expression = pywarpx.my_constants.mangle_expression(self.plot_filter_function, self.mangle_dict)
             diag.__setattr__('plot_filter_function(t,x,y,z,ux,uy,uz)', expression)
             self.diagnostic._species_dict[name] = diag


### PR DESCRIPTION
Currently all species included in a `ParticleDiagnostic` will be output with the same stride or random fraction. This PR allows a list of strides to be given so that each species can use a different stride.