### PR TITLE
[WIP]Reorganize the finite difference advance

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
@@ -56,7 +56,7 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
 #ifdef WARPX_DIM_RZ
     // Calculate relevant coefficients
     amrex::Real const cdt = PhysConst::c*dt;
-    amrex::Real const cdt_over_dr = cdt*m_h_stencil_coefs_r[0];
+    amrex::Real const cdt_over_dr = cdt*m_h_stencil_coefs_x[0];
     amrex::Real const coef1_r = (1._rt - cdt_over_dr)/(1._rt + cdt_over_dr);
     amrex::Real const coef2_r = 2._rt*cdt_over_dr/(1._rt + cdt_over_dr) / PhysConst::c;
     amrex::Real const coef3_r = cdt/(1._rt + cdt_over_dr) / PhysConst::c;

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeDivE.cpp
@@ -143,8 +143,8 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
         Array4<Real> const& Ez = Efield[2]->array(mfi);
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -163,15 +163,15 @@ void FiniteDifferenceSolver::ComputeDivECylindrical (
                 Real const r = rmin + i*dr; // r on a nodal grid (F is nodal in r)
                 if (r != 0) { // Off-axis, regular equations
                     divE(i, j, 0, 0) =
-                          T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 0)
+                          T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 0)
                         + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 0);
                     for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
                         divE(i, j, 0, 2*m-1) =
-                              T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                              T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                             + m * Et( i, j, 0, 2*m )/r
                             + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 2*m-1); // Real part
                         divE(i, j, 0, 2*m  ) =
-                              T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m)
+                              T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m)
                             - m * Et( i, j, 0, 2*m-1 )/r
                             + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 2*m  ); // Imaginary part
                     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -412,8 +412,8 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
         Array4<Real> const& Ez = Efield[2]->array(mfi);
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -465,26 +465,26 @@ void FiniteDifferenceSolver::EvolveBCylindrical (
 
             [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Bt(i, j, 0, 0) += dt*(
-                    T_Algo::UpwardDr(Ez, coefs_r, n_coefs_r, i, j, 0, 0)
+                    T_Algo::UpwardDr(Ez, coefs_x, n_coefs_x, i, j, 0, 0)
                     - T_Algo::UpwardDz(Er, coefs_z, n_coefs_z, i, j, 0, 0)); // Mode m=0
                 for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
                     Bt(i, j, 0, 2*m-1) += dt*(
-                        T_Algo::UpwardDr(Ez, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                        T_Algo::UpwardDr(Ez, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                         - T_Algo::UpwardDz(Er, coefs_z, n_coefs_z, i, j, 0, 2*m-1)); // Real part
                     Bt(i, j, 0, 2*m  ) += dt*(
-                        T_Algo::UpwardDr(Ez, coefs_r, n_coefs_r, i, j, 0, 2*m  )
+                        T_Algo::UpwardDr(Ez, coefs_x, n_coefs_x, i, j, 0, 2*m  )
                         - T_Algo::UpwardDz(Er, coefs_z, n_coefs_z, i, j, 0, 2*m  )); // Imaginary part
                 }
             },
 
             [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
                 Real const r = rmin + (i + 0.5_rt)*dr; // r on a cell-centered grid (Bz is cell-centered in r)
-                Bz(i, j, 0, 0) += dt*( - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_r, n_coefs_r, i, j, 0, 0));
+                Bz(i, j, 0, 0) += dt*( - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_x, n_coefs_x, i, j, 0, 0));
                 for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
                     Bz(i, j, 0, 2*m-1) += dt*( m * Er(i, j, 0, 2*m  )/r
-                        - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)); // Real part
+                        - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m-1)); // Real part
                     Bz(i, j, 0, 2*m  ) += dt*(-m * Er(i, j, 0, 2*m-1)/r
-                        - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m  )); // Imaginary part
+                        - T_Algo::UpwardDrr_over_r(Et, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m  )); // Imaginary part
                 }
             }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -176,19 +176,19 @@ void FiniteDifferenceSolver::EvolveECartesian (
         Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
-        amrex::ParallelFor(tex, tey, tez,
+        amrex::ParallelFor(tex, m_ncomps,
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lx && lx(i, j, k) <= 0) { return; }
 
                 Ex(i, j, k) += c2 * dt * (
-                    - T_Algo::DownwardDz(By, coefs_z, n_coefs_z, i, j, k)
-                    + T_Algo::DownwardDy(Bz, coefs_y, n_coefs_y, i, j, k)
-                    - PhysConst::mu0 * jx(i, j, k) );
+                    + T_Algo::Curl_Nodal_0(By, Bz, coefs_y, coefs_z, i, j, k, n)
+                    - PhysConst::mu0 * jx(i, j, k, n) );
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        tey, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
 #ifdef WARPX_DIM_3D
                 if (ly && ly(i,j,k) <= 0) { return; }
@@ -199,17 +199,18 @@ void FiniteDifferenceSolver::EvolveECartesian (
 #endif
 
                 Ey(i, j, k) += c2 * dt * (
-                    - T_Algo::DownwardDx(Bz, coefs_x, n_coefs_x, i, j, k)
-                    + T_Algo::DownwardDz(Bx, coefs_z, n_coefs_z, i, j, k)
+                    - T_Algo::DownwardDx(Bz, coefs_x, n_coefs_x, i, j, k, n)
+                    + T_Algo::DownwardDz(Bx, coefs_z, n_coefs_z, i, j, k, n)
                     - PhysConst::mu0 * jy(i, j, k) );
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        tez, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i,j,k) <= 0) { return; }
                 Ez(i, j, k) += c2 * dt * (
-                    - T_Algo::DownwardDy(Bx, coefs_y, n_coefs_y, i, j, k)
-                    + T_Algo::DownwardDx(By, coefs_x, n_coefs_x, i, j, k)
+                    - T_Algo::DownwardDy(Bx, coefs_y, n_coefs_y, i, j, k, n)
+                    + T_Algo::DownwardDx(By, coefs_x, n_coefs_x, i, j, k, n)
                     - PhysConst::mu0 * jz(i, j, k) );
             }
 
@@ -297,6 +298,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
         auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_t = m_stencil_coefs_t.dataPtr();
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -313,29 +315,19 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         Real const c2 = PhysConst::c * PhysConst::c;
 
         // Loop over the cells and update the fields
-        amrex::ParallelFor(ter, tet, tez,
+        amrex::ParallelFor(
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
+            ter, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lr && lr(i, j, 0) <= 0) { return; }
 
-                Real const r = rmin + (i + 0.5_rt)*dr; // r on cell-centered point (Er is cell-centered in r)
-                Er(i, j, 0, 0) +=  c2 * dt*(
-                    - T_Algo::DownwardDz(Bt, coefs_z, n_coefs_z, i, j, 0, 0)
-                    - PhysConst::mu0 * jr(i, j, 0, 0) ); // Mode m=0
-                for (int m=1; m<nmodes; m++) { // Higher-order modes
-                    Er(i, j, 0, 2*m-1) += c2 * dt*(
-                        - T_Algo::DownwardDz(Bt, coefs_z, n_coefs_z, i, j, 0, 2*m-1)
-                        + m * Bz(i, j, 0, 2*m  )/r
-                        - PhysConst::mu0 * jr(i, j, 0, 2*m-1) );  // Real part
-                    Er(i, j, 0, 2*m  ) += c2 * dt*(
-                        - T_Algo::DownwardDz(Bt, coefs_z, n_coefs_z, i, j, 0, 2*m  )
-                        - m * Bz(i, j, 0, 2*m-1)/r
-                        - PhysConst::mu0 * jr(i, j, 0, 2*m  ) ); // Imaginary part
-                }
+                Er(i, j, k, n) += c2 * dt * (
+                    + T_Algo::Curl_Nodal_0(Bt, Bz, coefs_t, coefs_z, i, j, k, n)
+                    - PhysConst::mu0 * jr(i, j, k, n) );
+
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
+            tet, 1, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int /*n*/){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 // The Et field is at a node, so we need to check if the node is covered
                 if (lr && (lr(i, j, 0)<=0 || lr(i-1, j, 0)<=0 || lz(i, j-1, 0)<=0 || lz(i, j, 0)<=0)) { return; }
@@ -380,7 +372,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
                 }
             },
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
+            tez, 1, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int /*n*/){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i, j, 0) <= 0) { return; }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -199,8 +199,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
 #endif
 
                 Ey(i, j, k) += c2 * dt * (
-                    - T_Algo::DownwardDx(Bz, coefs_x, n_coefs_x, i, j, k, n)
-                    + T_Algo::DownwardDz(Bx, coefs_z, n_coefs_z, i, j, k, n)
+                    + T_Algo::Curl_Nodal_1(Bz, Bx, coefs_z, coefs_x, i, j, k, n)
                     - PhysConst::mu0 * jy(i, j, k) );
             },
 
