### PR TITLE
CI: avoid duplicate runs for secondary branches on main repo

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,12 +3,13 @@
 pool:
   vmImage: 'ubuntu-20.04'
 
-pr:
-  autoCancel: true
-  drafts: false
+trigger:
   branches:
     include:
     - development
+pr:
+  autoCancel: true
+  drafts: false
   paths:
     exclude:
     - Docs


### PR DESCRIPTION
The fix introduced in #5308 was not correct for Azure pipelines.

In GitHub Actions we trigger a run on the `push` event only for the `development` branch.

The Azure equivalent of that is triggering a run on the `trigger` event only for the `development` branch. However, since the `trigger` event was completely absent from the Azure pipeline file (that is, the default setup was being used), I had erroneously added the filter branch to the `pr` event instead, unlike what I did for GitHub actions where the `push` was exposed in the YAML files.

This was originally aimed at avoiding duplicate runs for "individual CI" when `pre-commit` opens a pull request by pushing to a secondary branch `pre-commit-ci-update-config` in the main repo (instead of a fork).

The new setup is tested in #5393, where I copied these changes and where one can see that a commit pushed to that PR does not trigger an "individual CI" Azure pipeline anymore, but only a "PR automated" one.

Hopefully this is correct for the merge commits that get pushed to `development` once a PR is closed, but we'll be able to test this only after merging a PR.