### PR TITLE
CI: restore input for test `Langmuir_multi_nodal`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1509,7 +1509,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_nodal]
 buildDir = .
-inputFile =
+inputFile = Examples/Tests/langmuir/inputs_3d
 runtime_params = warpx.grid_type=collocated algo.current_deposition=direct
 dim = 3
 addToCompileString =


### PR DESCRIPTION
While running a number of CI tests through `run_test.sh`, I noticed that the following warning message appears, regardless of which tests are being executed:
```
finding tests and checking parameters...
WARNING: required params for test Langmuir_multi_nodal not set
         buildDir = .
         inputFile = 
         dim = 3
WARNING: test Langmuir_multi_nodal will be skipped
```

I found that the `inputFile` parameter for the test `Langmuir_multi_nodal` had been removed from WarpX-tests.ini in #4914, resulting in this test being skipped since then.

However, the test itself was kept in WarpX-tests.ini and given the description of #4914, seemingly not related to CI, I suspect that the removal of its input file might have been unintentional.

Assuming that that's the case, I'm restoring the input file for the test `Langmuir_multi_nodal`, allowing its execution through `run_test.sh`. 

If instead the intention was in fact to skip the test permanently, please let me know and I will remove the corresponding entry from WarpX-tests.ini, along with all related files (e.g., JSON benchmark).