### PR TITLE
[WIP] Recompute the macroscopic properties everytime the moving window moves.

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -38,20 +38,26 @@ public:
     void ReadParameters ();
 
     /**
-     * \brief Initialize multifabs storing macroscopic multifabs
+     * \brief Allocate multifabs storing macroscopic multifabs
      *
      * @param[in] ba the box array associated to the multifabs E and B
      * @param[in] dmap the distribution mapping
      * @param[in] ng_EB_alloc guard cells allocated for multifabs E and B
+     */
+    void AllocateLevelMFs (
+        const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm,
+        const amrex::IntVect& ng_EB_alloc );
+
+    /**
+     * \brief Initialize multifabs storing macroscopic multifabs
+     *
      * @param[in] geom the geometry
      * @param[in] Ex_stag staggering of the Ex field
      * @param[in] Ey_stag staggering of the Ey field
      * @param[in] Ez_stag staggering of the Ez field
      */
     void InitData (
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dmap,
-        const amrex::IntVect& ng_EB_alloc,
         const amrex::Geometry& geom,
         const amrex::IntVect& Ex_stag,
         const amrex::IntVect& Ey_stag,

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -128,8 +128,6 @@ MacroscopicProperties::InitData (
     const amrex::IntVect& Ey_stag,
     const amrex::IntVect& Ez_stag)
 {
-    amrex::Print() << Utils::TextMsg::Info("we are in init data of macro");
-
     // Define material property multifabs using ba and dmap from WarpX instance
     // sigma is cell-centered MultiFab
     m_sigma_mf = std::make_unique<amrex::MultiFab>(ba, dmap, 1, ng_EB_alloc);

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -119,22 +119,26 @@ MacroscopicProperties::ReadParameters ()
 }
 
 void
-MacroscopicProperties::InitData (
+MacroscopicProperties::AllocateLevelMFs (
     const amrex::BoxArray& ba,
     const amrex::DistributionMapping& dmap,
-    const amrex::IntVect& ng_EB_alloc,
-    const amrex::Geometry& geom,
-    const amrex::IntVect& Ex_stag,
-    const amrex::IntVect& Ey_stag,
-    const amrex::IntVect& Ez_stag)
+    const amrex::IntVect& ng_EB_alloc )
 {
-    // Define material property multifabs using ba and dmap from WarpX instance
     // sigma is cell-centered MultiFab
     m_sigma_mf = std::make_unique<amrex::MultiFab>(ba, dmap, 1, ng_EB_alloc);
     // epsilon is cell-centered MultiFab
     m_eps_mf = std::make_unique<amrex::MultiFab>(ba, dmap, 1, ng_EB_alloc);
     // mu is cell-centered MultiFab
     m_mu_mf = std::make_unique<amrex::MultiFab>(ba, dmap, 1, ng_EB_alloc);
+}
+
+void
+MacroscopicProperties::InitData (
+    const amrex::Geometry& geom,
+    const amrex::IntVect& Ex_stag,
+    const amrex::IntVect& Ey_stag,
+    const amrex::IntVect& Ez_stag)
+{
     // Initialize sigma
     if (m_sigma_s == "constant") {
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -474,7 +474,7 @@ WarpX::InitData ()
 
     BuildBufferMasks();
 
-    if (WarpX::em_solver_medium==1) {
+    if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
         const int lev_zero = 0;
         m_macroscopic_properties->InitData(
             boxArray(lev_zero),

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -477,9 +477,6 @@ WarpX::InitData ()
     if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
         const int lev_zero = 0;
         m_macroscopic_properties->InitData(
-            boxArray(lev_zero),
-            DistributionMap(lev_zero),
-            getngEB(),
             Geom(lev_zero),
             getField(warpx::fields::FieldType::Efield_fp, lev_zero,0).ixType().toIntVect(),
             getField(warpx::fields::FieldType::Efield_fp, lev_zero,1).ixType().toIntVect(),

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -19,6 +19,7 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 
 #include <ablastr/utils/Communication.H>
 
@@ -450,6 +451,21 @@ WarpX::MoveWindow (const int step, bool move_j)
             WarpXFluidContainer& fl = myfl->GetFluidContainer(i);
             fl.InitData( lev, injection_box, cur_time );
         }
+    }
+
+    // Recompute macroscopic properties of the medium
+    if (WarpX::em_solver_medium==1) {
+        const int lev_zero = 0;
+        amrex::Print() << Geom(lev_zero);
+        m_macroscopic_properties->InitData(
+            boxArray(lev_zero),
+            DistributionMap(lev_zero),
+            getngEB(),
+            Geom(lev_zero),
+            getField(warpx::fields::FieldType::Efield_fp, lev_zero,0).ixType().toIntVect(),
+            getField(warpx::fields::FieldType::Efield_fp, lev_zero,1).ixType().toIntVect(),
+            getField(warpx::fields::FieldType::Efield_fp, lev_zero,2).ixType().toIntVect()
+        );
     }
 
     return num_shift_base;

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -457,9 +457,6 @@ WarpX::MoveWindow (const int step, bool move_j)
     if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
         const int lev_zero = 0;
         m_macroscopic_properties->InitData(
-            boxArray(lev_zero),
-            DistributionMap(lev_zero),
-            getngEB(),
             Geom(lev_zero),
             getField(warpx::fields::FieldType::Efield_fp, lev_zero,0).ixType().toIntVect(),
             getField(warpx::fields::FieldType::Efield_fp, lev_zero,1).ixType().toIntVect(),

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -454,9 +454,8 @@ WarpX::MoveWindow (const int step, bool move_j)
     }
 
     // Recompute macroscopic properties of the medium
-    if (WarpX::em_solver_medium==1) {
+    if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
         const int lev_zero = 0;
-        amrex::Print() << Geom(lev_zero);
         m_macroscopic_properties->InitData(
             boxArray(lev_zero),
             DistributionMap(lev_zero),

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2373,6 +2373,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         myfl->InitData(lev, geom[lev].Domain(),cur_time);
     }
 
+    // Allocate extra multifabs for macroscopic properties of the medium
+    if (em_solver_medium == MediumForEM::Macroscopic) {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( lev==0,
+            "Macroscopic properties are not supported with mesh refinement.");
+        m_macroscopic_properties->AllocateLevelMFs(ba, dm, ngEB);
+    }
+
     if (fft_do_time_averaging)
     {
         AllocInitMultiFab(Bfield_avg_fp[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, lev, "Bfield_avg_fp[x]", 0.0_rt);


### PR DESCRIPTION
When using the macroscopic properties in WarpX, `epsilon`, `mu` and `sigma` are computed on the grid at t=0, but were never updated as the moving window moves. As a consequence, the simulation will always see the `epsilon`, `mu` and `sigma` that were initially in the box, even once the moving window has moved far past the its initial positions.

This PR fixes this by calling `MacroscopicProperties::InitData` everytime the moving window moves. In the process, I had to separate the allocation of the arrays, in a new member function `AllocateLevelMFs` (which is only called at `t=0`) and the filling out of the data, in the function `InitData` (which is called at `t=0`, as well as everytime the moving window moves).

Fixes #4952 

TODO:
- [ ] Add an automated test