### PR TITLE
CI: fix `AppleClang` workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: macos-latest
     if: github.event.pull_request.draft == false
     env:
-      CXXFLAGS: "-Werror -Wno-error=pass-failed"
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: TRUE
       # For macOS, Ninja is slower than the default:
       #CMAKE_GENERATOR: Ninja
@@ -64,6 +63,8 @@ jobs:
         export CCACHE_MAXSIZE=100M
         export CCACHE_SLOPPINESS=time_macros
         ccache -z
+
+        export CXXFLAGS="-Werror -Wno-error=pass-failed"
 
         cmake -S . -B build_dp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \


### PR DESCRIPTION
As suggested by @WeiqunZhang:
We should move `CXXFLAGS: "-Werror -Wno-error=pass-failed"` to when WarpX builds. It is picked up by `pip`. It didn't fail before probably because there was cached version of Python stuff. Now there is probably a new version of something that requires rebuilding some packages.