### PR TITLE
Nuclear fusion algorithm modifications

### DIFF
--- a/Examples/Tests/collision/analysis_collision_1d.py
+++ b/Examples/Tests/collision/analysis_collision_1d.py
@@ -11,7 +11,7 @@
 # run locally: python analysis_vandb_1d.py diags/diag1000600/
 #
 # This is a 1D intra-species Coulomb scattering relaxation test consisting
-# of a low density population streaming into a higher density population at rest.
+# of a low-density population streaming into a higher density population at rest.
 # Both populations belong to the same carbon12 ion species.
 # See test T1b from JCP 413 (2020) by D. Higginson, et al.
 #

--- a/Examples/Tests/collision/analysis_collision_1d.py
+++ b/Examples/Tests/collision/analysis_collision_1d.py
@@ -11,7 +11,7 @@
 # run locally: python analysis_vandb_1d.py diags/diag1000600/
 #
 # This is a 1D intra-species Coulomb scattering relaxation test consisting
-# of a low-density population streaming into a higher density population at rest.
+# of a low density population streaming into a higher density population at rest.
 # Both populations belong to the same carbon12 ion species.
 # See test T1b from JCP 413 (2020) by D. Higginson, et al.
 #

--- a/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_2D.json
+++ b/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_2D.json
@@ -16,14 +16,14 @@
     "particle_momentum_z": 9.279446607709548e-15,
     "particle_position_x": 4096178.1664224654,
     "particle_position_y": 8192499.7060386725,
-    "particle_weight": 6.399486212205656e+30
+    "particle_weight": 6.399499907503547e+30
   },
   "alpha5": {
-    "particle_momentum_x": 2.3827075626988002e-14,
-    "particle_momentum_y": 2.388035811027714e-14,
-    "particle_momentum_z": 2.4040151761604078e-14,
-    "particle_position_x": 2457556.8571638423,
-    "particle_position_y": 4914659.635379322,
+    "particle_momentum_x": 2.3859593638404282e-14,
+    "particle_momentum_y": 2.38840514351394e-14,
+    "particle_momentum_z": 2.3991308560597987e-14,
+    "particle_position_x": 2457556.8571638414,
+    "particle_position_y": 4914659.635379324,
     "particle_weight": 3.839999999999998e-19
   },
   "boron2": {
@@ -51,12 +51,12 @@
     "particle_weight": 1.2800000000000004e+37
   },
   "proton3": {
-    "particle_momentum_x": 1.6847290893972251e-15,
-    "particle_momentum_y": 1.6827074502304075e-15,
-    "particle_momentum_z": 1.6802489646490975e-15,
-    "particle_position_x": 2457270.6999197667,
-    "particle_position_y": 4914315.665267942,
-    "particle_weight": 1.279486212205663e+30
+    "particle_momentum_x": 1.6842001035542442e-15,
+    "particle_momentum_y": 1.6822700479972656e-15,
+    "particle_momentum_z": 1.6797740090740159e-15,
+    "particle_position_x": 2456930.3827292607,
+    "particle_position_y": 4913715.277730561,
+    "particle_weight": 1.2794999075035503e+30
   },
   "alpha2": {
     "particle_momentum_x": 4.140109871048478e-15,
@@ -91,11 +91,11 @@
     "particle_weight": 127.99999999999999
   },
   "alpha4": {
-    "particle_momentum_x": 2.3854178157605226e-14,
-    "particle_momentum_y": 2.3882457581100904e-14,
-    "particle_momentum_z": 2.403451456378969e-14,
-    "particle_position_x": 2457367.4582781536,
-    "particle_position_y": 4915112.044373056,
+    "particle_momentum_x": 2.3844872070315362e-14,
+    "particle_momentum_y": 2.3880317964250153e-14,
+    "particle_momentum_z": 2.4010930856446718e-14,
+    "particle_position_x": 2457367.4582781526,
+    "particle_position_y": 4915112.044373058,
     "particle_weight": 384.0000000000002
   },
   "proton2": {
@@ -107,11 +107,11 @@
     "particle_weight": 1.2885512788807322e+28
   },
   "alpha3": {
-    "particle_momentum_x": 5.079136896829917e-16,
-    "particle_momentum_y": 5.075922501147803e-16,
-    "particle_momentum_z": 4.962151258214859e-16,
-    "particle_position_x": 52678.192400911765,
-    "particle_position_y": 105483.59950020742,
-    "particle_weight": 1.5413633830148085e+27
+    "particle_momentum_x": 4.758972533179803e-16,
+    "particle_momentum_y": 4.744688612812961e-16,
+    "particle_momentum_z": 4.703298089277572e-16,
+    "particle_position_x": 49191.438625552386,
+    "particle_position_y": 98893.17267714937,
+    "particle_weight": 1.500277489351144e+27
   }
 }

