### PR TITLE
[WIP] Split Particle Container Init Logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,16 +81,16 @@ option(WarpX_QED_TABLE_GEN "QED table generation (requires PICSAR and Boost)"
 option(WarpX_QED_TOOLS     "Build external tool to generate QED lookup tables (requires PICSAR and Boost)"
                                                                         OFF)
 
-# Advanced option to automatically clean up CI test directories
-option(WarpX_TEST_CLEANUP "Clean up CI test directories" OFF)
+# Advanced option to run tests
+option(WarpX_TEST_CLEANUP "Clean up test directories (for CI)" OFF)
+option(WarpX_TEST_DEBUGGER "Run tests without AMReX signal handling (to attach debuggers)" OFF)
+option(WarpX_TEST_FPETRAP "Run tests with FPE-trapping runtime parameters (for CI)" OFF)
 mark_as_advanced(WarpX_TEST_CLEANUP)
-
-# Advanced option to run CI tests with FPE-trapping runtime parameters
-option(WarpX_TEST_FPETRAP "Run CI tests with FPE-trapping runtime parameters" OFF)
+mark_as_advanced(WarpX_TEST_DEBUGGER)
 mark_as_advanced(WarpX_TEST_FPETRAP)
 
 # Advanced option to run CI tests with the -g compile option
-option(WarpX_TEST_DEBUG "Run CI tests with the -g compile option" OFF)
+option(WarpX_TEST_DEBUG "Compile tests with -g1 for symbols (for CI)" OFF)
 mark_as_advanced(WarpX_TEST_DEBUG)
 if(WarpX_TEST_DEBUG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -143,6 +143,10 @@ CMake Option                  Default & Values                               Des
 ``WarpX_pybind11_repo``       ``https://github.com/pybind/pybind11.git``     Repository URI to pull and build pybind11 from
 ``WarpX_pybind11_branch``     *we set and maintain a compatible commit*      Repository branch for ``WarpX_pybind11_repo``
 ``WarpX_pybind11_internal``   **ON**/OFF                                     Needs a pre-installed pybind11 library if set to ``OFF``
+``WarpX_TEST_CLEANUP``        ON/**OFF**                                     Clean up test directories (for CI)
+``WarpX_TEST_DEBUG``          ON/**OFF**                                     Compile tests with -g1 for symbols (for CI)
+``WarpX_TEST_DEBUGGER``       ON/**OFF**                                     Run tests without AMReX signal handling (to attach debuggers)
+``WarpX_TEST_FPETRAP``        ON/**OFF**                                     Run tests with FPE-trapping runtime parameters (for CI)
 ============================= ============================================== ===========================================================
 
 For example, one can also build against a local AMReX copy.

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -145,6 +145,7 @@ function(add_warpx_test
         set(runtime_params
             "amrex.abort_on_unused_inputs = 1"
             "amrex.throw_exception = 1"
+            "amrex.signal_handling = 0"
             "warpx.always_warn_immediately = 1"
             "warpx.do_dynamic_scheduling = 0"
             "warpx.serialize_initial_conditions = 1"
@@ -158,6 +159,9 @@ function(add_warpx_test
                 "amrex.fpe_trap_overflow = 1"
                 "amrex.fpe_trap_zero = 1"
             )
+        endif()
+        if(WarpX_TEST_DEBUGGER)
+            set(runtime_params_fpetrap "amrex.signal_handling = 0")
         endif()
         add_test(
             NAME ${name}.run

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.H
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.H
@@ -26,7 +26,11 @@ public:
      * constructor
      * @param[in] rd_name reduced diags names
      */
-    ColliderRelevant(const std::string& rd_name);
+    ColliderRelevant (const std::string& rd_name);
+
+    /** initialize data after amr levels are initialized.
+     */
+    void InitData () override;
 
     /// name of the two colliding species
     std::vector<std::string> m_beam_name;
@@ -44,7 +48,7 @@ public:
      * [14]thetay_min, [15]thetay_ave, [16]thetay_max, [17]thetay_std
      * same for second species follows.
      */
-    void ComputeDiags(int step) final;
+    void ComputeDiags (int step) final;
 
 private:
     /// auxiliary structure to store headers and indices of the reduced diagnostics

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -63,6 +63,10 @@ using namespace amrex;
 
 ColliderRelevant::ColliderRelevant (const std::string& rd_name)
 : ReducedDiags{rd_name}
+{}
+
+void
+ColliderRelevant::InitData ()
 {
     // read colliding species names - must be 2
     const amrex::ParmParse pp_rd_name(m_rd_name);

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.H
@@ -25,7 +25,11 @@ public:
      * constructor
      * @param[in] rd_name reduced diags names
      */
-    ParticleExtrema(const std::string& rd_name);
+    ParticleExtrema (const std::string& rd_name);
+
+    /** initialize data after amr levels are initialized.
+     */
+    void InitData () override;
 
     /// name of species
     std::string m_species_name;
@@ -35,7 +39,7 @@ public:
      *
      * @param[in] step current time step
      */
-    void ComputeDiags(int step) final;
+    void ComputeDiags (int step) final;
 
 private:
     /// auxiliary structure to store headers and indices of the reduced diagnostics

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -59,9 +59,13 @@ using warpx::fields::FieldType;
 // constructor
 ParticleExtrema::ParticleExtrema (const std::string& rd_name)
 : ReducedDiags{rd_name}
+{}
+
+void
+ParticleExtrema::InitData ()
 {
     // read species name
-    const amrex::ParmParse pp_rd_name(rd_name);
+    const amrex::ParmParse pp_rd_name(m_rd_name);
     pp_rd_name.get("species",m_species_name);
 
     // get WarpX class object

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -46,7 +46,7 @@ public:
     /** Default constructor*/
     PlasmaInjector () = default;
 
-    PlasmaInjector (int ispecies, const std::string& name, const amrex::Geometry& geom,
+    PlasmaInjector (const std::string& name, const amrex::Geometry& geom,
                     const std::string& src_name="");
 
     // Default move and copy operations

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -46,9 +46,9 @@
 
 using namespace amrex::literals;
 
-PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name,
+PlasmaInjector::PlasmaInjector (const std::string& name,
     const amrex::Geometry& geom, const std::string& src_name):
-    species_id{ispecies}, species_name{name}, source_name{src_name}
+    species_name{name}, source_name{src_name}
 {
 
 #ifdef AMREX_USE_GPU

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -523,8 +523,6 @@ WarpX::InitData ()
 
     // Diagnostics
     multi_diags = std::make_unique<MultiDiagnostics>();
-
-    /** create object for reduced diagnostics */
     reduced_diags = std::make_unique<MultiReducedDiags>();
 
     // WarpX::computeMaxStepBoostAccelerator
@@ -542,10 +540,11 @@ WarpX::InitData ()
     }
     else
     {
-        InitFromCheckpoint();
+        InitFromCheckpoint();  // note: also restores BTD logic right now (split & move down?)
         WarpX::PrintDtDxDyDz();
         PostRestart();
         reduced_diags->InitData();
+        // InitDiagnostics();
     }
 
     ComputeMaxStep();
@@ -613,6 +612,9 @@ WarpX::InitData ()
     else {
         ExecutePythonCallback("afterInitatRestart");
     }
+
+
+    // Diagnostics
 
     if (restart_chkfile.empty() || write_diagnostics_on_restart) {
         // Write full diagnostics before the first iteration.

--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -42,7 +42,7 @@ class LaserParticleContainer
     : public WarpXParticleContainer
 {
 public:
-    LaserParticleContainer (amrex::AmrCore* amr_core, int ispecies, const std::string& name);
+    LaserParticleContainer (amrex::AmrCore* amr_core, const std::string& name);
     ~LaserParticleContainer () override = default;
 
     LaserParticleContainer ( LaserParticleContainer const &)             = delete;

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -81,8 +81,8 @@ namespace
     }
 }
 
-LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies, const std::string& name)
-    : WarpXParticleContainer(amr_core, ispecies),
+LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, const std::string& name)
+    : WarpXParticleContainer(amr_core),
       m_laser_name{name}
 {
     charge = 1.0;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -496,8 +496,10 @@ private:
 
     // physical particles (+ laser)
     amrex::Vector<std::unique_ptr<WarpXParticleContainer>> allcontainers;
+
     // Temporary particle container, used e.g. for particle splitting.
     std::unique_ptr<PhysicalParticleContainer> pc_tmp;
+
 
     void ReadParameters ();
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -415,23 +415,29 @@ MultiParticleContainer::AllocData ()
 void
 MultiParticleContainer::InitData ()
 {
+    InitMultiPhysicsModules();
+
     for (auto& pc : allcontainers) {
         pc->InitData();
     }
     pc_tmp->InitData();
 
-    InitMultiPhysicsModules();
+    // Setup particle collisions
+    collisionhandler = std::make_unique<CollisionHandler>(this);
 }
 
 void
 MultiParticleContainer::PostRestart ()
 {
+    InitMultiPhysicsModules();
+
     for (auto& pc : allcontainers) {
         pc->PostRestart();
     }
     pc_tmp->PostRestart();
 
-    InitMultiPhysicsModules();
+    // Setup particle collisions
+    collisionhandler = std::make_unique<CollisionHandler>(this);
 }
 
 void
@@ -450,9 +456,6 @@ MultiParticleContainer::InitMultiPhysicsModules ()
     InitQED();
     CheckQEDProductSpecies();
 #endif
-
-    // Setup particle collisions
-    collisionhandler = std::make_unique<CollisionHandler>(this);
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -430,12 +430,12 @@ MultiParticleContainer::InitData ()
 void
 MultiParticleContainer::PostRestart ()
 {
-    InitMultiPhysicsModules(); // TODO: move down?
-
     for (auto& pc : allcontainers) {
         pc->PostRestart();
     }
     pc_tmp->PostRestart();
+
+    InitMultiPhysicsModules();
 }
 
 void
@@ -451,8 +451,8 @@ MultiParticleContainer::InitMultiPhysicsModules ()
     mapSpeciesProduct();
     CheckIonizationProductSpecies();
 #ifdef WARPX_QED
-    CheckQEDProductSpecies();
     InitQED();
+    CheckQEDProductSpecies();
 #endif
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -103,20 +103,20 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     allcontainers.resize(nspecies + nlasers);
     for (int i = 0; i < nspecies; ++i) {
         if (species_types[i] == PCTypes::Physical) {
-            allcontainers[i] = std::make_unique<PhysicalParticleContainer>(amr_core, i, species_names[i]);
+            allcontainers[i] = std::make_unique<PhysicalParticleContainer>(amr_core, species_names[i]);
         }
         else if (species_types[i] == PCTypes::RigidInjected) {
-            allcontainers[i] = std::make_unique<RigidInjectedParticleContainer>(amr_core, i, species_names[i]);
+            allcontainers[i] = std::make_unique<RigidInjectedParticleContainer>(amr_core, species_names[i]);
         }
         else if (species_types[i] == PCTypes::Photon) {
-            allcontainers[i] = std::make_unique<PhotonParticleContainer>(amr_core, i, species_names[i]);
+            allcontainers[i] = std::make_unique<PhotonParticleContainer>(amr_core, species_names[i]);
         }
         allcontainers[i]->m_deposit_on_main_grid = m_deposit_on_main_grid[i];
         allcontainers[i]->m_gather_from_main_grid = m_gather_from_main_grid[i];
     }
 
     for (int i = nspecies; i < nspecies+nlasers; ++i) {
-        allcontainers[i] = std::make_unique<LaserParticleContainer>(amr_core, i, lasers_names[i-nspecies]);
+        allcontainers[i] = std::make_unique<LaserParticleContainer>(amr_core, lasers_names[i-nspecies]);
         allcontainers[i]->m_deposit_on_main_grid = m_laser_deposit_on_main_grid[i-nspecies];
     }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -121,10 +121,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     }
 
     pc_tmp = std::make_unique<PhysicalParticleContainer>(amr_core);
-
-    // Setup particle collisions
-    collisionhandler = std::make_unique<CollisionHandler>(this);
-
 }
 
 void
@@ -454,6 +450,9 @@ MultiParticleContainer::InitMultiPhysicsModules ()
     InitQED();
     CheckQEDProductSpecies();
 #endif
+
+    // Setup particle collisions
+    collisionhandler = std::make_unique<CollisionHandler>(this);
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -419,19 +419,18 @@ MultiParticleContainer::AllocData ()
 void
 MultiParticleContainer::InitData ()
 {
-    InitMultiPhysicsModules();
-
     for (auto& pc : allcontainers) {
         pc->InitData();
     }
     pc_tmp->InitData();
 
+    InitMultiPhysicsModules();
 }
 
 void
 MultiParticleContainer::PostRestart ()
 {
-    InitMultiPhysicsModules();
+    InitMultiPhysicsModules(); // TODO: move down?
 
     for (auto& pc : allcontainers) {
         pc->PostRestart();
@@ -1655,7 +1654,7 @@ void MultiParticleContainer::doQedQuantumSync (int lev,
     }
 }
 
-void MultiParticleContainer::CheckQEDProductSpecies()
+void MultiParticleContainer::CheckQEDProductSpecies ()
 {
     auto const nspecies = static_cast<int>(species_names.size());
     for (int i=0; i<nspecies; i++){

--- a/Source/Particles/ParticleCreation/SmartUtils.cpp
+++ b/Source/Particles/ParticleCreation/SmartUtils.cpp
@@ -19,6 +19,7 @@ PolicyVec getPolicies (const NameMap& names) noexcept
     h_policies.resize(names.size());
     for (const auto& kv : names)
     {
+        //amrex::Print() << "getPolicies: " << kv.first << " " << kv.second << std::endl;
         h_policies[kv.second] = initialization_policies[kv.first];
     }
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -35,8 +35,7 @@ class PhotonParticleContainer
 {
 public:
     PhotonParticleContainer (amrex::AmrCore* amr_core,
-                                    int ispecies,
-                                    const std::string& name);
+                             const std::string& name);
     ~PhotonParticleContainer () override = default;
 
     PhotonParticleContainer ( PhotonParticleContainer const &)             = delete;

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -43,9 +43,9 @@
 
 using namespace amrex;
 
-PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core, int ispecies,
+PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core,
                                                   const std::string& name)
-    : PhysicalParticleContainer(amr_core, ispecies, name)
+    : PhysicalParticleContainer(amr_core, name)
 {
     const ParmParse pp_species_name(species_name);
 

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -7,6 +7,7 @@
  */
 #include "PhotonParticleContainer.H"
 
+#include "Particles/SpeciesPhysicalProperties.H"
 #ifdef WARPX_QED
 #   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
 #endif
@@ -47,6 +48,12 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core,
                                                   const std::string& name)
     : PhysicalParticleContainer(amr_core, name)
 {
+    // this is a physical photon
+    physical_species = PhysicalSpecies::photon;
+    charge = species::get_charge( physical_species );
+    mass = species::get_mass( physical_species );
+
+    // other properties and methods, e.g., QED
     const ParmParse pp_species_name(species_name);
 
 #ifdef WARPX_QED
@@ -56,6 +63,7 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core,
         //If Breit Wheeler process is enabled, look for the target electron and positron
         //species
         if(m_do_qed_breit_wheeler){
+            NewRealComp("opticalDepthBW");
             pp_species_name.get("qed_breit_wheeler_ele_product_species", m_qed_breit_wheeler_ele_product_name);
             pp_species_name.get("qed_breit_wheeler_pos_product_species", m_qed_breit_wheeler_pos_product_name);
         }
@@ -73,6 +81,8 @@ PhotonParticleContainer::PhotonParticleContainer (AmrCore* amr_core,
 
 void PhotonParticleContainer::InitData()
 {
+    PhysicalParticleContainer::InitData();
+
     AddParticles(0); // Note - add on level 0
 
     Redistribute();  // We then redistribute

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -48,7 +48,6 @@ class PhysicalParticleContainer
 public:
 
     PhysicalParticleContainer (amrex::AmrCore* amr_core,
-                               int ispecies,
                                const std::string& name);
 
     PhysicalParticleContainer (amrex::AmrCore* amr_core);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -374,14 +374,9 @@ void PhysicalParticleContainer::InitData ()
         NewRealComp("opticalDepthQSR");
     }
 
-    pp_species_name.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
-    if (m_do_qed_breit_wheeler) {
-        NewRealComp("opticalDepthBW");
-    }
-
-    if(m_do_qed_quantum_sync){
+    if (m_do_qed_quantum_sync){
         pp_species_name.get("qed_quantum_sync_phot_product_species",
-            m_qed_quantum_sync_phot_product_name);
+                            m_qed_quantum_sync_phot_product_name);
     }
 #endif
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -219,7 +219,32 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
       species_name(name)
 {
     BackwardCompatibility();
+}
 
+PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
+        : WarpXParticleContainer(amr_core, 0)
+{
+}
+
+void
+PhysicalParticleContainer::BackwardCompatibility ()
+{
+    const ParmParse pp_species_name(species_name);
+    std::vector<std::string> backward_strings;
+    if (pp_species_name.queryarr("plot_vars", backward_strings)){
+        WARPX_ABORT_WITH_MESSAGE("<species>.plot_vars is not supported anymore. "
+                                 "Please use the new syntax for diagnostics, see documentation.");
+    }
+
+    int backward_int;
+    if (pp_species_name.query("plot_species", backward_int)){
+        WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
+                                 "Please use the new syntax for diagnostics, see documentation.");
+    }
+}
+
+void PhysicalParticleContainer::InitData ()
+{
     const ParmParse pp_species_name(species_name);
 
     std::string injection_style = "none";
@@ -227,13 +252,13 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     if (injection_style != "none") {
         // The base plasma injector, whose input parameters have no source prefix.
         // Only created if needed
-        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, amr_core->Geom(0)));
+        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, Geom(0)));
     }
 
     std::vector<std::string> injection_sources;
     pp_species_name.queryarr("injection_sources", injection_sources);
     for (auto &source_name : injection_sources) {
-        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, amr_core->Geom(0),
+        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, Geom(0),
                                                                     source_name));
     }
 