@@ -209,8 +208,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i,j,k) <= 0) { return; }
                 Ez(i, j, k) += c2 * dt * (
-                    - T_Algo::DownwardDy(Bx, coefs_y, n_coefs_y, i, j, k, n)
-                    + T_Algo::DownwardDx(By, coefs_x, n_coefs_x, i, j, k, n)
+                    + T_Algo::Curl_Nodal_2(Bx, By, coefs_x, coefs_y, i, j, k, n)
                     - PhysConst::mu0 * jz(i, j, k) );
             }
 
@@ -327,82 +325,23 @@ void FiniteDifferenceSolver::EvolveECylindrical (
 
             },
 
-            tet, 1, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int /*n*/){
+            tet, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 // The Et field is at a node, so we need to check if the node is covered
                 if (lr && (lr(i, j, 0)<=0 || lr(i-1, j, 0)<=0 || lz(i, j-1, 0)<=0 || lz(i, j, 0)<=0)) { return; }
 
-                Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
-                if (r != 0) { // Off-axis, regular Maxwell equations
-                    Et(i, j, 0, 0) += c2 * dt*(
-                        - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 0)
-                        + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 0)
-                        - PhysConst::mu0 * jt(i, j, 0, 0 ) ); // Mode m=0
-                    for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
-                        Et(i, j, 0, 2*m-1) += c2 * dt*(
-                            - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
-                            + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 2*m-1)
-                            - PhysConst::mu0 * jt(i, j, 0, 2*m-1) ); // Real part
-                        Et(i, j, 0, 2*m  ) += c2 * dt*(
-                            - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 2*m  )
-                            + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 2*m  )
-                            - PhysConst::mu0 * jt(i, j, 0, 2*m  ) ); // Imaginary part
-                    }
-                } else { // r==0: on-axis corrections
-                    // Ensure that Et remains 0 on axis (except for m=1)
-                    Et(i, j, 0, 0) = 0.; // Mode m=0
-                    for (int m=1; m<nmodes; m++) { // Higher-order modes
-                        if (m == 1){
-                            // The bulk equation could in principle be used here since it does not diverge
-                            // on axis. However, it typically gives poor results e.g. for the propagation
-                            // of a laser pulse (the field is spuriously reduced on axis). For this reason
-                            // a modified on-axis condition is used here: we use the fact that
-                            // Etheta(r=0,m=1) should equal -iEr(r=0,m=1), for the fields Er and Et to be
-                            // independent of theta at r=0. Now with linear interpolation:
-                            // Er(r=0,m=1) = 0.5*[Er(r=dr/2,m=1) + Er(r=-dr/2,m=1)]
-                            // And using the rule applying for the guards cells
-                            // Er(r=-dr/2,m=1) = Er(r=dr/2,m=1). Thus: Et(i,j,m) = -i*Er(i,j,m)
-                            Et(i,j,0,2*m-1) =  Er(i,j,0,2*m  );
-                            Et(i,j,0,2*m  ) = -Er(i,j,0,2*m-1);
-                        } else {
-                            Et(i, j, 0, 2*m-1) = 0.;
-                            Et(i, j, 0, 2*m  ) = 0.;
-                        }
-                    }
-                }
+                Et(i, j, 0, 0) += c2 * dt*(
+                    + T_Algo::Curl_Nodal_1(Bz, Br, coefs_z, coefs_r, i, j, k, n)
+                    - PhysConst::mu0 * jt(i, j, 0, n) );
             },
 
-            tez, 1, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/, int /*n*/){
+            tez, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i, j, 0) <= 0) { return; }
 
-                Real const r = rmin + i*dr; // r on a nodal grid (Ez is nodal in r)
-                if (r != 0) { // Off-axis, regular Maxwell equations
-                    Ez(i, j, 0, 0) += c2 * dt*(
-                       T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 0)
-                        - PhysConst::mu0 * jz(i, j, 0, 0  ) ); // Mode m=0
-                    for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
-                        Ez(i, j, 0, 2*m-1) += c2 * dt *(
-                            - m * Br(i, j, 0, 2*m  )/r
-                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
-                            - PhysConst::mu0 * jz(i, j, 0, 2*m-1) ); // Real part
-                        Ez(i, j, 0, 2*m  ) += c2 * dt *(
-                            m * Br(i, j, 0, 2*m-1)/r
-                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m  )
-                            - PhysConst::mu0 * jz(i, j, 0, 2*m  ) ); // Imaginary part
-                    }
-                } else { // r==0: on-axis corrections
-                    // For m==0, Bt is linear in r, for small r
-                    // Therefore, the formula below regularizes the singularity
-                    Ez(i, j, 0, 0) += c2 * dt*(
-                         4*Bt(i, j, 0, 0)/dr // regularization
-                         - PhysConst::mu0 * jz(i, j, 0, 0  ) );
-                    // Ensure that Ez remains 0 for higher-order modes
-                    for (int m=1; m<nmodes; m++) {
-                        Ez(i, j, 0, 2*m-1) = 0.;
-                        Ez(i, j, 0, 2*m  ) = 0.;
-                    }
-                }
+                Ez(i, j, 0, 0) += c2 * dt*(
+                    + T_Algo::Curl_Nodal_2(Br, Bt, coefs_r, coefs_t, i, j, k, n)
+                    - PhysConst::mu0 * jz(i, j, 0, n) );
             }
 
         ); // end of loop over cells

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -346,6 +346,13 @@ void FiniteDifferenceSolver::EvolveECylindrical (
 
         ); // end of loop over cells
 
+        // Place holder
+        amrex::ParallelFor(tet, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                T_Algo::UpdateEthetaOnAxis(Et, Er, coefs_t, i, j, k, n);
+            }
+        );
+
         // If F is not a null pointer, further update E using the grad(F) term
         // (hyperbolic correction for errors in charge conservation)
         if (Ffield) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -44,7 +44,6 @@
 #include <array>
 #include <memory>
 
