### PR TITLE
CTest: fix bug with `WarpX_APP=OFF` and `WarpX_PYTHON=ON`

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -93,6 +93,11 @@ function(add_warpx_test
         return()
     endif()
 
+    # cannot run executable tests w/o WarpX executable application
+    if(NOT python AND NOT WarpX_APP)
+        return()
+    endif()
+
     # set MPI executable
     set(THIS_MPI_TEST_EXE
         ${MPIEXEC_EXECUTABLE}


### PR DESCRIPTION
Our `CMakeLists` to set up the `ctest` executable had a logic error when `WarpX_APP=OFF` and `WarpX_PYTHON=ON`, in that it was trying to install executable tests without an executable application.

The error message looked something like
```console
  Error evaluating generator expression:
    $<TARGET_FILE:app_3d>
  No target "app_3d"
```