### PR TITLE
Add `verbosity` flag for diagnostic output print statements

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1091,7 +1091,7 @@ BTDiagnostics::Flush (int i_buffer, bool force_flush)
         m_varnames, m_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
         labtime,
         m_output_species.at(i_buffer), nlev_output, file_name, m_file_min_digits,
-        m_plot_raw_fields, m_plot_raw_fields_guards,
+        m_plot_raw_fields, m_plot_raw_fields_guards, m_verbose,
         use_pinned_pc, isBTD, i_buffer, m_buffer_flush_counter.at(i_buffer),
         m_max_buffer_multifabs.at(i_buffer), m_geom_snapshot.at(i_buffer).at(0), isLastBTDFlush);
 

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -153,7 +153,7 @@ BoundaryScrapingDiagnostics::Flush (int i_buffer, bool /* force_flush */)
         warpx.gett_new(0),
         m_output_species.at(i_buffer),
         nlev_output, file_prefix,
-        m_file_min_digits, false, false, use_pinned_pc, isBTD,
+        m_file_min_digits, false, false, m_verbose, use_pinned_pc, isBTD,
         warpx.getistep(0), bufferID, numBTDBuffers, geom,
         isLastBTD);
 

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -190,6 +190,8 @@ public:
 protected:
     /** Read Parameters of the base Diagnostics class */
     bool BaseReadParameters ();
+    /** Whether to output a message when diagnostics are output */
+    int m_verbose = 2;
     /** Initialize member variables of the base Diagnostics class. */
     void InitBaseData ();
     /** Initialize m_mf_output vectors and data required to construct the buffers

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -62,6 +62,9 @@ Diagnostics::BaseReadParameters ()
     std::string dims;
     pp_geometry.get("dims", dims);
 
+    const amrex::ParmParse pp_warpx("warpx");
+    pp_warpx.query("verbose", m_verbose);
+
     // Query list of grid fields to write to output
     const bool varnames_specified = pp_diag_name.queryarr("fields_to_plot", m_varnames_fields);
     if (!varnames_specified){

--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -23,7 +23,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false) const = 0;
+        bool isLastBTDFlush = false,
+        int verbose = 2 ) const = 0;
 
     FlushFormat () = default;
     virtual ~FlushFormat() = default;

--- a/Source/Diagnostics/FlushFormats/FlushFormat.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormat.H
@@ -19,12 +19,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2 ) const = 0;
+        bool isLastBTDFlush = false) const = 0;
 
     FlushFormat () = default;
     virtual ~FlushFormat() = default;

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -41,7 +41,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false ) const override;
+        bool isLastBTDFlush = false,
+        int verbose = 2 ) const override;
 
     FlushFormatAscent ()          = default;
     ~FlushFormatAscent() override = default;

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.H
@@ -37,12 +37,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2 ) const override;
+        bool isLastBTDFlush = false) const override;
 
     FlushFormatAscent ()          = default;
     ~FlushFormatAscent() override = default;

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -21,7 +21,8 @@ FlushFormatAscent::WriteToFile (
     const bool /*use_pinned_pc*/,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool /*isLastBTDFlush*/) const
+    bool /*isLastBTDFlush*/,
+    int /*verbose*/) const
 {
 #ifdef AMREX_USE_ASCENT
     WARPX_PROFILE("FlushFormatAscent::WriteToFile()");

--- a/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatAscent.cpp
@@ -18,11 +18,11 @@ FlushFormatAscent::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    int verbose,
     const bool /*use_pinned_pc*/,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool /*isLastBTDFlush*/,
-    int /*verbose*/) const
+    bool /*isLastBTDFlush*/) const
 {
 #ifdef AMREX_USE_ASCENT
     WARPX_PROFILE("FlushFormatAscent::WriteToFile()");
@@ -33,7 +33,9 @@ FlushFormatAscent::WriteToFile (
         "In-situ visualization is not currently supported for back-transformed diagnostics.");
 
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);
-    amrex::Print() << Utils::TextMsg::Info("Writing Ascent file " + filename);
+    if (verbose > 0) {
+        amrex::Print() << Utils::TextMsg::Info("Writing Ascent file " + filename);
+    }
 
     // wrap mesh data
     WARPX_PROFILE_VAR("FlushFormatAscent::WriteToFile::MultiLevelToBlueprint", prof_ascent_mesh_blueprint);