-using namespace amrex;
 using namespace ablastr::fields;
 
 /**
@@ -128,13 +127,13 @@ void FiniteDifferenceSolver::EvolveE (
 #endif
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
-    Real constexpr c2 = PhysConst::c * PhysConst::c;
+    amrex::Real constexpr c2 = PhysConst::c * PhysConst::c;
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+    for ( amrex::MFIter mfi(*Efield[0], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {
             amrex::Gpu::synchronize();
@@ -142,15 +141,15 @@ void FiniteDifferenceSolver::EvolveE (
         auto wt = static_cast<amrex::Real>(amrex::second());
 
         // Extract field data for this grid/tile
-        Array4<Real> const& Ex = Efield[0]->array(mfi);
-        Array4<Real> const& Ey = Efield[1]->array(mfi);
-        Array4<Real> const& Ez = Efield[2]->array(mfi);
-        Array4<Real> const& Bx = Bfield[0]->array(mfi);
-        Array4<Real> const& By = Bfield[1]->array(mfi);
-        Array4<Real> const& Bz = Bfield[2]->array(mfi);
-        Array4<Real> const& jx = Jfield[0]->array(mfi);
-        Array4<Real> const& jy = Jfield[1]->array(mfi);
-        Array4<Real> const& jz = Jfield[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& Ex = Efield[0]->array(mfi);
+        amrex::Array4<amrex::Real> const& Ey = Efield[1]->array(mfi);
+        amrex::Array4<amrex::Real> const& Ez = Efield[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& Bx = Bfield[0]->array(mfi);
+        amrex::Array4<amrex::Real> const& By = Bfield[1]->array(mfi);
+        amrex::Array4<amrex::Real> const& Bz = Bfield[2]->array(mfi);
+        amrex::Array4<amrex::Real> const& jx = Jfield[0]->array(mfi);
+        amrex::Array4<amrex::Real> const& jy = Jfield[1]->array(mfi);
+        amrex::Array4<amrex::Real> const& jz = Jfield[2]->array(mfi);
 
         amrex::Array4<amrex::Real> lx, ly, lz;
         if (EB::enabled()) {
@@ -160,14 +159,14 @@ void FiniteDifferenceSolver::EvolveE (
         }
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
+        amrex::Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        amrex::Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
+        amrex::Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
 
         // Extract tileboxes for which to loop
-        Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
-        Box const& tey  = mfi.tilebox(Efield[1]->ixType().toIntVect());
-        Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
+        amrex::Box const& tex = mfi.tilebox(Efield[0]->ixType().toIntVect());
+        amrex::Box const& tey = mfi.tilebox(Efield[1]->ixType().toIntVect());
+        amrex::Box const& tez = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(
@@ -223,7 +222,7 @@ void FiniteDifferenceSolver::EvolveE (
         if (Ffield) {
 
             // Extract field data for this grid/tile
-            const Array4<Real const> F = Ffield->array(mfi);
+            const amrex::Array4<amrex::Real const> F = Ffield->array(mfi);
 
             // Loop over the cells and update the fields
             amrex::ParallelFor(

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -164,11 +164,8 @@ void FiniteDifferenceSolver::EvolveECartesian (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
-        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
-        auto const n_coefs_y = static_cast<int>(m_stencil_coefs_y.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
         // Extract tileboxes for which to loop
         Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
@@ -176,18 +173,19 @@ void FiniteDifferenceSolver::EvolveECartesian (
         Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the fields
-        amrex::ParallelFor(tex, m_ncomps,
+        amrex::ParallelFor(
 
+            tex, m_ncomps,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lx && lx(i, j, k) <= 0) { return; }
 
-                Ex(i, j, k) += c2 * dt * (
+                Ex(i, j, k, n) += c2 * dt * (
                     + T_Algo::Curl_Nodal_0(By, Bz, coefs_y, coefs_z, i, j, k, n)
                     - PhysConst::mu0 * jx(i, j, k, n) );
             },
 
-        tey, m_ncomps,
+            tey, m_ncomps,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
 #ifdef WARPX_DIM_3D
@@ -198,16 +196,16 @@ void FiniteDifferenceSolver::EvolveECartesian (
                 if (lx && (lx(i, j, k)<=0 || lx(i-1, j, k)<=0 || lz(i, j-1, k)<=0 || lz(i, j, k)<=0)) { return; }
 #endif
 
-                Ey(i, j, k) += c2 * dt * (
+                Ey(i, j, k, n) += c2 * dt * (
                     + T_Algo::Curl_Nodal_1(Bz, Bx, coefs_z, coefs_x, i, j, k, n)
                     - PhysConst::mu0 * jy(i, j, k) );
             },
 
-        tez, m_ncomps,
+            tez, m_ncomps,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i,j,k) <= 0) { return; }
-                Ez(i, j, k) += c2 * dt * (
+                Ez(i, j, k, n) += c2 * dt * (
                     + T_Algo::Curl_Nodal_2(Bx, By, coefs_x, coefs_y, i, j, k, n)
                     - PhysConst::mu0 * jz(i, j, k) );
             }
@@ -222,16 +220,21 @@ void FiniteDifferenceSolver::EvolveECartesian (
             const Array4<Real const> F = Ffield->array(mfi);
 
             // Loop over the cells and update the fields
-            amrex::ParallelFor(tex, tey, tez,
+            amrex::ParallelFor(
 
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                    Ex(i, j, k) += c2 * dt * T_Algo::UpwardDx(F, coefs_x, n_coefs_x, i, j, k);
+                tex, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Ex(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_0(F, coefs_x, i, j, k, n);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                    Ey(i, j, k) += c2 * dt * T_Algo::UpwardDy(F, coefs_y, n_coefs_y, i, j, k);
+
+                tey, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Ey(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_1(F, coefs_y, i, j, k, n);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                    Ez(i, j, k) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, k);
+
+                tez, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Ez(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_2(F, coefs_z, i, j, k, n);
                 }
 
             );
@@ -295,15 +298,8 @@ void FiniteDifferenceSolver::EvolveECylindrical (
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
         Real const * const AMREX_RESTRICT coefs_t = m_stencil_coefs_t.dataPtr();
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-        auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
-
-        // Extract cylindrical specific parameters
-        Real const dr = m_dr;
-        int const nmodes = m_nmodes;
-        Real const rmin = m_rmin;
 
         // Extract tileboxes for which to loop
         Box const& ter  = mfi.tilebox(Efield[0]->ixType().toIntVect());
@@ -315,7 +311,8 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         // Loop over the cells and update the fields
         amrex::ParallelFor(
 
-            ter, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+            ter, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lr && lr(i, j, 0) <= 0) { return; }
 
@@ -325,21 +322,23 @@ void FiniteDifferenceSolver::EvolveECylindrical (
 
             },
 
-            tet, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+            tet, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 // The Et field is at a node, so we need to check if the node is covered
                 if (lr && (lr(i, j, 0)<=0 || lr(i-1, j, 0)<=0 || lz(i, j-1, 0)<=0 || lz(i, j, 0)<=0)) { return; }
 
-                Et(i, j, 0, 0) += c2 * dt*(
+                Et(i, j, k, n) += c2 * dt*(
                     + T_Algo::Curl_Nodal_1(Bz, Br, coefs_z, coefs_r, i, j, k, n)
                     - PhysConst::mu0 * jt(i, j, 0, n) );
             },
 
-            tez, m_ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+            tez, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
                 // Skip field push if this cell is fully covered by embedded boundaries
                 if (lz && lz(i, j, 0) <= 0) { return; }
 
-                Ez(i, j, 0, 0) += c2 * dt*(
+                Ez(i, j, k, n) += c2 * dt*(
                     + T_Algo::Curl_Nodal_2(Br, Bt, coefs_r, coefs_t, i, j, k, n)
                     - PhysConst::mu0 * jz(i, j, 0, n) );
             }
@@ -361,39 +360,21 @@ void FiniteDifferenceSolver::EvolveECylindrical (
             const Array4<Real const> F = Ffield->array(mfi);
 
             // Loop over the cells and update the fields
-            amrex::ParallelFor(ter, tet, tez,
+            amrex::ParallelFor(
 
-                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
-                    Er(i, j, 0, 0) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 0);
-                    for (int m=1; m<nmodes; m++) { // Higher-order modes
-                        Er(i, j, 0, 2*m-1) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 2*m-1); // Real part
-                        Er(i, j, 0, 2*m  ) += c2 * dt * T_Algo::UpwardDr(F, coefs_r, n_coefs_r, i, j, 0, 2*m  ); // Imaginary part
-                    }
+                ter, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Er(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_0(F, coefs_r, i, j, k, n);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
-                    // Mode m=0: no update
-                    Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
-                    if (r != 0){ // Off-axis, regular Maxwell equations
-                        for (int m=1; m<nmodes; m++) { // Higher-order modes
-                            Et(i, j, 0, 2*m-1) += c2 * dt *  m * F(i, j, 0, 2*m  )/r; // Real part
-                            Et(i, j, 0, 2*m  ) += c2 * dt * -m * F(i, j, 0, 2*m-1)/r; // Imaginary part
-                        }
-                    } else { // r==0: on-axis corrections
-                        // For m==1, F is linear in r, for small r
-                        // Therefore, the formula below regularizes the singularity
-                        if (nmodes >= 2) { // needs to have at least m=0 and m=1
-                            int const m=1;
-                            Et(i, j, 0, 2*m-1) += c2 * dt *  m * F(i+1, j, 0, 2*m  )/dr; // Real part
-                            Et(i, j, 0, 2*m  ) += c2 * dt * -m * F(i+1, j, 0, 2*m-1)/dr; // Imaginary part
-                        }
-                    }
+
+                tet, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Et(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_1(F, coefs_t, i, j, k, n);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/){
-                    Ez(i, j, 0, 0) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, 0, 0);
-                    for (int m=1; m<nmodes; m++) { // Higher-order modes
-                        Ez(i, j, 0, 2*m-1) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, 0, 2*m-1); // Real part
-                        Ez(i, j, 0, 2*m  ) += c2 * dt * T_Algo::UpwardDz(F, coefs_z, n_coefs_z, i, j, 0, 2*m  ); // Imaginary part
-                    }
+
+                tez, m_ncomps,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
+                    Ez(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_2(F, coefs_z, i, j, k, n);
                 }
 
             ); // end of loop over cells

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -93,19 +93,19 @@ void FiniteDifferenceSolver::EvolveE (
     // but we compile code for each algorithm, using templates)
 #ifdef WARPX_DIM_RZ
     if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee){
-        EvolveECylindrical <CylindricalYeeAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
+        EvolveE <CylindricalYeeAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 #else
     if (m_grid_type == GridType::Collocated) {
 
-        EvolveECartesian <CartesianNodalAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
+        EvolveE <CartesianNodalAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 
     } else if (m_fdtd_algo == ElectromagneticSolverAlgo::Yee || m_fdtd_algo == ElectromagneticSolverAlgo::ECT) {
 
-        EvolveECartesian <CartesianYeeAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
+        EvolveE <CartesianYeeAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 
     } else if (m_fdtd_algo == ElectromagneticSolverAlgo::CKC) {
 
-        EvolveECartesian <CartesianCKCAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
+        EvolveE <CartesianCKCAlgorithm> ( Efield, Bfield, Jfield, edge_lengths, Ffield, lev, dt );
 
 #endif
     } else {
@@ -114,11 +114,8 @@ void FiniteDifferenceSolver::EvolveE (
 
 }
 
-
-#ifndef WARPX_DIM_RZ
-
 template<typename T_Algo>
-void FiniteDifferenceSolver::EvolveECartesian (
+void FiniteDifferenceSolver::EvolveE (
     ablastr::fields::VectorField const& Efield,
     ablastr::fields::VectorField const& Bfield,
     ablastr::fields::VectorField const& Jfield,
@@ -190,7 +187,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
                 // Skip field push if this cell is fully covered by embedded boundaries
 #ifdef WARPX_DIM_3D
                 if (ly && ly(i,j,k) <= 0) { return; }
-#elif defined(WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 //In XZ Ey is associated with a mesh node, so we need to check if the mesh node is covered
                 amrex::ignore_unused(ly);
                 if (lx && (lx(i, j, k)<=0 || lx(i-1, j, k)<=0 || lz(i, j-1, k)<=0 || lz(i, j, k)<=0)) { return; }
@@ -211,6 +208,15 @@ void FiniteDifferenceSolver::EvolveECartesian (
             }
 
         );
+
+#ifdef WARPX_DIM_RZ
+        // Place holder
+        amrex::ParallelFor(tey, m_ncomps,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                T_Algo::UpdateEthetaOnAxis(Ey, Ex, coefs_y, i, j, k, n);
+            }
+        );
+#endif
 
         // If F is not a null pointer, further update E using the grad(F) term
         // (hyperbolic correction for errors in charge conservation)
@@ -250,145 +256,3 @@ void FiniteDifferenceSolver::EvolveECartesian (
     }
 
 }
-
-#else // corresponds to ifndef WARPX_DIM_RZ
-
-template<typename T_Algo>
-void FiniteDifferenceSolver::EvolveECylindrical (
-    ablastr::fields::VectorField const& Efield,
-    ablastr::fields::VectorField const& Bfield,
-    ablastr::fields::VectorField const& Jfield,
-    ablastr::fields::VectorField const& edge_lengths,
-    amrex::MultiFab const* Ffield,
-    int lev, amrex::Real const dt ) {
-
-#ifndef AMREX_USE_EB
-    amrex::ignore_unused(edge_lengths);
-#endif
-
-    amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
-
-    // Loop through the grids, and over the tiles within each grid
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-    for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
-        if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
-        {
-            amrex::Gpu::synchronize();
-        }
-        auto wt = static_cast<amrex::Real>(amrex::second());
-
-        // Extract field data for this grid/tile
-        Array4<Real> const& Er = Efield[0]->array(mfi);
-        Array4<Real> const& Et = Efield[1]->array(mfi);
-        Array4<Real> const& Ez = Efield[2]->array(mfi);
-        Array4<Real> const& Br = Bfield[0]->array(mfi);
-        Array4<Real> const& Bt = Bfield[1]->array(mfi);
-        Array4<Real> const& Bz = Bfield[2]->array(mfi);
-        Array4<Real> const& jr = Jfield[0]->array(mfi);
-        Array4<Real> const& jt = Jfield[1]->array(mfi);
-        Array4<Real> const& jz = Jfield[2]->array(mfi);
-
-        amrex::Array4<amrex::Real> lr, lz;
-        if (EB::enabled()) {
-            lr = edge_lengths[0]->array(mfi);
-            lz = edge_lengths[2]->array(mfi);
-        }
-
-        // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        Real const * const AMREX_RESTRICT coefs_t = m_stencil_coefs_t.dataPtr();
-        Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
-
-        // Extract tileboxes for which to loop
-        Box const& ter  = mfi.tilebox(Efield[0]->ixType().toIntVect());
-        Box const& tet  = mfi.tilebox(Efield[1]->ixType().toIntVect());
-        Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
-
-        Real const c2 = PhysConst::c * PhysConst::c;
-
-        // Loop over the cells and update the fields
-        amrex::ParallelFor(
-
-            ter, m_ncomps,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                // Skip field push if this cell is fully covered by embedded boundaries
-                if (lr && lr(i, j, 0) <= 0) { return; }
-
-                Er(i, j, k, n) += c2 * dt * (
-                    + T_Algo::Curl_Nodal_0(Bt, Bz, coefs_t, coefs_z, i, j, k, n)
-                    - PhysConst::mu0 * jr(i, j, k, n) );
-
-            },
-
-            tet, m_ncomps,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                // Skip field push if this cell is fully covered by embedded boundaries
-                // The Et field is at a node, so we need to check if the node is covered
-                if (lr && (lr(i, j, 0)<=0 || lr(i-1, j, 0)<=0 || lz(i, j-1, 0)<=0 || lz(i, j, 0)<=0)) { return; }
-
-                Et(i, j, k, n) += c2 * dt*(
-                    + T_Algo::Curl_Nodal_1(Bz, Br, coefs_z, coefs_r, i, j, k, n)
-                    - PhysConst::mu0 * jt(i, j, 0, n) );
-            },
-
-            tez, m_ncomps,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                // Skip field push if this cell is fully covered by embedded boundaries
-                if (lz && lz(i, j, 0) <= 0) { return; }
-
-                Ez(i, j, k, n) += c2 * dt*(
-                    + T_Algo::Curl_Nodal_2(Br, Bt, coefs_r, coefs_t, i, j, k, n)
-                    - PhysConst::mu0 * jz(i, j, 0, n) );
-            }
-
-        ); // end of loop over cells
-
-        // Place holder
-        amrex::ParallelFor(tet, m_ncomps,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                T_Algo::UpdateEthetaOnAxis(Et, Er, coefs_t, i, j, k, n);
-            }
-        );
-
-        // If F is not a null pointer, further update E using the grad(F) term
-        // (hyperbolic correction for errors in charge conservation)
-        if (Ffield) {
-
-            // Extract field data for this grid/tile
-            const Array4<Real const> F = Ffield->array(mfi);
-
-            // Loop over the cells and update the fields
-            amrex::ParallelFor(
-
-                ter, m_ncomps,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                    Er(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_0(F, coefs_r, i, j, k, n);
-                },
-
-                tet, m_ncomps,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                    Et(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_1(F, coefs_t, i, j, k, n);
-                },
-
-                tez, m_ncomps,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n){
-                    Ez(i, j, k, n) += c2 * dt * T_Algo::Grad_cell_2(F, coefs_z, i, j, k, n);
-                }
-
-            ); // end of loop over cells
-
-        } // end of if condition for F
-
-        if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
-        {
-            amrex::Gpu::synchronize();
-            wt = static_cast<amrex::Real>(amrex::second()) - wt;
-            amrex::HostDevice::Atomic::Add( &(*cost)[mfi.index()], wt);
-        }
-    } // end of loop over grid/tiles
-
-}
-
-#endif // corresponds to ifndef WARPX_DIM_RZ

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -195,7 +195,7 @@ void FiniteDifferenceSolver::EvolveE (
 
                 Ey(i, j, k, n) += c2 * dt * (
                     + T_Algo::Curl_Nodal_1(Bz, Bx, coefs_z, coefs_x, i, j, k, n)
-                    - PhysConst::mu0 * jy(i, j, k) );
+                    - PhysConst::mu0 * jy(i, j, k, n) );
             },
 
             tez, m_ncomps,
@@ -204,7 +204,7 @@ void FiniteDifferenceSolver::EvolveE (
                 if (lz && lz(i,j,k) <= 0) { return; }
                 Ez(i, j, k, n) += c2 * dt * (
                     + T_Algo::Curl_Nodal_2(Bx, By, coefs_x, coefs_y, i, j, k, n)
-                    - PhysConst::mu0 * jz(i, j, k) );
+                    - PhysConst::mu0 * jz(i, j, k, n) );
             }
 
         );

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveF.cpp
@@ -155,8 +155,8 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
         Array4<Real> const& rho = rhofield->array(mfi);
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        auto const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        auto const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         auto const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -186,17 +186,17 @@ void FiniteDifferenceSolver::EvolveFCylindrical (
                 if (r != 0) { // Off-axis, regular equations
                     F(i, j, 0, 0) += dt * (
                         - rho(i, j, 0, rho_shift) * inv_epsilon0
-                        + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 0)
+                        + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 0)
                         + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 0) );
                     for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
                         F(i, j, 0, 2*m-1) += dt * (
                             - rho(i, j, 0, rho_shift + 2*m-1) * inv_epsilon0
-                            + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                            + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                             + m * Et( i, j, 0, 2*m )/r
                             + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 2*m-1) ); // Real part
                         F(i, j, 0, 2*m  ) += dt *(
                             - rho(i, j, 0, rho_shift + 2*m-1) * inv_epsilon0
-                            + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                            + T_Algo::DownwardDrr_over_r(Er, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                             - m * Et( i, j, 0, 2*m-1 )/r
                             + T_Algo::DownwardDz(Ez, coefs_z, n_coefs_z, i, j, 0, 2*m  ) ); // Imaginary part
                     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -183,6 +183,27 @@ struct CartesianCKCAlgorithm {
     }
 
     /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+#if (defined WARPX_DIM_1D_Z)
+        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+        return 0._rt; // 1D Cartesian: curl along x is 0
+#else
+        return (- DownwardDz(Fy, coefs_z, 6, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 6, i, j, k, ncomp));
+#endif
+    }
+
+    /**
      * Perform derivative along y on a cell-centered grid, from a nodal field `F` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDy (

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -183,27 +183,6 @@ struct CartesianCKCAlgorithm {
     }
 
     /**
-     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
-    template< typename T_Field>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real Curl_Nodal_0 (
-        T_Field const& Fy,
-        T_Field const& Fz,
-        amrex::Real const * const coefs_y,
-        amrex::Real const * const coefs_z,
-        int const i, int const j, int const k, int const ncomp=0 ) {
-
-        using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: curl along x is 0
-#else
-        return (- DownwardDz(Fy, coefs_z, 6, i, j, k, ncomp)
-                + DownwardDy(Fz, coefs_y, 6, i, j, k, ncomp));
-#endif
-    }
-
-    /**
      * Perform derivative along y on a cell-centered grid, from a nodal field `F` */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDy (
@@ -317,6 +296,51 @@ struct CartesianCKCAlgorithm {
 #elif (defined WARPX_DIM_1D_Z)
         return inv_dz*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
 #endif
+    }
+
+    /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDz(Fy, coefs_z, 6, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 6, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along y on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_1 (
+        T_Field const& Fz,
+        T_Field const& Fx,
+        amrex::Real const * const coefs_z,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDx(Fz, coefs_x, 6, i, j, k, ncomp)
+                + DownwardDz(Fx, coefs_z, 6, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along z on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_2 (
+        T_Field const& Fx,
+        T_Field const& Fy,
+        amrex::Real const * const coefs_x,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDy(Fx, coefs_y, 6, i, j, k, ncomp)
+                + DownwardDx(Fy, coefs_x, 6, i, j, k, ncomp));
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -343,6 +343,42 @@ struct CartesianCKCAlgorithm {
                 + DownwardDx(Fy, coefs_x, 6, i, j, k, ncomp));
     }
 
+    /**
+     * Calculate the gradiant along x on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_0 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDx(F, coefs_x, 6, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along y on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_1 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDy(F, coefs_y, 6, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along z on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_2 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDz(F, coefs_z, 6, i, j, k, ncomp);
+
+    }
+
 };
 
 #endif // WARPX_FINITE_DIFFERENCE_ALGORITHM_CARTESIAN_CKC_H_

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
@@ -104,6 +104,27 @@ struct CartesianNodalAlgorithm {
     }
 
     /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+#if (defined WARPX_DIM_1D_Z)
+        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+        return 0._rt; // 1D Cartesian: curl along x is 0
+#else
+        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
+#endif
+    }
+
+    /**
      * Perform derivative along y
      * (For a solver on a staggered grid, `UpwardDy` and `DownwardDy` take into
      * account the staggering; but for `CartesianNodalAlgorithm`, they are equivalent) */

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
@@ -104,27 +104,6 @@ struct CartesianNodalAlgorithm {
     }
 
     /**
-     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
-    template< typename T_Field>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real Curl_Nodal_0 (
-        T_Field const& Fy,
-        T_Field const& Fz,
-        amrex::Real const * const coefs_y,
-        amrex::Real const * const coefs_z,
-        int const i, int const j, int const k, int const ncomp=0 ) {
-
-        using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: curl along x is 0
-#else
-        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
-                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
-#endif
-    }
-
-    /**
      * Perform derivative along y
      * (For a solver on a staggered grid, `UpwardDy` and `DownwardDy` take into
      * account the staggering; but for `CartesianNodalAlgorithm`, they are equivalent) */
@@ -191,6 +170,51 @@ struct CartesianNodalAlgorithm {
 
         return UpwardDz( F, coefs_z, n_coefs_z, i, j, k ,ncomp);
         // For CartesianNodalAlgorithm, UpwardDz and DownwardDz are equivalent
+    }
+
+    /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along y on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_1 (
+        T_Field const& Fz,
+        T_Field const& Fx,
+        amrex::Real const * const coefs_z,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDx(Fz, coefs_x, 1, i, j, k, ncomp)
+                + DownwardDz(Fx, coefs_z, 1, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along z on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_2 (
+        T_Field const& Fx,
+        T_Field const& Fy,
+        amrex::Real const * const coefs_x,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDy(Fx, coefs_y, 1, i, j, k, ncomp)
+                + DownwardDx(Fy, coefs_x, 1, i, j, k, ncomp));
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
@@ -217,6 +217,42 @@ struct CartesianNodalAlgorithm {
                 + DownwardDx(Fy, coefs_x, 1, i, j, k, ncomp));
     }
 
+    /**
+     * Calculate the gradiant along x on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_0 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDx(F, coefs_x, 1, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along y on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_1 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDy(F, coefs_y, 1, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along z on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_2 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDz(F, coefs_z, 1, i, j, k, ncomp);
+
+    }
+
 };
 
 #endif // WARPX_FINITE_DIFFERENCE_ALGORITHM_CARTESIAN_NODAL_H_

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -101,6 +101,27 @@ struct CartesianYeeAlgorithm {
     }
 
     /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        using namespace amrex;
+#if (defined WARPX_DIM_1D_Z)
+        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+        return 0._rt; // 1D Cartesian: curl along x is 0
+#else
+        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
+#endif
+    }
+
+    /**
      * Perform second derivative along x on a cell-centered grid, from a cell-centered field `F`*/
     template< typename T_Field>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -101,27 +101,6 @@ struct CartesianYeeAlgorithm {
     }
 
     /**
-     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
-    template< typename T_Field>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real Curl_Nodal_0 (
-        T_Field const& Fy,
-        T_Field const& Fz,
-        amrex::Real const * const coefs_y,
-        amrex::Real const * const coefs_z,
-        int const i, int const j, int const k, int const ncomp=0 ) {
-
-        using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: curl along x is 0
-#else
-        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
-                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
-#endif
-    }
-
-    /**
      * Perform second derivative along x on a cell-centered grid, from a cell-centered field `F`*/
     template< typename T_Field>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -263,6 +242,51 @@ struct CartesianYeeAlgorithm {
 #elif (defined WARPX_DIM_1D_Z)
         return inv_dz2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
 #endif
+    }
+
+    /**
+     * Perform curl along x on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Fy,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_y,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDz(Fy, coefs_z, 1, i, j, k, ncomp)
+                + DownwardDy(Fz, coefs_y, 1, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along y on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_1 (
+        T_Field const& Fz,
+        T_Field const& Fx,
+        amrex::Real const * const coefs_z,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDx(Fz, coefs_x, 1, i, j, k, ncomp)
+                + DownwardDz(Fx, coefs_z, 1, i, j, k, ncomp));
+    }
+
+    /**
+     * Perform curl along z on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_2 (
+        T_Field const& Fx,
+        T_Field const& Fy,
+        amrex::Real const * const coefs_x,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return (- DownwardDy(Fx, coefs_y, 1, i, j, k, ncomp)
+                + DownwardDx(Fy, coefs_x, 1, i, j, k, ncomp));
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -124,20 +124,19 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDy (
         amrex::Array4<amrex::Real const> const& F,
-        amrex::Real const * const coefs_y, int const n_coefs_y,
+        amrex::Real const * const coefs_y, int const /*n_coefs_y*/,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
 #if defined WARPX_DIM_3D
         Real const inv_dy = coefs_y[0];
-        amrex::ignore_unused(n_coefs_y);
         return inv_dy*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
 #elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+        amrex::ignore_unused(F, coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
 #else
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+        amrex::ignore_unused(F, coefs_y,
             i, j, k, ncomp);
 #endif
     }
@@ -148,20 +147,19 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real DownwardDy (
         T_Field const& F,
-        amrex::Real const * const coefs_y, int const n_coefs_y,
+        amrex::Real const * const coefs_y, int const /*n_coefs_y*/,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
 #if defined WARPX_DIM_3D
         Real const inv_dy = coefs_y[0];
-        amrex::ignore_unused(n_coefs_y);
         return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
 #elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+        amrex::ignore_unused(F, coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
 #else
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
+        amrex::ignore_unused(F, coefs_y,
             i, j, k, ncomp);
 #endif
     }
@@ -287,6 +285,42 @@ struct CartesianYeeAlgorithm {
 
         return (- DownwardDy(Fx, coefs_y, 1, i, j, k, ncomp)
                 + DownwardDx(Fy, coefs_x, 1, i, j, k, ncomp));
+    }
+
+    /**
+     * Calculate the gradiant along x on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_0 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDx(F, coefs_x, 1, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along y on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_1 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_y,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDy(F, coefs_y, 1, i, j, k, ncomp);
+
+    }
+
+    /**
+     * Calculate the gradiant along z on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_2 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const ncomp=0 ) {
+
+        return UpwardDz(F, coefs_z, 1, i, j, k, ncomp);
+
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -34,8 +34,10 @@ struct CylindricalYeeAlgorithm {
 
         using namespace amrex;
         // Store the inverse cell size along each direction in the coefficients
-        stencil_coefs_r.resize(1);
+        stencil_coefs_r.resize(3);
         stencil_coefs_r[0] = 1._rt/cell_size[0];  // 1./dr
+        stencil_coefs_r[1] = cell_size[0];  // dr
+        stencil_coefs_r[2] = rmin;
         stencil_coefs_t.resize(2);
         stencil_coefs_t[0] = cell_size[0];  // dr
         stencil_coefs_t[1] = rmin;
@@ -107,36 +109,6 @@ struct CylindricalYeeAlgorithm {
 
         Real const inv_dr = coefs_r[0];
         return 1._rt/r * inv_dr*( (r+0.5_rt*dr)*F(i,j,k,comp) - (r-0.5_rt*dr)*F(i-1,j,k,comp) );
-    }
-
-    /**
-     * Perform curl along r on a nodal grid, from a cell-centered field `F`*/
-    template< typename T_Field>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real Curl_Nodal_0 (
-        T_Field const& Ft,
-        T_Field const& Fz,
-        amrex::Real const * const coefs_t,
-        amrex::Real const * const coefs_z,
-        int const i, int const j, int const k, int const comp ) {
-
-        using namespace amrex::literals;
-
-        if (comp == 0) {
-            return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp);
-        } else {
-            amrex::Real const dr = coefs_t[0];
-            amrex::Real const rmin = coefs_t[1];
-            amrex::Real const r = rmin + (i + 0.5_rt)*dr; // r on cell-centered point (Er is cell-centered in r)
-            if ((comp % 2) == 1) {
-                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
-                       + (comp + 1)/2*Fz(i,j,k,comp+1)/r; // Real part
-            } else {
-                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
-                       - (comp)/2*Fz(i,j,k,comp-1)/r; // Imaginary part
-            }
-        }
-
     }
 
     /**
@@ -228,6 +200,130 @@ struct CylindricalYeeAlgorithm {
         Real const inv_dz2 = coefs_z[0]*coefs_z[0];
 
         return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
+    }
+
+    /**
+     * Perform curl along r on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Ft,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_t,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const comp ) {
+
+        using namespace amrex::literals;
+
+        if (comp == 0) {
+            return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp);
+        } else {
+            amrex::Real const dr = coefs_t[0];
+            amrex::Real const rmin = coefs_t[1];
+            amrex::Real const r = rmin + (i + 0.5_rt)*dr; // r on cell-centered point (Er is cell-centered in r)
+            if ((comp % 2) == 1) {
+                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
+                       + (comp + 1)/2*Fz(i,j,k,comp+1)/r; // Real part
+            } else {
+                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
+                       - (comp)/2*Fz(i,j,k,comp-1)/r; // Imaginary part
+            }
+        }
+
+    }
+
+    /**
+     * Perform curl along theta on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_1 (
+        T_Field const& Fz,
+        T_Field const& Fr,
+        amrex::Real const * const coefs_z,
+        amrex::Real const * const coefs_r,
+        int const i, int const j, int const k, int const comp ) {
+
+        amrex::Real const dr = coefs_r[1];
+        amrex::Real const rmin = coefs_r[2];
+        amrex::Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
+        if (r != 0) { // Off-axis, regular Maxwell equations
+            return - DownwardDr(Fz, coefs_r, 3, i, j, k, comp)
+                   + DownwardDz(Fr, coefs_z, 1, i, j, k, comp);
+        } else { // r==0: on-axis corrections
+            return 0.;
+        }
+
+    }
+
+    /**
+     * Perform curl along r on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_2 (
+        T_Field const& Fr,
+        T_Field const& Ft,
+        amrex::Real const * const coefs_r,
+        amrex::Real const * const coefs_t,
+        int const i, int const j, int const k, int const comp ) {
+
+        using namespace amrex::literals;
+
+        amrex::Real const dr = coefs_t[0];
+        amrex::Real const rmin = coefs_t[1];
+        amrex::Real const r = rmin + i*dr; // r on a nodal grid (Ez is nodal in r)
+        if (r != 0) { // Off-axis, regular Maxwell equations
+            if (comp == 0) {
+                return DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, 0);
+            } else if ((comp % 2) == 1) {
+                return - (comp + 1)/2 * Fr(i, j, 0, comp+1)/r
+                       + DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, comp);
+            } else { // (comp % 2) == 0
+                return + (comp)/2 * Fr(i, j, 0, comp-1)/r
+                       + DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, comp);
+            }
+        } else { // r==0: on-axis corrections
+            if (comp == 0) {
+                // For m==0, Ft is linear in r, for small r
+                // Therefore, the formula below regularizes the singularity
+                return 4*Ft(i, j, k, 0)/dr; // regularization
+            } else {
+                return 0.;
+            }
+        }
+
+    }
+
+    /**
+     * Updates Etheta on the axis
+     *
+     * The bulk curl equation could in principle be used here since it does not diverge
+     * on axis. However, it typically gives poor results e.g. for the propagation
+     * of a laser pulse (the field is spuriously reduced on axis). For this reason
+     * a modified on-axis condition is used here: we use the fact that
+     * Etheta(r=0,m=1) should equal -iEr(r=0,m=1), for the fields Er and Et to be
+     * independent of theta at r=0. Now with linear interpolation:
+     * Er(r=0,m=1) = 0.5*[Er(r=dr/2,m=1) + Er(r=-dr/2,m=1)]
+     * And using the rule applying for the guards cells
+     * Er(r=-dr/2,m=1) = Er(r=dr/2,m=1). Thus: Et(i,j,m) = -i*Er(i,j,m)
+     */
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real UpdateEthetaOnAxis (
+        T_Field const& Et,
+        T_Field const& Er,
+        amrex::Real const * const coefs_t,
+        int const i, int const j, int const k, int const comp ) {
+
+        amrex::Real const dr = coefs_t[0];
+        amrex::Real const rmin = coefs_t[1];
+        amrex::Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
+        if (r == 0) {
+            if (comp == 1) {
+                Et(i,j,0,1) =  Er(i,j,k,2);
+            } else if (comp == 2) {
+                Et(i,j,0,2) = -Er(i,j,k,1);
+            }
+        }
     }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -223,10 +223,10 @@ struct CylindricalYeeAlgorithm {
             amrex::Real const r = rmin + (i + 0.5_rt)*dr; // r on cell-centered point (Er is cell-centered in r)
             if ((comp % 2) == 1) {
                 return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
-                       + (comp + 1)/2*Fz(i,j,k,comp+1)/r; // Real part
+                       + (comp + 1._rt)/2._rt*Fz(i,j,k,comp+1)/r; // Real part
             } else {
                 return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
-                       - (comp)/2*Fz(i,j,k,comp-1)/r; // Imaginary part
+                       - (comp)/2._rt*Fz(i,j,k,comp-1)/r; // Imaginary part
             }
         }
 
@@ -275,10 +275,10 @@ struct CylindricalYeeAlgorithm {
             if (comp == 0) {
                 return DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, 0);
             } else if ((comp % 2) == 1) {
-                return - (comp + 1)/2 * Fr(i, j, 0, comp+1)/r
+                return - (comp + 1._rt)/2._rt * Fr(i, j, 0, comp+1)/r
                        + DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, comp);
             } else { // (comp % 2) == 0
-                return + (comp)/2 * Fr(i, j, 0, comp-1)/r
+                return + (comp)/2._rt * Fr(i, j, 0, comp-1)/r
                        + DownwardDrr_over_r(Ft, r, dr, coefs_r, 3, i, j, k, comp);
             }
         } else { // r==0: on-axis corrections

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -308,7 +308,7 @@ struct CylindricalYeeAlgorithm {
      */
     template< typename T_Field>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real UpdateEthetaOnAxis (
+    static void UpdateEthetaOnAxis (
         T_Field const& Et,
         T_Field const& Er,
         amrex::Real const * const coefs_t,
@@ -319,7 +319,7 @@ struct CylindricalYeeAlgorithm {
         amrex::Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
         if (r == 0) {
             if (comp == 1) {
-                Et(i,j,0,1) =  Er(i,j,k,2);
+                Et(i,j,0,1) = +Er(i,j,k,2);
             } else if (comp == 2) {
                 Et(i,j,0,2) = -Er(i,j,k,1);
             }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -27,13 +27,18 @@ struct CylindricalYeeAlgorithm {
 
     static void InitializeStencilCoefficients (
         std::array<amrex::Real,3>& cell_size,
+        amrex::Real rmin,
         amrex::Vector<amrex::Real>& stencil_coefs_r,
+        amrex::Vector<amrex::Real>& stencil_coefs_t,
         amrex::Vector<amrex::Real>& stencil_coefs_z ) {
 
         using namespace amrex;
         // Store the inverse cell size along each direction in the coefficients
         stencil_coefs_r.resize(1);
         stencil_coefs_r[0] = 1._rt/cell_size[0];  // 1./dr
+        stencil_coefs_t.resize(2);
+        stencil_coefs_t[0] = cell_size[0];  // dr
+        stencil_coefs_t[1] = rmin;
         stencil_coefs_z.resize(1);
         stencil_coefs_z[0] = 1._rt/cell_size[2];  // 1./dz
     }
@@ -102,6 +107,36 @@ struct CylindricalYeeAlgorithm {
 
         Real const inv_dr = coefs_r[0];
         return 1._rt/r * inv_dr*( (r+0.5_rt*dr)*F(i,j,k,comp) - (r-0.5_rt*dr)*F(i-1,j,k,comp) );
+    }
+
+    /**
+     * Perform curl along r on a nodal grid, from a cell-centered field `F`*/
+    template< typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Curl_Nodal_0 (
+        T_Field const& Ft,
+        T_Field const& Fz,
+        amrex::Real const * const coefs_t,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const comp ) {
+
+        using namespace amrex::literals;
+
+        if (comp == 0) {
+            return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp);
+        } else {
+            amrex::Real const dr = coefs_t[0];
+            amrex::Real const rmin = coefs_t[1];
+            amrex::Real const r = rmin + (i + 0.5_rt)*dr; // r on cell-centered point (Er is cell-centered in r)
+            if ((comp % 2) == 1) {
+                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
+                       + (comp + 1)/2*Fz(i,j,k,comp+1)/r; // Real part
+            } else {
+                return - DownwardDz(Ft, coefs_z, 1, i, j, k, comp)
+                       - (comp)/2*Fz(i,j,k,comp-1)/r; // Imaginary part
+            }
+        }
+
     }
 
     /**

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H
@@ -326,6 +326,67 @@ struct CylindricalYeeAlgorithm {
         }
     }
 
+    /**
+     * Calculate the gradiant along x on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_0 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_x,
+        int const i, int const j, int const k, int const comp=0 ) {
+
+        return UpwardDr(F, coefs_x, 3, i, j, k, comp);
+
+    }
+
+    /**
+     * Calculate the gradiant along y on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_1 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_t,
+        int const i, int const j, int const k, int const comp=0 ) {
+
+        using namespace amrex::literals;
+
+        amrex::Real const dr = coefs_t[0];
+        amrex::Real const rmin = coefs_t[1];
+        amrex::Real const r = rmin + i*dr; // r on a nodal grid (Et is nodal in r)
+        if (r != 0) { // Off-axis, regular Maxwell equations
+            if (comp > 0) {
+                if ((comp % 2) == 1) {
+                    return (comp + 1._rt)/2._rt * F(i, j, k, comp+1)/r; // Real part
+                } else { // (comp % 2) == 0
+                    return -(comp)/2._rt * F(i, j, k, comp-1)/r; // Imaginary part
+                }
+            } else {
+                return 0._rt;
+            }
+        } else { // r==0: on-axis corrections
+            // For m==1, F is linear in r, for small r
+            // Therefore, the formula below regularizes the singularity
+            if (comp == 1) {
+                return F(i+1, j, k, 2)/dr; // Real part
+            } else if (comp == 2) {
+                return -F(i+1, j, k, 1)/dr; // Imaginary part
+            } else {
+                return 0._rt;
+            }
+        }
+
+    }
+
+    /**
+     * Calculate the gradiant along z on a cell-centered grid, from a nodal field `F`*/
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real Grad_cell_2 (
+        amrex::Array4<amrex::Real const> const& F,
+        amrex::Real const * const coefs_z,
+        int const i, int const j, int const k, int const comp=0 ) {
+
+        return UpwardDz(F, coefs_z, 1, i, j, k, comp);
+
+    }
+
 };
 
 #endif // WARPX_FINITE_DIFFERENCE_ALGORITHM_CYLINDRICAL_YEE_H_

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -180,14 +180,16 @@ class FiniteDifferenceSolver
 
         ElectromagneticSolverAlgo m_fdtd_algo;
         ablastr::utils::enums::GridType m_grid_type;
+        int m_ncomps;
 
 #ifdef WARPX_DIM_RZ
         amrex::Real m_dr, m_rmin;
         int m_nmodes;
         // host-only
-        amrex::Vector<amrex::Real> m_h_stencil_coefs_r, m_h_stencil_coefs_z;
+        amrex::Vector<amrex::Real> m_h_stencil_coefs_r, m_h_stencil_coefs_t, m_h_stencil_coefs_z;
         // device copy after init
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_r;
+        amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_t;
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
 #else
         // host-only

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -50,7 +50,8 @@ class FiniteDifferenceSolver
         FiniteDifferenceSolver (
             ElectromagneticSolverAlgo fdtd_algo,
             std::array<amrex::Real,3> cell_size,
-            ablastr::utils::enums::GridType grid_type );
+            ablastr::utils::enums::GridType grid_type,
+            int ncomps);
 
         void EvolveB ( ablastr::fields::MultiFabRegister& fields,
                        int lev,

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -185,40 +185,32 @@ class FiniteDifferenceSolver
 #ifdef WARPX_DIM_RZ
         amrex::Real m_dr, m_rmin;
         int m_nmodes;
-        // host-only
-        amrex::Vector<amrex::Real> m_h_stencil_coefs_r, m_h_stencil_coefs_t, m_h_stencil_coefs_z;
-        // device copy after init
-        amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_r;
-        amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_t;
-        amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
-#else
+#endif
         // host-only
         amrex::Vector<amrex::Real> m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z;
         // device copy after init
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_x;
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_y;
         amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
-#endif
 
     public:
         // The member functions below contain extended __device__ lambda.
         // In order to compile with nvcc, they need to be public.
+
+        template< typename T_Algo >
+        void EvolveE (
+            ablastr::fields::VectorField const& Efield,
+            ablastr::fields::VectorField const& Bfield,
+            ablastr::fields::VectorField const& Jfield,
+            ablastr::fields::VectorField const& edge_lengths,
+            amrex::MultiFab const* Ffield,
+            int lev, amrex::Real dt );
 
 #ifdef WARPX_DIM_RZ
         template< typename T_Algo >
         void EvolveBCylindrical (
             ablastr::fields::VectorField const& Bfield,
             ablastr::fields::VectorField const& Efield,
-            int lev,
-            amrex::Real dt );
-
-        template< typename T_Algo >
-        void EvolveECylindrical (
-            ablastr::fields::VectorField const& Efield,
-            ablastr::fields::VectorField const& Bfield,
-            ablastr::fields::VectorField const& Jfield,
-            ablastr::fields::VectorField const& edge_lengths,
-            amrex::MultiFab const* Ffield,
             int lev,
             amrex::Real dt );
 
@@ -262,15 +254,6 @@ class FiniteDifferenceSolver
             ablastr::fields::VectorField const& Bfield,
             ablastr::fields::VectorField const& Efield,
             amrex::MultiFab const * Gfield,
-            int lev, amrex::Real dt );
-
-        template< typename T_Algo >
-        void EvolveECartesian (
-            ablastr::fields::VectorField const& Efield,
-            ablastr::fields::VectorField const& Bfield,
-            ablastr::fields::VectorField const& Jfield,
-            ablastr::fields::VectorField const& edge_lengths,
-            amrex::MultiFab const* Ffield,
             int lev, amrex::Real dt );
 
         template< typename T_Algo >

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
@@ -47,21 +47,10 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
     m_rmin = WarpX::GetInstance().Geom(0).ProbLo(0);
     if (fdtd_algo == ElectromagneticSolverAlgo::Yee ||
         fdtd_algo == ElectromagneticSolverAlgo::HybridPIC ) {
+
         CylindricalYeeAlgorithm::InitializeStencilCoefficients( cell_size, m_rmin,
-            m_h_stencil_coefs_r, m_h_stencil_coefs_t, m_h_stencil_coefs_z );
-        m_stencil_coefs_r.resize(m_h_stencil_coefs_r.size());
-        m_stencil_coefs_t.resize(m_h_stencil_coefs_t.size());
-        m_stencil_coefs_z.resize(m_h_stencil_coefs_z.size());
-        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                              m_h_stencil_coefs_r.begin(), m_h_stencil_coefs_r.end(),
-                              m_stencil_coefs_r.begin());
-        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                              m_h_stencil_coefs_t.begin(), m_h_stencil_coefs_t.end(),
-                              m_stencil_coefs_t.begin());
-        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                              m_h_stencil_coefs_z.begin(), m_h_stencil_coefs_z.end(),
-                              m_stencil_coefs_z.begin());
-        amrex::Gpu::synchronize();
+            m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );
+
     } else {
         WARPX_ABORT_WITH_MESSAGE(
             "FiniteDifferenceSolver: Unknown algorithm");
@@ -88,6 +77,7 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
         WARPX_ABORT_WITH_MESSAGE(
             "FiniteDifferenceSolver: Unknown algorithm");
     }
