### PR TITLE
potential fix to varying results for collisionXZ and collisionXYZ CI tests

### DIFF
--- a/Examples/Tests/collision/analysis_collision_1d.py
+++ b/Examples/Tests/collision/analysis_collision_1d.py
@@ -26,8 +26,8 @@ sys.path.insert(1, '../../../../warpx/Regression/Checksum/')
 import checksumAPI
 
 # this will be the name of the plot file
-fn = sys.argv[1]
-ds = yt.load(fn)
+last_fn = sys.argv[1]
+ds = yt.load(last_fn)
 data = ds.covering_grid(level = 0, left_edge = ds.domain_left_edge, dims = ds.domain_dimensions)
 
 # carbon 12 ion (mass = 12*amu - 6*me)
@@ -123,4 +123,4 @@ print('tolerance = ', tolerance);
 assert error < tolerance
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, rtol=2.5e-3)
+checksumAPI.evaluate_checksum(test_name, last_fn)

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -114,4 +114,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, last_fn, rtol=1e-1)
+checksumAPI.evaluate_checksum(test_name, last_fn)

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -26,7 +26,6 @@
 import glob
 import math
 import os
-import re
 import sys
 
 import numpy

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -55,12 +55,10 @@ a =  0.04330638981264072
 b = -0.11588277796546632
 
 last_fn = sys.argv[1]
-# Remove trailing '/' from file name, if necessary
-last_fn.rstrip('/')
-# Find last iteration in file name, such as 'test_name_plt000001' (last_it = '000001')
-last_it = re.search('\d+', last_fn).group()
-# Find output prefix in file name, such as 'test_name_plt000001' (prefix = 'test_name_plt')
-prefix = last_fn[:-len(last_it)]
+if (last_fn[-1] == "/"): last_fn = last_fn[:-1]
+last_it = last_fn[-6:] # i.e., 000150
+prefix = last_fn[:-6]  # i.e., diags/diag1
+
 # Collect all output files in fn_list (names match pattern prefix + arbitrary number)
 fn_list = glob.glob(prefix + '*[0-9]')
 
@@ -92,7 +90,7 @@ assert(error < tolerance)
 if "Python" in last_fn:
     exit()
 
-## In the second past of the test, we verify that the diagnostic particle filter function works as
+## In the second part of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
 dim = "2d"

--- a/Examples/Tests/collision/analysis_collision_2d.py
+++ b/Examples/Tests/collision/analysis_collision_2d.py
@@ -114,4 +114,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-1)
+checksumAPI.evaluate_checksum(test_name, last_fn, rtol=1e-1)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -26,7 +26,6 @@
 import glob
 import math
 import os
-import re
 import sys
 
 import numpy

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -55,12 +55,10 @@ a =  0.041817463099883
 b = -0.083851393560288
 
 last_fn = sys.argv[1]
-# Remove trailing '/' from file name, if necessary
-last_fn.rstrip('/')
-# Find last iteration in file name, such as 'test_name_plt000001' (last_it = '000001')
-last_it = re.search('\d+', last_fn).group()
-# Find output prefix in file name, such as 'test_name_plt000001' (prefix = 'test_name_plt')
-prefix = last_fn[:-len(last_it)]
+if (last_fn[-1] == "/"): last_fn = last_fn[:-1]
+last_it = last_fn[-6:] # i.e., 000150
+prefix = last_fn[:-6]  # i.e., diags/diag1
+
 # Collect all output files in fn_list (names match pattern prefix + arbitrary number)
 fn_list = glob.glob(prefix + '*[0-9]')
 
@@ -89,7 +87,7 @@ print('tolerance = ', tolerance)
 assert(error < tolerance)
 
 
-## In the second past of the test, we verify that the diagnostic particle filter function works as
+## In the second part of the test, we verify that the diagnostic particle filter function works as
 ## expected. For this, we only use the last simulation timestep.
 
 dim = "3d"

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -111,4 +111,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, rtol=1e-1)
+checksumAPI.evaluate_checksum(test_name, last_fn, rtol=1e-1)

--- a/Examples/Tests/collision/analysis_collision_3d.py
+++ b/Examples/Tests/collision/analysis_collision_3d.py
@@ -111,4 +111,4 @@ post_processing_utils.check_random_filter(last_fn, random_filter_fn, random_frac
                                           dim, species_name)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, last_fn, rtol=1e-1)
+checksumAPI.evaluate_checksum(test_name, last_fn)

