### PR TITLE
CI: remove unused params, check particles in `collisionXYZ`

### DIFF
--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -111,4 +111,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)
+checksumAPI.evaluate_checksum(test_name, fn)

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -10,21 +10,21 @@
     "T_ion": 348277.2774202612
   },
   "electron": {
-    "particle_momentum_x": 9.108702343135804e-19,
-    "particle_momentum_y": 8.801195411233669e-19,
-    "particle_momentum_z": 8.816815290807643e-19,
-    "particle_position_x": 21266946.257950526,
-    "particle_position_y": 21292689.65997002,
-    "particle_position_z": 21260711.69173724,
+    "particle_momentum_x": 8.378820415249081e-19,
+    "particle_momentum_y": 8.238482720534644e-19,
+    "particle_momentum_z": 8.189221038447925e-19,
+    "particle_position_x": 21268719.554914076,
+    "particle_position_y": 21282437.437205918,
+    "particle_position_z": 21231947.47401523,
     "particle_weight": 7.168263344048695e+28
   },
   "ion": {
-    "particle_momentum_x": 1.809890020661812e-18,
-    "particle_momentum_y": 1.645673677483818e-18,
-    "particle_momentum_z": 1.6432932109907352e-18,
-    "particle_position_x": 21228437.585619796,
-    "particle_position_y": 21292038.94996104,
-    "particle_position_z": 21250306.994454175,
+    "particle_momentum_x": 2.013855005436386e-18,
+    "particle_momentum_y": 1.8231305152698165e-18,
+    "particle_momentum_z": 1.8194149390229157e-18,
+    "particle_position_x": 21217737.157987915,
+    "particle_position_y": 21263096.30516862,
+    "particle_position_z": 21261343.069983635,
     "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -8,5 +8,23 @@
     "Ez": 0.0,
     "T_electron": 353384.4616461907,
     "T_ion": 348277.2774202612
+  },
+  "electron": {
+    "particle_momentum_x": 9.108702343135804e-19,
+    "particle_momentum_y": 8.801195411233669e-19,
+    "particle_momentum_z": 8.816815290807643e-19,
+    "particle_position_x": 21266946.257950526,
+    "particle_position_y": 21292689.65997002,
+    "particle_position_z": 21260711.69173724,
+    "particle_weight": 7.168263344048695e+28
+  },
+  "ion": {
+    "particle_momentum_x": 1.809890020661812e-18,
+    "particle_momentum_y": 1.645673677483818e-18,
+    "particle_momentum_z": 1.6432932109907352e-18,
+    "particle_position_x": 21228437.585619796,
+    "particle_position_y": 21292038.94996104,
+    "particle_position_z": 21250306.994454175,
+    "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -81,10 +81,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [averaged_galilean_2d_psatd_hybrid]
@@ -99,10 +95,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [averaged_galilean_3d_psatd]
@@ -117,10 +109,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [averaged_galilean_3d_psatd_hybrid]
@@ -135,10 +123,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [background_mcc]
@@ -153,10 +137,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons he_ions
 analysisRoutine = Examples/analysis_default_regression.py
 
 [background_mcc_dp_psp]
@@ -171,10 +151,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons he_ions
 analysisRoutine = Examples/analysis_default_regression.py
 
 [bilinear_filter]
@@ -189,8 +165,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/single_particle/analysis_bilinear_filter.py
 
 [BTD_rz]
@@ -205,8 +179,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/btd_rz/analysis_BTD_laser_antenna.py
 
 [collider_diagnostics]
@@ -221,8 +193,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/collider_relevant_diags/analysis_multiple_particles.py
 
 [collisionISO]
@@ -237,8 +207,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_3d_isotropization.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
@@ -254,9 +222,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/collision/analysis_collision_rz.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
@@ -272,9 +237,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/collision/analysis_collision_3d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
@@ -290,9 +252,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
@@ -308,10 +267,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Deuterium_Deuterium_Fusion_3D]
@@ -326,8 +281,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 
 [Deuterium_Deuterium_Fusion_3D_intraspecies]
@@ -342,8 +295,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_intraspecies.py
 
 [Deuterium_Tritium_Fusion_3D]
@@ -358,8 +309,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 
 [Deuterium_Tritium_Fusion_RZ]
@@ -374,8 +323,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 
 [dirichletbc]
@@ -390,9 +337,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
 
 [divb_cleaning_3d]
