### PR TITLE
[DoNotMerge] Revert "Doc: Conda-Forge w/ heFFTe (#4989)"

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -81,7 +81,7 @@ Conda (Linux/macOS/Windows)
 
       .. code-block:: bash
 
-         conda create -n warpx-cpu-mpich-dev -c conda-forge blaspp boost ccache cmake compilers git "heffte=*=mpi_mpich*" lapackpp "openpmd-api=*=mpi_mpich*" openpmd-viewer python make numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba mpich mpi4py ninja pip virtualenv
+         conda create -n warpx-cpu-mpich-dev -c conda-forge blaspp boost ccache cmake compilers git lapackpp "openpmd-api=*=mpi_mpich*" openpmd-viewer python make numpy pandas scipy yt "fftw=*=mpi_mpich*" pkg-config matplotlib mamba mpich mpi4py ninja pip virtualenv
          conda activate warpx-cpu-mpich-dev
 
          # compile WarpX with -DWarpX_MPI=ON


### PR DESCRIPTION
The installation instructions include `heffte` in the dependencies that are installed by default for WarpX (when compiling by hand). However, this does not work on MacOS. (The `conda` installation fails in this case.) 
Since we are not yet using heFFTe in WarpX anyway, I would recommend to temporarily remove heffte from the installation instructions.

This reverts commit a4fbb137583372d7d632d5317845f7a15fdc162d.

