### PR TITLE
Update script to compile WarpX on Frontier (OLCF)

### DIFF
--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -6,6 +6,7 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
+module load Core/24.07
 module load cmake/3.27.9
 module load craype-accel-amd-gfx90a
 module load rocm/5.7.1

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -29,9 +29,11 @@ export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/lapackpp-2024.05.31/lib64:$LD_LIB
 module load boost/1.79.0
 
 # optional: for openPMD support
-export CMAKE_PREFIX_PATH=${SHAREDHOMEDIR}/sw/frontier/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${SHAREDHOMEDIR}/sw/frontier/gpu/adios2-2.9.2:$CMAKE_PREFIX_PATH
-module load hdf5/1.12.1-mpi
+export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/hdf5-1.14.1.2:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/adios2-2.9.2:$CMAKE_PREFIX_PATH
+export PATH=${HOME}/sw/frontier/gpu/hdf5-1.14.1.2/bin:${PATH}
+export PATH=${HOME}/sw/frontier/gpu/adios2-2.9.2/bin:${PATH}
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -6,11 +6,11 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load cmake/3.23.2
+module load cmake/3.27.9
 module load craype-accel-amd-gfx90a
-module load rocm/5.2.0  # waiting for 5.6 for next bump
-module load cray-mpich
-module load cce/15.0.0  # must be loaded after rocm
+module load rocm/5.7.1
+module load cray-mpich/8.1.28
+module load cce/17.0.0  # must be loaded after rocm
 
 # optional: faster builds
 module load ccache
@@ -26,14 +26,14 @@ export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/blaspp-2024.05.31/lib64:$LD_LIBRA
 export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
-module load boost/1.79.0-cxx17
+module load boost/1.82.0
 
 # optional: for openPMD support
-module load adios2/2.8.3
-module load hdf5/1.14.0
+module load adios2/2.9.0
+module load hdf5/1.14.3
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load cray-python/3.11.5
 
 if [ -d "${HOME}/sw/frontier/gpu/venvs/warpx-frontier" ]
 then

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -29,11 +29,8 @@ export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/lapackpp-2024.05.31/lib64:$LD_LIB
 module load boost/1.79.0
 
 # optional: for openPMD support
-export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/hdf5-1.14.1.2:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${HOME}/sw/frontier/gpu/adios2-2.9.2:$CMAKE_PREFIX_PATH
-export PATH=${HOME}/sw/frontier/gpu/hdf5-1.14.1.2/bin:${PATH}
-export PATH=${HOME}/sw/frontier/gpu/adios2-2.9.2/bin:${PATH}
+module load adios2/2.8.3-mpi
+module load hdf5/1.12.1-mpi
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -6,8 +6,7 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load Core/24.07
-module load cmake/3.27.9
+module load cmake/3.23.2
 module load craype-accel-amd-gfx90a
 module load rocm/5.7.1
 module load cray-mpich/8.1.28
@@ -27,11 +26,12 @@ export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/blaspp-2024.05.31/lib64:$LD_LIBRA
 export LD_LIBRARY_PATH=${HOME}/sw/frontier/gpu/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
-module load boost/1.82.0
+module load boost/1.79.0
 
 # optional: for openPMD support
-module load adios2/2.9.0
-module load hdf5/1.14.3
+export CMAKE_PREFIX_PATH=${SHAREDHOMEDIR}/sw/frontier/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SHAREDHOMEDIR}/sw/frontier/gpu/adios2-2.9.2:$CMAKE_PREFIX_PATH
+module load hdf5/1.12.1-mpi
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -108,8 +108,6 @@ CUPY_INSTALL_USE_HIP=1  \
 ROCM_HOME=${ROCM_PATH}  \
 HCC_AMDGPU_TARGET=${AMREX_AMD_ARCH}  \
   python3 -m pip install -v cupy
-# optional: for libEnsemble
-python3 -m pip install -r $HOME/src/warpx/Tools/LibEnsemble/requirements.txt
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
 #python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/rocm5.4.2
 #python3 -m pip install -r $HOME/src/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -75,30 +75,30 @@ cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
 
 # c-blosc (I/O compression, for OpenPMD)
-if [ -d $SHAREDHOMEDIR/src/c-blosc ]
+if [ -d $HOME/src/c-blosc ]
 then
   # git repository is already there
   :
 else
-  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $SHAREDHOMEDIR/src/c-blosc
+  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
-rm -rf $SHAREDHOMEDIR/src/c-blosc-frontier-build
-cmake -S $SHAREDHOMEDIR/src/c-blosc -B $SHAREDHOMEDIR/src/c-blosc-frontier-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build $SHAREDHOMEDIR/src/c-blosc-frontier-build --target install --parallel 16
-rm -rf $SHAREDHOMEDIR/src/c-blosc-frontier-build
+rm -rf $HOME/src/c-blosc-frontier-build
+cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-frontier-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
+cmake --build $HOME/src/c-blosc-frontier-build --target install --parallel 16
+rm -rf $HOME/src/c-blosc-frontier-build
 
 # ADIOS2 v. 2.9.2 (for OpenPMD)
-if [ -d $SHAREDHOMEDIR/src/adios2 ]
+if [ -d $HOME/src/adios2 ]
 then
   # git repository is already there
   :
 else
