### PR TITLE
Remove work-around in regression testing script

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -80,8 +80,6 @@ cd -
 
 # Clone the AMReX regression test utility
 git clone https://github.com/AMReX-Codes/regression_testing.git
-# FIXME: https://github.com/AMReX-Codes/regression_testing/issues/136
-cd regression_testing && git checkout 93ddfb11456f47d6555c39388ba1a4ead61fbf4e && cd -
 
 # Prepare regression tests
 mkdir -p rt-WarpX/WarpX-benchmarks


### PR DESCRIPTION
Based on the comment https://github.com/AMReX-Codes/regression_testing/issues/136#issuecomment-2180755627, the issue reported in https://github.com/AMReX-Codes/regression_testing/issues/136 should now be fixed thanks to https://github.com/AMReX-Codes/regression_testing/pull/141.

If that's the case, it should be possible to remove the work-around that had been introduced in https://github.com/ECP-WarpX/WarpX/pull/4882.