### PR TITLE
Docs: update list of TC members

### DIFF
--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -54,7 +54,9 @@ Technical Committee
 Current Roster
 ^^^^^^^^^^^^^^
 
+- Justin Ray Angus
 - Luca Fedeli
+- Arianna Formenti
 - Roelof Groenewald
 - David Grote
 - Axel Huebl


### PR DESCRIPTION
I think we forgot to update the list of TC members available in the GitHub repository and in the online documentation.