### PR TITLE
Generalization of WarpXSolverVec class used by implicit solvers

### DIFF
--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -42,15 +42,14 @@ namespace warpx::fields
     inline bool
     isFieldArray (const FieldType field_type)
     {
-        if (field_type == FieldType::Efield_aux || field_type == FieldType::Bfield_aux ||
-            field_type == FieldType::Efield_fp  || field_type == FieldType::Bfield_fp ||
-            field_type == FieldType::current_fp || field_type == FieldType::current_fp_nodal ||
-            field_type == FieldType::vector_potential_fp ||
-            field_type == FieldType::Efield_cp  || field_type == FieldType::Bfield_cp ||
-            field_type == FieldType::current_cp ||
-            field_type == FieldType::Efield_avg_fp || field_type == FieldType::Bfield_avg_fp ||
-            field_type == FieldType::Efield_avg_cp || field_type == FieldType::Bfield_avg_cp) { return true; }
-        else { return false; }
+        return (field_type == FieldType::Efield_aux || field_type == FieldType::Bfield_aux ||
+                field_type == FieldType::Efield_fp  || field_type == FieldType::Bfield_fp ||
+                field_type == FieldType::current_fp || field_type == FieldType::current_fp_nodal ||
+                field_type == FieldType::vector_potential_fp ||
+                field_type == FieldType::Efield_cp  || field_type == FieldType::Bfield_cp ||
+                field_type == FieldType::current_cp ||
+                field_type == FieldType::Efield_avg_fp || field_type == FieldType::Bfield_avg_fp ||
+                field_type == FieldType::Efield_avg_cp || field_type == FieldType::Bfield_avg_cp);
     }
 }
 

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -8,6 +8,7 @@
 #define WARPX_FIELDS_H_
 
 #include <algorithm>
+#include <iterator>
 
 namespace warpx::fields
 {

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -11,6 +11,7 @@ namespace warpx::fields
 {
     enum struct FieldType : int
     {
+        None,
         Efield_aux,
         Bfield_aux,
         Efield_fp,

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -38,6 +38,20 @@ namespace warpx::fields
         Efield_avg_cp,
         Bfield_avg_cp
     };
+
+    inline bool
+    isFieldArray (const FieldType field_type)
+    {
+        if (field_type == FieldType::Efield_aux || field_type == FieldType::Bfield_aux ||
+            field_type == FieldType::Efield_fp  || field_type == FieldType::Bfield_fp ||
+            field_type == FieldType::current_fp || field_type == FieldType::current_fp_nodal ||
+            field_type == FieldType::vector_potential_fp ||
+            field_type == FieldType::Efield_cp  || field_type == FieldType::Bfield_cp ||
+            field_type == FieldType::current_cp ||
+            field_type == FieldType::Efield_avg_fp || field_type == FieldType::Bfield_avg_fp ||
+            field_type == FieldType::Efield_avg_cp || field_type == FieldType::Bfield_avg_cp) { return true; }
+        else { return false; }
+    }
 }
 
 #endif //WARPX_FIELDS_H_

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -7,6 +7,8 @@
 #ifndef WARPX_FIELDS_H_
 #define WARPX_FIELDS_H_
 
+#include <algorithm>
+
 namespace warpx::fields
 {
     enum struct FieldType : int
@@ -45,13 +47,11 @@ namespace warpx::fields
             FieldType::Efield_cp, FieldType::Bfield_cp, FieldType::current_cp,
             FieldType::Efield_avg_fp, FieldType::Bfield_avg_fp, FieldType::Efield_avg_cp, FieldType::Bfield_avg_cp};
 
-    constexpr bool
+    inline bool
     isFieldArray (const FieldType field_type)
     {
-        for (const auto& f : ArrayFieldTypes) {
-            if (f == field_type) { return true; }
-        }
-        return false;
+        return std::any_of( std::begin(ArrayFieldTypes), std::end(ArrayFieldTypes),
+            [field_type](const FieldType& f) { return f == field_type; });
     }
 
 }

--- a/Source/FieldSolver/Fields.H
+++ b/Source/FieldSolver/Fields.H
@@ -39,18 +39,21 @@ namespace warpx::fields
         Bfield_avg_cp
     };
 
-    inline bool
+    constexpr FieldType ArrayFieldTypes[] = {
+            FieldType::Efield_aux, FieldType::Bfield_aux, FieldType::Efield_fp, FieldType::Bfield_fp,
+            FieldType::current_fp, FieldType::current_fp_nodal, FieldType::vector_potential_fp,
+            FieldType::Efield_cp, FieldType::Bfield_cp, FieldType::current_cp,
+            FieldType::Efield_avg_fp, FieldType::Bfield_avg_fp, FieldType::Efield_avg_cp, FieldType::Bfield_avg_cp};
+
+    constexpr bool
     isFieldArray (const FieldType field_type)
     {
-        return (field_type == FieldType::Efield_aux || field_type == FieldType::Bfield_aux ||
-                field_type == FieldType::Efield_fp  || field_type == FieldType::Bfield_fp ||
-                field_type == FieldType::current_fp || field_type == FieldType::current_fp_nodal ||
-                field_type == FieldType::vector_potential_fp ||
-                field_type == FieldType::Efield_cp  || field_type == FieldType::Bfield_cp ||
-                field_type == FieldType::current_cp ||
-                field_type == FieldType::Efield_avg_fp || field_type == FieldType::Bfield_avg_fp ||
-                field_type == FieldType::Efield_avg_cp || field_type == FieldType::Bfield_avg_cp);
+        for (const auto& f : ArrayFieldTypes) {
+            if (f == field_type) { return true; }
+        }
+        return false;
     }
+
 }
 
 #endif //WARPX_FIELDS_H_

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -67,16 +67,16 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
 
     // Save electric field at the start of the step
     m_Eold.Copy( FieldType::Efield_fp );
+    m_E.Copy( m_Eold ); // initial guess for E
 
-    // Advance WarpX owned Bfield_fp to t_{n+1/2}
+    // Compute Bfield at time n+1/2
     m_WarpX->EvolveB(a_dt, DtType::Full);
     m_WarpX->ApplyMagneticFieldBCs();
 
     const amrex::Real half_time = a_time + 0.5_rt*a_dt;
 
-    // Solve nonlinear system for Eg at t_{n+1/2}
+    // Solve nonlinear system for E at t_{n+1/2}
     // Particles will be advanced to t_{n+1/2}
-    m_E.Copy( m_Eold ); // initial guess for Eg^{n+1/2}
     m_nlsolver->Solve( m_E, m_Eold, half_time, a_dt );
 
     // Update WarpX owned Efield_fp to t_{n+1/2}
@@ -85,8 +85,8 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     // Advance particles from time n+1/2 to time n+1
     m_WarpX->FinishImplicitParticleUpdate();
 
-    // Advance Eg from time n+1/2 to time n+1
-    // Eg^{n+1} = 2.0*Eg^{n+1/2} - Eg^n
+    // Advance E fields from time n+1/2 to time n+1
+    // Eg^{n+1} = 2.0*E_g^{n+1/2} - E_g^n
     m_E.linComb( 2._rt, m_E, -1._rt, m_Eold );
     m_WarpX->SetElectricFieldAndApplyBCs( m_E );
 
@@ -107,6 +107,6 @@ void SemiImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
     // of Eg and Bg. Deposit current density at time n+1/2
     m_WarpX->ImplicitPreRHSOp( a_time, a_dt, a_nl_iter, a_from_jacobian );
 
-    // RHS = cvac^2*0.5*dt*( curl(Bg^{n+1/2}) - mu0*Jg^{n+1/2} )
+    // RHS = cvac^2*0.5*dt*( curl(B^{n+1/2}) - mu0*J^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(0.5_rt*a_dt, a_RHS);
 }

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -20,13 +20,8 @@ void SemiImplicitEM::Define ( WarpX*  a_WarpX )
     m_WarpX = a_WarpX;
 
     // Define E and Eold vectors
-    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
-    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
-
-    // Need to define the WarpXSolverVec owned dot_mask to do dot
-    // product correctly for linear and nonlinear solvers
-    const amrex::Vector<amrex::Geometry>& Geom = m_WarpX->Geom();
-    m_E.SetDotMask(Geom);
+    m_E.Define( m_WarpX, FieldType::Efield_fp );
+    m_Eold.Define( m_E );
 
     // Parse implicit solver parameters
     const amrex::ParmParse pp("implicit_evolve");

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -76,7 +76,7 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
 
     // Solve nonlinear system for Eg at t_{n+1/2}
     // Particles will be advanced to t_{n+1/2}
-    m_E.Copy(m_Eold); // initial guess for Eg^{n+1/2}
+    m_E.Copy( m_Eold ); // initial guess for Eg^{n+1/2}
     m_nlsolver->Solve( m_E, m_Eold, half_time, a_dt );
 
     // Update WarpX owned Efield_fp to t_{n+1/2}

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -20,8 +20,8 @@ void SemiImplicitEM::Define ( WarpX*  a_WarpX )
     m_WarpX = a_WarpX;
 
     // Define E and Eold vectors
-    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp) );
-    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp) );
+    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
+    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
 
     // Need to define the WarpXSolverVec owned dot_mask to do dot
     // product correctly for linear and nonlinear solvers