@@ -423,32 +448,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         utils::parser::getWithParser(pp_species_boundary,"u_th",boundary_uth);
         m_boundary_conditions.SetThermalVelocity(boundary_uth);
     }
-}
 
-PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
-    : WarpXParticleContainer(amr_core, 0)
-{
-}
-
-void
-PhysicalParticleContainer::BackwardCompatibility ()
-{
-    const ParmParse pp_species_name(species_name);
-    std::vector<std::string> backward_strings;
-    if (pp_species_name.queryarr("plot_vars", backward_strings)){
-        WARPX_ABORT_WITH_MESSAGE("<species>.plot_vars is not supported anymore. "
-                     "Please use the new syntax for diagnostics, see documentation.");
-    }
-
-    int backward_int;
-    if (pp_species_name.query("plot_species", backward_int)){
-        WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
-                     "Please use the new syntax for diagnostics, see documentation.");
-    }
-}
-
-void PhysicalParticleContainer::InitData ()
-{
     AddParticles(0); // Note - add on level 0
     Redistribute();  // We then redistribute
 }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -222,7 +222,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core,
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
-        : WarpXParticleContainer(amr_core)
+    : WarpXParticleContainer(amr_core)
 {
 }
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -213,38 +213,42 @@ namespace
     }
 }
 
-PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int ispecies,
+PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core,
                                                       const std::string& name)
-    : WarpXParticleContainer(amr_core, ispecies),
+    : WarpXParticleContainer(amr_core),
       species_name(name)
 {
     BackwardCompatibility();
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
-        : WarpXParticleContainer(amr_core, 0)
+        : WarpXParticleContainer(amr_core)
 {
 }
 
 void
 PhysicalParticleContainer::BackwardCompatibility ()
 {
-    const ParmParse pp_species_name(species_name);
-    std::vector<std::string> backward_strings;
-    if (pp_species_name.queryarr("plot_vars", backward_strings)){
-        WARPX_ABORT_WITH_MESSAGE("<species>.plot_vars is not supported anymore. "
-                                 "Please use the new syntax for diagnostics, see documentation.");
-    }
+    if (!species_name.empty()) {  // TODO: remove this if once pc_tmp is removed from WarpX
+        const ParmParse pp_species_name(species_name);
+        std::vector<std::string> backward_strings;
+        if (pp_species_name.queryarr("plot_vars", backward_strings)) {
+            WARPX_ABORT_WITH_MESSAGE("<species>.plot_vars is not supported anymore. "
+                                     "Please use the new syntax for diagnostics, see documentation.");
+        }
 
-    int backward_int;
-    if (pp_species_name.query("plot_species", backward_int)){
-        WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
-                                 "Please use the new syntax for diagnostics, see documentation.");
+        int backward_int;
+        if (pp_species_name.query("plot_species", backward_int)) {
+            WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
+                                     "Please use the new syntax for diagnostics, see documentation.");
+        }
     }
 }
 
 void PhysicalParticleContainer::InitData ()
 {
+    if (!species_name.empty()) {  // TODO: remove this if once pc_tmp is removed from WarpX
+
     const ParmParse pp_species_name(species_name);
 
     std::string injection_style = "none";
@@ -252,13 +256,13 @@ void PhysicalParticleContainer::InitData ()
     if (injection_style != "none") {
         // The base plasma injector, whose input parameters have no source prefix.
         // Only created if needed
-        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, Geom(0)));
+        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_name, Geom(0)));
     }
 
     std::vector<std::string> injection_sources;
     pp_species_name.queryarr("injection_sources", injection_sources);
     for (auto &source_name : injection_sources) {
-        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_id, species_name, Geom(0),
+        plasma_injectors.push_back(std::make_unique<PlasmaInjector>(species_name, Geom(0),
                                                                     source_name));
     }
 
