### PR TITLE
Revert "Python: Warn old `warpx.multifab` Signature (#5326)"

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -115,11 +115,6 @@ void init_WarpX (py::module& m)
         )
         .def("multifab",
              [](WarpX & wx, std::string internal_name) {
-                 py::print("WARNING: WarpX' multifab('internal_name') signature is deprecated.\nPlease use:\n"
-                           "- multifab('prefix', level=...) for scalar fields\n"
-                           "- multifab('prefix', dir=..., level=...) for vector field components\n"
-                           "where 'prefix' is the part of 'internal_name';'  before the []",
-                           py::arg("file") = py::module_::import("sys").attr("stderr"));
                  if (wx.m_fields.internal_has(internal_name)) {
                      return wx.m_fields.internal_get(internal_name);
                  } else {


### PR DESCRIPTION
It seems that the changes of #5326 is causing confusion among some users.

With #5326, users typically receive a message saying that the "signature is deprecated" (which is actually incorrect ; this should say "will soon be deprecated"). As a consequence, users think that their simulation result is invalid (which is again incorrect ; using this signature is still fine for now), and try to change it according the printed instuctions, i.e.:
```
Please use:
- multifab('prefix', level=...) for scalar fields
- multifab('prefix', dir=..., level=...) for vector field components
```
But because there is no link to a concrete example or test, users typically try:
```
multifab("Efield_fp", dir=0, level=0)
```
and then get 
```
TypeError: multifab(): incompatible function arguments. The following argument types are supported:
    1. (self: pywarpx.warpx_pybind_3d.WarpX, internal_name: str) -> amrex.space3d.amrex_3d_pybind.MultiFab
    2. (self: pywarpx.warpx_pybind_3d.WarpX, scalar_name: str, level: int) -> amrex.space3d.amrex_3d_pybind.MultiFab
    3. (self: pywarpx.warpx_pybind_3d.WarpX, vector_name: str, dir: pywarpx.warpx_pybind_3d.Direction, level: int) -> amrex.space3d.amrex_3d_pybind.MultiFab
```
I am guessing that most users will get stuck at this point. 

The error message does suggest that the user has to create a `Direction` object, but since there is no example on how to create this, it is unlikely that most users will be able to overcome this issue.

I would suggest to temporarily revert #5326, and then re-introduce it with:
- updated instructions on how to create a `Direction` objects
- updated warning that says "will be deprecated" instead of "is deprecated".