@@ -70,8 +70,9 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     // Save up and xp at the start of the time step
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
-    // Save Eg at the start of the time step
-    m_Eold.Copy( m_WarpX->getMultiLevelField(FieldType::Efield_fp) );
+    // Save the fields at the start of the step
+    m_Eold.Copy( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
+    m_E.Copy(m_Eold); // initial guess for E
 
     // Advance WarpX owned Bfield_fp to t_{n+1/2}
     m_WarpX->EvolveB(a_dt, DtType::Full);

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -65,9 +65,9 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     // Save up and xp at the start of the time step
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
-    // Save electric field at the start of the step
+    // Save the fields at the start of the step
     m_Eold.Copy( FieldType::Efield_fp );
-    m_E.Copy( m_Eold ); // initial guess for E
+    m_E.Copy(m_Eold); // initial guess for E
 
     // Compute Bfield at time n+1/2
     m_WarpX->EvolveB(a_dt, DtType::Full);

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -65,9 +65,8 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     // Save up and xp at the start of the time step
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
-    // Save the fields at the start of the step
-    m_Eold.Copy( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
-    m_E.Copy(m_Eold); // initial guess for E
+    // Save electric field at the start of the step
+    m_Eold.Copy( FieldType::Efield_fp );
 
     // Advance WarpX owned Bfield_fp to t_{n+1/2}
     m_WarpX->EvolveB(a_dt, DtType::Full);

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -154,8 +154,8 @@ void ThetaImplicitEM::FinishFieldUpdate ( amrex::Real  a_new_time )
 {
     amrex::ignore_unused(a_new_time);
 
-    // Eg^{n+1} = (1/theta)*Eg^{n+theta} + (1-1/theta)*Eg^n
-    // Bg^{n+1} = (1/theta)*Bg^{n+theta} + (1-1/theta)*Bg^n
+    // Eg^{n+1} = (1/theta)*E_g^{n+theta} + (1-1/theta)*E_g^n
+    // Bg^{n+1} = (1/theta)*B_g^{n+theta} + (1-1/theta)*B_g^n
 
     const amrex::Real c0 = 1._rt/m_theta;
     const amrex::Real c1 = 1._rt - c0;

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -102,7 +102,7 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  a_time,
 
     // Solve nonlinear system for Eg at t_{n+theta}
     // Particles will be advanced to t_{n+1/2}
-    m_E.Copy(m_Eold); // initial guess for Eg^{n+theta}
+    m_E.Copy( m_Eold ); // initial guess for Eg^{n+theta}
     m_nlsolver->Solve( m_E, m_Eold, theta_time, a_dt );
 
     // Update WarpX owned Efield_fp and Bfield_fp to t_{n+theta}

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -21,13 +21,8 @@ void ThetaImplicitEM::Define ( WarpX* const  a_WarpX )
     m_WarpX = a_WarpX;
 
     // Define E and Eold vectors
-    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
-    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
-
-    // Need to define the WarpXSolverVec owned dot_mask to do dot
-    // product correctly for linear and nonlinear solvers
-    const amrex::Vector<amrex::Geometry>& Geom = m_WarpX->Geom();
-    m_E.SetDotMask(Geom);
+    m_E.Define( m_WarpX, FieldType::Efield_fp );
+    m_Eold.Define( m_E );
 
     // Define Bold MultiFab
     const int num_levels = 1;

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -86,9 +86,9 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  a_time,
     // Save up and xp at the start of the time step
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
-    // Save electric field at the start of the step
+    // Save the fields at the start of the step
     m_Eold.Copy( FieldType::Efield_fp );
-    m_E.Copy( m_Eold ); // initial guess for E
+    m_E.Copy(m_Eold); // initial guess for E
 
     const int num_levels = static_cast<int>(m_Bold.size());
     for (int lev = 0; lev < num_levels; ++lev) {

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -86,9 +86,8 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  a_time,
     // Save up and xp at the start of the time step
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
-    // Save the fields at the start of the step
+    // Save Eg at the start of the time step
     m_Eold.Copy( FieldType::Efield_fp );
-    m_E.Copy(m_Eold); // initial guess for E
 
     const int num_levels = static_cast<int>(m_Bold.size());
     for (int lev = 0; lev < num_levels; ++lev) {
@@ -101,8 +100,9 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  a_time,
 
     const amrex::Real theta_time = a_time + m_theta*a_dt;
 
-    // Solve nonlinear system for E at t_{n+theta}
+    // Solve nonlinear system for Eg at t_{n+theta}
     // Particles will be advanced to t_{n+1/2}
+    m_E.Copy(m_Eold); // initial guess for Eg^{n+theta}
     m_nlsolver->Solve( m_E, m_Eold, theta_time, a_dt );
 
     // Update WarpX owned Efield_fp and Bfield_fp to t_{n+theta}
@@ -111,7 +111,7 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  a_time,
     // Advance particles from time n+1/2 to time n+1
     m_WarpX->FinishImplicitParticleUpdate();
 
-    // Advance E and B fields from time n+theta to time n+1
+    // Advance Eg and Bg from time n+theta to time n+1
     const amrex::Real new_time = a_time + a_dt;
     FinishFieldUpdate( new_time );
 
@@ -132,7 +132,7 @@ void ThetaImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
     // of Eg and Bg. Deposit current density at time n+1/2
     m_WarpX->ImplicitPreRHSOp( a_time, a_dt, a_nl_iter, a_from_jacobian );
 
-    // RHS = cvac^2*m_theta*dt*( curl(B^{n+theta}) - mu0*J^{n+1/2} )
+    // RHS = cvac^2*m_theta*dt*( curl(Bg^{n+theta}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(m_theta*a_dt, a_RHS);
 }
 
@@ -154,8 +154,8 @@ void ThetaImplicitEM::FinishFieldUpdate ( amrex::Real  a_new_time )
 {
     amrex::ignore_unused(a_new_time);
 
-    // Eg^{n+1} = (1/theta)*E_g^{n+theta} + (1-1/theta)*E_g^n
-    // Bg^{n+1} = (1/theta)*B_g^{n+theta} + (1-1/theta)*B_g^n
+    // Eg^{n+1} = (1/theta)*Eg^{n+theta} + (1-1/theta)*Eg^n
+    // Bg^{n+1} = (1/theta)*Bg^{n+theta} + (1-1/theta)*Bg^n
 
     const amrex::Real c0 = 1._rt/m_theta;
     const amrex::Real c1 = 1._rt - c0;

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -21,8 +21,8 @@ void ThetaImplicitEM::Define ( WarpX* const  a_WarpX )
     m_WarpX = a_WarpX;
 
     // Define E and Eold vectors
-    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp) );
-    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp) );
+    m_E.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
+    m_Eold.Define( m_WarpX->getMultiLevelField(FieldType::Efield_fp), FieldType::Efield_fp );
 
     // Need to define the WarpXSolverVec owned dot_mask to do dot
     // product correctly for linear and nonlinear solvers

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -11,6 +11,7 @@
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 #include "Evolve/WarpXDtType.H"
 #include "Evolve/WarpXPushType.H"
+#include "FieldSolver/Fields.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "Parallelization/GuardCellManager.H"
 #include "Particles/MultiParticleContainer.H"
@@ -68,7 +69,11 @@ WarpX::ImplicitPreRHSOp ( amrex::Real  a_cur_time,
 void
 WarpX::SetElectricFieldAndApplyBCs ( const WarpXSolverVec&  a_E )
 {
-    const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& Evec = a_E.getVec();
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        a_E.getFieldVecType()==warpx::fields::FieldType::Efield_fp,
+        "WarpX::SetElectricFieldAndApplyBCs() must be called with Efield_fp type");
+
+    const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& Evec = a_E.getFieldVec();
     amrex::MultiFab::Copy(*Efield_fp[0][0], *Evec[0][0], 0, 0, ncomps, Evec[0][0]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][1], *Evec[0][1], 0, 0, ncomps, Evec[0][1]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][2], *Evec[0][2], 0, 0, ncomps, Evec[0][2]->nGrowVect());
@@ -316,22 +321,26 @@ WarpX::ImplicitComputeRHSE (int lev, amrex::Real a_dt, WarpXSolverVec&  a_Erhs_v
 void
 WarpX::ImplicitComputeRHSE (int lev, PatchType patch_type, amrex::Real a_dt, WarpXSolverVec&  a_Erhs_vec)
 {
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        a_Erhs_vec.getFieldVecType()==warpx::fields::FieldType::Efield_fp,
+        "WarpX::ImplicitComputeRHSE() must be called with Efield_fp type");
+
     // set RHS to zero value
-    a_Erhs_vec.getVec()[lev][0]->setVal(0.0);
-    a_Erhs_vec.getVec()[lev][1]->setVal(0.0);
-    a_Erhs_vec.getVec()[lev][2]->setVal(0.0);
+    a_Erhs_vec.getFieldVec()[lev][0]->setVal(0.0);
+    a_Erhs_vec.getFieldVec()[lev][1]->setVal(0.0);
+    a_Erhs_vec.getFieldVec()[lev][2]->setVal(0.0);
 
     // Compute Efield_rhs in regular cells by calling EvolveE. Because
     // a_Erhs_vec is set to zero above, calling EvolveE below results in
     // a_Erhs_vec storing only the RHS of the update equation. I.e.,
     // c^2*dt*(curl(B^{n+theta} - mu0*J^{n+1/2})
     if (patch_type == PatchType::fine) {
-        m_fdtd_solver_fp[lev]->EvolveE( a_Erhs_vec.getVec()[lev], Bfield_fp[lev],
+        m_fdtd_solver_fp[lev]->EvolveE( a_Erhs_vec.getFieldVec()[lev], Bfield_fp[lev],
                                         current_fp[lev], m_edge_lengths[lev],
                                         m_face_areas[lev], ECTRhofield[lev],
                                         F_fp[lev], lev, a_dt );
     } else {
-        m_fdtd_solver_cp[lev]->EvolveE( a_Erhs_vec.getVec()[lev], Bfield_cp[lev],
+        m_fdtd_solver_cp[lev]->EvolveE( a_Erhs_vec.getFieldVec()[lev], Bfield_cp[lev],
                                         current_cp[lev], m_edge_lengths[lev],
                                         m_face_areas[lev], ECTRhofield[lev],
                                         F_cp[lev], lev, a_dt );

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -70,10 +70,10 @@ void
 WarpX::SetElectricFieldAndApplyBCs ( const WarpXSolverVec&  a_E )
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        a_E.getFieldVecType()==warpx::fields::FieldType::Efield_fp,
+        a_E.getArrayVecType()==warpx::fields::FieldType::Efield_fp,
         "WarpX::SetElectricFieldAndApplyBCs() must be called with Efield_fp type");
 
-    const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& Evec = a_E.getFieldVec();
+    const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& Evec = a_E.getArrayVec();
     amrex::MultiFab::Copy(*Efield_fp[0][0], *Evec[0][0], 0, 0, ncomps, Evec[0][0]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][1], *Evec[0][1], 0, 0, ncomps, Evec[0][1]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][2], *Evec[0][2], 0, 0, ncomps, Evec[0][2]->nGrowVect());
@@ -322,25 +322,25 @@ void
 WarpX::ImplicitComputeRHSE (int lev, PatchType patch_type, amrex::Real a_dt, WarpXSolverVec&  a_Erhs_vec)
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        a_Erhs_vec.getFieldVecType()==warpx::fields::FieldType::Efield_fp,
+        a_Erhs_vec.getArrayVecType()==warpx::fields::FieldType::Efield_fp,
         "WarpX::ImplicitComputeRHSE() must be called with Efield_fp type");
 
     // set RHS to zero value
-    a_Erhs_vec.getFieldVec()[lev][0]->setVal(0.0);
-    a_Erhs_vec.getFieldVec()[lev][1]->setVal(0.0);
-    a_Erhs_vec.getFieldVec()[lev][2]->setVal(0.0);
+    a_Erhs_vec.getArrayVec()[lev][0]->setVal(0.0);
+    a_Erhs_vec.getArrayVec()[lev][1]->setVal(0.0);
+    a_Erhs_vec.getArrayVec()[lev][2]->setVal(0.0);
 
     // Compute Efield_rhs in regular cells by calling EvolveE. Because
     // a_Erhs_vec is set to zero above, calling EvolveE below results in
     // a_Erhs_vec storing only the RHS of the update equation. I.e.,
     // c^2*dt*(curl(B^{n+theta} - mu0*J^{n+1/2})
     if (patch_type == PatchType::fine) {
-        m_fdtd_solver_fp[lev]->EvolveE( a_Erhs_vec.getFieldVec()[lev], Bfield_fp[lev],
+        m_fdtd_solver_fp[lev]->EvolveE( a_Erhs_vec.getArrayVec()[lev], Bfield_fp[lev],
                                         current_fp[lev], m_edge_lengths[lev],
                                         m_face_areas[lev], ECTRhofield[lev],
                                         F_fp[lev], lev, a_dt );
     } else {
-        m_fdtd_solver_cp[lev]->EvolveE( a_Erhs_vec.getFieldVec()[lev], Bfield_cp[lev],
+        m_fdtd_solver_cp[lev]->EvolveE( a_Erhs_vec.getArrayVec()[lev], Bfield_cp[lev],
                                         current_cp[lev], m_edge_lengths[lev],
                                         m_face_areas[lev], ECTRhofield[lev],
                                         F_cp[lev], lev, a_dt );

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -62,7 +62,7 @@ public:
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
     void Define ( WarpX*     a_WarpX,
-                  warpx::fields::FieldType  a_field_type,
+                  warpx::fields::FieldType  a_array_type,
                   warpx::fields::FieldType  a_scalar_type = warpx::fields::FieldType::None );
 
     inline
@@ -72,13 +72,13 @@ public:
             a_solver_vec.IsDefined(),
             "WarpXSolverVec::Define(solver_vec) called with undefined solver_vec");
         Define( WarpXSolverVec::m_WarpX,
-                a_solver_vec.getFieldVecType(),
+                a_solver_vec.getArrayVecType(),
                 a_solver_vec.getScalarVecType() );
     }
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
-    void Copy ( warpx::fields::FieldType  a_field_type,
+    void Copy ( warpx::fields::FieldType  a_array_type,
                 warpx::fields::FieldType  a_scalar_type = warpx::fields::FieldType::None );
 
     inline
@@ -89,17 +89,17 @@ public:
             "WarpXSolverVec::Copy(solver_vec) called with undefined solver_vec");
         if (IsDefined()) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                a_solver_vec.getFieldVecType()==m_field_type &&
+                a_solver_vec.getArrayVecType()==m_array_type &&
                 a_solver_vec.getScalarVecType()==m_scalar_type,
                 "WarpXSolverVec::Copy(solver_vec) called with vecs of different types");
         }
         else { Define(a_solver_vec); }
 
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
+            if (m_array_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; ++n) {
-                    const std::unique_ptr<amrex::MultiFab>& this_field = a_solver_vec.getFieldVec()[lev][n];
-                    amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_field, 0, 0, m_ncomp,
+                    const std::unique_ptr<amrex::MultiFab>& this_field = a_solver_vec.getArrayVec()[lev][n];
+                    amrex::MultiFab::Copy( *m_array_vec[lev][n], *this_field, 0, 0, m_ncomp,
                                            amrex::IntVect::TheZeroVector() );
                 }
             }
