### PR TITLE
Fix: `species_type` init memory

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -433,7 +433,7 @@ protected:
 
     amrex::ParticleReal charge;
     amrex::ParticleReal mass;
-    PhysicalSpecies physical_species;
+    PhysicalSpecies physical_species = PhysicalSpecies::unspecified;
 
     // Controls boundaries for particles exiting the domain
     ParticleBoundaries m_boundary_conditions;


### PR DESCRIPTION
The `PC::physical_species` was undefined memory unless `<species_name>.species_type` was provided in the input set. This initializes this member variable to a clear `PhysicalSpecies::unspecified` instead of random memory, which caused UB in functions such as `IamA<...>` during I/O.

Seen first in `openbc_poisson_solver` test for both plotfiles and openPMD by running with `valgrind`.