### PR TITLE
Adding path to cmake for lapackpp so it can find installed blaspp on …

### DIFF
--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -103,7 +103,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31 -DCMAKE_PREFIX_PATH=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/lapackpp-pm-gpu-build --target install --parallel 16
 rm -rf ${build_dir}/lapackpp-pm-gpu-build
 


### PR DESCRIPTION
…perlmutter.

Error during dependency reinstall on perlmutter showed up as:

```
-- Check for BLAS++
CMake Warning at CMakeLists.txt:710 (find_package):
  By not providing "Findblaspp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "blaspp", but
  CMake did not find one.

  Could not find a package configuration file provided by "blaspp" with any
  of the following names:

    blasppConfig.cmake
    blaspp-config.cmake

  Add the installation prefix of "blaspp" to CMAKE_PREFIX_PATH or set
  "blaspp_DIR" to a directory containing one of the above files.  If "blaspp"
  provides a separate development package or SDK, be sure it has been
  installed.


CMake Error at CMakeLists.txt:714 (message):
  BLAS++ not found.  LAPACK++ requires BLAS++ to be installed first.


-- Configuring incomplete, errors occurred!

```

Adding the blaspp install directory fixed this issue.