### PR TITLE
Added abort message if 1D PSATD is used

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1080,12 +1080,10 @@ WarpX::ReadParameters ()
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD,
             "algo.maxwell_solver = psatd is not supported because WarpX was built without spectral solvers");
 #endif
-
 #if defined(WARPX_DIM_1D_Z) && defined(WARPX_USE_FFT)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE( electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD,
             "algo.maxwell_solver = psatd is not available for 1D geometry");
 #endif
-
 #ifdef WARPX_DIM_RZ
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(0) == 0,
             "The problem must not be periodic in the radial direction");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1081,6 +1081,11 @@ WarpX::ReadParameters ()
             "algo.maxwell_solver = psatd is not supported because WarpX was built without spectral solvers");
 #endif
 
+#if defined(WARPX_DIM_1D_Z) && defined(WARPX_USE_FFT)
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE( electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD,
+            "algo.maxwell_solver = psatd is not available for 1D geometry");
+#endif
+
 #ifdef WARPX_DIM_RZ
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(Geom(0).isPeriodic(0) == 0,
             "The problem must not be periodic in the radial direction");


### PR DESCRIPTION
Added an abort message for cases where 1D PSATD is used, as it’s not implemented for this geometry.