### PR TITLE
CI: fix Clang UB sanitizer, disable Clang thread sanitizer

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -77,7 +77,8 @@ jobs:
   build_thread_sanitizer:
     name: Clang thread sanitizer
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.draft == false
+    # TODO Fix data race conditions and re-enable job
+    if: 0 #github.event.pull_request.draft == false
     env:
       CC: clang
       CXX: clang++
@@ -107,8 +108,6 @@ jobs:
         export CXXFLAGS="-fsanitize=thread"
 
         cmake -S . -B build                 \
-          -DWarpX_amrex_repo=https://github.com/EZoni/amrex.git \
-          -DWarpX_amrex_branch=fix_data_race \
           -GNinja                           \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -123,8 +122,6 @@ jobs:
         cmake --build build -j 4
 
         cmake -S . -B build_EB              \
-          -DWarpX_amrex_repo=https://github.com/EZoni/amrex.git \
-          -DWarpX_amrex_branch=fix_data_race \
           -GNinja                           \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -144,7 +141,7 @@ jobs:
     - name: run with thread sanitizer
       run: |
         export PMIX_MCA_gds=hash
-        export TSAN_OPTIONS='symbolize=1 symbolize_inline=1 ignore_noninstrumented_modules=1'
+        export TSAN_OPTIONS='ignore_noninstrumented_modules=1'
         export ARCHER_OPTIONS="verbose=1"
 
         export OMP_NUM_THREADS=2

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -15,8 +15,7 @@ concurrency:
 jobs:
   build_UB_sanitizer:
     name: Clang UB sanitizer
-    runs-on: ubuntu-22.04
-    container: ubuntu:23.10
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     env:
       CC: clang
@@ -65,10 +64,6 @@ jobs:
     - name: run with UB sanitizer
       run: |
 
-        # We need these two lines because these tests run inside a docker container
-        export OMPI_ALLOW_RUN_AS_ROOT=1
-        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
         export OMP_NUM_THREADS=2
 
         #MPI implementations often leak memory
@@ -81,8 +76,7 @@ jobs:
 
   build_thread_sanitizer:
     name: Clang thread sanitizer
-    runs-on: ubuntu-22.04
-    container: ubuntu:23.10
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     env:
       CC: clang
@@ -148,10 +142,6 @@ jobs:
         export PMIX_MCA_gds=hash
         export TSAN_OPTIONS='ignore_noninstrumented_modules=1'
         export ARCHER_OPTIONS="verbose=1"
-
-        # We need these two lines because these tests run inside a docker container
-        export OMPI_ALLOW_RUN_AS_ROOT=1
-        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
         export OMP_NUM_THREADS=2
 

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -107,6 +107,8 @@ jobs:
         export CXXFLAGS="-fsanitize=thread"
 
         cmake -S . -B build                 \
+          -DWarpX_amrex_repo=https://github.com/EZoni/amrex.git \
+          -DWarpX_amrex_branch=fix_data_race \
           -GNinja                           \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -121,6 +123,8 @@ jobs:
         cmake --build build -j 4
 
         cmake -S . -B build_EB              \
+          -DWarpX_amrex_repo=https://github.com/EZoni/amrex.git \
+          -DWarpX_amrex_branch=fix_data_race \
           -GNinja                           \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -140,7 +140,7 @@ jobs:
     - name: run with thread sanitizer
       run: |
         export PMIX_MCA_gds=hash
-        export TSAN_OPTIONS='ignore_noninstrumented_modules=1'
+        export TSAN_OPTIONS='symbolize=1 symbolize_inline=1 ignore_noninstrumented_modules=1'
         export ARCHER_OPTIONS="verbose=1"
 
         export OMP_NUM_THREADS=2

--- a/.github/workflows/dependencies/clang17.sh
+++ b/.github/workflows/dependencies/clang17.sh
@@ -7,11 +7,6 @@
 
 set -eu -o pipefail
 
-# This dependency file is currently used within a docker container,
-# which does not come with sudo.
-apt-get -qqq update
-apt-get -y install sudo
-
 # `man apt.conf`:
 #   Number of retries to perform. If this is non-zero APT will retry
 #   failed files the given number of times.


### PR DESCRIPTION
I started seeing this error from the Clang sanitizer workflow in several PRs:
```console
E: The repository 'http://archive.ubuntu.com/ubuntu mantic Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu mantic-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu mantic-backports Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu mantic-security Release' does not have a Release file.
```

The Ubuntu 23.10 container was introduced in #5181 when `ubuntu-24.04` was pre-release as GitHub-hosted runner.

I think we can try to move to `ubuntu-24.04` now and see if this is enough to fix the issue above.