### PR TITLE
Polaris: PHDF5

### DIFF
--- a/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
+++ b/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
@@ -45,6 +45,25 @@ cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -
 cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 16
 rm -rf $HOME/src/c-blosc-pm-gpu-build
 
+# HDF5 (for openPMD)
+if [ -d $HOME/src/hdf5 ]
+then
+  cd $HOME/src/hdf5
+  git fetch --prune
+  git checkout hdf5-1_14_1-2
+  cd -
+else
+  git clone -b hdf5-1_14_1-2 https://github.com/HDFGroup/hdf5.git $HOME/src/hdf5
+fi
+rm -rf $HOME/src/hdf5-build
+cmake -S $HOME/src/hdf5          \
+      -B $HOME/src/hdf5-build    \
+      -DBUILD_TESTING=OFF        \
+      -DHDF5_ENABLE_PARALLEL=ON  \
+      -DCMAKE_INSTALL_PREFIX=${SW_DIR}/hdf5-1.14.1.2
+cmake --build $HOME/src/hdf5-build --target install --parallel 10
+rm -rf $HOME/src/hdf5-build
+
 # ADIOS2
 if [ -d $HOME/src/adios2 ]
 then

--- a/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
+++ b/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
@@ -20,17 +20,19 @@ module load cmake/3.27.7
 module load boost
 
 # optional: for openPMD and PSATD+RZ support
-module load hdf5/1.14.3
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/hdf5-1.14.1.2:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/blaspp-2024.05.31:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=/home/${USER}/sw/polaris/gpu/lapackpp-2024.05.31:$CMAKE_PREFIX_PATH
 
 export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/hdf5-1.14.1.2/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/blaspp-2024.05.31/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/home/${USER}/sw/polaris/gpu/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
+export PATH=/home/${USER}/sw/polaris/gpu/hdf5-1.14.1.2/bin:${PATH}
 export PATH=/home/${USER}/sw/polaris/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: for Python bindings or libEnsemble


### PR DESCRIPTION
The Cray module and the regular HDF5 module seem to be both broken for us in Polaris. Let's just build our own as we do on LUMI.

See:
https://github.com/ECP-WarpX/WarpX/discussions/5304#discussioncomment-10886494

Follow-up to #5358