### PR TITLE
CI: fix IntelLLVM builds

### DIFF
--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -29,13 +29,16 @@ df -h
 # https://github.com/ECP-WarpX/WarpX/pull/1566#issuecomment-790934878
 
 # try apt install up to five times, to avoid connection splits
+# FIXME install latest version of IntelLLVM, Intel MKL
+#       after conflicts with openPMD are resolved
 status=1
 for itry in {1..5}
 do
     sudo apt-get install -y --no-install-recommends \
         build-essential \
         cmake           \
-        intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel \
+        intel-oneapi-compiler-dpcpp-cpp=2024.2.1-1079 \
+        intel-oneapi-mkl-devel=2024.2.1-103 \
         g++ gfortran    \
         libopenmpi-dev  \
         openmpi-bin     \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -112,6 +112,7 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
+        export PATH=$PATH:/opt/intel/oneapi/compiler/2024.2/bin  # FIXME
         export CXX=$(which icpx)
         export CC=$(which icx)
 
@@ -176,6 +177,7 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
+        export PATH=$PATH:/opt/intel/oneapi/compiler/2024.2/bin  # FIXME
         export CXX=$(which icpx)
         export CC=$(which icx)
         export CXXFLAGS="-fsycl ${CXXFLAGS}"


### PR DESCRIPTION
The CI checks `Intel / oneAPI ICX SP` and `Intel / oneAPI DPC++ SP` are failing since a few days.

This is likely due to the fact that the GitHub Actions runner is now installing IntelLLVM 2025.0.0 instead of IntelLLVM 2024.2.1, as until a few days ago.

This causes the following issue when building openPMD:
```console
/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedopenpmd-src/include/openPMD/backend/Container.hpp:263:32: error: no member named 'm_container' in 'Container<T, T_key, T_container>'
  263 |         container().swap(other.m_container);
      |                          ~~~~~ ^
1 error generated.
```

We can try to install the previous version of IntelLLVM manually and see if that fixes the issue.