### PR TITLE
Fix FieldEnergy reduced diagnostic

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.H
@@ -41,7 +41,7 @@ public:
 
     /**
      * \brief Calculate the integral of the field squared, taking into
-     *        account the covered cell volume.
+     *        account the fraction of the cell volume within the domain.
      *
      * \param field The MultiFab to be integrated
      * \param lev   The refinement level

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.H
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.H
@@ -40,13 +40,14 @@ public:
     void ComputeDiags(int step) final;
 
     /**
-     * \brief Calculate the integral of the field squared in RZ
+     * \brief Calculate the integral of the field squared, taking into
+     *        account the covered cell volume.
      *
      * \param field The MultiFab to be integrated
      * \param lev   The refinement level
      * \return The integral
      */
-    amrex::Real ComputeNorm2RZ(const amrex::MultiFab& field, int lev);
+    amrex::Real ComputeNorm2(const amrex::MultiFab& field, int lev);
 
 };
 

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -159,6 +159,17 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
     amrex::IntVect const domain_lo = matched_domain_box.smallEnd();
     amrex::IntVect const domain_hi = matched_domain_box.bigEnd();
 
+    amrex::IntVect is_periodic;
+    amrex::IntVect half_volume;;
+    for (int idir=0 ; idir < AMREX_SPACEDIM ; idir++) {
+        is_periodic[idir] = (WarpX::field_boundary_hi[idir] == FieldBoundaryType::Periodic);
+        // Only half of the cell volume is within the domain if the field
+        // is nodal but not periodic. For periodic, only the value on the lower
+        // boundary is used, accounting for the half cell at the lower and upper
+        // ends of the domain.
+        half_volume[idir] = (is_nodal[idir] && !is_periodic[idir]);
+    }
+
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
     amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
     using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -172,7 +183,15 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
         amrex::Array4<const amrex::Real> const& field_arr = field.array(mfi);
 
         amrex::Box const tilebox = mfi.tilebox();
-        amrex::Box const tb = convert(tilebox, is_nodal);
+        amrex::Box tb = convert(tilebox, is_nodal);
+
+        for (int idir=0 ; idir < AMREX_SPACEDIM ; idir++) {
+            if (is_periodic[idir]) {
+                // For periodic boundaries, do not include the data in the nodes
+                // on the upper edge of the domain
+                tb.enclosedCells(idir);
+            }
+        }
 
 #if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain
@@ -195,21 +214,21 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
             } else if (rmin == 0._rt && i == irmax) {
                 volume_factor = r/2._rt - dr/8._rt;
             }
-            if (j == domain_lo[1] && is_nodal[1]) { volume_factor *= 0.5_rt; }
-            if (j == domain_hi[1] && is_nodal[1]) { volume_factor *= 0.5_rt; }
+            if (j == domain_lo[1] && half_volume[1]) { volume_factor *= 0.5_rt; }
+            if (j == domain_hi[1] && half_volume[1]) { volume_factor *= 0.5_rt; }
             amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
             return MathConst::pi*volume_factor*theta_integral;
 #else
             // On the boundaries, if the grid is nodal, use half of the volume.
             amrex::Real volume_factor = 1._rt;
             AMREX_D_TERM(
-            if (i == domain_lo[0] && is_nodal[0]) { volume_factor *= 0.5_rt; },
-            if (j == domain_lo[1] && is_nodal[1]) { volume_factor *= 0.5_rt; },
-            if (k == domain_lo[2] && is_nodal[2]) { volume_factor *= 0.5_rt; })
+            if (i == domain_lo[0] && half_volume[0]) { volume_factor *= 0.5_rt; },
+            if (j == domain_lo[1] && half_volume[1]) { volume_factor *= 0.5_rt; },
+            if (k == domain_lo[2] && half_volume[2]) { volume_factor *= 0.5_rt; })
             AMREX_D_TERM(
-            if (i == domain_hi[0] && is_nodal[0]) { volume_factor *= 0.5_rt; },
-            if (j == domain_hi[1] && is_nodal[1]) { volume_factor *= 0.5_rt; },
-            if (k == domain_hi[2] && is_nodal[2]) { volume_factor *= 0.5_rt; })
+            if (i == domain_hi[0] && half_volume[0]) { volume_factor *= 0.5_rt; },
+            if (j == domain_hi[1] && half_volume[1]) { volume_factor *= 0.5_rt; },
+            if (k == domain_hi[2] && half_volume[2]) { volume_factor *= 0.5_rt; })
             return volume_factor;
 #endif
         };

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -147,11 +147,8 @@ void FieldEnergy::ComputeDiags (int step)
 // This takes into account the fraction of the cell volumes within the domain
 // and the cell volumes in cylindrical coordinates.
 amrex::Real
-FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
+FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, [[maybe_unused]]int lev)
 {
-    // get a reference to WarpX instance
-    auto const & warpx = WarpX::GetInstance();
-
     amrex::IntVect const is_nodal = field.ixType().toIntVect();
 
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
@@ -173,14 +170,11 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
 
 #if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain
-        amrex::XDim3 const xyzmin = WarpX::LowerCorner(tilebox, lev, 0._rt);
-        amrex::Dim3 const lo = amrex::lbound(tilebox);
-        amrex::Dim3 const hi = amrex::ubound(tilebox);
+        auto const & warpx = WarpX::GetInstance();
         amrex::Geometry const & geom = warpx.Geom(lev);
         amrex::Real const dr = geom.CellSize(0);
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(tilebox, lev, 0._rt);
         amrex::Real const rmin = xyzmin.x + (is_nodal[0] ? 0._rt : 0.5_rt*dr);
-        int const irmin = lo.x;
-        int const irmax = hi.x;
 #endif
 
         // On the boundaries, if the grid is nodal, use half of the volume.
@@ -192,16 +186,13 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
         auto volume_factor = [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
             amrex::ignore_unused(i,j,k,n);
 #if defined WARPX_DIM_RZ
-            amrex::Real const r = rmin + (i - irmin)*dr;
-            amrex::Real v_factor = r;
-            if (r == 0._rt) {
-                v_factor = dr/8._rt;
-            } else if (rmin == 0._rt && i == irmax) {
-                v_factor = r/2._rt - dr/8._rt;
-            }
+            amrex::Real const r = rmin + (i - tb_lo[0])*dr;
+            amrex::Real v_factor = 2._rt*r;
+            if (i == tb_lo[0] && is_nodal[0]) { v_factor = r + dr/4._rt; }
+            if (i == tb_hi[0] && is_nodal[0]) { v_factor = r - dr/4._rt; }
             if (j == tb_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
             if (j == tb_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
-            amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
+            amrex::Real const theta_integral = (n == 0 ? 1._rt : 0.5_rt);
             return MathConst::pi*v_factor*theta_integral;
 #else
             amrex::Real v_factor = 1._rt;

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -159,17 +159,6 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
     amrex::IntVect const domain_lo = matched_domain_box.smallEnd();
     amrex::IntVect const domain_hi = matched_domain_box.bigEnd();
 
-    amrex::IntVect is_periodic;
-    amrex::IntVect half_volume;;
-    for (int idir=0 ; idir < AMREX_SPACEDIM ; idir++) {
-        is_periodic[idir] = (WarpX::field_boundary_hi[idir] == FieldBoundaryType::Periodic);
-        // Only half of the cell volume is within the domain if the field
-        // is nodal but not periodic. For periodic, only the value on the lower
-        // boundary is used, accounting for the half cell at the lower and upper
-        // ends of the domain.
-        half_volume[idir] = (is_nodal[idir] && !is_periodic[idir]);
-    }
-
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
     amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
     using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -184,14 +173,6 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
 
         amrex::Box const tilebox = mfi.tilebox();
         amrex::Box tb = convert(tilebox, is_nodal);
-
-        for (int idir=0 ; idir < AMREX_SPACEDIM ; idir++) {
-            if (is_periodic[idir]) {
-                // For periodic boundaries, do not include the data in the nodes
-                // on the upper edge of the domain
-                tb.enclosedCells(idir);
-            }
-        }
 
 #if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain
@@ -214,21 +195,21 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
             } else if (rmin == 0._rt && i == irmax) {
                 v_factor = r/2._rt - dr/8._rt;
             }
-            if (j == domain_lo[1] && half_volume[1]) { v_factor *= 0.5_rt; }
-            if (j == domain_hi[1] && half_volume[1]) { v_factor *= 0.5_rt; }
+            if (j == domain_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
+            if (j == domain_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
             amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
             return MathConst::pi*v_factor*theta_integral;
 #else
             // On the boundaries, if the grid is nodal, use half of the volume.
             amrex::Real v_factor = 1._rt;
             AMREX_D_TERM(
-            if (i == domain_lo[0] && half_volume[0]) { v_factor *= 0.5_rt; },
-            if (j == domain_lo[1] && half_volume[1]) { v_factor *= 0.5_rt; },
-            if (k == domain_lo[2] && half_volume[2]) { v_factor *= 0.5_rt; })
+            if (i == domain_lo[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
+            if (j == domain_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
+            if (k == domain_lo[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
             AMREX_D_TERM(
-            if (i == domain_hi[0] && half_volume[0]) { v_factor *= 0.5_rt; },
-            if (j == domain_hi[1] && half_volume[1]) { v_factor *= 0.5_rt; },
-            if (k == domain_hi[2] && half_volume[2]) { v_factor *= 0.5_rt; })
+            if (i == domain_hi[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
+            if (j == domain_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
+            if (k == domain_hi[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
             return v_factor;
 #endif
         };

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -172,7 +172,7 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
         amrex::Array4<const amrex::Real> const& field_arr = field.array(mfi);
 
         amrex::Box const tilebox = mfi.tilebox();
-        amrex::Box tb = convert(tilebox, is_nodal);
+        amrex::Box const tb = convert(tilebox, is_nodal);
 
 #if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -155,9 +155,6 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
     amrex::Geometry const & geom = warpx.Geom(lev);
 
     amrex::IntVect const is_nodal = field.ixType().toIntVect();
-    amrex::Box const matched_domain_box = convert(geom.Domain(), is_nodal);
-    amrex::IntVect const domain_lo = matched_domain_box.smallEnd();
-    amrex::IntVect const domain_hi = matched_domain_box.bigEnd();
 
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
     amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
@@ -173,6 +170,8 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
 
         amrex::Box const tilebox = mfi.tilebox();
         amrex::Box const tb = convert(tilebox, is_nodal);
+        amrex::IntVect const tb_lo = tb.smallEnd();
+        amrex::IntVect const tb_hi = tb.bigEnd();
 
 #if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain
@@ -185,6 +184,12 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
         int const irmax = hi.x;
 #endif
 
+        // On the boundaries, if the grid is nodal, use half of the volume.
+        // This applies to all boundary conditions, and to the overlap of
+        // boxes within the domain.
+        // Previously, the code used MultiFab::norm2, but that does not do
+        // the half-volume scaling for the domain boundaries when not periodic.
+
         auto volume_factor = [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
             amrex::ignore_unused(i,j,k,n);
 #if defined WARPX_DIM_RZ
@@ -195,21 +200,20 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
             } else if (rmin == 0._rt && i == irmax) {
                 v_factor = r/2._rt - dr/8._rt;
             }
-            if (j == domain_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
-            if (j == domain_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
+            if (j == tb_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
+            if (j == tb_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; }
             amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
             return MathConst::pi*v_factor*theta_integral;
 #else
-            // On the boundaries, if the grid is nodal, use half of the volume.
             amrex::Real v_factor = 1._rt;
             AMREX_D_TERM(
-            if (i == domain_lo[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
-            if (j == domain_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
-            if (k == domain_lo[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
+            if (i == tb_lo[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
+            if (j == tb_lo[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
+            if (k == tb_lo[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
             AMREX_D_TERM(
-            if (i == domain_hi[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
-            if (j == domain_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
-            if (k == domain_hi[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
+            if (i == tb_hi[0] && is_nodal[0]) { v_factor *= 0.5_rt; },
+            if (j == tb_hi[1] && is_nodal[1]) { v_factor *= 0.5_rt; },
+            if (k == tb_hi[2] && is_nodal[2]) { v_factor *= 0.5_rt; })
             return v_factor;
 #endif
         };

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -30,7 +30,7 @@
 #include <fstream>
 #include <vector>
 
-using namespace amrex;
+using namespace amrex::literals;
 using warpx::fields::FieldType;
 
 // constructor
@@ -40,7 +40,7 @@ FieldEnergy::FieldEnergy (const std::string& rd_name)
 
     // read number of levels
     int nLevel = 0;
-    const ParmParse pp_amr("amr");
+    amrex::ParmParse const pp_amr("amr");
     pp_amr.query("max_level", nLevel);
     nLevel += 1;
 
@@ -48,7 +48,7 @@ FieldEnergy::FieldEnergy (const std::string& rd_name)
     // resize data array
     m_data.resize(noutputs*nLevel, 0.0_rt);
 
-    if (ParallelDescriptor::IOProcessor())
+    if (amrex::ParallelDescriptor::IOProcessor())
     {
         if ( m_write_header )
         {
@@ -84,10 +84,10 @@ void FieldEnergy::ComputeDiags (int step)
     if (!m_intervals.contains(step+1)) { return; }
 
     // get a reference to WarpX instance
-    auto & warpx = WarpX::GetInstance();
+    auto const & warpx = WarpX::GetInstance();
 
     // get number of level
-    const auto nLevel = warpx.finestLevel() + 1;
+    int const nLevel = warpx.finestLevel() + 1;
 
     using ablastr::fields::Direction;
 
@@ -95,42 +95,29 @@ void FieldEnergy::ComputeDiags (int step)
     for (int lev = 0; lev < nLevel; ++lev)
     {
         // get MultiFab data at lev
-        const MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        amrex::MultiFab const & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
+        amrex::MultiFab const & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
+        amrex::MultiFab const & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
+        amrex::MultiFab const & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
+        amrex::MultiFab const & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
+        amrex::MultiFab const & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
 
         // get cell volume
-        const std::array<Real, 3> &dx = WarpX::CellSize(lev);
-        const amrex::Real dV = dx[0]*dx[1]*dx[2];
-
-#if defined(WARPX_DIM_RZ)
-        amrex::Real const tmpEx = ComputeNorm2RZ(Ex, lev);
-        amrex::Real const tmpEy = ComputeNorm2RZ(Ey, lev);
-        amrex::Real const tmpEz = ComputeNorm2RZ(Ez, lev);
-        amrex::Real const Es = tmpEx + tmpEy + tmpEz;
-
-        amrex::Real const tmpBx = ComputeNorm2RZ(Bx, lev);
-        amrex::Real const tmpBy = ComputeNorm2RZ(By, lev);
-        amrex::Real const tmpBz = ComputeNorm2RZ(Bz, lev);
-        amrex::Real const Bs = tmpBx + tmpBy + tmpBz;
-#else
-        Geometry const & geom = warpx.Geom(lev);
+        std::array<amrex::Real, 3> const &dx = WarpX::CellSize(lev);
+        amrex::Real const dV = dx[0]*dx[1]*dx[2];
 
         // compute E squared
-        Real const tmpEx = Ex.norm2(0,geom.periodicity());
-        Real const tmpEy = Ey.norm2(0,geom.periodicity());
-        Real const tmpEz = Ez.norm2(0,geom.periodicity());
-        Real const Es = tmpEx*tmpEx + tmpEy*tmpEy + tmpEz*tmpEz;
+        amrex::Real const tmpEx = ComputeNorm2(Ex, lev);
+        amrex::Real const tmpEy = ComputeNorm2(Ey, lev);
+        amrex::Real const tmpEz = ComputeNorm2(Ez, lev);
 
         // compute B squared
-        Real const tmpBx = Bx.norm2(0,geom.periodicity());
-        Real const tmpBy = By.norm2(0,geom.periodicity());
-        Real const tmpBz = Bz.norm2(0,geom.periodicity());
-        Real const Bs = tmpBx*tmpBx + tmpBy*tmpBy + tmpBz*tmpBz;
-#endif
+        amrex::Real const tmpBx = ComputeNorm2(Bx, lev);
+        amrex::Real const tmpBy = ComputeNorm2(By, lev);
+        amrex::Real const tmpBz = ComputeNorm2(Bz, lev);
+
+        amrex::Real const Es = tmpEx + tmpEy + tmpEz;
+        amrex::Real const Bs = tmpBx + tmpBy + tmpBz;
 
         constexpr int noutputs = 3; // total energy, E-field energy and B-field energy
         constexpr int index_total = 0;
@@ -156,15 +143,21 @@ void FieldEnergy::ComputeDiags (int step)
 }
 // end void FieldEnergy::ComputeDiags
 
-// Function that computes the sum of the field squared in RZ
+// Function that computes the sum of the field squared.
+// This takes into account the half-cell volumes at the edges of the domain
+// and the cell volumes in cylindrical coordinates.
 amrex::Real
-FieldEnergy::ComputeNorm2RZ(const amrex::MultiFab& field, const int lev)
+FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
 {
     // get a reference to WarpX instance
-    auto & warpx = WarpX::GetInstance();
+    auto const & warpx = WarpX::GetInstance();
 
-    Geometry const & geom = warpx.Geom(lev);
-    const amrex::Real dr = geom.CellSize(0);
+    amrex::Geometry const & geom = warpx.Geom(lev);
+
+    amrex::IntVect const is_nodal = field.ixType().toIntVect();
+    amrex::Box const matched_domain_box = convert(geom.Domain(), is_nodal);
+    amrex::IntVect const domain_lo = matched_domain_box.smallEnd();
+    amrex::IntVect const domain_hi = matched_domain_box.bigEnd();
 
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
     amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
@@ -178,45 +171,59 @@ FieldEnergy::ComputeNorm2RZ(const amrex::MultiFab& field, const int lev)
 
         amrex::Array4<const amrex::Real> const& field_arr = field.array(mfi);
 
-        const amrex::Box tilebox = mfi.tilebox();
-        amrex::Box tb = convert(tilebox, field.ixType().toIntVect());
+        amrex::Box const tilebox = mfi.tilebox();
+        amrex::Box const tb = convert(tilebox, is_nodal);
 
+#if defined(WARPX_DIM_RZ)
         // Lower corner of tile box physical domain
-        const amrex::XDim3 xyzmin = WarpX::LowerCorner(tilebox, lev, 0._rt);
-        const Dim3 lo = lbound(tilebox);
-        const Dim3 hi = ubound(tilebox);
-        const Real rmin = xyzmin.x + (tb.ixType().nodeCentered(0) ? 0._rt : 0.5_rt*dr);
-        const int irmin = lo.x;
-        const int irmax = hi.x;
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(tilebox, lev, 0._rt);
+        amrex::Dim3 const lo = amrex::lbound(tilebox);
+        amrex::Dim3 const hi = amrex::ubound(tilebox);
+        amrex::Real const dr = geom.CellSize(0);
+        amrex::Real const rmin = xyzmin.x + (is_nodal[0] ? 0._rt : 0.5_rt*dr);
+        int const irmin = lo.x;
+        int const irmax = hi.x;
+#endif
+
+        auto volume_factor = [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+            amrex::ignore_unused(i,j,k,n);
+#if defined WARPX_DIM_RZ
+            amrex::Real const r = rmin + (i - irmin)*dr;
+            amrex::Real volume_factor = r;
+            if (r == 0._rt) {
+                volume_factor = dr/8._rt;
+            } else if (rmin == 0._rt && i == irmax) {
+                volume_factor = r/2._rt - dr/8._rt;
+            }
+            if (j == domain_lo[1] && is_nodal[1]) { volume_factor *= 0.5_rt; }
+            if (j == domain_hi[1] && is_nodal[1]) { volume_factor *= 0.5_rt; }
+            amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
+            return MathConst::pi*volume_factor*theta_integral;
+#else
+            // On the boundaries, if the grid is nodal, use half of the volume.
+            amrex::Real volume_factor = 1._rt;
+            AMREX_D_TERM(
+            if (i == domain_lo[0] && is_nodal[0]) { volume_factor *= 0.5_rt; },
+            if (j == domain_lo[1] && is_nodal[1]) { volume_factor *= 0.5_rt; },
+            if (k == domain_lo[2] && is_nodal[2]) { volume_factor *= 0.5_rt; })
+            AMREX_D_TERM(
+            if (i == domain_hi[0] && is_nodal[0]) { volume_factor *= 0.5_rt; },
+            if (j == domain_hi[1] && is_nodal[1]) { volume_factor *= 0.5_rt; },
+            if (k == domain_hi[2] && is_nodal[2]) { volume_factor *= 0.5_rt; })
+            return volume_factor;
+#endif
+        };
 
         int const ncomp = field.nComp();
-
-        for (int idir=0 ; idir < AMREX_SPACEDIM ; idir++) {
-            if (WarpX::field_boundary_hi[idir] == FieldBoundaryType::Periodic) {
-                // For periodic boundaries, do not include the data in the nodes
-                // on the upper edge of the domain
-                tb.enclosedCells(idir);
-            }
-        }
 
         reduce_ops.eval(tb, ncomp, reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) -> ReduceTuple
             {
-                const amrex::Real r = rmin + (i - irmin)*dr;
-                amrex::Real volume_factor = r;
-                if (r == 0._rt) {
-                    volume_factor = dr/8._rt;
-                } else if (rmin == 0._rt && i == irmax) {
-                    volume_factor = r/2._rt - dr/8._rt;
-                }
-                const amrex::Real theta_integral = (n == 0 ? 2._rt : 1._rt);
-                return theta_integral*field_arr(i,j,k,n)*field_arr(i,j,k,n)*volume_factor;
+                return field_arr(i,j,k,n)*field_arr(i,j,k,n)*volume_factor(i,j,k,n);
             });
 
     }
 
-    const amrex::Real field_sum = amrex::get<0>(reduce_data.value());
-    const amrex::Real result = MathConst::pi*field_sum;
+    amrex::Real const result = amrex::get<0>(reduce_data.value());
     return result;
 }
-// end Real FieldEnergy::ComputeNorm2RZ

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -218,6 +218,8 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, [[maybe_unused]]int lev)
 
     }
 
-    amrex::Real const result = amrex::get<0>(reduce_data.value());
+    amrex::Real result = amrex::get<0>(reduce_data.value());
+    amrex::ParallelDescriptor::ReduceRealSum(result);
+
     return result;
 }

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -208,28 +208,28 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
             amrex::ignore_unused(i,j,k,n);
 #if defined WARPX_DIM_RZ
             amrex::Real const r = rmin + (i - irmin)*dr;
-            amrex::Real volume_factor = r;
+            amrex::Real v_factor = r;
             if (r == 0._rt) {
-                volume_factor = dr/8._rt;
+                v_factor = dr/8._rt;
             } else if (rmin == 0._rt && i == irmax) {
-                volume_factor = r/2._rt - dr/8._rt;
+                v_factor = r/2._rt - dr/8._rt;
             }
-            if (j == domain_lo[1] && half_volume[1]) { volume_factor *= 0.5_rt; }
-            if (j == domain_hi[1] && half_volume[1]) { volume_factor *= 0.5_rt; }
+            if (j == domain_lo[1] && half_volume[1]) { v_factor *= 0.5_rt; }
+            if (j == domain_hi[1] && half_volume[1]) { v_factor *= 0.5_rt; }
             amrex::Real const theta_integral = (n == 0 ? 2._rt : 1._rt);
-            return MathConst::pi*volume_factor*theta_integral;
+            return MathConst::pi*v_factor*theta_integral;
 #else
             // On the boundaries, if the grid is nodal, use half of the volume.
-            amrex::Real volume_factor = 1._rt;
+            amrex::Real v_factor = 1._rt;
             AMREX_D_TERM(
-            if (i == domain_lo[0] && half_volume[0]) { volume_factor *= 0.5_rt; },
-            if (j == domain_lo[1] && half_volume[1]) { volume_factor *= 0.5_rt; },
-            if (k == domain_lo[2] && half_volume[2]) { volume_factor *= 0.5_rt; })
+            if (i == domain_lo[0] && half_volume[0]) { v_factor *= 0.5_rt; },
+            if (j == domain_lo[1] && half_volume[1]) { v_factor *= 0.5_rt; },
+            if (k == domain_lo[2] && half_volume[2]) { v_factor *= 0.5_rt; })
             AMREX_D_TERM(
-            if (i == domain_hi[0] && half_volume[0]) { volume_factor *= 0.5_rt; },
-            if (j == domain_hi[1] && half_volume[1]) { volume_factor *= 0.5_rt; },
-            if (k == domain_hi[2] && half_volume[2]) { volume_factor *= 0.5_rt; })
-            return volume_factor;
+            if (i == domain_hi[0] && half_volume[0]) { v_factor *= 0.5_rt; },
+            if (j == domain_hi[1] && half_volume[1]) { v_factor *= 0.5_rt; },
+            if (k == domain_hi[2] && half_volume[2]) { v_factor *= 0.5_rt; })
+            return v_factor;
 #endif
         };
 

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -144,7 +144,7 @@ void FieldEnergy::ComputeDiags (int step)
 // end void FieldEnergy::ComputeDiags
 
 // Function that computes the sum of the field squared.
-// This takes into account the half-cell volumes at the edges of the domain
+// This takes into account the fraction of the cell volumes within the domain
 // and the cell volumes in cylindrical coordinates.
 amrex::Real
 FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -152,8 +152,6 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
     // get a reference to WarpX instance
     auto const & warpx = WarpX::GetInstance();
 
-    amrex::Geometry const & geom = warpx.Geom(lev);
-
     amrex::IntVect const is_nodal = field.ixType().toIntVect();
 
     amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
@@ -178,6 +176,7 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, int lev)
         amrex::XDim3 const xyzmin = WarpX::LowerCorner(tilebox, lev, 0._rt);
         amrex::Dim3 const lo = amrex::lbound(tilebox);
         amrex::Dim3 const hi = amrex::ubound(tilebox);
+        amrex::Geometry const & geom = warpx.Geom(lev);
         amrex::Real const dr = geom.CellSize(0);
         amrex::Real const rmin = xyzmin.x + (is_nodal[0] ? 0._rt : 0.5_rt*dr);
         int const irmin = lo.x;


### PR DESCRIPTION
Fix FieldEnergy reduced diagnostic to account for partial cell volumes on the domain boundaries. For fields that are nodal on the boundary, the integral is only over the fraction of the cell centered about the field value within the domain.

This PR also tidies up the code for the diagnostic.