### PR TITLE
Fix: heFFTe on Perlmutter GPU

### DIFF
--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -145,6 +145,10 @@ cmake \
 cmake --build ${build_dir}/heffte-pm-gpu-build --target install --parallel 16
 rm -rf ${build_dir}/heffte-pm-gpu-build
 
+# work-around for heFFTe 2.4.0 bug with NVCC
+# https://github.com/icl-utk-edu/heffte/pull/54
+sed -i 's/__AVX__/NOTDEFINED_DONOTUSE/g' ${SW_DIR}/heffte-2.4.0/include/stock_fft/heffte_stock_vec_types.h
+
 
 # Python ######################################################################
 #


### PR DESCRIPTION
heFFTe 2.4.0 usage with NVCC 12.2 on Perlmutter fails to compile WarpX once its public header is included, due to unguarded include of a CPU AVX intrincics header in its stock backend.

We do not need a fast stock CPU backend if we compile for CUDA, so we patch it out now to avoid the issue. A future (post v2.4.0) release of heFFTe will ship our fix for this, until then we post-install patch heFFTe on Perlmutter for GPU builds: https://github.com/icl-utk-edu/heffte/pull/54