### PR TITLE
Improving Coulomb collision method for weighted-particles 

### DIFF
--- a/Examples/Tests/collision/analysis_collision_1d.py
+++ b/Examples/Tests/collision/analysis_collision_1d.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Justin Angus
+#
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# This is a script that analyses the simulation results from the script `inputs_1d`.
+# run locally: python analysis_vandb_1d.py diags/diag1000600/
+#
+# This is a 1D intra-species Coulomb scattering relaxation test consisting
+# of a low-density population streaming into a higher density population at rest.
+# Both populations belong to the same carbon12 ion species.
+# See test T1b from JCP 413 (2020) by D. Higginson, et al.
+#
+import os
+import sys
+
+import numpy as np
+import yt
+from scipy.constants import e
+
+sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
+import checksumAPI
+
+# this will be the name of the plot file
+fn = sys.argv[1]
+ds = yt.load(fn)
+data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
+
+# carbon 12 ion (mass = 12*amu - 6*me)
+mass = 1.992100316897910e-26
+
+# Separate macroparticles from group A (low weight) and group B (high weight)
+# by sorting based on weight
+sorted_indices = data['ions','particle_weight'].argsort()
+sorted_wp = data['ions', 'particle_weight'][sorted_indices].value
+sorted_px = data['ions', 'particle_momentum_x'][sorted_indices].value
+sorted_py = data['ions', 'particle_momentum_y'][sorted_indices].value
+sorted_pz = data['ions', 'particle_momentum_z'][sorted_indices].value
+
+# Find the index 'Npmin' that separates macroparticles from group A and group B
+Np = len(sorted_wp)
+wpmin = sorted_wp.min();
+wpmax = sorted_wp.max();
+for i in range(len(sorted_wp)):
+    if sorted_wp[i] > wpmin:
+        Npmin = i
+        break
+
+NpA = Npmin
+wpA = wpmin;
+NpB = Np - Npmin
+wpB = wpmax;
+NpAs = 0
+NpAe = Npmin
+NpBs = Npmin
+NpBe = Np
+
+#############
+
+sorted_px_sum = np.abs(sorted_px).sum();
+sorted_py_sum = np.abs(sorted_py).sum();
+sorted_pz_sum = np.abs(sorted_pz).sum();
+sorted_wp_sum = np.abs(sorted_wp).sum();
+
+# compute mean velocities
+wAtot = wpA*NpA
+wBtot = wpB*NpB
+
+uBx = uBy = uBz = 0.
+for i in range(NpBs,NpBe):
+    uBx += wpB*sorted_px[i]
+    uBy += wpB*sorted_py[i]
+    uBz += wpB*sorted_pz[i]
+uBx /= (mass*wBtot) # [m/s]
+uBy /= (mass*wBtot) # [m/s]
+uBz /= (mass*wBtot) # [m/s]
+
+uAx = uAy = uAz = 0.
+for i in range(NpAs,NpAe):
+    uAx += wpA*sorted_px[i]
+    uAy += wpA*sorted_py[i]
+    uAz += wpA*sorted_pz[i]
+uAx /= (mass*wAtot) # [m/s]
+uAy /= (mass*wAtot) # [m/s]
+uAz /= (mass*wAtot) # [m/s]
+
+# compute temperatures
+TBx = TBy = TBz = 0.
+for i in range(NpBs,NpBe):
+    TBx += wpB*(sorted_px[i]/mass - uBx)**2
+    TBy += wpB*(sorted_py[i]/mass - uBy)**2
+    TBz += wpB*(sorted_pz[i]/mass - uBz)**2
+TBx *= mass/(e*wBtot)
+TBy *= mass/(e*wBtot)
+TBz *= mass/(e*wBtot)
+
+TAx = TAy = TAz = 0.
+for i in range(NpAs,NpAe):
+    TAx += wpA*(sorted_px[i]/mass - uAx)**2
+    TAy += wpA*(sorted_py[i]/mass - uAy)**2
+    TAz += wpA*(sorted_pz[i]/mass - uAz)**2
+TAx *= mass/(e*wAtot)
+TAy *= mass/(e*wAtot)
+TAz *= mass/(e*wAtot)
+
+TApar = TAz
+TAperp = (TAx + TAy)/2.0
+TA = (TAx + TAy + TAz)/3.0
+
+TBpar = TBz
+TBperp = (TBx + TBy)/2.0
+TB = (TBx + TBy + TBz)/3.0
+
+TApar_30ps_soln = 6.15e3 # TA parallel solution at t = 30 ps
+error = np.abs(TApar-TApar_30ps_soln)/TApar_30ps_soln
+tolerance = 0.02
+print('TApar at 30ps error = ', error);
+print('tolerance = ', tolerance);
+assert error < tolerance
+
+test_name = os.path.split(os.getcwd())[1]
+checksumAPI.evaluate_checksum(test_name, fn)

