### PR TITLE
Update license to explicitly list LLNL

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -14,10 +14,11 @@ this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-(3) Neither the name of the University of California, Lawrence Berkeley
-National Laboratory, U.S. Dept. of Energy nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
+(3) Neither the name of the University of California,
+Lawrence Berkeley National Laboratory, Lawrence Livermore National Security,
+Lawrence Livermore National Laboratory, U.S. Dept. of Energy nor the names of
+its contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
 
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"


### PR DESCRIPTION
I noticed this oversight in the LICENSE.txt file. Is there some official way of fixing this or is this PR enough?