### PR TITLE
C++17 mordernization: replace std::is_same<T1, T2>::value with std::is_same_v<T1, T2>

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -212,15 +212,15 @@ public:
         amrex::Real reduce_value = amrex::get<0>(reduce_data.value());
 
         // MPI reduce
-        if (std::is_same<ReduceOp, amrex::ReduceOpMax>::value)
+        if (std::is_same_v<ReduceOp, amrex::ReduceOpMax>)
         {
             amrex::ParallelDescriptor::ReduceRealMax(reduce_value);
         }
-        if (std::is_same<ReduceOp, amrex::ReduceOpMin>::value)
+        if (std::is_same_v<ReduceOp, amrex::ReduceOpMin>)
         {
             amrex::ParallelDescriptor::ReduceRealMin(reduce_value);
         }
-        if (std::is_same<ReduceOp, amrex::ReduceOpSum>::value)
+        if (std::is_same_v<ReduceOp, amrex::ReduceOpSum>)
         {
             amrex::ParallelDescriptor::ReduceRealSum(reduce_value);
         // If reduction operation is a sum, multiply the value by the cell volume so that the

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -155,13 +155,13 @@ WarpX::PrintMainPICparameters ()
     amrex::Print() << "-------------------------------------------------------------------------------\n";
 
     // print warpx build information
-    if constexpr (std::is_same<Real, float>::value) {
+    if constexpr (std::is_same_v<Real, float>) {
       amrex::Print() << "Precision:            | SINGLE" << "\n";
     }
     else {
       amrex::Print() << "Precision:            | DOUBLE" << "\n";
     }
-    if constexpr (std::is_same<ParticleReal, float>::value) {
+    if constexpr (std::is_same_v<ParticleReal, float>) {
       amrex::Print() << "Particle precision:   | SINGLE" << "\n";
     }
     else {

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -108,7 +108,7 @@ public:
         }
         m_have_product_species = !m_product_species.empty();
 
-        if ((std::is_same<CopyTransformFunctor, NoParticleCreationFunc>::value) && (m_have_product_species)) {
+        if ((std::is_same_v<CopyTransformFunctor, NoParticleCreationFunc>) && (m_have_product_species)) {
             WARPX_ABORT_WITH_MESSAGE( "Binary collision " + collision_name +
                 " does not produce species. Thus, `product_species` should not be specified in the input script." );
         }

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -719,7 +719,7 @@ LaserParticleContainer::ComputeSpacing (int lev, Real& Sx, Real& Sy) const
 #if !defined(WARPX_DIM_RZ)
     constexpr float small_float_coeff = 1.e-25f;
     constexpr double small_double_coeff = 1.e-50;
-    constexpr Real small_coeff = std::is_same<Real,float>::value ?
+    constexpr Real small_coeff = std::is_same_v<Real,float> ?
         static_cast<Real>(small_float_coeff) :
         static_cast<Real>(small_double_coeff);
     const auto eps = static_cast<Real>(dx[0]*small_coeff);

--- a/Source/Utils/Parser/ParserUtils.H
+++ b/Source/Utils/Parser/ParserUtils.H
@@ -147,7 +147,7 @@ namespace utils::parser
 
             auto parser = makeParser(str_val, {});
 
-            if constexpr (std::is_same<T, int>::value) {
+            if constexpr (std::is_same_v<T, int>) {
 
                 val = safeCastToInt(
                     static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
@@ -174,7 +174,7 @@ namespace utils::parser
             val.resize(n);
             for (int i=0 ; i < n ; i++) {
                 auto parser = makeParser(tmp_str_arr[i], {});
-                if constexpr (std::is_same<T, int>::value) {
+                if constexpr (std::is_same_v<T, int>) {
                     val[i] = safeCastToInt(
                         static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
                 }
@@ -217,7 +217,7 @@ namespace utils::parser
             val.resize(n);
             for (int i=0 ; i < n ; i++) {
                 auto parser = makeParser(tmp_str_arr[i], {});
-                if constexpr (std::is_same<T, int>::value) {
+                if constexpr (std::is_same_v<T, int>) {
                     val[i] = safeCastToInt(
                         static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
                 }
@@ -250,7 +250,7 @@ namespace utils::parser
         Store_parserString(a_pp, str, str_val);
 
         auto parser = makeParser(str_val, {});
-        if constexpr (std::is_same<T, int>::value) {
+        if constexpr (std::is_same_v<T, int>) {
             val = safeCastToInt(
                 static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
         }
@@ -270,7 +270,7 @@ namespace utils::parser
         val.resize(n);
         for (int i=0 ; i < n ; i++) {
             auto parser = makeParser(tmp_str_arr[i], {});
-            if constexpr (std::is_same<T, int>::value) {
+            if constexpr (std::is_same_v<T, int>) {
                 val[i] = safeCastToInt(
                     static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
             }
@@ -308,7 +308,7 @@ namespace utils::parser
         val.resize(n);
         for (int i=0 ; i < n ; i++) {
             auto parser = makeParser(tmp_str_arr[i], {});
-            if constexpr (std::is_same<T, int>::value) {
+            if constexpr (std::is_same_v<T, int>) {
                 val[i] = safeCastToInt(
                     static_cast<amrex::Real>(std::round(parser.compileHost<0>()())), str);
             }

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -315,7 +315,7 @@ computePhi (amrex::Vector<amrex::MultiFab*> const & rho,
         }
 
         // Run additional operations, such as calculation of the E field for embedded boundaries
-        if constexpr (!std::is_same<T_PostPhiCalculationFunctor, std::nullopt_t>::value) {
+        if constexpr (!std::is_same_v<T_PostPhiCalculationFunctor, std::nullopt_t>) {
             if (post_phi_calculation.has_value()) {
                 post_phi_calculation.value()(mlmg, lev);
             }

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -241,7 +241,7 @@ computeVectorPotential   (  amrex::Vector<amrex::Array<amrex::MultiFab*, 3> > co
             curr[lev][adim]->mult(-1._rt/ablastr::constant::SI::mu0);
         } // Loop over adim
         // Run additional operations, such as calculation of the B fields for embedded boundaries
-        if constexpr (!std::is_same<T_PostACalculationFunctor, std::nullopt_t>::value) {
+        if constexpr (!std::is_same_v<T_PostACalculationFunctor, std::nullopt_t>) {
             if (post_A_calculation.has_value()) {
                     post_A_calculation.value()(mlmg, lev);
             }

--- a/Tools/QedTablesUtils/Source/QedTableGenerator.cpp
+++ b/Tools/QedTablesUtils/Source/QedTableGenerator.cpp
@@ -106,7 +106,7 @@ template<typename RealType>
 void GenerateTableBW (const ParsedArgs& args, const string& outfile_name)
 {
     cout << "    Generating BW table " <<
-        (is_same<RealType, double>::value ? "(double "s : "(single "s) << " precision)\n"s;
+        (is_same_v<RealType, double> ? "(double "s : "(single "s) << " precision)\n"s;
 
     if (!Contains(args, "--dndt_chi_min")      || !Contains(args, "--dndt_chi_max") ||
         !Contains(args, "--dndt_how_many")     || !Contains(args, "--pair_chi_min") ||
@@ -173,7 +173,7 @@ template<typename RealType>
 void GenerateTableQS (const ParsedArgs& args, const string& outfile_name)
 {
     cout << "    Generating QS table " <<
-        (is_same<RealType, double>::value ? "(double "s : "(single "s) << " precision)\n"s;
+        (is_same_v<RealType, double> ? "(double "s : "(single "s) << " precision)\n"s;
 
     if (!Contains(args, "--dndt_chi_min")      || !Contains(args, "--dndt_chi_max") ||
         !Contains(args, "--dndt_how_many")     || !Contains(args, "--em_chi_min")   ||

--- a/Tools/QedTablesUtils/Source/QedTableReader.cpp
+++ b/Tools/QedTablesUtils/Source/QedTableReader.cpp
@@ -117,7 +117,7 @@ template<typename RealType>
 void ReadTableBW (const string& input_file, const string& outfile_name)
 {
     cout << "    Reading BW table " <<
-        (is_same<RealType, double>::value ? "(double "s : "(single "s) << " precision)\n"s;
+        (is_same_v<RealType, double> ? "(double "s : "(single "s) << " precision)\n"s;
 
     auto ifs = ifstream(input_file, std::ios::binary);
     auto raw_data = vector<char>(istreambuf_iterator<char>(ifs), {});
@@ -161,7 +161,7 @@ void ReadTableQS (
     const string& input_file, const string& outfile_name)
 {
     cout << "    Reading QS table " <<
-        (is_same<RealType, double>::value ? "(double "s : "(single "s) << " precision)\n"s;
+        (is_same_v<RealType, double> ? "(double "s : "(single "s) << " precision)\n"s;
 
     auto ifs = ifstream(input_file, std::ios::binary);
     auto raw_data = vector<char>(istreambuf_iterator<char>(ifs), {});


### PR DESCRIPTION
This PR modernizes the use of `std::is_same<T1, T2>::value` by replacing it with `std::is_same_v<T1, T2>`
(see https://en.cppreference.com/w/cpp/types/is_same)