### PR TITLE
General parser function for external fields

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -53,13 +53,7 @@ public:
      * external current multifab. Note the external current can be a function
      * of time and therefore this should be re-evaluated at every step.
      */
-    void GetCurrentExternal (
-        ablastr::fields::MultiLevelVectorField const& edge_lengths
-    );
-    void GetCurrentExternal (
-        ablastr::fields::VectorField const& edge_lengths,
-        int lev
-    );
+    void GetCurrentExternal ();
 
     /**
      * \brief

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -228,7 +228,7 @@ void HybridPICModel::InitData ()
             m_J_external[2],
             warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
             warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
-            "edge", lev, PatchType::fine);
+            'e', lev, PatchType::fine);
     }
 }
 
@@ -246,7 +246,7 @@ void HybridPICModel::GetCurrentExternal ()
             m_J_external[2],
             warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
             warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
-            "edge", lev, PatchType::fine);
+            'e', lev, PatchType::fine);
     }
 }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -226,9 +226,9 @@ void HybridPICModel::InitData ()
             m_J_external[0],
             m_J_external[1],
             m_J_external[2],
+            lev, PatchType::fine, 'e',
             warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
-            warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
-            'e', lev, PatchType::fine);
+            warpx.m_fields.get_alldirs(FieldType::face_areas, lev));
     }
 }
 
@@ -244,9 +244,9 @@ void HybridPICModel::GetCurrentExternal ()
             m_J_external[0],
             m_J_external[1],
             m_J_external[2],
+            lev, PatchType::fine, 'e',
             warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
-            warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
-            'e', lev, PatchType::fine);
+            warpx.m_fields.get_alldirs(FieldType::face_areas, lev));
     }
 }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -221,167 +221,32 @@ void HybridPICModel::InitData ()
     // if the current is time dependent which is what needs to be done to
     // write time independent fields on the first step.
     for (int lev = 0; lev <= warpx.finestLevel(); ++lev) {
-        auto edge_lengths = std::array<std::unique_ptr<amrex::MultiFab>, 3>();
-#ifdef AMREX_USE_EB
-        if (EB::enabled()) {
-            using ablastr::fields::Direction;
-            auto const & edge_lengths_x = *warpx.m_fields.get(FieldType::edge_lengths, Direction{0}, lev);
-            auto const & edge_lengths_y = *warpx.m_fields.get(FieldType::edge_lengths, Direction{1}, lev);
-            auto const & edge_lengths_z = *warpx.m_fields.get(FieldType::edge_lengths, Direction{2}, lev);
-
-            edge_lengths = std::array< std::unique_ptr<amrex::MultiFab>, 3 >{
-                std::make_unique<amrex::MultiFab>(
-                    edge_lengths_x, amrex::make_alias, 0, edge_lengths_x.nComp()),
-                std::make_unique<amrex::MultiFab>(
-                    edge_lengths_y, amrex::make_alias, 0, edge_lengths_y.nComp()),
-                std::make_unique<amrex::MultiFab>(
-                    edge_lengths_z, amrex::make_alias, 0, edge_lengths_z.nComp())
-            };
-        }
-#endif
-        GetCurrentExternal(ablastr::fields::a2m(edge_lengths), lev);
+        warpx.ComputeExternalFieldOnGridUsingParser(
+            FieldType::hybrid_current_fp_external,
+            m_J_external[0],
+            m_J_external[1],
+            m_J_external[2],
+            warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
+            warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
+            "edge", lev, PatchType::fine);
     }
 }
 
-void HybridPICModel::GetCurrentExternal (
-    ablastr::fields::MultiLevelVectorField const& edge_lengths)
+void HybridPICModel::GetCurrentExternal ()
 {
     if (!m_external_field_has_time_dependence) { return; }
 
     auto& warpx = WarpX::GetInstance();
     for (int lev = 0; lev <= warpx.finestLevel(); ++lev)
     {
-        GetCurrentExternal(edge_lengths[lev], lev);
-    }
-}
-
-
-void HybridPICModel::GetCurrentExternal (
-    ablastr::fields::VectorField const& edge_lengths,
-    int lev)
-{
-    // This logic matches closely to WarpX::InitializeExternalFieldsOnGridUsingParser
-    // except that the parsers include time dependence.
-    auto & warpx = WarpX::GetInstance();
-
-    auto t = warpx.gett_new(lev);
-
-    auto dx_lev = warpx.Geom(lev).CellSizeArray();
-    const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-
-    using ablastr::fields::Direction;
-    amrex::MultiFab * mfx = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{0}, lev);
-    amrex::MultiFab * mfy = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{1}, lev);
-    amrex::MultiFab * mfz = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{2}, lev);
-
-    const amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
-    const amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
-    const amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
-
-    // avoid implicit lambda capture
-    auto Jx_external = m_J_external[0];
-    auto Jy_external = m_J_external[1];
-    auto Jz_external = m_J_external[2];
-
-    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
-        const amrex::Box& tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
-        const amrex::Box& tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
-
-        auto const& mfxfab = mfx->array(mfi);
-        auto const& mfyfab = mfy->array(mfi);
-        auto const& mfzfab = mfz->array(mfi);
-
-        amrex::Array4<amrex::Real> lx, ly, lz;
-        if (EB::enabled()) {
-            lx = edge_lengths[0]->array(mfi);
-            ly = edge_lengths[1]->array(mfi);
-            lz = edge_lengths[2]->array(mfi);
-        }
-
-        amrex::ParallelFor (tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                // skip if node is covered by an embedded boundary
-                if (lx && lx(i, j, k) <= 0) { return; }
-
-                // Shift required in the x-, y-, or z- position
-                // depending on the index type of the multifab
-#if defined(WARPX_DIM_1D_Z)
-                const amrex::Real x = 0._rt;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
-#else
-                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real fac_y = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
-                const amrex::Real fac_z = (1._rt - x_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
-                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
-#endif
-                // Initialize the x-component of the field.
-                mfxfab(i,j,k) = Jx_external(x,y,z,t);
-            },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                // skip if node is covered by an embedded boundary
-                if (ly && ly(i, j, k) <= 0) { return; }
-
-#if defined(WARPX_DIM_1D_Z)
-                const amrex::Real x = 0._rt;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - y_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
-#elif defined(WARPX_DIM_3D)
-                const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real fac_y = (1._rt - y_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
-                const amrex::Real fac_z = (1._rt - y_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
-                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
-#endif
-                // Initialize the y-component of the field.
-                mfyfab(i,j,k) = Jy_external(x,y,z,t);
-            },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                // skip if node is covered by an embedded boundary
-                if (lz && lz(i, j, k) <= 0) { return; }
-
-#if defined(WARPX_DIM_1D_Z)
-                const amrex::Real x = 0._rt;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real y = 0._rt;
-                const amrex::Real fac_z = (1._rt - z_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
-#elif defined(WARPX_DIM_3D)
-                const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
-                const amrex::Real fac_y = (1._rt - z_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
-                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
-                const amrex::Real fac_z = (1._rt - z_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
-                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
-#endif
-                // Initialize the z-component of the field.
-                mfzfab(i,j,k) = Jz_external(x,y,z,t);
-            }
-        );
+        warpx.ComputeExternalFieldOnGridUsingParser(
+            FieldType::hybrid_current_fp_external,
+            m_J_external[0],
+            m_J_external[1],
+            m_J_external[2],
+            warpx.m_fields.get_alldirs(FieldType::edge_lengths, lev),
+            warpx.m_fields.get_alldirs(FieldType::face_areas, lev),
+            "edge", lev, PatchType::fine);
     }
 }
 

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -68,8 +68,7 @@ void WarpX::HybridPICEvolveFields ()
     const int sub_steps = m_hybrid_pic_model->m_substeps;
 
     // Get the external current
-    m_hybrid_pic_model->GetCurrentExternal(
-        m_fields.get_mr_levels_alldirs(FieldType::edge_lengths, finest_level));
+    m_hybrid_pic_model->GetCurrentExternal();
 
     // Reference hybrid-PIC multifabs
     ablastr::fields::MultiLevelScalarField rho_fp_temp = m_fields.get_mr_levels(FieldType::hybrid_rho_fp_temp, finest_level);

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -1010,24 +1010,23 @@ void WarpXFluidContainer::GatherAndPush (
     // External field parsers
     external_e_fields = (m_E_ext_s == "parse_e_ext_function");
     external_b_fields = (m_B_ext_s == "parse_b_ext_function");
+
     amrex::ParserExecutor<4> Exfield_parser;
     amrex::ParserExecutor<4> Eyfield_parser;
     amrex::ParserExecutor<4> Ezfield_parser;
     amrex::ParserExecutor<4> Bxfield_parser;
     amrex::ParserExecutor<4> Byfield_parser;
     amrex::ParserExecutor<4> Bzfield_parser;
-    if (external_e_fields){
-        constexpr int num_arguments = 4; //x,y,z,t
-        Exfield_parser = m_Ex_parser->compile<num_arguments>();
-        Eyfield_parser = m_Ey_parser->compile<num_arguments>();
-        Ezfield_parser = m_Ez_parser->compile<num_arguments>();
-    }
 
+    if (external_e_fields){
+        Exfield_parser = m_Ex_parser->compile<4>();
+        Eyfield_parser = m_Ey_parser->compile<4>();
+        Ezfield_parser = m_Ez_parser->compile<4>();
+    }
     if (external_b_fields){
-        constexpr int num_arguments = 4; //x,y,z,t
-        Bxfield_parser = m_Bx_parser->compile<num_arguments>();
-        Byfield_parser = m_By_parser->compile<num_arguments>();
-        Bzfield_parser = m_Bz_parser->compile<num_arguments>();
+        Bxfield_parser = m_Bx_parser->compile<4>();
+        Byfield_parser = m_By_parser->compile<4>();
+        Bzfield_parser = m_Bz_parser->compile<4>();
     }
 
 

--- a/Source/Initialization/ExternalField.cpp
+++ b/Source/Initialization/ExternalField.cpp
@@ -127,11 +127,11 @@ ExternalFieldParams::ExternalFieldParams(const amrex::ParmParse& pp_warpx)
             str_Bz_ext_grid_function);
 
         Bxfield_parser = std::make_unique<amrex::Parser>(
-            utils::parser::makeParser(str_Bx_ext_grid_function,{"x","y","z"}));
+            utils::parser::makeParser(str_Bx_ext_grid_function,{"x","y","z","t"}));
         Byfield_parser = std::make_unique<amrex::Parser>(
-            utils::parser::makeParser(str_By_ext_grid_function,{"x","y","z"}));
+            utils::parser::makeParser(str_By_ext_grid_function,{"x","y","z","t"}));
         Bzfield_parser = std::make_unique<amrex::Parser>(
-            utils::parser::makeParser(str_Bz_ext_grid_function,{"x","y","z"}));
+            utils::parser::makeParser(str_Bz_ext_grid_function,{"x","y","z","t"}));
     }
     //___________________________________________________________________________
 
@@ -163,11 +163,11 @@ ExternalFieldParams::ExternalFieldParams(const amrex::ParmParse& pp_warpx)
            str_Ez_ext_grid_function);
 
         Exfield_parser = std::make_unique<amrex::Parser>(
-           utils::parser::makeParser(str_Ex_ext_grid_function,{"x","y","z"}));
+           utils::parser::makeParser(str_Ex_ext_grid_function,{"x","y","z","t"}));
         Eyfield_parser = std::make_unique<amrex::Parser>(
-           utils::parser::makeParser(str_Ey_ext_grid_function,{"x","y","z"}));
+           utils::parser::makeParser(str_Ey_ext_grid_function,{"x","y","z","t"}));
         Ezfield_parser = std::make_unique<amrex::Parser>(
-           utils::parser::makeParser(str_Ez_ext_grid_function,{"x","y","z"}));
+           utils::parser::makeParser(str_Ez_ext_grid_function,{"x","y","z","t"}));
     }
     //___________________________________________________________________________
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1528,7 +1528,7 @@ WarpX::LoadExternalFields (int const lev)
             m_p_ext_field_params->Ezfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            'f', lev, PatchType::fine);
+            'e', lev, PatchType::fine);
     }
     else if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::read_from_file) {
 #if defined(WARPX_DIM_RZ)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -979,7 +979,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            "face", lev, PatchType::fine);
+            'f', lev, PatchType::fine);
 
         ComputeExternalFieldOnGridUsingParser(
             FieldType::Bfield_cp,
@@ -988,7 +988,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_mr_levels_alldirs(FieldType::face_areas, max_level)[lev],
-            "face", lev, PatchType::coarse);
+            'f', lev, PatchType::coarse);
     }
 
     // if the input string for the E-field is "parse_e_ext_grid_function",
@@ -1021,7 +1021,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                 m_p_ext_field_params->Ezfield_parser->compile<4>(),
                 m_fields.get_alldirs(FieldType::edge_lengths, lev),
                 m_fields.get_alldirs(FieldType::face_areas, lev),
-                "edge", lev, PatchType::fine);
+                'e', lev, PatchType::fine);
 
             ComputeExternalFieldOnGridUsingParser(
                 FieldType::Efield_cp,
@@ -1030,7 +1030,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                 m_p_ext_field_params->Ezfield_parser->compile<4>(),
                 m_fields.get_alldirs(FieldType::edge_lengths, lev),
                 m_fields.get_alldirs(FieldType::face_areas, lev),
-                "edge", lev, PatchType::coarse);
+                'e', lev, PatchType::coarse);
 #ifdef AMREX_USE_EB
             if (eb_enabled) {
                 if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
@@ -1180,7 +1180,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
     amrex::ParserExecutor<4> const& fz_parser,
     ablastr::fields::VectorField const& edge_lengths,
     ablastr::fields::VectorField const& face_areas,
-    [[maybe_unused]] std::string topology,
+    [[maybe_unused]] const char topology,
     int lev, PatchType patch_type)
 {
     auto t = gett_new(lev);
@@ -1242,10 +1242,10 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(lx && ((topology=="edge" and lx(i, j, k)<=0) or (topology=="face" and Sx(i, j, k)<=0))) { return; }
+                if(lx && ((topology=='e' and lx(i, j, k)<=0) or (topology=='f' and Sx(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ex is associated with a x-edge, while Bx is associated with a z-edge
-                if(lx && ((topology=="edge" and lx(i, j, k)<=0) or (topology=="face" and lz(i, j, k)<=0))) { return; }
+                if(lx && ((topology=='e' and lx(i, j, k)<=0) or (topology=='f' and lz(i, j, k)<=0))) { return; }
 #endif
 #endif
                 // Shift required in the x-, y-, or z- position
@@ -1275,15 +1275,15 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(ly && ((topology=="edge" and ly(i, j, k)<=0) or (topology=="face" and Sy(i, j, k)<=0))) { return; }
+                if(ly && ((topology=='e' and ly(i, j, k)<=0) or (topology=='f' and Sy(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ey is associated with a mesh node, so we need to check if  the mesh node is covered
                 if(lx &&
-                  ((topology=="edge" and (lx(std::min(i  , lx_hi.x), std::min(j  , lx_hi.y), k)<=0
+                  ((topology=='e' and (lx(std::min(i  , lx_hi.x), std::min(j  , lx_hi.y), k)<=0
                                  || lx(std::max(i-1, lx_lo.x), std::min(j  , lx_hi.y), k)<=0
                                  || lz(std::min(i  , lz_hi.x), std::min(j  , lz_hi.y), k)<=0
                                  || lz(std::min(i  , lz_hi.x), std::max(j-1, lz_lo.y), k)<=0)) or
-                   (topology=="face" and Sy(i,j,k)<=0))) { return; }
+                   (topology=='f' and Sy(i,j,k)<=0))) { return; }
 #endif
 #endif
 #if defined(WARPX_DIM_1D_Z)
@@ -1311,10 +1311,10 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(lz && ((topology=="edge" and lz(i, j, k)<=0) or (topology=="face" and Sz(i, j, k)<=0))) { return; }
+                if(lz && ((topology=='e' and lz(i, j, k)<=0) or (topology=='f' and Sz(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ez is associated with a z-edge, while Bz is associated with a x-edge
-                if(lz && ((topology=="edge" and lz(i, j, k)<=0) or (topology=="face" and lx(i, j, k)<=0))) { return; }
+                if(lz && ((topology=='e' and lz(i, j, k)<=0) or (topology=='f' and lx(i, j, k)<=0))) { return; }
 #endif
 #endif
 #if defined(WARPX_DIM_1D_Z)
@@ -1503,7 +1503,7 @@ WarpX::LoadExternalFields (int const lev)
             m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            "face", lev, PatchType::fine);
+            'f', lev, PatchType::fine);
     }
     else if (m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::read_from_file) {
 #if defined(WARPX_DIM_RZ)
@@ -1528,7 +1528,7 @@ WarpX::LoadExternalFields (int const lev)
             m_p_ext_field_params->Ezfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            "edge", lev, PatchType::fine);
+            'f', lev, PatchType::fine);
     }
     else if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::read_from_file) {
 #if defined(WARPX_DIM_RZ)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -972,30 +972,23 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     // The default maxlevel_extEMfield_init value is the total number of levels in the simulation
     if ((m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::parse_ext_grid_function)
          && (lev > 0) && (lev <= maxlevel_extEMfield_init)) {
-
-        InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_aux, Direction{2}, lev),
-            m_p_ext_field_params->Bxfield_parser->compile<3>(),
-            m_p_ext_field_params->Byfield_parser->compile<3>(),
-            m_p_ext_field_params->Bzfield_parser->compile<3>(),
+        ComputeExternalFieldOnGridUsingParser(
+            FieldType::Bfield_aux,
+            m_p_ext_field_params->Bxfield_parser->compile<4>(),
+            m_p_ext_field_params->Byfield_parser->compile<4>(),
+            m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            'B',
-            lev, PatchType::fine);
+            "face", lev, PatchType::fine);
 
-        InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
-            m_p_ext_field_params->Bxfield_parser->compile<3>(),
-            m_p_ext_field_params->Byfield_parser->compile<3>(),
-            m_p_ext_field_params->Bzfield_parser->compile<3>(),
+        ComputeExternalFieldOnGridUsingParser(
+            FieldType::Bfield_cp,
+            m_p_ext_field_params->Bxfield_parser->compile<4>(),
+            m_p_ext_field_params->Byfield_parser->compile<4>(),
+            m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_mr_levels_alldirs(FieldType::face_areas, max_level)[lev],
-            'B',
-            lev, PatchType::coarse);
+            "face", lev, PatchType::coarse);
     }
 
     // if the input string for the E-field is "parse_e_ext_grid_function",
@@ -1021,29 +1014,23 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 #endif
 
         if (lev > 0) {
-            InitializeExternalFieldsOnGridUsingParser(
-                m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-                m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-                m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
-                m_p_ext_field_params->Exfield_parser->compile<3>(),
-                m_p_ext_field_params->Eyfield_parser->compile<3>(),
-                m_p_ext_field_params->Ezfield_parser->compile<3>(),
+            ComputeExternalFieldOnGridUsingParser(
+                FieldType::Efield_aux,
+                m_p_ext_field_params->Exfield_parser->compile<4>(),
+                m_p_ext_field_params->Eyfield_parser->compile<4>(),
+                m_p_ext_field_params->Ezfield_parser->compile<4>(),
                 m_fields.get_alldirs(FieldType::edge_lengths, lev),
                 m_fields.get_alldirs(FieldType::face_areas, lev),
-                'E',
-                lev, PatchType::fine);
+                "edge", lev, PatchType::fine);
 
-            InitializeExternalFieldsOnGridUsingParser(
-                m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
-                m_p_ext_field_params->Exfield_parser->compile<3>(),
-                m_p_ext_field_params->Eyfield_parser->compile<3>(),
-                m_p_ext_field_params->Ezfield_parser->compile<3>(),
+            ComputeExternalFieldOnGridUsingParser(
+                FieldType::Efield_cp,
+                m_p_ext_field_params->Exfield_parser->compile<4>(),
+                m_p_ext_field_params->Eyfield_parser->compile<4>(),
+                m_p_ext_field_params->Ezfield_parser->compile<4>(),
                 m_fields.get_alldirs(FieldType::edge_lengths, lev),
                 m_fields.get_alldirs(FieldType::face_areas, lev),
-                'E',
-                lev, PatchType::coarse);
+                "edge", lev, PatchType::coarse);
 #ifdef AMREX_USE_EB
             if (eb_enabled) {
                 if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
@@ -1072,39 +1059,162 @@ WarpX::InitLevelData (int lev, Real /*time*/)
     }
 }
 
