### PR TITLE
Doc: Governance GitHub Team Links

### DIFF
--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -16,7 +16,7 @@ Current Roster
 - Remi Lehe
 - Axel Huebl
 
-See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-admins>`__
+See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-steering-committee>`__
 
 Role
 ^^^^
@@ -66,7 +66,7 @@ Current Roster
 - Weiqun Zhang
 - Edoardo Zoni
 
-See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-push-merge-write>`__
+See: `GitHub team <https://github.com/orgs/ECP-WarpX/teams/warpx-technical-committee>`__
 
 Role
 ^^^^


### PR DESCRIPTION
Fix the link in the governance doc to the steering committee (formerly: admin) and technical committee (formerly: maintainers). This was a rename when we adopted the governance doc #4743 and fixes two broken links.

cc @ECP-WarpX/warpx-steering-committee (for approval)
cc @ECP-WarpX/warpx-technical-committee (FYI)