@@ -68,7 +70,7 @@ FlushFormatAscent::WriteToFile (
 
 #else
     amrex::ignore_unused(varnames, mf, geom, iteration, time,
-        particle_diags, nlev, file_min_digits, isBTD);
+        particle_diags, nlev, file_min_digits, verbose, isBTD);
 #endif // AMREX_USE_ASCENT
     amrex::ignore_unused(prefix, plot_raw_fields, plot_raw_fields_guards);
 }

--- a/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.H
@@ -47,7 +47,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false)  const override;
+        bool isLastBTDFlush = false,
+        int verbose = 2)  const override;
 
 #ifdef AMREX_USE_CATALYST
     ~FlushFormatCatalyst() override;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.H
@@ -43,12 +43,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2)  const override;
+        bool isLastBTDFlush = false)  const override;
 
 #ifdef AMREX_USE_CATALYST
     ~FlushFormatCatalyst() override;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.cpp
@@ -127,11 +127,11 @@ FlushFormatCatalyst::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    int /*verbose*/,
     bool /*use_pinned_pc*/,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool /*isLastBTDFlush*/,
-    int /*verbose*/) const
+    bool /*isLastBTDFlush*/) const
 {
 #ifdef AMREX_USE_CATALYST
     amrex::Print() << Utils::TextMsg::Info("Running Catalyst pipeline scripts...");

--- a/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCatalyst.cpp
@@ -130,7 +130,8 @@ FlushFormatCatalyst::WriteToFile (
     bool /*use_pinned_pc*/,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool /*isLastBTDFlush*/) const
+    bool /*isLastBTDFlush*/,
+    int /*verbose*/) const
 {
 #ifdef AMREX_USE_CATALYST
     amrex::Print() << Utils::TextMsg::Info("Running Catalyst pipeline scripts...");

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -24,12 +24,12 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2) const final;
+        bool isLastBTDFlush = false) const final;
 
     void CheckpointParticles (const std::string& dir,
                               const amrex::Vector<ParticleDiag>& particle_diags) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.H
@@ -28,7 +28,8 @@ class FlushFormatCheckpoint final : public FlushFormatPlotfile
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false) const final;
+        bool isLastBTDFlush = false,
+        int verbose = 2) const final;
 
     void CheckpointParticles (const std::string& dir,
                               const amrex::Vector<ParticleDiag>& particle_diags) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -39,12 +39,12 @@ FlushFormatCheckpoint::WriteToFile (
         const std::string prefix, int file_min_digits,
         bool /*plot_raw_fields*/,
         bool /*plot_raw_fields_guards*/,
+        int verbose,
         const bool /*use_pinned_pc*/,
         bool /*isBTD*/, int /*snapshotID*/,
         int /*bufferID*/, int /*numBuffers*/,
         const amrex::Geometry& /*full_BTD_snapshot*/,
-        bool /*isLastBTDFlush*/,
-        int verbose) const
+        bool /*isLastBTDFlush*/) const
 {
     using ablastr::fields::Direction;
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -43,7 +43,8 @@ FlushFormatCheckpoint::WriteToFile (
         bool /*isBTD*/, int /*snapshotID*/,
         int /*bufferID*/, int /*numBuffers*/,
         const amrex::Geometry& /*full_BTD_snapshot*/,
-        bool /*isLastBTDFlush*/) const
+        bool /*isLastBTDFlush*/,
+        int verbose) const
 {
     using ablastr::fields::Direction;
 
@@ -56,8 +57,10 @@ FlushFormatCheckpoint::WriteToFile (
 
     const std::string& checkpointname = amrex::Concatenate(prefix, iteration[0], file_min_digits);
 
-    amrex::Print() << Utils::TextMsg::Info(
-        "Writing checkpoint " + checkpointname);
+    if (verbose > 0) {
+        amrex::Print() << Utils::TextMsg::Info(
+            "Writing checkpoint " + checkpointname);
+    }
 
     // const int nlevels = finestLevel()+1;
     amrex::PreBuildDirectorHierarchy(checkpointname, default_level_prefix, nlev, true);

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -36,12 +36,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2 ) const override;
+        bool isLastBTDFlush = false) const override;
 
     ~FlushFormatOpenPMD () override = default;
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.H
@@ -40,7 +40,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false ) const override;
+        bool isLastBTDFlush = false,
+        int verbose = 2 ) const override;
 
     ~FlushFormatOpenPMD () override = default;
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -126,20 +126,23 @@ FlushFormatOpenPMD::WriteToFile (
     const bool use_pinned_pc,
     bool isBTD, int snapshotID, int bufferID, int numBuffers,
     const amrex::Geometry& full_BTD_snapshot,
-    bool isLastBTDFlush) const
+    bool isLastBTDFlush,
+    int verbose) const
 {
     WARPX_PROFILE("FlushFormatOpenPMD::WriteToFile()");
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);
-    if (!isBTD)
-    {
-        amrex::Print() << Utils::TextMsg::Info("Writing openPMD file " + filename);
-    } else
-    {
-        amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
-                            + " to snapshot " + std::to_string(snapshotID) +  " to openPMD BTD " + prefix);
-        if (isLastBTDFlush)
+    if (verbose > 0) {
+        if (!isBTD)
         {
-            amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in openPMD BTD " + prefix);
+            amrex::Print() << Utils::TextMsg::Info("Writing openPMD file " + filename);
+        } else
+        {
+            amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
+                                + " to snapshot " + std::to_string(snapshotID) +  " to openPMD BTD " + prefix);
+            if (isLastBTDFlush)
+            {
+                amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in openPMD BTD " + prefix);
+            }
         }
     }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -123,11 +123,11 @@ FlushFormatOpenPMD::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int output_levels,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    int verbose,
     const bool use_pinned_pc,
     bool isBTD, int snapshotID, int bufferID, int numBuffers,
     const amrex::Geometry& full_BTD_snapshot,
