### PR TITLE
[WIP] CI: 30-40sec install w/ pixi

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,7 @@
 # -*- mode: yaml -*-
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-22.04'
 
 pr:
   autoCancel: true
@@ -9,37 +9,23 @@ pr:
 
 jobs:
 - job:
-  # FIXME remove unused variables
   variables:
-    BLASPP_HOME: '/usr/local'
-    CEI_SUDO: 'sudo'
-    CEI_TMP: '/tmp/cei'
-    CMAKE_GENERATOR: 'Ninja'
-    FFTW_HOME: '/usr'
-    LAPACKPP_HOME: '/usr/local'
-    WARPX_CI_CCACHE: 'TRUE'
-    #WARPX_OPENPMD: 'TRUE'
-
+    AMREX_CMAKE_FLAGS: -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON -DpyAMReX_IPO=OFF
+    CMAKE_BUILD_PARALLEL_LEVEL: 2
+    CMAKE_GENERATOR: Ninja
+    CXXFLAGS: -Wno-array-bounds  # many false positives in g++ 12
   strategy:
     matrix:
-      # Cartesian 1D
       cartesian_1d:
-        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=1 -DWarpX_FFT=ON -DWarpX_PYTHON=ON
-      # Cartesian 2D
+        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=1
       cartesian_2d:
-        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=2 -DWarpX_FFT=ON -DWarpX_PYTHON=ON
-      # Cartesian 3D
+        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=2
       cartesian_3d:
-        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_PYTHON=ON
-        WARPX_HEFFTE: 'TRUE'
-      # Cylindrical RZ
+        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=3
       cylindrical_rz:
-        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=RZ -DWarpX_FFT=ON -DWarpX_PYTHON=ON
-        WARPX_RZ_FFT: 'TRUE'
-      # single precision
-      #single_precision:
-      #  WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;2;3;RZ' -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PRECISION=SINGLE
-      #  WARPX_RZ_FFT: 'TRUE'
+        WARPX_CMAKE_FLAGS: -DWarpX_DIMS=RZ
+      #single_precision:  # TODO: will be reintroduced systematically at a later point
+      #  WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;2;3;RZ' -DWarpX_PRECISION=SINGLE
 
   # default: 60; maximum: 360
   timeoutInMinutes: 240
@@ -57,107 +43,63 @@ jobs:
          Ccache | "$(System.JobName)" | .azure-pipelines.yml
       path: /home/vsts/.ccache
       cacheHitVar: CCACHE_CACHE_RESTORED
-    displayName: Cache Ccache Objects
-
-  - task: Cache@2
-    continueOnError: true
-    inputs:
-      key: 'Python3 | "$(System.JobName)" | .azure-pipelines.yml'
-      restoreKeys: |
-         Python3 | "$(System.JobName)" | .azure-pipelines.yml
-      path: /home/vsts/.local/lib/python3.8
-      cacheHitVar: PYTHON38_CACHE_RESTORED
-    displayName: Cache Python Libraries
+    displayName: Cache CCache Objects
 
   - bash: |
       set -eu -o pipefail
       cat /proc/cpuinfo | grep "model name" | sort -u
       df -h