--- a/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_3D.json
+++ b/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_3D.json
@@ -82,7 +82,7 @@
     "particle_position_x": 48732.63289890166,
     "particle_position_y": 46262.85664926968,
     "particle_position_z": 95593.72900482587,
-    "particle_weight": 9.680898262134895e+28
+    "particle_weight": 9.680898262134895e+27
   },
   "alpha5": {
     "particle_momentum_x": 2.3875154301762454e-14,

--- a/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_3D.json
+++ b/Regression/Checksum/benchmarks_json/Proton_Boron_Fusion_3D.json
@@ -27,7 +27,7 @@
     "particle_position_x": 4096178.1664224654,
     "particle_position_y": 4096499.7060386725,
     "particle_position_z": 8191465.586938233,
-    "particle_weight": 5.1196455431551905e+31
+    "particle_weight": 5.119677303391259e+31
   },
   "alpha2": {
     "particle_momentum_x": 4.172264972648105e-15,
@@ -58,13 +58,13 @@
     "particle_weight": 1023.9999999999999
   },
   "proton3": {
-    "particle_momentum_x": 1.6847282386883186e-15,
-    "particle_momentum_y": 1.6828065767793222e-15,
-    "particle_momentum_z": 1.6803456707569493e-15,
-    "particle_position_x": 2457343.371083716,
-    "particle_position_y": 2457033.3891170574,
-    "particle_position_z": 4914529.855222688,
-    "particle_weight": 1.023645543155193e+31
+    "particle_momentum_x": 1.6843593058271961e-15,
+    "particle_momentum_y": 1.6823892851456668e-15,
+    "particle_momentum_z": 1.6800222030208115e-15,
+    "particle_position_x": 2457072.7669634065,
+    "particle_position_y": 2456771.196542574,
+    "particle_position_z": 4914021.8271464575,
+    "particle_weight": 1.0236773033912632e+31
   },
   "proton4": {
     "particle_momentum_x": 0.0,
@@ -76,29 +76,29 @@
     "particle_weight": 1.0240000000000003e+38
   },
   "alpha3": {
-    "particle_momentum_x": 4.822525301678111e-16,
-    "particle_momentum_y": 4.78793407068675e-16,
-    "particle_momentum_z": 4.710411155693663e-16,
-    "particle_position_x": 50987.442011759704,
-    "particle_position_y": 48999.674675246955,
-    "particle_position_z": 101142.57224226737,
-    "particle_weight": 1.0633705344227063e+28
+    "particle_momentum_x": 4.529369912319074e-16,
+    "particle_momentum_y": 4.55762819982174e-16,
+    "particle_momentum_z": 4.501223434274883e-16,
+    "particle_position_x": 48732.63289890166,
+    "particle_position_y": 46262.85664926968,
+    "particle_position_z": 95593.72900482587,
+    "particle_weight": 9.680898262134895e+28
   },
   "alpha5": {
-    "particle_momentum_x": 2.3856918226484716e-14,
-    "particle_momentum_y": 2.3827536503955812e-14,
-    "particle_momentum_z": 2.405465166862308e-14,
-    "particle_position_x": 2457556.857163843,
-    "particle_position_y": 2457059.6353793247,
-    "particle_position_z": 4915847.043341331,
+    "particle_momentum_x": 2.3875154301762454e-14,
+    "particle_momentum_y": 2.3859525730749002e-14,
+    "particle_momentum_z": 2.4029799910201597e-14,
+    "particle_position_x": 2457556.8571638423,
+    "particle_position_y": 2457059.6353793237,
+    "particle_position_z": 4915847.043341332,
     "particle_weight": 3.0719999999999984e-18
   },
   "alpha4": {
-    "particle_momentum_x": 2.386438069023501e-14,
-    "particle_momentum_y": 2.3877492448396915e-14,
-    "particle_momentum_z": 2.4013650859080414e-14,
-    "particle_position_x": 2457367.458278153,
-    "particle_position_y": 2457512.0443730573,
+    "particle_momentum_x": 2.3842314895045605e-14,
+    "particle_momentum_y": 2.386245392919704e-14,
+    "particle_momentum_z": 2.4007606987094537e-14,
+    "particle_position_x": 2457367.4582781545,
+    "particle_position_y": 2457512.044373057,
     "particle_position_z": 4914475.7765130745,
     "particle_weight": 3072.000000000002
   },

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -181,59 +181,54 @@ public:
                 if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
                     idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
                     p_mask[pair_index] = false;
