### PR TITLE
Python: `warpx.multifab` legacy signature

### DIFF
--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -135,9 +135,9 @@ This example accesses the :math:`E_x(x,y,z)` field at level 0 after every time s
 
        # data access
        #   vector field E, component x, on the fine patch of MR level 0
-       E_x_mf = warpx.multifab(f"Efield_fp", dir=0, level=0)
+       E_x_mf = warpx.multifab("Efield_fp", dir=0, level=0)
        #   scalar field rho, on the fine patch of MR level 0
-       rho_mf = warpx.multifab(f"rho_fp", level=0)
+       rho_mf = warpx.multifab("rho_fp", level=0)
 
        # compute on E_x_mf
        # iterate over mesh-refinement levels

--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -134,9 +134,12 @@ This example accesses the :math:`E_x(x,y,z)` field at level 0 after every time s
        warpx = sim.extension.warpx
 
        # data access
-       E_x_mf = warpx.multifab(f"Efield_fp[x][level=0]")
+       #   vector field E, component x, on the fine patch of MR level 0
+       E_x_mf = warpx.multifab(f"Efield_fp", dir=0, level=0)
+       #   scalar field rho, on the fine patch of MR level 0
+       rho_mf = warpx.multifab(f"rho_fp", level=0)
 
-       # compute
+       # compute on E_x_mf
        # iterate over mesh-refinement levels
        for lev in range(warpx.finest_level + 1):
            # grow (aka guard/ghost/halo) regions

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -121,11 +121,6 @@ void init_WarpX (py::module& m)
         )
         .def("multifab",
              [](WarpX & wx, std::string internal_name) {
-                 py::print("WARNING: WarpX' multifab('internal_name') signature is deprecated.\nPlease use:\n"
-                           "- multifab('prefix', level=...) for scalar fields\n"
-                           "- multifab('prefix', dir=..., level=...) for vector field components\n"
-                           "where 'prefix' is the part of 'internal_name';'  before the []",
-                           py::arg("file") = py::module_::import("sys").attr("stderr"));
                  if (wx.m_fields.internal_has(internal_name)) {
                      return wx.m_fields.internal_get(internal_name);
                  } else {

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -120,17 +120,32 @@ void init_WarpX (py::module& m)
              R"doc(Registry to all WarpX MultiFab (fields).)doc"
         )
         .def("multifab",
-            [](WarpX & wx, std::string multifab_name, int level) {
-                if (wx.m_fields.has(multifab_name, level)) {
-                    return wx.m_fields.get(multifab_name, level);
+             [](WarpX & wx, std::string internal_name) {
+                 py::print("WARNING: WarpX' multifab('internal_name') signature is deprecated.\nPlease use:\n"
+                           "- multifab('prefix', level=...) for scalar fields\n"
+                           "- multifab('prefix', dir=..., level=...) for vector field components\n"
+                           "where 'prefix' is the part of 'internal_name';'  before the []",
+                           py::arg("file") = py::module_::import("sys").attr("stderr"));
+                 if (wx.m_fields.internal_has(internal_name)) {
+                     return wx.m_fields.internal_get(internal_name);
+                 } else {
+                     throw std::runtime_error("MultiFab '" + internal_name + "' is unknown or is not allocated!");
+                 }
+             },
+             py::arg("internal_name")
+        )
+        .def("multifab",
+            [](WarpX & wx, std::string scalar_name, int level) {
+                if (wx.m_fields.has(scalar_name, level)) {
+                    return wx.m_fields.get(scalar_name, level);
                 } else {
-                    throw std::runtime_error("The MultiFab '" + multifab_name + "' is unknown or is not allocated!");
+                    throw std::runtime_error("The scalar field '" + scalar_name + "' is unknown or is not allocated!");
                 }
             },
-            py::arg("multifab_name"),
+            py::arg("scalar_name"),
             py::arg("level"),
             py::return_value_policy::reference_internal,
-            R"doc(Return MultiFabs by name and level, e.g., ``\"Efield_aux\"``, ``\"Efield_fp"``, ...
+            R"doc(Return scalar fields (MultiFabs) by name and level, e.g., ``\"rho_fp\"``, ``\"phi_fp"``, ...
 
 The physical fields in WarpX have the following naming:
 
@@ -141,18 +156,18 @@ The physical fields in WarpX have the following naming:
   (only for level 1 and higher).)doc"
         )
         .def("multifab",
-            [](WarpX & wx, std::string multifab_name, Direction dir, int level) {
-                if (wx.m_fields.has(multifab_name, dir, level)) {
-                    return wx.m_fields.get(multifab_name, dir, level);
+            [](WarpX & wx, std::string vector_name, Direction dir, int level) {
+                if (wx.m_fields.has(vector_name, dir, level)) {
+                    return wx.m_fields.get(vector_name, dir, level);
                 } else {
-                    throw std::runtime_error("The MultiFab '" + multifab_name + "' is unknown or is not allocated!");
+                    throw std::runtime_error("The vector field '" + vector_name + "' is unknown or is not allocated!");
                 }
             },
-            py::arg("multifab_name"),
+            py::arg("vector_name"),
             py::arg("dir"),
             py::arg("level"),
             py::return_value_policy::reference_internal,
-            R"doc(Return MultiFabs by name, direction, and level, e.g., ``\"Efield_aux\"``, ``\"Efield_fp"``, ...
+            R"doc(Return the component of a vector field (MultiFab) by name, direction, and level, e.g., ``\"Efield_aux\"``, ``\"Efield_fp"``, ...
 
 The physical fields in WarpX have the following naming:
 

--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -661,14 +661,21 @@ namespace ablastr::fields
             int level
         ) const;
 
-    private:
+        /** Temporary test function for legacy Python bindings */
+        [[nodiscard]] bool
+        internal_has (
+            std::string const & internal_name
+        );
         [[nodiscard]] amrex::MultiFab *
         internal_get (
-            std::string const & key
+            std::string const & internal_name
         );
+
+    private:
+
         [[nodiscard]] amrex::MultiFab const *
         internal_get (
-            std::string const & key
+            std::string const & internal_name
         ) const;
 
         amrex::MultiFab*

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -361,15 +361,15 @@ namespace ablastr::fields
 
     amrex::MultiFab const *
     MultiFabRegister::internal_get (
-        std::string const & key
+        std::string const & internal_name
     ) const
     {
-        if (m_mf_register.count(key) == 0) {
+        if (m_mf_register.count(internal_name) == 0) {
             // FIXME: temporary, throw a std::runtime_error
-            // throw std::runtime_error("MultiFabRegister::get name does not exist in register: " + key);
+            // throw std::runtime_error("MultiFabRegister::get name does not exist in register: " + internal_name);
             return nullptr;
         }
-        amrex::MultiFab const & mf = m_mf_register.at(key).m_mf;
+        amrex::MultiFab const & mf = m_mf_register.at(internal_name).m_mf;
 
         return &mf;
     }

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -336,17 +336,25 @@ namespace ablastr::fields
         return count == 3;
     }
 
-    amrex::MultiFab*
-    MultiFabRegister::internal_get (
-        std::string const & key
+    bool
+    MultiFabRegister::internal_has (
+        std::string const & internal_name
     )
     {
-        if (m_mf_register.count(key) == 0) {
+        return m_mf_register.count(internal_name) > 0;
+    }
+
+    amrex::MultiFab*
+    MultiFabRegister::internal_get (
+        std::string const & internal_name
+    )
+    {
+        if (m_mf_register.count(internal_name) == 0) {
             // FIXME: temporary, throw a std::runtime_error
             // throw std::runtime_error("MultiFabRegister::get name does not exist in register: " + key);
             return nullptr;
         }
-        amrex::MultiFab & mf = m_mf_register.at(key).m_mf;
+        amrex::MultiFab & mf = m_mf_register.at(internal_name).m_mf;
 
         return &mf;
     }


### PR DESCRIPTION
Keep the legacy signature of the fully qualified name a bit longer to avoid breakage. Throw warnings for users to migrate.

Follow-up to #5230