-      echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
-      sudo apt update
-      sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
-        openmpi-bin libopenmpi-dev \
-        libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
-        python3 python3-pandas python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
-      ccache --set-config=max_size=10.0G
-      python3 -m pip install --upgrade pip
-      python3 -m pip install --upgrade build
-      python3 -m pip install --upgrade packaging
-      python3 -m pip install --upgrade setuptools
-      python3 -m pip install --upgrade wheel
-      python3 -m pip install --upgrade virtualenv
-      python3 -m pip install --upgrade pipx
-      python3 -m pipx install cmake
-      python3 -m pipx ensurepath
-      export PATH="$HOME/.local/bin:$PATH"
-      sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.com/ax3l/cmake-easyinstall/main/cmake-easyinstall
-      sudo chmod a+x /usr/local/bin/cmake-easyinstall
-      #if [ "${WARPX_OPENPMD:-FALSE}" == "TRUE" ]; then
-      #  cmake-easyinstall --prefix=/usr/local                   \
-      #    git+https://github.com/openPMD/openPMD-api.git@0.14.3 \
-      #    -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)         \
-      #    -DCMAKE_VERBOSE_MAKEFILE=ON                           \
-      #    -DopenPMD_USE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_CLI_TOOLS=OFF
-      #  #python3 -m pip install --upgrade openpmd-api
-      #fi
-      if [ "${WARPX_RZ_FFT:-FALSE}" == "TRUE" ]; then
-        # BLAS++
-        cmake-easyinstall --prefix=/usr/local           \
-          git+https://github.com/icl-utk-edu/blaspp.git \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
-          -DCMAKE_CXX_STANDARD=17                       \
-          -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-        # LAPACK++
-        cmake-easyinstall --prefix=/usr/local             \
-          git+https://github.com/icl-utk-edu/lapackpp.git \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)   \
-          -DCMAKE_CXX_STANDARD=17                         \
-          -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-      fi
-      if [ "${WARPX_HEFFTE:-FALSE}" == "TRUE" ]; then
-        cmake-easyinstall --prefix=/usr/local git+https://github.com/icl-utk-edu/heffte.git@v2.4.0 \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)          \
-          -DCMAKE_CXX_STANDARD=17 -DHeffte_ENABLE_DOXYGEN=OFF    \
-          -DHeffte_ENABLE_FFTW=ON -DHeffte_ENABLE_TESTING=OFF    \
-          -DHeffte_ENABLE_CUDA=OFF -DHeffte_ENABLE_ROCM=OFF      \
-          -DHeffte_ENABLE_ONEAPI=OFF -DHeffte_ENABLE_MKL=OFF     \
-          -DHeffte_ENABLE_PYTHON=OFF -DHeffte_ENABLE_FORTRAN=OFF \
-          -DHeffte_ENABLE_MAGMA=OFF                              \
-          -DCMAKE_VERBOSE_MAKEFILE=ON
-      fi
-      # Python modules required for test analysis
-      python3 -m pip install --upgrade -r Regression/requirements.txt
-      python3 -m pip cache purge
-      # external repositories required for test analysis
-      cd ..
-      git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git
-      # TODO select only specific datasets?
-      git clone --depth 1 https://github.com/openPMD/openPMD-example-datasets.git
-      cd -
-      rm -rf ${CEI_TMP}
-      df -h
-    displayName: 'Install dependencies'
+
+      # Setup pixi for Azure Pipelines
+      curl -fsSL https://pixi.sh/install.sh | bash
+      export PATH=$HOME/.pixi/bin:$PATH
+      echo "##vso[task.setvariable variable=PATH]$PATH"
+
+      # configure in pyproject.toml [tool.pixi.dependencies]
+      pixi install
+      pixi list
+    displayName: Install dependencies
 
   - bash: |
       set -eu -o pipefail
+
+      # external repositories required for test analysis
+      git clone --depth 1 https://github.com/ECP-WarpX/warpx-data.git \
+        ../warpx-data
+      # TODO select only specific datasets?
+      git clone --depth 1 https://github.com/openPMD/openPMD-example-datasets.git \
+        ../openPMD-example-datasets
+
       df -h
+    displayName: Download test data
+
+  - bash: |
+      eval "$(pixi shell-hook)"
+      set -eu -o pipefail
 
       # configure
-      export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
-      cmake -S . -B build       \
-        ${AMReX_CMAKE_FLAGS}    \
-        ${WARPX_CMAKE_FLAGS}    \
-        -DWarpX_TEST_CLEANUP=ON \
+      cmake -S . -B build             \
+        ${AMREX_CMAKE_FLAGS}          \
+        ${WARPX_CMAKE_FLAGS}          \
+        -DWarpX_FFT=ON                \
+        -DWarpX_HEFFTE=ON             \
+        -DWarpX_openpmd_internal=OFF  \
+        -DWarpX_pybind11_internal=OFF \
+        -DWarpX_PYTHON=ON             \
+        -DWarpX_PYTHON_IPO=OFF        \
+        -DWarpX_TEST_CLEANUP=ON       \
         -DWarpX_TEST_FPETRAP=ON
 
       # build
-      cmake --build build -j 2
-      df -h
-    displayName: 'Build'
+      cmake --build build
+    displayName: Build WarpX
 
   - bash: |
+      eval "$(pixi shell-hook)"
       set -eu -o pipefail
 
       # run tests (exclude pytest.AMReX when running Python tests)
       ctest --test-dir build --output-on-failure -E AMReX
-    displayName: 'Test'
+
+      df -h
+    displayName: Test WarpX

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,11 @@ pr:
 jobs:
 - job:
   variables:
-    AMREX_CMAKE_FLAGS: -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON -DpyAMReX_IPO=OFF
+    # TODO: fpe_trap_invalid broken in HDF5 1.14.3
+    #       Remove "-DWarpX_TEST_FPETRAP_ARGS=..." once 1.14.4 is available.
+    #       https://github.com/HDFGroup/hdf5/issues/4801
+    #       https://github.com/conda-forge/hdf5-feedstock/pull/231
+    AMREX_CMAKE_FLAGS: -DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON -DpyAMReX_IPO=OFF -DWarpX_TEST_FPETRAP_ARGS=amrex.fpe_trap_overflow=1 amrex.fpe_trap_zero=1"
     CMAKE_BUILD_PARALLEL_LEVEL: 2
     CMAKE_GENERATOR: Ninja
     CXXFLAGS: -Wno-array-bounds  # many false positives in g++ 12

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Docs/source/_static/doxyhtml
 ####################
 # Package Managers #
 ####################
