### PR TITLE
Docs: warn about default variables set by conda

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -122,7 +122,8 @@ For Nvidia CUDA GPU support, you will need to have `a recent CUDA driver install
 More info for `CUDA-enabled ML packages <https://twitter.com/jeremyphoward/status/1697435241152127369>`__.
 
 .. warning::
-   When you install CMake in a conda environment, conda sets several environment variables, e.g., ``CXXFLAGS``, to default values that are specific to the conda environment. Such values are concatenated to the values set by WarpX during buildsystem generation. In order to avoid unintended side effects (e.g., compiling with ``-O2`` instead of ``-O3``), please consider clearing ``CXXFLAGS`` and/or other relevant variables (e.g., via ``export CXXFLAGS=""``) before generating the buildsystem and compiling.
+
+   When you install CMake in a conda environment, conda sets several environment variables, e.g., ``CXXFLAGS``, to default values that are specific to the conda environment. Such values are concatenated to the values set by WarpX during buildsystem generation. In order to avoid unintended side effects (e.g., compiling with ``-O2`` instead of ``-O3``), please consider clearing ``CXXFLAGS`` and/or other relevant variables (e.g., via ``unset CXXFLAGS``) before generating the buildsystem and compiling.
 
 Spack (Linux/macOS)
 -------------------

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -122,7 +122,7 @@ For Nvidia CUDA GPU support, you will need to have `a recent CUDA driver install
 More info for `CUDA-enabled ML packages <https://twitter.com/jeremyphoward/status/1697435241152127369>`__.
 
 .. warning::
-   When you install CMake in a conda environment, conda sets several environment variables, e.g., ``CXXFLAGS``, to default values that are specific to the conda environment. Such values are concatenated to the values set by WarpX during buildsystem generation. In order to avoid unintended side effects (e.g., compiling with ``-O2`` instead of ``-O3``), please consider clearing ``CXXFLAGS`` (and/or other relevant variables) before generating the buildsystem and compiling.
+   When you install CMake in a conda environment, conda sets several environment variables, e.g., ``CXXFLAGS``, to default values that are specific to the conda environment. Such values are concatenated to the values set by WarpX during buildsystem generation. In order to avoid unintended side effects (e.g., compiling with ``-O2`` instead of ``-O3``), please consider clearing ``CXXFLAGS`` and/or other relevant variables (e.g., via ``export CXXFLAGS=""``) before generating the buildsystem and compiling.
 
 Spack (Linux/macOS)
 -------------------

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -121,6 +121,8 @@ For Nvidia CUDA GPU support, you will need to have `a recent CUDA driver install
 
 More info for `CUDA-enabled ML packages <https://twitter.com/jeremyphoward/status/1697435241152127369>`__.
 
+.. warning::
+   When you install CMake in a conda environment, conda sets several environment variables, e.g., ``CXXFLAGS``, to default values that are specific to the conda environment. Such values are concatenated to the values set by WarpX during buildsystem generation. In order to avoid unintended side effects (e.g., compiling with ``-O2`` instead of ``-O3``), please consider clearing ``CXXFLAGS`` (and/or other relevant variables) before generating the buildsystem and compiling.
 
 Spack (Linux/macOS)
 -------------------


### PR DESCRIPTION
Adding a warning about conda setting default environment variables when installing CMake, as discussed during the developer meeting.

It will be displayed at the onde of the conda section (https://warpx.readthedocs.io/en/latest/install/dependencies.html#conda-linux-macos-windows):

![Screenshot from 2024-11-15 12-39-42](https://github.com/user-attachments/assets/16b49907-6b66-4be3-a9fd-283d8ddc64f2)