@@ -119,9 +119,9 @@ public:
     WarpXSolverVec& operator= ( WarpXSolverVec&&  a_solver_vec ) noexcept
     {
         if (this != &a_solver_vec) {
-            m_field_vec = std::move(a_solver_vec.m_field_vec);
+            m_array_vec = std::move(a_solver_vec.m_array_vec);
             m_scalar_vec = std::move(a_solver_vec.m_scalar_vec);
-            m_field_type = a_solver_vec.m_field_type;
+            m_array_type = a_solver_vec.m_array_type;
             m_scalar_type = a_solver_vec.m_scalar_type;
             m_is_defined = true;
         }
@@ -132,14 +132,14 @@ public:
     void operator+= ( const WarpXSolverVec&  a_solver_vec )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.getFieldVecType()==m_field_type &&
+            a_solver_vec.getArrayVecType()==m_array_type &&
             a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator += solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
-                m_field_vec[lev][0]->plus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
-                m_field_vec[lev][1]->plus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
-                m_field_vec[lev][2]->plus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
+            if (m_array_type != warpx::fields::FieldType::None) {
+                m_array_vec[lev][0]->plus(*(a_solver_vec.getArrayVec()[lev][0]), 0, 1, 0);
+                m_array_vec[lev][1]->plus(*(a_solver_vec.getArrayVec()[lev][1]), 0, 1, 0);
+                m_array_vec[lev][2]->plus(*(a_solver_vec.getArrayVec()[lev][2]), 0, 1, 0);
             }
             if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->plus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
@@ -151,14 +151,14 @@ public:
     void operator-= (const WarpXSolverVec& a_solver_vec)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.getFieldVecType()==m_field_type &&
+            a_solver_vec.getArrayVecType()==m_array_type &&
             a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator -= solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
-                m_field_vec[lev][0]->minus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
-                m_field_vec[lev][1]->minus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
-                m_field_vec[lev][2]->minus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
+            if (m_array_type != warpx::fields::FieldType::None) {
+                m_array_vec[lev][0]->minus(*(a_solver_vec.getArrayVec()[lev][0]), 0, 1, 0);
+                m_array_vec[lev][1]->minus(*(a_solver_vec.getArrayVec()[lev][1]), 0, 1, 0);
+                m_array_vec[lev][2]->minus(*(a_solver_vec.getArrayVec()[lev][2]), 0, 1, 0);
             }
             if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->minus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
@@ -173,18 +173,18 @@ public:
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.getFieldVecType()==m_field_type &&
+            X.getArrayVecType()==m_array_type &&
             X.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec X of different type");
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            Y.getFieldVecType()==m_field_type &&
+            Y.getArrayVecType()==m_array_type &&
             Y.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec Y of different type");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
+            if (m_array_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
-                    amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getFieldVec()[lev][n], 0,
-                                                                   b, *Y.getFieldVec()[lev][n], 0,
+                    amrex::MultiFab::LinComb(*m_array_vec[lev][n], a, *X.getArrayVec()[lev][n], 0,
+                                                                   b, *Y.getArrayVec()[lev][n], 0,
                                                                    0, 1, 0);
                 }
             }
@@ -202,13 +202,13 @@ public:
     void increment (const WarpXSolverVec& X, const RT a)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.getFieldVecType()==m_field_type &&
+            X.getArrayVecType()==m_array_type &&
             X.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::increment(X,a) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
+            if (m_array_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
-                    amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getFieldVec()[lev][n],
+                    amrex::MultiFab::Saxpy( *m_array_vec[lev][n], a, *X.getArrayVec()[lev][n],
                                             0, 0, 1, amrex::IntVect::TheZeroVector() );
                 }
             }
@@ -226,10 +226,10 @@ public:
     void scale (RT a_a)
     {
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
-                m_field_vec[lev][0]->mult(a_a, 0, 1);
-                m_field_vec[lev][1]->mult(a_a, 0, 1);
-                m_field_vec[lev][2]->mult(a_a, 0, 1);
+            if (m_array_type != warpx::fields::FieldType::None) {
+                m_array_vec[lev][0]->mult(a_a, 0, 1);
+                m_array_vec[lev][1]->mult(a_a, 0, 1);
+                m_array_vec[lev][2]->mult(a_a, 0, 1);
             }
             if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->mult(a_a, 0, 1);
@@ -247,10 +247,10 @@ public:
             IsDefined(),
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != warpx::fields::FieldType::None) {
-                m_field_vec[lev][0]->setVal(a_val);
-                m_field_vec[lev][1]->setVal(a_val);
-                m_field_vec[lev][2]->setVal(a_val);
+            if (m_array_type != warpx::fields::FieldType::None) {
+                m_array_vec[lev][0]->setVal(a_val);
+                m_array_vec[lev][1]->setVal(a_val);
+                m_array_vec[lev][2]->setVal(a_val);
             }
             if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->setVal(a_val);
@@ -264,22 +264,22 @@ public:
         return std::sqrt(norm);
     }
 
-    [[nodiscard]] const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getFieldVec() const {return m_field_vec;}
-    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getFieldVec() {return m_field_vec;}
+    [[nodiscard]] const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getArrayVec() const {return m_array_vec;}
+    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getArrayVec() {return m_array_vec;}
 
     [[nodiscard]] const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() const {return m_scalar_vec;}
     amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() {return m_scalar_vec;}
 
     // solver vec types are limited to warpx::fields::warpx::fields::FieldType
-    [[nodiscard]] warpx::fields::FieldType getFieldVecType () const { return m_field_type; }
+    [[nodiscard]] warpx::fields::FieldType getArrayVecType () const { return m_array_type; }
     [[nodiscard]] warpx::fields::FieldType getScalarVecType () const { return m_scalar_type; }
 
 private:
 
     bool m_is_defined = false;
-    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>> m_field_vec;
+    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>> m_array_vec;
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_scalar_vec;
-    warpx::fields::FieldType m_field_type = warpx::fields::FieldType::None;
+    warpx::fields::FieldType m_array_type = warpx::fields::FieldType::None;
     warpx::fields::FieldType m_scalar_type = warpx::fields::FieldType::None;
 
     static constexpr int m_ncomp = 1;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -62,91 +62,91 @@ public:
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
     void Define ( WarpX*                    a_WarpX,
-            const warpx::fields::FieldType  a_solver_vec_type );
+            const warpx::fields::FieldType  a_field_type );
 
     inline
-    void Define (const WarpXSolverVec& a_vec)
+    void Define ( const WarpXSolverVec&  a_solver_vec )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_vec.IsDefined(),
-            "WarpXSolverVec::Define(a_vec) called with undefined a_vec");
-        Define( a_vec.m_WarpX, a_vec.getVecType() );
+            a_solver_vec.IsDefined(),
+            "WarpXSolverVec::Define(solver_vec) called with undefined solver_vec");
+        Define( a_solver_vec.m_WarpX, a_solver_vec.getVecType() );
     }
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
     inline
-    void Copy ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec,
-                const warpx::fields::FieldType                                           a_solver_vec_type )
+    void Copy ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_field_vec,
+                const warpx::fields::FieldType                                           a_field_type )
     {
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
             "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec_type==m_solver_vec_type,
+            a_field_type==m_field_type,
             "WarpXSolverVec::Copy() called with vecs of different types");
         for (int lev=0; lev<m_num_amr_levels; ++lev) {
             for (int n=0; n<3; ++n) {
-                amrex::MultiFab::Copy( *m_solver_vec[lev][n], *a_solver_vec[lev][n], 0, 0, m_ncomp,
+                amrex::MultiFab::Copy( *m_field_vec[lev][n], *a_field_vec[lev][n], 0, 0, m_ncomp,
                                        amrex::IntVect::TheZeroVector() );
             }
         }
     }
 
     inline
-    void Copy ( const WarpXSolverVec&  a_vec )
+    void Copy ( const WarpXSolverVec&  a_solver_vec )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_vec.IsDefined(),
-            "WarpXSolverVec::Copy(a_vec) called with undefined a_vec");
+            a_solver_vec.IsDefined(),
+            "WarpXSolverVec::Copy(solver_vec) called with undefined solver_vec");
         if (IsDefined()) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                a_vec.m_solver_vec_type==m_solver_vec_type,
-                "WarpXSolverVec::Copy(a_vec) called with vecs of different types");
+                a_solver_vec.m_field_type==m_field_type,
+                "WarpXSolverVec::Copy(solver_vec) called with vecs of different types");
         }
-        else { Define(a_vec); }
-        const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& solver_vec = a_vec.getVec();
-        Copy(solver_vec, a_vec.getVecType());
+        else { Define(a_solver_vec); }
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& solver_vec = a_solver_vec.getVec();
+        Copy(solver_vec, a_solver_vec.getVecType());
     }
 
     // Prohibit Copy assignment operator
-    WarpXSolverVec& operator= ( const WarpXSolverVec&  a_vec ) = delete;
+    WarpXSolverVec& operator= ( const WarpXSolverVec&  a_solver_vec ) = delete;
 
     // Move assignment operator
     WarpXSolverVec(WarpXSolverVec&&) noexcept = default;
-    WarpXSolverVec& operator= ( WarpXSolverVec&&  a_vec ) noexcept
+    WarpXSolverVec& operator= ( WarpXSolverVec&&  a_solver_vec ) noexcept
     {
-        if (this != &a_vec) {
-            m_solver_vec = std::move(a_vec.m_solver_vec);
-            m_solver_vec_type = a_vec.m_solver_vec_type;
+        if (this != &a_solver_vec) {
+            m_field_vec = std::move(a_solver_vec.m_field_vec);
+            m_field_type = a_solver_vec.m_field_type;
             m_is_defined = true;
         }
         return *this;
     }
 
     inline
-    void operator+= ( const WarpXSolverVec&  a_vec )
+    void operator+= ( const WarpXSolverVec&  a_solver_vec )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_vec.m_solver_vec_type==m_solver_vec_type,
-            "WarpXSolverVec operator += a_vec called with solver vecs of different types");
+            a_solver_vec.m_field_type==m_field_type,
+            "WarpXSolverVec operator += solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_solver_vec[lev][n]->plus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
+                m_field_vec[lev][n]->plus(*(a_solver_vec.getVec()[lev][n]), 0, 1, 0);
             }
         }
     }
 
     inline
-    void operator-= (const WarpXSolverVec& a_vec)
+    void operator-= (const WarpXSolverVec& a_solver_vec)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_vec.m_solver_vec_type==m_solver_vec_type,
-            "WarpXSolverVec operator -= a_vec called with solver vecs of different types");
+            a_solver_vec.m_field_type==m_field_type,
+            "WarpXSolverVec operator -= solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_solver_vec[lev][n]->minus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
+                m_field_vec[lev][n]->minus(*(a_solver_vec.getVec()[lev][n]), 0, 1, 0);
             }
         }
     }
@@ -158,12 +158,12 @@ public:
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.m_solver_vec_type==m_solver_vec_type &&
-            Y.m_solver_vec_type==m_solver_vec_type,
+            X.m_field_type==m_field_type &&
+            Y.m_field_type==m_field_type,
             "WarpXSolverVec::linComb(a,X,b,Y) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                amrex::MultiFab::LinComb(*m_solver_vec[lev][n], a, *X.getVec()[lev][n], 0,
+                amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getVec()[lev][n], 0,
                                                                 b, *Y.getVec()[lev][n], 0,
                                                                 0, 1, 0);
             }
@@ -176,11 +176,11 @@ public:
     void increment (const WarpXSolverVec& X, const RT a)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.m_solver_vec_type==m_solver_vec_type,
-            "WarpXSolverVec::increment(X,z) called with solver vecs of different types");
+            X.m_field_type==m_field_type,
+            "WarpXSolverVec::increment(X,a) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                amrex::MultiFab::Saxpy( *m_solver_vec[lev][n], a, *X.getVec()[lev][n],
+                amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getVec()[lev][n],
                                         0, 0, 1, amrex::IntVect::TheZeroVector() );
             }
         }
@@ -194,7 +194,7 @@ public:
     {
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_solver_vec[lev][n]->mult(a_a, 0, 1);
+                m_field_vec[lev][n]->mult(a_a, 0, 1);
             }
         }
     }
@@ -210,7 +210,7 @@ public:
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_solver_vec[lev][n]->setVal(a_val);
+                m_field_vec[lev][n]->setVal(a_val);
             }
         }
     }
@@ -221,11 +221,11 @@ public:
         return std::sqrt(norm);
     }
 
-    [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() const {return m_solver_vec;}
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_solver_vec;}
+    [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() const {return m_field_vec;}
+    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_field_vec;}
 
     // solver vec types are for now limited to warpx::fields::FieldType
-    warpx::fields::FieldType getVecType () const { return m_solver_vec_type; }
+    warpx::fields::FieldType getVecType () const { return m_field_type; }
 
     // clearDotMask() must be called by the highest class that owns WarpXSolverVec()
     // after it is done being used ( typically in the destructor ) to avoid the
@@ -236,8 +236,8 @@ public:
 private:
 
     bool m_is_defined = false;
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_solver_vec;
-    warpx::fields::FieldType m_solver_vec_type;
+    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_field_vec;
+    warpx::fields::FieldType m_field_type;
 
     static constexpr int m_ncomp = 1;
     static constexpr int m_num_amr_levels = 1;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -229,6 +229,9 @@ public:
     inline
     void scale (RT a_a)
     {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            IsDefined(),
+            "WarpXSolverVec::scale() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 m_array_vec[lev][0]->mult(a_a, 0, 1);
@@ -249,7 +252,7 @@ public:
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
-            "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
+            "WarpXSolverVec::setVal() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 m_array_vec[lev][0]->setVal(a_val);

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -96,10 +96,10 @@ public:
                 const warpx::fields::FieldType                                           a_solver_vec_type )
     {
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
             "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_solver_vec_type==m_solver_vec_type,
             "WarpXSolverVec::Copy() called with vecs of different types");
         for (int lev=0; lev<m_num_amr_levels; ++lev) {
@@ -113,11 +113,11 @@ public:
     inline
     void Copy ( const WarpXSolverVec&  a_vec )
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.IsDefined(),
             "WarpXSolverVec::Copy(a_vec) called with undefined a_vec");
         if (IsDefined()) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 a_vec.m_solver_vec_type==m_solver_vec_type,
                 "WarpXSolverVec::Copy(a_vec) called with vecs of different types");
         }