-                    if (max_N == NI1) { i1 += min_N; }
-                    if (max_N == NI2) { i2 += min_N; }
-                    pair_index += min_N;
-                    continue;
                 }
+                else {
 
 #if (defined WARPX_DIM_RZ)
-                /* In RZ geometry, macroparticles can collide with other macroparticles
-                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                 * are actually not local in space. In this case, the underlying assumption is that
-                 * particles within the same cylindrical cell represent a cylindrically-symmetry
-                 * momentum distribution function. Therefore, here, we temporarily rotate the
-                 * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                 * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                 * there is a corresponding assert statement at initialization.) */
-                amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
+                    /* In RZ geometry, macroparticles can collide with other macroparticles
+                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
+                     * are actually not local in space. In this case, the underlying assumption is that
+                     * particles within the same cylindrical cell represent a cylindrically-symmetry
+                     * momentum distribution function. Therefore, here, we temporarily rotate the
+                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
+                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
+                     * there is a corresponding assert statement at initialization.) */
+                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
+                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
+                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
+                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
 #endif
 
-                SingleNuclearFusionEvent(
-                    u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
-                    u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
-                    m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
-                    dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
-                    m_fusion_multiplier, multiplier_ratio,
-                    m_probability_threshold,
-                    m_probability_target_value,
-                    m_fusion_type, engine);
+                    SingleNuclearFusionEvent(
+                        u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
+                        u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
+                        m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
+                        dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
+                        m_fusion_multiplier, multiplier_ratio,
+                        m_probability_threshold,
+                        m_probability_target_value,
+                        m_fusion_type, engine);
 
 #if (defined WARPX_DIM_RZ)
-                amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
+                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
+                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
+                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
 #endif
 
-                // Remove pair reaction weight from the colliding particles' weights
-                if (p_mask[pair_index]) {
-                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                        w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
-                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                        w2[ I2[i2] ], idcpu2[ I2[i2] ], p_pair_reaction_weight[pair_index]);
+                    // Remove pair reaction weight from the colliding particles' weights
+                    if (p_mask[pair_index]) {
+                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                            w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
+                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                            w2[ I2[i2] ], idcpu2[ I2[i2] ], p_pair_reaction_weight[pair_index]);
+                    }
+
                 }
 
                 p_pair_indices_1[pair_index] = I1[i1];
                 p_pair_indices_2[pair_index] = I2[i2];
-                if (max_N == NI1) {
-                    i1 += min_N;
-                }
-                if (max_N == NI2) {
-                    i2 += min_N;
-                }
+                if (max_N == NI1) { i1 += min_N; }
+                if (max_N == NI2) { i2 += min_N; }
                 pair_index += min_N;
             }
         }

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -159,18 +159,9 @@ public:
 
             index_type pair_index = cell_start_pair + coll_idx;
 
