### PR TITLE
Add Time-Averaged Field Diagnostics

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2634,10 +2634,10 @@ In-situ visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 WarpX has five types of diagnostics:
-``FullDiagnostics`` consist in dumps of fields and particles at given iterations,
-``TimeAveragedDiagnostics`` only allow field data which they output after averaging over a period of time,
-``BackTransformedDiagnostics`` are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame,
-``BoundaryScrapingDiagnostics`` are used to collect the particles that are absorbed at the boundary, throughout the simulation, and
+``Full`` diagnostics consist in dumps of fields and particles at given iterations,
+``TimeAveraged`` diagnostics only allow field data, which they output after averaging over a period of time,
+``BackTransformed`` diagnostics are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame,
+``BoundaryScraping`` diagnostics are used to collect the particles that are absorbed at the boundary, throughout the simulation, and
 ``ReducedDiags`` allow the user to compute some reduced quantity (particle temperature, max of a field) and write a small amount of data to text files.
 Similar to what is done for physical species, WarpX has a class Diagnostics that allows users to initialize different diagnostics, each of them with different fields, resolution and period.
 This currently applies to standard diagnostics, but should be extended to back-transformed diagnostics and reduced diagnostics (and others) in a near future.
@@ -2889,13 +2889,13 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 Time-Averaged Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``TimeAveraged`` diagnostics are a special type of ``FullDiagnostics`` that allows for the output of time-averaged field data.
+``TimeAveraged`` diagnostics are a special type of ``Full`` diagnostics that allows for the output of time-averaged field data.
 This type of diagnostics can be created using ``<diag_name>.diag_type = TimeAveraged``.
 We support only field data and related options from the list at `Full Diagnostics`_.
 
 .. note::
 
-    As with ``FullDiagnostics``, ``TimeAveraged`` diagnostics output the initial **instantaneous** conditions of the selected fields on step 0 (unless more specific output intervals exclude output for step 0).
+    As with ``Full`` diagnostics, ``TimeAveraged`` diagnostics output the initial **instantaneous** conditions of the selected fields on step 0 (unless more specific output intervals exclude output for step 0).
 
 In addition, ``TimeAveraged`` diagnostic options include:
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2934,6 +2934,7 @@ BackTransformed Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``BackTransformed`` diag type are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame. This option can be set using ``<diag_name>.diag_type = BackTransformed``. We support the following list of options from `Full Diagnostics`_
+
     ``<diag_name>.format``, ``<diag_name>.openpmd_backend``, ``<diag_name>.dump_rz_modes``, ``<diag_name>.file_prefix``, ``<diag_name>.diag_lo``, ``<diag_name>.diag_hi``, ``<diag_name>.write_species``, ``<diag_name>.species``.
 
     Additional options for this diagnostic include:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2633,8 +2633,9 @@ Diagnostics and output
 In-situ visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-WarpX has four types of diagnostics:
+WarpX has five types of diagnostics:
 ``FullDiagnostics`` consist in dumps of fields and particles at given iterations,
+``TimeAveragedDiagnostics`` only allow field data which they output after averaging over a period of time,
 ``BackTransformedDiagnostics`` are used when running a simulation in a boosted frame, to reconstruct output data to the lab frame,
 ``BoundaryScrapingDiagnostics`` are used to collect the particles that are absorbed at the boundary, throughout the simulation, and
 ``ReducedDiags`` allow the user to compute some reduced quantity (particle temperature, max of a field) and write a small amount of data to text files.
@@ -2881,6 +2882,47 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``warpx.mffile_nstreams`` (`int`) optional (default `4`)
     Limit the number of concurrent readers per file.
+
+
+.. _running-cpp-parameters-diagnostics-timeavg:
+
+Time-Averaged Diagnostics
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``TimeAveraged`` diagnostics are a special type of ``FullDiagnostics`` that allows for the output of time-averaged field data.
+This type of diagnostics can be created using ``<diag_name>.diag_type = TimeAveraged``.
+We support only field data and related options from the list at `Full Diagnostics`_.
+
+    In addition, `TimeAveraged` diagnostic options include:
+
+* ``<diag_name>.time_average_mode`` (`string`, default `none`)
+    Describes the operating mode for time averaged field output.
+
+    * ``none`` for no averaging (instantaneous fields)
+
+    * ``fixed_start`` for a diagnostic that averages all fields between the current output step and a fixed point in time
+
+    * ``dynamic_start`` for a constant averaging period and output at different points in time (non-overlapping)
+
+    .. note::
+
+        To enable time-averaged field output with intervals tightly spaced enough for overlapping averaging periods,
+        please create additional instances of ``TimeAveraged`` diagnostics.
+
+* ``<diag_name>.average_period_steps`` (`int`)
+    Configures the number of time steps in an averaging period.
+    Set this only in the ``dynamic_start`` mode and only if ``average_period_time`` has not already been set.
+    Will be ignored in the ``fixed_start`` mode (with warning).
+
+* ``<diag_name>.average_period_time`` (`float`, in seconds)
+    Configures the time (SI units) in an averaging period.
+    Set this only in the ``dynamic_start`` mode and only if ``average_period_steps`` has not already been set.
+    Will be ignored in the ``fixed_start`` mode (with warning).
+
+* ``<diag_name>.average_start_step`` (`int`)
+    Configures the time step at which time-averaging begins.
+    Set this only in the ``fixed_start`` mode.
+    Will be ignored in the ``dynamic_start`` mode (with warning).
 
 .. _running-cpp-parameters-diagnostics-btd:
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2893,7 +2893,11 @@ Time-Averaged Diagnostics
 This type of diagnostics can be created using ``<diag_name>.diag_type = TimeAveraged``.
 We support only field data and related options from the list at `Full Diagnostics`_.
 
-    In addition, `TimeAveraged` diagnostic options include:
+.. note::
+
+    As with ``FullDiagnostics``, ``TimeAveraged`` diagnostics output the initial **instantaneous** conditions of the selected fields on step 0 (unless more specific output intervals exclude output for step 0).
+
+In addition, ``TimeAveraged`` diagnostic options include:
 
 * ``<diag_name>.time_average_mode`` (`string`, default `none`)
     Describes the operating mode for time averaged field output.

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -114,6 +114,8 @@ Diagnostics
 
 .. autoclass:: pywarpx.picmi.FieldDiagnostic
 
+.. autoclass:: pywarpx.picmi.TimeAveragedFieldDiagnostic
+
 .. autoclass:: pywarpx.picmi.ElectrostaticFieldDiagnostic
 
 .. autoclass:: pywarpx.picmi.Checkpoint

