### PR TITLE
Use latest PICMI version in readthedocs

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -13,7 +13,7 @@ openpmd-viewer  # for checksumAPI
 
 # PICMI API docs
 # note: keep in sync with version in ../requirements.txt
-picmistandard==0.28.0
+picmistandard==0.29.0
 # for development against an unreleased PICMI version, use:
 # picmistandard @ git+https://github.com/picmi-standard/picmi.git#subdirectory=PICMI_Python
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -59,7 +59,7 @@ setup(name = 'pywarpx',
       package_dir = {'pywarpx': 'pywarpx'},
       description = """Wrapper of WarpX""",
       package_data = package_data,
-      install_requires = ['numpy', 'picmistandard==0.28.0', 'periodictable'],
+      install_requires = ['numpy', 'picmistandard==0.29.0', 'periodictable'],
       python_requires = '>=3.8',
       zip_safe=False
 )

--- a/Tools/machines/karolina-it4i/install_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_dependencies.sh
@@ -53,7 +53,7 @@ python -m pip install --user --upgrade matplotlib
 #python -m pip install --user --upgrade yt
 
 # install or update WarpX dependencies
-python -m pip install --user --upgrade picmistandard==0.28.0
+python -m pip install --user --upgrade picmistandard==0.29.0
 python -m pip install --user --upgrade lasy
 
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)


### PR DESCRIPTION
The Readthedocs documentation was still using picmistandard 0.28.0 instead of 0.29.0, and the build was therefore failing. (0.29.0 is required as of #4997)

Fixes #5041 