-            // Because the number of particles of each species is not always equal (NI1 != NI2
-            // in general), some macroparticles will be paired with multiple macroparticles of the
-            // other species and we need to decrease their weight accordingly.
-            // c1 corresponds to the minimum number of times a particle of species 1 will be paired
-            // with a particle of species 2. Same for c2.
-            // index_type(1): https://github.com/AMReX-Codes/amrex/pull/3684
-            const index_type c1 = amrex::max(NI2/NI1, index_type(1));
-            const index_type c2 = amrex::max(NI1/NI2, index_type(1));
-
             // multiplier ratio to take into account unsampled pairs
             const auto multiplier_ratio = static_cast<int>(
-                m_isSameSpecies ? 2*max_N - 1 : max_N);
+                m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
 #if (defined WARPX_DIM_RZ)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
@@ -182,10 +173,6 @@ public:
             // stride (smaller set size) until we do all collisions (larger set size)
             for (index_type k = coll_idx; k < max_N; k += min_N)
             {
-                // c1k : how many times the current particle of species 1 is paired with a particle
-                // of species 2. Same for c2k.
-                const index_type c1k = (k%NI1 < max_N%NI1) ? c1 + 1: c1;
-                const index_type c2k = (k%NI2 < max_N%NI2) ? c2 + 1: c2;
 
 #if (defined WARPX_DIM_RZ)
                 /* In RZ geometry, macroparticles can collide with other macroparticles
@@ -205,7 +192,7 @@ public:
                 SingleNuclearFusionEvent(
                     u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                     u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
-                    m1, m2, w1[ I1[i1] ]/c1k, w2[ I2[i2] ]/c2k,
+                    m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
                     dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
                     m_fusion_multiplier, multiplier_ratio,
                     m_probability_threshold,

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -145,11 +145,13 @@ public:
             amrex::ParticleReal * const AMREX_RESTRICT u1x = soa_1.m_rdata[PIdx::ux];
             amrex::ParticleReal * const AMREX_RESTRICT u1y = soa_1.m_rdata[PIdx::uy];
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
+            uint64_t* AMREX_RESTRICT idcpu1 = soa_1.m_idcpu;
 
             amrex::ParticleReal * const AMREX_RESTRICT w2 = soa_2.m_rdata[PIdx::w];
             amrex::ParticleReal * const AMREX_RESTRICT u2x = soa_2.m_rdata[PIdx::ux];
             amrex::ParticleReal * const AMREX_RESTRICT u2y = soa_2.m_rdata[PIdx::uy];
             amrex::ParticleReal * const AMREX_RESTRICT u2z = soa_2.m_rdata[PIdx::uz];
+            uint64_t* AMREX_RESTRICT idcpu2 = soa_2.m_idcpu;
 
             // Number of macroparticles of each species
             const index_type NI1 = I1e - I1s;
@@ -174,36 +176,54 @@ public:
             for (index_type k = coll_idx; k < max_N; k += min_N)
             {
 
-#if (defined WARPX_DIM_RZ)
-                /* In RZ geometry, macroparticles can collide with other macroparticles
-                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                 * are actually not local in space. In this case, the underlying assumption is that
-                 * particles within the same cylindrical cell represent a cylindrically-symmetry
-                 * momentum distribution function. Therefore, here, we temporarily rotate the
-                 * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                 * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                 * there is a corresponding assert statement at initialization.) */
-                amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
-
-                SingleNuclearFusionEvent(
-                    u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
-                    u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
-                    m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
-                    dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
-                    m_fusion_multiplier, multiplier_ratio,
-                    m_probability_threshold,
-                    m_probability_target_value,
-                    m_fusion_type, engine);
+                // do not check for collision if a particle's weight was
+                // reduced to zero from a previous collision
+                if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
+                    idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
+                    p_mask[pair_index] = false;
+                }
+                else {
 
 #if (defined WARPX_DIM_RZ)
-                amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
+                    /* In RZ geometry, macroparticles can collide with other macroparticles
+                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
+                     * are actually not local in space. In this case, the underlying assumption is that
+                     * particles within the same cylindrical cell represent a cylindrically-symmetry
+                     * momentum distribution function. Therefore, here, we temporarily rotate the
+                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
+                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
+                     * there is a corresponding assert statement at initialization.) */
+                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
+                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
+                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
+                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
 #endif
+
+                    SingleNuclearFusionEvent(
+                        u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
+                        u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
+                        m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
+                        dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
+                        m_fusion_multiplier, multiplier_ratio,
+                        m_probability_threshold,
+                        m_probability_target_value,
+                        m_fusion_type, engine);
+
+#if (defined WARPX_DIM_RZ)
+                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
+                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
+                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
+#endif
+
+                    // Remove pair reaction weight from the colliding particles' weights
+                    if (p_mask[pair_index]) {
+                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                            w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
+                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                            w2[ I2[i2] ], idcpu2[ I2[i2] ], p_pair_reaction_weight[pair_index]);
+                    }
+
+                }
 
                 p_pair_indices_1[pair_index] = I1[i1];
                 p_pair_indices_2[pair_index] = I2[i2];

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -181,48 +181,49 @@ public:
                 if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
                     idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
                     p_mask[pair_index] = false;