+#endif
 
     m_stencil_coefs_x.resize(m_h_stencil_coefs_x.size());
     m_stencil_coefs_y.resize(m_h_stencil_coefs_y.size());
@@ -103,5 +93,4 @@ FiniteDifferenceSolver::FiniteDifferenceSolver (
                           m_h_stencil_coefs_z.begin(), m_h_stencil_coefs_z.end(),
                           m_stencil_coefs_z.begin());
     amrex::Gpu::synchronize();
-#endif
 }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.cpp
@@ -28,17 +28,17 @@
 FiniteDifferenceSolver::FiniteDifferenceSolver (
     ElectromagneticSolverAlgo const fdtd_algo,
     std::array<amrex::Real,3> cell_size,
-    ablastr::utils::enums::GridType grid_type):
+    ablastr::utils::enums::GridType grid_type,
+    int ncomps):
     // Register the type of finite-difference algorithm
     m_fdtd_algo{fdtd_algo},
-    m_grid_type{grid_type}
+    m_grid_type{grid_type},
+    m_ncomps{ncomps}
 {
     // return if not FDTD
     if (fdtd_algo == ElectromagneticSolverAlgo::None || fdtd_algo == ElectromagneticSolverAlgo::PSATD) {
         return;
     }
-
-    m_ncomps = WarpX::ncomps;
 
     // Calculate coefficients of finite-difference stencil
 #ifdef WARPX_DIM_RZ

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -101,8 +101,8 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCylindrical (
         }
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        int const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         int const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -157,18 +157,18 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCylindrical (
                 if (r > 0.5_rt*dr) {
                     // Mode m=0
                     Jt(i, j, 0, 0) = one_over_mu0 * (
-                        - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 0)
+                        - T_Algo::DownwardDr(Bz, coefs_x, n_coefs_x, i, j, 0, 0)
                         + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 0)
                     );
 
                     // Higher-order modes
                     for (int m=1 ; m<nmodes ; m++) { // Higher-order modes
                         Jt(i, j, 0, 2*m-1) = one_over_mu0 * (
-                            - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                            - T_Algo::DownwardDr(Bz, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                             + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 2*m-1)
                         ); // Real part
                         Jt(i, j, 0, 2*m  ) = one_over_mu0 * (
-                            - T_Algo::DownwardDr(Bz, coefs_r, n_coefs_r, i, j, 0, 2*m  )
+                            - T_Algo::DownwardDr(Bz, coefs_x, n_coefs_x, i, j, 0, 2*m  )
                             + T_Algo::DownwardDz(Br, coefs_z, n_coefs_z, i, j, 0, 2*m  )
                         ); // Imaginary part
                     }
@@ -202,17 +202,17 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCylindrical (
                 if (r > 0.5_rt*dr) {
                     // Mode m=0
                     Jz(i, j, 0, 0) = one_over_mu0 * (
-                       T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 0)
+                       T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_x, n_coefs_x, i, j, 0, 0)
                     );
                     // Higher-order modes
                     for (int m=1 ; m<nmodes ; m++) {
                         Jz(i, j, 0, 2*m-1) = one_over_mu0 * (
                             - m * Br(i, j, 0, 2*m  ) / r
-                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m-1)
+                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m-1)
                         ); // Real part
                         Jz(i, j, 0, 2*m  ) = one_over_mu0 * (
                             m * Br(i, j, 0, 2*m-1) / r
-                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_r, n_coefs_r, i, j, 0, 2*m  )
+                            + T_Algo::DownwardDrr_over_r(Bt, r, dr, coefs_x, n_coefs_x, i, j, 0, 2*m  )
                         ); // Imaginary part
                     }
                 // r==0: on-axis corrections
