### PR TITLE
Add base 2D Langmuir test, fix broken docs link

### DIFF
--- a/Examples/Tests/langmuir/CMakeLists.txt
+++ b/Examples/Tests/langmuir/CMakeLists.txt
@@ -12,6 +12,16 @@ add_warpx_test(
 )
 
 add_warpx_test(
+    test_2d_langmuir_multi  # name
+    2  # dims
+    2  # nprocs
+    inputs_test_2d_langmuir_multi  # inputs
+    analysis_2d.py  # analysis
+    diags/diag1000080  # output
+    OFF  # dependency
+)
+
+add_warpx_test(
     test_2d_langmuir_multi_mr  # name
     2  # dims
     2  # nprocs

--- a/Examples/Tests/langmuir/inputs_test_2d_langmuir_multi
+++ b/Examples/Tests/langmuir/inputs_test_2d_langmuir_multi
@@ -1,0 +1,7 @@
+# base input parameters
+FILE = inputs_base_2d
+
+# test input parameters
+algo.current_deposition = direct
+diag1.electrons.variables = x z w ux uy uz
+diag1.positrons.variables = x z w ux uy uz

--- a/Regression/Checksum/benchmarks_json/test_2d_langmuir_multi.json
+++ b/Regression/Checksum/benchmarks_json/test_2d_langmuir_multi.json
@@ -1,0 +1,29 @@
+{
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 5.726296856755232,
+    "Bz": 0.0,
+    "Ex": 3751589134191.326,
+    "Ey": 0.0,
+    "Ez": 3751589134191.332,
+    "jx": 1.0100623329922576e+16,
+    "jy": 0.0,
+    "jz": 1.0100623329922578e+16
+  },
+  "electrons": {
+    "particle_momentum_x": 5.668407513430198e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 5.668407513430198e-20,
+    "particle_position_x": 0.6553599999999999,
+    "particle_position_y": 0.65536,
+    "particle_weight": 3200000000000000.5
+  },
+  "positrons": {
+    "particle_momentum_x": 5.668407513430198e-20,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 5.668407513430198e-20,
+    "particle_position_x": 0.6553599999999999,
+    "particle_position_y": 0.65536,
+    "particle_weight": 3200000000000000.5
+  }
+}


### PR DESCRIPTION
Add base 2D Langmuir test, similarly to the base 3D test we already have.

Discussed offline with @RemiLehe and seen first due to a broken link in the "Examples" section of the documentation (originally pointing to the test input file added in this PR, which did not exist). 

Whether or not we need/want to reduce the amount of variants of Langmuir tests could be the subject of a separate issue and possibly subsequent PR.