### PR TITLE
Simplify main file

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -306,6 +306,9 @@ WarpX::Evolve (int numsteps)
         multi_diags->FilterComputePackFlushLastTimestep( istep[0] );
         if (m_exit_loop_due_to_interrupt_signal) { ExecutePythonCallback("onbreaksignal"); }
     }
+
+    amrex::Print() <<
+        ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("THE END");
 }
 
 /* /brief Perform one PIC iteration, without subcycling

--- a/Source/Initialization/CMakeLists.txt
+++ b/Source/Initialization/CMakeLists.txt
@@ -11,6 +11,7 @@ foreach(D IN LISTS WarpX_DIMS)
         TemperatureProperties.cpp
         VelocityProperties.cpp
         WarpXAMReXInit.cpp
+        WarpXInit.cpp
         WarpXInitData.cpp
     )
 endforeach()

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -7,6 +7,7 @@ CEXE_sources += PlasmaInjector.cpp
 CEXE_sources += TemperatureProperties.cpp
 CEXE_sources += VelocityProperties.cpp
 CEXE_sources += WarpXAMReXInit.cpp
+CEXE_sources += WarpXInit.cpp
 CEXE_sources += WarpXInitData.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Initialization

--- a/Source/Initialization/WarpXInit.H
+++ b/Source/Initialization/WarpXInit.H
@@ -1,0 +1,30 @@
+/* Copyright 2024 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_INIT_H_
+#define WARPX_INIT_H_
+
+namespace warpx::initialization
+{
+    /** Initializes, in the following order:
+     * - the MPI library through the mpi_init helper function in ablastr
+     * - the AMReX library
+     * - the FFT library through the anyfft::setup() function in ablastr
+     *
+     * @param[in] argc number of arguments from main()
+     * @param[in] argv argument strings from main()
+     */
+    void initialize_external_libraries(int argc, char* argv[]);
+
+    /** Initializes, in the following order:
+     * - the FFT library through the anyfft::cleanup() function in ablastr
+     * - the AMReX library
+     * - the MPI library through the mpi_finalize helper function in ablastr
+     */
+    void finalize_external_libraries();
+}
+
+#endif //WARPX_INIT_H_

--- a/Source/Initialization/WarpXInit.cpp
+++ b/Source/Initialization/WarpXInit.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2024 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "WarpXInit.H"
+
+#include "Initialization/WarpXAMReXInit.H"
+
+#include <AMReX.H>
+
+#include <ablastr/math/fft/AnyFFT.H>
+#include <ablastr/parallelization/MPIInitHelpers.H>
+
+void warpx::initialization::initialize_external_libraries(int argc, char* argv[])
+{
+    ablastr::parallelization::mpi_init(argc, argv);
+    warpx::initialization::amrex_init(argc, argv);
+    ablastr::math::anyfft::setup();
+}
+
+void warpx::initialization::finalize_external_libraries()
+{
+    ablastr::math::anyfft::cleanup();
+    amrex::Finalize();
+    ablastr::parallelization::mpi_finalize();
+}


### PR DESCRIPTION
This PR simplifies the main file of WarpX by:
- grouping together the initialization of MPI, FFT, and AMReX (now `WarpXInit.H/cpp`)
-  moving `amrex::Print() << ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("THE END");` to the end of `WarpX.Evolve()`
- moving `WarpX::Finalize();` before the stopping of the timer
- changing empty lines to show clearly the "warpx block" and the two "timer blocks"