### PR TITLE
GatherAndPush: Use CTO ParallelFor

### DIFF
--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -1072,7 +1072,8 @@ void WarpXFluidContainer::GatherAndPush (
 
 #ifdef AMREX_USE_CUDA
                     amrex::ignore_unused(Exfield_parser, Eyfield_parser, Ezfield_parser,
-                                         Bxfield_parser, Byfield_parser, Bzfield_parser, gamma_boost);
+                                         Bxfield_parser, Byfield_parser, Bzfield_parser,
+                                         gamma_boost, problo, dx, t, beta_boost);
 #endif
 
                     if constexpr (boost_control == has_gamma_boost) { // Lorentz transform fields due to moving frame

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -1055,6 +1055,7 @@ void WarpXFluidContainer::GatherAndPush (
                 if (N_arr(i,j,k)>0.0) {
 
                     // Interpolate fields from tmp to Nodal points
+                    // NOLINTBEGIN(misc-const-correctness)
                     amrex::Real Ex_Nodal = ablastr::coarsen::sample::Interp(Ex_arr,
                         Ex_type, Nodal_type, coarsening_ratio, i, j, k, 0);
                     amrex::Real Ey_Nodal = ablastr::coarsen::sample::Interp(Ey_arr,
@@ -1067,10 +1068,11 @@ void WarpXFluidContainer::GatherAndPush (
                         By_type, Nodal_type, coarsening_ratio, i, j, k, 0);
                     amrex::Real Bz_Nodal = ablastr::coarsen::sample::Interp(Bz_arr,
                         Bz_type, Nodal_type, coarsening_ratio, i, j, k, 0);
+                    // NOLINTEND(misc-const-correctness)
 
 #ifdef AMREX_USE_CUDA
-                    amrex::ignore_unused(Exfield_parser,Eyfield_parser,Ezfield_parser,
-                                         Bxfield_parser,Byfield_parser,Bzfield_parser,gamma_boost);
+                    amrex::ignore_unused(Exfield_parser, Eyfield_parser, Ezfield_parser,
+                                         Bxfield_parser, Byfield_parser, Bzfield_parser, gamma_boost);
 #endif
 
                     if constexpr (boost_control == has_gamma_boost) { // Lorentz transform fields due to moving frame


### PR DESCRIPTION
The GPU kernel in GatherAndPush contains Parsers for computing external E and B fields. It's known that even if the Parsers are not used at run time, the occupancy on AMD GPUs are still affected. This is probably reason why this kernel is 50% slower on MI200 than on A100. Using CTO ParallelFor should improve the performance.

Related to #5199 