### PR TITLE
Fix clang-tidy errors in `development` branch

### DIFF
--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
@@ -193,12 +193,12 @@ computePhiIGF ( amrex::MultiFab const & rho,
 
     // Prepare to perform global FFT
     // Since there is 1 MPI rank per box, here each MPI rank obtains its local box and the associated boxid
-    int local_boxid = amrex::ParallelDescriptor::MyProc(); // because of how we made the DistributionMapping
+    const int local_boxid = amrex::ParallelDescriptor::MyProc(); // because of how we made the DistributionMapping
     if (local_boxid < realspace_ba.size()) {
         // When not using heFFTe, there is only one box (the global box)
         // It is taken care of my MPI rank 0 ; other ranks have no work (hence the if condition)
 
-        amrex::Box local_nodal_box = realspace_ba[local_boxid];
+        const amrex::Box local_nodal_box = realspace_ba[local_boxid];
         amrex::Box local_box(local_nodal_box.smallEnd(), local_nodal_box.bigEnd());
         local_box.shift(-realspace_box.smallEnd()); // This simplifies the setup because the global lo is zero now
         // Since we the domain decompostion is in the z-direction, setting up c_local_box is simple.


### PR DESCRIPTION
While reviewing #5285, I noticed that #4937 did not pass our 3D clang-tidy check, which is currently failing in `development`:
- https://github.com/ECP-WarpX/WarpX/actions/runs/10925867109 (in `Haavaan:heffte`)
- https://github.com/ECP-WarpX/WarpX/actions/runs/10927325498 (in `ECP-WarpX:development`)

The RZ check was skipped due to the 3D one failing, so that might bring up issues too.

The clang-tidy errors fixed so far are:
- ```/home/runner/work/WarpX/WarpX/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp:196:5: error: variable 'local_boxid' of type 'int' can be declared 'const' [misc-const-correctness,-warnings-as-errors]```
- ```/home/runner/work/WarpX/WarpX/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp:201:9: error: variable 'local_nodal_box' of type 'amrex::Box' (aka 'BoxND<3>') can be declared 'const' [misc-const-correctness,-warnings-as-errors]```