### PR TITLE
[WIP] Clang-tidy CI tests: bump clang version from 15 to 18

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: '
     google-build-namespaces,
     google-global-names-in-headers,
     misc-*,
+        -misc-include-cleaner,
         -misc-no-recursion,
         -misc-non-private-member-variables-in-classes,
     modernize-*,

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang15.sh
+        .github/workflows/dependencies/clang17.sh
     - name: set up cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -13,6 +13,7 @@ jobs:
         dim: [1, 2, RZ, 3]
     name: clang-tidy-${{ matrix.dim }}D
     runs-on: ubuntu-22.04
+    container: ubuntu:23.10
     timeout-minutes: 180
     if: github.event.pull_request.draft == false
     steps:
@@ -36,8 +37,8 @@ jobs:
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
-        export CXX=$(which clang++-15)
-        export CC=$(which clang-15)
+        export CXX=$(which clang++-17)
+        export CC=$(which clang-17)
 
         cmake -S . -B build_clang_tidy      \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
@@ -55,7 +56,7 @@ jobs:
 
         ${{github.workspace}}/.github/workflows/source/makeMakefileForClangTidy.py --input ${{github.workspace}}/ccache.log.txt
         make -j4 --keep-going -f clang-tidy-ccache-misses.mak \
-            CLANG_TIDY=clang-tidy-15 \
+            CLANG_TIDY=clang-tidy-17 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang17.sh
+        .github/workflows/dependencies/clang18.sh
     - name: set up cache
       uses: actions/cache@v4
       with:
@@ -36,8 +36,8 @@ jobs:
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
-        export CXX=$(which clang++-17)
-        export CC=$(which clang-17)
+        export CXX=$(which clang++-18)
+        export CC=$(which clang-18)
 
         cmake -S . -B build_clang_tidy      \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
@@ -55,7 +55,7 @@ jobs:
 
         ${{github.workspace}}/.github/workflows/source/makeMakefileForClangTidy.py --input ${{github.workspace}}/ccache.log.txt
         make -j4 --keep-going -f clang-tidy-ccache-misses.mak \
-            CLANG_TIDY=clang-tidy-17 \
+            CLANG_TIDY=clang-tidy-18 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         dim: [1, 2, RZ, 3]
     name: clang-tidy-${{ matrix.dim }}D
-    runs-on: ubuntu-22.04
-    container: ubuntu:23.10
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/dependencies/clang17.sh
+++ b/.github/workflows/dependencies/clang17.sh
@@ -42,6 +42,9 @@ sudo apt-get install -y \
     ccache              \
     pkg-config
 
+# ccache
+$(dirname "$0")/ccache.sh
+
 # Use clang 17
 export CXX=$(which clang++-17)
 export CC=$(which clang-17)

--- a/.github/workflows/dependencies/clang18.sh
+++ b/.github/workflows/dependencies/clang18.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 The WarpX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Luca Fedeli
+
+set -eu -o pipefail
+
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
+# This dependency file is currently used within a docker container,
+# which does not come (among others) with wget, xz-utils, curl, git,
+# ccache, and pkg-config pre-installed.
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    cmake               \
+    clang-18            \
+    clang-tidy-18       \
+    libblas-dev         \
+    libc++-18-dev       \
+    libboost-math-dev   \
+    libfftw3-dev        \
+    libfftw3-mpi-dev    \
+    libhdf5-openmpi-dev \
+    liblapack-dev       \
+    libopenmpi-dev      \
+    libomp-18-dev       \
+    ninja-build         \
+    wget                \
+    xz-utils            \
+    curl                \
+    git                 \
+    ccache              \
+    pkg-config
+
+# ccache
+$(dirname "$0")/ccache.sh
+
+# Use clang 18
+export CXX=$(which clang++-18)
+export CC=$(which clang-18)
+
+# cmake-easyinstall
+#
+sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.com/ax3l/cmake-easyinstall/main/cmake-easyinstall
+sudo chmod a+x /usr/local/bin/cmake-easyinstall
+export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"
+
+# BLAS++ & LAPACK++
+cmake-easyinstall \
+  --prefix=/usr/local                           \
+  git+https://github.com/icl-utk-edu/blaspp.git \
+  -Duse_openmp=OFF                              \
+  -Dbuild_tests=OFF                             \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
+  -DCMAKE_VERBOSE_MAKEFILE=ON
+
+cmake-easyinstall \
+  --prefix=/usr/local                             \
+  git+https://github.com/icl-utk-edu/lapackpp.git \
+  -Duse_cmake_find_lapack=ON                      \
+  -Dbuild_tests=OFF                               \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)   \
+  -DCMAKE_VERBOSE_MAKEFILE=ON


### PR DESCRIPTION
⚠️ **DO NOT MERGE!**

`clang-18 instead of `clang-15` is used for clang-tidy tests in CI . This is also a test to try out the new `Ubuntu 24.04` OS available on github runners. 
