### PR TITLE
Fix bug in `PrintMainPICparameters` (uninitialized values)

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -233,7 +233,7 @@ public:
 
     //! If true, a correction is applied to the current in Fourier space,
     //  to satisfy the continuity equation and charge conservation
-    bool current_correction;
+    bool current_correction = true;
 
     //! If true, the PSATD update equation for E contains both J and rho
     //! (default is false for standard PSATD and true for Galilean PSATD)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1544,7 +1544,6 @@ WarpX::ReadParameters ()
         // Current correction activated by default, unless a charge-conserving
         // current deposition (Esirkepov, Vay) or the div(E) cleaning scheme
         // are used
-        current_correction = true;
         if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov ||
             WarpX::current_deposition_algo == CurrentDepositionAlgo::Villasenor ||
             WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay ||


### PR DESCRIPTION
Set initial value of `current_correction` to avoid unintialized values errors in `PrintMainPICparameters` (and possibly other locations). The value was previously set in WarpX.cpp under conditional statements. CI tests should not be affected by this change.