--- a/Examples/Tests/collision/inputs_1d
+++ b/Examples/Tests/collision/inputs_1d
@@ -1,0 +1,90 @@
+#################################
+########## CONSTANTS ############
+#################################
+
+my_constants.nA = 1.e25       # m^-3
+my_constants.NpA = 400        # m^-3
+my_constants.UA = 6.55e5      # m/s
+my_constants.TA = 500.        # eV
+#
+my_constants.nB = 1.e26       # m^-3
+my_constants.NpB = 400        # m^-3
+my_constants.UB = 0.          # m/s
+my_constants.TB = 500.        # eV
+#
+my_constants.q_c12 = 6.*q_e
+my_constants.m_c12 = 12.*m_u - 6.*m_e
+
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 600
+amr.n_cell = 180
+amr.max_level = 0
+amr.blocking_factor = 4
+geometry.dims = 1
+geometry.prob_lo = 0.
+geometry.prob_hi = 0.01
+
+#################################
+###### Boundary Condition #######
+#################################
+boundary.field_lo = periodic
+boundary.field_hi = periodic
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.const_dt = 0.05e-12
+warpx.use_filter = 0
+
+# Do not evolve the E and B fields
+algo.maxwell_solver = none
+
+# Order of particle shape factors
+algo.particle_shape = 1
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = ions
+
+ions.charge = q_c12
+ions.mass = m_c12
+ions.do_not_deposit = 1
+
+ions.injection_sources = groupA groupB
+
+ions.groupA.injection_style = "NUniformPerCell"
+ions.groupA.num_particles_per_cell_each_dim = NpA
+ions.groupA.profile = constant
+ions.groupA.density = nA  # number per m^3
+ions.groupA.momentum_distribution_type = "gaussian"
+ions.groupA.uz_m = UA/clight
+ions.groupA.ux_th = sqrt(TA*q_e/m_c12)/clight
+ions.groupA.uy_th = sqrt(TA*q_e/m_c12)/clight
+ions.groupA.uz_th = sqrt(TA*q_e/m_c12)/clight
+
+ions.groupB.injection_style = "NUniformPerCell"
+ions.groupB.num_particles_per_cell_each_dim = NpB
+ions.groupB.profile = constant
+ions.groupB.density = nB  # number per m^3
+ions.groupB.momentum_distribution_type = "gaussian"
+ions.groupB.uz_m = UB/clight
+ions.groupB.ux_th = sqrt(TB*q_e/m_c12)/clight
+ions.groupB.uy_th = sqrt(TB*q_e/m_c12)/clight
+ions.groupB.uz_th = sqrt(TB*q_e/m_c12)/clight
+
+#################################
+############ COLLISION ##########
+#################################
+collisions.collision_names = collision1
+collision1.species = ions ions
+collision1.CoulombLog = 10.0
+
+# Diagnostics
+diagnostics.diags_names = diag1
+diag1.intervals = 600
+diag1.diag_type = Full

