### PR TITLE
BLAS++: v2024.05.31+

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -36,7 +36,8 @@ HankelTransform::HankelTransform (int const hankel_order,
     //   SYCL note: we need to double check AMReX device ID conventions and
     //   BLAS++ device ID conventions are the same
     int const device_id = amrex::Gpu::Device::deviceId();
-    m_queue = std::make_unique<blas::Queue>( device_id, 0 );
+    blas::Queue::stream_t stream_id = amrex::Gpu::gpuStream();
+    m_queue = std::make_unique<blas::Queue>( device_id, stream_id );
 #endif
 
     amrex::Vector<amrex::Real> alphas;


### PR DESCRIPTION
Update our HankelTransform logic calling into BLAS++ by using the latest APIs for [blas::Queue](https://github.com/icl-utk-edu/blaspp/blob/v2024.05.31/include/blas/device.hh#L142-L171). ([This is the constructor we used before.](https://github.com/icl-utk-edu/blaspp/blob/v2023.11.05/include/blas/device.hh#L166-L169)) Pass the active AMReX GPU stream.

Fix #4954
Fix #4996
Fix #5010