### PR TITLE
Tests: `useOMP = 1`

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -3801,7 +3801,7 @@ cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 outputFile = Point_of_contact_EB_3d_plt
 analysisRoutine = Examples/Tests/point_of_contact_EB/analysis.py
@@ -3816,7 +3816,7 @@ cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_EB=ON
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 outputFile = Point_of_contact_EB_rz_plt
 analysisRoutine = Examples/Tests/point_of_contact_EB/analysis.py
@@ -3831,7 +3831,7 @@ cmakeSetupOpts = -DWarpX_DIMS=1
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_1d.py
 
@@ -3845,7 +3845,7 @@ cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_vandb_jfnk_2d.py
 
@@ -3861,7 +3861,7 @@ target = pip_install
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_vandb_jfnk_2d.py
 
@@ -3875,7 +3875,7 @@ cmakeSetupOpts = -DWarpX_DIMS=1
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/Implicit/analysis_1d.py
 
@@ -3888,7 +3888,7 @@ cmakeSetupOpts = -DWarpX_DIMS=2
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 1
 analysisRoutine = Examples/Tests/energy_conserving_thermal_plasma/analysis.py
 


### PR DESCRIPTION
There were only a few tests using `useOMP = 0`. We use one thread, so compiling OpenMP is fine. This likely had no effect, just cleaning.