+                    if (max_N == NI1) { i1 += min_N; }
+                    if (max_N == NI2) { i2 += min_N; }
+                    pair_index += min_N;
+                    continue;
                 }
-                else {
 
 #if (defined WARPX_DIM_RZ)
-                    /* In RZ geometry, macroparticles can collide with other macroparticles
-                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                     * are actually not local in space. In this case, the underlying assumption is that
-                     * particles within the same cylindrical cell represent a cylindrically-symmetry
-                     * momentum distribution function. Therefore, here, we temporarily rotate the
-                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                     * there is a corresponding assert statement at initialization.) */
-                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
+                /* In RZ geometry, macroparticles can collide with other macroparticles
+                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
+                 * are actually not local in space. In this case, the underlying assumption is that
+                 * particles within the same cylindrical cell represent a cylindrically-symmetry
+                 * momentum distribution function. Therefore, here, we temporarily rotate the
+                 * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
+                 * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
+                 * there is a corresponding assert statement at initialization.) */
+                amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
+                amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
+                u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
+                u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
 #endif
 
-                    SingleNuclearFusionEvent(
-                        u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
-                        u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
-                        m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
-                        dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
-                        m_fusion_multiplier, multiplier_ratio,
-                        m_probability_threshold,
-                        m_probability_target_value,
-                        m_fusion_type, engine);
+                SingleNuclearFusionEvent(
+                    u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
+                    u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
+                    m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
+                    dt, dV, static_cast<int>(pair_index), p_mask, p_pair_reaction_weight,
+                    m_fusion_multiplier, multiplier_ratio,
+                    m_probability_threshold,
+                    m_probability_target_value,
+                    m_fusion_type, engine);
 
 #if (defined WARPX_DIM_RZ)
-                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
+                amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
+                u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
+                u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
 #endif
 
-                    // Remove pair reaction weight from the colliding particles' weights
-                    if (p_mask[pair_index]) {
-                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                            w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
-                        BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                            w2[ I2[i2] ], idcpu2[ I2[i2] ], p_pair_reaction_weight[pair_index]);
-                    }
-
+                // Remove pair reaction weight from the colliding particles' weights
+                if (p_mask[pair_index]) {
+                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                        w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
+                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                        w2[ I2[i2] ], idcpu2[ I2[i2] ], p_pair_reaction_weight[pair_index]);
                 }
 
                 p_pair_indices_1[pair_index] = I1[i1];

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -131,11 +131,6 @@ public:
         const auto soa_1 = ptile1.getParticleTileData();
         const auto soa_2 = ptile2.getParticleTileData();
 
