### PR TITLE
Laser initialization in PICMI: allow negative focal distance and t_peak

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1988,20 +1988,19 @@ class LaserAntenna(picmistandard.PICMI_LaserAntenna):
         self.normal_vector = laser.laser.direction  # The plane normal direction
         if isinstance(laser, GaussianLaser):
             # Focal distance from the antenna (in meters)
-            laser.laser.profile_focal_distance = np.sqrt(
-                (laser.focal_position[0] - self.position[0]) ** 2
-                + (laser.focal_position[1] - self.position[1]) ** 2
-                + (laser.focal_position[2] - self.position[2]) ** 2
+            laser.laser.profile_focal_distance = (
+                (laser.focal_position[0] - self.position[0]) * self.normal_vector[0]
+                + (laser.focal_position[1] - self.position[1]) * self.normal_vector[1]
+                + (laser.focal_position[2] - self.position[2]) * self.normal_vector[2]
             )
             # The time at which the laser reaches its peak (in seconds)
             laser.laser.profile_t_peak = (
-                np.sqrt(
-                    (self.position[0] - laser.centroid_position[0]) ** 2
-                    + (self.position[1] - laser.centroid_position[1]) ** 2
-                    + (self.position[2] - laser.centroid_position[2]) ** 2
-                )
-                / constants.c
-            )
+                (self.position[0] - laser.centroid_position[0]) * self.normal_vector[0]
+                + (self.position[1] - laser.centroid_position[1])
+                * self.normal_vector[1]
+                + (self.position[2] - laser.centroid_position[2])
+                * self.normal_vector[2]
+            ) / constants.c
 
 
 class LoadInitialField(picmistandard.PICMI_LoadGriddedField):

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1986,8 +1986,10 @@ class LaserAntenna(picmistandard.PICMI_LaserAntenna):
                 "specified antenna normal."
             )
         self.normal_vector = laser.laser.direction  # The plane normal direction
+        # Ensure the normal vector is a unit vector
+        self.normal_vector /= np.linalg.norm(self.normal_vector)
         if isinstance(laser, GaussianLaser):
-            # Focal distance from the antenna (in meters)
+            # Focal displacement from the antenna (in meters)
             laser.laser.profile_focal_distance = (
                 (laser.focal_position[0] - self.position[0]) * self.normal_vector[0]
                 + (laser.focal_position[1] - self.position[1]) * self.normal_vector[1]


### PR DESCRIPTION
This is a update on https://github.com/ECP-WarpX/WarpX/pull/3477. 
When initializing a laser with PICMI, we should allow the possibility of having negative focal distance (meaning the laser would have focused **before** the antenna, and the antenna is injecting a laser that is in the process of **defocusing**), as pointed out in https://github.com/ECP-WarpX/WarpX/issues/5144.

In this PR, the focal distance is computed as the **projection** of the distance between the antenna and the focal point, along the **normal vector**.

For consistency, this PR allows changes `t_peak` in a similar manner, although a negative `t_peak` is probably a less common use case.