### PR TITLE
Remove broken links from performance tests

### DIFF
--- a/Examples/Tests/performance_tests/automated_test_1_uniform_rest_32ppc
+++ b/Examples/Tests/performance_tests/automated_test_1_uniform_rest_32ppc
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_1_uniform_rest_32ppc

--- a/Examples/Tests/performance_tests/automated_test_2_uniform_rest_1ppc
+++ b/Examples/Tests/performance_tests/automated_test_2_uniform_rest_1ppc
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_2_uniform_rest_1ppc

--- a/Examples/Tests/performance_tests/automated_test_3_uniform_drift_4ppc
+++ b/Examples/Tests/performance_tests/automated_test_3_uniform_drift_4ppc
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_3_uniform_drift_4ppc

--- a/Examples/Tests/performance_tests/automated_test_4_labdiags_2ppc
+++ b/Examples/Tests/performance_tests/automated_test_4_labdiags_2ppc
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_4_labdiags_2ppc

--- a/Examples/Tests/performance_tests/automated_test_5_loadimbalance
+++ b/Examples/Tests/performance_tests/automated_test_5_loadimbalance
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_5_loadimbalance

--- a/Examples/Tests/performance_tests/automated_test_6_output_2ppc
+++ b/Examples/Tests/performance_tests/automated_test_6_output_2ppc
@@ -1,1 +1,0 @@
-../../../Tools/PerformanceTests/automated_test_6_output_2ppc


### PR DESCRIPTION
This removes broken links, left over from changes in PR #5124.

I found these when running ./run_test.sh, which quit with these errors:
```
cp: ./Examples/Tests/performance_tests/automated_test_5_loadimbalance: No such file or directory
cp: ./Examples/Tests/performance_tests/automated_test_1_uniform_rest_32ppc: No such file or directory
cp: ./Examples/Tests/performance_tests/automated_test_3_uniform_drift_4ppc: No such file or directory
cp: ./Examples/Tests/performance_tests/automated_test_6_output_2ppc: No such file or directory
cp: ./Examples/Tests/performance_tests/automated_test_4_labdiags_2ppc: No such file or directory
cp: ./Examples/Tests/performance_tests/automated_test_2_uniform_rest_1ppc: No such file or directory
```