### PR TITLE
Modernize usage of type traits in WarpX

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -51,11 +51,11 @@ PlasmaInjector::PlasmaInjector (int ispecies, const std::string& name,
 {
 
 #ifdef AMREX_USE_GPU
-    static_assert(std::is_trivially_copyable<InjectorPosition>::value,
+    static_assert(std::is_trivially_copyable_v<InjectorPosition>,
                   "InjectorPosition must be trivially copyable");
-    static_assert(std::is_trivially_copyable<InjectorDensity>::value,
+    static_assert(std::is_trivially_copyable_v<InjectorDensity>,
                   "InjectorDensity must be trivially copyable");
-    static_assert(std::is_trivially_copyable<InjectorMomentum>::value,
+    static_assert(std::is_trivially_copyable_v<InjectorMomentum>,
                   "InjectorMomentum must be trivially copyable");
 #endif
 

--- a/Source/Particles/ParticleCreation/FilterCopyTransform.H
+++ b/Source/Particles/ParticleCreation/FilterCopyTransform.H
@@ -51,7 +51,7 @@
  */
 template <int N, typename DstPC, typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc,
-          amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
+          amrex::EnableIf_t<std::is_integral_v<Index>, int> foo = 0>
 Index filterCopyTransformParticles (DstPC& pc, DstTile& dst, SrcTile& src,
                                     Index* mask, Index dst_index,
                                     CopyFunc&& copy, TransFunc&& transform) noexcept
@@ -210,7 +210,7 @@ Index filterCopyTransformParticles (DstPC& pc, DstTile& dst, SrcTile& src, Index
  */
 template <int N, typename DstPC, typename DstTile, typename SrcTile, typename Index,
           typename TransFunc, typename CopyFunc1, typename CopyFunc2,
-          amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
+          amrex::EnableIf_t<std::is_integral_v<Index>, int> foo = 0>
 Index filterCopyTransformParticles (DstPC& pc1, DstPC& pc2, DstTile& dst1, DstTile& dst2, SrcTile& src, Index* mask,
                                     Index dst1_index, Index dst2_index,
                                     CopyFunc1&& copy1, CopyFunc2&& copy2,

--- a/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
+++ b/Source/Particles/ParticleCreation/FilterCreateTransformFromFAB.H
@@ -45,7 +45,7 @@
  */
 template <int N, typename DstPC, typename DstTile, typename FAB, typename Index,
           typename CreateFunc1, typename CreateFunc2, typename TransFunc,
-          amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
+          amrex::EnableIf_t<std::is_integral_v<Index>, int> foo = 0>
 Index filterCreateTransformFromFAB (DstPC& pc1, DstPC& pc2,
                                     DstTile& dst1, DstTile& dst2, const amrex::Box box,
                                     const FAB *src_FAB, const Index* mask,

--- a/Source/Utils/Algorithms/IsIn.H
+++ b/Source/Utils/Algorithms/IsIn.H
@@ -26,7 +26,7 @@ namespace utils::algorithms
      * @return true if elem is in vect, false otherwise
      */
     template <typename TV, typename TE,
-        class = typename std::enable_if<std::is_convertible<TE,TV>::value>::type>
+        class = typename std::enable_if_t<std::is_convertible_v<TE,TV>>>
     bool is_in(const std::vector<TV>& vect,
                const TE& elem)
     {
@@ -46,7 +46,7 @@ namespace utils::algorithms
      * @return true if any element of elems is in vect, false otherwise
      */
     template <typename TV, typename TE,
-        class = typename std::enable_if<std::is_convertible<TE,TV>::value>::type>
+        class = typename std::enable_if_t<std::is_convertible_v<TE,TV>>>
     bool any_of_is_in(const std::vector<TV>& vect,
                const std::vector<TE>& elems)
     {


### PR DESCRIPTION
This PR implements C++14 style type templates  and C++17 style variable templates, as suggested by the 
- [[modernize-type-traits]](https://clang.llvm.org/extra/clang-tidy/checks/modernize/type-traits.html)

clang-tidy check.