@@ -407,9 +351,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/divb_cleaning/analysis.py
 
 [dive_cleaning_2d]
@@ -423,9 +364,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
@@ -441,9 +379,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params =
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
@@ -460,9 +395,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
 
 [ElectrostaticSphereLabFrame_MR_emass_10]
@@ -477,9 +409,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
 
 [ElectrostaticSphereEB]
@@ -494,9 +423,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
 
 [ElectrostaticSphereEB_mixedBCs]
@@ -511,9 +437,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [EmbeddedBoundaryDiffraction]
@@ -528,9 +451,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 outputFile = EmbeddedBoundaryDiffraction_plt
 analysisRoutine = Examples/Tests/embedded_boundary_diffraction/analysis_fields.py
 
@@ -546,9 +466,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
 
 [ElectrostaticSphereEB_RZ_MR]
@@ -563,9 +480,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis_rz.py
 
 [ElectrostaticSphereLabFrame]
@@ -580,9 +494,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
 
 [ElectrostaticSphereRZ]
@@ -597,9 +508,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
 
 [ElectrostaticSphereRelNodal]
@@ -614,9 +522,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
 
 [embedded_boundary_cube]
@@ -631,9 +536,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
 
 [embedded_boundary_cube_2d]
@@ -648,9 +550,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields_2d.py
 
 [embedded_boundary_cube_macroscopic]
@@ -665,9 +564,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_cube/analysis_fields.py
 
 [embedded_boundary_python_API]
@@ -684,9 +580,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_python_api/analysis.py
 
 [embedded_boundary_rotated_cube]
@@ -701,9 +594,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields.py
 
 [embedded_boundary_rotated_cube_2d]
@@ -718,9 +608,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/embedded_boundary_rotated_cube/analysis_fields_2d.py
 
 [embedded_circle]
@@ -735,10 +622,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ar_ions
 analysisRoutine = Examples/Tests/embedded_circle/analysis.py
 
 [FieldProbe]
@@ -753,9 +636,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/field_probe/analysis_field_probe.py
 
 [FluxInjection]
@@ -770,10 +650,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
 analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_rz.py
 
 [FluxInjection3D]
@@ -788,9 +664,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/flux_injection/analysis_flux_injection_3d.py
 
 [galilean_2d_psatd]
@@ -805,10 +678,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_2d_psatd_current_correction]
@@ -823,10 +692,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_2d_psatd_current_correction_psb]
@@ -841,10 +706,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_2d_psatd_hybrid]
@@ -859,10 +720,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [galilean_3d_psatd]
@@ -877,10 +734,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_3d_psatd_current_correction]
@@ -895,10 +748,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_3d_psatd_current_correction_psb]
@@ -913,10 +762,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_rz_psatd]
@@ -931,10 +776,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_rz_psatd_current_correction_psb]
@@ -949,10 +790,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [galilean_rz_psatd_current_correction]
@@ -967,10 +804,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 
 [hard_edged_plasma_lens]
@@ -985,10 +818,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 
 [hard_edged_quadrupoles]
@@ -1003,10 +832,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
 analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
 
 [hard_edged_quadrupoles_boosted]
@@ -1021,10 +846,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
 analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
 
 [hard_edged_quadrupoles_moving]
@@ -1039,10 +860,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron
 analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
 
 [initial_distribution]
@@ -1057,9 +874,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/initial_distribution/analysis_distribution.py
 aux1File = Tools/PostProcessing/read_raw_data.py
 
@@ -1075,8 +889,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
 
 [ionization_lab]
@@ -1091,8 +903,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
 
 [ion_stopping]
@@ -1107,9 +917,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ion_stopping/analysis_ion_stopping.py
 
 [Langmuir_multi]
@@ -1124,10 +931,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1143,9 +946,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_1d.py
 analysisOutputImage = langmuir_fluid_multi_1d_analysis.png
 
@@ -1161,9 +961,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_rz.py
 analysisOutputImage = langmuir_fluid_rz_analysis.png
 
@@ -1179,9 +976,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_2d.py
 analysisOutputImage = langmuir_fluid_multi_2d_analysis.png
 
@@ -1197,9 +991,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_3d.py
 analysisOutputImage = langmuir_fluid_multi_analysis.png
 
@@ -1215,10 +1006,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_1d.py
 analysisOutputImage = langmuir_multi_1d_analysis.png
 
