### PR TITLE
CI: ignore all `.rst` files in the repository

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,6 +13,7 @@ pr:
   paths:
     exclude:
     - Docs
+    - '**/*.rst'
 
 jobs:
 - job:

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangsanitizers

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangtidy

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "Docs/**"
+      - "**.rst"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
Following up on #5387, I think we should also ignore all `.rst` files in the repository when we decide whether or not to run the CI workflows. 

GitHub Actions syntax taken from the examples [here](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths) (see `'**.js'` example). Azure syntax to be tested.

If we merge this before #5522, we can test it (i.e., test that CI is skipped) in #5522 after rebasing there.
