### PR TITLE
CI: clean test dirs, reset `collisionXZ` checksums

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,6 +18,7 @@ jobs:
     LAPACKPP_HOME: '/usr/local'
     OMP_NUM_THREADS: 1
     WARPX_CI_CCACHE: 'TRUE'
+    WARPX_CI_CLEAN_TESTS: 'TRUE'
     WARPX_CI_NUM_MAKE_JOBS: 2
     WARPX_CI_OPENPMD: 'TRUE'
     WARPX_CI_TMP: '/tmp/ci'
@@ -116,7 +117,7 @@ jobs:
   - bash: |
       set -eu -o pipefail
       df -h
-      ./run_test.sh -c
+      ./run_test.sh
       rm -rf ${WARPX_CI_TMP}
       df -h
     displayName: 'Build & test'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
   - bash: |
       set -eu -o pipefail
       df -h
-      ./run_test.sh
+      ./run_test.sh -c
       rm -rf ${WARPX_CI_TMP}
       df -h
     displayName: 'Build & test'

--- a/Regression/Checksum/benchmarks_json/collisionXZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXZ.json
@@ -7,20 +7,20 @@
     "Ey": 0.0,
     "Ez": 0.0
   },
-  "ion": {
-    "particle_momentum_x": 2.4932317055825563e-19,
-    "particle_momentum_y": 2.274916403334278e-19,
-    "particle_momentum_z": 2.2528161767665816e-19,
-    "particle_position_x": 2648815.601036139,
-    "particle_position_y": 2662836.7581390506,
+  "electron": {
+    "particle_momentum_x": 1.0618161248729303e-19,
+    "particle_momentum_y": 1.0331186403682394e-19,
+    "particle_momentum_z": 1.0375409035564829e-19,
+    "particle_position_x": 2652982.4592067804,
+    "particle_position_y": 2666143.4238272114,
     "particle_weight": 1.7256099431746894e+26
   },
-  "electron": {
-    "particle_momentum_x": 1.0489203687862582e-19,
-    "particle_momentum_y": 1.0209657029567292e-19,
-    "particle_momentum_z": 1.0248962872393911e-19,
-    "particle_position_x": 2657004.8285825616,
-    "particle_position_y": 2670174.272797987,
+  "ion": {
+    "particle_momentum_x": 2.4479519290953386e-19,
+    "particle_momentum_y": 2.2313460312794214e-19,
+    "particle_momentum_z": 2.207395147435577e-19,
+    "particle_position_x": 2666525.886108531,
+    "particle_position_y": 2666683.4040517565,
     "particle_weight": 1.7256099431746894e+26
   }
 }


### PR DESCRIPTION
Trying temporary work-arounds to fix current CI failures. Based on the temporary branch `EZoni_rm_testdir` in my own fork of the `regression_testing` repo, see https://github.com/AMReX-Codes/regression_testing/pull/146.

To-do:
- [x] ~~Fix local runs (if `-c` is not passed, we do not parse all test names correctly as is)~~