### PR TITLE
Increase time limit for clang-tidy

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -13,7 +13,7 @@ jobs:
         dim: [1, 2, RZ, 3]
     name: clang-tidy-${{ matrix.dim }}D
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 180
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The RZ clang-tidy test has been failing recently due to time-out.
This PR increases the time limit.