### PR TITLE
`MultiFabRegister`: use `has_vector` when possible

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1234,7 +1234,7 @@ PML::CheckPoint (
 {
     using ablastr::fields::Direction;
 
-    if (fields.has(FieldType::pml_E_fp, Direction{0}, 0))
+    if (fields.has_vector(FieldType::pml_E_fp, 0))
     {
         ablastr::fields::VectorField pml_E_fp = fields.get_alldirs(FieldType::pml_E_fp, 0);
         ablastr::fields::VectorField pml_B_fp = fields.get_alldirs(FieldType::pml_B_fp, 0);
@@ -1246,7 +1246,7 @@ PML::CheckPoint (
         VisMF::AsyncWrite(*pml_B_fp[2], dir+"_Bz_fp");
     }
 
-    if (fields.has(FieldType::pml_E_cp, Direction{0}, 0))
+    if (fields.has_vector(FieldType::pml_E_cp, 0))
     {
         ablastr::fields::VectorField pml_E_cp = fields.get_alldirs(FieldType::pml_E_cp, 0);
         ablastr::fields::VectorField pml_B_cp = fields.get_alldirs(FieldType::pml_B_cp, 0);
@@ -1267,7 +1267,7 @@ PML::Restart (
 {
     using ablastr::fields::Direction;
 
-    if (fields.has(FieldType::pml_E_fp, Direction{0}, 0))
+    if (fields.has_vector(FieldType::pml_E_fp, 0))
     {
         ablastr::fields::VectorField pml_E_fp = fields.get_alldirs(FieldType::pml_E_fp, 0);
         ablastr::fields::VectorField pml_B_fp = fields.get_alldirs(FieldType::pml_B_fp, 0);
@@ -1279,7 +1279,7 @@ PML::Restart (
         VisMF::Read(*pml_B_fp[2], dir+"_Bz_fp");
     }
 
-    if (fields.has(FieldType::pml_E_cp, Direction{0}, 0))
+    if (fields.has_vector(FieldType::pml_E_cp, 0))
     {
         ablastr::fields::VectorField pml_E_cp = fields.get_alldirs(FieldType::pml_E_cp, 0);
         ablastr::fields::VectorField pml_B_cp = fields.get_alldirs(FieldType::pml_B_cp, 0);

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -1147,7 +1147,7 @@ WarpX::PushParticlesandDeposit (int lev, amrex::Real cur_time, DtType a_dt_type,
             m_fields.get(FieldType::current_fp, Direction{1}, lev),
             m_fields.get(FieldType::current_fp, Direction{2}, lev),
             lev);
-        if (m_fields.has(FieldType::current_buf, Direction{0}, lev)) {
+        if (m_fields.has_vector(FieldType::current_buf, lev)) {
             ApplyInverseVolumeScalingToCurrentDensity(
                 m_fields.get(FieldType::current_buf, Direction{0}, lev),
                 m_fields.get(FieldType::current_buf, Direction{1}, lev),

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -79,19 +79,19 @@ void FiniteDifferenceSolver::EvolveB (
             fields.get(FieldType::G_fp, lev) : fields.get(FieldType::G_cp, lev);
     }
     ablastr::fields::VectorField face_areas;
-    if (fields.has(FieldType::face_areas, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::face_areas, lev)) {
         face_areas = fields.get_alldirs(FieldType::face_areas, lev);
     }
     ablastr::fields::VectorField area_mod;
-    if (fields.has(FieldType::area_mod, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::area_mod, lev)) {
         area_mod = fields.get_alldirs(FieldType::area_mod, lev);
     }
     ablastr::fields::VectorField ECTRhofield;
-    if (fields.has(FieldType::ECTRhofield, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::ECTRhofield, lev)) {
         ECTRhofield = fields.get_alldirs(FieldType::ECTRhofield, lev);
     }
     ablastr::fields::VectorField Venl;
-    if (fields.has(FieldType::Venl, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::Venl, lev)) {
         Venl = fields.get_alldirs(FieldType::Venl, lev);
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -73,19 +73,19 @@ void FiniteDifferenceSolver::EvolveE (
     }
 
     ablastr::fields::VectorField edge_lengths;
-    if (fields.has(FieldType::edge_lengths, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::edge_lengths, lev)) {
         edge_lengths = fields.get_alldirs(FieldType::edge_lengths, lev);
     }
     ablastr::fields::VectorField face_areas;
-    if (fields.has(FieldType::face_areas, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::face_areas, lev)) {
         face_areas = fields.get_alldirs(FieldType::face_areas, lev);
     }
     ablastr::fields::VectorField area_mod;
-    if (fields.has(FieldType::area_mod, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::area_mod, lev)) {
         area_mod = fields.get_alldirs(FieldType::area_mod, lev);
     }
     ablastr::fields::VectorField ECTRhofield;
-    if (fields.has(FieldType::ECTRhofield, Direction{0}, lev)) {
+    if (fields.has_vector(FieldType::ECTRhofield, lev)) {
         ECTRhofield = fields.get_alldirs(FieldType::ECTRhofield, lev);
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -69,7 +69,7 @@ void FiniteDifferenceSolver::EvolveEPML (
     const ablastr::fields::VectorField Jfield = (patch_type == PatchType::fine) ?
         fields.get_alldirs(FieldType::pml_j_fp, level) : fields.get_alldirs(FieldType::pml_j_cp, level);
     ablastr::fields::VectorField edge_lengths;
-    if (fields.has(FieldType::pml_edge_lengths, Direction{0}, level)) {
+    if (fields.has_vector(FieldType::pml_edge_lengths, level)) {
         edge_lengths = fields.get_alldirs(FieldType::pml_edge_lengths, level);
     }
     amrex::MultiFab * Ffield = nullptr;

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -196,7 +196,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
                 Array<std::unique_ptr<MultiFab>,3> Btmp;
-                if (m_fields.has(FieldType::Bfield_cax, Direction{0}, lev)) {
+                if (m_fields.has_vector(FieldType::Bfield_cax, lev)) {
                     for (int i = 0; i < 3; ++i) {
                         Btmp[i] = std::make_unique<MultiFab>(
                             *m_fields.get(FieldType::Bfield_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
@@ -290,7 +290,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
                 Array<std::unique_ptr<MultiFab>,3> Etmp;
-                if (m_fields.has(FieldType::Efield_cax, Direction{0}, lev)) {
+                if (m_fields.has_vector(FieldType::Efield_cax, lev)) {
                     for (int i = 0; i < 3; ++i) {
                         Etmp[i] = std::make_unique<MultiFab>(
                             *m_fields.get(FieldType::Efield_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
@@ -450,7 +450,7 @@ WarpX::UpdateAuxilaryDataSameType ()
                                                             Bfield_aux[lev - 1][2]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
                                                             crse_period);
 
-                if (m_fields.has(FieldType::Bfield_cax, Direction{0}, lev))
+                if (m_fields.has_vector(FieldType::Bfield_cax, lev))
                 {
                     MultiFab::Copy(*m_fields.get(FieldType::Bfield_cax, Direction{0}, lev), dBx, 0, 0, m_fields.get(FieldType::Bfield_cax, Direction{0}, lev)->nComp(), ng);
                     MultiFab::Copy(*m_fields.get(FieldType::Bfield_cax, Direction{1}, lev), dBy, 0, 0, m_fields.get(FieldType::Bfield_cax, Direction{1}, lev)->nComp(), ng);
@@ -535,7 +535,7 @@ WarpX::UpdateAuxilaryDataSameType ()
                                                             WarpX::do_single_precision_comms,
                                                             crse_period);
 
-                if (m_fields.has(FieldType::Efield_cax, Direction{0}, lev))
+                if (m_fields.has_vector(FieldType::Efield_cax, lev))
                 {
                     MultiFab::Copy(*m_fields.get(FieldType::Efield_cax, Direction{0}, lev), dEx, 0, 0, m_fields.get(FieldType::Efield_cax, Direction{0}, lev)->nComp(), ng);
                     MultiFab::Copy(*m_fields.get(FieldType::Efield_cax, Direction{1}, lev), dEy, 0, 0, m_fields.get(FieldType::Efield_cax, Direction{1}, lev)->nComp(), ng);

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -586,7 +586,7 @@ LaserParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
     const bool has_rho = fields.has(FieldType::rho_fp, lev);
-    const bool has_buffer = fields.has(FieldType::current_buf, lev);
+    const bool has_buffer = fields.has_vector(FieldType::current_buf, lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1753,9 +1753,9 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
     const iMultiFab* gather_masks = WarpX::GatherBufferMasks(lev);
 
     const bool has_rho = fields.has(FieldType::rho_fp, lev);
-    const bool has_cjx = fields.has(FieldType::current_buf, Direction{0}, lev);
-    const bool has_cEx = fields.has(FieldType::Efield_cax, Direction{0}, lev);
-    const bool has_buffer = has_cEx || has_cjx;
+    const bool has_J_buf = fields.has_vector(FieldType::current_buf, lev);
+    const bool has_E_cax = fields.has_vector(FieldType::Efield_cax, lev);
+    const bool has_buffer = has_E_cax || has_J_buf;
 
     amrex::MultiFab & Ex = *fields.get(FieldType::Efield_aux, Direction{0}, lev);
     amrex::MultiFab & Ey = *fields.get(FieldType::Efield_aux, Direction{1}, lev);
@@ -1850,7 +1850,7 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                     pti, lev, current_masks, gather_masks );
             }
 
-            const long np_current = has_cjx ? nfine_current : np;
+            const long np_current = has_J_buf ? nfine_current : np;
 
             if (has_rho && ! skip_deposition && ! do_not_deposit) {
                 // Deposit charge before particle push, in component 0 of MultiFab rho.
@@ -1870,7 +1870,7 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
 
             if (! do_not_push)
             {
-                const long np_gather = has_cEx ? nfine_gather : np;
+                const long np_gather = has_E_cax ? nfine_gather : np;
 
                 int e_is_nodal = Ex.is_nodal() and Ey.is_nodal() and Ez.is_nodal();
 


### PR DESCRIPTION
Follow-up on #5230: use `has_vector` for vector fields when possible, instead of `has` on a single direction.

This PR may fix #5305.