### PR TITLE
CI: avoid duplicate runs for secondary branches on main repo

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,6 +6,10 @@ pool:
 pr:
   autoCancel: true
   drafts: false
+  branches:
+    include:
+    - development
+    - nightly
 
 jobs:
 - job:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,7 +9,6 @@ pr:
   branches:
     include:
     - development
-    - nightly
 
 jobs:
 - job:

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -1,6 +1,11 @@
 name: 🧴 clang sanitizers
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangsanitizers

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,6 +1,11 @@
 name: 🧹 clang-tidy
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangtidy

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,6 +1,11 @@
 name: 🐧 CUDA
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,6 +1,11 @@
 name: 🐧 HIP
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -1,6 +1,11 @@
 name: 🐧 In Situ Vis
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,6 +1,11 @@
 name: 🐧 Intel
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,11 @@
 name: 🍏 macOS
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -6,7 +6,12 @@
 
 name: 📜 Source
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-source

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,11 @@
 name: 🐧 OpenMP
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "development"
-      - "nightly"
   pull_request:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,11 @@
 name: 🪟 Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "development"
+      - "nightly"
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
When `pre-commit` gets auto-updated, we typically see a PR from the branch `pre-commit-ci-update-config`. 

This branch is created directly in the main fork (unlike the individual branches that WarpX contributors create from their own forks) and all CI checks run twice:
- once for the activity on the PR that `pre-commit` automatically opens (these CI checks are labeled "PR automated")
- once for the activity on the branch `pre-commit-ci-update-config` (these CI checks are labeled "individual CI")

Here's an example:
![Screenshot from 2024-09-23 15-54-57](https://github.com/user-attachments/assets/836476f4-e6f6-4ca8-92a6-128050727ed5)

On top of this, once the PR is merged, CI runs a third time, because the merge is counted as activity on the branch `development` (again "individual CI").

We should be able to safely skip "individual CI" for the activity on the branch `pre-commit-ci-update-config`. This PR should do the trick, although it's good to double check the syntax for GitHub Actions and Azure pipelines.

My understanding is that the cleanup-cache and post-PR workflows don't need to be updated, also to be double checked.