-  git clone -b v2.9.2 https://github.com/ornladios/ADIOS2.git $SHAREDHOMEDIR/src/adios2
+  git clone -b v2.9.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
-rm -rf $SHAREDHOMEDIR/src/adios2-frontier-build
-cmake -S $SHAREDHOMEDIR/src/adios2 -B $SHAREDHOMEDIR/src/adios2-ad-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
-cmake --build $SHAREDHOMEDIR/src/adios2-frontier-build --target install -j 16
-rm -rf $SHAREDHOMEDIR/src/adios2-frontier-build
+rm -rf $HOME/src/adios2-frontier-build
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-ad-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
+cmake --build $HOME/src/adios2-frontier-build --target install -j 16
+rm -rf $HOME/src/adios2-frontier-build
 
 
 # Python ######################################################################

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -74,52 +74,6 @@ CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B 
 cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
 
-# c-blosc (I/O compression, for OpenPMD)
-if [ -d $HOME/src/c-blosc ]
-then
-  # git repository is already there
-  :
-else
-  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
-fi
-rm -rf $HOME/src/c-blosc-frontier-build
-cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-frontier-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build $HOME/src/c-blosc-frontier-build --target install --parallel 16
-rm -rf $HOME/src/c-blosc-frontier-build
-
-# HDF5 (for openPMD)
-if [ -d $HOME/src/hdf5 ]
-then
-  cd $HOME/src/hdf5
-  git fetch --prune
-  git checkout hdf5-1_14_1-2
-  cd -
-else
-  git clone -b hdf5-1_14_1-2 https://github.com/HDFGroup/hdf5.git $HOME/src/hdf5
-fi
-rm -rf $HOME/src/hdf5-frontier-build
-cmake -S $HOME/src/hdf5          \
-      -B $HOME/src/hdf5-frontier-build  \
-      -DBUILD_TESTING=OFF         \
-      -DHDF5_ENABLE_PARALLEL=ON   \
-      -DCMAKE_INSTALL_PREFIX=${SW_DIR}/hdf5-1.14.1.2
-cmake --build $HOME/src/hdf5-frontier-build --target install --parallel 10
-rm -rf $HOME/src/hdf5-frontier-build
-
-# ADIOS2 v. 2.9.2 (for OpenPMD)
-if [ -d $HOME/src/adios2 ]
-then
-  # git repository is already there
-  :
-else
-  git clone -b v2.9.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
-fi
-rm -rf $HOME/src/adios2-frontier-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-frontier-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
-cmake --build $HOME/src/adios2-frontier-build --target install -j 16
-rm -rf $HOME/src/adios2-frontier-build
-
-
 # Python ######################################################################
 #
 python3 -m pip install --upgrade pip

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -87,6 +87,25 @@ cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-frontier-build -DBUILD_TESTS=OFF
 cmake --build $HOME/src/c-blosc-frontier-build --target install --parallel 16
 rm -rf $HOME/src/c-blosc-frontier-build
 
+# HDF5 (for openPMD)
+if [ -d $HOME/src/hdf5 ]
+then
+  cd $HOME/src/hdf5
+  git fetch --prune
+  git checkout hdf5-1_14_1-2
+  cd -
+else
+  git clone -b hdf5-1_14_1-2 https://github.com/HDFGroup/hdf5.git $HOME/src/hdf5
+fi
+rm -rf $HOME/src/hdf5-frontier-build
+cmake -S $HOME/src/hdf5          \
+      -B $HOME/src/hdf5-frontier-build  \
+      -DBUILD_TESTING=OFF         \
+      -DHDF5_ENABLE_PARALLEL=ON   \
+      -DCMAKE_INSTALL_PREFIX=${SW_DIR}/hdf5-1.14.1.2
+cmake --build $HOME/src/hdf5-frontier-build --target install --parallel 10
+rm -rf $HOME/src/hdf5-frontier-build
+
 # ADIOS2 v. 2.9.2 (for OpenPMD)
 if [ -d $HOME/src/adios2 ]
 then

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -74,6 +74,32 @@ CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B 
 cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
 
+# c-blosc (I/O compression, for OpenPMD)
+if [ -d $SHAREDHOMEDIR/src/c-blosc ]
+then
+  # git repository is already there
+  :
+else
+  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $SHAREDHOMEDIR/src/c-blosc
+fi
+rm -rf $SHAREDHOMEDIR/src/c-blosc-frontier-build
+cmake -S $SHAREDHOMEDIR/src/c-blosc -B $SHAREDHOMEDIR/src/c-blosc-frontier-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
+cmake --build $SHAREDHOMEDIR/src/c-blosc-frontier-build --target install --parallel 16
+rm -rf $SHAREDHOMEDIR/src/c-blosc-frontier-build
+
+# ADIOS2 v. 2.9.2 (for OpenPMD)
+if [ -d $SHAREDHOMEDIR/src/adios2 ]
+then
+  # git repository is already there
+  :
+else
+  git clone -b v2.9.2 https://github.com/ornladios/ADIOS2.git $SHAREDHOMEDIR/src/adios2
+fi
+rm -rf $SHAREDHOMEDIR/src/adios2-frontier-build
+cmake -S $SHAREDHOMEDIR/src/adios2 -B $SHAREDHOMEDIR/src/adios2-ad-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
+cmake --build $SHAREDHOMEDIR/src/adios2-frontier-build --target install -j 16
+rm -rf $SHAREDHOMEDIR/src/adios2-frontier-build
+
 
 # Python ######################################################################
 #

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -96,7 +96,7 @@ else
   git clone -b v2.9.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 rm -rf $HOME/src/adios2-frontier-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-ad-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
+cmake -S $HOME/src/adios2 -B $HOME/src/adios2-frontier-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.9.2
 cmake --build $HOME/src/adios2-frontier-build --target install -j 16
 rm -rf $HOME/src/adios2-frontier-build
 


### PR DESCRIPTION
After the recent update of the software environment on Frontier, we need to update the scripts to compile WarpX on that machine.