### PR TITLE
`magnetostatic_eb` test: fix warnings

### DIFF
--- a/Examples/Tests/magnetostatic_eb/inputs_test_3d_magnetostatic_eb_picmi.py
+++ b/Examples/Tests/magnetostatic_eb/inputs_test_3d_magnetostatic_eb_picmi.py
@@ -225,7 +225,7 @@ plt.legend(["Analytical", "Electrostatic"])
 
 er_err = np.abs(Er_mean[r_idx] - Er_an(r_sub)).max() / np.abs(Er_an(r_sub)).max()
 
-plt.ylabel("$E_r$ (V/m)")
+plt.ylabel(r"$E_r$ (V/m)")
 plt.xlabel("r (m)")
 plt.title("Max % Error: {} %".format(er_err * 100.0))
 plt.tight_layout()
@@ -298,7 +298,7 @@ plt.legend(["Analytical", "Magnetostatic"])
 
 bt_err = np.abs(Bt_mean[r_idx] - Bt_an(r_sub)).max() / np.abs(Bt_an(r_sub)).max()
 
-plt.ylabel("$B_{\Theta}$ (T)")
+plt.ylabel(r"$B_{\Theta}$ (T)")
 plt.xlabel("r (m)")
 plt.title("Max % Error: {} %".format(bt_err * 100.0))
 plt.tight_layout()

--- a/Examples/Tests/magnetostatic_eb/inputs_test_rz_magnetostatic_eb_picmi.py
+++ b/Examples/Tests/magnetostatic_eb/inputs_test_rz_magnetostatic_eb_picmi.py
@@ -195,7 +195,7 @@ plt.legend(["Analytical", "Electrostatic"])
 
 er_err = np.abs(Er_mean[r_idx] - Er_an(r_sub)).max() / np.abs(Er_an(r_sub)).max()
 
-plt.ylabel("$E_r$ (V/m)")
+plt.ylabel(r"$E_r$ (V/m)")
 plt.xlabel("r (m)")
 plt.title("Max % Error: {} %".format(er_err * 100.0))
 plt.tight_layout()
@@ -246,7 +246,7 @@ plt.legend(["Analytical", "Magnetostatic"])
 
 bth_err = np.abs(Bth_mean[r_idx] - Bth_an(r_sub)).max() / np.abs(Bth_an(r_sub)).max()
 
-plt.ylabel("$B_{\Theta}$ (T)")
+plt.ylabel(r"$B_{\Theta}$ (T)")
 plt.xlabel("r (m)")
 plt.title("Max % Error: {} %".format(bth_err * 100.0))
 plt.tight_layout()

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -137,7 +137,7 @@ class WarpX(Bucket):
             for arg in argv:
                 # This prints the name of the input group (prefix) as a header
                 # before each group to make the input file more human readable
-                prefix_new = re.split(" |\.", arg)[0]
+                prefix_new = re.split(r" |\.", arg)[0]
                 if prefix_new != prefix_old:
                     if prefix_old != "":
                         ff.write("\n")


### PR DESCRIPTION
Fix observed warnings for latex strings, use raw strings.

Isolated from #5230