### PR TITLE
Fix C++20 issue

### DIFF
--- a/Source/NonlinearSolvers/JacobianFunctionMF.H
+++ b/Source/NonlinearSolvers/JacobianFunctionMF.H
@@ -21,8 +21,8 @@ class JacobianFunctionMF
 
     using RT = typename T::value_type;
 
-    JacobianFunctionMF<T,Ops>() = default;
-    ~JacobianFunctionMF<T,Ops>() = default;
+    JacobianFunctionMF() = default;
+    ~JacobianFunctionMF() = default;
 
     // Default move and copy operations
     JacobianFunctionMF(const JacobianFunctionMF&) = default;

--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -28,9 +28,9 @@ class NewtonSolver : public NonlinearSolver<Vec,Ops>
 {
 public:
 
-    NewtonSolver<Vec,Ops>() = default;
+    NewtonSolver() = default;
 
-    ~NewtonSolver<Vec,Ops>() override = default;
+    ~NewtonSolver() override = default;
 
     // Prohibit Move and Copy operations
     NewtonSolver(const NewtonSolver&) = delete;

--- a/Source/NonlinearSolvers/NonlinearSolver.H
+++ b/Source/NonlinearSolvers/NonlinearSolver.H
@@ -28,9 +28,9 @@ class NonlinearSolver
 {
 public:
 
-    NonlinearSolver<Vec,Ops>() = default;
+    NonlinearSolver() = default;
 
-    virtual ~NonlinearSolver<Vec,Ops>() = default;
+    virtual ~NonlinearSolver() = default;
 
     // Prohibit Move and Copy operations
     NonlinearSolver(const NonlinearSolver&) = delete;

--- a/Source/NonlinearSolvers/PicardSolver.H
+++ b/Source/NonlinearSolvers/PicardSolver.H
@@ -26,9 +26,9 @@ class PicardSolver : public NonlinearSolver<Vec,Ops>
 {
 public:
 
-    PicardSolver<Vec,Ops>() = default;
+    PicardSolver() = default;
 
-    ~PicardSolver<Vec,Ops>() override = default;
+    ~PicardSolver() override = default;
 
     // Prohibit Move and Copy operations
     PicardSolver(const PicardSolver&) = delete;


### PR DESCRIPTION
This PR fixes the following warning, observed with `g++ 14`:


```
warning: template-id not allowed for constructor in C++20
```

See for instance https://stackoverflow.com/questions/71978335/class-templates-constructor-declaration-doesnt-compile-for-c20-but-compiles