@@ -448,6 +452,8 @@ void PhysicalParticleContainer::InitData ()
         utils::parser::getWithParser(pp_species_boundary,"u_th",boundary_uth);
         m_boundary_conditions.SetThermalVelocity(boundary_uth);
     }
+
+    } // !species_name.empty()  TODO: remove this if once pc_tmp is removed from WarpX
 
     AddParticles(0); // Note - add on level 0
     Redistribute();  // We then redistribute

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -219,6 +219,90 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core,
       species_name(name)
 {
     BackwardCompatibility();
+
+    const ParmParse pp_species_name(species_name);
+
+    // species type
+    {
+        // Setup the charge and mass. There are multiple ways that they can be specified, so checks are needed to
+        // ensure that a value is specified and warnings given if multiple values are specified.
+        // The ordering is that species.charge and species.mass take precedence over all other values.
+        // Next is charge and mass determined from species_type.
+        // Last is charge and mass from the plasma injector setup
+        bool charge_from_source = false;
+        bool mass_from_source = false;
+        for (auto const& plasma_injector : plasma_injectors) {
+            // For now, use the last value for charge and mass that is found.
+            // A check could be added for consistency of multiple values, but it'll probably never be needed
+            charge_from_source |= plasma_injector->queryCharge(charge);
+            mass_from_source |= plasma_injector->queryMass(mass);
+        }
+
+        std::string physical_species_s;
+        const bool species_is_specified = pp_species_name.query("species_type", physical_species_s);
+        if (species_is_specified) {
+            const auto physical_species_from_string = species::from_string( physical_species_s );
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(physical_species_from_string,
+                                             physical_species_s + " does not exist!");
+            physical_species = physical_species_from_string.value();
+            charge = species::get_charge( physical_species );
+            mass = species::get_mass( physical_species );
+        }
+
+        // parse charge and mass (overriding values of an earlier species type)
+        const bool charge_is_specified = utils::parser::queryWithParser(pp_species_name, "charge", charge);
+        const bool mass_is_specified = utils::parser::queryWithParser(pp_species_name, "mass", mass);
+
+        if (charge_is_specified && species_is_specified) {
+            ablastr::warn_manager::WMRecordWarning("Species",
+                                                   "Both '" + species_name +  ".charge' and " +
+                                                   species_name + ".species_type' are specified.\n" +
+                                                   species_name + ".charge' will take precedence.\n");
+        }
+        if (mass_is_specified && species_is_specified) {
+            ablastr::warn_manager::WMRecordWarning("Species",
+                                                   "Both '" + species_name +  ".mass' and " +
+                                                   species_name + ".species_type' are specified.\n" +
+                                                   species_name + ".mass' will take precedence.\n");
+        }
+
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                charge_from_source ||
+                charge_is_specified ||
+                species_is_specified,
+                "Need to specify at least one of species_type or charge for species '" +
+                species_name + "'."
+        );
+
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                mass_from_source ||
+                mass_is_specified ||
+                species_is_specified,
+                "Need to specify at least one of species_type or mass for species '" +
+                species_name + "'."
+        );
+    }
+
+    // add runtime components
+    {
+        pp_species_name.query("do_field_ionization", do_field_ionization);
+        if (do_field_ionization) {
+            // Add runtime integer component for ionization level
+            NewIntComp("ionizationLevel");
+        }
+
+#ifdef WARPX_QED
+        pp_species_name.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
+        if (m_do_qed_quantum_sync) {
+            NewRealComp("opticalDepthQSR");
+        }
+
+        if (m_do_qed_quantum_sync) {
+            pp_species_name.get("qed_quantum_sync_phot_product_species",
+                                m_qed_quantum_sync_phot_product_name);
+        }
+#endif
+    }
 }
 
 PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core)
