### PR TITLE
Fix FieldProbe Check: Particle Shape

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -154,7 +154,12 @@ FieldProbe::FieldProbe (const std::string& rd_name)
             ablastr::warn_manager::WarnPriority::low);
     }
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(interp_order <= WarpX::nox ,
+    // ensure assumption holds: we read the fields in the interpolation kernel as they are,
+    // without further communication of guard/ghost/halo regions
+    int particle_shape;
+    const ParmParse pp_algo("algo");
+    utils::parser::getWithParser(pp_algo, "particle_shape", particle_shape);
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(interp_order <= particle_shape ,
                                      "Field probe interp_order should be less than or equal to algo.particle_shape");
     if (ParallelDescriptor::IOProcessor())
     {


### PR DESCRIPTION
The constructor of FieldProbe might be called earlier than the WarpX class parameter init. That could lead to relying on an uninitialized particle shape static. Use the parser instead, similar to our general efforts to reduce the static members stored in the WarpX class.

Fix #4958