### PR TITLE
[WIP] CTest: No Backtrace Handler

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -129,6 +129,7 @@ function(add_warpx_test
         set(runtime_params
             "amrex.abort_on_unused_inputs = 1"
             "amrex.throw_exception = 1"
+            "amrex.signal_handling = 0"
             "warpx.always_warn_immediately = 1"
             "warpx.do_dynamic_scheduling = 0"
             "warpx.serialize_initial_conditions = 1"


### PR DESCRIPTION
Missing in #5068.

We want to be able to user debuggers in IDEs and development by default, not read `Backtrace.0.0` files.

- [ ] make this a `WarpX_TEST_...` option.
- [ ] Document all `WarpX_TEST_...` options in CTest section.

See:
- https://github.com/ECP-WarpX/impactx/blob/71d0e5b3f7a5e27f337c303c1fde61700f5ea702/examples/CMakeLists.txt#L82-L83
- https://amrex-codes.github.io/amrex/docs_html/Debugging.html#breaking-into-debuggers