--- a/Regression/Checksum/benchmarks_json/collisionISO.json
+++ b/Regression/Checksum/benchmarks_json/collisionISO.json
@@ -11,12 +11,12 @@
     "jz": 0.0
   },
   "electron": {
-    "particle_momentum_x": 3.579989064013309e-19,
-    "particle_momentum_y": 3.5822945977746767e-19,
-    "particle_momentum_z": 3.579753452653627e-19,
-    "particle_position_x": 1.0241322532163375,
-    "particle_position_y": 1.0238995904625479,
-    "particle_position_z": 1.02402135051502,
+    "particle_momentum_x": 3.5790777034053853e-19,
+    "particle_momentum_y": 3.5815348106229496e-19,
+    "particle_momentum_z": 3.577963316718249e-19,
+    "particle_position_x": 1.024180253191667,
+    "particle_position_y": 1.023919590453571,
+    "particle_position_z": 1.0240653505082926,
     "particle_weight": 714240000000.0
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -6,25 +6,25 @@
     "Ex": 0.0,
     "Ey": 0.0,
     "Ez": 0.0,
-    "T_electron": 381488.6528070591,
-    "T_ion": 320091.2785835478
+    "T_electron": 381957.7394223898,
+    "T_ion": 319565.6269784763
   },
   "electron": {
-    "particle_momentum_x": 8.667025573698235e-19,
-    "particle_momentum_y": 8.457499789250831e-19,
-    "particle_momentum_z": 8.482438182280524e-19,
-    "particle_position_x": 21262567.138872623,
-    "particle_position_y": 21245135.070665065,
-    "particle_position_z": 21232644.283726066,
+    "particle_momentum_x": 8.631833485301232e-19,
+    "particle_momentum_y": 8.476316745254719e-19,
+    "particle_momentum_z": 8.514139891331418e-19,
+    "particle_position_x": 21253105.73686561,
+    "particle_position_y": 21282643.519070115,
+    "particle_position_z": 21239057.457948968,
     "particle_weight": 7.168263344048695e+28
   },
   "ion": {
-    "particle_momentum_x": 1.9300495097720012e-18,
-    "particle_momentum_y": 1.747257416857836e-18,
-    "particle_momentum_z": 1.7510296287537058e-18,
-    "particle_position_x": 21217348.883301035,
-    "particle_position_y": 21300859.0630925,
-    "particle_position_z": 21237901.246521123,
+    "particle_momentum_x": 1.9215585867122464e-18,
+    "particle_momentum_y": 1.7471481568315848e-18,
+    "particle_momentum_z": 1.7510887207292533e-18,
+    "particle_position_x": 21228900.948879313,
+    "particle_position_y": 21304564.011731848,
+    "particle_position_z": 21250585.221808463,
     "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionXZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXZ.json
@@ -8,19 +8,19 @@
     "Ez": 0.0
   },
   "ion": {
-    "particle_momentum_x": 2.458306853810186e-19,
-    "particle_momentum_y": 2.272685285153902e-19,
-    "particle_momentum_z": 2.281205462681013e-19,
-    "particle_position_x": 2645436.647039526,
-    "particle_position_y": 2672571.48688055,
+    "particle_momentum_x": 2.4932317055825563e-19,
+    "particle_momentum_y": 2.274916403334278e-19,
+    "particle_momentum_z": 2.2528161767665816e-19,
+    "particle_position_x": 2648815.601036139,
+    "particle_position_y": 2662836.7581390506,
     "particle_weight": 1.7256099431746894e+26
   },
   "electron": {
-    "particle_momentum_x": 1.0454942263455085e-19,
-    "particle_momentum_y": 1.0323735347957779e-19,
-    "particle_momentum_z": 1.0199134968670343e-19,
-    "particle_position_x": 2681776.3648108337,
-    "particle_position_y": 2663907.8843079703,
+    "particle_momentum_x": 1.0489203687862582e-19,
+    "particle_momentum_y": 1.0209657029567292e-19,
+    "particle_momentum_z": 1.0248962872393911e-19,
+    "particle_position_x": 2657004.8285825616,
+    "particle_position_y": 2670174.272797987,
     "particle_weight": 1.7256099431746894e+26
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionZ.json
@@ -1,0 +1,20 @@
+{
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 0.0,
+    "Bz": 0.0,
+    "Ex": 0.0,
+    "Ey": 0.0,
+    "Ez": 0.0,
+    "jx": 0.0,
+    "jy": 0.0,
+    "jz": 0.0
+  },
+  "ions": {
+    "particle_momentum_x": 3.4283649966834414e-16,
+    "particle_momentum_y": 3.4358954060667462e-16,
+    "particle_momentum_z": 5.530678357178482e-16,
+    "particle_position_x": 719.9215445002424,
+    "particle_weight": 1.1000000000001e+24
+  }
+}

