### PR TITLE
CMake: Replace `FetchContent_Populate`

### DIFF
--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -22,6 +22,8 @@ jobs:
       image: senseiinsitu/ci:fedora35-amrex-20220613
     steps:
     - uses: actions/checkout@v4
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
     - name: Configure
       run: |
         cmake -S . -B build     \

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -73,7 +73,7 @@ jobs:
 
   catalyst:
     name: Catalyst
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     env:
       CXX: g++
@@ -83,8 +83,10 @@ jobs:
       CATALYST_IMPLEMENTATION_PATHS: /opt/paraview/lib/catalyst
       OMP_NUM_THREADS: 1
 
+    # Container build scripts:
+    # https://gitlab.kitware.com/christos.tsolakis/catalyst-amrex-docker-images
     container:
-      image: kitware/paraview:ci-catalyst-amrex-warpx-20240701
+      image: kitware/paraview:ci-catalyst-amrex-warpx-20240828
     steps:
     - uses: actions/checkout@v4
     - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(WarpX VERSION 24.08)
 
 include(${WarpX_SOURCE_DIR}/cmake/WarpXFunctions.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,6 @@ if(POLICY CMP0104)
     cmake_policy(SET CMP0104 OLD)
 endif()
 
-# We use simple syntax in cmake_dependent_option, so we are compatible with the
-# extended syntax in CMake 3.22+
-# https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
-if(POLICY CMP0127)
-    cmake_policy(SET CMP0127 NEW)
-endif()
-
 
 # C++ Standard in Superbuilds #################################################
 #

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 8.4+, Clang 7, NVCC 11.0, MSVC 19.15 or newer
-- `CMake 3.20.0+ <https://cmake.org>`__
+- `CMake 3.24.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `PICSAR <https://github.com/ECP-WarpX/picsar>`__: we automatically download and compile a copy of PICSAR

--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -6,7 +6,8 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load cmake/3.23.2
+module switch Core Core/24.07
+module load cmake/3.27.9
 module load craype-accel-amd-gfx90a
 module load rocm/5.7.1
 module load cray-mpich/8.1.28

--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -6,7 +6,7 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load cmake/3.22.1
+module load cmake/3.22.1  # we need 3.24+ - installing via pipx until module is available
 module load gcc/11.2.0
 module load cuda/11.7.1
 module load openmpi/4.1.2/gcc.11.2.0

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -118,6 +118,8 @@ python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade pipx
+python3 -m pipx install --upgrade cmake
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/lassen-llnl/lassen_v100_warpx_toss3.profile.example
+++ b/Tools/machines/lassen-llnl/lassen_v100_warpx_toss3.profile.example
@@ -2,7 +2,7 @@
 #export proj="<yourProjectNameHere>"  # edit this and comment in
 
 # required dependencies
-module load cmake/3.23.1
+module load cmake/3.29.2
 module load gcc/11.2.1
 module load cuda/12.0.0
 

--- a/Tools/machines/ookami-sbu/ookami_warpx.profile.example
+++ b/Tools/machines/ookami-sbu/ookami_warpx.profile.example
@@ -2,7 +2,7 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cmake/3.19.0
+module load cmake/3.19.0  # please check for a 3.24+ module and report back
 module load gcc/10.3.0
 module load openmpi/gcc10/4.1.0
 

--- a/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
+++ b/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
@@ -3,20 +3,24 @@ export proj=""  # change me!
 
 # swap to GNU programming environment (with gcc 11.2)
 module swap PrgEnv-nvhpc PrgEnv-gnu
-module swap gcc/12.2.0 gcc/11.2.0
-module load nvhpc-mixed/22.11
+module load gcc-native/12.3
+module load nvhpc-mixed/23.9
 
 # swap to the Milan cray package
-module swap craype-x86-rome craype-x86-milan
+module load craype-x86-milan
+
+# extra modules
+module use /soft/modulefiles
+module load spack-pe-gnu
 
 # required dependencies
-module load cmake/3.23.2
+module load cmake/3.27.7
 
 # optional: for QED support with detailed tables
-# module load boost/1.81.0
+module load boost
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.3
+module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/blaspp-2024.05.31:$CMAKE_PREFIX_PATH
@@ -30,7 +34,7 @@ export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/lapackpp-2024.05.31/lib64:$L
 export PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load python/3.10.9
 
 if [ -d "/home/${USER}/sw/polaris/gpu/venvs/warpx" ]
 then

--- a/Tools/machines/taurus-zih/taurus_warpx.profile.example
+++ b/Tools/machines/taurus-zih/taurus_warpx.profile.example
@@ -5,7 +5,7 @@
 module load modenv/hiera
 module load foss/2021b
 module load CUDA/11.8.0
-module load CMake/3.22.1
+module load CMake/3.27.6
 
 # optional: for QED support with detailed tables
 #module load Boost  # TODO

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -145,22 +145,17 @@ macro(find_amrex)
             endif()
             add_subdirectory(${WarpX_amrex_src} _deps/localamrex-build/)
         else()
+            if(WarpX_COMPUTE STREQUAL CUDA)
+                enable_language(CUDA)
+                # AMReX 21.06+ supports CUDA_ARCHITECTURES
+            endif()
             FetchContent_Declare(fetchedamrex
                 GIT_REPOSITORY ${WarpX_amrex_repo}
                 GIT_TAG        ${WarpX_amrex_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedamrex)
-
-            if(NOT fetchedamrex_POPULATED)
-                FetchContent_Populate(fetchedamrex)
-                list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
-                if(WarpX_COMPUTE STREQUAL CUDA)
-                    enable_language(CUDA)
-                    # AMReX 21.06+ supports CUDA_ARCHITECTURES
-                endif()
-                add_subdirectory(${fetchedamrex_SOURCE_DIR} ${fetchedamrex_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedamrex)
+            list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -53,19 +53,13 @@ function(find_picsar)
             get_source_version(PXRMP_QED ${WarpX_picsar_src})
         else()
             FetchContent_Declare(fetchedpicsar
-                GIT_REPOSITORY ${WarpX_picsar_repo}
-                GIT_TAG        ${WarpX_picsar_branch}
+                GIT_REPOSITORY  ${WarpX_picsar_repo}
+                GIT_TAG         ${WarpX_picsar_branch}
                 BUILD_IN_SOURCE 0
+                SOURCE_SUBDIR   multi_physics/QED
             )
-            FetchContent_GetProperties(fetchedpicsar)
+            FetchContent_MakeAvailable(fetchedpicsar)
 
-            if(NOT fetchedpicsar_POPULATED)
-                FetchContent_Populate(fetchedpicsar)
-                add_subdirectory(
-                    ${fetchedpicsar_SOURCE_DIR}/multi_physics/QED
-                    ${fetchedpicsar_BINARY_DIR}
-                )
-            endif()
             get_source_version(PXRMP_QED ${fetchedpicsar_SOURCE_DIR})
             if(NOT PXRMP_QED_GIT_VERSION)
                 set(PXRMP_QED_GIT_VERSION "${WarpX_picsar_branch}" CACHE INTERNAL "")

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -32,12 +32,7 @@ function(find_openpmd)
                 GIT_TAG        ${WarpX_openpmd_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedopenpmd)
-
-            if(NOT fetchedopenpmd_POPULATED)
-                FetchContent_Populate(fetchedopenpmd)
-                add_subdirectory(${fetchedopenpmd_SOURCE_DIR} ${fetchedopenpmd_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedopenpmd)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -47,12 +47,7 @@ function(find_pyamrex)
                 GIT_TAG        ${WarpX_pyamrex_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedpyamrex)
-
-            if(NOT fetchedpyamrex_POPULATED)
-                FetchContent_Populate(fetchedpyamrex)
-                add_subdirectory(${fetchedpyamrex_SOURCE_DIR} ${fetchedpyamrex_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedpyamrex)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -21,12 +21,7 @@ function(find_pybind11)
                 GIT_TAG        ${WarpX_pybind11_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedpybind11)
-
-            if(NOT fetchedpybind11_POPULATED)
-                FetchContent_Populate(fetchedpybind11)
-                add_subdirectory(${fetchedpybind11_SOURCE_DIR} ${fetchedpybind11_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedpybind11)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.20.0,<4.0.0",
+    "cmake>=3.24.0,<4.0.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -63,14 +63,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.20.0+ must be installed to build the following "
+                "CMake 3.24.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.20.0"):
-            raise RuntimeError("CMake >= 3.20.0 is required")
+        if cmake_version < parse("3.24.0"):
+            raise RuntimeError("CMake >= 3.24.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
In CMake superbuilds, `FetchContent_Populate` is now deprecated. Use `FetchContent_MakeAvailable` instead.

Bump CMake to 3.24+ to have the [latest behavioral changes](https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_makeavailable) in it. We anyway need a bump as we will soon rework the CUDA/HIP language support from AMReX to downstream.

- [x] Wait for HPC3 users
- [x] Wait for Taurus users