### PR TITLE
Move isAnyBoundaryPML to Warpx.cpp

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -735,7 +735,7 @@ public:
     void DampJPML (int lev, PatchType patch_type);
 
     void CopyJPML ();
-    bool isAnyBoundaryPML();
+
     /** True if any of the particle boundary condition type is Thermal */
     static bool isAnyParticleBoundaryThermal();
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -196,6 +196,22 @@ amrex::IntVect m_rho_nodal_flag;
 
 WarpX* WarpX::m_instance = nullptr;
 
+namespace
+{
+
+    [[nodiscard]] bool
+    isAnyBoundaryPML(
+        const amrex::Array<FieldBoundaryType,AMREX_SPACEDIM>& field_boundary_lo,
+        const amrex::Array<FieldBoundaryType,AMREX_SPACEDIM>& field_boundary_hi)
+    {
+        constexpr auto is_pml = [](const FieldBoundaryType fbt) {return (fbt == FieldBoundaryType::PML);};
+        const auto is_any_pml =
+            std::any_of(field_boundary_lo.begin(), field_boundary_lo.end(), is_pml) ||
+            std::any_of(field_boundary_hi.begin(), field_boundary_hi.end(), is_pml);
+        return is_any_pml;
+    }
+}
+
 void WarpX::MakeWarpX ()
 {
     ParseGeometryInput();
@@ -879,7 +895,7 @@ WarpX::ReadParameters ()
         }
 
 #ifdef WARPX_DIM_RZ
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( isAnyBoundaryPML() == false || electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( ::isAnyBoundaryPML(field_boundary_lo, field_boundary_hi) == false || electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD,
             "PML are not implemented in RZ geometry with FDTD; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( field_boundary_lo[1] != FieldBoundaryType::PML && field_boundary_hi[1] != FieldBoundaryType::PML,
             "PML are not implemented in RZ geometry along z; please set a different boundary condition using boundary.field_lo and boundary.field_hi.");
@@ -2015,7 +2031,7 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
         safe_guard_cells,
         WarpX::do_multi_J,
         WarpX::fft_do_time_averaging,
-        WarpX::isAnyBoundaryPML(),
+        ::isAnyBoundaryPML(field_boundary_lo, field_boundary_hi),
         WarpX::do_pml_in_domain,
         WarpX::pml_ncell,
         this->refRatio(),
@@ -2743,7 +2759,7 @@ void WarpX::AllocLevelSpectralSolverRZ (amrex::Vector<std::unique_ptr<SpectralSo
                                                   m_v_galilean,
                                                   dx_vect,
                                                   solver_dt,
-                                                  isAnyBoundaryPML(),
+                                                  ::isAnyBoundaryPML(field_boundary_lo, field_boundary_hi),
                                                   update_with_rho,
                                                   fft_do_time_averaging,
                                                   J_in_time,
@@ -3254,16 +3270,6 @@ WarpX::RestoreCurrent (int lev)
             );
         }
     }
-}
-
-bool
-WarpX::isAnyBoundaryPML()
-{
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if ( WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) { return true; }
-        if ( WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) { return true; }
-    }
-    return false;
 }
 
 bool


### PR DESCRIPTION
`isAnyBoundaryPML` is used only inside `WarpX.cpp`. It does not need to be a member function of the WarpX class and it can be moved into an anonymous namespace inside `WarpX.cpp`