@@ -545,8 +545,8 @@ void FiniteDifferenceSolver::HybridPICSolveECylindrical (
         }
 
         // Extract stencil coefficients
-        Real const * const AMREX_RESTRICT coefs_r = m_stencil_coefs_r.dataPtr();
-        int const n_coefs_r = static_cast<int>(m_stencil_coefs_r.size());
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        int const n_coefs_x = static_cast<int>(m_stencil_coefs_x.size());
         Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
         int const n_coefs_z = static_cast<int>(m_stencil_coefs_z.size());
 
@@ -584,7 +584,7 @@ void FiniteDifferenceSolver::HybridPICSolveECylindrical (
                 // Get the gradient of the electron pressure if the longitudinal part of
                 // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
                 Real grad_Pe = 0._rt;
-                if (!solve_for_Faraday) { grad_Pe = T_Algo::UpwardDr(Pe, coefs_r, n_coefs_r, i, j, 0, 0); }
+                if (!solve_for_Faraday) { grad_Pe = T_Algo::UpwardDr(Pe, coefs_x, n_coefs_x, i, j, 0, 0); }
 
                 // interpolate the nodal neE values to the Yee grid
                 auto enE_r = Interp(enE, nodal, Er_stag, coarsen, i, j, 0, 0);
@@ -598,7 +598,7 @@ void FiniteDifferenceSolver::HybridPICSolveECylindrical (
                     // r on cell-centered point (Jr is cell-centered in r)
                     Real const r = rmin + (i + 0.5_rt)*dr;
 
-                    auto nabla2Jr = T_Algo::Dr_rDr_over_r(Jr, r, dr, coefs_r, n_coefs_r, i, j, 0, 0);
+                    auto nabla2Jr = T_Algo::Dr_rDr_over_r(Jr, r, dr, coefs_x, n_coefs_x, i, j, 0, 0);
                     Er(i, j, 0) -= eta_h * nabla2Jr;
                 }
             },

