### PR TITLE
Update test to use lasy 0.5.0

### DIFF
--- a/Examples/Tests/laser_injection_from_file/inputs.1d_boost_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.1d_boost_test
@@ -47,7 +47,7 @@ lasy_laser.e_max        = 1.e14        # Maximum amplitude of the laser field (i
 lasy_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_laser.profile      = from_file
 lasy_laser.time_chunk_size = 50
-lasy_laser.lasy_file_name = "gaussianlaser3d_00000.h5"
+lasy_laser.lasy_file_name = "diags/gaussianlaser3d_00000.h5"
 lasy_laser.delay = 0.0
 
 # Diagnostics

--- a/Examples/Tests/laser_injection_from_file/inputs.1d_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.1d_test
@@ -40,7 +40,7 @@ lasy_laser.e_max        = 1.e14        # Maximum amplitude of the laser field (i
 lasy_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_laser.profile      = from_file
 lasy_laser.time_chunk_size = 50
-lasy_laser.lasy_file_name = "gaussianlaser3d_00000.h5"
+lasy_laser.lasy_file_name = "diags/gaussianlaser3d_00000.h5"
 lasy_laser.delay = 0.0
 
 # Diagnostics

--- a/Examples/Tests/laser_injection_from_file/inputs.2d_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.2d_test
@@ -40,7 +40,7 @@ lasy_laser.e_max        = 1.e14        # Maximum amplitude of the laser field (i
 lasy_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_laser.profile      = from_file
 lasy_laser.time_chunk_size = 50
-lasy_laser.lasy_file_name = "gaussianlaser3d_00000.h5"
+lasy_laser.lasy_file_name = "diags/gaussianlaser3d_00000.h5"
 lasy_laser.delay = 0.0
 
 # Diagnostics

--- a/Examples/Tests/laser_injection_from_file/inputs.3d_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.3d_test
@@ -40,7 +40,7 @@ lasy_laser.e_max        = 1.e14        # Maximum amplitude of the laser field (i
 lasy_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_laser.profile      = from_file
 lasy_laser.time_chunk_size = 50
-lasy_laser.lasy_file_name = "gaussianlaser3d_00000.h5"
+lasy_laser.lasy_file_name = "diags/gaussianlaser3d_00000.h5"
 lasy_laser.delay = 0.0
 
 # Diagnostics

--- a/Examples/Tests/laser_injection_from_file/inputs.RZ_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.RZ_test
@@ -41,7 +41,7 @@ lasy_laser.e_max        = 1.e14        # Maximum amplitude of the laser field (i
 lasy_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_laser.profile      = from_file
 lasy_laser.time_chunk_size = 50
-lasy_laser.lasy_file_name = "gaussianlaser3d_00000.h5"
+lasy_laser.lasy_file_name = "diags/gaussianlaser3d_00000.h5"
 lasy_laser.delay = 0.0
 
 # Diagnostics

--- a/Examples/Tests/laser_injection_from_file/inputs.from_RZ_file_test
+++ b/Examples/Tests/laser_injection_from_file/inputs.from_RZ_file_test
@@ -40,7 +40,7 @@ lasy_RZ_laser.e_max        = 1.e14        # Maximum amplitude of the laser field
 lasy_RZ_laser.wavelength = 1.0e-6         # The wavelength of the laser (in meters)
 lasy_RZ_laser.profile      = from_file
 lasy_RZ_laser.time_chunk_size = 50
-lasy_RZ_laser.lasy_file_name = "laguerrelaserRZ_00000.h5"
+lasy_RZ_laser.lasy_file_name = "diags/laguerrelaserRZ_00000.h5"
 lasy_RZ_laser.delay = 0.0
 
 # Diagnostics


### PR DESCRIPTION
The latest version of `lasy` (`lasy 0.5.0`) was released 2 days ago. 
With this new release, the files produced by `lasy` are automatically saved in the folder `diags` (see https://github.com/LASY-org/lasy/pull/260). CI tests therefore need to be updated to read files from this folder.