### PR TITLE
Doc: HPC3 has CMake 3.30.2

### DIFF
--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -6,7 +6,7 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load cmake/3.22.1  # we need 3.24+ - installing via pipx until module is available
+module load cmake/3.30.2
 module load gcc/11.2.0
 module load cuda/11.7.1
 module load openmpi/4.1.2/gcc.11.2.0

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -119,7 +119,6 @@ python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools
 python3 -m pip install --upgrade pipx
-python3 -m pipx install --upgrade cmake
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas


### PR DESCRIPTION
HPC3 (UCI) now has a modern CMake module. Use this instead of installing our own.
Thank you to @floresv299 for opening & resolving the request with support!

Follow-up to #5179 

attn @erny123 @floresv299 @Aquios7 @jinze-liu is th