@@ -266,64 +350,6 @@ void PhysicalParticleContainer::InitData ()
                                                                     source_name));
     }
 
-    // Setup the charge and mass. There are multiple ways that they can be specified, so checks are needed to
-    // ensure that a value is specified and warnings given if multiple values are specified.
-    // The ordering is that species.charge and species.mass take precedence over all other values.
-    // Next is charge and mass determined from species_type.
-    // Last is charge and mass from the plasma injector setup
-    bool charge_from_source = false;
-    bool mass_from_source = false;
-    for (auto const& plasma_injector : plasma_injectors) {
-        // For now, use the last value for charge and mass that is found.
-        // A check could be added for consistency of multiple values, but it'll probably never be needed
-        charge_from_source |= plasma_injector->queryCharge(charge);
-        mass_from_source |= plasma_injector->queryMass(mass);
-    }
-
-    std::string physical_species_s;
-    const bool species_is_specified = pp_species_name.query("species_type", physical_species_s);
-    if (species_is_specified) {
-        const auto physical_species_from_string = species::from_string( physical_species_s );
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(physical_species_from_string,
-            physical_species_s + " does not exist!");
-        physical_species = physical_species_from_string.value();
-        charge = species::get_charge( physical_species );
-        mass = species::get_mass( physical_species );
-    }
-
-    // parse charge and mass (overriding values above)
-    const bool charge_is_specified = utils::parser::queryWithParser(pp_species_name, "charge", charge);
-    const bool mass_is_specified = utils::parser::queryWithParser(pp_species_name, "mass", mass);
-
-    if (charge_is_specified && species_is_specified) {
-        ablastr::warn_manager::WMRecordWarning("Species",
-            "Both '" + species_name +  ".charge' and " +
-                species_name + ".species_type' are specified.\n" +
-                species_name + ".charge' will take precedence.\n");
-    }
-    if (mass_is_specified && species_is_specified) {
-        ablastr::warn_manager::WMRecordWarning("Species",
-            "Both '" + species_name +  ".mass' and " +
-                species_name + ".species_type' are specified.\n" +
-                species_name + ".mass' will take precedence.\n");
-    }
-
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        charge_from_source ||
-        charge_is_specified ||
-        species_is_specified,
-        "Need to specify at least one of species_type or charge for species '" +
-        species_name + "'."
-    );
-
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        mass_from_source ||
-        mass_is_specified ||
-        species_is_specified,
-        "Need to specify at least one of species_type or mass for species '" +
-        species_name + "'."
-    );
-
     pp_species_name.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
     pp_species_name.query("do_backward_propagation", do_backward_propagation);
     pp_species_name.query("random_theta", m_rz_random_theta);