--- a/Regression/Checksum/benchmarks_json/collisionZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionZ.json
@@ -11,10 +11,10 @@
     "jz": 0.0
   },
   "ions": {
-    "particle_momentum_x": 3.4283649966834414e-16,
-    "particle_momentum_y": 3.4358954060667462e-16,
-    "particle_momentum_z": 5.530678357178482e-16,
-    "particle_position_x": 719.9215445002424,
-    "particle_weight": 1.1000000000001e+24
+    "particle_momentum_x": 3.425400072687143e-16,
+    "particle_momentum_y": 3.421937133999805e-16,
+    "particle_momentum_z": 5.522701882677923e-16,
+    "particle_position_x": 720.0011611411148,
+    "particle_weight": 1.0999999999999999e+24
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -195,6 +195,20 @@ useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/collider_relevant_diags/analysis_multiple_particles.py
 
+[collisionZ]
+buildDir = .
+inputFile = Examples/Tests/collision/inputs_1d
+runtime_params =
+dim = 1
+addToCompileString =
+cmakeSetupOpts = -DWarpX_DIMS=1
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+analysisRoutine = Examples/Tests/collision/analysis_collision_1d.py
+
 [collisionISO]
 buildDir = .
 inputFile = Examples/Tests/collision/inputs_3d_isotropization

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -363,17 +363,14 @@ public:
 
             // create vectors to store density and temperature on cell level
             amrex::Gpu::DeviceVector<amrex::ParticleReal> n1_vec;
-            amrex::Gpu::DeviceVector<amrex::ParticleReal> n12_vec;
             amrex::Gpu::DeviceVector<amrex::ParticleReal> T1_vec;
             if (binary_collision_functor.m_computeSpeciesDensities) {
                 n1_vec.resize(n_cells);
-                n12_vec.resize(n_cells);
             }
             if (binary_collision_functor.m_computeSpeciesTemperatures) {
                 T1_vec.resize(n_cells);
             }
             amrex::ParticleReal* AMREX_RESTRICT n1_in_each_cell = n1_vec.dataPtr();
-            amrex::ParticleReal* AMREX_RESTRICT n12_in_each_cell = n12_vec.dataPtr();
             amrex::ParticleReal* AMREX_RESTRICT T1_in_each_cell = T1_vec.dataPtr();
 
             // Loop over cells
@@ -384,7 +381,6 @@ public:
                     // given by the `indices_1[cell_start_1:cell_stop_1]`
                     index_type const cell_start_1 = cell_offsets_1[i_cell];
                     index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
-                    index_type const cell_half_1  = (cell_start_1+cell_stop_1)/2;
 
                     // Do not collide if there is only one particle in the cell
                     if ( cell_stop_1 - cell_start_1 <= 1 ) { return; }
@@ -415,29 +411,6 @@ public:
 
                     // shuffle
                     ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-
-                    // compute n12 for intra-species
-                    if (binary_collision_functor.m_computeSpeciesDensities) {
-                        amrex::ParticleReal n12 = 0.0;
-                        index_type const NI1 = cell_half_1 - cell_start_1;
-                        index_type const NI2 = cell_stop_1 - cell_half_1;
-                        index_type const max_N = amrex::max(NI1,NI2);
-                        index_type i1 = cell_start_1;
-                        index_type i2 = cell_half_1;
-                        amrex::ParticleReal * const AMREX_RESTRICT w1  = soa_1.m_rdata[PIdx::w];
-                        for (index_type k=0; k<max_N; ++k) {
-                           n12 += amrex::min( w1[ indices_1[i1] ], w1[ indices_1[i2] ] );
-                           ++i1; if ( i1 == cell_half_1 ) { i1 = cell_start_1; }
-                           ++i2; if ( i2 == cell_stop_1 ) { i2 = cell_half_1; }
-                        }
-#if defined WARPX_DIM_RZ
-                        const int ri = (i_cell - i_cell%nz) / nz;
-                        auto dV = MathConst::pi*(2.0_prt*ri+1.0_prt)*dr*dr*dz;
-#endif
-                        n12 = 2.0_prt * n12 / dV;
-                        n12_in_each_cell[i_cell] = n12;
-                    }
-
                 }
             );
 