--- a/Examples/Tests/collision/analysis_collision_rz.py
+++ b/Examples/Tests/collision/analysis_collision_rz.py
@@ -55,4 +55,4 @@ print('tolerance = ', tolerance)
 assert(error < tolerance)
 
 test_name = os.path.split(os.getcwd())[1]
-checksumAPI.evaluate_checksum(test_name, fn, do_particles=False)
+checksumAPI.evaluate_checksum(test_name, last_fn, do_particles=False)

--- a/Regression/Checksum/benchmarks_json/collisionXYZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXYZ.json
@@ -6,25 +6,25 @@
     "Ex": 0.0,
     "Ey": 0.0,
     "Ez": 0.0,
-    "T_electron": 351982.0169218243,
-    "T_ion": 349599.6939052666
+    "T_electron": 351188.7347045234,
+    "T_ion": 350097.5453711827
   },
   "electron": {
-    "particle_momentum_x": 8.359982321196841e-19,
-    "particle_momentum_y": 8.192841151167721e-19,
-    "particle_momentum_z": 8.182985690701241e-19,
-    "particle_position_x": 21255110.08090505,
-    "particle_position_y": 21303488.6242626,
-    "particle_position_z": 21238676.122703437,
+    "particle_momentum_x": 8.348736016166693e-19,
+    "particle_momentum_y": 8.175754844970833e-19,
+    "particle_momentum_z": 8.209507928471627e-19,
+    "particle_position_x": 21258578.13072786,
+    "particle_position_y": 21266758.00828195,
+    "particle_position_z": 21207386.447255243,
     "particle_weight": 7.168263344048695e+28
   },
   "ion": {
-    "particle_momentum_x": 2.0034830240966893e-18,
-    "particle_momentum_y": 1.8323959076577197e-18,
-    "particle_momentum_z": 1.827953230828629e-18,
-    "particle_position_x": 21246214.748882487,
-    "particle_position_y": 21280709.710960124,
-    "particle_position_z": 21206153.002106402,
+    "particle_momentum_x": 2.008818164997072e-18,
+    "particle_momentum_y": 1.829384185025146e-18,
+    "particle_momentum_z": 1.8289477333243715e-18,
+    "particle_position_x": 21233610.538310427,
+    "particle_position_y": 21280892.516510233,
+    "particle_position_z": 21213150.945697505,
     "particle_weight": 7.168263344048695e+28
   }
 }

--- a/Regression/Checksum/benchmarks_json/collisionXZ.json
+++ b/Regression/Checksum/benchmarks_json/collisionXZ.json
@@ -7,20 +7,20 @@
     "Ey": 0.0,
     "Ez": 0.0
   },
-  "electron": {
-    "particle_momentum_x": 1.0618161248729303e-19,
-    "particle_momentum_y": 1.0331186403682394e-19,
-    "particle_momentum_z": 1.0375409035564829e-19,
-    "particle_position_x": 2652982.4592067804,
-    "particle_position_y": 2666143.4238272114,
+  "ion": {
+    "particle_momentum_x": 2.5066842316209183e-19,
+    "particle_momentum_y": 2.2863311215256246e-19,
+    "particle_momentum_z": 2.2682377973998022e-19,
+    "particle_position_x": 2656041.6379113654,
+    "particle_position_y": 2669548.664572591,
     "particle_weight": 1.7256099431746894e+26
   },
-  "ion": {
-    "particle_momentum_x": 2.4479519290953386e-19,
-    "particle_momentum_y": 2.2313460312794214e-19,
-    "particle_momentum_z": 2.207395147435577e-19,
-    "particle_position_x": 2666525.886108531,
-    "particle_position_y": 2666683.4040517565,
+  "electron": {
+    "particle_momentum_x": 1.0390618975838188e-19,
+    "particle_momentum_y": 1.0241645067704406e-19,
+    "particle_momentum_z": 1.0173387880649568e-19,
+    "particle_position_x": 2646162.5818311535,
+    "particle_position_y": 2661127.0162632912,
     "particle_weight": 1.7256099431746894e+26
   }
 }


### PR DESCRIPTION
The file passed to checksumAPI.evaluate_checksum() at the end of the analysis scripts for the collisionXZ and collisionXYZ CI tests currently uses a file name (fn) that comes from the end of a loop over filenames. This does not always return the same name. The intended file here is the last time step, which is given by last_fn = sys.argv[1]. 

This PR changes it such that last_fn is used in checksumAPI.evaluate_checksum() for these two CI tests. This may fix the random failures of these tests experienced recently.

- [x] also update collisionZ and collisionRZ