@@ -144,7 +144,7 @@ public:
     inline
     void operator+= ( const WarpXSolverVec&  a_vec )
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.m_solver_vec_type==m_solver_vec_type,
             "WarpXSolverVec operator += a_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
@@ -157,7 +157,7 @@ public:
     inline
     void operator-= (const WarpXSolverVec& a_vec)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.m_solver_vec_type==m_solver_vec_type,
             "WarpXSolverVec operator -= a_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
@@ -173,7 +173,7 @@ public:
     inline
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             X.m_solver_vec_type==m_solver_vec_type &&
             Y.m_solver_vec_type==m_solver_vec_type,
             "WarpXSolverVec::linComb(a,X,b,Y) called with solver vecs of different types");
@@ -191,7 +191,7 @@ public:
      */
     void increment (const WarpXSolverVec& X, const RT a)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             X.m_solver_vec_type==m_solver_vec_type,
             "WarpXSolverVec::increment(X,z) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
@@ -221,7 +221,7 @@ public:
     inline
     void setVal ( const RT  a_val )
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -32,6 +32,8 @@
 #include <ostream>
 #include <vector>
 
+#include "FieldSolver/Fields.H"
+
 /**
  * \brief This is a wrapper class around a Vector of array of pointers to MultiFabs that
  *  contains basic math operators and functionality needed to interact with nonlinear
@@ -65,22 +67,24 @@ public:
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.IsDefined(),
             "WarpXSolverVec::Define(a_vec) called with undefined a_vec");
-        Define( a_vec.getVec() );
+        Define( a_vec.getVec(), a_vec.getVecType() );
     }
 
     inline
-    void Define ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec )
+    void Define ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec,
+                  const warpx::fields::FieldType                                           a_solver_vec_type )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             !IsDefined(),
             "WarpXSolverVec::Define() called on undefined WarpXSolverVec");
-        m_field_vec.resize(m_num_amr_levels);
+        m_solver_vec.resize(m_num_amr_levels);
         const int lev = 0;
         for (int n=0; n<3; n++) {
             const amrex::MultiFab& mf_model = *a_solver_vec[lev][n];
-            m_field_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(), mf_model.DistributionMap(),
-                                                                     mf_model.nComp(), amrex::IntVect::TheZeroVector() );
+            m_solver_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(), mf_model.DistributionMap(),
+                                                                      mf_model.nComp(), amrex::IntVect::TheZeroVector() );
         }
+        m_solver_vec_type = a_solver_vec_type;
         m_is_defined = true;
     }
 
@@ -88,14 +92,20 @@ public:
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
     inline
-    void Copy ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec )
+    void Copy ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec,
+                const warpx::fields::FieldType                                           a_solver_vec_type )
     {
-        AMREX_ASSERT_WITH_MESSAGE(
+
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
             "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
-        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n = 0; n < 3; ++n) {
-                amrex::MultiFab::Copy(*m_field_vec[lev][n], *a_solver_vec[lev][n], 0, 0, m_ncomp, amrex::IntVect::TheZeroVector() );
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            a_solver_vec_type==m_solver_vec_type,
+            "WarpXSolverVec::Copy() called with vecs of different types");
+        for (int lev=0; lev<m_num_amr_levels; ++lev) {
+            for (int n=0; n<3; ++n) {
+                amrex::MultiFab::Copy( *m_solver_vec[lev][n], *a_solver_vec[lev][n], 0, 0, m_ncomp,
+                                       amrex::IntVect::TheZeroVector() );
             }
         }
     }
@@ -103,12 +113,17 @@ public:
     inline
     void Copy ( const WarpXSolverVec&  a_vec )
     {
-        AMREX_ASSERT_WITH_MESSAGE(
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.IsDefined(),
             "WarpXSolverVec::Copy(a_vec) called with undefined a_vec");
-        if (!IsDefined()) { Define(a_vec); }
-        const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& field_vec = a_vec.getVec();
-        Copy(field_vec);
+        if (IsDefined()) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                a_vec.m_solver_vec_type==m_solver_vec_type,
+                "WarpXSolverVec::Copy(a_vec) called with vecs of different types");
+        }
+        else { Define(a_vec); }
+        const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& solver_vec = a_vec.getVec();
+        Copy(solver_vec, a_vec.getVecType());
     }
 
     // Prohibit Copy assignment operator
@@ -119,7 +134,8 @@ public:
     WarpXSolverVec& operator= ( WarpXSolverVec&&  a_vec ) noexcept
     {
         if (this != &a_vec) {
-            m_field_vec = std::move(a_vec.m_field_vec);
+            m_solver_vec = std::move(a_vec.m_solver_vec);
+            m_solver_vec_type = a_vec.m_solver_vec_type;
             m_is_defined = true;
         }
         return *this;
@@ -128,9 +144,12 @@ public:
     inline
     void operator+= ( const WarpXSolverVec&  a_vec )
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            a_vec.m_solver_vec_type==m_solver_vec_type,
+            "WarpXSolverVec operator += a_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->plus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
+                m_solver_vec[lev][n]->plus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
             }
         }
     }
@@ -138,9 +157,12 @@ public:
     inline
     void operator-= (const WarpXSolverVec& a_vec)
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            a_vec.m_solver_vec_type==m_solver_vec_type,
+            "WarpXSolverVec operator -= a_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->minus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
+                m_solver_vec[lev][n]->minus(*(a_vec.getVec()[lev][n]), 0, 1, 0);
             }
         }
     }
@@ -151,11 +173,15 @@ public:
     inline
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            X.m_solver_vec_type==m_solver_vec_type &&
+            Y.m_solver_vec_type==m_solver_vec_type,
+            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getVec()[lev][n], 0,
-                                                               b, *Y.getVec()[lev][n], 0,
-                                                               0, 1, 0);
+                amrex::MultiFab::LinComb(*m_solver_vec[lev][n], a, *X.getVec()[lev][n], 0,
+                                                                b, *Y.getVec()[lev][n], 0,
+                                                                0, 1, 0);
             }
         }
     }
@@ -165,9 +191,12 @@ public:
      */
     void increment (const WarpXSolverVec& X, const RT a)
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            X.m_solver_vec_type==m_solver_vec_type,
+            "WarpXSolverVec::increment(X,z) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getVec()[lev][n],
+                amrex::MultiFab::Saxpy( *m_solver_vec[lev][n], a, *X.getVec()[lev][n],
                                         0, 0, 1, amrex::IntVect::TheZeroVector() );
             }
         }
@@ -181,7 +210,7 @@ public:
     {
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->mult(a_a, 0, 1);
+                m_solver_vec[lev][n]->mult(a_a, 0, 1);
             }
         }
     }
@@ -192,12 +221,12 @@ public:
     inline
     void setVal ( const RT  a_val )
     {
-        AMREX_ASSERT_WITH_MESSAGE(
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             IsDefined(),
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->setVal(a_val);
+                m_solver_vec[lev][n]->setVal(a_val);
             }
         }
     }
@@ -208,8 +237,11 @@ public:
         return std::sqrt(norm);
     }
 
-    [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() const {return m_field_vec;}
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_field_vec;}
+    [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() const {return m_solver_vec;}
+    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_solver_vec;}
+
+    // solver vec types are for now limited to warpx::fields::FieldType
+    warpx::fields::FieldType getVecType () const { return m_solver_vec_type; }
 
     // clearDotMask() must be called by the highest class that owns WarpXSolverVec()
     // after it is done being used ( typically in the destructor ) to avoid the
@@ -219,8 +251,9 @@ public:
 
 private:
 
-    bool  m_is_defined = false;
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_field_vec;
+    bool m_is_defined = false;
+    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_solver_vec;
+    warpx::fields::FieldType m_solver_vec_type;
 
     static constexpr int m_ncomp = 1;
     static constexpr int m_num_amr_levels = 1;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -45,6 +45,8 @@
  *  be used for other solver vectors, such as electrostatic (array size 1) or Darwin (array size 4).
  */
 
+using namespace warpx::fields;
+
 class WarpX;
 class WarpXSolverVec
 {
@@ -61,8 +63,9 @@ public:
 
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
-    void Define ( WarpX*                    a_WarpX,
-                  warpx::fields::FieldType  a_field_type );
+    void Define ( WarpX*     a_WarpX,
+                  FieldType  a_field_type,
+                  FieldType  a_scalar_type = FieldType::None );
 
     inline
     void Define ( const WarpXSolverVec&  a_solver_vec )
@@ -70,12 +73,15 @@ public:
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_solver_vec.IsDefined(),
             "WarpXSolverVec::Define(solver_vec) called with undefined solver_vec");
-        Define( WarpXSolverVec::m_WarpX, a_solver_vec.getVecType() );
+        Define( WarpXSolverVec::m_WarpX,
+                a_solver_vec.getFieldVecType(),
+                a_solver_vec.getScalarVecType() );
     }
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
-    void Copy ( warpx::fields::FieldType  a_field_type );
+    void Copy ( FieldType  a_field_type,
+                FieldType  a_scalar_type = FieldType::None );
 
     inline
     void Copy ( const WarpXSolverVec&  a_solver_vec )
@@ -85,15 +91,23 @@ public:
             "WarpXSolverVec::Copy(solver_vec) called with undefined solver_vec");
         if (IsDefined()) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                a_solver_vec.m_field_type==m_field_type,
+                a_solver_vec.getFieldVecType()==m_field_type &&
+                a_solver_vec.getScalarVecType()==m_scalar_type,
                 "WarpXSolverVec::Copy(solver_vec) called with vecs of different types");
         }
         else { Define(a_solver_vec); }
 
-        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec = a_solver_vec.getVec();
-        for (int lev=0; lev<m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; ++n) {
-                amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_vec[lev][n], 0, 0, m_ncomp,
+        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+            if (m_field_type != FieldType::None) {
+                for (int n = 0; n < 3; ++n) {
+                    const std::unique_ptr<amrex::MultiFab>& this_field = a_solver_vec.getFieldVec()[lev][n];
+                    amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_field, 0, 0, m_ncomp,
+                                           amrex::IntVect::TheZeroVector() );
+                }
+            }
+            if (m_scalar_type != FieldType::None) {
+                const std::unique_ptr<amrex::MultiFab>& this_scalar = a_solver_vec.getScalarVec()[lev];
+                amrex::MultiFab::Copy( *m_scalar_vec[lev], *this_scalar, 0, 0, m_ncomp,
                                        amrex::IntVect::TheZeroVector() );
             }
         }
@@ -108,7 +122,9 @@ public:
     {
         if (this != &a_solver_vec) {
             m_field_vec = std::move(a_solver_vec.m_field_vec);
+            m_scalar_vec = std::move(a_solver_vec.m_scalar_vec);
             m_field_type = a_solver_vec.m_field_type;
+            m_scalar_type = a_solver_vec.m_scalar_type;
             m_is_defined = true;
         }
         return *this;
@@ -118,11 +134,17 @@ public:
     void operator+= ( const WarpXSolverVec&  a_solver_vec )
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.m_field_type==m_field_type,
+            a_solver_vec.getFieldVecType()==m_field_type &&
+            a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator += solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->plus(*(a_solver_vec.getVec()[lev][n]), 0, 1, 0);
+            if (m_field_type != FieldType::None) {
+                m_field_vec[lev][0]->plus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
+                m_field_vec[lev][1]->plus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
+                m_field_vec[lev][2]->plus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
+            }
+            if (m_scalar_type != FieldType::None) {
+                m_scalar_vec[lev]->plus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
             }
         }
     }
@@ -131,11 +153,17 @@ public:
     void operator-= (const WarpXSolverVec& a_solver_vec)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.m_field_type==m_field_type,
+            a_solver_vec.getFieldVecType()==m_field_type &&
+            a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator -= solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->minus(*(a_solver_vec.getVec()[lev][n]), 0, 1, 0);
+            if (m_field_type != FieldType::None) {
+                m_field_vec[lev][0]->minus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
+                m_field_vec[lev][1]->minus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
+                m_field_vec[lev][2]->minus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
+            }
+            if (m_scalar_type != FieldType::None) {
+                m_scalar_vec[lev]->minus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
             }
         }
     }