-        amrex::ParticleReal* AMREX_RESTRICT w1 = soa_1.m_rdata[PIdx::w];
-        amrex::ParticleReal* AMREX_RESTRICT w2 = soa_2.m_rdata[PIdx::w];
-        uint64_t* AMREX_RESTRICT idcpu1 = soa_1.m_idcpu;
-        uint64_t* AMREX_RESTRICT idcpu2 = soa_2.m_idcpu;
-
         // Create necessary GPU vectors, that will be used in the kernel below
         amrex::Vector<SoaData_type> soa_products;
         for (int i = 0; i < m_num_product_species; i++)

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -198,10 +198,12 @@ public:
                 }
 
                 // Remove p_pair_reaction_weight[i] from the colliding particles' weights
-                BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                    w1[p_pair_indices_1[i]], idcpu1[p_pair_indices_1[i]], p_pair_reaction_weight[i]);
-                BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                    w2[p_pair_indices_2[i]], idcpu2[p_pair_indices_2[i]], p_pair_reaction_weight[i]);
+                if (t_collision_type == CollisionType::DSMC) { // performed locally for fusion
+                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                        w1[p_pair_indices_1[i]], idcpu1[p_pair_indices_1[i]], p_pair_reaction_weight[i]);
+                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
+                        w2[p_pair_indices_2[i]], idcpu2[p_pair_indices_2[i]], p_pair_reaction_weight[i]);
+                }
 
                 // Initialize the product particles' momentum, using a function depending on the
                 // specific collision type

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -197,14 +197,6 @@ public:
                     }
                 }
 
-                // Remove p_pair_reaction_weight[i] from the colliding particles' weights
-                if (t_collision_type == CollisionType::DSMC) { // performed locally for fusion
-                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                        w1[p_pair_indices_1[i]], idcpu1[p_pair_indices_1[i]], p_pair_reaction_weight[i]);
-                    BinaryCollisionUtils::remove_weight_from_colliding_particle(
-                        w2[p_pair_indices_2[i]], idcpu2[p_pair_indices_2[i]], p_pair_reaction_weight[i]);
-                }
-
                 // Initialize the product particles' momentum, using a function depending on the
                 // specific collision type
                 if (t_collision_type == CollisionType::ProtonBoronToAlphasFusion)


### PR DESCRIPTION
This PR makes  changes to the Nuclear Fusion algorithm that allows for better control of the particle weights.

The current implentation uses an effective fusion_multiplier equal to max(NA,NB)/min(NA,NB), where NA and NB are, respectively, the number of macro-particles in a cell for species A and species B. The probability of a collision is enhanced by Nmax/Nmin, and the weight of the fusion products is decreased by the same factor to keep the physical number of particles created correct. This implementation does not permit maintaining equally-weighted particles for the incident species.

The new implementation introduced in this PR only uses the fusion_multiplier specified in the input file. If that value is set to 1, and the particles are equally-weighted, then the particles of the colliding species will remain equally-weighted.

Below are results from a mono-energetic Deuterium beam incident on a cold stationary Tritium background. The density of the beam is 10X less than the stationary Tritium background. The number of particles per cell for the deuterium beam is 160 and that for the tritium background is 1600. Thus, the particles have equal weights initially. The total weight of deuterium particles decays exponentially for this problem.

Results using this PR (fusion branch) with fusion_multiplier = 1 is shown in the top right panel. It agrees with the analytic solution until the number of macro particle becomes close to zero. Results from the new branch with fusion_multiplier = 10 (lower left) are identical to results obtained using the development branch (upper left) with fusion_multiplier = 1. 

The total number of macro particles in the simulation, shown in the lower right panel of the figure, remains roughly fixed using this PR with fusion_multiplier = 1. The only reason it is not strictly fixed is because the alpha particle produced in the fusion reaction is split into two to maintain local charge conservation.

![development_vs_fusion_4x4](https://github.com/user-attachments/assets/b50f68ed-ea42-41d3-be59-f64c27dd3f1f)


