### PR TITLE
Divide rho by epsilon to undo the multiplication before computing phi

### DIFF
--- a/Examples/Physics_applications/spacecraft_charging/inputs_test_rz_spacecraft_charging_picmi.py
+++ b/Examples/Physics_applications/spacecraft_charging/inputs_test_rz_spacecraft_charging_picmi.py
@@ -121,12 +121,12 @@ def compute_virtual_charge_on_spacecraft():
     # Compute integral of rho over volume of the domain
     # (i.e. total charge of the plasma particles)
     rho_integral = (
-        (rho[1 : nr - 1, 1 : nz - 1] * r[1 : nr - 1, np.newaxis]).sum() * dr * dz
+        (rho[1 : nr - 1, 1 : nz - 1] * r[1 : nr - 1, np.newaxis]).sum()
+        * 2
+        * np.pi
+        * dr
+        * dz
     )
-
-    # Due to an oddity in WarpX (which will probably be solved later)
-    # we need to multiply `rho` by `-epsilon_0` to get the correct charge
-    rho_integral *= 2 * np.pi * -scc.epsilon_0  # does this oddity still exist?
 
     # Compute charge of the spacecraft, based on Gauss theorem
     q_spacecraft = -rho_integral - scc.epsilon_0 * grad_phi_integral

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -275,7 +275,7 @@ computePhi (
 #endif
         // Use the Multigrid (MLMG) solver if selected or on refined patches
         // but first scale rho appropriately
-        rho[lev]->mult(-1._rt / ablastr::constant::SI::ep0);  // TODO: when do we "un-multiply" this? We need to document this side-effect!
+        rho[lev]->mult(-1._rt / ablastr::constant::SI::ep0);
 
 #ifdef WARPX_DIM_RZ
         constexpr bool is_rz = true;
@@ -409,6 +409,8 @@ computePhi (
                 post_phi_calculation.value()(mlmg, lev);
             }
         }
+        rho[lev]->mult(-ablastr::constant::SI::ep0);  // Divide rho by epsilon again
+
     } // loop over lev(els)
 } // computePhi
 } // namespace ablastr::fields

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -409,7 +409,7 @@ computePhi (
                 post_phi_calculation.value()(mlmg, lev);
             }
         }
-        rho[lev]->mult(-ablastr::constant::SI::ep0);  // Divide rho by epsilon again
+        rho[lev]->mult(-ablastr::constant::SI::ep0);  // Multiply rho by epsilon again
 
     } // loop over lev(els)
 } // computePhi


### PR DESCRIPTION
Just before phi is computed, rho is divided by -epsilon 
but it is not divided back and this in python callbacks, the `RhoFPWrapper` points to rho/(-epsilon)
which is mis-leading and can lead to errors