@@ -147,14 +175,25 @@ public:
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.m_field_type==m_field_type &&
-            Y.m_field_type==m_field_type,
-            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vecs of different types");
+            X.getFieldVecType()==m_field_type &&
+            X.getScalarVecType()==m_scalar_type,
+            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec X of different type");
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            Y.getFieldVecType()==m_field_type &&
+            Y.getScalarVecType()==m_scalar_type,
+            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec Y of different type");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getVec()[lev][n], 0,
-                                                                b, *Y.getVec()[lev][n], 0,
-                                                                0, 1, 0);
+            if (m_field_type != FieldType::None) {
+                for (int n = 0; n < 3; n++) {
+                    amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getFieldVec()[lev][n], 0,
+                                                                   b, *Y.getFieldVec()[lev][n], 0,
+                                                                   0, 1, 0);
+                }
+            }
+            if (m_scalar_type != FieldType::None) {
+                amrex::MultiFab::LinComb(*m_scalar_vec[lev], a, *X.getScalarVec()[lev], 0,
+                                                             b, *Y.getScalarVec()[lev], 0,
+                                                             0, 1, 0);
             }
         }
     }
@@ -165,11 +204,18 @@ public:
     void increment (const WarpXSolverVec& X, const RT a)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.m_field_type==m_field_type,
+            X.getFieldVecType()==m_field_type &&
+            X.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::increment(X,a) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getVec()[lev][n],
+            if (m_field_type != FieldType::None) {
+                for (int n = 0; n < 3; n++) {
+                    amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getFieldVec()[lev][n],
+                                            0, 0, 1, amrex::IntVect::TheZeroVector() );
+                }
+            }
+            if (m_scalar_type != FieldType::None) {
+                amrex::MultiFab::Saxpy( *m_scalar_vec[lev], a, *X.getScalarVec()[lev],
                                         0, 0, 1, amrex::IntVect::TheZeroVector() );
             }
         }
@@ -182,8 +228,13 @@ public:
     void scale (RT a_a)
     {
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->mult(a_a, 0, 1);
+            if (m_field_type != FieldType::None) {
+                m_field_vec[lev][0]->mult(a_a, 0, 1);
+                m_field_vec[lev][1]->mult(a_a, 0, 1);
+                m_field_vec[lev][2]->mult(a_a, 0, 1);
+            }
+            if (m_scalar_type != FieldType::None) {
+                m_scalar_vec[lev]->mult(a_a, 0, 1);
             }
         }
     }
@@ -198,8 +249,13 @@ public:
             IsDefined(),
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; n++) {
-                m_field_vec[lev][n]->setVal(a_val);
+            if (m_field_type != FieldType::None) {
+                m_field_vec[lev][0]->setVal(a_val);
+                m_field_vec[lev][1]->setVal(a_val);
+                m_field_vec[lev][2]->setVal(a_val);
+            }
+            if (m_scalar_type != FieldType::None) {
+                m_scalar_vec[lev]->setVal(a_val);
             }
         }
     }
@@ -210,17 +266,23 @@ public:
         return std::sqrt(norm);
     }
 
-    [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() const {return m_field_vec;}
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_field_vec;}
+    [[nodiscard]] const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getFieldVec() const {return m_field_vec;}
+    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& getFieldVec() {return m_field_vec;}
 
-    // solver vec types are for now limited to warpx::fields::FieldType
-    [[nodiscard]] warpx::fields::FieldType getVecType () const { return m_field_type; }
+    [[nodiscard]] const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() const {return m_scalar_vec;}
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() {return m_scalar_vec;}
+
+    // solver vec types are limited to warpx::fields::FieldType
+    [[nodiscard]] FieldType getFieldVecType () const { return m_field_type; }
+    [[nodiscard]] FieldType getScalarVecType () const { return m_scalar_type; }
 
 private:
 
     bool m_is_defined = false;
-    amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > m_field_vec;
-    warpx::fields::FieldType m_field_type;
+    amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>> m_field_vec;
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_scalar_vec;
+    FieldType m_field_type = FieldType::None;
+    FieldType m_scalar_type = FieldType::None;
 
     static constexpr int m_ncomp = 1;
     static constexpr int m_num_amr_levels = 1;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -216,12 +216,6 @@ public:
     // solver vec types are for now limited to warpx::fields::FieldType
     warpx::fields::FieldType getVecType () const { return m_field_type; }
 
-    // clearDotMask() must be called by the highest class that owns WarpXSolverVec()
-    // after it is done being used ( typically in the destructor ) to avoid the
-    // following error message after the simulation finishes:
-    // malloc_consolidate(): unaligned fastbin chunk detected
-    static void clearDotMask() { m_dotMask.clear(); }
-
 private:
 
     bool m_is_defined = false;
@@ -234,10 +228,6 @@ private:
     inline static bool m_warpx_ptr_defined = false;
     inline static WarpX* m_WarpX = nullptr;
     void SetWarpXPointer( WarpX*  a_WarpX );
-
-    inline static bool m_dot_mask_defined = false;
-    inline static amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>,3>> m_dotMask;
-    void SetDotMask();
 
 };
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -91,12 +91,7 @@ public:
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_solver_vec.IsDefined(),
             "WarpXSolverVec::Copy(solver_vec) called with undefined solver_vec");
-        if (IsDefined()) {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                a_solver_vec.getArrayVecType()==m_array_type &&
-                a_solver_vec.getScalarVecType()==m_scalar_type,
-                "WarpXSolverVec::Copy(solver_vec) called with vecs of different types");
-        }
+        if (IsDefined()) { assertSameType( a_solver_vec ); }
         else { Define(a_solver_vec); }
 
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
@@ -135,10 +130,7 @@ public:
     inline
     void operator+= ( const WarpXSolverVec&  a_solver_vec )
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.getArrayVecType()==m_array_type &&
-            a_solver_vec.getScalarVecType()==m_scalar_type,
-            "WarpXSolverVec operator += solver_vec called with solver vecs of different types");
+        assertSameType( a_solver_vec );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 m_array_vec[lev][0]->plus(*(a_solver_vec.getArrayVec()[lev][0]), 0, 1, 0);
@@ -154,10 +146,7 @@ public:
     inline
     void operator-= (const WarpXSolverVec& a_solver_vec)
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.getArrayVecType()==m_array_type &&
-            a_solver_vec.getScalarVecType()==m_scalar_type,
-            "WarpXSolverVec operator -= solver_vec called with solver vecs of different types");
+        assertSameType( a_solver_vec );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 m_array_vec[lev][0]->minus(*(a_solver_vec.getArrayVec()[lev][0]), 0, 1, 0);
@@ -176,14 +165,8 @@ public:
     inline
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.getArrayVecType()==m_array_type &&
-            X.getScalarVecType()==m_scalar_type,
-            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec X of different type");
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            Y.getArrayVecType()==m_array_type &&
-            Y.getScalarVecType()==m_scalar_type,
-            "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec Y of different type");
+        assertSameType( X );
+        assertSameType( Y );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
@@ -205,10 +188,7 @@ public:
      */
     void increment (const WarpXSolverVec& X, const RT a)
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            X.getArrayVecType()==m_array_type &&
-            X.getScalarVecType()==m_scalar_type,
-            "WarpXSolverVec::increment(X,a) called with solver vecs of different types");
+        assertSameType( X );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
@@ -263,6 +243,15 @@ public:
                 m_scalar_vec[lev]->setVal(a_val);
             }
         }
+    }
+
+    inline
+    void assertSameType( const WarpXSolverVec&  a_solver_vec ) const
+    {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            a_solver_vec.getArrayVecType()==m_array_type &&
+            a_solver_vec.getScalarVecType()==m_scalar_type,
+            "WarpXSolverVec::function(X) called with WarpXSolverVec X of different type");
     }
 
     [[nodiscard]] inline RT norm2 () const

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -75,24 +75,7 @@ public:
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
-    inline
-    void Copy ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_field_vec,
-                const warpx::fields::FieldType                                           a_field_type )
-    {
-
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            IsDefined(),
-            "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_field_type==m_field_type,
-            "WarpXSolverVec::Copy() called with vecs of different types");
-        for (int lev=0; lev<m_num_amr_levels; ++lev) {
-            for (int n=0; n<3; ++n) {
-                amrex::MultiFab::Copy( *m_field_vec[lev][n], *a_field_vec[lev][n], 0, 0, m_ncomp,
-                                       amrex::IntVect::TheZeroVector() );
-            }
-        }
-    }
+    void Copy ( const warpx::fields::FieldType  a_field_type );
 
     inline
     void Copy ( const WarpXSolverVec&  a_solver_vec )
@@ -106,8 +89,14 @@ public:
                 "WarpXSolverVec::Copy(solver_vec) called with vecs of different types");
         }
         else { Define(a_solver_vec); }
-        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& solver_vec = a_solver_vec.getVec();
-        Copy(solver_vec, a_solver_vec.getVecType());
+
+        const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec = a_solver_vec.getVec();
+        for (int lev=0; lev<m_num_amr_levels; ++lev) {
+            for (int n=0; n<3; ++n) {
+                amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_vec[lev][n], 0, 0, m_ncomp,
+                                       amrex::IntVect::TheZeroVector() );
+            }
+        }
     }
 
     // Prohibit Copy assignment operator

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -65,7 +65,7 @@ public:
 
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
-    void Define ( WarpX*     a_WarpX,
+    void Define ( WarpX*  a_WarpX,
                   warpx::fields::FieldType  a_array_type,
                   warpx::fields::FieldType  a_scalar_type = warpx::fields::FieldType::None );
 
@@ -282,8 +282,10 @@ public:
 private:
 
     bool m_is_defined = false;
+
     amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>> m_array_vec;
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_scalar_vec;
+
     warpx::fields::FieldType m_array_type = warpx::fields::FieldType::None;
     warpx::fields::FieldType m_scalar_type = warpx::fields::FieldType::None;
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -62,7 +62,7 @@ public:
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
     void Define ( WarpX*                    a_WarpX,
-            const warpx::fields::FieldType  a_field_type );
+                  warpx::fields::FieldType  a_field_type );
 
     inline
     void Define ( const WarpXSolverVec&  a_solver_vec )
@@ -70,12 +70,12 @@ public:
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_solver_vec.IsDefined(),
             "WarpXSolverVec::Define(solver_vec) called with undefined solver_vec");
-        Define( a_solver_vec.m_WarpX, a_solver_vec.getVecType() );
+        Define( WarpXSolverVec::m_WarpX, a_solver_vec.getVecType() );
     }
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
-    void Copy ( const warpx::fields::FieldType  a_field_type );
+    void Copy ( warpx::fields::FieldType  a_field_type );
 
     inline
     void Copy ( const WarpXSolverVec&  a_solver_vec )
@@ -214,7 +214,7 @@ public:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& getVec() {return m_field_vec;}
 
     // solver vec types are for now limited to warpx::fields::FieldType
-    warpx::fields::FieldType getVecType () const { return m_field_type; }
+    [[nodiscard]] warpx::fields::FieldType getVecType () const { return m_field_type; }
 
 private:
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -15,7 +15,6 @@
 #include <AMReX.H>
 #include <AMReX_Array.H>
 #include <AMReX_BLassert.H>
-#include <AMReX_Geometry.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_LayoutData.H>
 #include <AMReX_MultiFab.H>
@@ -46,6 +45,7 @@
  *  be used for other solver vectors, such as electrostatic (array size 1) or Darwin (array size 4).
  */
 
+class WarpX;
 class WarpXSolverVec
 {
 public:
@@ -61,34 +61,18 @@ public:
 
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
+    void Define ( WarpX*                    a_WarpX,
+            const warpx::fields::FieldType  a_solver_vec_type );
+
     inline
     void Define (const WarpXSolverVec& a_vec)
     {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             a_vec.IsDefined(),
             "WarpXSolverVec::Define(a_vec) called with undefined a_vec");
-        Define( a_vec.getVec(), a_vec.getVecType() );
+        Define( a_vec.m_WarpX, a_vec.getVecType() );
     }
 
-    inline
-    void Define ( const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > >& a_solver_vec,
-                  const warpx::fields::FieldType                                           a_solver_vec_type )
-    {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            !IsDefined(),
-            "WarpXSolverVec::Define() called on undefined WarpXSolverVec");
-        m_solver_vec.resize(m_num_amr_levels);
-        const int lev = 0;
-        for (int n=0; n<3; n++) {
-            const amrex::MultiFab& mf_model = *a_solver_vec[lev][n];
-            m_solver_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(), mf_model.DistributionMap(),
-                                                                      mf_model.nComp(), amrex::IntVect::TheZeroVector() );
-        }
-        m_solver_vec_type = a_solver_vec_type;
-        m_is_defined = true;
-    }
-
-    void SetDotMask( const amrex::Vector<amrex::Geometry>&  a_Geom );
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
     inline
@@ -258,8 +242,13 @@ private:
     static constexpr int m_ncomp = 1;
     static constexpr int m_num_amr_levels = 1;
 
+    inline static bool m_warpx_ptr_defined = false;
+    inline static WarpX* m_WarpX = nullptr;
+    void SetWarpXPointer( WarpX*  a_WarpX );
+
     inline static bool m_dot_mask_defined = false;
     inline static amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>,3>> m_dotMask;
