### PR TITLE
Make WarpX class final and make destructor private

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -78,7 +78,7 @@
 #include <string>
 #include <vector>
 
-class WARPX_EXPORT WarpX
+class WARPX_EXPORT WarpX final
     : public amrex::AmrCore
 {
 public:
@@ -92,9 +92,6 @@ public:
      * This method has to be called at the end of the simulation. It deletes the WarpX instance.
      */
     static void Finalize();
-
-    /** Destructor */
-    ~WarpX () override;
 
     /** Copy constructor */
     WarpX ( WarpX const &) = delete;
@@ -1261,6 +1258,9 @@ protected:
     void ClearLevel (int lev) final;
 
 private:
+
+    /** Destructor */
+    ~WarpX () override;
 
     /**
      * \brief


### PR DESCRIPTION
Since the WarpX class is (sadly ;-)) still a singleton, the WarpX instance should not be directly destructible (`WarpX::Finalize` should take care of that). This PR, by making the constructor private enforces this.

Moreover, the WarpX class is declared `final`, as we don't (currently) want to inherit the WarpX class.

 