+# Pixi
+# https://pixi.sh
+pixi.lock
 # anonymous Spack environments
 # https://spack.readthedocs.io/en/latest/environments.html#anonymous-environments
 .spack-env/
@@ -70,3 +73,6 @@ cmake-build-*/
 .DS_Store
 .AppleDouble
 .LSOverride
+# pixi environments
+.pixi
+*.egg-info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,15 @@ mark_as_advanced(WarpX_TEST_CLEANUP)
 
 # Advanced option to run CI tests with FPE-trapping runtime parameters
 option(WarpX_TEST_FPETRAP "Run CI tests with FPE-trapping runtime parameters" OFF)
+set(WarpX_TEST_FPETRAP_ARGS
+    "amrex.fpe_trap_invalid = 1"
+    "amrex.fpe_trap_overflow = 1"
+    "amrex.fpe_trap_zero = 1"
+    CACHE STRING
+    "AMReX FPE-trapping runtime options if(WarpX_TEST_FPETRAP)"
+)
 mark_as_advanced(WarpX_TEST_FPETRAP)
+mark_as_advanced(WarpX_TEST_FPETRAP_ARGS)
 
 set(WarpX_DIMS_VALUES 1 2 3 RZ)
 set(WarpX_DIMS 3 CACHE STRING "Simulation dimensionality <1;2;3;RZ>")

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -137,11 +137,7 @@ function(add_warpx_test
         )
         set(runtime_params_fpetrap "")
         if(WarpX_TEST_FPETRAP)
-            set(runtime_params_fpetrap
-                "amrex.fpe_trap_invalid = 1"
-                "amrex.fpe_trap_overflow = 1"
-                "amrex.fpe_trap_zero = 1"
-            )
+            set(runtime_params_fpetrap ${WarpX_TEST_FPETRAP_ARGS})
         endif()
         add_test(
             NAME ${name}.run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,65 @@ known-first-party = ["amrex", "picmistandard", "pywarpx", "warpx"]
 [tool.isort]
 known_first_party = ["amrex", "picmistandard", "pywarpx", "warpx"]
 profile = "black"
+
+[tool.pixi.project]
+name = "warpx-omp-dev"
+channels = ["conda-forge"]
+platforms = ["linux-64"]  # Azure CI
+# platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "osx-arm64", "win-64"]  # generally what we support with conda-forge
+
+[tool.pixi.dependencies]
+boost = ">=1.85.0"
+ccache = "*"
+cmake = ">=3.24.0"
+compilers = "*"
+dill = "*"
+fftw = ">=3.3"
+git = ">=2.18"
+heffte = { version = ">=2.4.0", build = "mpi_mpich_*" }
+lapackpp = ">=2022.5.0"
+lasy = ">=0.5.0"
+matplotlib = "*"
+mpi = { build = "mpich" }
+mpi4py = "*"
+ninja = "*"
+numpy = "~=1.15"  # unyt 2.9.5 in yt 4.3.1 does not support numpy 2 yet
+openpmd-api = { version = ">=0.15.2", build = "mpi_mpich_*" }
+openpmd-viewer = "*"
+packaging = "*"
+pandas = "*"
+periodictable = "*"
+picmistandard = "==0.30.0"  # see requirements.txt
+pip = ">=24.2"
+pkg-config = "*"
+pybind11 = ">=2.12.0"
+python = "*"
+setuptools = ">=42"
+scipy ="*"
+virtualenv = "*"
+wheel = ">=0.44.0"
+yt = ">=4.3.1"
+
+# For packages not yet available on Conda-Forge
+# [tool.pixi.pypi-dependencies]
+# lasy = ">=0.5.0"
+# picmistandard = "==0.30.0"  # see requirements.txt
+# pywarpx = { path = ".", editable = true }
+
+[tool.linux-64.dependencies]
+libgomp = "*"
+
+[tool.linux-aarch64.dependencies]
+libgomp = "*"
+
+[tool.linux-ppc64le.dependencies]
+libgomp = "*"
+
+[tool.osx-64.dependencies]
+llvm-openmp = "*"
+
+[tool.osx-arm64.dependencies]
+llvm-openmp = "*"
+
+[tool.win-64.dependencies]
+llvm-openmp = "*"


### PR DESCRIPTION
Update our unit tests to use:
- Ubuntu 22.04 (from 20.04)
- GCC 12 (from GCC 9)

This speeds up dependency installs significantly.

- [ ] many test are too unstable to produce the same checksums and their tolerances need to be bumped
- [x] rebase after #5068 was merged
- [x] some analysis scripts might fail with the SciPy update (i.e., see #5661)