### PR TITLE
Fix again the collisionXYZ benchmark

### DIFF
--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -114,4 +114,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)
+checksumAPI.evaluate_checksum(test_name, fn)

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -6,25 +6,25 @@
     "Ex": 0.0,
     "Ey": 0.0,
     "Ez": 0.0,
-    "T_electron": 353604.6247926339,
-    "T_ion": 347976.6168136309
+    "T_electron": 381488.6528070591,
+    "T_ion": 320091.2785835478
   },
   "electron": {
-    "particle_momentum_x": 8.370755929299189e-19,
-    "particle_momentum_y": 8.228112213603589e-19,
-    "particle_momentum_z": 8.204295817378347e-19,
-    "particle_position_x": 21284971.94721422,
-    "particle_position_y": 21212829.42991966,
-    "particle_position_z": 21214774.536558084,
+    "particle_momentum_x": 8.667025573698235e-19,
+    "particle_momentum_y": 8.457499789250831e-19,
+    "particle_momentum_z": 8.482438182280524e-19,
+    "particle_position_x": 21262567.138872623,
+    "particle_position_y": 21245135.070665065,
+    "particle_position_z": 21232644.283726066,
     "particle_weight": 7.168263344048695e+28
   },
   "ion": {
-    "particle_momentum_x": 2.0074097598289766e-18,
-    "particle_momentum_y": 1.8203553942782305e-18,
-    "particle_momentum_z": 1.823420185235695e-18,
-    "particle_position_x": 21227192.857240494,
-    "particle_position_y": 21286501.692027714,
-    "particle_position_z": 21245587.6706009,
+    "particle_momentum_x": 1.9300495097720012e-18,
+    "particle_momentum_y": 1.747257416857836e-18,
+    "particle_momentum_z": 1.7510296287537058e-18,
+    "particle_position_x": 21217348.883301035,
+    "particle_position_y": 21300859.0630925,
+    "particle_position_z": 21237901.246521123,
     "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionXZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXZ.json
@@ -6,5 +6,21 @@
     "Ex": 0.0,
     "Ey": 0.0,
     "Ez": 0.0
+  },
+  "ion": {
+    "particle_momentum_x": 2.458306853810186e-19,
+    "particle_momentum_y": 2.272685285153902e-19,
+    "particle_momentum_z": 2.281205462681013e-19,
+    "particle_position_x": 2645436.647039526,
+    "particle_position_y": 2672571.48688055,
+    "particle_weight": 1.7256099431746894e+26
+  },
+  "electron": {
+    "particle_momentum_x": 1.0454942263455085e-19,
+    "particle_momentum_y": 1.0323735347957779e-19,
+    "particle_momentum_z": 1.0199134968670343e-19,
+    "particle_position_x": 2681776.3648108337,
+    "particle_position_y": 2663907.8843079703,
+    "particle_weight": 1.7256099431746894e+26
   }
 }


### PR DESCRIPTION
This is yet another update of the collisionXYZ benchmark.

We have some more information this time - the benchmarks values for the particle positions and momenta changed, so the issue is not necessarily related to the temperature diagnostic which originally triggered this issue.

To gather more info, this PR also turns the particle checking on for the other CI test for Coulomb collision, collisionXZ.