@@ -477,11 +450,9 @@ public:
 
                     // Get the local density and temperature for this cell
                     amrex::ParticleReal n1 = 0.0;
-                    amrex::ParticleReal n12 = 0.0;
                     amrex::ParticleReal T1 = 0.0;
                     if (binary_collision_functor.m_computeSpeciesDensities) {
                         n1 = n1_in_each_cell[i_cell];
-                        n12 = n12_in_each_cell[i_cell];
                     }
                     if (binary_collision_functor.m_computeSpeciesTemperatures) {
                         T1 = T1_in_each_cell[i_cell];
@@ -495,7 +466,7 @@ public:
                         cell_half_1, cell_stop_1,
                         indices_1, indices_1,
                         soa_1, soa_1, get_position_1, get_position_1,
-                        n1, n1, n12, T1, T1,
+                        n1, n1, T1, T1,
                         q1, q1, m1, m1, dt, dV, coll_idx,
                         cell_start_pair, p_mask, p_pair_indices_1, p_pair_indices_2,
                         p_pair_reaction_weight, engine);
@@ -642,12 +613,10 @@ public:
 
             // create vectors to store density and temperature on cell level
             amrex::Gpu::DeviceVector<amrex::ParticleReal> n1_vec, n2_vec;
-            amrex::Gpu::DeviceVector<amrex::ParticleReal> n12_vec;
             amrex::Gpu::DeviceVector<amrex::ParticleReal> T1_vec, T2_vec;
             if (binary_collision_functor.m_computeSpeciesDensities) {
                 n1_vec.resize(n_cells);
                 n2_vec.resize(n_cells);
-                n12_vec.resize(n_cells);
             }
             if (binary_collision_functor.m_computeSpeciesTemperatures) {
                 T1_vec.resize(n_cells);
@@ -655,7 +624,6 @@ public:
             }
             amrex::ParticleReal* AMREX_RESTRICT n1_in_each_cell = n1_vec.dataPtr();
             amrex::ParticleReal* AMREX_RESTRICT n2_in_each_cell = n2_vec.dataPtr();
-            amrex::ParticleReal* AMREX_RESTRICT n12_in_each_cell = n12_vec.dataPtr();
             amrex::ParticleReal* AMREX_RESTRICT T1_in_each_cell = T1_vec.dataPtr();
             amrex::ParticleReal* AMREX_RESTRICT T2_in_each_cell = T2_vec.dataPtr();
 
@@ -719,29 +687,6 @@ public:
                     // shuffle
                     ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
                     ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-
-                    // compute n12 for inter-species
-                    if (binary_collision_functor.m_computeSpeciesDensities) {
-                        amrex::ParticleReal n12 = 0.0;
-                        index_type const NI1 = cell_stop_1 - cell_start_1;
-                        index_type const NI2 = cell_stop_2 - cell_start_2;
-                        index_type const max_N = amrex::max(NI1,NI2);
-                        index_type i1 = cell_start_1;
-                        index_type i2 = cell_start_2;
-                        amrex::ParticleReal * const AMREX_RESTRICT w1  = soa_1.m_rdata[PIdx::w];
-                        amrex::ParticleReal * const AMREX_RESTRICT w2  = soa_2.m_rdata[PIdx::w];
-                        for (index_type k=0; k<max_N; ++k) {
-                           n12 += amrex::min( w1[ indices_1[i1] ], w2[ indices_1[i2] ] );
-                           ++i1; if ( i1 == cell_stop_1 ) { i1 = cell_start_1; }
-                           ++i2; if ( i2 == cell_stop_2 ) { i2 = cell_start_2; }
-                        }
-#if defined WARPX_DIM_RZ
-                        const int ri = (i_cell - i_cell%nz) / nz;
-                        auto dV = MathConst::pi*(2.0_prt*ri+1.0_prt)*dr*dr*dz;
-#endif
-                        n12 = n12 / dV;
-                        n12_in_each_cell[i_cell] = n12;
-                    }
                 }
             );
 