@@ -1234,10 +1021,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
 
@@ -1253,10 +1036,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR.png
 
@@ -1272,10 +1051,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR_momentum_conserving.png
 
@@ -1291,10 +1066,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
 
@@ -1310,10 +1081,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1329,10 +1096,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1348,10 +1111,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1367,10 +1126,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1386,10 +1141,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1405,10 +1156,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_psatd_multiJ.png
 
@@ -1424,10 +1171,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = Langmuir_multi_2d_psatd_multiJ_nodal.png
 
@@ -1443,10 +1186,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1462,10 +1201,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1481,10 +1216,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1500,10 +1231,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
 analysisOutputImage = langmuir_multi_2d_analysis.png
 
@@ -1519,10 +1246,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1538,10 +1261,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1557,10 +1276,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1576,10 +1291,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1595,10 +1306,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1614,10 +1321,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1633,10 +1336,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = Langmuir_multi_psatd_multiJ.png
 
@@ -1652,10 +1351,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = Langmuir_multi_psatd_multiJ_nodal.png
 
@@ -1671,10 +1366,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1690,10 +1381,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1709,10 +1396,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1728,10 +1411,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1747,10 +1426,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
@@ -1767,10 +1442,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
@@ -1787,10 +1458,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
@@ -1807,10 +1474,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
 analysisOutputImage = Langmuir_multi_rz_psatd_multiJ_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
@@ -1827,10 +1490,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons positrons
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
 analysisOutputImage = langmuir_multi_analysis.png
 
@@ -1846,8 +1505,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAcceleration]
@@ -1862,10 +1519,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 outputFile = LaserAcceleration_plt
 analysisRoutine = Examples/analysis_default_openpmd_regression.py
 
@@ -1881,10 +1534,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAcceleration_1d_fluid]
@@ -1899,10 +1548,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_1d_fluids.py
 
 [LaserAcceleration_1d_fluid_boosted]
@@ -1917,10 +1562,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_1d_fluids_boosted.py
 
 [LaserAccelerationBoost]
@@ -1935,8 +1576,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAcceleration_BTD]
@@ -1951,10 +1590,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/boosted_diags/analysis.py
 
 [LaserAccelerationMR]
@@ -1969,10 +1604,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAccelerationRZ]
@@ -1987,10 +1618,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [LaserAccelerationRZ_opmd]
@@ -2005,10 +1632,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons beam
 outputFile = LaserAccelerationRZ_opmd_plt
 analysisRoutine = Examples/Tests/openpmd_rz/analysis_openpmd_rz.py
 
@@ -2024,10 +1647,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 outputFile = LaserAcceleration_single_precision_comms_plt
 analysisRoutine = Examples/analysis_default_openpmd_regression.py
 
@@ -2043,9 +1662,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/laser_injection/analysis_laser.py
 analysisOutputImage = laser_analysis.png
 
@@ -2061,9 +1677,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/laser_injection/analysis_1d.py
 
 [LaserInjection_2d]
@@ -2078,9 +1691,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/laser_injection/analysis_2d.py
 
 [LaserInjectionFromBINARYFile]
@@ -2097,10 +1707,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromLASYFile]
 buildDir = .
@@ -2116,10 +1724,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromLASYFile_1d]
 buildDir = .
@@ -2135,10 +1741,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromLASYFile_1d_boost]
 buildDir = .
@@ -2154,10 +1758,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromLASYFile_2d]
 buildDir = .
@@ -2173,10 +1775,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromLASYFile_RZ]
 buildDir = .
@@ -2192,10 +1792,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserInjectionFromRZLASYFile]
 buildDir = .
@@ -2211,10 +1809,8 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
 selfTest = 1
 stSuccessString = Passed
-doVis = 0
 
 [LaserIonAcc2d]
 buildDir = .
@@ -2229,8 +1825,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_openpmd_regression.py
 
 [LaserOnFine]
@@ -2245,8 +1839,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [leveling_thinning]
@@ -2261,9 +1853,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/resampling/analysis_leveling_thinning.py
 
 [LoadExternalFieldRZGrid]
@@ -2279,10 +1868,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
 analysisRoutine = Examples/Tests/LoadExternalField/analysis_rz.py
 
 [LoadExternalFieldRZParticles]
@@ -2298,10 +1883,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
 analysisRoutine = Examples/Tests/LoadExternalField/analysis_rz.py
 
 [magnetostatic_eb_3d]
