### PR TITLE
PoissonSolver: Missing Include

### DIFF
--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -14,6 +14,7 @@
 #include <ablastr/warn_manager/WarnManager.H>
 #include <ablastr/math/fft/AnyFFT.H>
 #include <ablastr/fields/Interpolate.H>
+#include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/profiler/ProfilerWrapper.H>
 
 #if defined(ABLASTR_USE_FFT) && defined(WARPX_DIM_3D)


### PR DESCRIPTION
Fix the missing include for `MultiLevelRegister`, which includes the MultiLevel MF types.

Seen as an issue in ImpactX.

Follow-up to #5230 