### PR TITLE
Make quantum_xi_c2 a non-static member variable of the WarpX class

### DIFF
--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -169,7 +169,7 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real a_dt)
         );
 
         // Make local copy of xi, to use on device.
-        const Real xi_c2 = WarpX::quantum_xi_c2;
+        const Real xi_c2 = quantum_xi_c2;
 
         // Apply QED correction to electric field, using temporary arrays.
         amrex::ParallelFor(

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -169,7 +169,7 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real a_dt)
         );
 
         // Make local copy of xi, to use on device.
-        const Real xi_c2 = quantum_xi_c2;
+        const Real xi_c2 = m_quantum_xi_c2;
 
         // Apply QED correction to electric field, using temporary arrays.
         amrex::ParallelFor(

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -665,7 +665,7 @@ public:
      */
     void Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real dt);
 
-    static amrex::Real quantum_xi_c2;
+    amrex::Real quantum_xi_c2;
 
     /** Check and potentially compute load balancing
      */

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -665,7 +665,7 @@ public:
      */
     void Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real dt);
 
-    amrex::Real quantum_xi_c2;
+    amrex::Real m_quantum_xi_c2;
 
     /** Check and potentially compute load balancing
      */

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -100,7 +100,6 @@ bool WarpX::fft_do_time_averaging = false;
 amrex::IntVect WarpX::m_fill_guards_fields  = amrex::IntVect(0);
 amrex::IntVect WarpX::m_fill_guards_current = amrex::IntVect(0);
 
-Real WarpX::quantum_xi_c2 = PhysConst::xi_c2;
 Real WarpX::gamma_boost = 1._rt;
 Real WarpX::beta_boost = 0._rt;
 Vector<int> WarpX::boost_direction = {0,0,0};
@@ -902,6 +901,9 @@ WarpX::ReadParameters ()
             pp_warpx, "n_field_gather_buffer", n_field_gather_buffer);
         utils::parser::queryWithParser(
             pp_warpx, "n_current_deposition_buffer", n_current_deposition_buffer);
+
+        //Default value for the quantum parameter used in Maxwell’s QED equations
+        quantum_xi_c2 = PhysConst::xi_c2;
 
         amrex::Real quantum_xi_tmp;
         const auto quantum_xi_is_specified =

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -903,14 +903,14 @@ WarpX::ReadParameters ()
             pp_warpx, "n_current_deposition_buffer", n_current_deposition_buffer);
 
         //Default value for the quantum parameter used in Maxwell’s QED equations
-        quantum_xi_c2 = PhysConst::xi_c2;
+        m_quantum_xi_c2 = PhysConst::xi_c2;
 
         amrex::Real quantum_xi_tmp;
         const auto quantum_xi_is_specified =
             utils::parser::queryWithParser(pp_warpx, "quantum_xi", quantum_xi_tmp);
         if (quantum_xi_is_specified) {
             double const quantum_xi = quantum_xi_tmp;
-            quantum_xi_c2 = static_cast<amrex::Real>(quantum_xi * PhysConst::c * PhysConst::c);
+            m_quantum_xi_c2 = static_cast<amrex::Real>(quantum_xi * PhysConst::c * PhysConst::c);
         }
 
         const auto at_least_one_boundary_is_pml =


### PR DESCRIPTION
This PR is part of the effort to make the WarpX class less static.