### PR TITLE
Remove multifab_map and associated functions

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -112,13 +112,6 @@ void init_WarpX (py::module& m)
             //py::overload_cast< int >(&WarpX::boxArray, py::const_),
             py::arg("lev")
         )
-        .def("field",
-             [](WarpX const & wx) {
-                 return wx.multifab_map;
-             },
-             py::return_value_policy::reference_internal,
-             R"doc(Registry to all WarpX MultiFab (fields).)doc"
-        )
         .def("multifab",
              [](WarpX & wx, std::string internal_name) {
                  if (wx.m_fields.internal_has(internal_name)) {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -405,31 +405,6 @@ public:
 
     /**
      * \brief
-     * Allocate and optionally initialize the MultiFab. This also adds the MultiFab
-     * to the map of MultiFabs (used to ease the access to MultiFabs from the Python
-     * interface
-     *
-     * \param[out] mf The MultiFab unique pointer to be allocated
-     * \param[in] ba The BoxArray describing the MultiFab
-     * \param[in] dm The DistributionMapping describing the MultiFab
-     * \param[in] ncomp The number of components in the MultiFab
-     * \param[in] ngrow The number of guard cells in the MultiFab
-     * \param[in] level The refinement level
-     * \param[in] name The name of the MultiFab to use in the map
-     * \param[in] initial_value The optional initial value
-     */
-    static void AllocInitMultiFab (
-        std::unique_ptr<amrex::MultiFab>& mf,
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dm,
-        int ncomp,
-        const amrex::IntVect& ngrow,
-        int level,
-        const std::string& name,
-        std::optional<const amrex::Real> initial_value = {});
-
-    /**
-     * \brief
      * Allocate and optionally initialize the iMultiFab. This also adds the iMultiFab
      * to the map of MultiFabs (used to ease the access to MultiFabs from the Python
      * interface
@@ -453,30 +428,9 @@ public:
         const std::string& name,
         std::optional<const int> initial_value = {});
 
-    /**
-     * \brief
-     * Create an alias of a MultiFab, adding the alias to the MultiFab map
-     * \param[out] mf The MultiFab to create
-     * \param[in] mf_to_alias The MultiFab to alias
-     * \param[in] scomp The starting component to be aliased
-     * \param[in] ncomp The number of components to alias
-     * \param[in] level The refinement level
-     * \param[in] name The name of the MultiFab to use in the map
-     * \param[in] initial_value optional initial value for MultiFab
-     */
-    static void AliasInitMultiFab (
-        std::unique_ptr<amrex::MultiFab>& mf,
-        const amrex::MultiFab& mf_to_alias,
-        int scomp,
-        int ncomp,
-        int level,
-        const std::string& name,
-        std::optional<const amrex::Real> initial_value);
-
-    // Maps of all of the MultiFabs and iMultiFabs used (this can include MFs from other classes)
-    // This is a convenience for the Python interface, allowing all MultiFabs
+    // Maps of all of the iMultiFabs used (this can include MFs from other classes)
+    // This is a convenience for the Python interface, allowing all iMultiFabs
     // to be easily referenced from Python.
-    static std::map<std::string, amrex::MultiFab *> multifab_map;
     static std::map<std::string, amrex::iMultiFab *> imultifab_map;
 
     /**

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -184,7 +184,6 @@ bool WarpX::safe_guard_cells = false;
 
 utils::parser::IntervalsParser WarpX::dt_update_interval;
 
-std::map<std::string, amrex::MultiFab *> WarpX::multifab_map;
 std::map<std::string, amrex::iMultiFab *> WarpX::imultifab_map;
 
 IntVect WarpX::filter_npass_each_dir(1);
@@ -3286,26 +3285,6 @@ TagWithLevelSuffix (std::string name, int const level)
 
 void
 WarpX::AllocInitMultiFab (
-    std::unique_ptr<amrex::MultiFab>& mf,
-    const amrex::BoxArray& ba,
-    const amrex::DistributionMapping& dm,
-    const int ncomp,
-    const amrex::IntVect& ngrow,
-    const int level,
-    const std::string& name,
-    std::optional<const amrex::Real> initial_value)
-{
-    const auto name_with_suffix = TagWithLevelSuffix(name, level);
-    const auto tag = amrex::MFInfo().SetTag(name_with_suffix);
-    mf = std::make_unique<amrex::MultiFab>(ba, dm, ncomp, ngrow, tag);
-    if (initial_value) {
-        mf->setVal(*initial_value);
-    }
-    multifab_map[name_with_suffix] = mf.get();
-}
-
-void
-WarpX::AllocInitMultiFab (
     std::unique_ptr<amrex::iMultiFab>& mf,
     const amrex::BoxArray& ba,
     const amrex::DistributionMapping& dm,
@@ -3322,24 +3301,6 @@ WarpX::AllocInitMultiFab (
         mf->setVal(*initial_value);
     }
     imultifab_map[name_with_suffix] = mf.get();
-}
-
-void
-WarpX::AliasInitMultiFab (
-    std::unique_ptr<amrex::MultiFab>& mf,
-    const amrex::MultiFab& mf_to_alias,
-    const int scomp,
-    const int ncomp,
-    const int level,
-    const std::string& name,
-    std::optional<const amrex::Real> initial_value)
-{
-    const auto name_with_suffix = TagWithLevelSuffix(name, level);
-    mf = std::make_unique<amrex::MultiFab>(mf_to_alias, amrex::make_alias, scomp, ncomp);
-    if (initial_value) {
-        mf->setVal(*initial_value);
-    }
-    multifab_map[name_with_suffix] = mf.get();
 }
 
 amrex::DistributionMapping


### PR DESCRIPTION
Now that all MultiFabs are registered in the new system, the old `multifab_map` can be removed.

Note that the `imultifab_map` is still needed since the new system does not yet work with `iMultiFabs`.

This breaks the Python API since it removes `warpx.field` which was returning the old map.