### PR TITLE
CI: fix fluctuations in `collisionXZ` checksums

### DIFF
--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -114,4 +114,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-1)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -111,4 +111,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn)
+checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-1)


### PR DESCRIPTION
Trying to see if we can get under control the fluctuations observed in the checksums of the `collisionXZ` test.