### PR TITLE
Install `lasy` on Perlmutter by default

### DIFF
--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -177,7 +177,7 @@ python3 -m pip install --upgrade cupy-cuda12x  # CUDA 12 compatible wheel
 # optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
 python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel
 python3 -m pip install --upgrade optimas[all]
-
+python3 -m pip install --upgrade lasy
 
 # remove build temporary directory
 rm -rf ${build_dir}


### PR DESCRIPTION
This modifies Perlmutter's installation instructions so that `lasy` is installed by default.