### PR TITLE
Cleanup dimension macros around ignore_unused

### DIFF
--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -510,12 +510,7 @@ PEC::ApplyPECtoEfield (
         amrex::ParallelFor(
             tex, nComp_x,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 0;
                 ::SetEfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -523,12 +518,7 @@ PEC::ApplyPECtoEfield (
             },
             tey, nComp_y,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 1;
                 ::SetEfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -536,12 +526,7 @@ PEC::ApplyPECtoEfield (
             },
             tez, nComp_z,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 2;
                 ::SetEfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -602,12 +587,7 @@ PEC::ApplyPECtoBfield (
         amrex::ParallelFor(
             tbx, nComp_x,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 0;
                 ::SetBfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -615,12 +595,7 @@ PEC::ApplyPECtoBfield (
             },
             tby, nComp_y,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 1;
                 ::SetBfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -628,12 +603,7 @@ PEC::ApplyPECtoBfield (
             },
             tbz, nComp_z,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-                amrex::ignore_unused(k);
-#endif
-#if (defined WARPX_DIM_1D_Z)
                 amrex::ignore_unused(j,k);
-#endif
                 const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
                 const int icomp = 2;
                 ::SetBfieldOnPEC(icomp, domain_lo, domain_hi, iv, n,
@@ -727,11 +697,7 @@ PEC::ApplyReflectiveBoundarytoRhofield (
         // Loop over valid cells (i.e. cells inside the domain)
         amrex::ParallelFor(mfi.validbox(), nComp,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            amrex::ignore_unused(k);
-#elif (defined WARPX_DIM_1D_Z)
             amrex::ignore_unused(j,k);
-#endif
             // Store the array index
             const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
 
@@ -859,11 +825,7 @@ PEC::ApplyReflectiveBoundarytoJfield(
         // Loop over valid cells (i.e. cells inside the domain)
         amrex::ParallelFor(mfi.validbox(), Jx->nComp(),
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            amrex::ignore_unused(k);
-#elif (defined WARPX_DIM_1D_Z)
             amrex::ignore_unused(j,k);
-#endif
             // Store the array index
             const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
 
@@ -894,11 +856,7 @@ PEC::ApplyReflectiveBoundarytoJfield(
         // Loop over valid cells (i.e. cells inside the domain)
         amrex::ParallelFor(mfi.validbox(), Jy->nComp(),
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            amrex::ignore_unused(k);
-#elif (defined WARPX_DIM_1D_Z)
             amrex::ignore_unused(j,k);
-#endif
             // Store the array index
             const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
 
@@ -929,11 +887,7 @@ PEC::ApplyReflectiveBoundarytoJfield(
         // Loop over valid cells (i.e. cells inside the domain)
         amrex::ParallelFor(mfi.validbox(), Jz->nComp(),
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            amrex::ignore_unused(k);
-#elif (defined WARPX_DIM_1D_Z)
             amrex::ignore_unused(j,k);
-#endif
             // Store the array index
             const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
 
@@ -1000,11 +954,7 @@ PEC::ApplyPECtoElectronPressure (
         // Loop over valid cells (i.e. cells inside the domain)
         amrex::ParallelFor(mfi.validbox(), nComp,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            amrex::ignore_unused(k);
-#elif (defined WARPX_DIM_1D_Z)
             amrex::ignore_unused(j,k);
-#endif
             // Store the array index
             const amrex::IntVect iv(AMREX_D_DECL(i,j,k));
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -48,32 +48,25 @@ using namespace amrex;
  * \brief Update the B field, over one timestep
  */
 void FiniteDifferenceSolver::EvolveB (
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Bfield,
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Efield,
-    std::unique_ptr<amrex::MultiFab> const& Gfield,
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& face_areas,
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& area_mod,
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 >& ECTRhofield,
-    std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Venl,
-    std::array< std::unique_ptr<amrex::iMultiFab>, 3 >& flag_info_cell,
-    std::array< std::unique_ptr<amrex::LayoutData<FaceInfoBox> >, 3 >& borrowing,
-    int lev, amrex::Real const dt ) {
-
-#if defined(WARPX_DIM_RZ) || !defined(AMREX_USE_EB)
-  amrex::ignore_unused(area_mod, ECTRhofield, Venl, flag_info_cell, borrowing);
-#endif
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Bfield,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Efield,
+    [[maybe_unused]] std::unique_ptr<amrex::MultiFab> const& Gfield,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& face_areas,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& area_mod,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 >& ECTRhofield,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Venl,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::iMultiFab>, 3 >& flag_info_cell,
+    [[maybe_unused]] std::array< std::unique_ptr<amrex::LayoutData<FaceInfoBox> >, 3 >& borrowing,
+    [[maybe_unused]] int lev,
+    [[maybe_unused]] amrex::Real const dt ) {
 
     // Select algorithm (The choice of algorithm is a runtime option,
     // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
     if ((m_fdtd_algo == ElectromagneticSolverAlgo::Yee)||
         (m_fdtd_algo == ElectromagneticSolverAlgo::HybridPIC)){
-        ignore_unused(Gfield, face_areas);
         EvolveBCylindrical <CylindricalYeeAlgorithm> ( Bfield, Efield, lev, dt );
 #else
-    if(m_grid_type == GridType::Collocated || m_fdtd_algo != ElectromagneticSolverAlgo::ECT){
-        amrex::ignore_unused(face_areas);
-    }
 
     if (m_grid_type == GridType::Collocated) {
 

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -216,12 +216,7 @@ struct SetParticlePosition
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (const long i, RType x, RType y, RType z) const noexcept
     {
-#if defined(WARPX_DIM_XZ)
-        amrex::ignore_unused(y);
-#endif
-#if defined(WARPX_DIM_1D_Z)
-        amrex::ignore_unused(x,y);
-#endif
+        amrex::ignore_unused(x,y,z);
 #ifdef WARPX_DIM_RZ
         m_theta[i] = std::atan2(y, x);
         m_x[i] = std::sqrt(x*x + y*y);
@@ -245,12 +240,7 @@ struct SetParticlePosition
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AsStored (const long i, RType x, RType y, RType z) const noexcept
     {
-#if defined(WARPX_DIM_XZ)
-        amrex::ignore_unused(y);
-#endif
-#if defined(WARPX_DIM_1D_Z)
-        amrex::ignore_unused(x,y);
-#endif
+        amrex::ignore_unused(x,y,z);
 #ifdef WARPX_DIM_RZ
         m_x[i] = x;
         m_theta[i] = y;


### PR DESCRIPTION
Removed macros around `ignore_unused`. For example
```
#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
                amrex::ignore_unused(k);
#endif
#if AMREX_SPACEDIM == 1
                amrex::ignore_unused(j,k);
#endif
```
with 
```
                amrex::ignore_unused(j,k);
```