@@ -2316,9 +1897,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 2
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Maxwell_Hybrid_QED_solver]
@@ -2333,8 +1911,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/maxwell_hybrid_qed/analysis_Maxwell_QED_Hybrid.py
 
 [momentum-conserving-gather]
@@ -2349,10 +1925,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam driver plasma_e
 analysisRoutine = Examples/analysis_default_regression.py
 
 [multi_J_rz_psatd]
@@ -2367,10 +1939,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = driver plasma_e plasma_p
 analysisRoutine = Examples/analysis_default_regression.py
 
 [nci_corrector]
@@ -2385,9 +1953,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
 
 [nci_correctorMR]
@@ -2402,9 +1967,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/nci_fdtd_stability/analysis_ncicorr.py
 
 [parabolic_channel_initialization_2d_single_precision]
@@ -2418,9 +1980,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params =
 analysisRoutine = Examples/Tests/initial_plasma_profile/analysis.py
 
@@ -2436,10 +1995,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/particle_boundary_process/analysis_absorption.py
 
 [particle_boundaries_3d]
@@ -2454,9 +2009,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/boundaries/analysis.py
 
 [particle_fields_diags]
@@ -2472,9 +2024,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags.py
 
 [particle_fields_diags_single_precision]
@@ -2490,9 +2039,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags_single.py
 
 [particle_pusher]
@@ -2507,9 +2053,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine =  Examples/Tests/particle_pusher/analysis_pusher.py
 
 [particle_scrape]
@@ -2524,10 +2067,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
 
 [particles_in_pml]
@@ -2542,9 +2081,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
 [particles_in_pml_2d]
@@ -2559,9 +2095,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
 [particles_in_pml_2d_MR]
@@ -2576,9 +2109,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
 [particles_in_pml_3d_MR]
@@ -2593,9 +2123,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particles_in_pml/analysis_particles_in_pml.py
 
 [PEC_field]
@@ -2610,9 +2137,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/pec/analysis_pec.py
 
 [PEC_field_mr]
@@ -2627,9 +2151,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/pec/analysis_pec_mr.py
 
 [PEC_particle]
@@ -2644,10 +2165,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron proton
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Performance_works_1_uniform_rest_32ppc]
@@ -2662,10 +2179,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine =
 
 [Performance_works_2_uniform_rest_1ppc]
@@ -2680,10 +2193,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine =
 
 [Performance_works_3_uniform_drift_4ppc]
@@ -2698,10 +2207,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine =
 
 [Performance_works_4_labdiags_2ppc]
@@ -2716,10 +2221,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine =
 
 [Performance_works_5_loadimbalance]
@@ -2734,10 +2235,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine =
 
 [Performance_works_6_output_2ppc]
@@ -2752,10 +2249,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine =
 
 [photon_pusher]
@@ -2770,9 +2263,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/photon_pusher/analysis_photon_pusher.py
 
 [PlasmaAccelerationBoost2d]
@@ -2787,8 +2277,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [PlasmaAccelerationBoost3d]
@@ -2803,8 +2291,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [PlasmaAccelerationBoost3d_hybrid]
@@ -2818,8 +2304,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [PlasmaAccelerationMR]
@@ -2834,10 +2318,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam driver plasma_e
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Plasma_lens]
@@ -2852,10 +2332,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 
 [Plasma_lens_boosted]
@@ -2870,10 +2346,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 
 [Plasma_lens_short]
@@ -2888,10 +2360,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 
 [PlasmaMirror]
@@ -2906,8 +2374,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [pml_psatd_dive_divb_cleaning]
@@ -2922,8 +2388,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [pml_psatd_rz]
@@ -2938,8 +2402,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_psatd_rz.py
 
 [pml_x_ckc]
@@ -2954,8 +2416,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_ckc.py
 
 [pml_x_galilean]
@@ -2970,8 +2430,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
 
 [pml_x_psatd]
@@ -2987,8 +2445,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
 
 [pml_x_yee]
@@ -3004,8 +2460,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
 
 [pml_x_yee_eb]
@@ -3021,8 +2475,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
 
 [Proton_Boron_Fusion_2D]
@@ -3037,8 +2489,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
 
 [Proton_Boron_Fusion_3D]
@@ -3053,8 +2503,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
 
 [Python_background_mcc]
@@ -3071,9 +2519,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_2d.py
 
 [Python_background_mcc_1d]
