### PR TITLE
CI: remove unused parameter `analysisOutputImage`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -366,7 +366,6 @@ useOMP = 1
 numthreads = 1
 runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
-analysisOutputImage = Comparison.png
 
 [dive_cleaning_3d]
 buildDir = .
@@ -381,7 +380,6 @@ useOMP = 1
 numthreads = 1
 runtime_params =
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
-analysisOutputImage = Comparison.png
 
 [ElectrostaticSphere]
 buildDir = .
@@ -932,7 +930,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_fluid_1D]
 buildDir = .
@@ -947,7 +944,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_1d.py
-analysisOutputImage = langmuir_fluid_multi_1d_analysis.png
 
 [Langmuir_fluid_RZ]
 buildDir = .
@@ -962,7 +958,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_rz.py
-analysisOutputImage = langmuir_fluid_rz_analysis.png
 
 [Langmuir_fluid_2D]
 buildDir = .
@@ -977,7 +972,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_2d.py
-analysisOutputImage = langmuir_fluid_multi_2d_analysis.png
 
 [Langmuir_fluid_multi]
 buildDir = .
@@ -992,7 +986,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir_fluids/analysis_3d.py
-analysisOutputImage = langmuir_fluid_multi_analysis.png
 
 [Langmuir_multi_1d]
 buildDir = .
@@ -1007,7 +1000,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_1d.py
-analysisOutputImage = langmuir_multi_1d_analysis.png
 
 [Langmuir_multi_2d_MR]
 buildDir = .
@@ -1022,7 +1014,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_MR.png
 
 [Langmuir_multi_2d_MR_anisotropic]
 buildDir = .
@@ -1037,7 +1028,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_MR.png
 
 [Langmuir_multi_2d_MR_momentum_conserving]
 buildDir = .
@@ -1052,7 +1042,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_MR_momentum_conserving.png
 
 [Langmuir_multi_2d_MR_psatd]
 buildDir = .
@@ -1067,7 +1056,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_MR_psatd.png
 
 [Langmuir_multi_2d_nodal]
 buildDir = .
@@ -1082,7 +1070,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd]
 buildDir = .
@@ -1097,7 +1084,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_current_correction]
 buildDir = .
@@ -1112,7 +1098,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_current_correction_nodal]
 buildDir = .
@@ -1127,7 +1112,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_momentum_conserving]
 buildDir = .
@@ -1142,7 +1126,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_multiJ]
 buildDir = .
@@ -1157,7 +1140,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_psatd_multiJ.png
 
 [Langmuir_multi_2d_psatd_multiJ_nodal]
 buildDir = .
@@ -1172,7 +1154,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = Langmuir_multi_2d_psatd_multiJ_nodal.png
 
 [Langmuir_multi_2d_psatd_nodal]
 buildDir = .
@@ -1187,7 +1168,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_Vay_deposition]
 buildDir = .
@@ -1202,7 +1182,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_Vay_deposition_particle_shape_4]
 buildDir = .
@@ -1217,7 +1196,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_2d_psatd_Vay_deposition_nodal]
 buildDir = .
@@ -1232,7 +1210,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_2d.py
-analysisOutputImage = langmuir_multi_2d_analysis.png
 
 [Langmuir_multi_nodal]
 buildDir = .
@@ -1247,7 +1224,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd]
 buildDir = .
@@ -1262,7 +1238,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_current_correction]
 buildDir = .
@@ -1277,7 +1252,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_current_correction_nodal]
 buildDir = .
@@ -1292,7 +1266,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_div_cleaning]
 buildDir = .
@@ -1307,7 +1280,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_momentum_conserving]
 buildDir = .
@@ -1322,7 +1294,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_multiJ]
 buildDir = .
@@ -1337,7 +1308,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = Langmuir_multi_psatd_multiJ.png
 
 [Langmuir_multi_psatd_multiJ_nodal]
 buildDir = .
@@ -1352,7 +1322,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = Langmuir_multi_psatd_multiJ_nodal.png
 
 [Langmuir_multi_psatd_nodal]
 buildDir = .
@@ -1367,7 +1336,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_single_precision]
 buildDir = .
@@ -1382,7 +1350,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_Vay_deposition]
 buildDir = .
@@ -1397,7 +1364,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_psatd_Vay_deposition_nodal]
 buildDir = .
@@ -1412,7 +1378,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Langmuir_multi_rz]
 buildDir = .
@@ -1427,7 +1392,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
-analysisOutputImage = Langmuir_multi_rz_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
 [Langmuir_multi_rz_psatd]
@@ -1443,7 +1407,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
-analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
 [Langmuir_multi_rz_psatd_current_correction]
@@ -1459,7 +1422,6 @@ numprocs = 1
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
-analysisOutputImage = Langmuir_multi_rz_psatd_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
 [Langmuir_multi_rz_psatd_multiJ]
@@ -1475,7 +1437,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_rz.py
-analysisOutputImage = Langmuir_multi_rz_psatd_multiJ_analysis.png
 aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 
 [Langmuir_multi_single_precision]
@@ -1491,7 +1452,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/langmuir/analysis_3d.py
-analysisOutputImage = langmuir_multi_analysis.png
 
 [Larmor]
 buildDir = .
@@ -1663,7 +1623,6 @@ numprocs = 2
 useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/laser_injection/analysis_laser.py
-analysisOutputImage = laser_analysis.png
 
 [LaserInjection_1d]
 buildDir = .
@@ -3473,7 +3432,6 @@ useOMP = 1
 numthreads = 1
 runtime_params =
 analysisRoutine = Examples/Tests/relativistic_space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
 
 [RepellingParticles]
 buildDir = .
@@ -3687,7 +3645,6 @@ useOMP = 1
 numthreads = 1
 runtime_params =
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
 
 [space_charge_initialization_2d]
 buildDir = .
@@ -3702,7 +3659,6 @@ useOMP = 1
 numthreads = 1
 runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
-analysisOutputImage = Comparison.png
 
 [subcyclingMR]
 buildDir = .
@@ -3834,7 +3790,6 @@ useOMP = 1
 numthreads = 1
 outputFile = spacecraft_charging_plt
 analysisRoutine = Examples/Physics_applications/spacecraft_charging/analysis.py
-analysisOutputImage = min_phi_analysis.png
 
 [Point_of_contact_EB_3d]
 buildDir = .


### PR DESCRIPTION
Following up on #5043, `analysisOutputImage` is another parameter related to AMReX's regression testing suite that we do not use in our current regression testing workflow. The names of our test output images are set manually in our custom analysis scripts.

I think we can remove this parameter from WarpX-tests.ini in order to keep that configuration file as minimal as possible, making it easier for developers and users to spot the parameters that are actually revelant for our tests.