### PR TITLE
Add call to HandleParticlesAtBoundaries in WarpXEvolve.cpp to prevent oob segfaults

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -172,32 +172,6 @@ WarpX::Evolve (int numsteps)
             // B : guard cells are NOT up-to-date
         }
 
-        // TODO: move out
-        if (evolve_scheme == EvolveScheme::Explicit) {
-            if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
-                // At the end of last step, push p by 0.5*dt to synchronize
-                const int num_moved = MoveWindow(step+1, is_synchronized);
-                HandleParticlesAtBoundaries(step, cur_time, num_moved);
-                FillBoundaryE(guard_cells.ng_FieldGather);
-                FillBoundaryB(guard_cells.ng_FieldGather);
-                if (fft_do_time_averaging)
-                {
-                    FillBoundaryE_avg(guard_cells.ng_FieldGather);
-                    FillBoundaryB_avg(guard_cells.ng_FieldGather);
-                }
-                UpdateAuxilaryData();
-                FillBoundaryAux(guard_cells.ng_UpdateAux);
-                for (int lev = 0; lev <= finest_level; ++lev) {
-                    mypc->PushP(lev, 0.5_rt*dt[lev],
-                                *Efield_aux[lev][0],*Efield_aux[lev][1],
-                                *Efield_aux[lev][2],
-                                *Bfield_aux[lev][0],*Bfield_aux[lev][1],
-                                *Bfield_aux[lev][2]);
-                }
-                is_synchronized = true;
-            }
-        }
-
         for (int lev = 0; lev <= max_level; ++lev) {
             ++istep[lev];
         }
@@ -262,6 +236,29 @@ WarpX::Evolve (int numsteps)
                 HybridPICEvolveFields();
             }
             ExecutePythonCallback("afterEsolve");
+        }
+
+        if (evolve_scheme == EvolveScheme::Explicit) {
+            if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
+                // At the end of last step, push p by 0.5*dt to synchronize
+                FillBoundaryE(guard_cells.ng_FieldGather);
+                FillBoundaryB(guard_cells.ng_FieldGather);
+                if (fft_do_time_averaging)
+                {
+                    FillBoundaryE_avg(guard_cells.ng_FieldGather);
+                    FillBoundaryB_avg(guard_cells.ng_FieldGather);
+                }
+                UpdateAuxilaryData();
+                FillBoundaryAux(guard_cells.ng_UpdateAux);
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    mypc->PushP(lev, 0.5_rt*dt[lev],
+                                *Efield_aux[lev][0],*Efield_aux[lev][1],
+                                *Efield_aux[lev][2],
+                                *Bfield_aux[lev][0],*Bfield_aux[lev][1],
+                                *Bfield_aux[lev][2]);
+                }
+                is_synchronized = true;
+            }
         }
 
         // afterstep callback runs with the updated global time. It is included

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -239,7 +239,7 @@ WarpX::Evolve (int numsteps)
         }
 
         if (evolve_scheme == EvolveScheme::Explicit) {
-            if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
+            if (cur_time >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
                 // At the end of last step, push p by 0.5*dt to synchronize
                 FillBoundaryE(guard_cells.ng_FieldGather);
                 FillBoundaryB(guard_cells.ng_FieldGather);

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -176,6 +176,8 @@ WarpX::Evolve (int numsteps)
         if (evolve_scheme == EvolveScheme::Explicit) {
             if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
                 // At the end of last step, push p by 0.5*dt to synchronize
+                const int num_moved = MoveWindow(step+1, is_synchronized);
+                HandleParticlesAtBoundaries(step, cur_time, num_moved);
                 FillBoundaryE(guard_cells.ng_FieldGather);
                 FillBoundaryB(guard_cells.ng_FieldGather);
                 if (fft_do_time_averaging)


### PR DESCRIPTION
Fixes bug found here https://github.com/ECP-WarpX/WarpX/issues/5065 and partially addresses https://github.com/ECP-WarpX/WarpX/issues/5113

This PR just adds a call to HandleParticlesAtBoundaries to the synchronization step part of WarpXEvolve.cpp to prevent unhelpful memory access errors when particles travel too far in one step.

Before, this error would be thrown:
```
amrex::Abort::3::CUDA error 700 in file /home/marksta/src/warpx/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuDevice.cpp
line 648: an illegal memory access was encountered !!!
SIGABRT
```

Now, no error is thrown and the simulation finishes successfully.

Ideally, we would still like to warn users about CFL violations in ES simulations, or adapt the timestep to account for a user-specified CFL number (which may be greater than 1 for semi-implicit schemes). I'll keep looking at that. 


