### PR TITLE
AMReX_BLProfiler.H should be included, not AMReX_TinyProfiler.H

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -12,7 +12,7 @@
 #include <AMReX.H>
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_ParmParse.H>
-#include <AMReX_TinyProfiler.H>
+#include <AMReX_BLProfiler.H>
 
 #include <string>
 


### PR DESCRIPTION
This should fix compilation when the tiny profiler is off.