### PR TITLE
CI: Clean out Pip Caches

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
   - bash: |
       set -eu -o pipefail
       df -h
-      ./run_test.sh LaserInjectionFromLASYFile openbc_poisson_solver
+      ./run_test.sh
       rm -rf ${WARPX_CI_TMP}
       df -h
     displayName: 'Build & test'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -24,21 +24,21 @@ jobs:
 
   strategy:
     matrix:
-      #cartesian1d:
-      #  WARPX_CI_REGULAR_CARTESIAN_1D: 'TRUE'
-      #  WARPX_CI_PSATD: 'FALSE'
-      #cartesian2d:
-      #  WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
+      cartesian1d:
+        WARPX_CI_REGULAR_CARTESIAN_1D: 'TRUE'
+        WARPX_CI_PSATD: 'FALSE'
+      cartesian2d:
+        WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
       cartesian3d:
         WARPX_CI_REGULAR_CARTESIAN_3D: 'TRUE'
-      #single_precision:
-      #  WARPX_CI_SINGLE_PRECISION: 'TRUE'
-      #rz_or_nompi:
-      #  WARPX_CI_RZ_OR_NOMPI: 'TRUE'
-      #qed:
-      #  WARPX_CI_QED: 'TRUE'
-      #embedded_boundary:
-      #  WARPX_CI_EB: 'TRUE'
+      single_precision:
+        WARPX_CI_SINGLE_PRECISION: 'TRUE'
+      rz_or_nompi:
+        WARPX_CI_RZ_OR_NOMPI: 'TRUE'
+      qed:
+        WARPX_CI_QED: 'TRUE'
+      embedded_boundary:
+        WARPX_CI_EB: 'TRUE'
 
   # default: 60; maximum: 360
   timeoutInMinutes: 240

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -24,21 +24,21 @@ jobs:
 
   strategy:
     matrix:
-      cartesian1d:
-        WARPX_CI_REGULAR_CARTESIAN_1D: 'TRUE'
-        WARPX_CI_PSATD: 'FALSE'
-      cartesian2d:
-        WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
+      #cartesian1d:
+      #  WARPX_CI_REGULAR_CARTESIAN_1D: 'TRUE'
+      #  WARPX_CI_PSATD: 'FALSE'
+      #cartesian2d:
+      #  WARPX_CI_REGULAR_CARTESIAN_2D: 'TRUE'
       cartesian3d:
         WARPX_CI_REGULAR_CARTESIAN_3D: 'TRUE'
-      single_precision:
-        WARPX_CI_SINGLE_PRECISION: 'TRUE'
-      rz_or_nompi:
-        WARPX_CI_RZ_OR_NOMPI: 'TRUE'
-      qed:
-        WARPX_CI_QED: 'TRUE'
-      embedded_boundary:
-        WARPX_CI_EB: 'TRUE'
+      #single_precision:
+      #  WARPX_CI_SINGLE_PRECISION: 'TRUE'
+      #rz_or_nompi:
+      #  WARPX_CI_RZ_OR_NOMPI: 'TRUE'
+      #qed:
+      #  WARPX_CI_QED: 'TRUE'
+      #embedded_boundary:
+      #  WARPX_CI_EB: 'TRUE'
 
   # default: 60; maximum: 360
   timeoutInMinutes: 240
@@ -116,7 +116,7 @@ jobs:
   - bash: |
       set -eu -o pipefail
       df -h
-      ./run_test.sh
+      ./run_test.sh LaserInjectionFromLASYFile openbc_poisson_solver
       rm -rf ${WARPX_CI_TMP}
       df -h
     displayName: 'Build & test'

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -6,25 +6,25 @@
     "Ex": 0.0,
     "Ey": 0.0,
     "Ez": 0.0,