-void
-WarpX::InitializeExternalFieldsOnGridUsingParser (
-       MultiFab *mfx, MultiFab *mfy, MultiFab *mfz,
-       ParserExecutor<3> const& xfield_parser, ParserExecutor<3> const& yfield_parser,
-       ParserExecutor<3> const& zfield_parser,
-       ablastr::fields::VectorField const& edge_lengths,
-       ablastr::fields::VectorField const& face_areas,
-       [[maybe_unused]] const char field,
-       const int lev, PatchType patch_type)
+void WarpX::ComputeExternalFieldOnGridUsingParser (
+    warpx::fields::FieldType field,
+    amrex::ParserExecutor<4> const& fx_parser,
+    amrex::ParserExecutor<4> const& fy_parser,
+    amrex::ParserExecutor<4> const& fz_parser,
+    int lev, PatchType patch_type)
 {
+    auto t = gett_new(lev);
 
     auto dx_lev = geom[lev].CellSizeArray();
-    amrex::IntVect refratio = (lev > 0 ) ? WarpX::RefRatio(lev-1) : amrex::IntVect(1);
+    const RealBox& real_box = geom[lev].ProbDomain();
+
+    amrex::IntVect refratio = (lev > 0 ) ? RefRatio(lev-1) : amrex::IntVect(1);
     if (patch_type == PatchType::coarse) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            dx_lev[idim] = dx_lev[idim] * refratio[idim];
+            dx_lev[idim] *= refratio[idim];
         }
     }
