### PR TITLE
Slightly increase tolerance for embedded_circle test

### DIFF
--- a/Examples/Tests/embedded_circle/inputs_2d
+++ b/Examples/Tests/embedded_circle/inputs_2d
@@ -5,7 +5,7 @@
 max_step = 11
 warpx.const_dt = 3.99e-13
 warpx.do_electrostatic = labframe
-warpx.self_fields_required_precision = 1e-06
+warpx.self_fields_required_precision = 2e-06
 warpx.eb_implicit_function = -((x-0.00005)**2+(z-0.00005)**2-1e-05**2)
 warpx.eb_potential(x,y,z,t) = -10
 warpx.self_fields_absolute_tolerance = 0.02


### PR DESCRIPTION
This test fails quite often due to small numerical errors. It is possible that the required tolerance for the self fields is a bit too small. This PR increases it from 1e-6 to 2e-6.