-    "T_electron": 381957.7394223898,
-    "T_ion": 319565.6269784763
+    "T_electron": 351982.0169218243,
+    "T_ion": 349599.6939052666
   },
   "electron": {
-    "particle_momentum_x": 8.631833485301232e-19,
-    "particle_momentum_y": 8.476316745254719e-19,
-    "particle_momentum_z": 8.514139891331418e-19,
-    "particle_position_x": 21253105.73686561,
-    "particle_position_y": 21282643.519070115,
-    "particle_position_z": 21239057.457948968,
+    "particle_momentum_x": 8.359982321196841e-19,
+    "particle_momentum_y": 8.192841151167721e-19,
+    "particle_momentum_z": 8.182985690701241e-19,
+    "particle_position_x": 21255110.08090505,
+    "particle_position_y": 21303488.6242626,
+    "particle_position_z": 21238676.122703437,
     "particle_weight": 7.168263344048695e+28
   },
   "ion": {
-    "particle_momentum_x": 1.9215585867122464e-18,
-    "particle_momentum_y": 1.7471481568315848e-18,
-    "particle_momentum_z": 1.7510887207292533e-18,
-    "particle_position_x": 21228900.948879313,
-    "particle_position_y": 21304564.011731848,
-    "particle_position_z": 21250585.221808463,
+    "particle_momentum_x": 2.0034830240966893e-18,
+    "particle_momentum_y": 1.8323959076577197e-18,
+    "particle_momentum_z": 1.827953230828629e-18,
+    "particle_position_x": 21246214.748882487,
+    "particle_position_y": 21280709.710960124,
+    "particle_position_z": 21206153.002106402,
     "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3958,7 +3958,7 @@ inputFile = Examples/Tests/openbc_poisson_solver/inputs_3d
 runtime_params = warpx.abort_on_warning_threshold = high
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE USE_FFT=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_OPENPMD=ON -DCMAKE_BUILD_TYPE=Debug
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_OPENPMD=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1692,7 +1692,7 @@ customRunCmd = ./analysis_3d.py
 runtime_params =
 dim = 3
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3
+cmakeSetupOpts = -DWarpX_DIMS=3 -DCMAKE_BUILD_TYPE=Debug
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -3958,7 +3958,7 @@ inputFile = Examples/Tests/openbc_poisson_solver/inputs_3d
 runtime_params = warpx.abort_on_warning_threshold = high
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE USE_FFT=TRUE
-cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_OPENPMD=ON
+cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_OPENPMD=ON -DCMAKE_BUILD_TYPE=Debug
 restartTest = 0
 useMPI = 1
 numprocs = 2

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1692,7 +1692,7 @@ customRunCmd = ./analysis_3d.py
 runtime_params =
 dim = 3
 addToCompileString =
-cmakeSetupOpts = -DWarpX_DIMS=3 -DCMAKE_BUILD_TYPE=Debug
+cmakeSetupOpts = -DWarpX_DIMS=3
 restartTest = 0
 useMPI = 1
 numprocs = 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -23,6 +23,8 @@
 
 set -eu -o pipefail
 
+df -h
+
 # Parse command line arguments: if test names are given as command line arguments,
 # store them in variable tests_arg and define new command line argument to call
 # regtest.py with option --tests (works also for single test)
@@ -57,6 +59,8 @@ ln -s ${tmp_dir} test_dir
 cd test_dir
 echo "cd $PWD"
 
+df -h
+
 # Prepare a virtual environment
 rm -rf py-venv
 python3 -m venv py-venv
@@ -66,6 +70,8 @@ python3 -m pip install --upgrade build packaging setuptools wheel
 python3 -m pip install --upgrade cmake
 python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 python3 -m pip cache purge
+
+df -h
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
@@ -79,8 +85,12 @@ curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/4ba1d257c5b489
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/4ba1d257c5b4897c0a3cd57742bb0987343a902e/example-femm-3d.h5
 cd -
 
+df -h
+
 # Clone the AMReX regression test utility
 git clone https://github.com/AMReX-Codes/regression_testing.git
+
+df -h
 
 # Prepare regression tests
 mkdir -p rt-WarpX/WarpX-benchmarks
@@ -89,6 +99,8 @@ echo "cd $PWD"
 python3 prepare_file_ci.py
 cp ci-tests.ini ../../rt-WarpX
 cp -r Checksum ../../regression_testing/
+
+df -h
 
 # Run tests
 cd ../../regression_testing/
@@ -101,7 +113,11 @@ else
   python3 regtest.py ../rt-WarpX/ci-tests.ini --skip_comparison --no_update all
 fi
 
+df -h
+
 # clean up python virtual environment
 cd ../
 echo "cd $PWD"
 deactivate
+
+df -h

--- a/run_test.sh
+++ b/run_test.sh
@@ -23,8 +23,6 @@
 
 set -eu -o pipefail
 
-df -h
-
 # Parse command line arguments: if test names are given as command line arguments,
 # store them in variable tests_arg and define new command line argument to call
 # regtest.py with option --tests (works also for single test)
@@ -59,8 +57,6 @@ ln -s ${tmp_dir} test_dir
 cd test_dir
 echo "cd $PWD"
 
-df -h
-
 # Prepare a virtual environment
 rm -rf py-venv
 python3 -m venv py-venv
@@ -70,8 +66,6 @@ python3 -m pip install --upgrade build packaging setuptools wheel
 python3 -m pip install --upgrade cmake
 python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
 python3 -m pip cache purge
-
-df -h
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git
@@ -85,12 +79,8 @@ curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/4ba1d257c5b489
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/4ba1d257c5b4897c0a3cd57742bb0987343a902e/example-femm-3d.h5
 cd -
 
-df -h
-
 # Clone the AMReX regression test utility
 git clone https://github.com/AMReX-Codes/regression_testing.git
-
-df -h
 
 # Prepare regression tests
 mkdir -p rt-WarpX/WarpX-benchmarks
@@ -99,8 +89,6 @@ echo "cd $PWD"
 python3 prepare_file_ci.py
 cp ci-tests.ini ../../rt-WarpX
 cp -r Checksum ../../regression_testing/
-
-df -h
 
 # Run tests
 cd ../../regression_testing/
@@ -113,11 +101,7 @@ else
   python3 regtest.py ../rt-WarpX/ci-tests.ini --skip_comparison --no_update all
 fi
 
-df -h
-
 # clean up python virtual environment
 cd ../
 echo "cd $PWD"
 deactivate
-
-df -h

--- a/run_test.sh
+++ b/run_test.sh
@@ -65,6 +65,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build packaging setuptools wheel
 python3 -m pip install --upgrade cmake
 python3 -m pip install --upgrade -r warpx/Regression/requirements.txt
+python3 -m pip cache purge
 
 # Clone AMReX and warpx-data
 git clone https://github.com/AMReX-Codes/amrex.git


### PR DESCRIPTION
Revert #5117, fix issues with CI tests running out of memory because of multi-GB pip caches.