@@ -3090,9 +2535,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
 
 [Python_background_mcc_1d_tridiag]
@@ -3109,9 +2551,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_1d.py
 
 [Python_collisionXZ]
@@ -3128,9 +2567,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/collision/analysis_collision_2d.py
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
@@ -3148,9 +2584,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_dirichlet_bc/analysis.py
 
 [Python_dsmc_1d]
@@ -3167,9 +2600,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Physics_applications/capacitive_discharge/analysis_dsmc.py
 
 [Python_ElectrostaticSphereEB]
@@ -3186,9 +2616,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/electrostatic_sphere_eb/analysis.py
 
 [Python_gaussian_beam]
@@ -3205,10 +2632,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_gaussian_beam_no_field_output]
@@ -3225,10 +2648,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine =
 
 [Python_gaussian_beam_opmd]
@@ -3245,10 +2664,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine =
 
 [Python_gaussian_beam_opmd_no_field_output]
@@ -3265,10 +2680,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine =
 
 [Python_id_cpu_read]
@@ -3285,10 +2696,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 
 [Python_ionization]
 buildDir = .
@@ -3304,8 +2711,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/ionization/analysis_ionization.py
 
 [Python_Langmuir]
@@ -3322,10 +2727,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_Langmuir_2d]
@@ -3342,10 +2743,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_Langmuir_rz_multimode]
@@ -3362,10 +2759,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons protons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_LaserAcceleration]
@@ -3382,10 +2775,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_LaserAcceleration_1d]
@@ -3402,10 +2791,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_LaserAccelerationMR]
@@ -3422,10 +2807,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_LaserAccelerationRZ]
@@ -3442,10 +2823,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_LaserIonAcc2d]
@@ -3463,8 +2840,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_openpmd_regression.py
 
 [Python_LoadExternalGridField3D]
@@ -3481,10 +2856,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
 analysisRoutine = Examples/Tests/LoadExternalField/analysis_3d.py
 
 [Python_LoadExternalParticleField3D]
@@ -3501,10 +2872,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = proton
 analysisRoutine = Examples/Tests/LoadExternalField/analysis_3d.py
 
 [Python_magnetostatic_eb_3d]
@@ -3521,10 +2888,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 2
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_magnetostatic_eb_rz]
@@ -3541,10 +2904,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 2
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 analysisRoutine = Examples/Tests/magnetostatic_eb/analysis_rz.py
 
 [Python_ohms_law_solver_EM_modes_1d]
@@ -3561,9 +2920,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ohm_solver_EM_modes/analysis.py
 
 [Python_ohms_law_solver_EM_modes_rz]
@@ -3580,9 +2936,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ohm_solver_EM_modes/analysis_rz.py
 
 [Python_ohms_law_solver_ion_beam_1d]
@@ -3599,9 +2952,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ohm_solver_ion_beam_instability/analysis.py
 
 [Python_ohms_law_solver_landau_damping_2d]
@@ -3618,9 +2968,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ohm_solver_ion_Landau_damping/analysis.py
 
 [Python_ohms_law_solver_magnetic_reconnection_2d]
@@ -3637,9 +2984,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/ohm_solver_magnetic_reconnection/analysis.py
 
 [Python_particle_attr_access]
@@ -3656,8 +3000,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/particle_data_python/analysis.py
 
 [Python_particle_attr_access_unique]
@@ -3674,8 +3016,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/particle_data_python/analysis.py
 
 [Python_particle_reflection]
@@ -3692,8 +3032,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/particle_boundary_process/analysis_reflection.py
 
 [Python_particle_scrape]
@@ -3710,10 +3048,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/particle_boundary_scrape/analysis_scrape.py
 
 # TODO: Enable in pyAMReX, then enable lines in PICMI_inputs_2d.py again
@@ -3732,10 +3066,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 # TODO: comment in again once enabled
 #analysisRoutine = Examples/Tests/pass_mpi_communicator/analysis.py
 
@@ -3753,10 +3083,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_PlasmaAcceleration1d]
@@ -3773,10 +3099,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_PlasmaAccelerationMR]
@@ -3793,10 +3115,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = beam
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_plasma_lens]
@@ -3813,10 +3131,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 
 [Python_prev_positions]
@@ -3833,9 +3147,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Python_reduced_diags_loadbalancecosts_timers]
@@ -3852,9 +3163,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
 [Python_restart_eb]
