### PR TITLE
Remove debug build type from Langmuir 2D fluid test

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1173,7 +1173,7 @@ inputFile = Examples/Tests/langmuir_fluids/inputs_2d
 runtime_params =
 dim = 2
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=2 -DCMAKE_BUILD_TYPE=Debug
+cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2


### PR DESCRIPTION
While working on another PR, I noticed that the CI test `Langmuir_fluid_2D` was compiled in debug mode.

The test was added originally in #3991 and it might be that the debug build type was left over unintentionally.

In general, I think we avoid running CI tests in debug mode, in order to keep the runtime of the tests as low as possible (the current runtime of this test in debug mode is around 80 seconds). 

However, we might have changed policy in the last months or there might have been specific reasons for running this test in debug mode and I might not be up-to-date, so feel free to let me know and close this PR without merging if it is not relevant.