-    const RealBox& real_box = geom[lev].ProbDomain();
+
+    using ablastr::fields::Direction;
+    amrex::MultiFab * mfx = m_fields.get(field, Direction{0}, lev);
+    amrex::MultiFab * mfy = m_fields.get(field, Direction{1}, lev);
+    amrex::MultiFab * mfz = m_fields.get(field, Direction{2}, lev);
+
     const amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
     const amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
     const amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
 
-    bool const eb_enabled = EB::enabled();
+    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
+        const amrex::Box& tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
+        const amrex::Box& tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
 
-    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box &tbx = mfi.tilebox(x_nodal_flag, mfx->nGrowVect());
-        const amrex::Box &tby = mfi.tilebox(y_nodal_flag, mfy->nGrowVect());
-        const amrex::Box &tbz = mfi.tilebox(z_nodal_flag, mfz->nGrowVect());
+        auto const& mfxfab = mfx->array(mfi);
+        auto const& mfyfab = mfy->array(mfi);
+        auto const& mfzfab = mfz->array(mfi);
 
-        auto const &mfxfab = mfx->array(mfi);
-        auto const &mfyfab = mfy->array(mfi);
-        auto const &mfzfab = mfz->array(mfi);
+        amrex::ParallelFor (tbx, tby, tbz,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                // Shift required in the x-, y-, or z- position
+                // depending on the index type of the multifab
+#if defined(WARPX_DIM_1D_Z)
+                const amrex::Real x = 0._rt;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
+#else
+                const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real fac_y = (1._rt - x_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
+                const amrex::Real fac_z = (1._rt - x_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
+                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
+#endif
+                // Initialize the x-component of the field.
+                mfxfab(i,j,k) = fx_parser(x, y, z, t);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+#if defined(WARPX_DIM_1D_Z)
+                const amrex::Real x = 0._rt;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - y_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
+#elif defined(WARPX_DIM_3D)
+                const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real fac_y = (1._rt - y_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
+                const amrex::Real fac_z = (1._rt - y_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
+                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
+#endif
+                // Initialize the y-component of the field.
+                mfyfab(i,j,k) = fy_parser(x, y, z, t);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+#if defined(WARPX_DIM_1D_Z)
+                const amrex::Real x = 0._rt;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real y = 0._rt;
+                const amrex::Real fac_z = (1._rt - z_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real z = j*dx_lev[1] + real_box.lo(1) + fac_z;
+#elif defined(WARPX_DIM_3D)
+                const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
+                const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
+                const amrex::Real fac_y = (1._rt - z_nodal_flag[1]) * dx_lev[1] * 0.5_rt;
+                const amrex::Real y = j*dx_lev[1] + real_box.lo(1) + fac_y;
+                const amrex::Real fac_z = (1._rt - z_nodal_flag[2]) * dx_lev[2] * 0.5_rt;
+                const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
+#endif
+                // Initialize the z-component of the field.
+                mfzfab(i,j,k) = fz_parser(x, y, z, t);
+            }
+        );
+    }
+}
+
+void WarpX::ComputeExternalFieldOnGridUsingParser (
+    warpx::fields::FieldType field,
+    amrex::ParserExecutor<4> const& fx_parser,
+    amrex::ParserExecutor<4> const& fy_parser,
+    amrex::ParserExecutor<4> const& fz_parser,
+    ablastr::fields::VectorField const& edge_lengths,
+    ablastr::fields::VectorField const& face_areas,
+    [[maybe_unused]] std::string topology,
+    int lev, PatchType patch_type)
+{
+    auto t = gett_new(lev);
+
+    auto dx_lev = geom[lev].CellSizeArray();
+    const RealBox& real_box = geom[lev].ProbDomain();
+
+    amrex::IntVect refratio = (lev > 0 ) ? RefRatio(lev-1) : amrex::IntVect(1);
+    if (patch_type == PatchType::coarse) {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            dx_lev[idim] *= refratio[idim];
+        }
+    }
+
+    using ablastr::fields::Direction;
+    amrex::MultiFab * mfx = m_fields.get(field, Direction{0}, lev);
+    amrex::MultiFab * mfy = m_fields.get(field, Direction{1}, lev);
+    amrex::MultiFab * mfz = m_fields.get(field, Direction{2}, lev);
+
+    const amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
+    const amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
+    const amrex::IntVect z_nodal_flag = mfz->ixType().toIntVect();
+
+    const bool eb_enabled = EB::enabled();
+
+    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
+        const amrex::Box& tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
+        const amrex::Box& tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
+
+        auto const& mfxfab = mfx->array(mfi);
+        auto const& mfyfab = mfy->array(mfi);
+        auto const& mfzfab = mfz->array(mfi);
 
         amrex::Array4<amrex::Real> lx, ly, lz, Sx, Sy, Sz;
         if (eb_enabled) {
@@ -1132,10 +1242,10 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(lx && ((field=='E' and lx(i, j, k)<=0) or (field=='B' and Sx(i, j, k)<=0))) { return; }
+                if(lx && ((topology=="edge" and lx(i, j, k)<=0) or (topology=="face" and Sx(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ex is associated with a x-edge, while Bx is associated with a z-edge
-                if(lx && ((field=='E' and lx(i, j, k)<=0) or (field=='B' and lz(i, j, k)<=0))) { return; }
+                if(lx && ((topology=="edge" and lx(i, j, k)<=0) or (topology=="face" and lz(i, j, k)<=0))) { return; }
 #endif
 #endif
                 // Shift required in the x-, y-, or z- position
@@ -1144,7 +1254,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
@@ -1160,27 +1270,27 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the x-component of the field.
-                mfxfab(i,j,k) = xfield_parser(x,y,z);
+                mfxfab(i,j,k) = fx_parser(x, y, z, t);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(ly && ((field=='E' and ly(i, j, k)<=0) or (field=='B' and Sy(i, j, k)<=0))) { return; }
+                if(ly && ((topology=="edge" and ly(i, j, k)<=0) or (topology=="face" and Sy(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ey is associated with a mesh node, so we need to check if  the mesh node is covered
                 if(lx &&
-                  ((field=='E' and (lx(std::min(i  , lx_hi.x), std::min(j  , lx_hi.y), k)<=0
+                  ((topology=="edge" and (lx(std::min(i  , lx_hi.x), std::min(j  , lx_hi.y), k)<=0
                                  || lx(std::max(i-1, lx_lo.x), std::min(j  , lx_hi.y), k)<=0
                                  || lz(std::min(i  , lz_hi.x), std::min(j  , lz_hi.y), k)<=0
                                  || lz(std::min(i  , lz_hi.x), std::max(j-1, lz_lo.y), k)<=0)) or
-                   (field=='B' and Sy(i,j,k)<=0))) { return; }
+                   (topology=="face" and Sy(i,j,k)<=0))) { return; }
 #endif
 #endif
 #if defined(WARPX_DIM_1D_Z)
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
@@ -1196,22 +1306,22 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the y-component of the field.
-                mfyfab(i,j,k)  = yfield_parser(x,y,z);
+                mfyfab(i,j,k) = fy_parser(x, y, z, t);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
 #ifdef WARPX_DIM_3D
-                if(lz && ((field=='E' and lz(i, j, k)<=0) or (field=='B' and Sz(i, j, k)<=0))) { return; }
+                if(lz && ((topology=="edge" and lz(i, j, k)<=0) or (topology=="face" and Sz(i, j, k)<=0))) { return; }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ and RZ Ez is associated with a z-edge, while Bz is associated with a x-edge
-                if(lz && ((field=='E' and lz(i, j, k)<=0) or (field=='B' and lx(i, j, k)<=0))) { return; }
+                if(lz && ((topology=="edge" and lz(i, j, k)<=0) or (topology=="face" and lx(i, j, k)<=0))) { return; }
 #endif
 #endif
 #if defined(WARPX_DIM_1D_Z)
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
@@ -1227,7 +1337,7 @@ WarpX::InitializeExternalFieldsOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the z-component of the field.
-                mfzfab(i,j,k) = zfield_parser(x,y,z);
+                mfzfab(i,j,k) = fz_parser(x, y, z, t);
             }
         );
     }
@@ -1386,17 +1496,14 @@ WarpX::LoadExternalFields (int const lev)
     // External grid fields
     if (m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::parse_ext_grid_function) {
         // Initialize Bfield_fp_external with external function
-        InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_fp_external, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_fp_external, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_fp_external, Direction{2}, lev),
-            m_p_ext_field_params->Bxfield_parser->compile<3>(),
-            m_p_ext_field_params->Byfield_parser->compile<3>(),
-            m_p_ext_field_params->Bzfield_parser->compile<3>(),
+        ComputeExternalFieldOnGridUsingParser(
+            FieldType::Bfield_fp_external,
+            m_p_ext_field_params->Bxfield_parser->compile<4>(),
+            m_p_ext_field_params->Byfield_parser->compile<4>(),
+            m_p_ext_field_params->Bzfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            'B',
-            lev, PatchType::fine);
+            "face", lev, PatchType::fine);
     }
     else if (m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::read_from_file) {
 #if defined(WARPX_DIM_RZ)
@@ -1414,17 +1521,14 @@ WarpX::LoadExternalFields (int const lev)
 
     if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::parse_ext_grid_function) {
         // Initialize Efield_fp_external with external function
-        InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Efield_fp_external, Direction{0}, lev),
-            m_fields.get(FieldType::Efield_fp_external, Direction{1}, lev),
-            m_fields.get(FieldType::Efield_fp_external, Direction{2}, lev),
-            m_p_ext_field_params->Exfield_parser->compile<3>(),
-            m_p_ext_field_params->Eyfield_parser->compile<3>(),
-            m_p_ext_field_params->Ezfield_parser->compile<3>(),
+        ComputeExternalFieldOnGridUsingParser(
+            FieldType::Efield_fp_external,
+            m_p_ext_field_params->Exfield_parser->compile<4>(),
+            m_p_ext_field_params->Eyfield_parser->compile<4>(),
+            m_p_ext_field_params->Ezfield_parser->compile<4>(),
             m_fields.get_alldirs(FieldType::edge_lengths, lev),
             m_fields.get_alldirs(FieldType::face_areas, lev),
-            'E',
-            lev, PatchType::fine);
+            "edge", lev, PatchType::fine);
     }
     else if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::read_from_file) {
 #if defined(WARPX_DIM_RZ)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1103,13 +1103,13 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
         amrex::Array4<amrex::Real> lx, ly, lz, Sx, Sy, Sz;
         if (eb_enabled) {
             if (edge_lengths.has_value()) {
-                auto& edge_lengths_array = edge_lengths.value();
+                const auto& edge_lengths_array = edge_lengths.value();
                 lx = edge_lengths_array[0]->array(mfi);
                 ly = edge_lengths_array[1]->array(mfi);
                 lz = edge_lengths_array[2]->array(mfi);
             }
             if (face_areas.has_value()) {
-                auto& face_areas_array = face_areas.value();
+                const auto& face_areas_array = face_areas.value();
                 Sx = face_areas_array[0]->array(mfi);
                 Sy = face_areas_array[1]->array(mfi);
                 Sz = face_areas_array[2]->array(mfi);

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1076,14 +1076,14 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
     amrex::IntVect refratio = (lev > 0 ) ? RefRatio(lev-1) : amrex::IntVect(1);
     if (patch_type == PatchType::coarse) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            dx_lev[idim] *= refratio[idim];
+            dx_lev[idim] = dx_lev[idim] + refratio[idim];
         }
     }
 
     using ablastr::fields::Direction;
-    amrex::MultiFab * mfx = m_fields.get(field, Direction{0}, lev);
-    amrex::MultiFab * mfy = m_fields.get(field, Direction{1}, lev);
-    amrex::MultiFab * mfz = m_fields.get(field, Direction{2}, lev);
+    amrex::MultiFab* mfx = m_fields.get(field, Direction{0}, lev);
+    amrex::MultiFab* mfy = m_fields.get(field, Direction{1}, lev);
+    amrex::MultiFab* mfz = m_fields.get(field, Direction{2}, lev);
 
     const amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
     const amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
@@ -1091,8 +1091,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
 
     const bool eb_enabled = EB::enabled();
 
-    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for ( MFIter mfi(*mfx, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& tbx = mfi.tilebox( x_nodal_flag, mfx->nGrowVect() );
         const amrex::Box& tby = mfi.tilebox( y_nodal_flag, mfy->nGrowVect() );
         const amrex::Box& tbz = mfi.tilebox( z_nodal_flag, mfz->nGrowVect() );
@@ -1161,7 +1160,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the x-component of the field.
-                mfxfab(i,j,k) = fx_parser(x, y, z, t);
+                mfxfab(i,j,k) = fx_parser(x,y,z,t);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
@@ -1197,7 +1196,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the y-component of the field.
-                mfyfab(i,j,k) = fy_parser(x, y, z, t);
+                mfyfab(i,j,k) = fy_parser(x,y,z,t);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 #ifdef AMREX_USE_EB
@@ -1228,7 +1227,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
                 // Initialize the z-component of the field.
-                mfzfab(i,j,k) = fz_parser(x, y, z, t);
+                mfzfab(i,j,k) = fz_parser(x,y,z,t);
             }
         );
     }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1076,7 +1076,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
     amrex::IntVect refratio = (lev > 0 ) ? RefRatio(lev-1) : amrex::IntVect(1);
     if (patch_type == PatchType::coarse) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            dx_lev[idim] = dx_lev[idim] + refratio[idim];
+            dx_lev[idim] = dx_lev[idim] * refratio[idim];
         }
     }
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1145,7 +1145,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - x_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
@@ -1181,7 +1181,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - y_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;
@@ -1212,7 +1212,7 @@ void WarpX::ComputeExternalFieldOnGridUsingParser (
                 const amrex::Real x = 0._rt;
                 const amrex::Real y = 0._rt;
                 const amrex::Real fac_z = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
-                const amrex::Real z = j*dx_lev[0] + real_box.lo(0) + fac_z;
+                const amrex::Real z = i*dx_lev[0] + real_box.lo(0) + fac_z;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const amrex::Real fac_x = (1._rt - z_nodal_flag[0]) * dx_lev[0] * 0.5_rt;
                 const amrex::Real x = i*dx_lev[0] + real_box.lo(0) + fac_x;

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -50,19 +50,17 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
     if (mypc.m_E_ext_particle_s == "parse_e_ext_particle_function")
     {
         m_Etype = ExternalFieldInitType::Parser;
-        constexpr auto num_arguments = 4; //x,y,z,t
-        m_Exfield_partparser = mypc.m_Ex_particle_parser->compile<num_arguments>();
-        m_Eyfield_partparser = mypc.m_Ey_particle_parser->compile<num_arguments>();
-        m_Ezfield_partparser = mypc.m_Ez_particle_parser->compile<num_arguments>();
+        m_Exfield_partparser = mypc.m_Ex_particle_parser->compile<4>();
+        m_Eyfield_partparser = mypc.m_Ey_particle_parser->compile<4>();
+        m_Ezfield_partparser = mypc.m_Ez_particle_parser->compile<4>();
     }
 
     if (mypc.m_B_ext_particle_s == "parse_b_ext_particle_function")
     {
         m_Btype = ExternalFieldInitType::Parser;
-        constexpr auto num_arguments = 4; //x,y,z,t
-        m_Bxfield_partparser = mypc.m_Bx_particle_parser->compile<num_arguments>();
-        m_Byfield_partparser = mypc.m_By_particle_parser->compile<num_arguments>();
-        m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<num_arguments>();
+        m_Bxfield_partparser = mypc.m_Bx_particle_parser->compile<4>();
+        m_Byfield_partparser = mypc.m_By_particle_parser->compile<4>();
+        m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<4>();
     }
 
     if (mypc.m_E_ext_particle_s == "repeated_plasma_lens" ||

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -972,17 +972,9 @@ public:
         amrex::ParserExecutor<4> const& fx_parser,
         amrex::ParserExecutor<4> const& fy_parser,
         amrex::ParserExecutor<4> const& fz_parser,
-        ablastr::fields::VectorField const& edge_lengths,
-        ablastr::fields::VectorField const& face_areas,
-        [[maybe_unused]] char topology,
-        int lev, PatchType patch_type);
-
-    void ComputeExternalFieldOnGridUsingParser (
-        warpx::fields::FieldType field,
-        amrex::ParserExecutor<4> const& fx_parser,
-        amrex::ParserExecutor<4> const& fy_parser,
-        amrex::ParserExecutor<4> const& fz_parser,
-        int lev, PatchType patch_type);
+        int lev, PatchType patch_type, [[maybe_unused]] char topology,
+        std::optional<ablastr::fields::VectorField> const& edge_lengths = std::nullopt,
+        std::optional<ablastr::fields::VectorField> const& face_areas = std::nullopt);
 
     /**
      * \brief Load field values from a user-specified openPMD file,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -974,7 +974,7 @@ public:
         amrex::ParserExecutor<4> const& fz_parser,
         ablastr::fields::VectorField const& edge_lengths,
         ablastr::fields::VectorField const& face_areas,
-        [[maybe_unused]] const char topology,
+        [[maybe_unused]] char topology,
         int lev, PatchType patch_type);
 
     void ComputeExternalFieldOnGridUsingParser (

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -974,7 +974,7 @@ public:
         amrex::ParserExecutor<4> const& fz_parser,
         ablastr::fields::VectorField const& edge_lengths,
         ablastr::fields::VectorField const& face_areas,
-        [[maybe_unused]] std::string topology,
+        [[maybe_unused]] const char topology,
         int lev, PatchType patch_type);
 
     void ComputeExternalFieldOnGridUsingParser (

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -950,34 +950,39 @@ public:
 
     /**
      * \brief
-     * This function initializes the E and B fields on each level
+     * This function computes the E, B, and J fields on each level
      * using the parser and the user-defined function for the external fields.
      * The subroutine will parse the x_/y_z_external_grid_function and
      * then, the field multifab is initialized based on the (x,y,z) position
      * on the staggered yee-grid or cell-centered grid, in the interior cells
      * and guard cells.
      *
-     * \param[in] mfx x-component of the field to be initialized
-     * \param[in] mfy y-component of the field to be initialized
-     * \param[in] mfz z-component of the field to be initialized
-     * \param[in] xfield_parser parser function to initialize x-field
-     * \param[in] yfield_parser parser function to initialize y-field
-     * \param[in] zfield_parser parser function to initialize z-field
+     * \param[in] field FieldType
+     * \param[in] fx_parser parser function to initialize x-field
+     * \param[in] fy_parser parser function to initialize y-field
+     * \param[in] fz_parser parser function to initialize z-field
      * \param[in] edge_lengths edge lengths information
      * \param[in] face_areas face areas information
-     * \param[in] field flag indicating which field is being initialized ('E' for electric, 'B' for magnetic)
+     * \param[in] topology flag indicating if field is edge-based or face-based
      * \param[in] lev level of the Multifabs that is initialized
      * \param[in] patch_type PatchType on which the field is initialized (fine or coarse)
      */
-    void InitializeExternalFieldsOnGridUsingParser (
-         amrex::MultiFab *mfx, amrex::MultiFab *mfy, amrex::MultiFab *mfz,
-         amrex::ParserExecutor<3> const& xfield_parser,
-         amrex::ParserExecutor<3> const& yfield_parser,
-         amrex::ParserExecutor<3> const& zfield_parser,
-         ablastr::fields::VectorField const& edge_lengths,
-         ablastr::fields::VectorField const& face_areas,
-         [[maybe_unused]] char field,
-         int lev, PatchType patch_type);
+    void ComputeExternalFieldOnGridUsingParser (
+        warpx::fields::FieldType field,
+        amrex::ParserExecutor<4> const& fx_parser,
+        amrex::ParserExecutor<4> const& fy_parser,
+        amrex::ParserExecutor<4> const& fz_parser,
+        ablastr::fields::VectorField const& edge_lengths,
+        ablastr::fields::VectorField const& face_areas,
+        [[maybe_unused]] std::string topology,
+        int lev, PatchType patch_type);
+
+    void ComputeExternalFieldOnGridUsingParser (
+        warpx::fields::FieldType field,
+        amrex::ParserExecutor<4> const& fx_parser,
+        amrex::ParserExecutor<4> const& fy_parser,
+        amrex::ParserExecutor<4> const& fz_parser,
+        int lev, PatchType patch_type);
 
     /**
      * \brief Load field values from a user-specified openPMD file,


### PR DESCRIPTION
This feature replaces the InitializeExternalFieldsOnGridUsingParser with a more general function ComputeExternalFieldOnGridUsingParser. The new function takes parsed functions with four dimensions (x,y,z,t), so that it can be used to evaluate functions throughout the simulation, for example time-dependent external fields.

The function ComputeExternalFieldOnGridUsingParser has optional edge length and face areas. 