### PR TITLE
Use amrex::ParmParse::prettyPrintTable

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -226,7 +226,7 @@ FlushFormatPlotfile::WriteJobInfo(const std::string& dir) const
         jobInfoFile << " Inputs File Parameters\n";
         jobInfoFile << PrettyLine;
 
-        ParmParse::dumpTable(jobInfoFile, true);
+        ParmParse::prettyPrintTable(jobInfoFile);
 
         jobInfoFile.close();
     }

--- a/Source/ablastr/utils/UsedInputsFile.cpp
+++ b/Source/ablastr/utils/UsedInputsFile.cpp
@@ -23,7 +23,7 @@ ablastr::utils::write_used_inputs_file (std::string const & filename)
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream jobInfoFile;
         jobInfoFile.open(filename.c_str(), std::ios::out);
-        amrex::ParmParse::dumpTable(jobInfoFile, true);
+        amrex::ParmParse::prettyPrintTable(jobInfoFile);
         jobInfoFile.close();
     }
 }


### PR DESCRIPTION
Instead of `amrex::ParmParse::dumpTable`, we use `prettyPrintTable` that removes duplicates.

Related to #5192 and https://github.com/AMReX-Codes/amrex/issues/4087
Improves #3132