@@ -787,12 +732,10 @@ public:
 
                     // Get the local densities and temperatures for this cell
                     amrex::ParticleReal n1 = 0.0, n2 = 0.0;
-                    amrex::ParticleReal n12 = 0.0;
                     amrex::ParticleReal T1 = 0.0, T2 = 0.0;
                     if (binary_collision_functor.m_computeSpeciesDensities) {
                         n1 = n1_in_each_cell[i_cell];
                         n2 = n2_in_each_cell[i_cell];
-                        n12 = n12_in_each_cell[i_cell];
                     }
                     if (binary_collision_functor.m_computeSpeciesTemperatures) {
                         T1 = T1_in_each_cell[i_cell];
@@ -806,7 +749,7 @@ public:
                         cell_start_1, cell_stop_1, cell_start_2, cell_stop_2,
                         indices_1, indices_2,
                         soa_1, soa_2, get_position_1, get_position_2,
-                        n1, n2, n12, T1, T2,
+                        n1, n2, T1, T2,
                         q1, q2, m1, m2, dt, dV, coll_idx,
                         cell_start_pair, p_mask, p_pair_indices_1, p_pair_indices_2,
                         p_pair_reaction_weight, engine);

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -48,7 +48,7 @@ void ElasticCollisionPerez (
     T_PR const  T1, T_PR const  T2,
     T_PR const  q1, T_PR const  q2,
     T_PR const  m1, T_PR const  m2,
-    T_R const  dt, T_PR const  L, T_PR const  dV,
+    T_R const  dt, T_PR const  L, T_R const  dV,
     amrex::RandomEngine const& engine,
     bool const isSameSpecies, T_index coll_idx)
 {

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -25,7 +25,6 @@
  * @param[in] I1,I2 the index arrays. They determine all elements that will be used.
  * @param[in,out] soa_1,soa_2 the struct of array for species 1/2
  * @param[in] n1,n2 density of species 1/2
- * @param[in] n12 density parameter for s12
  * @param[in] T1,T2 temperature [Joules] of species 1/2
  *            only used if L <= 0
  * @param[in] q1,q2 charge of species 1/2
@@ -46,13 +45,12 @@ void ElasticCollisionPerez (
     T_index const* AMREX_RESTRICT I2,
     SoaData_type soa_1, SoaData_type soa_2,
     T_PR const  n1, T_PR const  n2,
-    T_PR const  n12,
     T_PR const  T1, T_PR const  T2,
     T_PR const  q1, T_PR const  q2,
     T_PR const  m1, T_PR const  m2,
-    T_R const  dt, T_PR const  L,
+    T_R const  dt, T_PR const  L, T_PR const  dV,
     amrex::RandomEngine const& engine,
-    T_index coll_idx)
+    bool const isSameSpecies, T_index coll_idx)
 {
     const T_index NI1 = I1e - I1s;
     const T_index NI2 = I2e - I2s;
@@ -69,15 +67,19 @@ void ElasticCollisionPerez (
     T_PR * const AMREX_RESTRICT u2y = soa_2.m_rdata[PIdx::uy];
     T_PR * const AMREX_RESTRICT u2z = soa_2.m_rdata[PIdx::uz];
 
-    // compute Debye length lmdD
+    // compute Debye length lmdD (if not using a fixed L = Coulomb log)
     T_PR lmdD = T_PR(-1.0);
     if ( L <= T_PR(0.0) ) {
         lmdD = T_PR(1.0)/std::sqrt( n1*q1*q1/(T1*PhysConst::ep0) +
                                     n2*q2*q2/(T2*PhysConst::ep0) );
     }
-    T_PR rmin = std::pow( T_PR(4.0) * MathConst::pi / T_PR(3.0) *
-               amrex::max(n1,n2), T_PR(-1.0/3.0) );
-    lmdD = amrex::max(lmdD, rmin);
+
+    // compute atomic spacing
+    const T_PR maxn = amrex::max(n1,n2);
+    const auto rmin = static_cast<T_PR>( 1.0/std::cbrt(4.0*MathConst::pi/3.0*maxn) );
+
+    // bmax (screening length) cannot be smaller than atomic spacing
+    const T_PR bmax = amrex::max(lmdD, rmin);
 
 #if (defined WARPX_DIM_RZ)
     T_PR * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
@@ -108,12 +110,23 @@ void ElasticCollisionPerez (
           u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
 #endif
 
+          // Compute the effective density n12 used to compute the normalized
+          // scattering path s12 in UpdateMomentumPerezElastic().
+          // s12 is defined such that the expected value of the change in particle
+          // velocity is equal to that from the full NxN pairing method, as described
+          // here https://arxiv.org/submit/5758216/view. This method is a direct extension
+          // of the original method by Takizuka and Abe JCP 25 (1977) to weighted particles.
+          T_PR n12;
+          const T_PR wpmax = amrex::max(w1[ I1[i1] ],w2[ I2[i2] ]);
+          if (isSameSpecies) { n12 = wpmax*static_cast<T_PR>(min_N+max_N-1)/dV; }
+          else { n12 = wpmax*static_cast<T_PR>(min_N)/dV; }
+
           UpdateMomentumPerezElastic(
               u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
               u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
               n1, n2, n12,
               q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
-              dt, L, lmdD,
+              dt, L, bmax,
               engine);
 
 #if (defined WARPX_DIM_RZ)

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
@@ -91,11 +91,10 @@ public:
             const SoaData_type& soa_1, const SoaData_type& soa_2,
             GetParticlePosition<PIdx> /*get_position_1*/, GetParticlePosition<PIdx> /*get_position_2*/,
             amrex::ParticleReal const  n1, amrex::ParticleReal const  n2,
-            amrex::ParticleReal const  n12,
             amrex::ParticleReal const  T1, amrex::ParticleReal const  T2,
             amrex::ParticleReal const  q1, amrex::ParticleReal const  q2,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
-            amrex::Real const  dt, amrex::Real const /*dV*/, index_type coll_idx,
+            amrex::Real const  dt, amrex::Real const dV, index_type coll_idx,
             index_type const /*cell_start_pair*/, index_type* /*p_mask*/,
             index_type* /*p_pair_indices_1*/, index_type* /*p_pair_indices_2*/,
             amrex::ParticleReal* /*p_pair_reaction_weight*/,
@@ -105,9 +104,9 @@ public:
 
             ElasticCollisionPerez(
                     I1s, I1e, I2s, I2e, I1, I2,
-                    soa_1, soa_2, n1, n2, n12, T1, T2,
+                    soa_1, soa_2, n1, n2, T1, T2,
                     q1, q2, m1, m2,
-                    dt, m_CoulombLog, engine, coll_idx);
+                    dt, m_CoulombLog, dV, engine, m_isSameSpecies, coll_idx);
         }
 
         amrex::ParticleReal m_CoulombLog;

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/UpdateMomentumPerezElastic.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/UpdateMomentumPerezElastic.H
@@ -18,9 +18,10 @@
 /* \brief Update particle velocities according to
  *        F. Perez et al., Phys.Plasmas.19.083104 (2012),
  *        which is based on Nanbu's method, PhysRevE.55.4642 (1997).
- *        @param[in] LmdD is max(Debye length, minimal interparticle distance).
+ *        @param[in] bmax is max(Debye length, minimal interparticle distance).
  *        @param[in] L is the Coulomb log. A fixed L will be used if L > 0,
  *        otherwise L will be calculated based on the algorithm.
+ *        @param[in] n12 = max(w1,w2)*min(N1,N2)/dV is the effective density used for s12
  *        To see if there are nan or inf updated velocities,
  *        compile with USE_ASSERTION=TRUE.
  *
@@ -36,7 +37,7 @@ void UpdateMomentumPerezElastic (
     T_PR const n1, T_PR const n2, T_PR const n12,
     T_PR const q1, T_PR const m1, T_PR const w1,
     T_PR const q2, T_PR const m2, T_PR const w2,
-    T_R const dt, T_PR const L, T_PR const lmdD,
+    T_R const dt, T_PR const L, T_PR const bmax,
     amrex::RandomEngine const& engine)
 {
 
@@ -128,13 +129,13 @@ void UpdateMomentumPerezElastic (
 
             // Compute the Coulomb log lnLmd
             lnLmd = amrex::max( T_PR(2.0),
-                    T_PR(0.5)*std::log(T_PR(1.0)+lmdD*lmdD/(bmin*bmin)) );
+                    T_PR(0.5)*std::log(T_PR(1.0) + bmax*bmax/(bmin*bmin)) );
         }
 
         // Compute s
         const auto tts = m1*g1s*m2*g2s/(inv_c2*p1sm*p1sm) + T_PR(1.0);
         const auto tts2 = tts*tts;
-        s = n1*n2/n12 * dt*lnLmd*q1*q1*q2*q2 /
+        s = n12 * dt*lnLmd*q1*q1*q2*q2 /
             ( T_PR(4.0) * MathConst::pi * PhysConst::ep0 * PhysConst::ep0 *
                 m1*g1*m2*g2/(inv_c2*inv_c2) ) * gc*p1sm/mass_g * tts2;
 
@@ -144,7 +145,7 @@ void UpdateMomentumPerezElastic (
         const auto coeff = static_cast<T_PR>(
             std::pow(4.0*MathConst::pi/3.0,1.0/3.0));
         T_PR const vrel = mass_g*p1sm/(m1*g1s*m2*g2s*gc);
-        T_PR const sp = coeff * n1*n2/n12 * dt * vrel * (m1+m2) /
+        T_PR const sp = coeff * n12 * dt * vrel * (m1+m2) /
             amrex::max( m1*cbrt_n1*cbrt_n1,
                         m2*cbrt_n2*cbrt_n2);
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -97,7 +97,6 @@ public:
             const SoaData_type& soa_1, const SoaData_type& soa_2,
             GetParticlePosition<PIdx> /*get_position_1*/, GetParticlePosition<PIdx> /*get_position_2*/,
             amrex::ParticleReal const /*n1*/, amrex::ParticleReal const /*n2*/,
-            amrex::ParticleReal const /*n12*/,
             amrex::ParticleReal const /*T1*/, amrex::ParticleReal const /*T2*/,
             amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -132,7 +132,6 @@ public:
             const SoaData_type& soa_1, const SoaData_type& soa_2,
             GetParticlePosition<PIdx> /*get_position_1*/, GetParticlePosition<PIdx> /*get_position_2*/,
             amrex::ParticleReal const /*n1*/, amrex::ParticleReal const /*n2*/,
-            amrex::ParticleReal const /*n12*/,
             amrex::ParticleReal const /*T1*/, amrex::ParticleReal const /*T2*/,
             amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,


### PR DESCRIPTION
Separating part 2 of PR #5047 into two parts. One that fixes the weighted scattering issue (this PR) and another that improves on the Perez 2012 method for relativistic Coulomb scattering.

Description edited by @RemiLehe:

The current method for doing weighted-particle scattering for Coulomb collisions is from Perez et al 2012 (https://doi.org/10.1063/1.4742167) which follows from Nanbu and Yonemura 1998 (http://dx.doi.org/10.1006/jcph.1998.6049). That method has been shown to result in incorrect relaxation rates for certain problems by Higginson et al 2020 (https://doi.org/10.1016/j.jcp.2020.109450). The present PR fixes this issue using a method similar to that by Higginson 2020 that produces correct relaxation rates with weighted particles. Below are results from Tests T1a-T1d from Higginson 2020 (but with 10X less particles). The physical setup is the same for each of tests T1a-T1d, but they use different particle weighting setups for the different populations. In contrast to results obtained using the development branch, the results obtained using this PR show identical relaxation results for the various particle weight combinations.

Using this PR
![T1abcd_binaryOpt_branch](https://github.com/user-attachments/assets/d68f0bd6-a2fc-4527-b194-90d72a092c75)


Using the development branch:
![T1abcd_develop_branch_new](https://github.com/user-attachments/assets/23834c3b-5ced-4bf6-be55-5b987eb91fe4)
