### PR TITLE
AMReX/pyAMReX/PICSAR: weekly update

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -126,7 +126,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd ../amrex && git checkout --detach 24.12 && cd -
+        cd ../amrex && git checkout --detach 96db0a665ff1e6bbe638490fd02d3aafb9188f6b && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_FFT=TRUE USE_CCACHE=TRUE -j 4
 
         ccache -s

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -294,7 +294,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "24.12"
+set(WarpX_amrex_branch "96db0a665ff1e6bbe638490fd02d3aafb9188f6b"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 


### PR DESCRIPTION
Anticipating the weekly update due to upcoming retreat. This makes https://github.com/AMReX-Codes/amrex/pull/4255 visible to WarpX.


- Weekly update to latest AMReX:
```console
./Tools/Release/updateAMReX.py
```
- Weekly update to latest pyAMReX (no changes since 24.12):
```console
./Tools/Release/updatepyAMReX.py
```
- Weekly update to latest PICSAR (no changes since 24.09):
```console
./Tools/Release/updatePICSAR.py
```