--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
@@ -71,15 +71,11 @@ public:
     amrex::Vector< std::unique_ptr<amrex::MultiFab> > m_source;
 
     amrex::Vector<amrex::Real> m_h_stencil_coefs_x;
-#if !defined(WARPX_DIM_RZ)
     amrex::Vector<amrex::Real> m_h_stencil_coefs_y;
-#endif
     amrex::Vector<amrex::Real> m_h_stencil_coefs_z;
 
     amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_x;
-#if !defined(WARPX_DIM_RZ)
     amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_y;
-#endif
     amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
 
     // Default Constructor

--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
@@ -73,8 +73,9 @@ ProjectionDivCleaner::ProjectionDivCleaner(std::string const& a_field_name) :
 
     auto cell_size = WarpX::CellSize(0);
 #if defined(WARPX_DIM_RZ)
-    CylindricalYeeAlgorithm::InitializeStencilCoefficients( cell_size,
-            m_h_stencil_coefs_x, m_h_stencil_coefs_z );
+    amrex::Real const rmin = WarpX::GetInstance().Geom(0).ProbLo(0);
+    CylindricalYeeAlgorithm::InitializeStencilCoefficients( cell_size, rmin,
+            m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );
 #else
     CartesianYeeAlgorithm::InitializeStencilCoefficients( cell_size,
             m_h_stencil_coefs_x, m_h_stencil_coefs_y, m_h_stencil_coefs_z );

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2452,7 +2452,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 #endif
     } // ElectromagneticSolverAlgo::PSATD
     else {
-        m_fdtd_solver_fp[lev] = std::make_unique<FiniteDifferenceSolver>(electromagnetic_solver_id, dx, grid_type);
+        m_fdtd_solver_fp[lev] = std::make_unique<FiniteDifferenceSolver>(electromagnetic_solver_id, dx, grid_type, ncomps);
     }
 
     //
@@ -2664,7 +2664,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         } // ElectromagneticSolverAlgo::PSATD
         else {
             m_fdtd_solver_cp[lev] = std::make_unique<FiniteDifferenceSolver>(electromagnetic_solver_id, cdx,
-                                                                             grid_type);
+                                                                             grid_type, ncomps);
         }
     }
 


### PR DESCRIPTION
The intent of this PR is to push the geometry related code down to the lowest level, so that it only appears in the files in the `FiniteDifferenceAlgorithms` directory. This is done by writing the code in terms of the differential operators, i.e. `curl` and `gradient` rather than the specific derivatives.

Status:
- [x] Implement the nodal curl for `EvolveE`
- [x] Add call to correct `Etheta` on axis for RZ (fixing possible bug)
- [ ] Implement the cell-centered curl for `EvolveB`
- [x] Implement the gradient for the `F` advance
- [ ] Implement the divergence for the `G` advance
- [x] Remove `EvolveECylindrical`
- [ ] Remove `EvolveBCylindrical`
- [ ] Remove unneeded `n_coefs_` arguments
- [ ] Make parent class for Cartesian algorithms for common operators