### PR TITLE
Simplify WarpXFaceInfoBox.H

### DIFF
--- a/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
+++ b/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
@@ -14,9 +14,11 @@
 #include <AMReX_BaseFab.H>
 
 #include <bitset>
+#include <map>
+#include <utility>
 
 struct FaceInfoBox {
-    enum Neighbours : uint8_t {n, s, e, w, nw, ne, sw, se};
+    enum class Neighbours {n, s, e, w, nw, ne, sw, se};
 
     amrex::Gpu::DeviceVector<Neighbours> neigh_faces;
     amrex::Gpu::DeviceVector<amrex::Real> area;
@@ -29,66 +31,33 @@ struct FaceInfoBox {
 
     int vecs_size;
 
-
     /**
     * \brief add the neighbor i, j to the list of intruded neighbors.
     */
     AMREX_GPU_HOST_DEVICE
-    static void addConnectedNeighbor(int i, int j, int ind, Neighbours* neigh_face_ptr){
+    static void addConnectedNeighbor(int i, int j, int ind, Neighbours* neigh_face_ptr)
+    {
+        static const auto m_i_j_to_neig = std::map<std::pair<int,int>, Neighbours>{
+            {{-1,-1}, Neighbours::nw}, {{-1,0}, Neighbours::w}, {{-1,1}, Neighbours::sw},
+            {{0 ,-1}, Neighbours::n }, {{0 ,1}, Neighbours::s},
+            {{1 ,-1}, Neighbours::ne}, {{1 ,0}, Neighbours::e}, {{1 ,1}, Neighbours::se}};
 
-        if(i == -1 && j == -1){
-            *(neigh_face_ptr + ind) = nw;
-        }else if(i == -1 && j == 0){
-            *(neigh_face_ptr + ind) = w;
-        }else if(i == -1 && j == 1){
-            *(neigh_face_ptr + ind) = sw;
-        }else if(i == 0 && j == -1){
-            *(neigh_face_ptr + ind) = n;
-        }else if(i == 0 && j == 1){
-            *(neigh_face_ptr + ind) = s;
-        }else if(i == 1 && j == -1){
-            *(neigh_face_ptr + ind) = ne;
-        }else if(i == 1 && j == 0){
-            *(neigh_face_ptr + ind) = e;
-        }else if(i == 1 && j == 1){
-            *(neigh_face_ptr + ind) = se;
-        }
+        neigh_face_ptr[ind] = m_i_j_to_neig.at(std::make_pair(i,j));
     }
 
     /**
     * \brief writes into i_face and j_face the intruded neighbors indices;
     */
     AMREX_GPU_HOST_DEVICE
-    static amrex::Array1D<int, 0, 1> uint8_to_inds(Neighbours mask){
-        amrex::Array1D<int, 0, 1> res;
+    static amrex::Array1D<int, 0, 1> uint8_to_inds(Neighbours mask)
+    {
+        static const auto m_neig_to_i_j = std::map<Neighbours,std::pair<int,int>>{
+            {Neighbours::nw, {-1,-1}}, {Neighbours::w, {-1,0}}, {Neighbours::sw, {-1,1}},
+            {Neighbours::n , {0 ,-1}}, {Neighbours::s, {0 ,1}},
+            {Neighbours::ne, {1 ,-1}}, {Neighbours::e, {1 ,0}}, {Neighbours::se, {1 ,1}}};
 
-        if(mask == Neighbours::nw){
-            res(0) = -1;
-            res(1) = -1;
-        }else if(mask == Neighbours::w){
-            res(0) = -1;
-            res(1) = 0;
-        }else if(mask == Neighbours::sw){
-            res(0) = -1;
-            res(1) = 1;
-        }else if(mask == Neighbours::n){
-            res(0) = 0;
-            res(1) = -1;
-        }else if(mask == Neighbours::s){
-            res(0) = 0;
-            res(1) = 1;
-        }else if(mask == Neighbours::ne){
-            res(0) = 1;
-            res(1) = -1;
-        }else if(mask == Neighbours::e){
-            res(0) = 1;
-            res(1) = 0;
-        }else if(mask == Neighbours::se){
-            res(0) = 1;
-            res(1) = 1;
-        }
-
-        return res;
+        auto [i,j] = m_neig_to_i_j.at(mask);
+        return amrex::Array1D<int, 0, 1>{i, j};
     }
 };
 

--- a/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
+++ b/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
@@ -56,7 +56,7 @@ struct FaceInfoBox {
             {Neighbours::n , {0 ,-1}}, {Neighbours::s, {0 ,1}},
             {Neighbours::ne, {1 ,-1}}, {Neighbours::e, {1 ,0}}, {Neighbours::se, {1 ,1}}};
 
-        auto [i,j] = m_neig_to_i_j.at(mask);
+        const auto [i,j] = m_neig_to_i_j.at(mask);
         return amrex::Array1D<int, 0, 1>{i, j};
     }
 };


### PR DESCRIPTION
This PR simplifies `WarpXFaceInfoBox.H` by:
- replacing several `if/else if` with a `map`
- using an `enum class` instead of a simple `enum` for the `Neighbours` type
- replacing `*(neigh_face_ptr + ind)` with `neigh_face_ptr[ind]`

Note that the maps `m_i_j_to_neig` and `m_neig_to_i_j` are `static const` and therefore they are initialized only once.