-    bool isLastBTDFlush,
-    int verbose) const
+    bool isLastBTDFlush) const
 {
     WARPX_PROFILE("FlushFormatOpenPMD::WriteToFile()");
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -31,12 +31,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2 ) const override;
+        bool isLastBTDFlush = false) const override;
 
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.H
@@ -35,7 +35,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false) const override;
+        bool isLastBTDFlush = false,
+        int verbose = 2 ) const override;
 
     /** Write general info of the run into the plotfile */
     void WriteJobInfo(const std::string& dir) const;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -81,12 +81,12 @@ FlushFormatPlotfile::WriteToFile (
             amrex::Print() << Utils::TextMsg::Info("Writing plotfile " + filename);
         } else
         {
-        amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
-                            + " to snapshot " + std::to_string(snapshotID) +  " in plotfile BTD " + prefix );
-        if (isLastBTDFlush)
-        {
-            amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in plotfile BTD " + filename);
-        }
+            amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
+                                + " to snapshot " + std::to_string(snapshotID) +  " in plotfile BTD " + prefix );
+            if (isLastBTDFlush)
+            {
+                amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in plotfile BTD " + filename);
+            }
         }
     }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -69,22 +69,25 @@ FlushFormatPlotfile::WriteToFile (
     const bool /*use_pinned_pc*/,
     bool isBTD, int snapshotID,  int bufferID, int numBuffers,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool isLastBTDFlush) const
+    bool isLastBTDFlush,
+    int verbose) const
 {
     WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);
-    if (!isBTD)
-    {
-      amrex::Print() << Utils::TextMsg::Info("Writing plotfile " + filename);
-    } else
-    {
-      amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
-                        + " to snapshot " + std::to_string(snapshotID) +  " in plotfile BTD " + prefix );
-      if (isLastBTDFlush)
-      {
-        amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in plotfile BTD " + filename);
-      }
+    if (verbose > 0) {
+        if (!isBTD)
+        {
+            amrex::Print() << Utils::TextMsg::Info("Writing plotfile " + filename);
+        } else
+        {
+        amrex::Print() << Utils::TextMsg::Info("Writing buffer " + std::to_string(bufferID+1) + " of " + std::to_string(numBuffers)
+                            + " to snapshot " + std::to_string(snapshotID) +  " in plotfile BTD " + prefix );
+        if (isLastBTDFlush)
+        {
+            amrex::Print() << Utils::TextMsg::Info("Finished writing snapshot " + std::to_string(snapshotID) + " in plotfile BTD " + filename);
+        }
+        }
     }
 
     Vector<std::string> rfs;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -66,11 +66,11 @@ FlushFormatPlotfile::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags, int nlev,
     const std::string prefix, int file_min_digits, bool plot_raw_fields,
     bool plot_raw_fields_guards,