+    void SetDotMask();
 
 };
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -41,7 +41,8 @@
  *  Vector is the number of amr levels. Hardcoded for 1 right now.
  *
  *  A WarpXSolverVec can consist of an array size 3 of MultiFabs (for vector fields
- *  such as E, B, and A) or of a single MultiFab for scalar fields.
+ *  such as E, B, and A) or of a single MultiFab for scalar fields. Both the array
+ *  size 3 and scalar fields must be of type warpx::fields::FieldType.
  *  Additionally, a WarpXSolverVec can in general contain both an array size 3 field and a
  *  scalar field. For example, the array size 3 field can be used for the vector potential A
  *  and the scalar field can be used for the scalar potential phi, which is the full state of

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -34,15 +34,18 @@
 #include "FieldSolver/Fields.H"
 
 /**
- * \brief This is a wrapper class around a Vector of array of pointers to MultiFabs that
+ * \brief
+ *  This is a wrapper class around a Vector of pointers to MultiFabs that
  *  contains basic math operators and functionality needed to interact with nonlinear
- *  solvers in WarpX and linear solvers in AMReX, such as GMRES.
+ *  solvers in WarpX and linear solvers in AMReX, such as GMRES. The size of the
+ *  Vector is the number of amr levels. Hardcoded for 1 right now.
  *
- *  The size of the Vector is the number of amr levels. Hardcoded for 1 right now. The
- *  size of the array is the number of MultiFabs. It is hardcoded for 3 right now as it
- *  is only used for the electric field in the implicit electromagnetic time solvers. In
- *  the future, the array size can be made a template parameter so that this class can
- *  be used for other solver vectors, such as electrostatic (array size 1) or Darwin (array size 4).
+ *  A WarpXSolverVec can consist of an array size 3 of MultiFabs (for vector fields
+ *  such as E, B, and A) or of a single MultiFab for scalar fields.
+ *  Additionally, a WarpXSolverVec can in general contain both an array size 3 field and a
+ *  scalar field. For example, the array size 3 field can be used for the vector potential A
+ *  and the scalar field can be used for the scalar potential phi, which is the full state of
+ *  unknowns for a Darwin electromagnetic model.
  */
 
 class WarpX;
@@ -270,7 +273,7 @@ public:
     [[nodiscard]] const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() const {return m_scalar_vec;}
     amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() {return m_scalar_vec;}
 
-    // solver vec types are limited to warpx::fields::warpx::fields::FieldType
+    // solver vector types are type warpx::fields::FieldType
     [[nodiscard]] warpx::fields::FieldType getArrayVecType () const { return m_array_type; }
     [[nodiscard]] warpx::fields::FieldType getScalarVecType () const { return m_scalar_type; }
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -291,7 +291,6 @@ private:
 
     inline static bool m_warpx_ptr_defined = false;
     inline static WarpX* m_WarpX = nullptr;
-    void SetWarpXPointer( WarpX*  a_WarpX );
 
 };
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -32,6 +32,10 @@
 #include <ostream>
 #include <vector>
 
+
+// forward declaration
+class WarpX;
+
 /**
  * \brief
  *  This is a wrapper class around a Vector of pointers to MultiFabs that
@@ -47,8 +51,6 @@
  *  and the scalar field can be used for the scalar potential phi, which is the full state of
  *  unknowns for a Darwin electromagnetic model.
  */
-
-class WarpX;
 class WarpXSolverVec
 {
 public:

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -8,6 +8,7 @@
 #define WarpXSolverVec_H_
 
 #include "Utils/TextMsg.H"
+#include "FieldSolver/Fields.H"
 
 #include <ablastr/utils/SignalHandling.H>
 #include <ablastr/warn_manager/WarnManager.H>
@@ -30,8 +31,6 @@
 #include <memory>
 #include <ostream>
 #include <vector>
-
-#include "FieldSolver/Fields.H"
 
 /**
  * \brief

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -45,8 +45,6 @@
  *  be used for other solver vectors, such as electrostatic (array size 1) or Darwin (array size 4).
  */
 
-using namespace warpx::fields;
-
 class WarpX;
 class WarpXSolverVec
 {
@@ -64,8 +62,8 @@ public:
     [[nodiscard]] inline bool IsDefined () const { return m_is_defined; }
 
     void Define ( WarpX*     a_WarpX,
-                  FieldType  a_field_type,
-                  FieldType  a_scalar_type = FieldType::None );
+                  warpx::fields::FieldType  a_field_type,
+                  warpx::fields::FieldType  a_scalar_type = warpx::fields::FieldType::None );
 
     inline
     void Define ( const WarpXSolverVec&  a_solver_vec )
@@ -80,8 +78,8 @@ public:
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
-    void Copy ( FieldType  a_field_type,
-                FieldType  a_scalar_type = FieldType::None );
+    void Copy ( warpx::fields::FieldType  a_field_type,
+                warpx::fields::FieldType  a_scalar_type = warpx::fields::FieldType::None );
 
     inline
     void Copy ( const WarpXSolverVec&  a_solver_vec )
@@ -98,14 +96,14 @@ public:
         else { Define(a_solver_vec); }
 
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; ++n) {
                     const std::unique_ptr<amrex::MultiFab>& this_field = a_solver_vec.getFieldVec()[lev][n];
                     amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_field, 0, 0, m_ncomp,
                                            amrex::IntVect::TheZeroVector() );
                 }
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 const std::unique_ptr<amrex::MultiFab>& this_scalar = a_solver_vec.getScalarVec()[lev];
                 amrex::MultiFab::Copy( *m_scalar_vec[lev], *this_scalar, 0, 0, m_ncomp,
                                        amrex::IntVect::TheZeroVector() );
@@ -138,12 +136,12 @@ public:
             a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator += solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 m_field_vec[lev][0]->plus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
                 m_field_vec[lev][1]->plus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
                 m_field_vec[lev][2]->plus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->plus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
             }
         }
@@ -157,12 +155,12 @@ public:
             a_solver_vec.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec operator -= solver_vec called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 m_field_vec[lev][0]->minus(*(a_solver_vec.getFieldVec()[lev][0]), 0, 1, 0);
                 m_field_vec[lev][1]->minus(*(a_solver_vec.getFieldVec()[lev][1]), 0, 1, 0);
                 m_field_vec[lev][2]->minus(*(a_solver_vec.getFieldVec()[lev][2]), 0, 1, 0);
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->minus(*(a_solver_vec.getScalarVec()[lev]), 0, 1, 0);
             }
         }
@@ -183,14 +181,14 @@ public:
             Y.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::linComb(a,X,b,Y) called with solver vec Y of different type");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
                     amrex::MultiFab::LinComb(*m_field_vec[lev][n], a, *X.getFieldVec()[lev][n], 0,
                                                                    b, *Y.getFieldVec()[lev][n], 0,
                                                                    0, 1, 0);
                 }
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 amrex::MultiFab::LinComb(*m_scalar_vec[lev], a, *X.getScalarVec()[lev], 0,
                                                              b, *Y.getScalarVec()[lev], 0,
                                                              0, 1, 0);
@@ -208,13 +206,13 @@ public:
             X.getScalarVecType()==m_scalar_type,
             "WarpXSolverVec::increment(X,a) called with solver vecs of different types");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 for (int n = 0; n < 3; n++) {
                     amrex::MultiFab::Saxpy( *m_field_vec[lev][n], a, *X.getFieldVec()[lev][n],
                                             0, 0, 1, amrex::IntVect::TheZeroVector() );
                 }
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 amrex::MultiFab::Saxpy( *m_scalar_vec[lev], a, *X.getScalarVec()[lev],
                                         0, 0, 1, amrex::IntVect::TheZeroVector() );
             }
@@ -228,12 +226,12 @@ public:
     void scale (RT a_a)
     {
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 m_field_vec[lev][0]->mult(a_a, 0, 1);
                 m_field_vec[lev][1]->mult(a_a, 0, 1);
                 m_field_vec[lev][2]->mult(a_a, 0, 1);
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->mult(a_a, 0, 1);
             }
         }
@@ -249,12 +247,12 @@ public:
             IsDefined(),
             "WarpXSolverVec::ones() called on undefined WarpXSolverVec");
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            if (m_field_type != FieldType::None) {
+            if (m_field_type != warpx::fields::FieldType::None) {
                 m_field_vec[lev][0]->setVal(a_val);
                 m_field_vec[lev][1]->setVal(a_val);
                 m_field_vec[lev][2]->setVal(a_val);
             }
-            if (m_scalar_type != FieldType::None) {
+            if (m_scalar_type != warpx::fields::FieldType::None) {
                 m_scalar_vec[lev]->setVal(a_val);
             }
         }
@@ -272,17 +270,17 @@ public:
     [[nodiscard]] const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() const {return m_scalar_vec;}
     amrex::Vector<std::unique_ptr<amrex::MultiFab>>& getScalarVec() {return m_scalar_vec;}
 
-    // solver vec types are limited to warpx::fields::FieldType
-    [[nodiscard]] FieldType getFieldVecType () const { return m_field_type; }
-    [[nodiscard]] FieldType getScalarVecType () const { return m_scalar_type; }
+    // solver vec types are limited to warpx::fields::warpx::fields::FieldType
+    [[nodiscard]] warpx::fields::FieldType getFieldVecType () const { return m_field_type; }
+    [[nodiscard]] warpx::fields::FieldType getScalarVecType () const { return m_scalar_type; }
 
 private:
 
     bool m_is_defined = false;
     amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>> m_field_vec;
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_scalar_vec;
-    FieldType m_field_type = FieldType::None;
-    FieldType m_scalar_type = FieldType::None;
+    warpx::fields::FieldType m_field_type = warpx::fields::FieldType::None;
+    warpx::fields::FieldType m_scalar_type = warpx::fields::FieldType::None;
 
     static constexpr int m_ncomp = 1;
     static constexpr int m_num_amr_levels = 1;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -72,9 +72,7 @@ public:
     inline
     void Define ( const WarpXSolverVec&  a_solver_vec )
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.IsDefined(),
-            "WarpXSolverVec::Define(solver_vec) called with undefined solver_vec");
+        assertIsDefined( a_solver_vec );
         Define( WarpXSolverVec::m_WarpX,
                 a_solver_vec.getArrayVecType(),
                 a_solver_vec.getScalarVecType() );
@@ -88,9 +86,7 @@ public:
     inline
     void Copy ( const WarpXSolverVec&  a_solver_vec )
     {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            a_solver_vec.IsDefined(),
-            "WarpXSolverVec::Copy(solver_vec) called with undefined solver_vec");
+        assertIsDefined( a_solver_vec );
         if (IsDefined()) { assertSameType( a_solver_vec ); }
         else { Define(a_solver_vec); }
 
@@ -130,6 +126,7 @@ public:
     inline
     void operator+= ( const WarpXSolverVec&  a_solver_vec )
     {
+        assertIsDefined( a_solver_vec );
         assertSameType( a_solver_vec );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
@@ -146,6 +143,7 @@ public:
     inline
     void operator-= (const WarpXSolverVec& a_solver_vec)
     {
+        assertIsDefined( a_solver_vec );
         assertSameType( a_solver_vec );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
@@ -165,6 +163,8 @@ public:
     inline
     void linComb (const RT a, const WarpXSolverVec& X, const RT b, const WarpXSolverVec& Y)
     {
+        assertIsDefined( X );
+        assertIsDefined( Y );
         assertSameType( X );
         assertSameType( Y );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
@@ -188,6 +188,7 @@ public:
      */
     void increment (const WarpXSolverVec& X, const RT a)
     {
+        assertIsDefined( X );
         assertSameType( X );
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             if (m_array_type != warpx::fields::FieldType::None) {
@@ -243,6 +244,14 @@ public:
                 m_scalar_vec[lev]->setVal(a_val);
             }
         }
+    }
+
+    inline
+    void assertIsDefined( const WarpXSolverVec&  a_solver_vec ) const
+    {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            a_solver_vec.IsDefined(),
+            "WarpXSolverVec::function(X) called with undefined WarpXSolverVec X");
     }
 
     inline

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -14,18 +14,41 @@ void WarpXSolverVec::Define ( WarpX*                    a_WarpX,
         !IsDefined(),
         "WarpXSolverVec::Define(a_vec, a_type) called on already defined WarpXSolverVec");
 
-    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec(a_WarpX->getMultiLevelField(a_field_type));
+    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec(
+                                                            a_WarpX->getMultiLevelField(a_field_type));
     m_field_vec.resize(m_num_amr_levels);
-    const int lev = 0;
-    for (int n=0; n<3; n++) {
-        const amrex::MultiFab& mf_model = *this_vec[lev][n];
-        m_field_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(), mf_model.DistributionMap(),
-                                                                 mf_model.nComp(), amrex::IntVect::TheZeroVector() );
+    for (int lev=0; lev<m_num_amr_levels; ++lev) {
+        for (int n=0; n<3; n++) {
+            const amrex::MultiFab& mf_model = *this_vec[lev][n];
+            m_field_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(),
+                                                                     mf_model.DistributionMap(),
+                                                                     mf_model.nComp(),
+                                                                     amrex::IntVect::TheZeroVector() );
+        }
     }
     m_field_type = a_field_type;
     m_is_defined = true;
     SetWarpXPointer(a_WarpX);
     SetDotMask();
