### PR TITLE
Check that all E-field values are finite in Ohm solver

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -189,6 +189,18 @@ void WarpX::HybridPICEvolveFields ()
                            0, 0, 1, current_fp_temp[lev][idim]->nGrowVect());
         }
     }
+
+    // Check that the E-field does not have nan or inf values, otherwise print a clear message
+    ablastr::fields::MultiLevelVectorField Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level);
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        for (int idim = 0; idim < 3; ++idim) {
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                Efield_fp[lev][idim]->is_finite(),
+                "Non-finite value detected in E-field; this indicates more substeps should be used in the field solver."
+            );
+        }
+    }
 }
 
 void WarpX::HybridPICDepositInitialRhoAndJ ()

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -195,7 +195,7 @@ void WarpX::HybridPICEvolveFields ()
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         for (int idim = 0; idim < 3; ++idim) {
-            if !(Efield_fp[lev][idim]->is_finite(true)) {
+            if (!Efield_fp[lev][idim]->is_finite(true)) {
                 amrex::Abort("Non-finite value detected in E-field; this indicates more substeps should be used in the field solver.");
             }
         }

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -195,9 +195,9 @@ void WarpX::HybridPICEvolveFields ()
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         for (int idim = 0; idim < 3; ++idim) {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                Efield_fp[lev][idim]->is_finite(),
-                "Non-finite value detected in E-field; this indicates more substeps should be used in the field solver."
+            if !(Efield_fp[lev][idim]->is_finite(true)) {
+                amrex::Abort("Non-finite value detected in E-field; this indicates more substeps should be used in the field solver.");
+            }
             );
         }
     }

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -195,9 +195,10 @@ void WarpX::HybridPICEvolveFields ()
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         for (int idim = 0; idim < 3; ++idim) {
-            if (!Efield_fp[lev][idim]->is_finite(true)) {
-                amrex::Abort("Non-finite value detected in E-field; this indicates more substeps should be used in the field solver.");
-            }
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                Efield_fp[lev][idim]->is_finite(),
+                "Non-finite value detected in E-field; this indicates more substeps should be used in the field solver."
+            );
         }
     }
 }

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -198,7 +198,6 @@ void WarpX::HybridPICEvolveFields ()
             if !(Efield_fp[lev][idim]->is_finite(true)) {
                 amrex::Abort("Non-finite value detected in E-field; this indicates more substeps should be used in the field solver.");
             }
-            );
         }
     }
 }


### PR DESCRIPTION
This assert is meant to help identify the origin of a common problem in hybrid-PIC simulations, wherein unresolved Whistler waves cause runaway E-field values. Currently when this happens, WarpX fails in the current deposition routine.