### PR TITLE
UB sanitizer CI test: bump clang version from 15 to 17

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -10,6 +10,7 @@ jobs:
   build_UB_sanitizer:
     name: Clang UB sanitizer
     runs-on: ubuntu-22.04
+    container: ubuntu:23.10
     if: github.event.pull_request.draft == false
     env:
       CC: clang
@@ -20,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang15.sh
+        .github/workflows/dependencies/clang17.sh
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -35,8 +36,8 @@ jobs:
         export CCACHE_MAXSIZE=100M
         ccache -z
 
-        export CXX=$(which clang++-15)
-        export CC=$(which clang-15)
+        export CXX=$(which clang++-17)
+        export CC=$(which clang-17)
         export CXXFLAGS="-fsanitize=undefined,address,pointer-compare -fno-sanitize-recover=all"
 
         cmake -S . -B build                 \

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -59,6 +59,10 @@ jobs:
     - name: run with UB sanitizer
       run: |
 
+        # We need these two lines because these tests run inside a docker container
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
         export OMP_NUM_THREADS=2
 
         #MPI implementations often leak memory


### PR DESCRIPTION
With this PR, `clang-17` instead of `clang-15` is used for UB sanitizer test in CI .

Note: Ubuntu 24.04 seems to be in beta for GitHub-hosted runners (see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners ), so in the future we won't need to use the Ubuntu 23.10 container. 