+}
+
+void WarpXSolverVec::Copy ( const warpx::fields::FieldType  a_field_type )
+{
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        IsDefined(),
+        "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        a_field_type==m_field_type,
+        "WarpXSolverVec::Copy() called with vecs of different types");
+
+    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec(
+                                               m_WarpX->getMultiLevelField(a_field_type));
+    for (int lev=0; lev<m_num_amr_levels; ++lev) {
+        for (int n=0; n<3; ++n) {
+            amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_vec[lev][n], 0, 0, m_ncomp,
+                                   amrex::IntVect::TheZeroVector() );
+        }
+    }
 }
 
 void WarpXSolverVec::SetWarpXPointer( WarpX*  a_WarpX )

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -29,7 +29,6 @@ void WarpXSolverVec::Define ( WarpX*                    a_WarpX,
     m_field_type = a_field_type;
     m_is_defined = true;
     SetWarpXPointer(a_WarpX);
-    SetDotMask();
 }
 
 void WarpXSolverVec::Copy ( const warpx::fields::FieldType  a_field_type )
@@ -58,50 +57,22 @@ void WarpXSolverVec::SetWarpXPointer( WarpX*  a_WarpX )
     m_warpx_ptr_defined = true;
 }
 
-void WarpXSolverVec::SetDotMask()
-{
-    if (m_dot_mask_defined) { return; }
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        IsDefined(),
-        "WarpXSolverVec::SetDotMask() called from undefined instance ");
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        m_warpx_ptr_defined,
-        "WarpXSolverVec::SetDotMask() called before SetWarpXPointer() ");
-
-    const amrex::Vector<amrex::Geometry>& Geom = m_WarpX->Geom();
-    m_dotMask.resize(m_num_amr_levels);
-    for ( int n = 0; n < 3; n++) {
-        const amrex::BoxArray& grids = m_field_vec[0][n]->boxArray();
-        const amrex::MultiFab tmp( grids, m_field_vec[0][n]->DistributionMap(),
-                                   1, 0, amrex::MFInfo().SetAlloc(false) );
-        const amrex::Periodicity& period = Geom[0].periodicity();
-        m_dotMask[0][n] = tmp.OwnerMask(period);
-    }
-    m_dot_mask_defined = true;
-
-    // If the function below is not called, then the following
-    // error message occurs after the simulation finishes:
-    // malloc_consolidate(): unaligned fastbin chunk detected
-    amrex::ExecOnFinalize(WarpXSolverVec::clearDotMask);
-}
-
 [[nodiscard]] amrex::Real WarpXSolverVec::dotProduct ( const WarpXSolverVec&  a_X ) const
 {
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        m_dot_mask_defined,
-        "WarpXSolverVec::dotProduct called with m_dotMask not yet defined");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         a_X.m_field_type==m_field_type,
         "WarpXSolverVec::dotProduct(X) called with solver vecs of different types");
 
     amrex::Real result = 0.0;
-    const int lev = 0;
     const bool local = true;
-    for (int n = 0; n < 3; ++n) {
-        auto rtmp = amrex::MultiFab::Dot( *m_dotMask[lev][n],
-                                          *m_field_vec[lev][n], 0,
-                                          *a_X.getVec()[lev][n], 0, 1, 0, local);
-        result += rtmp;
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        for (int n = 0; n < 3; ++n) {
+            const amrex::iMultiFab* dotMask = m_WarpX->getFieldDotMaskPointer(m_field_type,lev,n);
+            auto rtmp = amrex::MultiFab::Dot( *dotMask,
+                                              *m_field_vec[lev][n], 0,
+                                              *a_X.getVec()[lev][n], 0, 1, 0, local);
+            result += rtmp;
+        }
     }
     amrex::ParallelAllReduce::Sum(result, amrex::ParallelContext::CommunicatorSub());
     return result;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -99,10 +99,7 @@ void WarpXSolverVec::Copy ( FieldType  a_array_type,
 
 [[nodiscard]] amrex::Real WarpXSolverVec::dotProduct ( const WarpXSolverVec&  a_X ) const
 {
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        a_X.getArrayVecType()==m_array_type &&
-        a_X.getScalarVecType()==m_scalar_type,
-        "WarpXSolverVec::dotProduct(X) called with solver vecs of different types");
+    assertSameType( a_X );
 
     amrex::Real result = 0.0;
     const bool local = true;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -7,6 +7,8 @@
 #include "FieldSolver/ImplicitSolvers/WarpXSolverVec.H"
 #include "WarpX.H"
 
+using namespace warpx::fields;
+
 void WarpXSolverVec::Define ( WarpX*     a_WarpX,
                               FieldType  a_field_type,
                               FieldType  a_scalar_type )

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -52,7 +52,12 @@ void WarpXSolverVec::Define ( WarpX*     a_WarpX,
     }
 
     m_is_defined = true;
-    SetWarpXPointer(a_WarpX);
+
+    // Define static member pointer to WarpX
+    if (!m_warpx_ptr_defined) {
+        m_WarpX = a_WarpX;
+        m_warpx_ptr_defined = true;
+    }
 }
 
 void WarpXSolverVec::Copy ( FieldType  a_array_type,
@@ -80,13 +85,6 @@ void WarpXSolverVec::Copy ( FieldType  a_array_type,
                                    amrex::IntVect::TheZeroVector() );
         }
     }
-}
-
-void WarpXSolverVec::SetWarpXPointer( WarpX*  a_WarpX )
-{
-    if (m_warpx_ptr_defined) { return; }
-    m_WarpX = a_WarpX;
-    m_warpx_ptr_defined = true;
 }
 
 [[nodiscard]] amrex::Real WarpXSolverVec::dotProduct ( const WarpXSolverVec&  a_X ) const

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -15,8 +15,8 @@ void WarpXSolverVec::SetDotMask( const amrex::Vector<amrex::Geometry>&  a_Geom )
 
     m_dotMask.resize(m_num_amr_levels);
     for ( int n = 0; n < 3; n++) {
-        const amrex::BoxArray& grids = m_field_vec[0][n]->boxArray();
-        const amrex::MultiFab tmp( grids, m_field_vec[0][n]->DistributionMap(),
+        const amrex::BoxArray& grids = m_solver_vec[0][n]->boxArray();
+        const amrex::MultiFab tmp( grids, m_solver_vec[0][n]->DistributionMap(),
                                    1, 0, amrex::MFInfo().SetAlloc(false) );
         const amrex::Periodicity& period = a_Geom[0].periodicity();
         m_dotMask[0][n] = tmp.OwnerMask(period);
@@ -42,7 +42,7 @@ void WarpXSolverVec::SetDotMask( const amrex::Vector<amrex::Geometry>&  a_Geom )
     const bool local = true;
     for (int n = 0; n < 3; ++n) {
         auto rtmp = amrex::MultiFab::Dot( *m_dotMask[lev][n],
-                                          *m_field_vec[lev][n], 0,
+                                          *m_solver_vec[lev][n], 0,
                                           *a_X.getVec()[lev][n], 0, 1, 0, local);
         result += rtmp;
     }

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -99,6 +99,7 @@ void WarpXSolverVec::Copy ( FieldType  a_array_type,
 
 [[nodiscard]] amrex::Real WarpXSolverVec::dotProduct ( const WarpXSolverVec&  a_X ) const
 {
+    assertIsDefined( a_X );
     assertSameType( a_X );
 
     amrex::Real result = 0.0;

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -7,44 +7,74 @@
 #include "FieldSolver/ImplicitSolvers/WarpXSolverVec.H"
 #include "WarpX.H"
 
-void WarpXSolverVec::Define ( WarpX*                    a_WarpX,
-                        const warpx::fields::FieldType  a_field_type )
+void WarpXSolverVec::Define ( WarpX*     a_WarpX,
+                              FieldType  a_field_type,
+                              FieldType  a_scalar_type )
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !IsDefined(),
         "WarpXSolverVec::Define(a_vec, a_type) called on already defined WarpXSolverVec");
 
-    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec(
-                                                            a_WarpX->getMultiLevelField(a_field_type));
-    m_field_vec.resize(m_num_amr_levels);
-    for (int lev=0; lev<m_num_amr_levels; ++lev) {
-        for (int n=0; n<3; n++) {
-            const amrex::MultiFab& mf_model = *this_vec[lev][n];
-            m_field_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model.boxArray(),
-                                                                     mf_model.DistributionMap(),
-                                                                     mf_model.nComp(),
-                                                                     amrex::IntVect::TheZeroVector() );
-        }
-    }
     m_field_type = a_field_type;
+    m_scalar_type = a_scalar_type;
+
+    m_field_vec.resize(m_num_amr_levels);
+    m_scalar_vec.resize(m_num_amr_levels);
+
+    // Define the 3D vector field data container
+    if (m_field_type != FieldType::None) {
+
+        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+            for (int n = 0; n < 3; n++) {
+                const amrex::MultiFab* mf_model = a_WarpX->getFieldPointer(m_field_type,lev,n);
+                m_field_vec[lev][n] = std::make_unique<amrex::MultiFab>( mf_model->boxArray(),
+                                                                         mf_model->DistributionMap(),
+                                                                         mf_model->nComp(),
+                                                                         amrex::IntVect::TheZeroVector() );
+            }
+        }
+
+    }
+
+    // Define the scalar data container
+    if (m_scalar_type != FieldType::None) {
+
+        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+            const amrex::MultiFab* mf_model = a_WarpX->getFieldPointer(m_scalar_type,lev,0);
+            m_scalar_vec[lev] = std::make_unique<amrex::MultiFab>( mf_model->boxArray(),
+                                                                   mf_model->DistributionMap(),
+                                                                   mf_model->nComp(),
+                                                                   amrex::IntVect::TheZeroVector() );
+        }
+
+    }
+
     m_is_defined = true;
     SetWarpXPointer(a_WarpX);
 }
 
-void WarpXSolverVec::Copy ( const warpx::fields::FieldType  a_field_type )
+void WarpXSolverVec::Copy ( FieldType  a_field_type,
+                            FieldType  a_scalar_type )
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         IsDefined(),
         "WarpXSolverVec::Copy() called on undefined WarpXSolverVec");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        a_field_type==m_field_type,
+        a_field_type==m_field_type &&
+        a_scalar_type==m_scalar_type,
         "WarpXSolverVec::Copy() called with vecs of different types");
 
-    const amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>,3>>& this_vec(
-                                               m_WarpX->getMultiLevelField(a_field_type));
-    for (int lev=0; lev<m_num_amr_levels; ++lev) {
-        for (int n=0; n<3; ++n) {
-            amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_vec[lev][n], 0, 0, m_ncomp,
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        if (m_field_type != FieldType::None) {
+            for (int n = 0; n < 3; ++n) {
+                const amrex::MultiFab* this_field = m_WarpX->getFieldPointer(m_field_type,lev,n);
+                amrex::MultiFab::Copy( *m_field_vec[lev][n], *this_field, 0, 0, m_ncomp,
+                                       amrex::IntVect::TheZeroVector() );
+            }
+        }
+        if (m_scalar_type != FieldType::None) {
+            const amrex::MultiFab* this_scalar = m_WarpX->getFieldPointer(m_scalar_type,lev,0);
+            amrex::MultiFab::Copy( *m_scalar_vec[lev], *this_scalar, 0, 0, m_ncomp,
                                    amrex::IntVect::TheZeroVector() );
         }
     }
@@ -60,17 +90,27 @@ void WarpXSolverVec::SetWarpXPointer( WarpX*  a_WarpX )
 [[nodiscard]] amrex::Real WarpXSolverVec::dotProduct ( const WarpXSolverVec&  a_X ) const
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        a_X.m_field_type==m_field_type,
+        a_X.getFieldVecType()==m_field_type &&
+        a_X.getScalarVecType()==m_scalar_type,
         "WarpXSolverVec::dotProduct(X) called with solver vecs of different types");
 
     amrex::Real result = 0.0;
     const bool local = true;
     for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-        for (int n = 0; n < 3; ++n) {
-            const amrex::iMultiFab* dotMask = m_WarpX->getFieldDotMaskPointer(m_field_type,lev,n);
+        if (m_field_type != FieldType::None) {
+            for (int n = 0; n < 3; ++n) {
+                const amrex::iMultiFab* dotMask = m_WarpX->getFieldDotMaskPointer(m_field_type,lev,n);
+                auto rtmp = amrex::MultiFab::Dot( *dotMask,
+                                                  *m_field_vec[lev][n], 0,
+                                                  *a_X.getFieldVec()[lev][n], 0, 1, 0, local);
+                result += rtmp;
+            }
+        }
+        if (m_scalar_type != FieldType::None) {
+            const amrex::iMultiFab* dotMask = m_WarpX->getFieldDotMaskPointer(m_scalar_type,lev,0);
             auto rtmp = amrex::MultiFab::Dot( *dotMask,
-                                              *m_field_vec[lev][n], 0,
-                                              *a_X.getVec()[lev][n], 0, 1, 0, local);
+                                              *m_scalar_vec[lev], 0,
+                                              *a_X.getScalarVec()[lev], 0, 1, 0, local);
             result += rtmp;
         }
     }

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -66,6 +66,11 @@ void WarpXSolverVec::Define ( WarpX*     a_WarpX,
 
     }
 
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_array_type != FieldType::None ||
+        m_scalar_type != FieldType::None,
+        "WarpXSolverVec cannot be defined with both array and scalar vecs FieldType::None");
+
     m_is_defined = true;
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -544,15 +544,14 @@ public:
      * Get pointer to the amrex::MultiFab containing the dotMask for the specified field
      */
     [[nodiscard]] const amrex::iMultiFab*
