### PR TITLE
Add density min and max arguments to `picmi.AnalyticDistribution`

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -560,6 +560,14 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution, DensityDist
     Parameters
     ----------
 
+    warpx_density_min: float
+        Minimum plasma density. No particle is injected where the density is
+        below this value.
+
+    warpx_density_max: float
+        Maximum plasma density. The density at each point is the minimum between
+        the value given in the profile, and density_max.
+
     warpx_momentum_spread_expressions: list of string
         Analytic expressions describing the gamma*velocity spread for each axis [m/s].
         Expressions should be in terms of the position, written as 'x', 'y', and 'z'.

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -504,6 +504,11 @@ class DensityDistributionBase(object):
             species.add_new_group_attr(source_name, 'uy', self.directed_velocity[1]/constants.c)
             species.add_new_group_attr(source_name, 'uz', self.directed_velocity[2]/constants.c)
 
+        if hasattr(self, 'density_min'):
+            species.add_new_group_attr(source_name, 'density_min', self.density_min)
+        if hasattr(self, 'density_max'):
+            species.add_new_group_attr(source_name, 'density_max', self.density_max)
+
     def setup_parse_momentum_functions(self, species, source_name, expressions, suffix, defaults):
         for sdir, idir in zip(['x', 'y', 'z'], [0, 1, 2]):
             if expressions[idir] is not None:
@@ -563,6 +568,8 @@ class AnalyticDistribution(picmistandard.PICMI_AnalyticDistribution, DensityDist
 
     """
     def init(self, kw):
+        self.density_min = kw.pop('warpx_density_min', None)
+        self.density_max = kw.pop('warpx_density_max', None)
         self.momentum_spread_expressions = kw.pop('warpx_momentum_spread_expressions', [None, None, None])
 
     def distribution_initialize_inputs(self, species_number, layout, species, density_scale, source_name):


### PR DESCRIPTION
The arguments `<species>.density_min` and `<species>.density_max` was added to avoid zero weight particles from being loaded in regions where the analytic density function is zero. This PR adds those arguments to `picmi.AnalyticDistribution`.
Note that this functionality is used in the new example from #5079.