### PR TITLE
Fix ambiguous AddRealComp

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -173,7 +173,7 @@ MultiParticleContainer::Restart (const std::string& dir)
                     + " was found in the checkpoint file, but it has not been added yet. "
                     + " Adding it now."
                 );
-                pc->AddRealComp(comp_name);
+                pc->AddRealComp(comp_name, true);
             }
         }
 
@@ -206,7 +206,7 @@ MultiParticleContainer::Restart (const std::string& dir)
                     + " was found in the checkpoint file, but it has not been added yet. "
                     + " Adding it now."
                 );
-                pc->AddIntComp(comp_name);
+                pc->AddIntComp(comp_name, true);
             }
         }
 
@@ -258,7 +258,7 @@ storePhiOnParticles ( PinnedMemoryParticleContainer& tmp,
         is_full_diagnostic,
         "Output of the electrostatic potential (phi) on the particles was requested, "
         "but this is only available with `diag_type = Full`.");
-    tmp.AddRealComp("phi");
+    tmp.AddRealComp("phi", true);
     int const phi_index = tmp.getParticleComps().at("phi");
     auto& warpx = WarpX::GetInstance();
 #ifdef AMREX_USE_OMP

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -688,15 +688,15 @@ WarpX::InitFromScratch ()
         // Add space to save the positions and velocities at the start of the time steps
         for (auto const& pc : *mypc) {
 #if (AMREX_SPACEDIM >= 2)
-            pc->AddRealComp("x_n");
+            pc->AddRealComp("x_n", true);
 #endif
 #if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
-            pc->AddRealComp("y_n");
+            pc->AddRealComp("y_n", true);
 #endif
-            pc->AddRealComp("z_n");
-            pc->AddRealComp("ux_n");
-            pc->AddRealComp("uy_n");
-            pc->AddRealComp("uz_n");
+            pc->AddRealComp("z_n", true);
+            pc->AddRealComp("ux_n", true);
+            pc->AddRealComp("uy_n", true);
+            pc->AddRealComp("uz_n", true);
         }
 
     }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -342,12 +342,12 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 #ifdef WARPX_QED
     pp_species_name.query("do_qed_quantum_sync", m_do_qed_quantum_sync);
     if (m_do_qed_quantum_sync) {
-        AddRealComp("opticalDepthQSR");
+        AddRealComp("opticalDepthQSR", true);
     }
 
     pp_species_name.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
     if (m_do_qed_breit_wheeler) {
-        AddRealComp("opticalDepthBW");
+        AddRealComp("opticalDepthBW", true);
     }
 
     if(m_do_qed_quantum_sync){
@@ -368,7 +368,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
             str_int_attrib_function.at(i));
         m_user_int_attrib_parser.at(i) = std::make_unique<amrex::Parser>(
             utils::parser::makeParser(str_int_attrib_function.at(i),{"x","y","z","ux","uy","uz","t"}));
-        AddIntComp(m_user_int_attribs.at(i));
+        AddIntComp(m_user_int_attribs.at(i), true);
     }
 
     // User-defined real attributes
@@ -383,19 +383,19 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
             str_real_attrib_function.at(i));
         m_user_real_attrib_parser.at(i) = std::make_unique<amrex::Parser>(
             utils::parser::makeParser(str_real_attrib_function.at(i),{"x","y","z","ux","uy","uz","t"}));
-        AddRealComp(m_user_real_attribs.at(i));
+        AddRealComp(m_user_real_attribs.at(i), true);
     }
 
     // If old particle positions should be saved add the needed components
     pp_species_name.query("save_previous_position", m_save_previous_position);
     if (m_save_previous_position) {
 #if (AMREX_SPACEDIM >= 2)
-        AddRealComp("prev_x");
+        AddRealComp("prev_x", true);
 #endif
 #if defined(WARPX_DIM_3D)
-        AddRealComp("prev_y");
+        AddRealComp("prev_y", true);
 #endif
-        AddRealComp("prev_z");
+        AddRealComp("prev_z", true);
 #ifdef WARPX_DIM_RZ
       amrex::Abort("Saving previous particle positions not yet implemented in RZ");
 #endif
@@ -3121,7 +3121,7 @@ PhysicalParticleContainer::InitIonizationModule ()
         physical_element == "H" || !do_adk_correction,
         "Correction to ADK by Zhang et al., PRA 90, 043410 (2014) only works with Hydrogen");
     // Add runtime integer component for ionization level
-    AddIntComp("ionizationLevel");
+    AddIntComp("ionizationLevel", true);
     // Get atomic number and ionization energies from file
     const int ion_element_id = utils::physics::ion_map_ids.at(physical_element);
     ion_atomic_number = utils::physics::ion_atomic_numbers[ion_element_id];


### PR DESCRIPTION
Add boolean argument so that the calls to `AddRealComp` and `AddIntComp` are not ambiguous. This is needed since in AMReX PR https://github.com/AMReX-Codes/amrex/pull/4163 the `AddRealComp` was added to AMReX that takes a string as the first argument. This duplicates the routine in WarpX, giving a compile time error (with gcc on Mac OS) that "call to member function 'AddRealComp' is ambiguous". The second arguments are different (WarpX takes a boolean, AMReX an integer), so adding the explicit boolean to the calls in WarpX makes the calls unambiguous.

Is the long term plan to remove the code from WarpX and rely on the name components capability in AMReX?