-    getFieldDotMaskPointer (warpx::fields::FieldType field_type, const int lev, const int dir) const;
+    getFieldDotMaskPointer (warpx::fields::FieldType field_type, int lev, int dir) const;
 
     /**
      * \brief
      * Set the dotMask container
      */
-    void SetDotMask( std::unique_ptr<amrex::iMultiFab>&  field_dotMask,
-                     warpx::fields::FieldType field_type,
-                     const int lev, const int dir ) const;
+    void SetDotMask( std::unique_ptr<amrex::iMultiFab>& field_dotMask,
+                     warpx::fields::FieldType field_type, int lev, int dir ) const;
 
     [[nodiscard]] bool DoPML () const {return do_pml;}
     [[nodiscard]] bool DoFluidSpecies () const {return do_fluid_species;}

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -539,6 +539,21 @@ public:
     [[nodiscard]] const amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>,3>>&
     getMultiLevelField(warpx::fields::FieldType field_type) const;
 
+    /**
+     * \brief
+     * Get pointer to the amrex::MultiFab containing the dotMask for the specified field
+     */
+    [[nodiscard]] const amrex::iMultiFab*
+    getFieldDotMaskPointer (warpx::fields::FieldType field_type, const int lev, const int dir) const;
+
+    /**
+     * \brief
+     * Set the dotMask container
+     */
+    void SetDotMask( std::unique_ptr<amrex::iMultiFab>&  field_dotMask,
+                     warpx::fields::FieldType field_type,
+                     const int lev, const int dir ) const;
+
     [[nodiscard]] bool DoPML () const {return do_pml;}
     [[nodiscard]] bool DoFluidSpecies () const {return do_fluid_species;}
 
@@ -1511,6 +1526,12 @@ private:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_avg_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_avg_fp;
+
+    // Masks for computing global moments of fields when using grids that have
+    // shared locations across different ranks (e.g., a Yee grid)
+    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Efield_dotMask;
+    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Bfield_dotMask;
+    mutable amrex::Vector<            std::unique_ptr<amrex::iMultiFab>     > phi_dotMask;
 
     // Memory buffers for computing magnetostatic fields
     // Vector Potential A and previous step.  Time buffer needed for computing dA/dt to first order

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1526,10 +1526,11 @@ private:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_avg_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_avg_fp;
 
-    // Masks for computing global moments of fields when using grids that have
-    // shared locations across different ranks (e.g., a Yee grid)
+    // Masks for computing dot product and global moments of fields when using grids that
+    // have shared locations across different ranks (e.g., a Yee grid)
     mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Efield_dotMask;
     mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Bfield_dotMask;
+    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Afield_dotMask;
     mutable amrex::Vector<            std::unique_ptr<amrex::iMultiFab>     > phi_dotMask;
 
     // Memory buffers for computing magnetostatic fields

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -327,6 +327,10 @@ WarpX::WarpX ()
     Efield_fp.resize(nlevs_max);
     Bfield_fp.resize(nlevs_max);
 
+    Efield_dotMask.resize(nlevs_max);
+    Bfield_dotMask.resize(nlevs_max);
+    phi_dotMask.resize(nlevs_max);
+
     // Only allocate vector potential arrays when using the Magnetostatic Solver
     if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic)
     {
@@ -2095,6 +2099,9 @@ WarpX::ClearLevel (int lev)
         Efield_fp [lev][i].reset();
         Bfield_fp [lev][i].reset();
 
+        Efield_dotMask [lev][i].reset();
+        Bfield_dotMask [lev][i].reset();
+
         current_store[lev][i].reset();
 
         if (do_current_centering)
@@ -2140,6 +2147,8 @@ WarpX::ClearLevel (int lev)
     F_cp  [lev].reset();
     G_cp  [lev].reset();
     rho_cp[lev].reset();
+
+    phi_dotMask[lev].reset();
 
 #ifdef WARPX_USE_FFT
     if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
@@ -3669,4 +3678,46 @@ WarpX::getMultiLevelField(warpx::fields::FieldType field_type) const
             WARPX_ABORT_WITH_MESSAGE("Invalid field type");
             return Efield_fp;
     }
+}
+
+const amrex::iMultiFab*
+WarpX::getFieldDotMaskPointer (warpx::fields::FieldType field_type, const int lev, const int dir) const
+{
+    switch(field_type)
+    {
+        case FieldType::Efield_fp :
+            if (Efield_dotMask[lev][dir] == nullptr) {
+                SetDotMask( Efield_dotMask[lev][dir], field_type, lev, dir );
+            }
+            return Efield_dotMask[lev][dir].get();
+        case FieldType::Bfield_fp :
+            if (Bfield_dotMask[lev][dir] == nullptr) {
+                SetDotMask( Bfield_dotMask[lev][dir], field_type, lev, dir );
+            }
+            return Bfield_dotMask[lev][dir].get();
+        case FieldType::phi_fp :
+            if (phi_dotMask[lev] == nullptr) {
+                SetDotMask( phi_dotMask[lev], field_type, lev, 0 );
+            }
+            return phi_dotMask[lev].get();
+        default:
+            WARPX_ABORT_WITH_MESSAGE("Invalid field type for dotMask");
+            return Efield_dotMask[lev][dir].get();
+    }
+}
+
+void WarpX::SetDotMask( std::unique_ptr<amrex::iMultiFab>&  field_dotMask,
+                        warpx::fields::FieldType  field_type,
+                        const int  lev, const int  dir ) const
+{
+    // Define the dot mask for this field_type needed to properly compute dotProduct()
+    // for field values that have shared locations on different MPI ranks
+
+    const amrex::MultiFab* this_field = getFieldPointer(field_type,lev,dir);
+    const amrex::BoxArray& this_ba = this_field->boxArray();
+    const amrex::MultiFab tmp( this_ba, this_field->DistributionMap(),
+                               1, 0, amrex::MFInfo().SetAlloc(false) );
+    const amrex::Periodicity& period = Geom(lev).periodicity();
+    field_dotMask = tmp.OwnerMask(period);
+
 }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -329,6 +329,7 @@ WarpX::WarpX ()
 
     Efield_dotMask.resize(nlevs_max);
     Bfield_dotMask.resize(nlevs_max);
+    Afield_dotMask.resize(nlevs_max);
     phi_dotMask.resize(nlevs_max);
 
     // Only allocate vector potential arrays when using the Magnetostatic Solver
@@ -2101,6 +2102,7 @@ WarpX::ClearLevel (int lev)
 
         Efield_dotMask [lev][i].reset();
         Bfield_dotMask [lev][i].reset();
+        Afield_dotMask [lev][i].reset();
 
         current_store[lev][i].reset();
 
@@ -3695,6 +3697,11 @@ WarpX::getFieldDotMaskPointer ( FieldType field_type, int lev, int dir ) const
                 SetDotMask( Bfield_dotMask[lev][dir], field_type, lev, dir );
             }
             return Bfield_dotMask[lev][dir].get();
+        case FieldType::vector_potential_fp :
+            if (Afield_dotMask[lev][dir] == nullptr) {
+                SetDotMask( Afield_dotMask[lev][dir], field_type, lev, dir );
+            }
+            return Afield_dotMask[lev][dir].get();
         case FieldType::phi_fp :
             if (phi_dotMask[lev] == nullptr) {
                 SetDotMask( phi_dotMask[lev], field_type, lev, 0 );

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3681,7 +3681,7 @@ WarpX::getMultiLevelField(warpx::fields::FieldType field_type) const
 }
 
 const amrex::iMultiFab*
-WarpX::getFieldDotMaskPointer (warpx::fields::FieldType field_type, const int lev, const int dir) const
+WarpX::getFieldDotMaskPointer ( FieldType field_type, int lev, int dir ) const
 {
     switch(field_type)
     {
@@ -3706,9 +3706,8 @@ WarpX::getFieldDotMaskPointer (warpx::fields::FieldType field_type, const int le
     }
 }
 
-void WarpX::SetDotMask( std::unique_ptr<amrex::iMultiFab>&  field_dotMask,
-                        warpx::fields::FieldType  field_type,
-                        const int  lev, const int  dir ) const
+void WarpX::SetDotMask( std::unique_ptr<amrex::iMultiFab>& field_dotMask,
+                        FieldType field_type, int lev, int dir ) const
 {
     // Define the dot mask for this field_type needed to properly compute dotProduct()
     // for field values that have shared locations on different MPI ranks

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3710,7 +3710,7 @@ void WarpX::SetDotMask( std::unique_ptr<amrex::iMultiFab>& field_dotMask,
 {
     // Define the dot mask for this field_type needed to properly compute dotProduct()
     // for field values that have shared locations on different MPI ranks
-    if (field_dotMask != nullptr) return;
+    if (field_dotMask != nullptr) { return; }
 
     const amrex::MultiFab* this_field = getFieldPointer(field_type,lev,dir);
     const amrex::BoxArray& this_ba = this_field->boxArray();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3688,24 +3688,16 @@ WarpX::getFieldDotMaskPointer ( FieldType field_type, int lev, int dir ) const
     switch(field_type)
     {
         case FieldType::Efield_fp :
-            if (Efield_dotMask[lev][dir] == nullptr) {
-                SetDotMask( Efield_dotMask[lev][dir], field_type, lev, dir );
-            }
+            SetDotMask( Efield_dotMask[lev][dir], field_type, lev, dir );
             return Efield_dotMask[lev][dir].get();
         case FieldType::Bfield_fp :
-            if (Bfield_dotMask[lev][dir] == nullptr) {
-                SetDotMask( Bfield_dotMask[lev][dir], field_type, lev, dir );
-            }
+            SetDotMask( Bfield_dotMask[lev][dir], field_type, lev, dir );
             return Bfield_dotMask[lev][dir].get();
         case FieldType::vector_potential_fp :
-            if (Afield_dotMask[lev][dir] == nullptr) {
-                SetDotMask( Afield_dotMask[lev][dir], field_type, lev, dir );
-            }
+            SetDotMask( Afield_dotMask[lev][dir], field_type, lev, dir );
             return Afield_dotMask[lev][dir].get();
         case FieldType::phi_fp :
-            if (phi_dotMask[lev] == nullptr) {
-                SetDotMask( phi_dotMask[lev], field_type, lev, 0 );
-            }
+            SetDotMask( phi_dotMask[lev], field_type, lev, 0 );
             return phi_dotMask[lev].get();
         default:
             WARPX_ABORT_WITH_MESSAGE("Invalid field type for dotMask");
@@ -3718,6 +3710,7 @@ void WarpX::SetDotMask( std::unique_ptr<amrex::iMultiFab>& field_dotMask,
 {
     // Define the dot mask for this field_type needed to properly compute dotProduct()
     // for field values that have shared locations on different MPI ranks
+    if (field_dotMask != nullptr) return;
 
     const amrex::MultiFab* this_field = getFieldPointer(field_type,lev,dir);
     const amrex::BoxArray& this_ba = this_field->boxArray();


### PR DESCRIPTION
The WarpXSovlerVec class is a wrapper around a Vector of pointers to MutliFabs that contains basic math operators and functionality needed to interact with nonlinear solvers in WarpX and linear solvers in AMReX, such as GMRES. The size of the Vector is the number of amr levels. The original implementation of this class was hard-wired to only work for the electric field. The PR generalizes this class to work for any arbitrary FieldType as listed in Fields.H. In addition to vector fields (array size 3), this class can now also be used for scalar fields, such as the electrostatic potential phi. In general, a WarpXSolver vector can consist of one array size 3 of Multifabs (for vector fields such as E, B, and A) and one scalar field. For example, the array size 3 field can be used for the vector potential A and the scalar field can be used for the scalar potential phi, which is the full state of unknowns for a Darwin electromagnetic model.

This PR does add some bloat to the main WarpX class. A logical next step to this PR would be to create a WarpXFields class and to transfer much of what is in the WarpX class related to the fields to the WarpXFields class.
