### PR TITLE
Fix directional comparisons in assertions

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -181,10 +181,11 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
 
     if (WarpX::gamma_boost > 1.) {
         // Check that the laser direction is equal to the boost direction
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(  m_nvec[0]*WarpX::boost_direction[0]
-                                         + m_nvec[1]*WarpX::boost_direction[1]
-                                         + m_nvec[2]*WarpX::boost_direction[2] - 1. < 1.e-12,
-                                           "The Lorentz boost should be in the same direction as the laser propagation");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            (m_nvec[0]-WarpX::boost_direction[0])*(m_nvec[0]-WarpX::boost_direction[0]) +
+            (m_nvec[1]-WarpX::boost_direction[1])*(m_nvec[1]-WarpX::boost_direction[1]) +
+            (m_nvec[2]-WarpX::boost_direction[2])*(m_nvec[2]-WarpX::boost_direction[2]) < 1.e-12,
+            "The Lorentz boost should be in the same direction as the laser propagation");
         // Get the position of the plane, along the boost direction, in the lab frame
         // and convert the position of the antenna to the boosted frame
         m_Z0_lab = m_nvec[0]*m_position[0] + m_nvec[1]*m_position[1] + m_nvec[2]*m_position[2];
@@ -246,8 +247,10 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
         windir[dir] = 1.0;
 #endif
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            (m_nvec[0]-windir[0]) + (m_nvec[1]-windir[1]) + (m_nvec[2]-windir[2])
-            < 1.e-12, "do_continous_injection for laser particle only works" +
+            (m_nvec[0]-windir[0])*(m_nvec[0]-windir[0]) +
+            (m_nvec[1]-windir[1])*(m_nvec[1]-windir[1]) +
+            (m_nvec[2]-windir[2])*(m_nvec[2]-windir[2]) < 1.e-12,
+            "do_continous_injection for laser particle only works" +
             " if moving window direction and laser propagation direction are the same");
         if ( WarpX::gamma_boost>1 ){
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(


### PR DESCRIPTION
Lorentz boost direction and laser propagation direction always evaluate as being in the same direction, assuming both are normalized.  For example, m_nvec = {0, 0, -1} and boost_direction = {0, 0, 1} failed to trigger the assertion.

Replaced faulty comparisons with idiom used elsewhere:
https://github.com/ECP-WarpX/WarpX/blob/cc6e7ea1074c0d9e97cdf60363d772c119cc1dea/Source/Initialization/WarpXInitData.cpp#L803