### PR TITLE
EB: Assert that its used

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -115,7 +115,7 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_PYTHON=ON            \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
 
         cmake -S . -B build_dp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF
         cmake --build build_dp -j 3
@@ -68,7 +68,7 @@ jobs:
         cmake -S . -B build_sp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DPython_EXECUTABLE=$(which python3) \
-          -DWarpX_EB=ON                \
+          -DWarpX_EB=OFF               \
           -DWarpX_PYTHON=ON            \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,7 +91,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release    ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DWarpX_COMPUTE=OMP           ^
-              -DWarpX_EB=ON                 ^
+              -DWarpX_EB=OFF                ^
               -DWarpX_PYTHON=ON             ^
               -DWarpX_MPI=OFF               ^
               -DWarpX_OPENPMD=ON

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -2436,21 +2436,6 @@ useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
 
-[pml_x_yee_eb]
-buildDir = .
-inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
-dim = 2
-addToCompileString = USE_EB=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
-restartTest = 1
-restartFileNum = 150
-useMPI = 1
-numprocs = 2
-useOMP = 1
-numthreads = 1
-analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
-
 [Proton_Boron_Fusion_2D]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_2d

--- a/Source/EmbeddedBoundary/CMakeLists.txt
+++ b/Source/EmbeddedBoundary/CMakeLists.txt
@@ -5,5 +5,6 @@ foreach(D IN LISTS WarpX_DIMS)
         WarpXInitEB.cpp
         WarpXFaceExtensions.cpp
         WarpXFaceInfoBox.H
+        Enabled.cpp
     )
 endforeach()

--- a/Source/EmbeddedBoundary/Enabled.H
+++ b/Source/EmbeddedBoundary/Enabled.H
@@ -1,0 +1,18 @@
+/* Copyright 2024 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_EB_ENABLED_H_
+#define WARPX_EB_ENABLED_H_
+
+#include <AMReX_ParmParse.H>
+
+namespace EB
+{
+    /** Are embedded boundaries enabled? */
+    bool enabled ();
+
+} // namespace EB
+#endif // WARPX_EB_ENABLED_H_

--- a/Source/EmbeddedBoundary/Enabled.cpp
+++ b/Source/EmbeddedBoundary/Enabled.cpp
@@ -32,12 +32,6 @@ namespace EB
         std::string eb_stl;
         eb_enabled |= pp_eb2.query("geom_type", eb_stl);
 
-#if defined(WARPX_DIM_RZ)
-        if (eb_enabled) {
-            throw std::runtime_error("RZ Geometry does not yet support EBs, but EBs are enabled in runtime inputs.");
-        }
-#endif
-
         return eb_enabled;
 #endif
     }

--- a/Source/EmbeddedBoundary/Enabled.cpp
+++ b/Source/EmbeddedBoundary/Enabled.cpp
@@ -1,0 +1,45 @@
+/* Copyright 2024 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "Enabled.H"
+
+#ifdef AMREX_USE_EB
+#include <AMReX_ParmParse.H>
+#endif
+#if defined(AMREX_USE_EB) && defined(WARPX_DIM_RZ)
+#include <stdexcept>
+#endif
+
+
+namespace EB
+{
+    bool enabled ()
+    {
+#ifndef AMREX_USE_EB
+        return false;
+#else
+        amrex::ParmParse const pp_warpx("warpx");
+        amrex::ParmParse const pp_eb2("eb2");
+
+        // test various runtime options to enable EBs
+        std::string eb_implicit_function;
+        bool eb_enabled = pp_warpx.query("eb_implicit_function", eb_implicit_function);
+
+        // https://amrex-codes.github.io/amrex/docs_html/EB.html
+        std::string eb_stl;
+        eb_enabled |= pp_eb2.query("geom_type", eb_stl);
+
+#if defined(WARPX_DIM_RZ)
+        if (eb_enabled) {
+            throw std::runtime_error("RZ Geometry does not yet support EBs, but EBs are enabled in runtime inputs.");
+        }
+#endif
+
+        return eb_enabled;
+#endif
+    }
+
+} // namespace EB

--- a/Source/EmbeddedBoundary/Make.package
+++ b/Source/EmbeddedBoundary/Make.package
@@ -1,8 +1,10 @@
+CEXE_headers += Enabled.H
 CEXE_headers += ParticleScraper.H
 CEXE_headers += ParticleBoundaryProcess.H
 CEXE_headers += DistanceToEB.H
 CEXE_headers += WarpXFaceInfoBox.H
 
+CEXE_sources += Enabled.cpp
 CEXE_sources += WarpXInitEB.cpp
 CEXE_sources += WarpXFaceExtensions.cpp
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -14,6 +14,7 @@
 #include "BoundaryConditions/PML.H"
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
+#include "EmbeddedBoundary/Enabled.H"
 #include "EmbeddedBoundary/WarpXFaceInfoBox.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
@@ -788,6 +789,13 @@ WarpX::ReadParameters ()
         potential_specified |= pp_boundary.query("potential_hi_z", m_poisson_boundary_handler.potential_zhi_str);
 #if defined(AMREX_USE_EB)
         potential_specified |= pp_warpx.query("eb_potential(x,y,z,t)", m_poisson_boundary_handler.potential_eb_str);
+
+        if (!EB::enabled()) {
+            throw std::runtime_error(
+                "Currently, users MUST use EB if it was compiled in. "
+                "This will change with https://github.com/ECP-WarpX/WarpX/pull/4865 ."
+            );
+        }
 #endif
         m_boundary_potential_specified = potential_specified;
         if (potential_specified & (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC)) {


### PR DESCRIPTION
Currently, users MUST use EB if it was compiled in, otherwise several locations of the code show undefined behavior. This will change with https://github.com/ECP-WarpX/WarpX/pull/4865 .

First reported by @lucafedeli88.

This assert logic already uses the logic we will use in #4865 for compatibility.