### PR TITLE
CI: skip build/test jobs if only `Docs/` is modified

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,6 +9,9 @@ pr:
   branches:
     include:
     - development
+  paths:
+    exclude:
+    - Docs
 
 jobs:
 - job:

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangsanitizers

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangtidy

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "development"
   pull_request:
+    paths-ignore:
+      - "Docs/**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
Could we do this to make sure that we run the GitHub Actions and Azure jobs (build, test) only if _at least one file outside the_ `Docs` _directory_ is modified, i.e., skip those jobs if only files in the `Docs` directory are modified?

I think it would be safe to do so (and a bit of a waste of resources to not do so...), but I leave it open for discussion.

If merged, we could test this rebasing #5386 and seeing if the correct CI jobs are skipped.

Note that this PR leaves the other CI jobs untouched, e.g., `source`, `docs`, `CodeQL`, etc.