@@ -3872,10 +3180,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 
 [Python_restart_runtime_components]
@@ -3893,10 +3197,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 
 [Python_wrappers]
 buildDir = .
@@ -3912,9 +3212,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [qed_breit_wheeler_2d]
@@ -3930,9 +3227,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_yt.py
 
 [qed_breit_wheeler_2d_opmd]
@@ -3948,9 +3242,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 outputFile = qed_breit_wheeler_2d_opmd_plt
 analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_opmd.py
 
@@ -3967,9 +3258,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_yt.py
 
 [qed_breit_wheeler_3d_opmd]
@@ -3985,9 +3273,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 outputFile = qed_breit_wheeler_3d_opmd_plt
 analysisRoutine = Examples/Tests/qed/breit_wheeler/analysis_opmd.py
 
@@ -4003,9 +3288,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/qed/quantum_synchrotron/analysis.py
 
 [qed_quantum_sync_3d]
@@ -4020,9 +3302,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/qed/quantum_synchrotron/analysis.py
 
 [qed_schwinger1]
@@ -4037,8 +3316,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/qed/schwinger/analysis_schwinger.py
 
 [qed_schwinger2]
@@ -4053,8 +3330,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/qed/schwinger/analysis_schwinger.py
 
 [qed_schwinger3]
@@ -4069,8 +3344,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/qed/schwinger/analysis_schwinger.py
 
 [qed_schwinger4]
@@ -4085,8 +3358,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/qed/schwinger/analysis_schwinger.py
 
 [radiation_reaction]
@@ -4101,9 +3372,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/analysis_classicalRR.py
 
 [reduced_diags]
@@ -4119,9 +3387,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
 
 [reduced_diags_loadbalancecosts_heuristic]
@@ -4136,9 +3401,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
 [reduced_diags_loadbalancecosts_timers]
@@ -4153,9 +3415,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
 [reduced_diags_loadbalancecosts_timers_psatd]
@@ -4170,9 +3429,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 
 [reduced_diags_single_precision]
@@ -4188,9 +3444,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_single.py
 
 [RefinedInjection]
@@ -4205,10 +3458,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons beam
 analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_refined_injection.py
 
 [relativistic_space_charge_initialization]
@@ -4222,9 +3471,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params =
 analysisRoutine = Examples/Tests/relativistic_space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
@@ -4241,8 +3487,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/repelling_particles/analysis_repelling.py
 
 [resample_velocity_coincidence_thinning]
@@ -4257,9 +3501,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [resample_velocity_coincidence_thinning_cartesian]
@@ -4274,9 +3515,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [restart]
@@ -4292,10 +3530,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 
 [restart_psatd]
@@ -4311,10 +3545,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 
 [restart_psatd_time_avg]
@@ -4330,10 +3560,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = beam
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 
 [RigidInjection_BTD]
@@ -4348,10 +3574,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_BoostedFrame.py
 
 [RigidInjection_lab]
@@ -4366,9 +3588,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_LabFrame.py
 
 [scraping]
@@ -4383,9 +3602,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/scraping/analysis_rz.py
 
 [scraping_filter]
@@ -4400,9 +3616,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/scraping/analysis_rz_filter.py
 
 [silver_mueller_1d]
@@ -4417,8 +3630,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
 
 [silver_mueller_2d_x]
@@ -4433,8 +3644,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
 
 [silver_mueller_2d_z]
@@ -4449,8 +3658,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
 
 [silver_mueller_rz_z]
@@ -4465,8 +3672,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/Tests/silver_mueller/analysis_silver_mueller.py
 
 [space_charge_initialization]
@@ -4480,9 +3685,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params =
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
@@ -4498,9 +3700,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
@@ -4517,9 +3716,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [Uniform_2d]
@@ -4534,8 +3730,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
 
 [uniform_plasma_restart]
@@ -4551,10 +3745,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 analysisRoutine = Examples/Tests/restart/analysis_restart.py
 
 [uniform_plasma_multiJ]
@@ -4569,10 +3759,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons ions
 analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_multiJ.py
 
 [VayDeposition2D]
@@ -4587,10 +3773,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron ion
 analysisRoutine = Examples/Tests/vay_deposition/analysis.py
 
 [VayDeposition3D]
@@ -4605,10 +3787,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electron ion
 analysisRoutine = Examples/Tests/vay_deposition/analysis.py
 
 [NodalElectrostaticSolver]
