### PR TITLE
Use only openPMD output for openbc_poisson_solver test

### DIFF
--- a/Examples/Tests/openbc_poisson_solver/analysis.py
+++ b/Examples/Tests/openbc_poisson_solver/analysis.py
@@ -33,7 +33,7 @@ def evaluate_E(x, y, z):
 
 fn = sys.argv[1]
 
-path=os.path.join('diags', 'diag2')
+path = 'openbc_poisson_solver_plt'
 ts = OpenPMDTimeSeries(path)
 
 Ex, info = ts.get_field(field='E', coord='x', iteration=0, plot=False)
@@ -62,4 +62,4 @@ for k, z in enumerate(grid_z,start=1):
 test_name = os.path.split(os.getcwd())[1]
 
 # Run checksum regression test
-checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-2)
+checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-2, output_format='openpmd')

--- a/Examples/Tests/openbc_poisson_solver/inputs_3d
+++ b/Examples/Tests/openbc_poisson_solver/inputs_3d
@@ -32,14 +32,9 @@ electron.uy = 0.0
 electron.uz = 25000
 electron.initialize_self_fields = 1
 
-diagnostics.diags_names = diag1 diag2
+diagnostics.diags_names = diag1
 
 diag1.intervals = 1
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho
-diag1.format = plotfile
-
-diag2.intervals = 1
-diag2.diag_type = Full
-diag2.fields_to_plot = Ex Ey
-diag2.format = openpmd
+diag1.format = openpmd

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3964,4 +3964,5 @@ useMPI = 1
 numprocs = 2
 useOMP = 1
 numthreads = 1
+outputFile = openbc_poisson_solver_plt
 analysisRoutine = Examples/Tests/openbc_poisson_solver/analysis.py


### PR DESCRIPTION
The aim of this PR is to bypass the current CI failure with plotfiles for the openbc_poisson test.