### PR TITLE
Add callback to write values to external field multifabs

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -25,6 +25,7 @@ extra reference to the method's object is saved.
 
 Functions can be called at the following times:
 
+* ``loadExternalFields``: during ``WarpX::LoadExternalFields`` to write ``B/Efield_fp_external`` values
 * ``beforeInitEsolve``: before the initial solve for the E fields (i.e. before the PIC loop starts)
 * ``afterinit``: immediately after the init is complete
 * ``beforeEsolve``: before the solve for E fields
@@ -276,6 +277,7 @@ class CallbackFunctions(object):
 # =============================================================================
 
 callback_instances = {
+    "loadExternalFields": {},
     "beforeInitEsolve": {},
     "afterInitEsolve": {},
     "afterinit": {},
@@ -330,7 +332,7 @@ def clear_all():
         val.clearlist()
 
 
-# =============================================================================
+# ============================================================================
 
 
 def printcallbacktimers(tmin=1.0, lminmax=False, ff=None):
@@ -371,7 +373,17 @@ def printcallbacktimers(tmin=1.0, lminmax=False, ff=None):
             ff.write("\n")
 
 
-# =============================================================================
+# ============================================================================
+
+
+# ----------------------------------------------------------------------------
+def callfromloadExternalFields(f):
+    installcallback("loadExternalFields", f)
+    return f
+
+
+def installloadExternalFields(f):
+    installcallback("loadExternalFields", f)
 
 
 # ----------------------------------------------------------------------------

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1410,6 +1410,9 @@ WarpX::LoadExternalFields (int const lev)
 #endif
     }
 
+    // Call Python callback which might write values to external field multifabs
+    ExecutePythonCallback("loadExternalFields");
+
     // External particle fields
 
     if (mypc->m_B_ext_particle_s == "read_from_file") {

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -578,6 +578,11 @@ WarpX::InitData ()
         if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic) {
             ComputeMagnetostaticField();
         }
+        // Add external fields to the fine patch fields. This makes it so that the
+        // net fields are the sum of the field solutions and any external fields.
+        for (int lev = 0; lev <= max_level; ++lev) {
+            AddExternalFields(lev);
+        }
     }
 
     if (restart_chkfile.empty() || write_diagnostics_on_restart) {
@@ -1013,8 +1018,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
     // load external grid fields into E/Bfield_fp_external multifabs
     LoadExternalFields(lev);
-    // add the external fields to the fine patch fields as initial conditions for the fields
-    AddExternalFields(lev);
 
     if (costs[lev]) {
         const auto iarr = costs[lev]->IndexArray();


### PR DESCRIPTION
Currently a standard practice for writing initial or external fields using Python is to use the `beforeInitEsolve` callback. However, this creates a problem when using electrostatic solvers since the external fields (`B/Efield_fp_external`) are then not added to the `B/Efield_fp` multifabs until after the first step (in the regular PIC loop) so the first step particle pushing does not use the external fields. This PR fixes that problem by truly handling external fields loaded from Python (through the new callback) equivalently to external fields loaded from file or from the parser.