### PR TITLE
For flux injection, improve the calculation of number of particles per cell

### DIFF
--- a/Regression/Checksum/benchmarks_json/test_rz_flux_injection.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_flux_injection.json
@@ -1,14 +1,15 @@
 {
-  "electron": {
-    "particle_momentum_x": 7.168456345337534e-18,
-    "particle_momentum_y": 7.02290351254873e-18,
-    "particle_momentum_z": 9.565641373942318e-42,
-    "particle_position_x": 6962.988311042427,
-    "particle_position_y": 2034.5301680154264,
-    "particle_theta": 6397.068924320389,
-    "particle_weight": 3.215011942598676e-08
-  },
   "lev=0": {
-    "Bz": 9.526664429810971e-24
+    "Bz": 9.524453851623612e-24
+  },
+  "electron": {
+    "particle_momentum_x": 7.146168286112378e-18,
+    "particle_momentum_y": 7.073108431229069e-18,
+    "particle_momentum_z": 9.282175511339672e-42,
+    "particle_position_x": 6978.157994231982,
+    "particle_position_y": 2044.6981840260364,
+    "particle_theta": 6298.956888689097,
+    "particle_weight": 3.2236798669537214e-08
   }
 }
+

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1453,8 +1453,6 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
             auto lo = getCellCoords(overlap_corner, dx, {0._rt, 0._rt, 0._rt}, iv);
             auto hi = getCellCoords(overlap_corner, dx, {1._rt, 1._rt, 1._rt}, iv);
 
-            const int num_ppc_int = static_cast<int>(num_ppc_real + amrex::Random(engine));
-
             if (flux_pos->overlapsWith(lo, hi))
             {
                 auto index = overlap_box.index(iv);
@@ -1464,7 +1462,8 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
                 } else {
                     r = 1;
                 }
-                pcounts[index] = num_ppc_int*r;
+                const int num_ppc_int = static_cast<int>(num_ppc_real*r + amrex::Random(engine));
+                pcounts[index] = num_ppc_int;
             }
             amrex::ignore_unused(j,k);
         });


### PR DESCRIPTION
This PR improves the calculation of the number of particles to inject when there is mesh refinement. The algorithm takes a real number of particles and does `num_pcc_int = (int)(num_ppc_real + random)`. This will on average get the number of particles injected correct.

However, this was being done before the scale factor for refinement was applied. This means that the variation in the number of particles will be the refinement factor. If for example `num_ppc_real = 4.4` and the refinement factor is 4, the number of particles injected will be either 16 or 20. With the fix, the random number is added after the refinement factor is applied. So in the example, the number of particles injected will be 17 or 18, giving less noise.