### PR TITLE
[mini] Fix stretch factor in Gaussian initialisation w/ spatial and angular chirps

### DIFF
--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -117,8 +117,8 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
     // Time stretching due to STCs and phi2 complex envelope
     // (1 if zeta=0, beta=0, phi2=0)
     const Complex stretch_factor = 1._rt + 4._rt *
-        (m_params.zeta+m_params.beta*m_params.focal_distance*inv_tau2)
-        * (m_params.zeta+m_params.beta*m_params.focal_distance*inv_complex_waist_2)
+        ((m_params.zeta+m_params.beta*m_params.focal_distance)*inv_tau2)
+        * ((m_params.zeta+m_params.beta*m_params.focal_distance)*inv_complex_waist_2)
         + 2._rt*I*(m_params.phi2-m_params.beta*m_params.beta*k0*m_params.focal_distance)*inv_tau2;
 
     // Amplitude and monochromatic oscillations


### PR DESCRIPTION
It seems to me that PR https://github.com/ECP-WarpX/WarpX/pull/2173 changed the actual terms of laser initialization in the presence of chirps. This PR proposes to revert back to the previous behavior, which I think is more correct. In this way, I think the advantage of https://github.com/ECP-WarpX/WarpX/pull/2173 regarding single-precision are preserved.