### PR TITLE
Update ALCF Polaris profile

### DIFF
--- a/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
+++ b/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
@@ -20,7 +20,7 @@ module load cmake/3.27.7
 module load boost
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.9
+module load hdf5/1.14.3
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/blaspp-2024.05.31:$CMAKE_PREFIX_PATH
@@ -53,7 +53,7 @@ export CXXFLAGS="-march=znver3"
 export CFLAGS="-march=znver3"
 
 # compiler environment hints
-export CC=$(which gcc)
-export CXX=$(which g++)
+export CC=$(which gcc-12)
+export CXX=$(which g++-12)
 export CUDACXX=$(which nvcc)
 export CUDAHOSTCXX=${CXX}


### PR DESCRIPTION
* Explicitly use gcc-12, because gcc points to gcc/7.5.
* Load the non-cray version of hdf5 because the cray version has some cmake issues.
