### PR TITLE
Fix bug where tmax was ignored in flux injection

### DIFF
--- a/Examples/Tests/flux_injection/analysis_flux_injection_from_eb.py
+++ b/Examples/Tests/flux_injection/analysis_flux_injection_from_eb.py
@@ -32,7 +32,7 @@ yt.funcs.mylog.setLevel(0)
 fn = sys.argv[1]
 ds = yt.load(fn)
 ad = ds.all_data()
-t_max = ds.current_time.item()  # time of simulation
+t_inj = 0.5e-8  # duration for which the flux injection was active
 
 # Extract the dimensionality of the simulation
 with open("./warpx_used_inputs", "r") as f:
@@ -52,7 +52,7 @@ if dims == "3D" or dims == "RZ":
     emission_surface = 4 * np.pi * R**2  # in m^2
 elif dims == "2D":
     emission_surface = 2 * np.pi * R  # in m
-Ntot = flux * emission_surface * t_max
+Ntot = flux * emission_surface * t_inj
 
 # Parameters of the histogram
 hist_bins = 50

--- a/Examples/Tests/flux_injection/inputs_base_from_eb
+++ b/Examples/Tests/flux_injection/inputs_base_from_eb
@@ -29,6 +29,8 @@ electron.inject_from_embedded_boundary = 1
 electron.num_particles_per_cell = 100
 electron.flux_profile = parse_flux_function
 electron.flux_function(x,y,z,t) = "1."
+electron.flux_tmin = 0.25e-8
+electron.flux_tmax = 0.75e-8
 electron.momentum_distribution_type = gaussianflux
 electron.ux_th = 0.01
 electron.uy_th = 0.01
@@ -37,6 +39,7 @@ electron.uz_m = 0.07
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 10
+diag1.intervals = 1
 diag1.diag_type = Full
 diag1.fields_to_plot = none
+diag1.format = openpmd

--- a/Examples/Tests/flux_injection/inputs_base_from_eb
+++ b/Examples/Tests/flux_injection/inputs_base_from_eb
@@ -39,7 +39,6 @@ electron.uz_m = 0.07
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 1
+diag1.intervals = 10
 diag1.diag_type = Full
 diag1.fields_to_plot = none
-diag1.format = openpmd

--- a/Regression/Checksum/benchmarks_json/test_2d_flux_injection_from_eb.json
+++ b/Regression/Checksum/benchmarks_json/test_2d_flux_injection_from_eb.json
@@ -1,11 +1,11 @@
 {
   "lev=0": {},
   "electron": {
-    "particle_momentum_x": 6.990772711451971e-19,
-    "particle_momentum_y": 5.4131306169803364e-20,
-    "particle_momentum_z": 6.997294931789925e-19,
-    "particle_position_x": 35518.95120597846,
-    "particle_position_y": 35517.855675902414,
-    "particle_weight": 1.25355e-07
+    "particle_momentum_x": 3.4911323396038835e-19,
+    "particle_momentum_y": 2.680312173420972e-20,
+    "particle_momentum_z": 3.4918430443688734e-19,
+    "particle_position_x": 17950.08139982036,
+    "particle_position_y": 17949.47183079554,
+    "particle_weight": 6.269e-08
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_flux_injection_from_eb.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_flux_injection_from_eb.json
@@ -1,12 +1,12 @@
 {
   "lev=0": {},
   "electron": {
-    "particle_momentum_x": 4.371688233196277e-18,
-    "particle_momentum_y": 4.368885079657374e-18,
-    "particle_momentum_z": 4.367429424105371e-18,
-    "particle_position_x": 219746.94401890738,
-    "particle_position_y": 219690.7015248918,
-    "particle_position_z": 219689.45580938633,
-    "particle_weight": 4.954974999999999e-07
+    "particle_momentum_x": 2.1855512033870577e-18,
+    "particle_momentum_y": 2.1826030840183147e-18,
+    "particle_momentum_z": 2.181852403122796e-18,
+    "particle_position_x": 111042.81925863726,
+    "particle_position_y": 111012.52928910403,
+    "particle_position_z": 111015.90903542604,
+    "particle_weight": 2.4775750000000003e-07
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_rz_flux_injection_from_eb.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_flux_injection_from_eb.json
@@ -1,12 +1,12 @@
 {
   "lev=0": {},
   "electron": {
-    "particle_momentum_x": 6.734984863106283e-19,
-    "particle_momentum_y": 6.786279785869023e-19,
-    "particle_momentum_z": 1.0527983828124758e-18,
-    "particle_position_x": 53309.270966506396,
-    "particle_position_y": 53302.3776094842,
-    "particle_theta": 58707.74469425615,
-    "particle_weight": 4.991396867417661e-07
+    "particle_momentum_x": 3.3665608248716305e-19,
+    "particle_momentum_y": 3.392690322852239e-19,
+    "particle_momentum_z": 5.254577143779578e-19,
+    "particle_position_x": 26933.772112044953,
+    "particle_position_y": 26926.994273876346,
+    "particle_theta": 29492.77423173835,
+    "particle_weight": 2.4953304765944705e-07
   }
 }

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -305,6 +305,9 @@ void PlasmaInjector::setupNFluxPerCell (amrex::ParmParse const& pp_species)
     }
 #endif
 
+    utils::parser::queryWithParser(pp_species, source_name, "flux_tmin", flux_tmin);
+    utils::parser::queryWithParser(pp_species, source_name, "flux_tmax", flux_tmax);
+
     // Check whether injection from the embedded boundary is requested
     utils::parser::queryWithParser(pp_species, source_name, "inject_from_embedded_boundary", m_inject_from_eb);
     if (m_inject_from_eb) {
@@ -318,8 +321,6 @@ void PlasmaInjector::setupNFluxPerCell (amrex::ParmParse const& pp_species)
         // Parse the parameters of the plane (position, normal direction, etc.)
 
         utils::parser::getWithParser(pp_species, source_name, "surface_flux_pos", surface_flux_pos);
-        utils::parser::queryWithParser(pp_species, source_name, "flux_tmin", flux_tmin);
-        utils::parser::queryWithParser(pp_species, source_name, "flux_tmax", flux_tmax);
         std::string flux_normal_axis_string;
         utils::parser::get(pp_species, source_name, "flux_normal_axis", flux_normal_axis_string);
         flux_normal_axis = -1;


### PR DESCRIPTION
There was a bug where WarpX would only read `flux_tmin`, `flux_tmax` for the injection from a plane, but not for the injection from the EB.

This PR fixes the bug, and uses `tmin`/`tmax` in the CI test for the EB injection.