+    int verbose,
     const bool /*use_pinned_pc*/,
     bool isBTD, int snapshotID,  int bufferID, int numBuffers,
     const amrex::Geometry& /*full_BTD_snapshot*/,
-    bool isLastBTDFlush,
-    int verbose) const
+    bool isLastBTDFlush) const
 {
     WARPX_PROFILE("FlushFormatPlotfile::WriteToFile()");
     auto & warpx = WarpX::GetInstance();

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -57,12 +57,12 @@ public:
         std::string prefix, int file_min_digits,
         bool plot_raw_fields,
         bool plot_raw_fields_guards,
+        int verbose = 2,
         bool use_pinned_pc = false,
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false,
-        int verbose = 2) const override;
+        bool isLastBTDFlush = false) const override;
 
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -61,7 +61,8 @@ public:
         bool isBTD = false, int snapshotID = -1,
         int bufferID = 1, int numBuffers = 1,
         const amrex::Geometry& full_BTD_snapshot = amrex::Geometry(),
-        bool isLastBTDFlush = false) const override;
+        bool isLastBTDFlush = false,
+        int verbose = 2) const override;
 
     /** \brief Do in-situ visualization for particle data.
      * \param[in] particle_diags Each element of this vector handles output of 1 species.

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -51,10 +51,9 @@ FlushFormatSensei::WriteToFile (
     const amrex::Vector<ParticleDiag>& particle_diags,
     int nlev, const std::string prefix, int file_min_digits,
     bool plot_raw_fields, bool plot_raw_fields_guards,
-    const bool use_pinned_pc,
+    int verbose, const bool use_pinned_pc,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
-    const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/,
-    int /*verbose*/ ) const
+    const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
 {
     amrex::ignore_unused(
         geom, nlev, prefix, file_min_digits,
@@ -64,7 +63,7 @@ FlushFormatSensei::WriteToFile (
 
 #ifndef AMREX_USE_SENSEI_INSITU
     amrex::ignore_unused(varnames, mf, iteration, time, particle_diags,
-                         isBTD);
+                         verbose, isBTD);
 #else
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !isBTD,
@@ -72,7 +71,9 @@ FlushFormatSensei::WriteToFile (
 
     WARPX_PROFILE("FlushFormatSensei::WriteToFile()");
     const std::string& filename = amrex::Concatenate(prefix, iteration[0], file_min_digits);
-    amrex::Print() << Utils::TextMsg::Info("Writing Sensei file " + filename);
+    if (verbose > 0) {
+        amrex::Print() << Utils::TextMsg::Info("Writing Sensei file " + filename);
+    }
 
     amrex::Vector<amrex::MultiFab> *mf_ptr =
         const_cast<amrex::Vector<amrex::MultiFab>*>(&mf);

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -53,7 +53,8 @@ FlushFormatSensei::WriteToFile (
     bool plot_raw_fields, bool plot_raw_fields_guards,
     const bool use_pinned_pc,
     bool isBTD, int /*snapshotID*/, int /*bufferID*/, int /*numBuffers*/,
-    const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/) const
+    const amrex::Geometry& /*full_BTD_snapshot*/, bool /*isLastBTDFlush*/,
+    int /*verbose*/ ) const
 {
     amrex::ignore_unused(
         geom, nlev, prefix, file_min_digits,

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -43,8 +43,6 @@ private:
     amrex::Real m_average_period_time = -1.0;
     /** Time step to start averaging */
     int m_average_start_step = -1;
-    /** Whether to output a message when diagnostics are output */
-    int m_verbose = 2;
     /** Flush m_mf_output or m_sum_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -43,6 +43,8 @@ private:
     amrex::Real m_average_period_time = -1.0;
     /** Time step to start averaging */
     int m_average_start_step = -1;
+    /** Whether to output a message when diagnostics are output */
+    int m_verbose = 2;
     /** Flush m_mf_output or m_sum_mf_output and particles to file for the i^th buffer */
     void Flush (int i_buffer, bool /* force_flush */) override;
     /** Flush raw data */

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -130,6 +130,7 @@ FullDiagnostics::ReadParameters ()
         pp_diag_name.get("time_average_mode", m_time_average_mode_str);
 
         const amrex::ParmParse pp_warpx("warpx");
+        pp_warpx.query("verbose", m_verbose);
         std::vector<std::string> dt_interval_vec = {"-1"};
         const bool timestep_may_vary = pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
         amrex::Print() << Utils::TextMsg::Warn("Time step varies?" + std::to_string(timestep_may_vary));
@@ -261,7 +262,8 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
                     m_varnames, m_sum_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
                     warpx.gett_new(0),
                     m_output_species.at(i_buffer), nlev_output, m_file_prefix,
-                    m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
+                    m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards,
+                    m_verbose);
 
             // Reset the values in the dynamic start time-averaged diagnostics after flush
             if (m_time_average_mode == TimeAverageType::Dynamic) {
@@ -281,7 +283,8 @@ FullDiagnostics::Flush ( int i_buffer, bool /* force_flush */ )
             m_varnames, m_mf_output.at(i_buffer), m_geom_output.at(i_buffer), warpx.getistep(),
             warpx.gett_new(0),
             m_output_species.at(i_buffer), nlev_output, m_file_prefix,
-            m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards);
+            m_file_min_digits, m_plot_raw_fields, m_plot_raw_fields_guards,
+            m_verbose);
     }
 
     FlushRaw();
@@ -340,7 +343,7 @@ FullDiagnostics::DoComputeAndPack (int step, bool force_flush)
                     }
                 }
                 // Print information on when time-averaging is active