@@ -345,8 +371,6 @@ void PhysicalParticleContainer::InitData ()
         pp_species_name, "self_fields_max_iters", self_fields_max_iters);
     pp_species_name.query("self_fields_verbosity", self_fields_verbosity);
 
-    pp_species_name.query("do_field_ionization", do_field_ionization);
-
     pp_species_name.query("do_resampling", do_resampling);
     if (do_resampling) { m_resampler = Resampling(species_name); }
 
@@ -367,18 +391,6 @@ void PhysicalParticleContainer::InitData ()
         WarpX::particle_pusher_algo == ParticlePusherAlgo::Boris,
         "Radiation reaction can be enabled only if Boris pusher is used");
     //_____________________________
-
-#ifdef WARPX_QED
-    pp_species_name.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
-    if (m_do_qed_quantum_sync) {
-        NewRealComp("opticalDepthQSR");
-    }
-
-    if (m_do_qed_quantum_sync){
-        pp_species_name.get("qed_quantum_sync_phot_product_species",
-                            m_qed_quantum_sync_phot_product_name);
-    }
-#endif
 
     // User-defined integer attributes
     pp_species_name.queryarr("addIntegerAttributes", m_user_int_attribs);
@@ -3118,8 +3130,7 @@ PhysicalParticleContainer::InitIonizationModule ()
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         physical_element == "H" || !do_adk_correction,
         "Correction to ADK by Zhang et al., PRA 90, 043410 (2014) only works with Hydrogen");
