### PR TITLE
Set default for m_current_injection_position

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -354,7 +354,7 @@ public:
     amrex::Vector<amrex::ParticleReal> m_E_external_particle;
 
     //! Current injection position
-    amrex::Real m_current_injection_position;
+    amrex::Real m_current_injection_position = 0.;
 
     // split along diagonals (0) or axes (1)
     int split_type = 0;


### PR DESCRIPTION
This gives a default value to `WarpXParticleContainer::m_current_injection_position`. This value is written out to the `WarpXHeader` file (in plot file diagnostics) and Valgrind was complaining that an uninitialized variable was being written out when the moving window was not being used.