### PR TITLE
Doc: Typos in LXPLUS (CERN)

### DIFF
--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -44,7 +44,7 @@ The easiest way to install the dependencies is to use the pre-prepared ``warpx.p
 
 .. code-block:: bash
 
-    cp $WORK/warpx/WarpX/Tools/machines/lxplus-cern/lxplus_warpx.profile.example $WORK/lxplus_warpx.profile
+    cp $WORK/warpx/Tools/machines/lxplus-cern/lxplus_warpx.profile.example $WORK/lxplus_warpx.profile
     source $WORK/lxplus_warpx.profile
 
 When doing this one can directly skip to the :ref:`Building WarpX <building-lxplus-warpx>` section.

--- a/Tools/machines/lxplus-cern/lxplus_warpx.profile.example
+++ b/Tools/machines/lxplus-cern/lxplus_warpx.profile.example
@@ -22,7 +22,7 @@ then
     # create and activate the spack environment
     export SPACK_STACK_USE_PYTHON=1
     export SPACK_STACK_USE_CUDA=1
-    spack env create warpx-lxplus-cuda-py $WORK/WarpX/Tools/machines/lxplus-cern/spack.yaml
+    spack env create warpx-lxplus-cuda-py $WORK/warpx/Tools/machines/lxplus-cern/spack.yaml
     spack env activate warpx-lxplus-cuda-py
     spack install
 else


### PR DESCRIPTION
Fix a few clear typos in the instructions of LXPLUS.

Related to #5140