### PR TITLE
CI: fix dimensionality of test `Python_ohms_law_solver_EM_modes_rz`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3571,7 +3571,7 @@ buildDir = .
 inputFile = Examples/Tests/ohm_solver_EM_modes/PICMI_inputs_rz.py
 runtime_params = warpx.abort_on_warning_threshold = medium
 customRunCmd = python3 PICMI_inputs_rz.py --test
-dim = 1
+dim = 2
 addToCompileString = USE_PYTHON_MAIN=TRUE USE_OPENPMD=TRUE QED=FALSE USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_APP=OFF -DWarpX_QED=OFF -DWarpX_PYTHON=ON
 target = pip_install


### PR DESCRIPTION
This CI failure came up in #5034, although I think it is not related to the changes in that PR.

This seems to be an RZ test, but `dim = 1` was set in WarpX-tests.ini. I think it should be replaced with `dim = 2`.

@roelof-groenewald 
I think the test was originally introduced in #4161. Would you be able to confirm that this change makes sense?

Not sure how this test could build and pass so far. Maybe it works when the 2D build is available thanks to other tests, but it doesn't work if the test is run alone?