@@ -4623,9 +3801,6 @@ useMPI = 1
 numprocs = 1
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/nodal_electrostatic/analysis_3d.py
 
 [BeamBeamCollision]
@@ -4640,8 +3815,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
 outputFile = BeamBeamCollision_plt
 analysisRoutine = Examples/analysis_default_openpmd_regression.py
 
@@ -4659,10 +3832,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons protons
 outputFile = spacecraft_charging_plt
 analysisRoutine = Examples/Physics_applications/spacecraft_charging/analysis.py
 analysisOutputImage = min_phi_analysis.png
@@ -4679,10 +3848,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 outputFile = Point_of_contact_EB_3d_plt
 analysisRoutine = Examples/Tests/point_of_contact_EB/analysis.py
 
@@ -4698,10 +3863,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-particleTypes = electrons
 outputFile = Point_of_contact_EB_rz_plt
 analysisRoutine = Examples/Tests/point_of_contact_EB/analysis.py
 
@@ -4717,9 +3878,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_1d.py
 
 [ThetaImplicitJFNK_VandB_2d]
@@ -4734,9 +3892,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_vandb_jfnk_2d.py
 
 [SemiImplicitPicard_1d]
@@ -4751,9 +3906,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_1d.py
 
 [EnergyConservingThermalPlasma]
@@ -4767,9 +3919,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 0
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
 analysisRoutine = Examples/Tests/energy_conserving_thermal_plasma/analysis.py
 
 [focusing_gaussian_beam]
@@ -4784,10 +3933,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/gaussian_beam/analysis_focusing_beam.py
 
 [particle_boundary_interaction]
@@ -4804,10 +3949,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 1
-particleTypes = electrons
 outputFile = particle_boundary_interaction_plt
 analysisRoutine = Examples/Tests/particle_boundary_interaction/analysis.py
 
@@ -4823,9 +3964,6 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
 analysisRoutine = Examples/Tests/particle_thermal_boundary/analysis_2d.py
 
 [openbc_poisson_solver]
@@ -4840,8 +3978,4 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
-compileTest = 0
-doVis = 0
-compareParticles = 0
-doComparison = 0
 analysisRoutine = Examples/Tests/openbc_poisson_solver/analysis.py

--- a/run_test.sh
+++ b/run_test.sh
@@ -96,10 +96,10 @@ cd ../../regression_testing/
 echo "cd $PWD"
 # run only tests specified in variable tests_arg (single test or multiple tests)
 if [[ ! -z "${tests_arg}" ]]; then
-  python3 regtest.py ../rt-WarpX/ci-tests.ini --no_update all "${tests_run}"
+  python3 regtest.py ../rt-WarpX/ci-tests.ini --skip_comparison --no_update all "${tests_run}"
 # run all tests (variables tests_arg and tests_run are empty)
 else
-  python3 regtest.py ../rt-WarpX/ci-tests.ini --no_update all
+  python3 regtest.py ../rt-WarpX/ci-tests.ini --skip_comparison --no_update all
 fi
 
 # clean up python virtual environment


### PR DESCRIPTION
This is a PR triggered by discussions with @RemiLehe after #5042, where we saw that particles checksums were not being checked as expected. 

I think we had a number of unused/obsolete parameters in WarpX-tests.ini, which are related to AMReX's regression testing suite and not to our own custom analysis routines.

As suggested in https://github.com/AMReX-Codes/regression_testing/blob/main/docs/source/analysis.rst, it is reasonable to disable the default comparison to benchmarks provided by AMReX's regression testing suite when custom analysis routines are used, as for all of our CI tests.

In fact, if we try to effectively activate those comparisons by setting `doComparison = 1` and, say, `compareParticles = 1`, then our tests fail due to the fact that there are no benchmark files available.

These are the parameters that I believe can be safely removed without reducing our CI coverage:
- `doComparison`
- `compareParticles`
- `particleTypes`
- `doVis`

As the fix for the test `collisionXYZ` in this PR shows, the particle data comparison is managed by our own analysis routines, in particular through the argument `do_particles` of the method `evaluate_checksum`, and not by setting `compareParticles` and/or `doComparison` and/or `particleTypes` in AMReX's regression testing suite.

Before merging the PR, it might be worth checking with some of the main developers of AMReX's regression testing suite that what I'm saying here is correct.
