### PR TITLE
Injection from EB: do not create particles outside of user-specified bounds

### DIFF
--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1483,17 +1483,14 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
                 if (eb_flag_arr(i,j,k).isRegular() || eb_flag_arr(i,j,k).isCovered()) { return; }
                 // Scale by the (normalized) area of the EB surface in this cell
                 num_ppc_real_in_this_cell *= eb_bnd_area_arr(i,j,k);
-            } else
+            }
 #else
             amrex::Real const num_ppc_real_in_this_cell = num_ppc_real; // user input: number of macroparticles per cell
 #endif
-            {
-                // Injection from a plane
-                auto lo = getCellCoords(overlap_corner, dx, {0._rt, 0._rt, 0._rt}, iv);
-                auto hi = getCellCoords(overlap_corner, dx, {1._rt, 1._rt, 1._rt}, iv);
-                // Skip cells that do not overlap with the plane
-                if (!flux_pos->overlapsWith(lo, hi)) { return; }
-            }
+            // Skip cells that do not overlap with the bounds specified by the user (xmin/xmax, ymin/ymax, zmin/zmax)
+            auto lo = getCellCoords(overlap_corner, dx, {0._rt, 0._rt, 0._rt}, iv);
+            auto hi = getCellCoords(overlap_corner, dx, {1._rt, 1._rt, 1._rt}, iv);
+            if (!flux_pos->overlapsWith(lo, hi)) { return; }
 
             auto index = overlap_box.index(iv);
             // Take into account refined injection region


### PR DESCRIPTION
When using the injection from embedded boundaries along with `zmin`, `zmax`, `xmin`, `xmax`, etc., we were creating a large number of macroparticles along the EB surface, and then removing the particles that are outside of `zmin`, `zmax`, `xmin`, `xmax`, etc. by setting their ID to an invalid value.

In case where the area defined by `zmin`, `zmax`, `xmin`, `xmax`, etc. is a small fraction of the EB surface, it is much more efficient not to create these particles in the first place. In addition, it avoids having to create a large number of particle IDs, which are eventually not used in the simulation. (In some use cases, this unnecessarily lead to a particle ID overflow, i.e. WarpX ended up having to generate particle IDs that were outside the maximum possible range given by the number of bits.)

This PR removes this issue.