### PR TITLE
Expose Synchronize to picmi

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -253,6 +253,10 @@ The physical fields in WarpX have the following naming:
             [] () { WarpX::ProjectionCleanDivB(); },
             "Executes projection based divergence cleaner on loaded Bfield_fp_external."
         )
+        .def("synchronize",
+            [] (WarpX& wx) { wx.Synchronize(); },
+            "Synchronize particle velocities and positions."
+        )
     ;
 
     py::class_<warpx::Config>(m, "Config")


### PR DESCRIPTION
Added the ability to synchronize particle velocities and positions inside a python script via simulation.extension.warx.synchronize().

Initiated after discussion with @roelof-groenewald in https://github.com/ECP-WarpX/WarpX/discussions/5331.

Implemented and tested by comparing to Turner's benchmark results (https://doi.org/10.1063/1.4775084).

<p align="center"> <img src="https://github.com/user-attachments/assets/366aab43-359d-440c-a67c-7eef97028f4f">