### PR TITLE
Use same MLMG parameters in MS solver as in ES solver

### DIFF
--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -128,22 +128,33 @@ WarpX::AddMagnetostaticFieldLabFrame()
 
     // const amrex::Real magnetostatic_absolute_tolerance = self_fields_absolute_tolerance*PhysConst::c;
     // temporary fix!!!
-    const amrex::Real magnetostatic_absolute_tolerance = 0.0;
-    amrex::Real self_fields_required_precision;
+    amrex::Real absolute_tolerance = 0.0;
+    amrex::Real required_precision;
     if constexpr (std::is_same<Real, float>::value) {
-        self_fields_required_precision = 1e-5;
+        required_precision = 1e-5;
     }
     else {
-        self_fields_required_precision = 1e-11;
+        required_precision = 1e-11;
     }
-    const int self_fields_max_iters = 200;
-    const int self_fields_verbosity = 2;
+    int max_iters = 200;
+    int verbosity = 2;
+
+    // load user specified parameters
+    const ParmParse pp_warpx("warpx");
+    utils::parser::queryWithParser(
+        pp_warpx, "self_fields_required_precision", required_precision);
+    utils::parser::queryWithParser(
+        pp_warpx, "self_fields_absolute_tolerance", absolute_tolerance);
+    utils::parser::queryWithParser(
+        pp_warpx, "self_fields_max_iters", max_iters);
+   utils::parser::queryWithParser(
+        pp_warpx, "self_fields_verbosity", verbosity);
 
     computeVectorPotential(
         m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_fp_nodal, finest_level),
-        self_fields_required_precision, magnetostatic_absolute_tolerance, self_fields_max_iters,
-        self_fields_verbosity);
+        required_precision, absolute_tolerance, max_iters, verbosity
+    );
 }
 
 /* Compute the vector potential `A` by solving the Poisson equation with `J` as

--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -128,7 +128,7 @@ WarpX::AddMagnetostaticFieldLabFrame()
 
     // const amrex::Real magnetostatic_absolute_tolerance = self_fields_absolute_tolerance*PhysConst::c;
     // temporary fix!!!
-    amrex::Real absolute_tolerance = 0.0;
+    const amrex::Real absolute_tolerance = 0.0;
     amrex::Real required_precision;
     if constexpr (std::is_same<Real, float>::value) {
         required_precision = 1e-5;
@@ -136,7 +136,7 @@ WarpX::AddMagnetostaticFieldLabFrame()
     else {
         required_precision = 1e-11;
     }
-    int verbosity = 2;
+    const int verbosity = 2;
 
     computeVectorPotential(
         m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),

--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -136,24 +136,13 @@ WarpX::AddMagnetostaticFieldLabFrame()
     else {
         required_precision = 1e-11;
     }
-    int max_iters = 200;
     int verbosity = 2;
-
-    // load user specified parameters
-    const ParmParse pp_warpx("warpx");
-    utils::parser::queryWithParser(
-        pp_warpx, "self_fields_required_precision", required_precision);
-    utils::parser::queryWithParser(
-        pp_warpx, "self_fields_absolute_tolerance", absolute_tolerance);
-    utils::parser::queryWithParser(
-        pp_warpx, "self_fields_max_iters", max_iters);
-   utils::parser::queryWithParser(
-        pp_warpx, "self_fields_verbosity", verbosity);
 
     computeVectorPotential(
         m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_fp_nodal, finest_level),
-        required_precision, absolute_tolerance, max_iters, verbosity
+        required_precision, absolute_tolerance, magnetostatic_solver_max_iters,
+        verbosity
     );
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -902,6 +902,7 @@ public:
 
     // Magnetostatic Solver Interface
     MagnetostaticSolver::VectorPoissonBoundaryHandler m_vector_poisson_boundary_handler;
+    int magnetostatic_solver_max_iters = 200;
     void ComputeMagnetostaticField ();
     void AddMagnetostaticFieldLabFrame ();
     void computeVectorPotential (ablastr::fields::MultiLevelVectorField const& curr,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -684,6 +684,7 @@ WarpX::ReadParameters ()
         poisson_solver_id!=PoissonSolverAlgo::IntegratedGreenFunction,
         "To use the FFT Poisson solver, compile with WARPX_USE_FFT=ON.");
 #endif
+        utils::parser::queryWithParser(pp_warpx, "self_fields_max_iters", magnetostatic_solver_max_iters);
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         (


### PR DESCRIPTION
Fixes #5508.

~~We might not want to set the solver precision with the same values as used for the ES solver but that can be debated in this PR.~~

Note this is a patch fix until we can refactor the MS solver to separate it from the `WarpX` class.