### PR TITLE
Set t_old

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -206,6 +206,7 @@ WarpX::Evolve (int numsteps)
 
         // sync up time
         for (int i = 0; i <= max_level; ++i) {
+            t_old[i] = t_new[i];
             t_new[i] = cur_time;
         }
         multi_diags->FilterComputePackFlush( step, false, true );


### PR DESCRIPTION
The `t_old` variable wasn't being updated. This fixes that, updating it during evolve.

But note that `t_old` is never used so it could possibly be deleted. However, it is written out to the `WarpXHeader` file so deleting it would change the format of that file. This matters since that file is used for checkpoint/restart, so changing its format would break old checkpoints. So, probably best to just keep it around since it doesn't cost much. It might be useful in the Python interface.