### PR TITLE
Docs: fix checksums section cross-reference

### DIFF
--- a/Docs/source/developers/testing.rst
+++ b/Docs/source/developers/testing.rst
@@ -123,7 +123,7 @@ An automated test typically consists of the following components:
 * analysis script;
 * checksum file.
 
-To learn more about how to use checksums in automated tests, please see the corresponding section :ref:`Checksums on Tests<developers-checksum>`.
+To learn more about how to use checksums in automated tests, please see the corresponding section :ref:`Checksums on Tests <developers-checksum>`.
 
 As mentioned above, the input files and scripts used by the automated tests can be found in the `Examples <https://github.com/ECP-WarpX/WarpX/tree/development/Examples>`__ directory, under either `Physics_applications <https://github.com/ECP-WarpX/WarpX/tree/development/Examples/Physics_applications>`__ or `Tests <https://github.com/ECP-WarpX/WarpX/tree/development/Examples/Tests>`__.
 

--- a/Docs/source/developers/testing.rst
+++ b/Docs/source/developers/testing.rst
@@ -1,6 +1,6 @@
 .. _developers-testing:
 
-Testing the code
+Testing the Code
 ================
 
 When proposing a code change, you want to make sure that
@@ -123,7 +123,7 @@ An automated test typically consists of the following components:
 * analysis script;
 * checksum file.
 
-To learn more about how to use checksums in automated tests, please see the corresponding section :ref:`Using checksums <developers-checksum>`.
+To learn more about how to use checksums in automated tests, please see the corresponding section :ref:`Checksums on Tests<developers-checksum>`.
 
 As mentioned above, the input files and scripts used by the automated tests can be found in the `Examples <https://github.com/ECP-WarpX/WarpX/tree/development/Examples>`__ directory, under either `Physics_applications <https://github.com/ECP-WarpX/WarpX/tree/development/Examples/Physics_applications>`__ or `Tests <https://github.com/ECP-WarpX/WarpX/tree/development/Examples/Tests>`__.
 


### PR DESCRIPTION
The checksums section title was changed to "Checksums on Tests" in the latest version of #5372, but the cross-reference in the testing section wasn't updated and still had the old name "Using checksums".