--- a/Examples/Physics_applications/laser_ion/CMakeLists.txt
+++ b/Examples/Physics_applications/laser_ion/CMakeLists.txt
@@ -6,19 +6,9 @@ add_warpx_test(
     2  # dims
     2  # nprocs
     inputs_test_2d_laser_ion_acc  # inputs
-    analysis_default_openpmd_regression.py  # analysis
+    analysis_test_laser_ion.py  # analysis
     diags/diagInst/  # output
     OFF  # dependency
-)
-
-add_warpx_test(
-    test_2d_laser_ion_acc_time_avg  # name
-    2  # dims
-    2  # nprocs
-    inputs_test_2d_laser_ion_acc  # inputs; will not be used b/c dependent test
-    analysis_time_avg_diags.py  # analysis
-    diags/diagTimeAvg/  # output
-    test_2d_laser_ion_acc  # dependency
 )
 
 add_warpx_test(
@@ -26,18 +16,7 @@ add_warpx_test(
     2  # dims
     2  # nprocs
     inputs_test_2d_laser_ion_acc_picmi.py  # inputs
-    analysis_default_openpmd_regression.py  # analysis
+    analysis_test_laser_ion.py  # analysis
     diags/diagInst/  # output
     OFF  # dependency
 )
-
-# We do not have an intervals parser for PICMI yet which would accept more than a single integer for the output period
-#add_warpx_test(
-#    test_2d_laser_ion_acc_time_avg_picmi  # name
-#    2  # dims
-#    2  # nprocs
-#    inputs_test_2d_laser_ion_acc_picmi.py  # inputs
-#    analysis_time_avg_diags.py  # analysis
-#    diags/diagTimeAvg/  # output
-#    test_2d_laser_ion_acc_picmi  # dependency
-#)

--- a/Examples/Physics_applications/laser_ion/CMakeLists.txt
+++ b/Examples/Physics_applications/laser_ion/CMakeLists.txt
@@ -12,6 +12,16 @@ add_warpx_test(
 )
 
 add_warpx_test(
+    test_2d_laser_ion_acc_time_avg  # name
+    2  # dims
+    2  # nprocs
+    inputs_test_2d_laser_ion_acc  # inputs; will not be used b/c dependent test
+    analysis_time_avg_diags.py  # analysis
+    diags/diagTimeAvg/  # output
+    test_2d_laser_ion_acc  # dependency
+)
+
+add_warpx_test(
     test_2d_laser_ion_acc_picmi  # name
     2  # dims
     2  # nprocs
@@ -20,3 +30,14 @@ add_warpx_test(
     diags/diagInst/  # output
     OFF  # dependency
 )
+
+# We do not have an intervals parser for PICMI yet which would accept more than a single integer for the output period
+#add_warpx_test(
+#    test_2d_laser_ion_acc_time_avg_picmi  # name
+#    2  # dims
+#    2  # nprocs
+#    inputs_test_2d_laser_ion_acc_picmi.py  # inputs
+#    analysis_time_avg_diags.py  # analysis
+#    diags/diagTimeAvg/  # output
+#    test_2d_laser_ion_acc_picmi  # dependency
+#)

--- a/Examples/Physics_applications/laser_ion/CMakeLists.txt
+++ b/Examples/Physics_applications/laser_ion/CMakeLists.txt
@@ -7,7 +7,7 @@ add_warpx_test(
     2  # nprocs
     inputs_test_2d_laser_ion_acc  # inputs
     analysis_default_openpmd_regression.py  # analysis
-    diags/diag1/  # output
+    diags/diagInst/  # output
     OFF  # dependency
 )
 
@@ -17,6 +17,6 @@ add_warpx_test(
     2  # nprocs
     inputs_test_2d_laser_ion_acc_picmi.py  # inputs
     analysis_default_openpmd_regression.py  # analysis
-    diags/diag1/  # output
+    diags/diagInst/  # output
     OFF  # dependency
 )

--- a/Examples/Physics_applications/laser_ion/README.rst
+++ b/Examples/Physics_applications/laser_ion/README.rst
@@ -87,7 +87,7 @@ Visualize
    :alt: Particle densities for electrons (top), protons (middle), and electrons again in logarithmic scale (bottom).
    :width: 80%
 
-    Particle densities for electrons (top), protons (middle), and electrons again in logarithmic scale (bottom).
+   Particle densities for electrons (top), protons (middle), and electrons again in logarithmic scale (bottom).
 
 Particle density output illustrates the evolution of the target in time and space.
 Logarithmic scales can help to identify where the target becomes transparent for the laser pulse (bottom panel in :numref:`fig-tnsa-densities` ).

--- a/Examples/Physics_applications/laser_ion/analysis_default_openpmd_regression.py
+++ b/Examples/Physics_applications/laser_ion/analysis_default_openpmd_regression.py
@@ -1,1 +1,0 @@
-../../analysis_default_openpmd_regression.py

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -72,6 +72,7 @@ if __name__ == "__main__":
     evaluate_checksum(
         test_name=os.path.split(os.getcwd())[1],
         output_file=sys.argv[1],
+        output_format="openpmd",
     )
 
     # TODO: implement intervals parser for PICMI that allows more complex output periods

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -85,7 +85,6 @@ def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
 
 
 if __name__ == "__main__":
-
     test_name = os.path.split(os.getcwd())[1]
     inst_output_file = sys.argv[1]
 

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -1,9 +1,31 @@
 #!/usr/bin/env python3
 
+import os
+import re
 import sys
 
 import numpy as np
 import openpmd_api as io
+
+sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
+from checksumAPI import evaluate_checksum
+
+
+def analyze_openpmd_regression(output_file):
+    # Run checksum regression test
+    if re.search("single_precision", output_file):
+        evaluate_checksum(
+            test_name=test_name,
+            output_file=output_file,
+            output_format="openpmd",
+            rtol=2e-6,
+        )
+    else:
+        evaluate_checksum(
+            test_name=test_name,
+            output_file=output_file,
+            output_format="openpmd",
+        )
 
 
 def load_field_from_iteration(
@@ -27,15 +49,15 @@ def load_field_from_iteration(
     return field_data
 
 
-def main():
+def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
+    """Compare instantaneous data (multiple iterations averaged in post-processing) with in-situ averaged data."""
+
     field = "E"
     coord = "z"
     avg_period_steps = 5
     avg_output_step = 100
 
-    path_tpl_inst = "diags/diagInst/openpmd_%T.h5"
-
-    dir_avg = sys.argv[1]
+    path_tpl_inst = f"{dir_inst}/openpmd_%T.h5"
     path_tpl_avg = f"{dir_avg}/openpmd_%T.h5"
 
     si = io.Series(path_tpl_inst, io.Access.read_only)
@@ -63,4 +85,18 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+
+    test_name = os.path.split(os.getcwd())[1]
+    inst_output_file = sys.argv[1]
+
+    # Regression checksum test
+    #   NOTE: works only in the example directory due to relative path import
+    analyze_openpmd_regression(inst_output_file)
+
+    # TODO: implement intervals parser for PICMI that allows more complex output periods
+    if "picmi" not in test_name:
+        # Functionality test for TimeAveragedDiagnostics
+        compare_time_avg_with_instantaneous_diags(
+            dir_inst=sys.argv[1],
+            dir_avg="diags/diagTimeAvg/",
+        )

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -11,23 +11,6 @@ sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
 from checksumAPI import evaluate_checksum
 
 
-def analyze_openpmd_regression(output_file):
-    # Run checksum regression test
-    if re.search("single_precision", output_file):
-        evaluate_checksum(
-            test_name=test_name,
-            output_file=output_file,
-            output_format="openpmd",
-            rtol=2e-6,
-        )
-    else:
-        evaluate_checksum(
-            test_name=test_name,
-            output_file=output_file,
-            output_format="openpmd",
-        )
-
-
 def load_field_from_iteration(
     series, iteration: int, field: str, coord: str = None
 ) -> np.ndarray:
@@ -85,14 +68,15 @@ def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
 
 
 if __name__ == "__main__":
-    test_name = os.path.split(os.getcwd())[1]
-    inst_output_file = sys.argv[1]
-
-    # Regression checksum test
-    #   NOTE: works only in the example directory due to relative path import
-    analyze_openpmd_regression(inst_output_file)
+    # NOTE: works only in the example directory due to relative path import
+    # compare checksums
+    evaluate_checksum(
+        test_name=os.path.split(os.getcwd())[1],
+        output_file=sys.argv[1],
+    )
 
     # TODO: implement intervals parser for PICMI that allows more complex output periods
+    test_name = os.path.split(os.getcwd())[1]
     if "picmi" not in test_name:
         # Functionality test for TimeAveragedDiagnostics
         compare_time_avg_with_instantaneous_diags(

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import re
 import sys
 
 import numpy as np

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -59,7 +59,7 @@ def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
     data_avg = load_field_from_iteration(sa, avg_output_step, field, coord)
 
     # Compare the data
-    if np.allclose(data_inst, data_avg):
+    if np.allclose(data_inst, data_avg, rtol=1e-12):
         print("Test passed: actual data is close to expected data.")
     else:
         print("Test failed: actual data is not close to expected data.")

--- a/Examples/Physics_applications/laser_ion/analysis_time_avg_diags.py
+++ b/Examples/Physics_applications/laser_ion/analysis_time_avg_diags.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import sys
+import numpy as np
+import openpmd_api as io
+
+
+def load_field_from_iteration(series, iteration : int, field : str, coord : str = None) -> np.ndarray:
+    """Load iteration of field data from file."""
+
+    it = series.iterations[iteration]
+    field_obj = it.meshes[f"{field}"]
+
+    if field_obj.scalar:
+        field_data = field_obj[io.Mesh_Record_Component.SCALAR].load_chunk()
+    elif coord in [item[0] for item in list(field_obj.items())]:
+        field_data = field_obj[coord].load_chunk()
+    else:
+        raise Exception(f"Specified coordinate: f{coord} is not available for field: f{field}.")
+    series.flush()
+
+    return field_data
+
+
+def main():
+
+    field = "E"
+    coord = "z"
+    avg_period_steps = 5
+    avg_output_step = 100
+
+    path_tpl_inst = "diags/diagInst/openpmd_%T.h5"
+
+    dir_avg = sys.argv[1]
+    path_tpl_avg = f"{dir_avg}/openpmd_%T.h5"
+
+    si = io.Series(path_tpl_inst, io.Access.read_only)
+    sa = io.Series(path_tpl_avg, io.Access.read_only)
+
+    ii0 = si.iterations[0]
+    fi0 = ii0.meshes[field][coord]
+    shape = fi0.shape
+
+    data_inst = np.zeros(shape)
+
+    for i in np.arange(avg_output_step-avg_period_steps+1,avg_output_step+1):
+        data_inst += load_field_from_iteration(si, i, field, coord)
+
+    data_inst = data_inst / avg_period_steps
+
+    data_avg = load_field_from_iteration(sa, avg_output_step, field, coord)
+
+    # Compare the data
+    if np.allclose(data_inst, data_avg):
+        print("Test passed: actual data is close to expected data.")
+    else:
+        print("Test failed: actual data is not close to expected data.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/Physics_applications/laser_ion/analysis_time_avg_diags.py
+++ b/Examples/Physics_applications/laser_ion/analysis_time_avg_diags.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import sys
+
 import numpy as np
 import openpmd_api as io
 
 
-def load_field_from_iteration(series, iteration : int, field : str, coord : str = None) -> np.ndarray:
+def load_field_from_iteration(
+    series, iteration: int, field: str, coord: str = None
+) -> np.ndarray:
     """Load iteration of field data from file."""
 
     it = series.iterations[iteration]
@@ -16,14 +19,15 @@ def load_field_from_iteration(series, iteration : int, field : str, coord : str 
     elif coord in [item[0] for item in list(field_obj.items())]:
         field_data = field_obj[coord].load_chunk()
     else:
-        raise Exception(f"Specified coordinate: f{coord} is not available for field: f{field}.")
+        raise Exception(
+            f"Specified coordinate: f{coord} is not available for field: f{field}."
+        )
     series.flush()
 
     return field_data
 
 
 def main():
-
     field = "E"
     coord = "z"
     avg_period_steps = 5
@@ -43,7 +47,7 @@ def main():
 
     data_inst = np.zeros(shape)
 
-    for i in np.arange(avg_output_step-avg_period_steps+1,avg_output_step+1):
+    for i in np.arange(avg_output_step - avg_period_steps + 1, avg_output_step + 1):
         data_inst += load_field_from_iteration(si, i, field, coord)
 
     data_inst = data_inst / avg_period_steps

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -202,7 +202,8 @@ laser1.profile_focal_distance = 4.0e-6  # focal distance from the antenna [m]
 #
 diagnostics.diags_names = diagInst diagTimeAvg openPMDfw openPMDbw
 
-diagInst.intervals = 100
+# instantaneous field and particle diagnostic
+diagInst.intervals = 100,96:100  # second interval only for CI testing the time-averaged diags
 diagInst.diag_type = Full
 diagInst.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
 # reduce resolution of output fields
@@ -213,10 +214,12 @@ diagInst.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) 
 diagInst.format = openpmd
 diagInst.openpmd_backend = h5
 
+# time-averaged particle and field diagnostic
 diagTimeAvg.intervals = 100
 diagTimeAvg.diag_type = TimeAveraged
 diagTimeAvg.time_average_mode = dynamic_start
-diagTimeAvg.average_period_time = 2.67e-15  # period of 800 nm light waves
+#diagTimeAvg.average_period_time = 2.67e-15  # period of 800 nm light waves
+diagTimeAvg.average_period_steps = 5  # use only either `time` or `steps`
 diagTimeAvg.write_species = 0
 diagTimeAvg.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
 # reduce resolution of output fields

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -200,18 +200,29 @@ laser1.profile_focal_distance = 4.0e-6  # focal distance from the antenna [m]
 #################################
 # Diagnostics
 #
-diagnostics.diags_names = diag1 openPMDfw openPMDbw
+diagnostics.diags_names = diagInst diagTimeAvg openPMDfw openPMDbw
 
-diag1.intervals = 100
-diag1.diag_type = Full
-diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
+diagInst.intervals = 100
+diagInst.diag_type = Full
+diagInst.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
 # reduce resolution of output fields
-diag1.coarsening_ratio = 4 4
+diagInst.coarsening_ratio = 4 4
 # demonstration of a spatial and momentum filter
-diag1.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) * (x>-1.0e-6)
-diag1.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) * (x>-1.0e-6)
-diag1.format = openpmd
-diag1.openpmd_backend = h5
+diagInst.electrons.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) * (x>-1.0e-6)
+diagInst.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) * (x>-1.0e-6)
+diagInst.format = openpmd
+diagInst.openpmd_backend = h5
+
+diagTimeAvg.intervals = 100::100  # TODO just write 100 and make step 0 an instantaneous diagnostic and do not forget to document
+diagTimeAvg.diag_type = TimeAveraged
+diagTimeAvg.time_average_mode = dynamic_start
+diagTimeAvg.average_period_time = 2.67e-15  # period of 800 nm light waves
+diagTimeAvg.write_species = 0
+diagTimeAvg.fields_to_plot = Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
+# reduce resolution of output fields
+diagTimeAvg.coarsening_ratio = 4 4
+diagTimeAvg.format = openpmd
+diagTimeAvg.openpmd_backend = h5
 
 openPMDfw.intervals = 100
 openPMDfw.diag_type = Full

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -213,7 +213,7 @@ diagInst.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>=0) * (x<1.0e-6) 
 diagInst.format = openpmd
 diagInst.openpmd_backend = h5
 
-diagTimeAvg.intervals = 100::100  # TODO just write 100 and make step 0 an instantaneous diagnostic and do not forget to document
+diagTimeAvg.intervals = 100
 diagTimeAvg.diag_type = TimeAveraged
 diagTimeAvg.time_average_mode = dynamic_start
 diagTimeAvg.average_period_time = 2.67e-15  # period of 800 nm light waves

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -218,7 +218,7 @@ diagTimeAvg.diag_type = TimeAveraged
 diagTimeAvg.time_average_mode = dynamic_start
 diagTimeAvg.average_period_time = 2.67e-15  # period of 800 nm light waves
 diagTimeAvg.write_species = 0
-diagTimeAvg.fields_to_plot = Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
+diagTimeAvg.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho rho_electrons rho_hydrogen
 # reduce resolution of output fields
 diagTimeAvg.coarsening_ratio = 4 4
 diagTimeAvg.format = openpmd

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
@@ -171,7 +171,7 @@ field_time_avg_diag = picmi.TimeAveragedFieldDiagnostic(
     warpx_format="openpmd",
     warpx_openpmd_backend="h5",
     warpx_time_average_mode="dynamic_start",
-    warpx_average_period_steps=10,
+    warpx_average_period_time=2.67e-15,
 )
 
 particle_fw_diag = picmi.ParticleDiagnostic(

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
@@ -162,6 +162,18 @@ field_diag = picmi.FieldDiagnostic(
     warpx_openpmd_backend="h5",
 )
 
+field_time_avg_diag = picmi.TimeAveragedFieldDiagnostic(
+    name="diagTimeAvg",
+    grid=grid,
+    period=100,
+    number_of_cells=ncell_field,
+    data_list=["B", "E", "J", "rho", "rho_electrons", "rho_hydrogen"],
+    warpx_format="openpmd",
+    warpx_openpmd_backend="h5",
+    warpx_time_average_mode="dynamic_start",
+    warpx_average_period_steps=10,
+)
+
 particle_fw_diag = picmi.ParticleDiagnostic(
     name="openPMDfw",
     period=100,
@@ -292,6 +304,7 @@ sim.add_laser(laser, injection_method=laser_antenna)
 # Add full diagnostics
 sim.add_diagnostic(particle_diag)
 sim.add_diagnostic(field_diag)
+sim.add_diagnostic(field_time_avg_diag)
 sim.add_diagnostic(particle_fw_diag)
 sim.add_diagnostic(particle_bw_diag)
 # Add reduced diagnostics

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
@@ -140,7 +140,7 @@ solver = picmi.ElectromagneticSolver(
 
 # Diagnostics
 particle_diag = picmi.ParticleDiagnostic(
-    name="diag1",
+    name="diagInst",
     period=100,
     warpx_format="openpmd",
     warpx_openpmd_backend="h5",
@@ -153,7 +153,7 @@ ncell_field = []
 for ncell_comp, cr in zip([nx, nz], coarsening_ratio):
     ncell_field.append(int(ncell_comp / cr))
 field_diag = picmi.FieldDiagnostic(
-    name="diag1",
+    name="diagInst",
     grid=grid,
     period=100,
     number_of_cells=ncell_field,

--- a/Examples/Physics_applications/laser_ion/plot_2d.py
+++ b/Examples/Physics_applications/laser_ion/plot_2d.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
         "-d",
         "--diag_dir",
         type=str,
-        default="./diags/diag1",
+        default="./diags/diagInst",
         help="Directory containing density and field diagnostics",
     )
     parser.add_argument(

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3270,6 +3270,7 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
 ElectrostaticFieldDiagnostic = FieldDiagnostic
 
+
 class TimeAveragedFieldDiagnostic(FieldDiagnostic):
     """
     See `Input Parameters <https://warpx.readthedocs.io/en/latest/usage/parameters.html>`__ for more information.
@@ -3319,7 +3320,6 @@ class TimeAveragedFieldDiagnostic(FieldDiagnostic):
         self.diagnostic.average_period_steps = self.average_period_steps
         self.diagnostic.average_period_time = self.average_period_time
         self.diagnostic.average_start_step = self.average_start_step
-
 
 
 class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3270,6 +3270,57 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
 
 ElectrostaticFieldDiagnostic = FieldDiagnostic
 
+class TimeAveragedFieldDiagnostic(FieldDiagnostic):
+    """
+    See `Input Parameters <https://warpx.readthedocs.io/en/latest/usage/parameters.html>`__ for more information.
+
+    Parameters
+    ----------
+    warpx_time_average_mode: str
+        Type of time averaging diagnostic
+        Supported values include ``"none"``, ``"fixed_start"``, and ``"dynamic_start"``
+
+            * ``"none"`` for no averaging (instantaneous fields)
+            * ``"fixed_start"`` for a diagnostic that averages all fields between the current output step and a fixed point in time
+            * ``"dynamic_start"`` for a constant averaging period and output at different points in time (non-overlapping)
+
+    warpx_average_period_steps: int, optional
+        Configures the number of time steps in an averaging period.
+        Set this only in the ``"dynamic_start"`` mode and only if ``warpx_average_period_time`` has not already been set.
+        Will be ignored in the ``"fixed_start"`` mode (with warning).
+
+    warpx_average_period_time: float, optional
+        Configures the time (SI units) in an averaging period.
+        Set this only in the ``"dynamic_start"`` mode and only if ``average_period_steps`` has not already been set.
+        Will be ignored in the ``"fixed_start"`` mode (with warning).
+
+    warpx_average_start_steps: int, optional
+        Configures the time step at which time-averaging begins.
+        Set this only in the ``"fixed_start"`` mode.
+        Will be ignored in the ``"dynamic_start"`` mode (with warning).
+    """
+
+    def init(self, kw):
+        super().init(kw)
+        self.time_average_mode = kw.pop("warpx_time_average_mode", None)
+        self.average_period_steps = kw.pop("warpx_average_period_steps", None)
+        self.average_period_time = kw.pop("warpx_average_period_time", None)
+        self.average_start_step = kw.pop("warpx_average_start_step", None)
+
+    def diagnostic_initialize_inputs(self):
+        super().diagnostic_initialize_inputs()
+
+        self.diagnostic.set_or_replace_attr("diag_type", "TimeAveraged")
+
+        if "write_species" not in self.diagnostic.argvattrs:
+            self.diagnostic.write_species = False
+
+        self.diagnostic.time_average_mode = self.time_average_mode
+        self.diagnostic.average_period_steps = self.average_period_steps
+        self.diagnostic.average_period_time = self.average_period_time
+        self.diagnostic.average_start_step = self.average_start_step
+
+
 
 class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     """

--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -28,7 +28,7 @@ class BTDiagnostics final : public Diagnostics
 {
 public:
 
-    BTDiagnostics (int i, const std::string& name);
+    BTDiagnostics (int i, const std::string& name, DiagTypes diag_type);
 
 private:
     /** Whether to plot raw (i.e., NOT cell-centered) fields */

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -55,8 +55,8 @@ namespace
     constexpr int permission_flag_rwxrxrx = 0755;
 }
 
-BTDiagnostics::BTDiagnostics (int i, const std::string& name)
-    : Diagnostics{i, name},
+BTDiagnostics::BTDiagnostics (int i, const std::string& name, DiagTypes diag_type)
+    : Diagnostics{i, name, diag_type},
       m_cell_centered_data_name("BTD_cell_centered_data_" + name)
 {
     ReadParameters();

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -23,7 +23,7 @@ public:
      * @param i index of diagnostics in MultiDiagnostics::alldiags
      * @param name diagnostics name in the inputs file
      */
-    BoundaryScrapingDiagnostics (int i, const std::string& name);
+    BoundaryScrapingDiagnostics (int i, const std::string& name, DiagTypes diag_type);
 
 private:
     /** Read relevant parameters for BoundaryScraping */

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -22,8 +22,8 @@
 
 using namespace amrex::literals;
 
-BoundaryScrapingDiagnostics::BoundaryScrapingDiagnostics (int i, const std::string& name)
-    : Diagnostics{i, name}
+BoundaryScrapingDiagnostics::BoundaryScrapingDiagnostics (int i, const std::string& name, DiagTypes diag_type)
+    : Diagnostics{i, name, diag_type}
 {
     ReadParameters();
 }

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -267,6 +267,8 @@ protected:
      */
     amrex::Vector< amrex::Vector< amrex::MultiFab > >  m_mf_output;
 
+    amrex::Vector< amrex::Vector <amrex::MultiFab > > m_sum_mf_output;
+
     /** Geometry that defines the domain attributes corresponding to output multifab.
      *  Specifically, the user-defined physical co-ordinates for the diagnostics
      *  is used to construct the geometry information for each MultiFab at

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -266,7 +266,11 @@ protected:
      *  The second vector is loops over the total number of levels.
      */
     amrex::Vector< amrex::Vector< amrex::MultiFab > >  m_mf_output;
-
+    /** summation multifab, where all fields (computed, cell-centered, and stacked)
+     *  are summed for every step in a time averaging period.
+     *  The first vector is for total number of snapshots. (=1 for FullDiagnostics)
+     *  The second vector is loops over the total number of levels.
+     */
     amrex::Vector< amrex::Vector <amrex::MultiFab > > m_sum_mf_output;
 
     /** Geometry that defines the domain attributes corresponding to output multifab.

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+/** All types of diagnostics. */
+enum struct DiagTypes {Full, BackTransformed, BoundaryScraping, TimeAveraged};
 /**
  * \brief base class for diagnostics.
  * Contains main routines to filter, compute and flush diagnostics.
@@ -35,7 +37,7 @@ public:
      * @param i index of diagnostics in MultiDiagnostics::alldiags
      * @param name diagnostics name in the inputs file
      */
-    Diagnostics (int i, std::string name);
+    Diagnostics (int i, std::string name, DiagTypes diag_type);
 
     /** Virtual Destructor to handle clean destruction of derived classes */
     virtual ~Diagnostics ();
@@ -45,6 +47,8 @@ public:
     Diagnostics(Diagnostics&& )                    = default;
     Diagnostics& operator=(Diagnostics&& )         = default;
 
+    /** Stores the diag type */
+    DiagTypes m_diag_type;
     /** Pack (stack) all fields in the cell-centered output MultiFab m_mf_output.
      *
      * Fields are computed (e.g., cell-centered or back-transformed)

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -535,6 +535,11 @@ Diagnostics::InitBaseData ()
     for (int i = 0; i < m_num_buffers; ++i) {
         m_mf_output[i].resize( nmax_lev );
     }
+    m_sum_mf_output.resize(m_num_buffers);
+    for (int i = 0; i < m_num_buffers; ++i) {
+        m_sum_mf_output[i].resize( nmax_lev );
+    }
+
 
     // allocate vector of geometry objects corresponding to each output multifab.
     m_geom_output.resize( m_num_buffers );
@@ -559,6 +564,8 @@ Diagnostics::ComputeAndPack ()
 
     auto & warpx = WarpX::GetInstance();
 
+    bool do_sum_now = cur_step >= time_ave 
+
     // compute the necessary fields and store result in m_mf_output.
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
         for(int lev=0; lev<nlev_output; lev++){
@@ -569,7 +576,11 @@ Diagnostics::ComputeAndPack ()
                 // a diagnostics and writes in one or more components of the output
                 // multifab m_mf_output[lev].
                 m_all_field_functors[lev][icomp]->operator()(m_mf_output[i_buffer][lev], icomp_dst, i_buffer);
+                if (do_sum_now)
                 // update the index of the next component to fill
+                int scalar_a = 1;
+                // call amrex sax operation to do the following
+                m_sum_mf_output[i_buffer][lev] += scalar_a * m_mf_output[i_buffer][lev]
                 icomp_dst += m_all_field_functors[lev][icomp]->nComp();
             }
             // Check that the proper number of components of mf_avg were updated.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -582,7 +582,7 @@ Diagnostics::ComputeAndPack ()
 
             if (m_diag_type == DiagTypes::TimeAveraged) {
 
-                amrex::Real real_a = 1.0;
+                const amrex::Real real_a = 1.0;
                 // call amrex sax operation to do the following
                 amrex::MultiFab::Saxpy(
                         m_sum_mf_output[i_buffer][lev], real_a, m_mf_output[i_buffer][lev],

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -574,20 +574,20 @@ Diagnostics::ComputeAndPack ()
                 // a diagnostics and writes in one or more components of the output
                 // multifab m_mf_output[lev].
                 m_all_field_functors[lev][icomp]->operator()(m_mf_output[i_buffer][lev], icomp_dst, i_buffer);
+                // update the index of the next component to fill
                 icomp_dst += m_all_field_functors[lev][icomp]->nComp();
             }
             // Check that the proper number of components of mf_avg were updated.
             AMREX_ALWAYS_ASSERT( icomp_dst == m_varnames.size() );
 
-            if (m_do_timeaverage) {
-                // update the index of the next component to fill
+            if (m_diag_type == DiagTypes::TimeAveraged) {
+
                 amrex::Real real_a = 1.0;
                 // call amrex sax operation to do the following
                 amrex::MultiFab::Saxpy(
-                        m_sum_mf_output[i_buffer][lev], real_a, m_mf_output[i_buffer][lev], 0, 0, m_mf_output[i_buffer][lev].nComp(), m_mf_output[i_buffer][lev].nGrowVect());
+                        m_sum_mf_output[i_buffer][lev], real_a, m_mf_output[i_buffer][lev],
+                        0, 0, m_mf_output[i_buffer][lev].nComp(), m_mf_output[i_buffer][lev].nGrowVect());
             }
-
-            m_sum_mf_output[i_buffer][lev] += scalar_a * m_mf_output[i_buffer][lev]
 
             // needed for contour plots of rho, i.e. ascent/sensei
             if (m_format == "sensei" || m_format == "ascent") {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -564,7 +564,8 @@ Diagnostics::ComputeAndPack ()
 
     auto & warpx = WarpX::GetInstance();
 
-    bool do_sum_now = cur_step >= time_ave 
+    // We sum up fields for later averaging and output when we are inside the averaging period
+    bool do_sum_now = cur_step >= time_ave
 
     // compute the necessary fields and store result in m_mf_output.
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -586,7 +586,7 @@ Diagnostics::ComputeAndPack ()
             if (m_diag_type == DiagTypes::TimeAveraged) {
 
                 const amrex::Real real_a = 1.0;
-                // call amrex sax operation to do the following
+                // Compute m_sum_mf_output += real_a*m_mf_output
                 amrex::MultiFab::Saxpy(
                         m_sum_mf_output[i_buffer][lev], real_a, m_mf_output[i_buffer][lev],
                         0, 0, m_mf_output[i_buffer][lev].nComp(), m_mf_output[i_buffer][lev].nGrowVect());

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -535,11 +535,14 @@ Diagnostics::InitBaseData ()
     for (int i = 0; i < m_num_buffers; ++i) {
         m_mf_output[i].resize( nmax_lev );
     }
-    m_sum_mf_output.resize(m_num_buffers);
-    for (int i = 0; i < m_num_buffers; ++i) {
-        m_sum_mf_output[i].resize( nmax_lev );
-    }
 
+    // allocate vector of buffers and vector of levels for each buffer for summation multifab for TimeAveragedDiagnostics
+    if (m_diag_type == DiagTypes::TimeAveraged) {
+        m_sum_mf_output.resize(m_num_buffers);
+        for (int i = 0; i < m_num_buffers; ++i) {
+            m_sum_mf_output[i].resize( nmax_lev );
+        }
+    }
 
     // allocate vector of geometry objects corresponding to each output multifab.
     m_geom_output.resize( m_num_buffers );

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -38,8 +38,8 @@
 
 using namespace amrex::literals;
 
-Diagnostics::Diagnostics (int i, std::string name)
-    : m_diag_name(std::move(name)), m_diag_index(i)
+Diagnostics::Diagnostics (int i, std::string name, DiagTypes diag_type)
+    : m_diag_type(diag_type), m_diag_name(std::move(name)), m_diag_index(i)
 {
 }
 
@@ -565,7 +565,7 @@ Diagnostics::ComputeAndPack ()
     auto & warpx = WarpX::GetInstance();
 
     // We sum up fields for later averaging and output when we are inside the averaging period
-    bool do_sum_now = cur_step >= time_ave
+    //bool do_sum_now = cur_step >= time_ave
 
     // compute the necessary fields and store result in m_mf_output.
     for (int i_buffer = 0; i_buffer < m_num_buffers; ++i_buffer) {
@@ -577,11 +577,11 @@ Diagnostics::ComputeAndPack ()
                 // a diagnostics and writes in one or more components of the output
                 // multifab m_mf_output[lev].
                 m_all_field_functors[lev][icomp]->operator()(m_mf_output[i_buffer][lev], icomp_dst, i_buffer);
-                if (do_sum_now)
-                // update the index of the next component to fill
-                int scalar_a = 1;
+                //if (do_sum_now)
+                //// update the index of the next component to fill
+                //int scalar_a = 1;
                 // call amrex sax operation to do the following
-                m_sum_mf_output[i_buffer][lev] += scalar_a * m_mf_output[i_buffer][lev]
+                //m_sum_mf_output[i_buffer][lev] += scalar_a * m_mf_output[i_buffer][lev]
                 icomp_dst += m_all_field_functors[lev][icomp]->nComp();
             }
             // Check that the proper number of components of mf_avg were updated.

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -38,15 +38,17 @@ private:
     /** Whether the diagnostics are averaging data over time or not */
     TimeAverageType m_time_average_type = TimeAverageType::None;
     /** Period to average fields over: in steps */
-    int m_average_period_steps = 0;
+    int m_average_period_steps = -1;
     /** Period to average fields over: in seconds */
-    amrex::Real m_average_period_time = 0;
+    amrex::Real m_average_period_time = -1.0;
     /** Time step to start averaging */
-    int m_average_start_step = 0;
+    int m_average_start_step = -1;
     /** Flush m_mf_output or m_sum_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */
     void FlushRaw ();
+    /** Initialize Data required to compute TimeAveraged diagnostics */
+    void DerivedInitData () override;
     /** whether to compute and pack cell-centered data in m_mf_output
      * \param[in] step current time step
      * \param[in] force_flush if true, return true for any step since output must be

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -36,7 +36,7 @@ private:
      */
     bool m_solver_deposits_current = true;
     /** Whether the diagnostics are averaging data over time or not */
-    TimeAverageType m_time_average_type = TimeAverageType::None;
+    TimeAverageType m_time_average_mode = TimeAverageType::None;
     /** Period to average fields over: in steps */
     int m_average_period_steps = -1;
     /** Period to average fields over: in seconds */

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -4,6 +4,8 @@
 #include "Diagnostics.H"
 #include "Utils/Parser/IntervalsParser.H"
 
+#include <AMReX_REAL.H>
+
 #include <string>
 
 class FullDiagnostics final : public Diagnostics
@@ -25,6 +27,16 @@ private:
      * before writing the diagnostic.
      */
     bool m_solver_deposits_current = true;
+    /** Whether the diagnostics are averaging data over time or not
+     * Valid options are "fixed_start" and "dynamic_start".
+     */
+    std::string m_time_averaging = "none";
+    /** Period to average fields over: in steps */
+    unsigned int m_average_period_steps = 0;
+    /** Period to average fields over: in seconds */
+    amrex::Real m_average_period_seconds = 0;
+    /** Time step to start averaging */
+    unsigned int m_average_start_step = 0;
     /** Flush m_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -19,7 +19,7 @@ public:
      * Dynamic corresponds to a moving period for averaging where the start step
      *     is as many steps before the output interval as the averaging period is long.
      */
-    enum TimeAverageType {None, Static, Dynamic};
+    enum struct TimeAverageType {None, Static, Dynamic};
 private:
     /** Read user-requested parameters for full diagnostics */
     void ReadParameters ();

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -12,8 +12,14 @@ class FullDiagnostics final : public Diagnostics
 {
 public:
     FullDiagnostics (int i, const std::string& name, DiagTypes diag_type);
-//    bool m_do_timeaverage = false;
-//    enum TimeAverageType {None, Static, Dynamic};
+    /** Type of time averaging for diagnostics (fields only)
+     * None corresponds to instantaneous diags
+     * Static corresponds to a fixed starting step for averaging,
+     *     will average until the end, and dump out intermediate average results
+     * Dynamic corresponds to a moving period for averaging where the start step
+     *     is as many steps before the output interval as the averaging period is long.
+     */
+    enum TimeAverageType {None, Static, Dynamic};
 private:
     /** Read user-requested parameters for full diagnostics */
     void ReadParameters ();
@@ -29,16 +35,14 @@ private:
      * before writing the diagnostic.
      */
     bool m_solver_deposits_current = true;
-    /** Whether the diagnostics are averaging data over time or not
-     * Valid options are "fixed_start" and "dynamic_start".
-     */
-    std::string m_time_averaging = "none";
+    /** Whether the diagnostics are averaging data over time or not */
+    TimeAverageType m_time_average_type = TimeAverageType::None;
     /** Period to average fields over: in steps */
-    unsigned int m_average_period_steps = 0;
+    int m_average_period_steps = 0;
     /** Period to average fields over: in seconds */
-    amrex::Real m_average_period_seconds = 0;
+    amrex::Real m_average_period_time = 0;
     /** Time step to start averaging */
-    unsigned int m_average_start_step = 0;
+    int m_average_start_step = 0;
     /** Flush m_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -11,7 +11,9 @@
 class FullDiagnostics final : public Diagnostics
 {
 public:
-    FullDiagnostics (int i, const std::string& name);
+    FullDiagnostics (int i, const std::string& name, DiagTypes diag_type);
+//    bool m_do_timeaverage = false;
+//    enum TimeAverageType {None, Static, Dynamic};
 private:
     /** Read user-requested parameters for full diagnostics */
     void ReadParameters ();

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -43,7 +43,7 @@ private:
     amrex::Real m_average_period_time = 0;
     /** Time step to start averaging */
     int m_average_start_step = 0;
-    /** Flush m_mf_output and particles to file for the i^th buffer */
+    /** Flush m_mf_output or m_sum_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */
     void FlushRaw ();

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -198,7 +198,7 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
         if (m_time_average_type == TimeAverageType::Static || m_time_average_type == TimeAverageType::Dynamic) {
             // Loop over the output levels and divide by the number of steps in the averaging period
             for (int lev = 0; lev < nlev_output; ++lev) {
-                m_sum_mf_output.at(i_buffer).at(lev).mult(1./m_average_period_steps);
+                m_sum_mf_output.at(i_buffer).at(lev).mult(1._rt/static_cast<amrex::Real>(m_average_period_steps));
             }
 
             m_flush_format->WriteToFile(

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -144,6 +144,18 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
         m_output_species.at(i_buffer), nlev_output, m_file_prefix,
         m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
 
+    if (time_average) {
+       //call amrex option to 
+       m_sum_mf_output.at(i_buffer).mult(1./time_average_step);
+           m_flush_format->WriteToFile(
+        m_varnames, m_sum_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
+        warpx.gett_new(0),
+        m_output_species.at(i_buffer), nlev_output, m_file_prefix,
+        m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
+
+
+    }
+
     FlushRaw();
 }
 
@@ -168,6 +180,7 @@ FullDiagnostics::DoComputeAndPack (int step, bool force_flush)
     // Data must be computed and packed for full diagnostics
     // whenever the data needs to be flushed.
     return (force_flush || m_intervals.contains(step+1));
+    // add logic here to do compute and pack if m_intervals.containes (step+1-time_average_period) or if (cur_step>time_average_startstep)
 }
 
 void
@@ -613,7 +626,8 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
     const int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
     int const ncomp = static_cast<int>(m_varnames.size());
     m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
-
+    m_sum_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
+    m_sum_mf_output[i_buffer][lev].setVal(0.);
     if (lev == 0) {
         // The extent of the domain covered by the diag multifab, m_mf_output
         //default non-periodic geometry for diags

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -47,8 +47,8 @@
 using namespace amrex::literals;
 using warpx::fields::FieldType;
 
-FullDiagnostics::FullDiagnostics (int i, const std::string& name):
-    Diagnostics{i, name},
+FullDiagnostics::FullDiagnostics (int i, const std::string& name, DiagTypes diag_type):
+    Diagnostics{i, name, diag_type},
     m_solver_deposits_current{
         (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::None) ||
         (WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic)}
@@ -144,20 +144,20 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
         m_output_species.at(i_buffer), nlev_output, m_file_prefix,
         m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
 
-    if (m_time_averaging == "fixed_start" || m_time_averaging == "dynamic_start") {
-        // Loop over the output levels and divide by the number of steps in the averaging period
-        for (int lev = 0; lev < nlev_output; ++lev) {
-            m_sum_mf_output.at(i_buffer).at(lev).mult(1./m_average_period_steps);
-        }
-
-        m_flush_format->WriteToFile(
-        m_varnames, m_sum_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
-        warpx.gett_new(0),
-        m_output_species.at(i_buffer), nlev_output, m_file_prefix,
-        m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
-
-
-    }
+//    if (m_time_averaging == "fixed_start" || m_time_averaging == "dynamic_start") {
+//        // Loop over the output levels and divide by the number of steps in the averaging period
+//        for (int lev = 0; lev < nlev_output; ++lev) {
+//            m_sum_mf_output.at(i_buffer).at(lev).mult(1./m_average_period_steps);
+//        }
+//
+//        m_flush_format->WriteToFile(
+//        m_varnames, m_sum_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
+//        warpx.gett_new(0),
+//        m_output_species.at(i_buffer), nlev_output, m_file_prefix,
+//        m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
+//
+//
+//    }
 
     FlushRaw();
 }
@@ -180,17 +180,18 @@ FullDiagnostics::DoDump (int step, int /*i_buffer*/, bool force_flush)
 bool
 FullDiagnostics::DoComputeAndPack (int step, bool force_flush)
 {
-    if (m_time_averaging == "dynamic_start")
-        m_average_start_step = m_intervals.nextContains(step) - m_average_period_steps;
-
-    // add logic here to do compute and pack if m_intervals.contains (step+1-time_average_period) or if (cur_step>time_average_startstep)
-    bool in_averaging_period = false;
-    if (step > m_intervals.nextContains(step) - m_average_start_step && step <= m_intervals.nextContains(step))
-        in_averaging_period = true;
-
+//    if (m_time_averaging == "dynamic_start")
+//        m_average_start_step = m_intervals.nextContains(step) - m_average_period_steps;
+//
+//    // add logic here to do compute and pack if m_intervals.contains (step+1-time_average_period) or if (cur_step>time_average_startstep)
+//    bool in_averaging_period = false;
+//    if (step > m_intervals.nextContains(step) - m_average_start_step && step <= m_intervals.nextContains(step))
+//        in_averaging_period = true;
+//
     // Data must be computed and packed for full diagnostics
     // whenever the data needs to be flushed.
-    return (force_flush || m_intervals.contains(step+1) || in_averaging_period);
+    //return (force_flush || m_intervals.contains(step+1) || in_averaging_period);
+    return (force_flush || m_intervals.contains(step+1) );
 
 }
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -129,6 +129,17 @@ FullDiagnostics::ReadParameters ()
          */
         pp_diag_name.get("time_average_mode", m_time_average_mode_str);
 
+        const amrex::ParmParse pp_warpx("warpx");
+        std::vector<std::string> dt_interval_vec = {"-1"};
+        const bool timestep_may_vary = pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
+        amrex::Print() << Utils::TextMsg::Warn("Time step varies?" + std::to_string(timestep_may_vary));
+        if (timestep_may_vary) {
+            WARPX_ABORT_WITH_MESSAGE(
+                    "Time-averaged diagnostics (encountered in: "
+                    + m_diag_name + ") are currently not supported with adaptive time-stepping"
+                    );
+        }
+
         if (m_time_average_mode_str == "fixed_start") {
             m_time_average_mode = TimeAverageType::Static;
             } else if (m_time_average_mode_str == "dynamic_start") {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -144,10 +144,13 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
         m_output_species.at(i_buffer), nlev_output, m_file_prefix,
         m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
 
-    if (time_average) {
-       //call amrex option to 
-       m_sum_mf_output.at(i_buffer).mult(1./time_average_step);
-           m_flush_format->WriteToFile(
+    if (m_time_averaging == "fixed_start" || m_time_averaging == "dynamic_start") {
+        // Loop over the output levels and divide by the number of steps in the averaging period
+        for (int lev = 0; lev < nlev_output; ++lev) {
+            m_sum_mf_output.at(i_buffer).at(lev).mult(1./m_average_period_steps);
+        }
+
+        m_flush_format->WriteToFile(
         m_varnames, m_sum_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
         warpx.gett_new(0),
         m_output_species.at(i_buffer), nlev_output, m_file_prefix,
@@ -177,10 +180,18 @@ FullDiagnostics::DoDump (int step, int /*i_buffer*/, bool force_flush)
 bool
 FullDiagnostics::DoComputeAndPack (int step, bool force_flush)
 {
+    if (m_time_averaging == "dynamic_start")
+        m_average_start_step = m_intervals.nextContains(step) - m_average_period_steps;
+
+    // add logic here to do compute and pack if m_intervals.contains (step+1-time_average_period) or if (cur_step>time_average_startstep)
+    bool in_averaging_period = false;
+    if (step > m_intervals.nextContains(step) - m_average_start_step && step <= m_intervals.nextContains(step))
+        in_averaging_period = true;
+
     // Data must be computed and packed for full diagnostics
     // whenever the data needs to be flushed.
-    return (force_flush || m_intervals.contains(step+1));
-    // add logic here to do compute and pack if m_intervals.containes (step+1-time_average_period) or if (cur_step>time_average_startstep)
+    return (force_flush || m_intervals.contains(step+1) || in_averaging_period);
+
 }
 
 void
@@ -626,7 +637,9 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
     const int ngrow = (m_format == "sensei" || m_format == "ascent") ? 1 : 0;
     int const ncomp = static_cast<int>(m_varnames.size());
     m_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
+    // Allocate MultiFab for cell-centered field output accumulation. The data will be averaged before flushing.
     m_sum_mf_output[i_buffer][lev] = amrex::MultiFab(ba, dmap, ncomp, ngrow);
+    // Initialize to zero because we add data.
     m_sum_mf_output[i_buffer][lev].setVal(0.);
     if (lev == 0) {
         // The extent of the domain covered by the diag multifab, m_mf_output

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -159,10 +159,10 @@ FullDiagnostics::ReadParameters ()
             }
 
             if (averaging_period_time_specified || averaging_period_steps_specified) {
-                const std::string period_spec_warn_msg = "An averaging period was specified for the 'static_start' averaging mode" \
-                                                         "but will be IGNORED. Averaging will be performed between step" \
+                const std::string period_spec_warn_msg = "An averaging period was specified for the 'static_start' averaging mode " \
+                                                         "but will be IGNORED. Averaging will be performed between step " \
                                                          + std::to_string(m_average_start_step) \
-                                                         + "and the specified intervals.";
+                                                         + " and the specified intervals.";
                 ablastr::warn_manager::WMRecordWarning(
                         "Diagnostics",
                         period_spec_warn_msg,

--- a/Source/Diagnostics/MultiDiagnostics.H
+++ b/Source/Diagnostics/MultiDiagnostics.H
@@ -12,7 +12,7 @@
 #include <vector>
 
 /** All types of diagnostics. */
-enum struct DiagTypes {Full, BackTransformed, BoundaryScraping};
+enum struct DiagTypes {Full, BackTransformed, BoundaryScraping, TimeAveraged};
 
 /**
  * \brief This class contains a vector of all diagnostics in the simulation.

--- a/Source/Diagnostics/MultiDiagnostics.H
+++ b/Source/Diagnostics/MultiDiagnostics.H
@@ -11,8 +11,6 @@
 #include <string>
 #include <vector>
 
-/** All types of diagnostics. */
-enum struct DiagTypes {Full, BackTransformed, BoundaryScraping, TimeAveraged};
 
 /**
  * \brief This class contains a vector of all diagnostics in the simulation.

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -70,9 +70,10 @@ MultiDiagnostics::ReadParameters ()
         std::string diag_type_str;
         pp_diag_name.get("diag_type", diag_type_str);
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            diag_type_str == "Full" || diag_type_str == "BackTransformed" || diag_type_str == "BoundaryScraping",
-            "<diag>.diag_type must be Full or BackTransformed or BoundaryScraping");
+            diag_type_str == "Full" || diag_type_str == "TimeAveraged" || diag_type_str == "BackTransformed" || diag_type_str == "BoundaryScraping",
+            "<diag>.diag_type must be Full, TimeAveraged, BackTransformed or BoundaryScraping");
         if (diag_type_str == "Full") { diags_types[i] = DiagTypes::Full; }
+        if (diag_type_str == "TimeAveraged") { diags_types[i] = DiagTypes::TimeAveraged; }
         if (diag_type_str == "BackTransformed") { diags_types[i] = DiagTypes::BackTransformed; }
         if (diag_type_str == "BoundaryScraping") { diags_types[i] = DiagTypes::BoundaryScraping; }
     }

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -23,6 +23,8 @@ MultiDiagnostics::MultiDiagnostics ()
     for (int i=0; i<ndiags; i++){
         if ( diags_types[i] == DiagTypes::Full ){
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
+        } else if ( diags_types[i] == DiagTypes::TimeAveraged ){
+            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
         } else if ( diags_types[i] == DiagTypes::BoundaryScraping ){

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -22,13 +22,13 @@ MultiDiagnostics::MultiDiagnostics ()
     alldiags.resize( ndiags );
     for (int i=0; i<ndiags; i++){
         if ( diags_types[i] == DiagTypes::Full ){
-            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
+            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i], diags_types[i]);
         } else if ( diags_types[i] == DiagTypes::TimeAveraged ){
-            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i]);
+            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i], diags_types[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
-            alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i]);
+            alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i], diags_types[i]);
         } else if ( diags_types[i] == DiagTypes::BoundaryScraping ){
-            alldiags[i] = std::make_unique<BoundaryScrapingDiagnostics>(i, diags_names[i]);
+            alldiags[i] = std::make_unique<BoundaryScrapingDiagnostics>(i, diags_names[i], diags_types[i]);
         } else {
             WARPX_ABORT_WITH_MESSAGE("Unknown diagnostic type");
         }

--- a/Source/Diagnostics/MultiDiagnostics.cpp
+++ b/Source/Diagnostics/MultiDiagnostics.cpp
@@ -21,9 +21,7 @@ MultiDiagnostics::MultiDiagnostics ()
      */
     alldiags.resize( ndiags );
     for (int i=0; i<ndiags; i++){
-        if ( diags_types[i] == DiagTypes::Full ){
-            alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i], diags_types[i]);
-        } else if ( diags_types[i] == DiagTypes::TimeAveraged ){
+        if ( diags_types[i] == DiagTypes::Full || diags_types[i] == DiagTypes::TimeAveraged ){
             alldiags[i] = std::make_unique<FullDiagnostics>(i, diags_names[i], diags_types[i]);
         } else if ( diags_types[i] == DiagTypes::BackTransformed ){
             alldiags[i] = std::make_unique<BTDiagnostics>(i, diags_names[i], diags_types[i]);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1195,6 +1195,8 @@ WarpXOpenPMDPlot::SetupFields ( openPMD::Container< openPMD::Mesh >& meshes,
     if (WarpX::do_dive_cleaning) {
         meshes.setAttribute("chargeCorrectionParameters", "period=1");
     }
+    // TODO set meta-data information for time-averaged quantities
+    // but we need information of the specific diagnostic in here
 }
 
 


### PR DESCRIPTION
This PR adds time-averaged field diagnostics to the WarpX output

- [x] code
- [x] docs
- [x] tests
- [x] example
- meta-data $\Longrightarrow$ Follow-up PR
- make compatible with adaptive time stepping $\Longrightarrow$ Follow-up PR

Currently, compiling for GPU creates a linking error. We would like to see the CI output to possibly find the issue.
Hence, we do not flag this as WIP right now.

This PR is based on work performed during the *2024 WarpX Refactoring Hackathon* and was created together with @RevathiJambunathan. :slightly_smiling_face: 

Successfully merging this pull request may close #5165.