### PR TITLE
Python 3.13 Support, 3.8 EOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,7 @@ foreach(D IN LISTS WarpX_DIMS)
                 warpx_enable_IPO(pyWarpX_${SD})
             else()
                 # conditionally defined target in pybind11
-                # https://github.com/pybind/pybind11/blob/v2.12.0/tools/pybind11Common.cmake#L397-L403
+                # https://github.com/pybind/pybind11/blob/v2.13.0/tools/pybind11Common.cmake#L407-L413
                 target_link_libraries(pyWarpX_${SD} PRIVATE pybind11::lto)
             endif()
         endif()

--- a/Docs/source/developers/gnumake/python.rst
+++ b/Docs/source/developers/gnumake/python.rst
@@ -3,7 +3,7 @@
 Installing WarpX as a Python package
 ====================================
 
-A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Python version 3.8 or newer.
+A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Python version 3.9 or newer.
 
 For a full Python installation of WarpX
 ---------------------------------------

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -37,7 +37,7 @@ Optional dependencies include:
 - `SENSEI 4.0.0+ <https://sensei-insitu.org>`__: for in situ analysis and visualization
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
-- `Python 3.8+ <https://www.python.org>`__
+- `Python 3.9+ <https://www.python.org>`__
 
   - `mpi4py <https://mpi4py.readthedocs.io>`__
   - `numpy <https://numpy.org>`__

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -71,6 +71,6 @@ setup(
     description="""Wrapper of WarpX""",
     package_data=package_data,
     install_requires=["numpy", "picmistandard==0.33.0", "periodictable"],
-    python_requires=">=3.8",
+    python_requires=">=3.8",  # left for CI, truly ">=3.9"
     zip_safe=False,
 )

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -37,7 +37,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 2.12.0 CONFIG REQUIRED)
+        find_package(pybind11 2.13.0 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -52,7 +52,7 @@ option(WarpX_pybind11_internal "Download & build pybind11" ON)
 set(WarpX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(WarpX_pybind11_internal)")
-set(WarpX_pybind11_branch "v2.12.0"
+set(WarpX_pybind11_branch "v2.13.6"
     CACHE STRING
     "Repository branch for WarpX_pybind11_repo if(WarpX_pybind11_internal)")
 

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ setup(
     cmdclass=cmdclass,
     # scripts=['warpx_1d', 'warpx_2d', 'warpx_rz', 'warpx_3d'],
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.8",  # left for CI, truly ">=3.9"
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -336,10 +336,11 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         (
             "License :: OSI Approved :: " "BSD License"
         ),  # TODO: use real SPDX: BSD-3-Clause-LBNL


### PR DESCRIPTION
Add support for Python 3.13.
Remove 3.8 because it is EOL as of Oct 2024.

Bump to pybind11 2.13.0+, which add Python 3.13 support in CI.