-    // Add runtime integer component for ionization level
-    NewIntComp("ionizationLevel");
+
     // Get atomic number and ionization energies from file
     const int ion_element_id = utils::physics::ion_map_ids.at(physical_element);
     ion_atomic_number = utils::physics::ion_atomic_numbers[ion_element_id];

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -47,7 +47,6 @@ class RigidInjectedParticleContainer
 {
 public:
     RigidInjectedParticleContainer (amrex::AmrCore* amr_core,
-                                    int ispecies,
                                     const std::string& name);
     ~RigidInjectedParticleContainer () override = default;
 

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -71,6 +71,8 @@ RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_cor
 
 void RigidInjectedParticleContainer::InitData()
 {
+    PhysicalParticleContainer::InitData();
+
     // Perform Lorentz transform of `z_inject_plane`
     const amrex::Real t_boost = WarpX::GetInstance().gett_new(0);
     const amrex::Real zinject_plane_boost = zinject_plane/WarpX::gamma_boost

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -56,9 +56,9 @@
 
 using namespace amrex;
 
-RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_core, int ispecies,
+RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_core,
                                                                 const std::string& name)
-    : PhysicalParticleContainer(amr_core, ispecies, name)
+    : PhysicalParticleContainer(amr_core, name)
 {
 
     const ParmParse pp_species_name(species_name);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -123,7 +123,7 @@ public:
     // DiagnosticParticleData (see above) on this tile.
     using DiagnosticParticles = amrex::Vector<std::map<std::pair<int, int>, DiagnosticParticleData> >;
 
-    WarpXParticleContainer (amrex::AmrCore* amr_core, int ispecies);
+    WarpXParticleContainer (amrex::AmrCore* amr_core);
     ~WarpXParticleContainer() override = default;
 
     // Move and copy operations
@@ -269,8 +269,6 @@ public:
 
     // Inject a continuous flux of particles from a defined plane
     virtual void ContinuousFluxInjection(amrex::Real /*t*/, amrex::Real /*dt*/) {}
-
-    int getSpeciesId() const {return species_id;}
 
     ///
     /// This returns the total charge for all the particles in this ParticleContainer.
@@ -426,8 +424,6 @@ public:
     void setDoNotPush (bool flag) { do_not_push = flag; }
 
 protected:
-    int species_id;
-
     amrex::ParticleReal charge;
     amrex::ParticleReal mass;
     PhysicalSpecies physical_species = PhysicalSpecies::unspecified;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -88,9 +88,8 @@ WarpXParIter::WarpXParIter (ContainerType& pc, int level, MFItInfo& info)
 {
 }
 
-WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies)
+WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core)
     : NamedComponentParticleContainer<DefaultAllocator>(amr_core->GetParGDB())
-    , species_id(ispecies)
 {
     SetParticleSize();
     ReadParameters();


### PR DESCRIPTION
Currently, the particle init is done very early in WarpX, which complicates new logic for when we want to query large, distributed fields to initialize particles from field values (external files of density and temperature maps, etc.).

This PR minimizes the logic done in the particle container constructor. We now init data explicitly in `InitData()` calls. This makes it easier to create particle container variables and meshes and then initialize particles based on initialized meshes at a later point in the logic.

Isolated from #4754 for separate testing & merging.