### PR TITLE
CI: build tests with `-g1` compile option

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -151,12 +151,19 @@ jobs:
       # display disk space usage
       df -h
       # configure
-      export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
-      cmake -S . -B build       \
-        ${AMReX_CMAKE_FLAGS}    \
-        ${WARPX_CMAKE_FLAGS}    \
-        -DWarpX_TEST_CLEANUP=ON \
-        -DWarpX_TEST_FPETRAP=ON
+      export AMReX_CMAKE_FLAGS=(
+        "-DAMReX_ASSERTIONS=ON"
+        "-DAMReX_TESTING=ON"
+      )
+      export WARPX_TEST_FLAGS=(
+        "-DWarpX_TEST_CLEANUP=ON"
+        "-DWarpX_TEST_FPETRAP=ON"
+        "-DWarpX_TEST_DEBUG=ON"
+      )
+      cmake -S . -B build    \
+        ${AMReX_CMAKE_FLAGS} \
+        ${WARPX_CMAKE_FLAGS} \
+        ${WARPX_TEST_FLAGS}
       # build
       cmake --build build -j 2
       # display disk space usage

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -151,15 +151,8 @@ jobs:
       # display disk space usage
       df -h
       # configure
-      export AMReX_CMAKE_FLAGS=(
-        "-DAMReX_ASSERTIONS=ON"
-        "-DAMReX_TESTING=ON"
-      )
-      export WARPX_TEST_FLAGS=(
-        "-DWarpX_TEST_CLEANUP=ON"
-        "-DWarpX_TEST_FPETRAP=ON"
-        "-DWarpX_TEST_DEBUG=ON"
-      )
+      export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
+      export WARPX_TEST_FLAGS="-DWarpX_TEST_CLEANUP=ON -DWarpX_TEST_FPETRAP=ON -DWarpX_TEST_DEBUG=ON"
       cmake -S . -B build    \
         ${AMReX_CMAKE_FLAGS} \
         ${WARPX_CMAKE_FLAGS} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ mark_as_advanced(WarpX_TEST_FPETRAP)
 option(WarpX_TEST_DEBUG "Run CI tests with the -g compile option" OFF)
 mark_as_advanced(WarpX_TEST_DEBUG)
 if(WarpX_TEST_DEBUG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")
 endif()
 
 set(WarpX_DIMS_VALUES 1 2 3 RZ)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,13 @@ mark_as_advanced(WarpX_TEST_CLEANUP)
 option(WarpX_TEST_FPETRAP "Run CI tests with FPE-trapping runtime parameters" OFF)
 mark_as_advanced(WarpX_TEST_FPETRAP)
 
+# Advanced option to run CI tests with the -g compile option
+option(WarpX_TEST_DEBUG "Run CI tests with the -g compile option" OFF)
+mark_as_advanced(WarpX_TEST_DEBUG)
+if(WarpX_TEST_DEBUG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+endif()
+
 set(WarpX_DIMS_VALUES 1 2 3 RZ)
 set(WarpX_DIMS 3 CACHE STRING "Simulation dimensionality <1;2;3;RZ>")
 list(REMOVE_DUPLICATES WarpX_DIMS)

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJConstantInTime.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJConstantInTime.cpp
@@ -845,18 +845,18 @@ PsatdAlgorithmJConstantInTime::VayDeposition (SpectralFieldData& field_data)
 #endif
 
             // Compute Jx
-            if (kx_mod != 0._rt) { fields(i,j,k,Idx.Jx_mid) = I * Dx / kx_mod; }
-            else                 { fields(i,j,k,Idx.Jx_mid) = 0._rt; }
+            if (kx_mod != 0._rt) { fields(i,j,k,Idx.Jx_mid) = std::nan(""); } //I * Dx / kx_mod; }
+            else                 { fields(i,j,k,Idx.Jx_mid) = std::nan(""); } //0._rt; }
 
 #if defined(WARPX_DIM_3D)
             // Compute Jy
-            if (ky_mod != 0._rt) { fields(i,j,k,Idx.Jy_mid) = I * Dy / ky_mod; }
-            else                 { fields(i,j,k,Idx.Jy_mid) = 0._rt; }
+            if (ky_mod != 0._rt) { fields(i,j,k,Idx.Jy_mid) = std::nan(""); } //I * Dy / ky_mod; }
+            else                 { fields(i,j,k,Idx.Jy_mid) = std::nan(""); } //0._rt; }
 #endif
 
             // Compute Jz
-            if (kz_mod != 0._rt) { fields(i,j,k,Idx.Jz_mid) = I * Dz / kz_mod; }
-            else                 { fields(i,j,k,Idx.Jz_mid) = 0._rt; }
+            if (kz_mod != 0._rt) { fields(i,j,k,Idx.Jz_mid) = std::nan(""); } //I * Dz / kz_mod; }
+            else                 { fields(i,j,k,Idx.Jz_mid) = std::nan(""); } //0._rt; }
         });
     }
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJConstantInTime.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmJConstantInTime.cpp
@@ -845,18 +845,18 @@ PsatdAlgorithmJConstantInTime::VayDeposition (SpectralFieldData& field_data)
 #endif
 
             // Compute Jx
-            if (kx_mod != 0._rt) { fields(i,j,k,Idx.Jx_mid) = std::nan(""); } //I * Dx / kx_mod; }
-            else                 { fields(i,j,k,Idx.Jx_mid) = std::nan(""); } //0._rt; }
+            if (kx_mod != 0._rt) { fields(i,j,k,Idx.Jx_mid) = I * Dx / kx_mod; }
+            else                 { fields(i,j,k,Idx.Jx_mid) = 0._rt; }
 
 #if defined(WARPX_DIM_3D)
             // Compute Jy
-            if (ky_mod != 0._rt) { fields(i,j,k,Idx.Jy_mid) = std::nan(""); } //I * Dy / ky_mod; }
-            else                 { fields(i,j,k,Idx.Jy_mid) = std::nan(""); } //0._rt; }
+            if (ky_mod != 0._rt) { fields(i,j,k,Idx.Jy_mid) = I * Dy / ky_mod; }
+            else                 { fields(i,j,k,Idx.Jy_mid) = 0._rt; }
 #endif
 
             // Compute Jz
-            if (kz_mod != 0._rt) { fields(i,j,k,Idx.Jz_mid) = std::nan(""); } //I * Dz / kz_mod; }
-            else                 { fields(i,j,k,Idx.Jz_mid) = std::nan(""); } //0._rt; }
+            if (kz_mod != 0._rt) { fields(i,j,k,Idx.Jz_mid) = I * Dz / kz_mod; }
+            else                 { fields(i,j,k,Idx.Jz_mid) = 0._rt; }
         });
     }
 }


### PR DESCRIPTION
Build and run CI tests with more debug information by adding the `-g1` compile option.