### PR TITLE
Express differential luminosity diagnostics in eV

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3462,8 +3462,8 @@ Reduced Diagnostics
     :math:`\int d\mathcal{E}^* \frac{d\mathcal{L}}{d\mathcal{E}^*} (\mathcal{E}^*, t)\sigma^*(\mathcal{E}^*)`
     gives the total number of collisions of that process (from the beginning of the simulation up until time :math:`t`).
 
-    The differential luminosity is given in units of :math:`\text{m}^{-2}.\text{J}^{-1}`. For collider-relevant WarpX simulations
-    involving two crossing, high-energy beams of particles, the differential luminosity in :math:`\text{s}^{-1}.\text{m}^{-2}.\text{J}^{-1}`
+    The differential luminosity is given in units of :math:`\text{m}^{-2}.\text{eV}^{-1}`. For collider-relevant WarpX simulations
+    involving two crossing, high-energy beams of particles, the differential luminosity in :math:`\text{s}^{-1}.\text{m}^{-2}.\text{eV}^{-1}`
     can be obtained by multiplying the above differential luminosity by the expected repetition rate of the beams.
 
     In practice, the above expression of the differential luminosity is evaluated over discrete bins in energy :math:`\mathcal{E}^*`,
@@ -3475,10 +3475,10 @@ Reduced Diagnostics
     * ``<reduced_diags_name>.bin_number`` (`int` > 0)
         The number of bins in energy :math:`\mathcal{E}^*`
 
-    * ``<reduced_diags_name>.bin_max`` (`float`, in Joules)
+    * ``<reduced_diags_name>.bin_max`` (`float`, in eV)
         The minimum value of :math:`\mathcal{E}^*` for which the differential luminosity is computed.
 
-    * ``<reduced_diags_name>.bin_min`` (`float`, in Joules)
+    * ``<reduced_diags_name>.bin_min`` (`float`, in eV)
         The maximum value of :math:`\mathcal{E}^*` for which the differential luminosity is computed.
 
 * ``<reduced_diags_name>.intervals`` (`string`)

--- a/Examples/Tests/diff_lumi_diag/analysis.py
+++ b/Examples/Tests/diff_lumi_diag/analysis.py
@@ -9,7 +9,6 @@ import sys
 
 import numpy as np
 from read_raw_data import read_reduced_diags_histogram
-from scipy.constants import eV
 
 sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
 import checksumAPI
@@ -22,7 +21,7 @@ dL_dE_sim = bin_data[-1]  # Differential luminosity at the end of the simulation
 
 # Beam parameters
 N = 1.2e10
-E_beam = 125e9 * eV
+E_beam = 125e9  # in eV
 sigma_x = 500e-9
 sigma_y = 10e-9
 

--- a/Examples/Tests/diff_lumi_diag/inputs
+++ b/Examples/Tests/diff_lumi_diag/inputs
@@ -1,12 +1,11 @@
 #################################
 ########## MY CONSTANTS #########
 #################################
-my_constants.mc2 = m_e*clight*clight
-my_constants.GeV = q_e*1.e9
+my_constants.mc2_eV = m_e*clight*clight/q_e
 
 # BEAMS
-my_constants.beam_energy = 125.*GeV
-my_constants.beam_gamma = beam_energy/(mc2)
+my_constants.beam_energy_eV = 125.e9
+my_constants.beam_gamma = beam_energy_eV/(mc2_eV)
 my_constants.beam_charge = 1.2e10*q_e
 my_constants.sigmax = 500e-9
 my_constants.sigmay = 10e-9
@@ -123,5 +122,5 @@ DifferentialLuminosity_beam1_beam2.type = DifferentialLuminosity
 DifferentialLuminosity_beam1_beam2.intervals = 5
 DifferentialLuminosity_beam1_beam2.species = beam1 beam2
 DifferentialLuminosity_beam1_beam2.bin_number = 128
-DifferentialLuminosity_beam1_beam2.bin_max = 2.1*beam_energy
-DifferentialLuminosity_beam1_beam2.bin_min = 1.9*beam_energy
+DifferentialLuminosity_beam1_beam2.bin_max = 2.1*beam_energy_eV
+DifferentialLuminosity_beam1_beam2.bin_min = 1.9*beam_energy_eV

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -113,7 +113,7 @@ DifferentialLuminosity::DifferentialLuminosity (const std::string& rd_name)
                 ofs << m_sep;
                 ofs << "[" << off++ << "]";
                 const Real b = m_bin_min + m_bin_size*(Real(i)+0.5_rt);
-                ofs << "bin" << 1+i << "=" << b << "(J)";
+                ofs << "bin" << 1+i << "=" << b << "(eV)";
             }
             ofs << std::endl;
             // close file
@@ -133,7 +133,8 @@ void DifferentialLuminosity::ComputeDiags (int step)
     // array d_data, we add contributions at *each timestep*, but
     // we only write the data to file at intervals specified by the user.
 
-    const Real c2 = PhysConst::c*PhysConst::c;
+    const Real c2_over_qe = PhysConst::c*PhysConst::c/PhysConst::q_e;
+    const Real inv_c2 = 1._rt/(PhysConst::c*PhysConst::c);
 
     // get a reference to WarpX instance
     auto& warpx = WarpX::GetInstance();
@@ -218,13 +219,13 @@ void DifferentialLuminosity::ComputeDiags (int step)
                         index_type const j_2 = indices_2[i_2];
 
                         Real const u1_square =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-                        Real const gamma1 = std::sqrt(1._rt + u1_square/c2);
+                        Real const gamma1 = std::sqrt(1._rt + u1_square*inv_c2);
                         Real const u2_square = u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-                        Real const gamma2 = std::sqrt(1._rt + u2_square/c2);
+                        Real const gamma2 = std::sqrt(1._rt + u2_square*inv_c2);
                         Real const u1_dot_u2 = u1x[j_1]*u2x[j_2] + u1y[j_1]*u2y[j_2] + u1z[j_1]*u2z[j_2];
 
-                        // center of mass energy
-                        Real const E_com = c2 * std::sqrt(m1*m1 + m2*m2 + 2*m1*m2* (gamma1*gamma2 - u1_dot_u2/c2));
+                        // center of mass energy in eV
+                        Real const E_com = c2_over_qe * std::sqrt(m1*m1 + m2*m2 + 2*m1*m2* (gamma1*gamma2 - u1_dot_u2*inv_c2));
 
                         // determine particle bin
                         int const bin = int(Math::floor((E_com-bin_min)/bin_size));
@@ -242,9 +243,9 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
                         Real const v1_cross_v2_square = (u1_cross_u2_x*u1_cross_u2_x + u1_cross_u2_y*u1_cross_u2_y + u1_cross_u2_z*u1_cross_u2_z) / (gamma1*gamma1*gamma2*gamma2);
 
-                        Real const radicand = v1_minus_v2_square - v1_cross_v2_square / c2;
+                        Real const radicand = v1_minus_v2_square - v1_cross_v2_square * inv_c2;
 
-                        Real const dL_dEcom = std::sqrt( radicand ) * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 J^-1
+                        Real const dL_dEcom = std::sqrt( radicand ) * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
                         amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 


### PR DESCRIPTION
Given the applications for this reduced diagnostic, I think it makes sense to express the center-of-mass energy in eV rather than in Joules.