-                if (in_averaging_period) {
+                if ((m_verbose > 1) && in_averaging_period) {
                     if (step == m_average_start_step) {
                         amrex::Print() << Utils::TextMsg::Info(
                                 "Begin time averaging for " + m_diag_name + " and output at step "

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -122,9 +122,6 @@ FullDiagnostics::ReadParameters ()
     const bool plot_raw_fields_guards_specified = pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
     const bool raw_specified = plot_raw_fields_specified || plot_raw_fields_guards_specified;
 
-    const amrex::ParmParse pp_warpx("warpx");
-    pp_warpx.query("verbose", m_verbose);
-
     if (m_diag_type == DiagTypes::TimeAveraged) {
         std::string m_time_average_mode_str = "none";
         /** Whether the diagnostics are averaging data over time or not
@@ -132,6 +129,7 @@ FullDiagnostics::ReadParameters ()
          */
         pp_diag_name.get("time_average_mode", m_time_average_mode_str);
 
+        const amrex::ParmParse pp_warpx("warpx");
         std::vector<std::string> dt_interval_vec = {"-1"};
         const bool timestep_may_vary = pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
         amrex::Print() << Utils::TextMsg::Warn("Time step varies?" + std::to_string(timestep_may_vary));

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -122,6 +122,9 @@ FullDiagnostics::ReadParameters ()
     const bool plot_raw_fields_guards_specified = pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
     const bool raw_specified = plot_raw_fields_specified || plot_raw_fields_guards_specified;
 
+    const amrex::ParmParse pp_warpx("warpx");
+    pp_warpx.query("verbose", m_verbose);
+
     if (m_diag_type == DiagTypes::TimeAveraged) {
         std::string m_time_average_mode_str = "none";
         /** Whether the diagnostics are averaging data over time or not
@@ -129,8 +132,6 @@ FullDiagnostics::ReadParameters ()
          */
         pp_diag_name.get("time_average_mode", m_time_average_mode_str);
 
-        const amrex::ParmParse pp_warpx("warpx");
-        pp_warpx.query("verbose", m_verbose);
         std::vector<std::string> dt_interval_vec = {"-1"};
         const bool timestep_may_vary = pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
         amrex::Print() << Utils::TextMsg::Warn("Time step varies?" + std::to_string(timestep_may_vary));


### PR DESCRIPTION
This PR passes the `warpx.verbose` value to diagnostics to set whether a message is output when the diagnostic is active. Specifically, this helps with the time-averaged diagnostic where currently a message is print at every step that averaging is done (commonly every step).